### PR TITLE
Refactor travel guide interactions into reusable cartographer mode

### DIFF
--- a/src/apps/cartographer/CartographerOverview.txt
+++ b/src/apps/cartographer/CartographerOverview.txt
@@ -6,6 +6,8 @@
 src/apps/cartographer/
 ├─ index.ts                 # Obsidian-View inkl. Ribbon/Command-Anbindung
 ├─ view-shell.ts            # Layout, Map-Stage und Modusverwaltung
+├─ modes/
+│  └─ travel-guide.ts       # Travel-Guide-Modus (Route/Token, Sidebar, Drag, Persistenz)
 └─ CartographerOverview.txt # Dieses Dokument
 ```
 
@@ -14,8 +16,9 @@ src/apps/cartographer/
 - **View-Registrierung:** `index.ts` meldet `VIEW_TYPE_CARTOGRAPHER` an, richtet Ribbon & Command ein und kümmert sich um Mount/Cleanup des Views.
 - **Layout-Shell:** `view-shell.ts` übernimmt das Travel-Guide-Grundlayout (Header + Body mit Map/Sidebar) und ersetzt Klassen durch `sm-cartographer`.
 - **Map-Stage:** Rendert Karten via `createMapLayer`/`renderHexMap`, verwaltet RenderHandles und sorgt für korrekte Hex-Klick-Delegation.
-- **Modus-System:** Stellt ein zentrales Mode-Interface (`onEnter`, `onExit`, `onFileChange`, `onHexClick`) bereit, schaltet per Header-Slot zwischen Modi und reicht Events/Cleanup sauber weiter.
-- **Sidebar-Panels:** Jeder Modus darf den Sidebar-Host exklusiv füllen; Standard-Modi demonstrieren Inspect-/Notizverhalten als Platzhalter für Erweiterungen.
+- **Modus-System:** Stellt ein zentrales Mode-Interface (`onEnter`, `onExit`, `onFileChange`, `onHexClick`, `onSave`) bereit, schaltet per Header-Slot zwischen Modi, delegiert Events inkl. Speichern und räumt Ressourcen deterministisch auf.
+- **Travel-Integration:** Der neue `modes/travel-guide.ts` spiegelt die Travel-Guide-Funktionalität (Route, Token, Playback) und kann sowohl im Cartographer als auch in der eigenständigen Travel-Guide-View eingesetzt werden.
+- **Sidebar-Panels:** Jeder Modus darf den Sidebar-Host exklusiv füllen; Inspect/Notes bleiben Beispiel-Modi und illustrieren einfache Panels.
 
 ## Dateibeschreibungen
 
@@ -25,9 +28,15 @@ src/apps/cartographer/
 - Der View erzeugt einen Host (`cartographer-host`) und mountet `view-shell.ts`, reicht `setFile`-Aufrufe weiter und räumt beim Schließen auf.
 
 ### `view-shell.ts`
-- Implementiert `CartographerMode` & `CartographerModeContext` als zentrales Interface.
+- Implementiert `CartographerMode` & `CartographerModeContext` (inkl. `onSave`) als zentrale Schnittstelle für Modi.
 - Baut Header, Body, Map- und Sidebar-Container mit `sm-cartographer`-Klassen auf.
 - Nutzt `createMapLayer` + `renderHexMap` zum Laden der Karte (inkl. Options-Parsing via `getFirstHexBlock`/`parseOptions`).
-- Leitet `hex:click`-Events an den aktiven Modus und ruft dessen Lifecycle-Hooks (`onEnter`/`onExit`/`onFileChange`).
-- Fügt über `createMapHeader` einen Title-Slot hinzu, um den Modus-Schalter (Segmented Control) im Header zu rendern.
-- Demonstriert zwei Beispiel-Modi (Inspect, Notes), die Sidebar-Inhalte setzen und RenderHandles/File-State berücksichtigen.
+- Leitet `hex:click` an den aktiven Modus weiter, koordiniert `onEnter`/`onExit`/`onFileChange` und serialisiert Moduswechsel.
+- Bindet den Map-Header samt Mode-Switch und Save-Hook: `onSave` des Modus kann persistieren/abbrechen, anschließend greift optional die Standard-Speicherlogik (`saveMap`/`saveMapAs`).
+- Registriert den Travel-Guide-Modus (`modes/travel-guide.ts`) plus einfache Beispiel-Modi (Inspect, Notes), die Sidebar-Inhalte und RenderHandles/File-State berücksichtigen.
+### `modes/travel-guide.ts`
+- Travel-Mode, der Sidebar, Playback-Controls, Route-/Token-Layer, Drag-Controller und Kontextmenü bündelt.
+- Lädt Terrains einmalig, verwaltet `createTravelLogic` + `handleStateChange` und räumt beim Dateiwechsel konsequent auf.
+- `onFileChange` erzeugt Adapter für `createTravelLogic`, ruft `initTokenFromTiles()` nach jedem Kartenwechsel auf und bindet Drag/Contextmenü an die aktuellen Layer.
+- `onSave` persistiert das Token (`logic.persistTokenToTiles()`), damit Header-Speicheraktionen weiterhin korrekt arbeiten.
+

--- a/src/apps/cartographer/modes/travel-guide.ts
+++ b/src/apps/cartographer/modes/travel-guide.ts
@@ -1,0 +1,221 @@
+import type { MapHeaderSaveMode } from "../../../ui/map-header";
+import type { CartographerMode, CartographerModeContext } from "../view-shell";
+import { loadTerrains } from "../../../core/terrain-store";
+import { setTerrains } from "../../../core/terrain";
+import { createSidebar, type Sidebar } from "../../travel-guide/ui/sidebar";
+import {
+    createPlaybackControls,
+    type PlaybackControlsHandle,
+} from "../../travel-guide/ui/controls";
+import { createRouteLayer } from "../../travel-guide/ui/route-layer";
+import { createTokenLayer } from "../../travel-guide/ui/token-layer";
+import {
+    createDragController,
+    type DragController,
+} from "../../travel-guide/ui/drag.controller";
+import { bindContextMenu } from "../../travel-guide/ui/contextmenue";
+import { createTravelLogic } from "../../travel-guide/domain/actions";
+import type {
+    LogicStateSnapshot,
+    RouteNode,
+} from "../../travel-guide/domain/types";
+import type { RenderAdapter } from "../../travel-guide/infra/adapter";
+
+export function createTravelGuideMode(): CartographerMode {
+    let sidebar: Sidebar | null = null;
+    let playback: PlaybackControlsHandle | null = null;
+    let logic = null as ReturnType<typeof createTravelLogic> | null;
+    let drag: DragController | null = null;
+    let unbindContext: (() => void) | null = null;
+    let routeLayer: ReturnType<typeof createRouteLayer> | null = null;
+    let tokenLayer: ReturnType<typeof createTokenLayer> | null = null;
+    let cleanupFile: (() => void | Promise<void>) | null = null;
+    let terrainsReady = false;
+
+    const handleStateChange = (state: LogicStateSnapshot) => {
+        if (routeLayer) {
+            routeLayer.draw(state.route, state.editIdx ?? null, state.tokenRC ?? null);
+        }
+        sidebar?.setTile(state.currentTile ?? state.tokenRC ?? null);
+        sidebar?.setSpeed(state.tokenSpeed);
+        playback?.setState({ playing: state.playing, route: state.route });
+    };
+
+    const resetUi = () => {
+        sidebar?.setTile(null);
+        sidebar?.setSpeed(1);
+        playback?.setState({ playing: false, route: [] as RouteNode[] });
+    };
+
+    const disposeInteractions = () => {
+        if (drag) {
+            drag.unbind();
+            drag = null;
+        }
+        if (unbindContext) {
+            unbindContext();
+            unbindContext = null;
+        }
+    };
+
+    const disposeFile = () => {
+        disposeInteractions();
+        if (tokenLayer) {
+            tokenLayer.destroy?.();
+            tokenLayer = null;
+        }
+        if (routeLayer) {
+            routeLayer.destroy();
+            routeLayer = null;
+        }
+        if (logic) {
+            try {
+                logic.pause();
+            } catch (err) {
+                console.error("[travel-mode] pause failed", err);
+            }
+            logic = null;
+        }
+    };
+
+    const ensureTerrains = async (ctx: CartographerModeContext) => {
+        if (terrainsReady) return;
+        await setTerrains(await loadTerrains(ctx.app));
+        terrainsReady = true;
+    };
+
+    return {
+        id: "travel",
+        label: "Travel",
+        async onEnter(ctx) {
+            await ensureTerrains(ctx);
+            ctx.sidebarHost.empty();
+            sidebar = createSidebar(ctx.sidebarHost);
+            sidebar.setTitle?.(ctx.getFile()?.basename ?? "");
+            sidebar.onSpeedChange((value) => {
+                logic?.setTokenSpeed(value);
+            });
+            playback = createPlaybackControls(sidebar.controlsHost, {
+                onPlay: () => {
+                    void logic?.play();
+                },
+                onStop: () => {
+                    logic?.pause();
+                },
+                onReset: () => {
+                    void logic?.reset();
+                },
+            });
+            resetUi();
+        },
+        async onExit() {
+            await cleanupFile?.();
+            cleanupFile = null;
+            disposeFile();
+            playback?.destroy();
+            playback = null;
+            sidebar?.destroy();
+            sidebar = null;
+        },
+        async onFileChange(file, handles, ctx) {
+            await cleanupFile?.();
+            cleanupFile = null;
+            disposeFile();
+            sidebar?.setTitle?.(file?.basename ?? "");
+            resetUi();
+
+            if (!file || !handles) {
+                return;
+            }
+
+            const mapLayer = ctx.getMapLayer();
+            if (!mapLayer) {
+                return;
+            }
+
+            routeLayer = createRouteLayer(
+                handles.contentG,
+                (rc) => mapLayer.centerOf(rc)
+            );
+            tokenLayer = createTokenLayer(handles.contentG);
+
+            const adapter: RenderAdapter = {
+                ensurePolys: (coords) => mapLayer.ensurePolys(coords),
+                centerOf: (rc) => mapLayer.centerOf(rc),
+                draw: (route, tokenRC) => {
+                    if (routeLayer) routeLayer.draw(route, null, tokenRC);
+                },
+                token: tokenLayer,
+            };
+
+            const activeLogic = createTravelLogic({
+                app: ctx.app,
+                minSecondsPerTile: 0.1,
+                getMapFile: () => ctx.getFile(),
+                adapter,
+                onChange: (state) => handleStateChange(state),
+            });
+            logic = activeLogic;
+
+            handleStateChange(activeLogic.getState());
+            await activeLogic.initTokenFromTiles();
+            if (logic !== activeLogic) return;
+
+            drag = createDragController({
+                routeLayerEl: routeLayer.el,
+                tokenEl: (tokenLayer as any).el as SVGGElement,
+                token: tokenLayer,
+                adapter,
+                logic: {
+                    getState: () => activeLogic.getState(),
+                    selectDot: (idx) => activeLogic.selectDot(idx),
+                    moveSelectedTo: (rc) => activeLogic.moveSelectedTo(rc),
+                    moveTokenTo: (rc) => activeLogic.moveTokenTo(rc),
+                },
+                polyToCoord: mapLayer.polyToCoord,
+            });
+            drag.bind();
+
+            unbindContext = bindContextMenu(routeLayer.el, {
+                getState: () => activeLogic.getState(),
+                deleteUserAt: (idx) => activeLogic.deleteUserAt(idx),
+            });
+
+            cleanupFile = async () => {
+                disposeInteractions();
+                if (logic === activeLogic) {
+                    logic = null;
+                }
+                try {
+                    activeLogic.pause();
+                } catch (err) {
+                    console.error("[travel-mode] pause during cleanup failed", err);
+                }
+                tokenLayer?.destroy?.();
+                tokenLayer = null;
+                routeLayer?.destroy();
+                routeLayer = null;
+            };
+        },
+        async onHexClick(coord, event) {
+            if (drag?.consumeClickSuppression()) {
+                if (event.cancelable) event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+            if (!logic) return;
+            if (event.cancelable) event.preventDefault();
+            event.stopPropagation();
+            logic.handleHexClick(coord);
+        },
+        async onSave(_mode: MapHeaderSaveMode, file, _ctx) {
+            if (!logic || !file) return false;
+            try {
+                await logic.persistTokenToTiles();
+            } catch (err) {
+                console.error("[travel-mode] persistTokenToTiles failed", err);
+            }
+            return false;
+        },
+    } satisfies CartographerMode;
+}

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -33,7 +33,7 @@ src/apps/travel-guide/
 │  └─ draw-route.ts               # Reines SVG-Rendering (Polyline, Dots, Highlight)
 │
 └─ ui/
-   ├─ view-shell.ts               # mountTravelGuide: Layout, Adapter, Wiring, Cleanup
+   ├─ view-shell.ts               # Mount-Shell: Layout, Header + Delegation an den Cartographer-Travel-Mode
    ├─ map-layer.ts                # renderHexMap + Poly-Index + ensurePolys/centerOf
    ├─ route-layer.ts              # Wrapper um drawRoute + Highlight-Steuerung
    ├─ token-layer.ts              # Sichtbares Token (SVG <g>, RAF-Animation)
@@ -41,6 +41,9 @@ src/apps/travel-guide/
    ├─ contextmenue.ts             # RMB auf Dots → deleteUserAt
    ├─ controls.ts                 # Playback-Steuerung (Start/Stopp/Reset) im Sidebar-Controls-Host
    └─ sidebar.ts                  # Sidebar inkl. Controls-Bereich für Karten-Titel, Status & Speed
+
+├─ ../cartographer/modes/
+│  └─ travel-guide.ts             # Wiederverwendbarer Modus: Sidebar, Route/Token-Layer, Drag & Persistenz
 ```
 
 > Zielgrößen: 80–180 LOC pro Modul, maximal 300 LOC.
@@ -120,15 +123,15 @@ export type TravelLogic = {
 
 ## Datenfluss (kurz)
 
-1. **Mount:** `index.ts` erstellt im View `mountTravelGuide(app, host, file)`. Die Shell richtet einen Spalten-Wrapper mit gemeinsamem Map-Header (`ui/map-header.ts`) ein, lädt Terrain-Daten, baut Map/Route/Token-Layer und instanziiert `createTravelLogic` (Mindestdauer 0,1 s pro Tile). Der Header verknüpft Open/Create mit `enqueueLoad` und ruft beim Speichern `persistTokenToTiles` plus `saveMap`/`saveMapAs`.
-2. **Store-Abos:** `createTravelLogic` subscribed auf den Store. Jede Änderung triggert `adapter.draw(route, tokenRC)` und optionales `onChange` (View rendert Highlight).
-3. **Hex-Klick:** `map-layer` emittiert `hex:click` → `view-shell` ruft `logic.handleHexClick(rc)` → `expandCoords` erzeugt Autos → Store-Update → Route-Layer zeichnet neu.
-4. **Dot-Drag:** `drag.controller` zeigt Ghost (nur UI), `pointerup` → `logic.moveSelectedTo(rc)` → neue Segmente via `expandCoords` → Store-Update.
-5. **Token-Drag:** `drag.controller` Ghost via `TokenCtl`, Commit → `logic.moveTokenTo(rc)` liest Route-Anker aus dem Store, rekonstruiert Token + Route über `store.set` und persistiert Tiles; der Store-Subscriber zeichnet unmittelbar neu.
-6. **RMB:** `contextmenue` prüft Dot-Kind, löscht nur `user` via `logic.deleteUserAt(idx)` → Brücke neu expandiert.
-7. **Playback-Steuerung:** `ui/controls.ts` nutzt den Header-Slot für Start/Stopp/Reset. `handleStateChange` füttert `setState` mit `playing` und der aktuellen Route, damit Buttons nur bei verfügbaren Wegpunkten aktiv sind. Klicks triggern `logic.play()`, `logic.pause()` (Stop) bzw. `logic.reset()`. Der Reset stoppt Playback, leert Route/`editIdx`/`currentTile` und ruft `initTokenFromTiles()` zur Token-Neuinitialisierung.
-8. **Playback:** `logic.play()` → `createPlayback` iteriert Route, lädt Terrain-Speed, animiert Token (`Math.max(minSecondsPerTile, tokenSpeed×terrainSpeed) * 1000`), persistiert Position und trimmt passierte Knoten. `pause()` setzt `playing=false`, ruft `token.stop()` auf und beendet den Durchlauf.
-9. **Token-Initialisierung:** `logic.initTokenFromTiles()` lädt einmalig das `token_travel`-Flag, rekonstruiert Token + Route via Store und legt Flag an, falls fehlend.
+1. **Mount:** `index.ts` erstellt im View `mountTravelGuide(app, host, file)`. Die Shell richtet Header + Spaltenlayout ein, instanziiert `createTravelGuideMode()` und übergibt einen `CartographerModeContext` (Hosts, Dateizugriff, Map-Layer-Getter). `mode.onEnter` kümmert sich um Terrain-Setup, Sidebar/Playback-Mounting und initiale UI-Räumung. Der Header verbindet Open/Create mit `enqueueLoad` und delegiert den Save-Hook zuerst an den Modus.
+2. **Dateiwechsel & Rendering:** `view-shell` serialisiert `setFile`, ruft `createMapLayer` für die Karte auf und übergibt `RenderHandles` bzw. `null` an `mode.onFileChange`. Der Modus baut Route-/Token-Layer, TravelLogic, Drag-Controller und Kontextmenü auf, synchronisiert Sidebar & Playback und räumt beim Wechsel vollständig auf.
+3. **Hex-Klick:** `map-layer` emittiert `hex:click` → Shell leitet das Event an `mode.onHexClick` weiter → der Modus prüft Drag-Unterdrückung und ruft `logic.handleHexClick(rc)` → `expandCoords` ergänzt Auto-Punkte → Store-Update → Route-Layer zeichnet neu.
+4. **Dot-Drag:** `drag.controller` (innerhalb des Modus) zeigt Ghost-Positionsupdates; `pointerup` commitet via `logic.moveSelectedTo(rc)` → neue Segmente durch `expandCoords` → Store-Update.
+5. **Token-Drag:** Derselbe Controller behandelt Token-Drags; Commit → `logic.moveTokenTo(rc)` rekonstruiert Route über `rebuildFromAnchors`, aktualisiert Store, Token-Position & Persistenz.
+6. **RMB:** `contextmenue` überwacht Dots, filtert nur `user`-Knoten und ruft `logic.deleteUserAt(idx)`; das UI bleibt vollständig im Modus gekapselt.
+7. **Playback-Steuerung:** `ui/controls.ts` sitzt im Sidebar-Controls-Host des Modus. `handleStateChange` liefert `playing` + Route an `setState`, Buttons triggern `logic.play()`, `logic.pause()` bzw. `logic.reset()`.
+8. **Playback:** `logic.play()` startet `createPlayback`, das Terrain-Speed + Token-Speed kombiniert, Token animiert, Tiles schreibt und Route-Knoten reduziert. `pause()` stoppt Animation & Status.
+9. **Token-Initialisierung & Persistenz:** `mode.onFileChange` ruft `logic.initTokenFromTiles()` nach jedem Kartenwechsel auf. Der Map-Header löst `mode.onSave` aus, damit `logic.persistTokenToTiles()` vor `saveMap`/`saveMapAs` läuft.
 
 ---
 
@@ -170,16 +173,11 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - `activateTravelGuide(file?)` holt oder erstellt das Leaf, setzt den View-State aktiv und reicht optional eine Map-Datei durch.
 - `getOrCreateLeaf()` bevorzugt vorhandene oder rechte Splits (Obsidian API).
 
-- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und führt das Karten-SVG über `createMapLayer` direkt in den linken Bereich ein. Der Header stammt aus `ui/map-header.ts`, verlinkt Öffnen/Erstellen mit `enqueueLoad` und erweitert den Save-Flow um `logic.persistTokenToTiles()`.
-- Lädt Terrain-Definitionen (`loadTerrains` → `setTerrains`) einmalig beim Mount.
-- Erstellt `routeLayer` und `tokenLayer` gemeinsam auf `mapLayer.handles.contentG` (kamera-transformierte Content-Gruppe), damit Karte, Route und Token identisch gescaled/panned werden.
-- Instanziiert `createSidebar` im rechten Bereich; der Wrapper stellt `controlsHost` für die Playback-Buttons bereit und hält zwei Status-Zeilen (aktuelles Hex, Token-Speed). `onSpeedChange` verbindet die Eingabe mit `logic.setTokenSpeed`.
-- Montiert `createPlaybackControls` im `sidebar.controlsHost`, damit Play/Stop/Reset an der Sidebar angedockt bleiben; `handleStateChange` beliefert sie mit `playing/route`, um Aktivierung und Disabled-State zu steuern.
-- Initialisiert `createTravelLogic` (Mindestdauer 0,1 s pro Tile) mit einem `onChange`, der Route-Highlight, Sidebar-Tile (`currentTile ?? tokenRC`) und Speed synchronisiert.
-- `logic.initTokenFromTiles()` lädt/persistiert die Tokenposition; Hook wird nach dem Mount einmal manuell aufgerufen.
-- Richtet Drag- & Kontextmenüs neu ein, sobald `setFile` eine Karte lädt; `setFile` returned ein `Promise` und serialisiert Ladevorgänge.
-- Der zurückgegebene `TravelGuideController` sorgt für Cleanup (Drag, Sidebar, Klassen) und akzeptiert `setFile`, um Karte, Titel und Route während der Laufzeit neu zu binden.
-- Prüft `drag.consumeClickSuppression()` und cancelt unterdrückte Klicks (`preventDefault` + `stopPropagation`), damit Drag-Abbrüche kein Tile-Open mehr triggern; echte Klicks leitet es weiterhin an `logic.handleHexClick` weiter.
+- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und instanziiert `createTravelGuideMode()`.
+- Baut einen `CartographerModeContext` (Hosts, File-Getter, Map-Layer-Getter), ruft `mode.onEnter` auf und serialisiert Dateiladevorgänge über `enqueueLoad`.
+- Lädt Karten via `createMapLayer`, reicht `RenderHandles` an `mode.onFileChange` weiter und leitet `hex:click`-Events an `mode.onHexClick` durch.
+- Koppelt den Map-Header (`createMapHeader`) mit dem Modus (`onSave`) und führt Standard-Speicherlogik (`saveMap`/`saveMapAs`) aus, falls der Modus das Speichern nicht vollständig übernimmt.
+- Der zurückgegebene `TravelGuideController` wartet laufende Loads ab, ruft `mode.onExit`, zerstört Map-Layer/DOM und entfernt View-Klassen.
 
 ### `ui/map-layer.ts`
 - Nutzt `renderHexMap` um das Kartensvg zu erzeugen, verwaltet `RenderHandles`.
@@ -225,8 +223,15 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 
 ### `ui/sidebar.ts`
 - Rendert eine kompakte Sidebar mit vorgelagertem `controlsHost` (Klasse `.sm-tg-sidebar__controls`) und zwei Status-Zeilen (aktuelles Hex, Token-Speed) inklusive Styles für Label/Value/Input.
-- `controlsHost` dient `view-shell` als Mount-Punkt für die Playback-Buttons; `setTile`, `setSpeed` aktualisieren Werte, `setTitle` hinterlegt den Dateinamen als `data-map-title` auf dem Host (für Tooltips/Debug) und validiert Eingaben (>0).
-- `onSpeedChange` registriert den externen Callback, `destroy()` leert den Host und entfernt das Daten-Attribut. Wird von `view-shell` genutzt.
+- `controlsHost` dient dem Travel-Mode als Mount-Punkt für die Playback-Buttons; `setTile`, `setSpeed` aktualisieren Werte, `setTitle` hinterlegt den Dateinamen als `data-map-title` auf dem Host (für Tooltips/Debug) und validiert Eingaben (>0).
+- `onSpeedChange` registriert den externen Callback, `destroy()` leert den Host und entfernt das Daten-Attribut. Wird vom Travel-Mode genutzt.
+
+### `../cartographer/modes/travel-guide.ts`
+- Wiederverwendbarer Modus für Cartographer und die Travel-Guide-Shell: bündelt Sidebar, Playback, Route-/Token-Layer sowie Drag- & Kontextmenü-Handling.
+- Lädt Terrain-Definitionen beim ersten `onEnter`, erstellt Sidebar + Playback-Controls und sorgt via Cleanup-Hooks für einen sauberen Abbau in `onExit`.
+- `onFileChange` räumt bestehende Layer/Logik auf, baut neue Route-/Token-Layer über `handles.contentG`, instanziiert `createTravelLogic`, bindet Drag/Contextmenü und ruft `logic.initTokenFromTiles()` nach jedem Kartenwechsel auf.
+- `handleStateChange` aktualisiert Route-Rendering, Sidebar (Tile/Speed) und Playback-State bei jeder Store-Änderung.
+- `onHexClick` respektiert `drag.consumeClickSuppression()` und delegiert echte Klicks an `logic.handleHexClick`; `onSave` persistiert das Token via `logic.persistTokenToTiles()` bevor der Header speichert.
 
 ### `domain/types.ts`
 - Definiert Basis-Koordinaten (`Coord`), Knotenarten (`NodeKind`) und `RouteNode`.


### PR DESCRIPTION
## Summary
- extract a reusable travel guide cartographer mode that owns sidebar, playback, layers, drag and persistence
- wire the cartographer shell to expose the new mode, including save hooks, and make the travel-guide shell delegate to it
- update the travel-guide and cartographer overview documents to document the new architecture

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12d0cf3808325a9992bf696696f9e