### PR TITLE
Fix Travel Guide drag suppression and context menu

### DIFF
--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -47,6 +47,17 @@ src/apps/travel-guide/
 
 ---
 
+## Featureliste
+
+- **Kartenverwaltung & Persistenz:** Karten lassen sich öffnen, erstellen und speichern; Terrain-Geschwindigkeiten werden beim Mount geladen und Token-Positionen (`token_travel`) automatisch aus den Hex-Notes gelesen bzw. dorthin zurückgeschrieben.
+- **Routenaufbau durch Hex-Klicks:** Hex-Klicks erzeugen Nutzeranker, ergänzen automatische Zwischenpunkte entlang der Linie und aktualisieren Highlight & Route-Rendering unmittelbar.
+- **Präzise Drag-Interaktionen:** Nutzeranker und Token können mit Ghost-Vorschau verschoben werden; während aktiver Drags werden Hex-Klick-Events vollständig unterdrückt, damit keine zusätzlichen Wegpunkte entstehen.
+- **Token-Steuerung & Playback:** Token lassen sich manuell positionieren oder über Play/Stop/Reset animieren; der Playback-Loop berücksichtigt Terrain-Speed, Token-Speed und persistiert Fortschritte pro Tile.
+- **Kontextmenü für Nutzeranker:** Rechtsklick auf Nutzerpunkte bietet schnelles Löschen, während Auto-Punkte geschützt bleiben.
+- **Sidebar & Statusanzeigen:** Die Sidebar bündelt Playback-Controls, aktuellen Hex, Speed-Regler sowie Karten-Titel, damit alle relevanten Zustände im Blick bleiben.
+
+---
+
 ## Öffentliche Schnittstellen
 
 ### `domain/types.ts`
@@ -199,11 +210,13 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - `ghostMoveSelectedDot/Token` verschieben nur UI (kein State).
 - `endDrag()` sorgt für Commit über `logic.moveSelectedTo` oder `logic.moveTokenTo` und ruft `adapter.ensurePolys` als Sicherheit.
 - Capture-Hook auf `window` setzt früh `suppressNextHexClick`, damit `hex:click` keine Wegpunkte erzeugt, wenn Token/Dots gedrückt werden.
+- `consumeClickSuppression` blockiert Hex-Klicks solange der Drag läuft und leert Unterdrückungs-Flags erst nach Drag-Ende.
 - Stellt `bind`, `unbind`, `consumeClickSuppression` bereit.
 
 ### `ui/contextmenue.ts`
 - Bindet `contextmenu` auf dem Route-Layer.
 - Ignoriert Nicht-Kreis-Elemente und `auto`-Dots, unterdrückt Browser-Menü.
+- Liest den Zielindex direkt aus `data-idx` (funktioniert für sichtbare Dots & Hitboxen).
 - Ruft bei `user`-Dots `logic.deleteUserAt(idx)` und stoppt Event-Bubbling.
 
 ### `ui/sidebar.ts`

--- a/src/apps/travel-guide/ui/contextmenue.ts
+++ b/src/apps/travel-guide/ui/contextmenue.ts
@@ -12,9 +12,11 @@ export function bindContextMenu(routeLayerEl: SVGGElement, logic: LogicPort): ()
         const t = ev.target as Element | null;
         if (!(t instanceof SVGCircleElement)) return;
 
-        const circles = Array.from(routeLayerEl.querySelectorAll<SVGCircleElement>("circle"));
-        const idx = circles.indexOf(t);
-        if (idx < 0) return;
+        const idxAttr = t.getAttribute("data-idx");
+        if (!idxAttr) return;
+
+        const idx = Number(idxAttr);
+        if (!Number.isFinite(idx) || idx < 0) return;
 
         const route = logic.getState().route;
         const node = route[idx];

--- a/src/apps/travel-guide/ui/drag.controller.ts
+++ b/src/apps/travel-guide/ui/drag.controller.ts
@@ -204,9 +204,10 @@ polyToCoord: WeakMap<SVGElement, Coord>;       // MapLayer-Index
         }
 
         function consumeClickSuppression(): boolean {
-            const r = suppressNextHexClick;
+            if (isDragging) return true;
+            if (!suppressNextHexClick) return false;
             suppressNextHexClick = false;
-            return r;
+            return true;
         }
 
         return { bind, unbind, consumeClickSuppression };


### PR DESCRIPTION
## Summary
- add a dedicated feature list to the Travel Guide overview and document the revised drag suppression and context menu responsibilities
- keep hex-click suppression active during drags so moving the token or waypoints no longer spawns unintended nodes
- read waypoint indices from data-idx in the context menu handler so right-click delete works on user dots again

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1210bb6648325aef7cd317eafec29