### PR TITLE
Adjust travel guide route dot radii

### DIFF
--- a/main.js
+++ b/main.js
@@ -1856,6 +1856,9 @@ async function createMapLayer(app, host, mapFile, opts) {
 }
 
 // src/apps/travel-guide/render/draw-route.ts
+var USER_RADIUS = 7;
+var AUTO_RADIUS = 5;
+var HIGHLIGHT_OFFSET = 2;
 function drawRoute(args) {
   const { layer, route, centerOf, highlightIndex = null, start = null } = args;
   while (layer.firstChild) layer.removeChild(layer.firstChild);
@@ -1881,7 +1884,9 @@ function drawRoute(args) {
     const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
     dot.setAttribute("cx", String(ctr.x));
     dot.setAttribute("cy", String(ctr.y));
-    dot.setAttribute("r", node.kind === "user" ? "5" : "4");
+    const baseRadius = node.kind === "user" ? USER_RADIUS : AUTO_RADIUS;
+    dot.setAttribute("r", String(baseRadius));
+    dot.setAttribute("data-radius", String(baseRadius));
     dot.setAttribute("data-kind", node.kind);
     dot.classList.add("tg-route-dot");
     dot.classList.add(node.kind === "user" ? "tg-route-dot--user" : "tg-route-dot--auto");
@@ -1894,10 +1899,11 @@ function updateHighlight(layer, highlightIndex) {
   const dots = Array.from(layer.querySelectorAll("circle"));
   dots.forEach((el, idx) => {
     const isHi = highlightIndex != null && idx === highlightIndex;
+    const baseRadius = Number(el.dataset.radius || el.getAttribute("r") || (el.dataset.kind === "user" ? USER_RADIUS : AUTO_RADIUS));
     el.classList.toggle("is-highlighted", isHi);
     el.setAttribute("stroke", isHi ? "var(--background-modifier-border)" : "none");
     el.setAttribute("stroke-width", isHi ? "2" : "0");
-    el.setAttribute("r", isHi ? String(Number(el.getAttribute("r") || "4") + 2) : el.dataset.kind === "user" ? "5" : "4");
+    el.setAttribute("r", String(isHi ? baseRadius + HIGHLIGHT_OFFSET : baseRadius));
     el.style.removeProperty("opacity");
     el.style.cursor = "pointer";
   });

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -242,6 +242,7 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 
 ### `render/draw-route.ts`
 - `drawRoute({ layer, route, centerOf, highlightIndex, start })` leert Layer, setzt den Token-Mittelpunkt als erstes Polyline-Segment (ohne zusätzlichen Dot), zeichnet anschließend die Route (falls ≥2 Punkte) und generiert Kreise pro Knoten inklusive `.tg-route-dot` + Typ-Klassen für CSS-gestützte Farbgebung.
-- `updateHighlight(layer, highlightIndex)` setzt Stroke/Radius, toggelt `.is-highlighted` und delegiert die finale Opazität an CSS.
+- Standardradien: User-Anker = 7 px, Auto-Punkte = 5 px; beide Werte werden als `data-radius` hinterlegt, damit spätere Updates den Baseline-Radius kennen.
+- `updateHighlight(layer, highlightIndex)` liest den Baseline-Radius aus `data-radius`, addiert den Highlight-Offset (+2 px), setzt Stroke/Radius, toggelt `.is-highlighted` und delegiert die finale Opazität an CSS.
 - Pointer-Events der Polyline deaktiviert, Dots behalten Pointer für Interaktion.
 

--- a/src/apps/travel-guide/render/draw-route.ts
+++ b/src/apps/travel-guide/render/draw-route.ts
@@ -2,6 +2,10 @@
 
 import type { RouteNode } from "../domain/types";
 
+const USER_RADIUS = 7;
+const AUTO_RADIUS = 5;
+const HIGHLIGHT_OFFSET = 2;
+
 type C = { r: number; c: number };
 type CtrFn = (rc: C) => { x: number; y: number } | null;
 
@@ -44,7 +48,9 @@ export function drawRoute(args: {
         const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
         dot.setAttribute("cx", String(ctr.x));
         dot.setAttribute("cy", String(ctr.y));
-        dot.setAttribute("r", node.kind === "user" ? "5" : "4");
+        const baseRadius = node.kind === "user" ? USER_RADIUS : AUTO_RADIUS;
+        dot.setAttribute("r", String(baseRadius));
+        dot.setAttribute("data-radius", String(baseRadius));
         dot.setAttribute("data-kind", node.kind);
         dot.classList.add("tg-route-dot");
         dot.classList.add(node.kind === "user" ? "tg-route-dot--user" : "tg-route-dot--auto");
@@ -60,10 +66,11 @@ export function updateHighlight(layer: SVGGElement, highlightIndex: number | nul
     const dots = Array.from(layer.querySelectorAll<SVGCircleElement>("circle"));
     dots.forEach((el, idx) => {
         const isHi = highlightIndex != null && idx === highlightIndex;
+        const baseRadius = Number(el.dataset.radius || el.getAttribute("r") || (el.dataset.kind === "user" ? USER_RADIUS : AUTO_RADIUS));
         el.classList.toggle("is-highlighted", isHi);
         el.setAttribute("stroke", isHi ? "var(--background-modifier-border)" : "none");
         el.setAttribute("stroke-width", isHi ? "2" : "0");
-        el.setAttribute("r", isHi ? String(Number(el.getAttribute("r") || "4") + 2) : (el.dataset.kind === "user" ? "5" : "4"));
+        el.setAttribute("r", String(isHi ? baseRadius + HIGHLIGHT_OFFSET : baseRadius));
         el.style.removeProperty("opacity");
         el.style.cursor = "pointer";
     });


### PR DESCRIPTION
## Summary
- add dedicated user/auto dot radii constants and persist them on the SVG circles so CSS transitions keep working when classes toggle
- update the highlight routine to reuse the stored base radius before adding the highlight offset
- document the new default radii in the travel guide overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03160d29c8325918579dbe8010e6f