### PR TITLE
Attach travel guide route layer to camera group

### DIFF
--- a/main.js
+++ b/main.js
@@ -1903,10 +1903,10 @@ function updateHighlight(layer, highlightIndex) {
 }
 
 // src/apps/travel-guide/ui/route-layer.ts
-function createRouteLayer(svgRoot, centerOf) {
+function createRouteLayer(contentRoot, centerOf) {
   const el = document.createElementNS("http://www.w3.org/2000/svg", "g");
   el.classList.add("tg-route-layer");
-  svgRoot.appendChild(el);
+  contentRoot.appendChild(el);
   function draw(route, highlightIndex = null, start) {
     drawRoute({ layer: el, route, centerOf, highlightIndex, start });
   }
@@ -2590,7 +2590,10 @@ async function mountTravelGuide(app, host, file) {
       mapLayer = null;
       return;
     }
-    routeLayer = createRouteLayer(mapLayer.handles.svg, (rc) => mapLayer.centerOf(rc));
+    routeLayer = createRouteLayer(
+      mapLayer.handles.contentG,
+      (rc) => mapLayer.centerOf(rc)
+    );
     tokenLayer = createTokenLayer(mapLayer.handles.svg);
     const adapter = {
       ensurePolys: (coords) => mapLayer.ensurePolys(coords),

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -138,7 +138,7 @@ export type TravelLogic = {
 
 - `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein. Der Header stammt aus `ui/map-header.ts`, verlinkt Öffnen/Erstellen mit `enqueueLoad` und erweitert den Save-Flow um `logic.persistTokenToTiles()`.
 - Lädt Terrain-Definitionen (`loadTerrains` → `setTerrains`) einmalig beim Mount.
-- Erstellt `routeLayer`/`tokenLayer` auf `mapLayer.handles.svg`, damit Route & Token im Renderer-SVG leben.
+- Erstellt `routeLayer` auf `mapLayer.handles.contentG` (kamera-transformierte Content-Gruppe) und `tokenLayer` auf `mapLayer.handles.svg`, damit beide innerhalb des Renderer-SVG leben.
 - Instanziiert `createSidebar` im rechten Bereich, füllt Titel/Status/Schnelleingaben und verbindet `onSpeedChange` mit `logic.setTokenSpeed`.
 - Initialisiert `createTravelLogic` (Basisdauer 900 ms) mit einem `onChange`, der Route-Highlight, Sidebar-Tile (`currentTile ?? tokenRC`) und Speed synchronisiert.
 - `logic.initTokenFromTiles()` lädt/persistiert die Tokenposition; Hook wird nach dem Mount einmal manuell aufgerufen.
@@ -154,7 +154,7 @@ export type TravelLogic = {
 - `destroy()` ruft `handles.destroy?.()` sicher.
 
 ### `ui/route-layer.ts`
-- Erstellt `<g class="tg-route-layer">` im SVG und delegiert `draw(route, highlightIndex, tokenRC)` an `drawRoute`.
+- Erstellt `<g class="tg-route-layer">` im kamera-transformierten `contentG` und delegiert `draw(route, highlightIndex, tokenRC)` an `drawRoute`.
 - `highlight(i)` ruft `updateHighlight` (nur UI-Anpassung).
 - `destroy()` entfernt die Gruppe.
 

--- a/src/apps/travel-guide/ui/route-layer.ts
+++ b/src/apps/travel-guide/ui/route-layer.ts
@@ -4,12 +4,12 @@ import type { Coord, RouteNode } from "../domain/types";
 import { drawRoute, updateHighlight } from "../render/draw-route";
 
 export function createRouteLayer(
-    svgRoot: SVGSVGElement,
+    contentRoot: SVGGElement,
     centerOf: (rc: { r: number; c: number }) => { x: number; y: number } | null
 ) {
     const el = document.createElementNS("http://www.w3.org/2000/svg", "g");
     el.classList.add("tg-route-layer");
-    svgRoot.appendChild(el);
+    contentRoot.appendChild(el);
 
     function draw(route: RouteNode[], highlightIndex: number | null = null, start?: Coord | null) {
         drawRoute({ layer: el, route, centerOf, highlightIndex, start });

--- a/src/apps/travel-guide/ui/view-shell.ts
+++ b/src/apps/travel-guide/ui/view-shell.ts
@@ -126,7 +126,10 @@ export async function mountTravelGuide(
             return;
         }
 
-        routeLayer = createRouteLayer(mapLayer.handles.svg, (rc) => mapLayer!.centerOf(rc));
+        routeLayer = createRouteLayer(
+            mapLayer.handles.contentG,
+            (rc) => mapLayer!.centerOf(rc)
+        );
         tokenLayer = createTokenLayer(mapLayer.handles.svg);
 
         const adapter: RenderAdapter = {


### PR DESCRIPTION
## Summary
- attach the travel guide route layer to the camera-transformed SVG content group so drawn paths stay aligned with panning/zooming
- update the travel guide shell and overview documentation to reference the new route layer mount point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01db2a1e8832591217ae3166b21be