### PR TITLE
Refactor travel guide layout with sidebar

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -85,6 +85,97 @@ export const HEX_PLUGIN_CSS = `
 .sm-terrain-editor .addbar input[type="text"] { flex:1; min-width:0; }
 
 /* === Travel Guide === */
+.sm-travel-guide {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    gap: 1.5rem;
+    padding: 1rem;
+    box-sizing: border-box;
+}
+
+.sm-travel-guide .sm-tg-map {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    position: relative;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 10px;
+    background: var(--background-primary);
+    padding: 0.75rem;
+    box-sizing: border-box;
+}
+
+.sm-travel-guide .sm-tg-map .hex3x3-map {
+    max-width: none;
+    height: 100%;
+}
+
+.sm-travel-guide .sm-tg-sidebar {
+    flex: 0 0 280px;
+    max-width: 340px;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 10px;
+    padding: 1rem;
+    box-sizing: border-box;
+    display: flex;
+}
+
+.sm-tg-sidebar__inner {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+}
+
+.sm-tg-sidebar__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.sm-tg-sidebar__section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sm-tg-sidebar__section-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.sm-tg-sidebar__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.sm-tg-sidebar__label {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.sm-tg-sidebar__value {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.sm-tg-sidebar__speed-input {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border-radius: 6px;
+}
+
 .sm-travel-guide .hex3x3-map circle[data-token] { opacity: .95; }
 .sm-travel-guide .hex3x3-map polyline { pointer-events: none; }
 `;

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -39,7 +39,7 @@ src/apps/travel-guide/
    ├─ token-layer.ts              # Sichtbares Token (SVG <g>, RAF-Animation)
    ├─ drag.controller.ts          # Pointerdown/move/up, Ghost-Preview, Commit via Logik
    ├─ contextmenue.ts             # RMB auf Dots → deleteUserAt
-   └─ sidebar.ts                  # (Derzeit unbenutzte) Sidebar für Status + Speed-Input
+   └─ sidebar.ts                  # Sidebar für Karten-Titel, Status & Speed-Steuerung
 ```
 
 > Zielgrößen: 80–180 LOC pro Modul, maximal 300 LOC.
@@ -137,14 +137,14 @@ export type TravelLogic = {
 - `getOrCreateLeaf()` bevorzugt vorhandene oder rechte Splits (Obsidian API).
 
 ### `ui/view-shell.ts`
-- `mountTravelGuide(app, host, file)` leert den Host, beendet sofort wenn keine Datei übergeben wurde, und richtet anschließend SVG-Root & Layers ein.
-- Lädt Terrain-Definitionen über den Core-Terrain-Store (`loadTerrains`) und registriert sie über `setTerrains` für die restliche App.
-- Baut `mapLayer`, `routeLayer`, `tokenLayer` und kombiniert sie zu einem `RenderAdapter`.
-- Initialisiert `createTravelLogic` (Basisdauer 900 ms) und reicht `onChange` durch, um `routeLayer.draw(route, editIdx)` zu triggern.
-- Ruft `logic.initTokenFromTiles()` (Token laden/anzeigen).
-- Verkabelt `createDragController` (inkl. `polyToCoord` für Hit-Tests) und `bindContextMenu`.
-- Listet auf `hex:click` (vom Map-Layer) und ruft `logic.handleHexClick` – Drag-Suppressions werden respektiert.
-- Exportiert `TravelGuideController` (mit `destroy()` und optionalem `setFile`) und liefert diesen Typ zurück; `undefined`, falls keine Datei vorhanden ist.
+- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Map-/Sidebar-Container und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein.
+- Lädt Terrain-Definitionen (`loadTerrains` → `setTerrains`) einmalig beim Mount.
+- Erstellt `routeLayer`/`tokenLayer` auf `mapLayer.handles.svg`, damit Route & Token im Renderer-SVG leben.
+- Instanziiert `createSidebar` im rechten Bereich, füllt Titel/Status/Schnelleingaben und verbindet `onSpeedChange` mit `logic.setTokenSpeed`.
+- Initialisiert `createTravelLogic` (Basisdauer 900 ms) mit einem `onChange`, der Route-Highlight, Sidebar-Tile (`currentTile ?? tokenRC`) und Speed synchronisiert.
+- `logic.initTokenFromTiles()` lädt/persistiert die Tokenposition; Hook wird nach dem Mount einmal manuell aufgerufen.
+- Richtet Drag- & Kontextmenüs neu ein, sobald `setFile` eine Karte lädt; `setFile` returned ein `Promise` und serialisiert Ladevorgänge.
+- Der zurückgegebene `TravelGuideController` sorgt für Cleanup (Drag, Sidebar, Klassen) und akzeptiert `setFile`, um Karte, Titel und Route während der Laufzeit neu zu binden.
 
 ### `ui/map-layer.ts`
 - Nutzt `renderHexMap` um das Kartensvg zu erzeugen, verwaltet `RenderHandles`.
@@ -176,9 +176,9 @@ export type TravelLogic = {
 - Ruft bei `user`-Dots `logic.deleteUserAt(idx)` und stoppt Event-Bubbling.
 
 ### `ui/sidebar.ts`
-- Baut eine rechte Sidebar mit „Status“-Heading, aktuellem Hex (`setTile`) und Speed-Input (`setSpeed`).
-- Validiert Speed-Eingaben (>0, default 1) und ruft registrierten Callback `onSpeedChange`.
-- `destroy()` entfernt das DOM-Fragment. Momentan noch nicht in `view-shell` eingebunden.
+- Rendert einen strukturierten Sidebar-Block (`Titel`, `Status`, `Geschwindigkeit`) inkl. CSS-Klassen.
+- `setTitle`, `setTile`, `setSpeed` aktualisieren sichtbare Werte; Eingaben werden (>0) validiert.
+- `onSpeedChange` registriert den externen Callback, `destroy()` leert den Host. Wird von `view-shell` genutzt.
 
 ### `domain/types.ts`
 - Definiert Basis-Koordinaten (`Coord`), Knotenarten (`NodeKind`) und `RouteNode`.

--- a/src/apps/travel-guide/index.ts
+++ b/src/apps/travel-guide/index.ts
@@ -30,7 +30,7 @@ export class TravelGuideView extends ItemView {
     /** Optional: open view with a preselected file */
     setFile(file: TFile | null) {
         this.initialFile = file;
-        this.controller?.setFile(file ?? null);
+        void this.controller?.setFile(file ?? null);
     }
 
     async onOpen(): Promise<void> {

--- a/src/apps/travel-guide/ui/sidebar.ts
+++ b/src/apps/travel-guide/ui/sidebar.ts
@@ -1,47 +1,74 @@
 export type Sidebar = {
     root: HTMLElement;
+    setTitle(title: string): void;
     setTile(rc: { r: number; c: number } | null): void;
     setSpeed(v: number): void;
     onSpeedChange(fn: (v: number) => void): void;
     destroy(): void;
 };
 
-export function createSidebar(host: HTMLElement): Sidebar {
-    const root = host.createDiv({ cls: "sm-tg-side" });
-    root.createEl("h4", { text: "Status" });
+export function createSidebar(host: HTMLElement, initialTitle?: string): Sidebar {
+    host.empty();
+    host.classList.add("sm-tg-sidebar");
 
-    const sideEls: { tile?: HTMLSpanElement; speed?: HTMLInputElement } = {};
-    const rowTile = root.createDiv({ cls: "row" });
-    rowTile.createEl("span", { text: "Aktuelles Hex:" });
-    sideEls.tile = rowTile.createEl("span", { text: "—" });
+    const root = host.createDiv({ cls: "sm-tg-sidebar__inner" });
 
-    const rowSpeed = root.createDiv({ cls: "row" });
-    rowSpeed.createEl("span", { text: "Token-Speed:" });
-    sideEls.speed = rowSpeed.createEl("input", {
+    const titleEl = root.createEl("div", {
+        cls: "sm-tg-sidebar__title",
+        text: initialTitle ?? "—",
+    });
+
+    const statusSection = root.createDiv({
+        cls: "sm-tg-sidebar__section sm-tg-sidebar__section--status",
+    });
+    statusSection.createEl("h3", {
+        cls: "sm-tg-sidebar__section-title",
+        text: "Status",
+    });
+    const tileRow = statusSection.createDiv({ cls: "sm-tg-sidebar__row" });
+    tileRow.createSpan({ cls: "sm-tg-sidebar__label", text: "Aktuelles Hex" });
+    const tileValue = tileRow.createSpan({ cls: "sm-tg-sidebar__value", text: "—" });
+
+    const speedSection = root.createDiv({
+        cls: "sm-tg-sidebar__section sm-tg-sidebar__section--speed",
+    });
+    speedSection.createEl("h3", {
+        cls: "sm-tg-sidebar__section-title",
+        text: "Geschwindigkeit",
+    });
+    const speedRow = speedSection.createDiv({ cls: "sm-tg-sidebar__row" });
+    speedRow.createSpan({ cls: "sm-tg-sidebar__label", text: "Token-Speed" });
+    const speedInput = speedRow.createEl("input", {
         type: "number",
+        cls: "sm-tg-sidebar__speed-input",
         attr: { step: "0.1", min: "0.1", value: "1" },
     }) as HTMLInputElement;
 
     let onChange: (v: number) => void = () => {};
-    sideEls.speed.onchange = () => {
-        const v = parseFloat(sideEls.speed!.value);
+    speedInput.onchange = () => {
+        const v = parseFloat(speedInput.value);
         const val = Number.isFinite(v) && v > 0 ? v : 1;
-        sideEls.speed!.value = String(val);
+        speedInput.value = String(val);
         onChange(val);
     };
 
     const setTile = (rc: { r: number; c: number } | null) => {
-        sideEls.tile!.textContent = rc ? `${rc.r},${rc.c}` : "—";
+        tileValue.textContent = rc ? `${rc.r},${rc.c}` : "—";
     };
     const setSpeed = (v: number) => {
-        if (sideEls.speed!.value !== String(v)) sideEls.speed!.value = String(v);
+        const next = String(v);
+        if (speedInput.value !== next) speedInput.value = next;
+    };
+    const setTitle = (title: string) => {
+        titleEl.textContent = title && title.trim().length > 0 ? title : "—";
     };
 
-        return {
-            root,
-            setTile,
-            setSpeed,
-            onSpeedChange: (fn) => (onChange = fn),
-            destroy: () => root.detach(),
-        };
+    return {
+        root,
+        setTitle,
+        setTile,
+        setSpeed,
+        onSpeedChange: (fn) => (onChange = fn),
+        destroy: () => host.empty(),
+    };
 }

--- a/src/apps/travel-guide/ui/view-shell.ts
+++ b/src/apps/travel-guide/ui/view-shell.ts
@@ -13,13 +13,14 @@ import { createRouteLayer } from "./route-layer";
 import { createTokenLayer } from "./token-layer";
 import { createDragController } from "./drag.controller";
 import { bindContextMenu } from "./contextmenue";
+import { createSidebar } from "./sidebar";
 
 import { createTravelLogic } from "../domain/actions";
-import type { Coord } from "../domain/types";
+import type { Coord, LogicStateSnapshot } from "../domain/types";
 
 export type TravelGuideController = {
     destroy(): void;
-    setFile?(file: TFile | null): void;
+    setFile?(file: TFile | null): Promise<void>;
 };
 
 export async function mountTravelGuide(
@@ -28,87 +29,163 @@ export async function mountTravelGuide(
     file: TFile | null
 ): Promise<TravelGuideController | undefined> {
     host.empty();
-    if (!file) return;
+    host.classList.add("sm-travel-guide");
 
-    // SVG-Root (für Route/Token-Layer)
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svg.setAttribute("width", "100%");
-    svg.setAttribute("height", "100%");
-    host.appendChild(svg);
+    const mapHost = host.createDiv({ cls: "sm-tg-map" });
+    const sidebarHost = host.createDiv({ cls: "sm-tg-sidebar" });
 
-    // Terrain laden
-    setTerrains(await loadTerrains(app));
+    const sidebar = createSidebar(sidebarHost, file?.basename ?? "—");
 
-    // Map-Layer (stellt centerOf/ensurePolys + polyIndex)
+    await setTerrains(await loadTerrains(app));
+
     const opts = parseOptions("radius: 42");
-    const mapLayer = await createMapLayer(app, host, file, opts);
 
-    // Route-/Token-Layer
-    const routeLayer = createRouteLayer(svg, (rc) => mapLayer.centerOf(rc));
-    const tokenLayer = createTokenLayer(svg);
+    let currentFile: TFile | null = null;
+    let mapLayer: Awaited<ReturnType<typeof createMapLayer>> | null = null;
+    let routeLayer: ReturnType<typeof createRouteLayer> | null = null;
+    let tokenLayer: ReturnType<typeof createTokenLayer> | null = null;
+    let drag: ReturnType<typeof createDragController> | null = null;
+    let unbindContext: () => void = () => {};
+    let logic: ReturnType<typeof createTravelLogic> | null = null;
+    let isDestroyed = false;
+    let loadChain = Promise.resolve();
 
-    // Adapter (Domain <-> UI)
-    const adapter: RenderAdapter = {
-        ensurePolys: (coords) => mapLayer.ensurePolys(coords),
-        centerOf: (rc) => mapLayer.centerOf(rc),
-        draw: (route) => routeLayer.draw(route),
-        token: tokenLayer,
+    const handleStateChange = (s: LogicStateSnapshot) => {
+        if (routeLayer) routeLayer.draw(s.route, s.editIdx ?? null);
+        sidebar.setTile(s.currentTile ?? s.tokenRC ?? null);
+        sidebar.setSpeed(s.tokenSpeed);
     };
 
-    // Domain-Logik
-    const logic = createTravelLogic({
-        app,
-        getMapFile: () => file,
-        baseMs: 900,
-        adapter,
-        onChange: () => {
-            const s = logic.getState();
-            routeLayer.draw(s.route, s.editIdx ?? null);
-        },
-    });
+    const cleanupInteractions = () => {
+        unbindContext();
+        unbindContext = () => {};
+        if (drag) {
+            drag.unbind();
+            drag = null;
+        }
+    };
 
-    // Token aus Tiles laden/anzeigen (Persistenz bleibt in der Domain)
-    await logic.initTokenFromTiles();
+    const cleanupLayers = () => {
+        cleanupInteractions();
+        if (tokenLayer) {
+            tokenLayer.destroy?.();
+            tokenLayer = null;
+        }
+        if (routeLayer) {
+            routeLayer.destroy();
+            routeLayer = null;
+        }
+        if (mapLayer) {
+            mapLayer.destroy();
+            mapLayer = null;
+        }
+        mapHost.empty();
+    };
 
-    // Drag-Controller (Ghost + Commit → Domain-Actions)
-    const drag = createDragController({
-        routeLayerEl: routeLayer.el,
-        tokenEl: (tokenLayer as any).el as SVGGElement,
-        token: tokenLayer,
-        adapter,
-        logic: {
-            getState: () => logic.getState(),
-            selectDot: (i) => logic.selectDot(i),
-            moveSelectedTo: (rc) => logic.moveSelectedTo(rc),
-            moveTokenTo: (rc) => logic.moveTokenTo(rc),
-        },
-        polyToCoord: mapLayer.polyToCoord,
-    });
-    drag.bind();
-
-    // RMB-Kontextmenü (nur user-Punkte löschen)
-    const unbindContext = bindContextMenu(routeLayer.el, {
-        getState: () => logic.getState(),
-        deleteUserAt: (idx) => logic.deleteUserAt(idx),
-    });
-
-    // hex:click → neuen user-Punkt setzen (Click nach Drag wird unterdrückt)
-    const onHexClick = (ev: any) => {
-        if (drag.consumeClickSuppression()) return;
-        const { r, c } = ev.detail as Coord;
+    const onHexClick = (ev: CustomEvent<Coord>) => {
+        if (!logic) return;
+        if (drag?.consumeClickSuppression()) return;
+        const { r, c } = ev.detail;
         logic.handleHexClick({ r, c });
     };
-    const clickTarget: any = (mapLayer as any).el ?? host;
-    clickTarget.addEventListener?.("hex:click", onHexClick, { passive: false });
+    mapHost.addEventListener("hex:click", onHexClick as any, { passive: false });
 
-    // Cleanup
-    const controller: TravelGuideController = {
-        destroy() {
-            clickTarget.removeEventListener?.("hex:click", onHexClick as any);
-            unbindContext();
-            drag.unbind();
-            tokenLayer.destroy?.();
+    const loadFile = async (nextFile: TFile | null) => {
+        if (isDestroyed) return;
+        const same = nextFile?.path === currentFile?.path;
+        if (same) return;
+
+        currentFile = nextFile;
+        sidebar.setTitle(nextFile?.basename ?? "—");
+        sidebar.setTile(null);
+
+        logic?.pause?.();
+        logic = null;
+
+        cleanupLayers();
+
+        if (!nextFile) {
+            sidebar.setSpeed(1);
+            return;
+        }
+
+        mapLayer = await createMapLayer(app, mapHost, nextFile, opts);
+        if (isDestroyed) {
             mapLayer.destroy();
+            mapLayer = null;
+            return;
+        }
+
+        routeLayer = createRouteLayer(mapLayer.handles.svg, (rc) => mapLayer!.centerOf(rc));
+        tokenLayer = createTokenLayer(mapLayer.handles.svg);
+
+        const adapter: RenderAdapter = {
+            ensurePolys: (coords) => mapLayer!.ensurePolys(coords),
+            centerOf: (rc) => mapLayer!.centerOf(rc),
+            draw: (route) => routeLayer!.draw(route),
+            token: tokenLayer!,
+        };
+
+        logic = createTravelLogic({
+            app,
+            baseMs: 900,
+            getMapFile: () => currentFile,
+            adapter,
+            onChange: (state) => handleStateChange(state),
+        });
+
+        handleStateChange(logic.getState());
+        await logic.initTokenFromTiles();
+        if (isDestroyed) return;
+
+        drag = createDragController({
+            routeLayerEl: routeLayer!.el,
+            tokenEl: (tokenLayer as any).el as SVGGElement,
+            token: tokenLayer!,
+            adapter,
+            logic: {
+                getState: () => logic!.getState(),
+                selectDot: (i) => logic!.selectDot(i),
+                moveSelectedTo: (rc) => logic!.moveSelectedTo(rc),
+                moveTokenTo: (rc) => logic!.moveTokenTo(rc),
+            },
+            polyToCoord: mapLayer!.polyToCoord,
+        });
+        drag.bind();
+
+        unbindContext = bindContextMenu(routeLayer!.el, {
+            getState: () => logic!.getState(),
+            deleteUserAt: (idx) => logic!.deleteUserAt(idx),
+        });
+    };
+
+    sidebar.onSpeedChange((v) => {
+        logic?.setTokenSpeed(v);
+    });
+
+    await loadFile(file);
+
+    const enqueueLoad = (next: TFile | null) => {
+        loadChain = loadChain
+            .then(() => loadFile(next))
+            .catch((err) => {
+                console.error("[travel-guide] setFile failed", err);
+            });
+        return loadChain;
+    };
+
+    const controller: TravelGuideController = {
+        setFile(next) {
+            return enqueueLoad(next ?? null);
+        },
+        destroy() {
+            isDestroyed = true;
+            mapHost.removeEventListener("hex:click", onHexClick as any);
+            cleanupLayers();
+            logic?.pause?.();
+            logic = null;
+            sidebar.destroy();
+            host.classList.remove("sm-travel-guide");
             host.empty();
         },
     };


### PR DESCRIPTION
## Summary
- Restructure the travel guide shell to build a flex layout with dedicated map and sidebar containers, reuse the renderer SVG for route/token layers, and support asynchronous map switching.
- Expand the sidebar UI to surface the current map title, tile and speed controls with reusable styling hooks.
- Add travel guide layout/typography styles and refresh the overview docs to describe the new wiring.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d001f1601c8325aa3b271a7c863ea9