### PR TITLE
Prevent default hex click dispatch

### DIFF
--- a/main.js
+++ b/main.js
@@ -2464,6 +2464,8 @@ async function mountTravelGuide(app, host, file) {
     mapHost.empty();
   };
   const onHexClick = (ev) => {
+    if (ev.cancelable) ev.preventDefault();
+    ev.stopPropagation();
     if (!logic) return;
     if (drag?.consumeClickSuppression()) return;
     const { r, c } = ev.detail;

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -145,6 +145,7 @@ export type TravelLogic = {
 - `logic.initTokenFromTiles()` lädt/persistiert die Tokenposition; Hook wird nach dem Mount einmal manuell aufgerufen.
 - Richtet Drag- & Kontextmenüs neu ein, sobald `setFile` eine Karte lädt; `setFile` returned ein `Promise` und serialisiert Ladevorgänge.
 - Der zurückgegebene `TravelGuideController` sorgt für Cleanup (Drag, Sidebar, Klassen) und akzeptiert `setFile`, um Karte, Titel und Route während der Laufzeit neu zu binden.
+- Unterdrückt das Default-Verhalten der `hex:click`-Events (`preventDefault`/`stopPropagation`), damit Obsidian keine Dash-Ansicht startet, bevor die Logik `handleHexClick` ausführt.
 
 ### `ui/map-layer.ts`
 - Nutzt `renderHexMap` um das Kartensvg zu erzeugen, verwaltet `RenderHandles`.

--- a/src/apps/travel-guide/ui/view-shell.ts
+++ b/src/apps/travel-guide/ui/view-shell.ts
@@ -83,6 +83,8 @@ export async function mountTravelGuide(
     };
 
     const onHexClick = (ev: CustomEvent<Coord>) => {
+        if (ev.cancelable) ev.preventDefault();
+        ev.stopPropagation();
         if (!logic) return;
         if (drag?.consumeClickSuppression()) return;
         const { r, c } = ev.detail;


### PR DESCRIPTION
## Summary
- call preventDefault/stopPropagation for travel guide hex clicks so Obsidian doesn't launch Dash when plotting routes
- document the new event handling in the Travel Guide overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00a25c5088325847573de2eb18647