### PR TITLE
Use grab cursor for travel guide route dots

### DIFF
--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -193,6 +193,10 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - `highlight(i)` ruft `updateHighlight` (nur UI-Anpassung).
 - `destroy()` entfernt die Gruppe.
 
+### `render/draw-route.ts`
+- Zeichnet Polyline und Wegpunkt-Dots rein über SVG und aktualisiert Highlight-Styles ohne eigenen Zustand.
+- Setzt `cursor: grab` für Dots und Hitboxen und belässt ihn auch während `updateHighlight`, damit Drag-Anker denselben Greif-Affordance wie das Token anzeigen.
+
 ### `ui/token-layer.ts`
 - Erstellt `<g class="tg-token">` inklusive auffälligem Kreis (Radius 14, dicker Rand), versteckt initial, und hängt ihn direkt an das kamera-transformierte `contentG`.
 - Nutzt `.tg-token__circle`, damit Farbe, Border und Opazität zentral über CSS gesteuert werden.

--- a/src/apps/travel-guide/render/draw-route.ts
+++ b/src/apps/travel-guide/render/draw-route.ts
@@ -59,7 +59,7 @@ export function drawRoute(args: {
         hit.style.fill = "transparent";
         hit.setAttribute("stroke", "transparent");
         hit.style.pointerEvents = "all";
-        hit.style.cursor = "pointer";
+        hit.style.cursor = "grab";
         layer.appendChild(hit);
 
         const dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
@@ -72,7 +72,7 @@ export function drawRoute(args: {
         dot.classList.add("tg-route-dot");
         dot.classList.add(node.kind === "user" ? "tg-route-dot--user" : "tg-route-dot--auto");
         dot.style.pointerEvents = "auto";
-        dot.style.cursor = "pointer";
+        dot.style.cursor = "grab";
         layer.appendChild(dot);
     });
 
@@ -90,6 +90,6 @@ export function updateHighlight(layer: SVGGElement, highlightIndex: number | nul
         el.setAttribute("stroke-width", isHi ? "2" : "0");
         el.setAttribute("r", String(isHi ? baseRadius + HIGHLIGHT_OFFSET : baseRadius));
         el.style.removeProperty("opacity");
-        el.style.cursor = "pointer";
+        el.style.cursor = "grab";
     });
 }


### PR DESCRIPTION
## Summary
- switch travel guide route dot hitboxes and circles to use the grab cursor so they match the draggable token
- preserve the grab cursor when updating highlights to avoid reverting to a pointer
- document the cursor affordance in the Travel Guide overview file

## Testing
- npm run build
- manual harness check to hover and drag a route dot

------
https://chatgpt.com/codex/tasks/task_e_68d124a046608325a99c85deb6b5b3a7