### PR TITLE
Increase travel guide token visibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -1920,18 +1920,18 @@ function createRouteLayer(contentRoot, centerOf) {
 }
 
 // src/apps/travel-guide/ui/token-layer.ts
-function createTokenLayer(svgRoot) {
+function createTokenLayer(contentG) {
   const el = document.createElementNS("http://www.w3.org/2000/svg", "g");
   el.classList.add("tg-token");
   el.style.pointerEvents = "auto";
   el.style.cursor = "grab";
-  svgRoot.appendChild(el);
+  contentG.appendChild(el);
   const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-  circle.setAttribute("r", "9");
+  circle.setAttribute("r", "14");
   circle.setAttribute("fill", "var(--color-accent)");
   circle.setAttribute("opacity", "0.95");
   circle.setAttribute("stroke", "var(--background-modifier-border)");
-  circle.setAttribute("stroke-width", "2");
+  circle.setAttribute("stroke-width", "3");
   el.appendChild(circle);
   let vx = 0, vy = 0;
   let rafId = null;
@@ -2594,7 +2594,7 @@ async function mountTravelGuide(app, host, file) {
       mapLayer.handles.contentG,
       (rc) => mapLayer.centerOf(rc)
     );
-    tokenLayer = createTokenLayer(mapLayer.handles.svg);
+    tokenLayer = createTokenLayer(mapLayer.handles.contentG);
     const adapter = {
       ensurePolys: (coords) => mapLayer.ensurePolys(coords),
       centerOf: (rc) => mapLayer.centerOf(rc),

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -159,7 +159,7 @@ export type TravelLogic = {
 - `destroy()` entfernt die Gruppe.
 
 ### `ui/token-layer.ts`
-- Erstellt `<g class="tg-token">` inklusive Kreis, versteckt initial, und hängt ihn direkt an das kamera-transformierte `contentG`.
+- Erstellt `<g class="tg-token">` inklusive auffälligem Kreis (Radius 14, dicker Rand), versteckt initial, und hängt ihn direkt an das kamera-transformierte `contentG`.
 - Stellt `setPos`, `moveTo` (RAF-Animation, optional durations), `show`, `hide`, `destroy` bereit und erfüllt damit `TokenCtl`.
 - Lässt Pointer-Events aktiv (`cursor: grab`) für Drag-Start.
 

--- a/src/apps/travel-guide/ui/token-layer.ts
+++ b/src/apps/travel-guide/ui/token-layer.ts
@@ -10,11 +10,11 @@ export function createTokenLayer(contentG: SVGGElement): TokenCtl & { el: SVGGEl
     contentG.appendChild(el);
 
     const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-    circle.setAttribute("r", "9");
+    circle.setAttribute("r", "14");
     circle.setAttribute("fill", "var(--color-accent)");
     circle.setAttribute("opacity", "0.95");
     circle.setAttribute("stroke", "var(--background-modifier-border)");
-    circle.setAttribute("stroke-width", "2");
+    circle.setAttribute("stroke-width", "3");
     el.appendChild(circle);
 
     let vx = 0, vy = 0;


### PR DESCRIPTION
## Summary
- enlarge the travel guide token circle so it stands out clearly from route dots
- document the more prominent token styling in the travel guide overview
- rebuild the compiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0224338888325af724be11f6a1651