### PR TITLE
Refocus plugin bootstrapping on cartographer view

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -8,7 +8,7 @@ analysieren und mit Reiserouten versehen. Das Plugin ist in klar getrennte Layer
 | Layer | Standort | Aufgabe | Detail-Dokument |
 | --- | --- | --- | --- |
 | Plugin-Bootstrap | `src/app/` | Registriert Views/Commands, lädt CSS & Terrain-Daten und koordiniert Lifecycle sowie Watcher. | – |
-| Feature-Apps | `src/apps/` | Enthalten eigenständige Obsidian-Views (Galerie, Editor, Terrain-Editor, Travel Guide, Cartographer). | Pro Feature in `*Overview.txt` |
+| Feature-Apps | `src/apps/` | Enthalten eigenständige Obsidian-Views (Cartographer, Terrain-Editor sowie Legacy-Galerie/-Editor/-Travel Guide). | Pro Feature in `*Overview.txt` |
 | Core-Services | `src/core/` | Bietet Hex-Geometrie, Map-/Tile-Dateioperationen, Terrain-Verwaltung und Workspace-Helfer. | `src/core/CoreOverview.txt` |
 | UI-Bausteine | `src/ui/` | Stellt wiederverwendbare Modals/Bestätigungsdialoge für Features bereit. | `src/ui/UiOverview.txt` |
 | Styling | `src/app/css.ts` | Liefert das zentrale CSS, das beim Plugin-Start injiziert wird. | – |
@@ -33,17 +33,18 @@ src/
 ## Layer-Highlights
 
 ### Plugin-Lifecycle (`src/app/`)
-- `main.ts` richtet Views (MapEditor, HexGallery, TerrainEditor, TravelGuide) sowie passende Commands/Ribbons ein.
+- `main.ts` registriert nur noch den Cartographer und den Terrain Editor als aktive Views; Legacy-Views bleiben im Code, werden aber nicht mehr automatisch angehängt.
+- Cartographer-Ribbons/Commands nutzen `getCenterLeaf`, um stets den mittleren Workspace-Leaf zu fokussieren, während der Terrain Editor weiterhin in einem neuen Leaf öffnet.
 - Lädt Terrain-Definitionen über den Core-Service (`core/terrain-store.ts`: `ensureTerrainFile → loadTerrains → setTerrains`) und beobachtet Änderungen via `watchTerrains`.
 - Injiziert das zentrale CSS (`injectCss`) und räumt beim Unload alle Listener/Watcher ab.
 - Verteilt Events/Handler an Feature-Layer und Core-Services.
 
 ### Feature-Apps (`src/apps/`)
-- **Map Gallery (`map-gallery.ts`):** Historische View, die beim Öffnen auf den Cartographer weiterleitet – Map-Verwaltung & Vorschau sitzen nun gesammelt dort.
-- **Map Editor (`map-editor/`):** Liefert Tooling für Hex-Auswahl, Brush-Painting, Tile-Speicherung und Inspector-Views (Details siehe `MapEditorOverview.txt`).
+- **Cartographer (`cartographer/`):** Stellt einen mehrstufigen Map-Viewer bereit, der das Travel-Guide-Layout wiederverwendet, `renderHexMap`/`createMapLayer` für die Stage nutzt, Modi über einen Header-Slot umschaltet und via `createMapManager` im Header Open/Create/Delete bündelt. View & Command sind die primären Entry-Points im Plugin.
 - **Terrain Editor (`terrain-editor/`):** Pflegt Farb- und Geschwindigkeits-Paletten über den Core-Terrain-Store und synchronisiert Änderungen mit `terrain.ts`.
-- **Travel Guide (`travel-guide/`):** Spielt Reiserouten auf Hex-Karten ab, bindet den View über die `ui/view-shell` (liefert `TravelGuideController`) ein und nutzt Rendering/Geometrie aus dem Core.
-- **Cartographer (`cartographer/`):** Stellt einen mehrstufigen Map-Viewer bereit, der das Travel-Guide-Layout wiederverwendet, `renderHexMap`/`createMapLayer` für die Stage nutzt, Modi über einen Header-Slot umschaltet und via `createMapManager` im Header Open/Create/Delete bündelt.
+- **Map Gallery (`map-gallery.ts`):** Historische View, die beim direkten Öffnen (z. B. aus alten Workspaces) weiterhin auf den Cartographer umleitet.
+- **Map Editor (`map-editor/`):** Liefert Tooling für Hex-Auswahl, Brush-Painting, Tile-Speicherung und Inspector-Views (Details siehe `MapEditorOverview.txt`); wird über neue Cartographer-Flows eröffnet.
+- **Travel Guide (`travel-guide/`):** Spielt Reiserouten auf Hex-Karten ab; der Standalone-View bleibt für Rückwärtskompatibilität erhalten, wird aber nicht mehr vom Haupt-Plugin registriert.
 
 ### Core-Services (`src/core/`)
 - Bündelt Hex-Mathematik, SVG-Rendering, Map/Terrain-Dateiverwaltung und Workspace-Utilities.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Salt Marcher",
   "version": "0.1.0",
   "minAppVersion": "1.4.0",
-  "description": "Hex map gallery & interactive viewer.",
+  "description": "Cartographer workspace and terrain palette for hex maps.",
   "author": "You",
   "authorUrl": "",
   "isDesktopOnly": true,

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,12 +1,10 @@
 // src/app/main.ts
 import { Plugin, WorkspaceLeaf } from "obsidian";
-import { VIEW_TYPE_HEX_GALLERY, HexGalleryView } from "../apps/map-gallery";
-import { VIEW_TYPE_MAP_EDITOR, MapEditorView } from "../apps/map-editor";
 import { TerrainEditorView, VIEW_TERRAIN_EDITOR } from "../apps/terrain-editor/view";
-import { VIEW_TRAVEL_GUIDE, TravelGuideView } from "../apps/travel-guide";
 import { VIEW_CARTOGRAPHER, CartographerView } from "../apps/cartographer";
 import { ensureTerrainFile, loadTerrains, watchTerrains } from "../core/terrain-store";
 import { setTerrains } from "../core/terrain";
+import { getCenterLeaf } from "../core/layout";
 import { HEX_PLUGIN_CSS } from "./css";
 
 export default class SaltMarcherPlugin extends Plugin {
@@ -14,10 +12,7 @@ export default class SaltMarcherPlugin extends Plugin {
 
     async onload() {
         // Views
-        this.registerView(VIEW_TYPE_HEX_GALLERY, (leaf) => new HexGalleryView(leaf));
-        this.registerView(VIEW_TYPE_MAP_EDITOR,  (leaf) => new MapEditorView(leaf));
         this.registerView(VIEW_TERRAIN_EDITOR,   (leaf: WorkspaceLeaf) => new TerrainEditorView(leaf));
-        this.registerView(VIEW_TRAVEL_GUIDE,     (leaf: WorkspaceLeaf) => new TravelGuideView(leaf));
         this.registerView(VIEW_CARTOGRAPHER,     (leaf: WorkspaceLeaf) => new CartographerView(leaf));
 
         // Terrains initial laden & live halten
@@ -26,12 +21,6 @@ export default class SaltMarcherPlugin extends Plugin {
         this.unwatchTerrains = watchTerrains(this.app, () => { /* Views reagieren via Event */ });
 
         // Ribbons
-        this.addRibbonIcon("images", "Open Map Gallery", async () => {
-            const leaf = this.app.workspace.getRightLeaf(false);
-            await leaf.setViewState({ type: VIEW_TYPE_HEX_GALLERY, active: true });
-            this.app.workspace.revealLeaf(leaf);
-        });
-
         const terrainRibbon = this.addRibbonIcon("palette", "Open Terrain Editor", async () => {
             const leaf = this.app.workspace.getLeaf(true);
             await leaf.setViewState({ type: VIEW_TERRAIN_EDITOR, active: true });
@@ -39,28 +28,13 @@ export default class SaltMarcherPlugin extends Plugin {
         });
         terrainRibbon.addClass("salt-terrain-ribbon");
 
-        this.addRibbonIcon("rocket", "Open Travel Guide", async () => {
-            const leaf = this.app.workspace.getLeaf(false);
-            await leaf.setViewState({ type: VIEW_TRAVEL_GUIDE, active: true });
-            this.app.workspace.revealLeaf(leaf);
-        });
-
         this.addRibbonIcon("compass", "Open Cartographer", async () => {
-            const leaf = this.app.workspace.getLeaf(false);
+            const leaf = getCenterLeaf(this.app);
             await leaf.setViewState({ type: VIEW_CARTOGRAPHER, active: true });
             this.app.workspace.revealLeaf(leaf);
         });
 
         // Commands
-        this.addCommand({
-            id: "open-map-editor",
-            name: "Open Map Editor (empty)",
-                        callback: async () => {
-                            const leaf = this.app.workspace.getLeaf(true);
-                            await leaf.setViewState({ type: VIEW_TYPE_MAP_EDITOR, active: true });
-                        },
-        });
-
         this.addCommand({
             id: "open-terrain-editor",
             name: "Terrain Editor öffnen",
@@ -72,20 +46,10 @@ export default class SaltMarcherPlugin extends Plugin {
         });
 
         this.addCommand({
-            id: "open-travel-guide",
-            name: "Travel Guide öffnen",
-            callback: async () => {
-                const leaf = this.app.workspace.getLeaf(false);
-                await leaf.setViewState({ type: VIEW_TRAVEL_GUIDE, active: true });
-                this.app.workspace.revealLeaf(leaf);
-            },
-        });
-
-        this.addCommand({
             id: "open-cartographer",
             name: "Cartographer öffnen",
             callback: async () => {
-                const leaf = this.app.workspace.getLeaf(false);
+                const leaf = getCenterLeaf(this.app);
                 await leaf.setViewState({ type: VIEW_CARTOGRAPHER, active: true });
                 this.app.workspace.revealLeaf(leaf);
             },


### PR DESCRIPTION
## Summary
- register only the Cartographer and Terrain Editor views in the main plugin bootstrap
- streamline ribbon buttons and commands so the Cartographer opens in the center leaf via layout helpers
- refresh the plugin overview and manifest description to reflect the Cartographer-focused entry points

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d13842710c832583f42cd9d85e2601