### PR TITLE
Align token layer with camera content group

### DIFF
--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -138,7 +138,7 @@ export type TravelLogic = {
 
 - `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein. Der Header stammt aus `ui/map-header.ts`, verlinkt Öffnen/Erstellen mit `enqueueLoad` und erweitert den Save-Flow um `logic.persistTokenToTiles()`.
 - Lädt Terrain-Definitionen (`loadTerrains` → `setTerrains`) einmalig beim Mount.
-- Erstellt `routeLayer` auf `mapLayer.handles.contentG` (kamera-transformierte Content-Gruppe) und `tokenLayer` auf `mapLayer.handles.svg`, damit beide innerhalb des Renderer-SVG leben.
+- Erstellt `routeLayer` und `tokenLayer` gemeinsam auf `mapLayer.handles.contentG` (kamera-transformierte Content-Gruppe), damit Karte, Route und Token identisch gescaled/panned werden.
 - Instanziiert `createSidebar` im rechten Bereich, füllt Titel/Status/Schnelleingaben und verbindet `onSpeedChange` mit `logic.setTokenSpeed`.
 - Initialisiert `createTravelLogic` (Basisdauer 900 ms) mit einem `onChange`, der Route-Highlight, Sidebar-Tile (`currentTile ?? tokenRC`) und Speed synchronisiert.
 - `logic.initTokenFromTiles()` lädt/persistiert die Tokenposition; Hook wird nach dem Mount einmal manuell aufgerufen.
@@ -159,7 +159,7 @@ export type TravelLogic = {
 - `destroy()` entfernt die Gruppe.
 
 ### `ui/token-layer.ts`
-- Erstellt `<g class="tg-token">` inklusive Kreis, versteckt initial.
+- Erstellt `<g class="tg-token">` inklusive Kreis, versteckt initial, und hängt ihn direkt an das kamera-transformierte `contentG`.
 - Stellt `setPos`, `moveTo` (RAF-Animation, optional durations), `show`, `hide`, `destroy` bereit und erfüllt damit `TokenCtl`.
 - Lässt Pointer-Events aktiv (`cursor: grab`) für Drag-Start.
 

--- a/src/apps/travel-guide/ui/token-layer.ts
+++ b/src/apps/travel-guide/ui/token-layer.ts
@@ -2,12 +2,12 @@
 
 import type { TokenCtl } from "../infra/adapter";
 
-export function createTokenLayer(svgRoot: SVGSVGElement): TokenCtl & { el: SVGGElement } {
+export function createTokenLayer(contentG: SVGGElement): TokenCtl & { el: SVGGElement } {
     const el = document.createElementNS("http://www.w3.org/2000/svg", "g");
     el.classList.add("tg-token");
     el.style.pointerEvents = "auto";
     el.style.cursor = "grab";
-    svgRoot.appendChild(el);
+    contentG.appendChild(el);
 
     const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
     circle.setAttribute("r", "9");

--- a/src/apps/travel-guide/ui/view-shell.ts
+++ b/src/apps/travel-guide/ui/view-shell.ts
@@ -130,7 +130,7 @@ export async function mountTravelGuide(
             mapLayer.handles.contentG,
             (rc) => mapLayer!.centerOf(rc)
         );
-        tokenLayer = createTokenLayer(mapLayer.handles.svg);
+        tokenLayer = createTokenLayer(mapLayer.handles.contentG);
 
         const adapter: RenderAdapter = {
             ensurePolys: (coords) => mapLayer!.ensurePolys(coords),


### PR DESCRIPTION
## Summary
- attach the token layer group to the camera-transformed content container
- update the travel guide shell to pass the content group to the token layer
- document the new wiring in the travel guide overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d020dde9ec8325aa43e082028fd4a6