### PR TITLE
feat: differentiate travel guide route visuals

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -86,6 +86,9 @@ export const HEX_PLUGIN_CSS = `
 
 /* === Travel Guide === */
 .sm-travel-guide {
+    --tg-color-token: var(--color-purple, #9c6dfb);
+    --tg-color-user-anchor: var(--color-orange, #f59e0b);
+    --tg-color-auto-point: var(--color-blue, #3b82f6);
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -137,6 +140,36 @@ export const HEX_PLUGIN_CSS = `
 .sm-travel-guide .sm-tg-map .hex3x3-map {
     max-width: none;
     height: 100%;
+}
+
+.sm-travel-guide .tg-token__circle {
+    fill: var(--tg-color-token);
+    opacity: 0.95;
+    stroke: var(--background-modifier-border);
+    stroke-width: 3;
+    transition: opacity 120ms ease;
+}
+
+.sm-travel-guide .tg-route-dot {
+    transition: opacity 120ms ease, r 120ms ease, stroke 120ms ease;
+}
+
+.sm-travel-guide .tg-route-dot--user {
+    fill: var(--tg-color-user-anchor);
+    opacity: 0.95;
+}
+
+.sm-travel-guide .tg-route-dot--auto {
+    fill: var(--tg-color-auto-point);
+    opacity: 0.55;
+}
+
+.sm-travel-guide .tg-route-dot--user.is-highlighted {
+    opacity: 1;
+}
+
+.sm-travel-guide .tg-route-dot--auto.is-highlighted {
+    opacity: 0.9;
 }
 
 .sm-travel-guide .sm-tg-sidebar {

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -128,6 +128,17 @@ export type TravelLogic = {
 
 ---
 
+## Farbkonzept (Token & Route)
+
+- **Token (`.tg-token__circle`):** kräftiges Violett (`--tg-color-token`, fallback `#9c6dfb`) mit Border (`var(--background-modifier-border)`) und 95 % Deckkraft für eine deutliche Start-/Playback-Markierung.
+- **User-Anker (`.tg-route-dot--user`):** warmes Orange (`--tg-color-user-anchor`, fallback `#f59e0b`) bei 95 % Deckkraft, damit manuelle Wegpunkte hervorstechen.
+- **Auto-Punkte (`.tg-route-dot--auto`):** kühles Blau (`--tg-color-auto-point`, fallback `#3b82f6`) mit reduzierter Deckkraft (55 %), um ergänzte Zwischenknoten subtiler zu halten.
+- **Highlight (`.is-highlighted`):** Domain-Highlighting erhöht weiterhin Radius + Border; zusätzlich hebt CSS die Deckkraft auf 100 % (User) bzw. 90 % (Auto), damit der aktuelle Fokus sofort sichtbar ist.
+
+Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben und nehmen vorhandene Obsidian-Theme-Variablen als bevorzugte Quelle.
+
+---
+
 ## Detailübersicht pro Datei
 
 ### `index.ts`
@@ -160,6 +171,7 @@ export type TravelLogic = {
 
 ### `ui/token-layer.ts`
 - Erstellt `<g class="tg-token">` inklusive auffälligem Kreis (Radius 14, dicker Rand), versteckt initial, und hängt ihn direkt an das kamera-transformierte `contentG`.
+- Nutzt `.tg-token__circle`, damit Farbe, Border und Opazität zentral über CSS gesteuert werden.
 - Stellt `setPos`, `moveTo` (RAF-Animation, optional durations), `show`, `hide`, `destroy` bereit und erfüllt damit `TokenCtl`.
 - Lässt Pointer-Events aktiv (`cursor: grab`) für Drag-Start.
 
@@ -229,7 +241,7 @@ export type TravelLogic = {
 - Keine Implementierung, reine Typen.
 
 ### `render/draw-route.ts`
-- `drawRoute({ layer, route, centerOf, highlightIndex, start })` leert Layer, setzt den Token-Mittelpunkt als erstes Polyline-Segment (ohne zusätzlichen Dot), zeichnet anschließend die Route (falls ≥2 Punkte) und generiert Kreise pro Knoten (`user` größer/opaker als `auto`).
-- `updateHighlight(layer, highlightIndex)` setzt Stroke/Radius/Opacity für ausgewählten Dot.
+- `drawRoute({ layer, route, centerOf, highlightIndex, start })` leert Layer, setzt den Token-Mittelpunkt als erstes Polyline-Segment (ohne zusätzlichen Dot), zeichnet anschließend die Route (falls ≥2 Punkte) und generiert Kreise pro Knoten inklusive `.tg-route-dot` + Typ-Klassen für CSS-gestützte Farbgebung.
+- `updateHighlight(layer, highlightIndex)` setzt Stroke/Radius, toggelt `.is-highlighted` und delegiert die finale Opazität an CSS.
 - Pointer-Events der Polyline deaktiviert, Dots behalten Pointer für Interaktion.
 

--- a/src/apps/travel-guide/render/draw-route.ts
+++ b/src/apps/travel-guide/render/draw-route.ts
@@ -45,9 +45,9 @@ export function drawRoute(args: {
         dot.setAttribute("cx", String(ctr.x));
         dot.setAttribute("cy", String(ctr.y));
         dot.setAttribute("r", node.kind === "user" ? "5" : "4");
-        dot.setAttribute("fill", "var(--interactive-accent)");
-        dot.setAttribute("opacity", node.kind === "user" ? "1" : "0.55");
         dot.setAttribute("data-kind", node.kind);
+        dot.classList.add("tg-route-dot");
+        dot.classList.add(node.kind === "user" ? "tg-route-dot--user" : "tg-route-dot--auto");
         dot.style.pointerEvents = "auto";
         layer.appendChild(dot);
     });
@@ -60,10 +60,11 @@ export function updateHighlight(layer: SVGGElement, highlightIndex: number | nul
     const dots = Array.from(layer.querySelectorAll<SVGCircleElement>("circle"));
     dots.forEach((el, idx) => {
         const isHi = highlightIndex != null && idx === highlightIndex;
+        el.classList.toggle("is-highlighted", isHi);
         el.setAttribute("stroke", isHi ? "var(--background-modifier-border)" : "none");
         el.setAttribute("stroke-width", isHi ? "2" : "0");
         el.setAttribute("r", isHi ? String(Number(el.getAttribute("r") || "4") + 2) : (el.dataset.kind === "user" ? "5" : "4"));
-        el.style.opacity = el.getAttribute("data-kind") === "user" ? (isHi ? "1" : "1") : (isHi ? "0.9" : "0.55");
+        el.style.removeProperty("opacity");
         el.style.cursor = "pointer";
     });
 }

--- a/src/apps/travel-guide/ui/token-layer.ts
+++ b/src/apps/travel-guide/ui/token-layer.ts
@@ -11,10 +11,7 @@ export function createTokenLayer(contentG: SVGGElement): TokenCtl & { el: SVGGEl
 
     const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
     circle.setAttribute("r", "14");
-    circle.setAttribute("fill", "var(--color-accent)");
-    circle.setAttribute("opacity", "0.95");
-    circle.setAttribute("stroke", "var(--background-modifier-border)");
-    circle.setAttribute("stroke-width", "3");
+    circle.classList.add("tg-token__circle");
     el.appendChild(circle);
 
     let vx = 0, vy = 0;


### PR DESCRIPTION
## Summary
- add dedicated route-dot classes and highlight handling so manual vs. auto anchors render with distinct styling
- move token and waypoint palette into CSS with shared custom properties for consistent theming
- document the Travel Guide colour scheme and styling responsibilities in the overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02d02d5b88325a67e8ae443db6488