### PR TITLE
feat: share map header between editor and travel guide

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -87,14 +87,39 @@ export const HEX_PLUGIN_CSS = `
 /* === Travel Guide === */
 .sm-travel-guide {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: stretch;
     width: 100%;
     height: 100%;
     min-height: 100%;
-    gap: 1.5rem;
+    gap: 1rem;
     padding: 1rem;
     box-sizing: border-box;
+}
+
+.sm-travel-guide__header {
+    padding-bottom: 0.25rem;
+}
+
+.sm-travel-guide__header .sm-map-header {
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 10px;
+    padding: 0.75rem;
+    gap: 0.5rem;
+}
+
+.sm-travel-guide__header .sm-map-header h2 {
+    margin: 0;
+}
+
+.sm-travel-guide__body {
+    display: flex;
+    flex: 1 1 auto;
+    gap: 1.5rem;
+    align-items: stretch;
+    width: 100%;
+    min-height: 0;
 }
 
 .sm-travel-guide .sm-tg-map {

--- a/src/apps/map-editor/MapEditorOverview.txt
+++ b/src/apps/map-editor/MapEditorOverview.txt
@@ -14,7 +14,7 @@
 ```
 src/apps/map-editor/
 ├─ index.ts                    # Obsidian-View (Lifecycle, State ↔ ViewState, mountMapEditor)
-├─ editor-ui.ts                # Haupt-UI (Header, Map-Canvas, Tool-Switch, Save-/Open-Aktionen)
+├─ editor-ui.ts                # Haupt-UI (Header via ui/map-header.ts, Map-Canvas, Tool-Switch, Save-/Open-Aktionen)
 ├─ MapEditorOverview.txt       # Dieses Dokument
 ├─ brush-circle.ts             # SVG-Kreis als Brush-Vorschau (Pointertracking)
 ├─ tools-api.ts                # Tool-Kontrakt (Context, Hooks, Controller)
@@ -60,7 +60,7 @@ export type ToolModule = {
 ## View-Lifecycle & Datenfluss
 
 1. **View-Initialisierung (`index.ts`):** `MapEditorView` leitet Obsidian-View-State (`mapPath`) an `mountMapEditor` weiter und speichert den vom UI zurückgegebenen Controller (`setFile`, `setTool`). `setState` synchronisiert spätere ViewState-Änderungen mit einer bereits gemounteten UI.
-2. **UI-Aufbau (`editor-ui.ts`):** Beim Mounten werden Header (Open/Create/Save), Optionspane und Map-Canvas erzeugt. Styling und Open/Create-Flows laufen über `ui/map-workflows.ts` (`applyMapButtonStyle`, `promptMapSelection`, `promptCreateMap`), sodass Editor und Galerie identische UX teilen. `state` hält aktuelle Datei, Hex-Optionen, Renderer-Handles, aktives Tool sowie ein Cleanup des Toolpanels.
+2. **UI-Aufbau (`editor-ui.ts`):** Beim Mounten erstellt die UI den Header über `createMapHeader` (`ui/map-header.ts`) und hängt die Optionen/Map-Container an. Open/Create-Flows laufen weiterhin über `ui/map-workflows.ts`, sodass Editor und Galerie identische UX teilen. `state` hält aktuelle Datei, Hex-Optionen, Renderer-Handles, aktives Tool sowie ein Cleanup des Toolpanels.
 3. **Dateiwechsel:** `setFile` aktualisiert `state.file` und delegiert das eigentliche Rendering an `renderHexMapFromFile` (ebenfalls aus `ui/map-workflows.ts`). Die Utility kümmert sich um Hex-Block-Suche, Options-Parsing und `renderHexMap`, der wiederum `RenderHandles` inkl. Overlay liefert.
 4. **Toolwechsel:** `switchTool` ruft `onDeactivate`/`mountPanel`/`onActivate` auf dem Modul auf. Tools können DOM in `optBody` anlegen und via Cleanup wieder entfernen.
 5. **Interaktion:** Hex-Klicks werden im `renderHexMap`-Host auf `hex:click` geloggt und an das aktive Tool (`onHexClick`) delegiert. Tools entscheiden, ob das Event verarbeitet wurde (Rückgabewert `true`) und können über `ctx.refreshMap()` einen vollständigen Re-Render auslösen.
@@ -93,8 +93,7 @@ export type ToolModule = {
 - Mountet UI auf `onOpen`, kümmert sich um leeren Container, CSS-Klasse `hex-map-editor-root` und initialen ViewState.
 - `setState` kann vor oder nach dem UI-Mount aufgerufen werden; lädt Karte nachträglich per `controller.setFile`.
 
-### `editor-ui.ts`
-- Erstellt DOM-Struktur für Header (Open/Neuanlage/Speichern) und Body (Map-Canvas + Optionspane) und nutzt `ui/map-workflows.ts`, um Button-Styling sowie Open/Create-Prompts zu teilen.
+- Erstellt DOM-Struktur für Body (Map-Canvas + Optionspane) und delegiert den Header (`Open/Neuanlage/Speichern`) an `createMapHeader` aus `ui/map-header.ts`, das Button-Styling sowie Save/Open-Flows bündelt.
 - Verwaltert `state` für aktive Datei, Hex-Optionen (über `renderHexMapFromFile`), Renderer-Handles und aktuelles Tool.
 - Stellt Controller `{ setFile, setTool }` bereit, der von `MapEditorView` genutzt wird.
 - Verantwortlich für `renderMap()` (Delegation an `renderHexMapFromFile`, danach Hex-Klick → Tool weiterreichen).

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -107,7 +107,7 @@ export type TravelLogic = {
 
 ## Datenfluss (kurz)
 
-1. **Mount:** `index.ts` erstellt im View `mountTravelGuide(app, host, file)`. Die Shell lädt Terrain-Daten, baut Map/Route/Token-Layer und instanziiert `createTravelLogic` (Basisdauer 900 ms).
+1. **Mount:** `index.ts` erstellt im View `mountTravelGuide(app, host, file)`. Die Shell richtet einen Spalten-Wrapper mit gemeinsamem Map-Header (`ui/map-header.ts`) ein, lädt Terrain-Daten, baut Map/Route/Token-Layer und instanziiert `createTravelLogic` (Basisdauer 900 ms). Der Header verknüpft Open/Create mit `enqueueLoad` und ruft beim Speichern `persistTokenToTiles` plus `saveMap`/`saveMapAs`.
 2. **Store-Abos:** `createTravelLogic` subscribed auf den Store. Jede Änderung triggert `adapter.draw(route, tokenRC)` und optionales `onChange` (View rendert Highlight).
 3. **Hex-Klick:** `map-layer` emittiert `hex:click` → `view-shell` ruft `logic.handleHexClick(rc)` → `expandCoords` erzeugt Autos → Store-Update → Route-Layer zeichnet neu.
 4. **Dot-Drag:** `drag.controller` zeigt Ghost (nur UI), `pointerup` → `logic.moveSelectedTo(rc)` → neue Segmente via `expandCoords` → Store-Update.
@@ -136,8 +136,7 @@ export type TravelLogic = {
 - `activateTravelGuide(file?)` holt oder erstellt das Leaf, setzt den View-State aktiv und reicht optional eine Map-Datei durch.
 - `getOrCreateLeaf()` bevorzugt vorhandene oder rechte Splits (Obsidian API).
 
-### `ui/view-shell.ts`
-- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Map-/Sidebar-Container und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein.
+- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein. Der Header stammt aus `ui/map-header.ts`, verlinkt Öffnen/Erstellen mit `enqueueLoad` und erweitert den Save-Flow um `logic.persistTokenToTiles()`.
 - Lädt Terrain-Definitionen (`loadTerrains` → `setTerrains`) einmalig beim Mount.
 - Erstellt `routeLayer`/`tokenLayer` auf `mapLayer.handles.svg`, damit Route & Token im Renderer-SVG leben.
 - Instanziiert `createSidebar` im rechten Bereich, füllt Titel/Status/Schnelleingaben und verbindet `onSpeedChange` mit `logic.setTokenSpeed`.

--- a/src/ui/UiOverview.txt
+++ b/src/ui/UiOverview.txt
@@ -14,6 +14,7 @@ Der UI-Layer stellt kleine, wiederverwendbare Dialoge bereit, die mehreren Featu
 | Modul | Verantwortung | Notizen |
 | --- | --- | --- |
 | `map-workflows.ts` | Bündelt wiederkehrende UI-Schritte der Map-Features: <br>• `applyMapButtonStyle` vereinheitlicht das Flex-Layout der Buttons für Öffnen/Erstellen/Speichern. <br>• `promptMapSelection` kapselt `getAllMapFiles` + `MapSelectModal` inklusive Leerstands-Notice. <br>• `promptCreateMap` nutzt `NameInputModal` und `createHexMapFile` und meldet den Erfolg via `Notice`. <br>• `renderHexMapFromFile` übernimmt den Standard-Renderweg (`getFirstHexBlock` → `parseOptions` → `renderHexMap`) und stellt Fallback-Meldungen bereit. | Map Editor und Map Gallery greifen auf diese Utilities zurück, um identische UX und weniger duplizierten Code sicherzustellen. |
+| `map-header.ts` | Erstellt den gemeinsamen Header mit Titel, Open/Create-Buttons und Save-Dropdown. Kümmert sich um Buttons (`applyMapButtonStyle`), ruft `promptMapSelection`/`promptCreateMap` und kapselt Standard-Save (`saveMap`/`saveMapAs`). Optionaler `onSave`-Hook erlaubt Feature-spezifische Persistenz vor/nach dem Speichern. | Wird u. a. vom Map Editor und Travel Guide genutzt, um Header-UX zu teilen und zusätzliche Persistenzschritte einzuhängen (z. B. `persistTokenToTiles`). |
 
 ## Zusammenspiel mit Feature-Apps
 

--- a/src/ui/map-header.ts
+++ b/src/ui/map-header.ts
@@ -1,0 +1,157 @@
+// src/ui/map-header.ts
+// Wiederverwendbarer Header für Map-Features (Open/Create/Save + Titel/Dateiname).
+
+import { App, Notice, TFile, setIcon } from "obsidian";
+import { applyMapButtonStyle, promptCreateMap, promptMapSelection } from "./map-workflows";
+import { saveMap, saveMapAs } from "../core/save";
+
+export type MapHeaderSaveMode = "save" | "saveAs";
+
+export type MapHeaderOptions = {
+    /** Überschrift im Header. */
+    title: string;
+    /** Optionales Startfile für die Anzeige. */
+    initialFile?: TFile | null;
+    /** Text, wenn keine Karte selektiert ist. Standard: "—". */
+    emptyLabel?: string;
+    /** Button-Beschriftungen / Notices anpassen. */
+    labels?: {
+        open?: string;
+        create?: string;
+        save?: string;
+        saveAs?: string;
+        trigger?: string;
+    };
+    notices?: {
+        missingFile?: string;
+        saveSuccess?: string;
+        saveError?: string;
+    };
+    /** Callback nach dem Öffnen einer vorhandenen Karte. */
+    onOpen?: (file: TFile) => void | Promise<void>;
+    /** Callback nach Erstellung einer neuen Karte. */
+    onCreate?: (file: TFile) => void | Promise<void>;
+    /**
+     * Optionaler Save-Hook. Rückgabewert `true` signalisiert, dass das Speichern
+     * vollständig behandelt wurde und kein Default-Save mehr nötig ist.
+     */
+    onSave?: (mode: MapHeaderSaveMode, file: TFile | null) => void | Promise<void | boolean> | boolean;
+};
+
+export type MapHeaderHandle = {
+    /** Wurzel-Element des Headers. */
+    readonly root: HTMLElement;
+    /** Aktualisiert den Dateinamen im Header und merkt sich das aktuelle File. */
+    setFileLabel(file: TFile | null): void;
+    /** Optional andere Überschrift setzen. */
+    setTitle(title: string): void;
+    /** Event-Handler entfernen und DOM säubern. */
+    destroy(): void;
+};
+
+export function createMapHeader(app: App, host: HTMLElement, options: MapHeaderOptions): MapHeaderHandle {
+    const labels = {
+        open: options.labels?.open ?? "Open Map",
+        create: options.labels?.create ?? "Create",
+        save: options.labels?.save ?? "Speichern",
+        saveAs: options.labels?.saveAs ?? "Speichern als",
+        trigger: options.labels?.trigger ?? "Los",
+    } as const;
+    const notices = {
+        missingFile: options.notices?.missingFile ?? "Keine Karte ausgewählt.",
+        saveSuccess: options.notices?.saveSuccess ?? "Gespeichert.",
+        saveError: options.notices?.saveError ?? "Speichern fehlgeschlagen.",
+    } as const;
+
+    let currentFile: TFile | null = options.initialFile ?? null;
+    let destroyed = false;
+
+    const root = host.createDiv({ cls: "sm-map-header" });
+    // Historische Klasse weiterreichen, damit bestehende Styles greifen.
+    root.classList.add("map-editor-header");
+    Object.assign(root.style, { display: "flex", flexDirection: "column", gap: ".4rem" });
+
+    const row1 = root.createDiv();
+    Object.assign(row1.style, { display: "flex", alignItems: "center", gap: ".5rem" });
+    const titleEl = row1.createEl("h2", { text: options.title });
+    titleEl.style.marginRight = "auto";
+
+    const openBtn = row1.createEl("button", { text: labels.open });
+    setIcon(openBtn, "folder-open");
+    applyMapButtonStyle(openBtn);
+    openBtn.onclick = () => {
+        if (destroyed) return;
+        void promptMapSelection(app, async (file) => {
+            if (destroyed) return;
+            setFileLabel(file);
+            await options.onOpen?.(file);
+        });
+    };
+
+    const createBtn = row1.createEl("button");
+    createBtn.append(" ", "+");
+    setIcon(createBtn, "plus");
+    applyMapButtonStyle(createBtn);
+    createBtn.onclick = () => {
+        if (destroyed) return;
+        promptCreateMap(app, async (file) => {
+            if (destroyed) return;
+            setFileLabel(file);
+            await options.onCreate?.(file);
+        });
+    };
+
+    const row2 = root.createDiv();
+    Object.assign(row2.style, { display: "flex", alignItems: "center", gap: ".5rem" });
+
+    const nameBox = row2.createEl("div", { text: options.initialFile?.basename ?? options.emptyLabel ?? "—" });
+    Object.assign(nameBox.style, { marginRight: "auto", opacity: ".85" });
+
+    const select = row2.createEl("select");
+    select.createEl("option", { text: labels.save }).value = "save";
+    select.createEl("option", { text: labels.saveAs }).value = "saveAs";
+
+    const triggerBtn = row2.createEl("button", { text: labels.trigger });
+    applyMapButtonStyle(triggerBtn);
+    triggerBtn.onclick = async () => {
+        if (destroyed) return;
+        const mode = (select.value as MapHeaderSaveMode) ?? "save";
+        const file = currentFile;
+        if (!file) {
+            await options.onSave?.(mode, null);
+            new Notice(notices.missingFile);
+            return;
+        }
+        try {
+            const handled = (await options.onSave?.(mode, file)) === true;
+            if (!handled) {
+                if (mode === "save") await saveMap(app, file);
+                else await saveMapAs(app, file);
+            }
+            new Notice(notices.saveSuccess);
+        } catch (err) {
+            console.error("[map-header] save failed", err);
+            new Notice(notices.saveError);
+        }
+    };
+
+    function setFileLabel(file: TFile | null) {
+        currentFile = file;
+        nameBox.textContent = file?.basename ?? options.emptyLabel ?? "—";
+    }
+
+    function setTitle(title: string) {
+        titleEl.textContent = title;
+    }
+
+    function destroy() {
+        if (destroyed) return;
+        destroyed = true;
+        openBtn.onclick = null;
+        createBtn.onclick = null;
+        triggerBtn.onclick = null;
+        root.remove();
+    }
+
+    return { root, setFileLabel, setTitle, destroy };
+}


### PR DESCRIPTION
## Summary
- extract the shared map header into `src/ui/map-header.ts` and swap the map editor to use it
- attach the new header to the travel guide, queue loads via the shared callbacks, and persist the token before manual saves
- refresh the travel guide layout/CSS and update the relevant overview docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d017b89b688325af0f07ec569cba9b