### PR TITLE
Add capture-phase suppression hook to drag controller

### DIFF
--- a/main.js
+++ b/main.js
@@ -2022,6 +2022,26 @@ function createDragController(deps) {
     token.setPos(ctr.x, ctr.y);
     token.show();
   }
+  const onGlobalPointerDownCapture = (ev) => {
+    if (ev.button !== 0) return;
+    const check = (el) => {
+      if (!(el instanceof Element)) return false;
+      if (el === tokenEl || tokenEl.contains(el)) return true;
+      if (el instanceof SVGCircleElement && routeLayerEl.contains(el)) return true;
+      return false;
+    };
+    const path = typeof ev.composedPath === "function" ? ev.composedPath() : [];
+    if (Array.isArray(path) && path.length > 0) {
+      for (const el of path) {
+        if (check(el)) {
+          suppressNextHexClick = true;
+          return;
+        }
+      }
+    } else if (check(ev.target)) {
+      suppressNextHexClick = true;
+    }
+  };
   const onDotPointerDown = (ev) => {
     if (ev.button !== 0) return;
     const t = ev.target;
@@ -2083,6 +2103,7 @@ function createDragController(deps) {
   const onPointerUp = () => endDrag();
   const onPointerCancel = () => endDrag();
   function bind() {
+    window.addEventListener("pointerdown", onGlobalPointerDownCapture, { capture: true });
     routeLayerEl.addEventListener("pointerdown", onDotPointerDown, { capture: true });
     tokenEl.addEventListener("pointerdown", onTokenPointerDown, { capture: true });
     window.addEventListener("pointermove", onPointerMove, { passive: true });
@@ -2090,6 +2111,7 @@ function createDragController(deps) {
     window.addEventListener("pointercancel", onPointerCancel, { passive: true });
   }
   function unbind() {
+    window.removeEventListener("pointerdown", onGlobalPointerDownCapture, { capture: true });
     routeLayerEl.removeEventListener("pointerdown", onDotPointerDown, { capture: true });
     tokenEl.removeEventListener("pointerdown", onTokenPointerDown, { capture: true });
     window.removeEventListener("pointermove", onPointerMove);

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -168,6 +168,7 @@ export type TravelLogic = {
 - Nutzt `polyToCoord` + `document.elementFromPoint` für Ziel-Hex-Erkennung.
 - `ghostMoveSelectedDot/Token` verschieben nur UI (kein State).
 - `endDrag()` sorgt für Commit über `logic.moveSelectedTo` oder `logic.moveTokenTo` und ruft `adapter.ensurePolys` als Sicherheit.
+- Capture-Hook auf `window` setzt früh `suppressNextHexClick`, damit `hex:click` keine Wegpunkte erzeugt, wenn Token/Dots gedrückt werden.
 - Stellt `bind`, `unbind`, `consumeClickSuppression` bereit.
 
 ### `ui/contextmenue.ts`

--- a/src/apps/travel-guide/ui/drag.controller.ts
+++ b/src/apps/travel-guide/ui/drag.controller.ts
@@ -75,6 +75,29 @@ polyToCoord: WeakMap<SVGElement, Coord>;       // MapLayer-Index
 
     // Event handlers -----------------------------------------------------------
 
+    const onGlobalPointerDownCapture = (ev: PointerEvent) => {
+        if (ev.button !== 0) return;
+
+        const check = (el: EventTarget | null | undefined): boolean => {
+            if (!(el instanceof Element)) return false;
+            if (el === tokenEl || tokenEl.contains(el)) return true;
+            if (el instanceof SVGCircleElement && routeLayerEl.contains(el)) return true;
+            return false;
+        };
+
+        const path = typeof ev.composedPath === "function" ? ev.composedPath() : [];
+        if (Array.isArray(path) && path.length > 0) {
+            for (const el of path) {
+                if (check(el)) {
+                    suppressNextHexClick = true;
+                    return;
+                }
+            }
+        } else if (check(ev.target)) {
+            suppressNextHexClick = true;
+        }
+    };
+
     const onDotPointerDown = (ev: PointerEvent) => {
         if (ev.button !== 0) return; // nur LMB
         const t = ev.target as Element;
@@ -152,6 +175,7 @@ polyToCoord: WeakMap<SVGElement, Coord>;       // MapLayer-Index
         // Public API ---------------------------------------------------------------
 
         function bind() {
+            window.addEventListener("pointerdown", onGlobalPointerDownCapture, { capture: true });
             routeLayerEl.addEventListener("pointerdown", onDotPointerDown, { capture: true });
             tokenEl.addEventListener("pointerdown", onTokenPointerDown, { capture: true });
             window.addEventListener("pointermove", onPointerMove, { passive: true });
@@ -160,6 +184,7 @@ polyToCoord: WeakMap<SVGElement, Coord>;       // MapLayer-Index
         }
 
         function unbind() {
+            window.removeEventListener("pointerdown", onGlobalPointerDownCapture as any, { capture: true } as any);
             routeLayerEl.removeEventListener("pointerdown", onDotPointerDown as any, { capture: true } as any);
             tokenEl.removeEventListener("pointerdown", onTokenPointerDown as any, { capture: true } as any);
             window.removeEventListener("pointermove", onPointerMove as any);


### PR DESCRIPTION
## Summary
- add a capture-phase pointerdown guard so drag starts suppress hex clicks before the map layer fires
- clean up the capture listener during unbind and regenerate the compiled bundle
- document the early suppression hook in the drag-controller overview section

## Testing
- npm run build
- Manual drag token/dots (not run in container)


------
https://chatgpt.com/codex/tasks/task_e_68d02c0d83808325b359abfd08896e14