### PR TITLE
Unify cartographer travel layout

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -8,7 +8,7 @@ analysieren und mit Reiserouten versehen. Das Plugin ist in klar getrennte Layer
 | Layer | Standort | Aufgabe | Detail-Dokument |
 | --- | --- | --- | --- |
 | Plugin-Bootstrap | `src/app/` | Registriert Views/Commands, lädt CSS & Terrain-Daten und koordiniert Lifecycle sowie Watcher. | – |
-| Feature-Apps | `src/apps/` | Enthalten eigenständige Obsidian-Views (Cartographer, Terrain-Editor sowie Legacy-Galerie/-Editor/-Travel Guide). | Pro Feature in `*Overview.txt` |
+| Feature-Apps | `src/apps/` | Enthalten eigenständige Obsidian-Views (Cartographer mit Travel/Editor/Inspector-Modi, Terrain-Editor sowie Legacy-Galerie-/Travel-Hüllen). | Pro Feature in `*Overview.txt` |
 | Core-Services | `src/core/` | Bietet Hex-Geometrie, Map-/Tile-Dateioperationen, Terrain-Verwaltung und Workspace-Helfer. | `src/core/CoreOverview.txt` |
 | UI-Bausteine | `src/ui/` | Stellt wiederverwendbare Modals/Bestätigungsdialoge für Features bereit. | `src/ui/UiOverview.txt` |
 | Styling | `src/app/css.ts` | Liefert das zentrale CSS, das beim Plugin-Start injiziert wird. | – |
@@ -23,8 +23,8 @@ src/
 │  ├─ map-gallery.ts         # Historische Galerie; leitet jetzt direkt in den Cartographer um
 │  ├─ map-editor/            # Interaktiver Hex-Editor – MapEditorOverview.txt
 │  ├─ terrain-editor/        # Terrain-Palette – TerrainEditorOverview.txt
-│  ├─ travel-guide/          # Reiseplanung – TravelGuideOverview.txt
-│  └─ cartographer/          # Multi-Mode Map Viewer – CartographerOverview.txt
+│  ├─ travel-guide/          # Legacy-View, mountet den Cartographer-Travel-Mode – TravelGuideOverview.txt
+│  └─ cartographer/          # Multi-Mode Map Viewer (Travel/Editor/Inspector) – CartographerOverview.txt
 │
 ├─ core/                     # Hex-Engine & Dateiservices – CoreOverview.txt
 └─ ui/                       # Modals & Dialoge – UiOverview.txt
@@ -40,11 +40,11 @@ src/
 - Verteilt Events/Handler an Feature-Layer und Core-Services.
 
 ### Feature-Apps (`src/apps/`)
-- **Cartographer (`cartographer/`):** Stellt einen mehrstufigen Map-Viewer bereit, der das Travel-Guide-Layout wiederverwendet, `renderHexMap`/`createMapLayer` für die Stage nutzt, Modi über einen Header-Slot umschaltet und via `createMapManager` im Header Open/Create/Delete bündelt. View & Command sind die primären Entry-Points im Plugin.
+- **Cartographer (`cartographer/`):** Stellt den `sm-cartographer`-Shell bereit, rendert Karten via `renderHexMap`/`createMapLayer`, schaltet Travel/Editor/Inspector-Modi über einen Header-Slot, kapselt deren Sidebars und bündelt Open/Create/Delete über `createMapManager`. View & Command sind die primären Entry-Points im Plugin.
 - **Terrain Editor (`terrain-editor/`):** Pflegt Farb- und Geschwindigkeits-Paletten über den Core-Terrain-Store und synchronisiert Änderungen mit `terrain.ts`.
 - **Map Gallery (`map-gallery.ts`):** Historische View, die beim direkten Öffnen (z. B. aus alten Workspaces) weiterhin auf den Cartographer umleitet.
 - **Map Editor (`map-editor/`):** Liefert Tooling für Hex-Auswahl, Brush-Painting, Tile-Speicherung und Inspector-Views (Details siehe `MapEditorOverview.txt`); wird über neue Cartographer-Flows eröffnet.
-- **Travel Guide (`travel-guide/`):** Spielt Reiserouten auf Hex-Karten ab; der Standalone-View bleibt für Rückwärtskompatibilität erhalten, wird aber nicht mehr vom Haupt-Plugin registriert.
+- **Travel Guide (`travel-guide/`):** Legacy-Hülle für Rückwärtskompatibilität. Mountet `createTravelGuideMode()` in derselben `sm-cartographer`-Shell, verwaltet nur View-Lifecycle und delegiert sämtliche UI/Logik an den Cartographer.
 
 ### Core-Services (`src/core/`)
 - Bündelt Hex-Mathematik, SVG-Rendering, Map/Terrain-Dateiverwaltung und Workspace-Utilities.
@@ -58,7 +58,7 @@ src/
 - Details im [UI Overview](src/ui/UiOverview.txt).
 
 ### Styling & Build
-- `src/app/css.ts` enthält alle SCSS-ähnlichen Styles für Maps, Tools, Terrain-Editor und Travel Guide.
+- `src/app/css.ts` liefert den konsolidierten `sm-cartographer`-Look (Stage, Header, Mode-Sidebars) sowie Travel-spezifische Controls. Galerie-Styles wurden entfernt; Modals oder optionale Komponenten bringen eigene CSS-Blöcke mit.
 - `manifest.json` definiert Plugin-ID/Version, `esbuild.config.mjs` + `tsconfig.json` stellen die Build-Pipeline für TypeScript sicher (`npm run build`).
 
 ## Typische Nutzerflüsse

--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -42,34 +42,6 @@ export const HEX_PLUGIN_CSS = `
     transition: opacity 120ms ease, r 120ms ease, cx 60ms ease, cy 60ms ease;
 }
 
-/* === Gallery-Layout (Header + Toolbar) === */
-.hex-gallery-header {
-    display: flex;
-    align-items: center;
-    gap: .75rem;
-    margin-bottom: .5rem;
-}
-
-/* Titel kürzen, falls der Dateiname zu lang ist */
-.hex-gallery-header h2 {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 60%;
-}
-
-.hex-gallery-card-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 6px;
-}
-
-.hex-gallery-card-row a {
-    font-weight: 600;
-    cursor: pointer;
-}
-
 /* === Live-Preview: Interaktion im Codeblock erlauben (optional) === */
 .markdown-source-view .cm-preview-code-block .hex3x3-container,
 .markdown-source-view .cm-preview-code-block .hex3x3-map { pointer-events: auto; }
@@ -84,11 +56,14 @@ export const HEX_PLUGIN_CSS = `
 .sm-terrain-editor .addbar { display:flex; gap:.5rem; margin-top:.5rem; }
 .sm-terrain-editor .addbar input[type="text"] { flex:1; min-width:0; }
 
-/* === Travel Guide === */
-.sm-travel-guide {
-    --tg-color-token: var(--color-purple, #9c6dfb);
-    --tg-color-user-anchor: var(--color-orange, #f59e0b);
-    --tg-color-auto-point: var(--color-blue, #3b82f6);
+/* === Cartographer Shell === */
+.cartographer-host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.sm-cartographer {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -100,11 +75,11 @@ export const HEX_PLUGIN_CSS = `
     box-sizing: border-box;
 }
 
-.sm-travel-guide__header {
+.sm-cartographer__header {
     padding-bottom: 0.25rem;
 }
 
-.sm-travel-guide__header .sm-map-header {
+.sm-cartographer__header .sm-map-header {
     background: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
     border-radius: 10px;
@@ -112,30 +87,25 @@ export const HEX_PLUGIN_CSS = `
     gap: 0.5rem;
 }
 
-.sm-travel-guide__header .sm-map-header h2 {
+.sm-cartographer__header .sm-map-header h2 {
     margin: 0;
 }
 
-
-.sm-travel-guide__header .sm-map-header .sm-map-header__secondary-left {
+.sm-cartographer__header .sm-map-header .sm-map-header__secondary-left {
     margin-left: auto;
     margin-right: 0;
 }
 
-.sm-tg-controls__btn {
-    font-weight: 600;
-}
-
-.sm-travel-guide__body {
+.sm-cartographer__body {
     display: flex;
     flex: 1 1 auto;
-    gap: 1.5rem;
+    gap: 1.25rem;
     align-items: stretch;
     width: 100%;
     min-height: 0;
 }
 
-.sm-travel-guide .sm-tg-map {
+.sm-cartographer__map {
     flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
@@ -147,84 +117,30 @@ export const HEX_PLUGIN_CSS = `
     box-sizing: border-box;
 }
 
-.sm-travel-guide .sm-tg-map .hex3x3-map {
-    max-width: none;
+.sm-cartographer__map .hex3x3-map {
     height: 100%;
+    max-width: none;
 }
 
-.sm-travel-guide .tg-token__circle {
-    fill: var(--tg-color-token);
-    opacity: 0.95;
-    stroke: var(--background-modifier-border);
-    stroke-width: 3;
-    transition: opacity 120ms ease;
-}
-
-.sm-travel-guide .tg-route-dot {
-    transition: opacity 120ms ease, r 120ms ease, stroke 120ms ease;
-}
-
-.sm-travel-guide .tg-route-dot--user {
-    fill: var(--tg-color-user-anchor);
-    opacity: 0.95;
-}
-
-.sm-travel-guide .tg-route-dot--auto {
-    fill: var(--tg-color-auto-point);
-    opacity: 0.55;
-}
-
-.sm-travel-guide .tg-route-dot-hitbox {
-    fill: transparent;
-    stroke: transparent;
-}
-
-.sm-travel-guide .tg-route-dot--user.is-highlighted {
-    opacity: 1;
-}
-
-.sm-travel-guide .tg-route-dot--auto.is-highlighted {
-    opacity: 0.9;
-}
-
-.sm-travel-guide .sm-tg-sidebar {
+.sm-cartographer__sidebar {
     flex: 0 0 280px;
-    max-width: 340px;
+    max-width: 320px;
     background: var(--background-secondary);
     border: 1px solid var(--background-modifier-border);
     border-radius: 10px;
     padding: 1rem;
     box-sizing: border-box;
     display: flex;
-}
-
-/* === Cartographer === */
-.cartographer-host {
-    display: flex;
     flex-direction: column;
-    height: 100%;
+    gap: 0.75rem;
 }
 
-.sm-cartographer {
+.sm-cartographer__empty {
     display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    width: 100%;
+    align-items: center;
+    justify-content: center;
     height: 100%;
-    padding: 1rem;
-    box-sizing: border-box;
-}
-
-.sm-cartographer__header .sm-map-header {
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 10px;
-    padding: 0.75rem;
-    background: var(--background-primary);
-    gap: 0.5rem;
-}
-
-.sm-cartographer__header .sm-map-header h2 {
-    margin: 0;
+    color: var(--text-muted);
 }
 
 .sm-cartographer__mode-switch {
@@ -247,45 +163,7 @@ export const HEX_PLUGIN_CSS = `
     color: var(--text-on-accent, #fff);
 }
 
-.sm-cartographer__body {
-    display: flex;
-    flex: 1 1 auto;
-    gap: 1.25rem;
-    align-items: stretch;
-    width: 100%;
-    min-height: 0;
-}
-
-.sm-cartographer__map {
-    flex: 1 1 auto;
-    min-width: 0;
-    min-height: 0;
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 10px;
-    background: var(--background-primary);
-    padding: 0.75rem;
-    box-sizing: border-box;
-    position: relative;
-}
-
-.sm-cartographer__map .hex3x3-map {
-    height: 100%;
-    max-width: none;
-}
-
-.sm-cartographer__sidebar {
-    flex: 0 0 280px;
-    max-width: 320px;
-    background: var(--background-secondary);
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 10px;
-    padding: 1rem;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-}
-
+/* === Cartographer Panels (Editor & Inspector) === */
 .sm-cartographer__panel {
     display: flex;
     flex-direction: column;
@@ -298,6 +176,7 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-cartographer__panel.is-disabled {
     opacity: 0.6;
+    pointer-events: none;
 }
 
 .sm-cartographer__panel-info {
@@ -305,58 +184,150 @@ export const HEX_PLUGIN_CSS = `
     color: var(--text-muted);
 }
 
-.sm-cartographer__empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
+.sm-cartographer__panel-file {
+    font-size: 0.9rem;
     color: var(--text-muted);
 }
 
-.sm-tg-sidebar__inner {
+.sm-cartographer__panel-tools {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sm-cartographer__panel-tools label {
+    font-weight: 600;
+}
+
+.sm-cartographer__panel-tools select {
+    flex: 1 1 auto;
+}
+
+.sm-cartographer__panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sm-cartographer__panel-status {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.sm-cartographer__panel-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sm-cartographer__panel-row label {
+    font-weight: 600;
+}
+
+.sm-cartographer__panel-row select,
+.sm-cartographer__panel-row textarea {
+    width: 100%;
+    border-radius: 6px;
+}
+
+.sm-cartographer__panel-row textarea {
+    resize: vertical;
+}
+
+/* === Travel Mode (Cartographer & Legacy Shell) === */
+.sm-cartographer--travel {
+    --tg-color-token: var(--color-purple, #9c6dfb);
+    --tg-color-user-anchor: var(--color-orange, #f59e0b);
+    --tg-color-auto-point: var(--color-blue, #3b82f6);
+}
+
+.sm-cartographer__sidebar--travel {
+    gap: 1rem;
+}
+
+.sm-cartographer__travel {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
     width: 100%;
 }
 
-.sm-tg-sidebar__controls {
+.sm-cartographer__travel-controls {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
 }
 
-.sm-tg-sidebar__controls .sm-tg-controls {
+.sm-cartographer__travel-buttons {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
 }
 
-.sm-tg-sidebar__row {
+.sm-cartographer__travel-button {
+    font-weight: 600;
+}
+
+.sm-cartographer__travel-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
 }
 
-.sm-tg-sidebar__label {
+.sm-cartographer__travel-label {
     font-size: 0.9rem;
     color: var(--text-muted);
 }
 
-.sm-tg-sidebar__value {
+.sm-cartographer__travel-value {
     font-size: 1rem;
     font-weight: 600;
 }
 
-.sm-tg-sidebar__speed-input {
+.sm-cartographer__travel-input {
     width: 100%;
     padding: 0.35rem 0.5rem;
     border-radius: 6px;
 }
 
-.sm-travel-guide .hex3x3-map circle[data-token] { opacity: .95; }
-.sm-travel-guide .hex3x3-map polyline { pointer-events: none; }
+.sm-cartographer--travel .tg-token__circle {
+    fill: var(--tg-color-token);
+    opacity: 0.95;
+    stroke: var(--background-modifier-border);
+    stroke-width: 3;
+    transition: opacity 120ms ease;
+}
+
+.sm-cartographer--travel .tg-route-dot {
+    transition: opacity 120ms ease, r 120ms ease, stroke 120ms ease;
+}
+
+.sm-cartographer--travel .tg-route-dot--user {
+    fill: var(--tg-color-user-anchor);
+    opacity: 0.95;
+}
+
+.sm-cartographer--travel .tg-route-dot--auto {
+    fill: var(--tg-color-auto-point);
+    opacity: 0.55;
+}
+
+.sm-cartographer--travel .tg-route-dot-hitbox {
+    fill: transparent;
+    stroke: transparent;
+}
+
+.sm-cartographer--travel .tg-route-dot--user.is-highlighted {
+    opacity: 1;
+}
+
+.sm-cartographer--travel .tg-route-dot--auto.is-highlighted {
+    opacity: 0.9;
+}
+
+.sm-cartographer--travel .hex3x3-map circle[data-token] { opacity: .95; }
+.sm-cartographer--travel .hex3x3-map polyline { pointer-events: none; }
 `;

--- a/src/apps/cartographer/modes/inspector.ts
+++ b/src/apps/cartographer/modes/inspector.ts
@@ -139,7 +139,7 @@ export function createInspectorMode(): CartographerMode {
             const messageRow = ui.panel.createEl("div", { cls: "sm-cartographer__panel-info" });
             ui.message = messageRow;
 
-            const terrRow = ui.panel.createDiv({ cls: "sm-row" });
+            const terrRow = ui.panel.createDiv({ cls: "sm-cartographer__panel-row" });
             terrRow.createEl("label", { text: "Terrain:" });
             ui.terrain = terrRow.createEl("select") as HTMLSelectElement;
             for (const key of Object.keys(TERRAIN_COLORS)) {
@@ -149,7 +149,7 @@ export function createInspectorMode(): CartographerMode {
             ui.terrain.disabled = true;
             ui.terrain.onchange = () => scheduleSave(ctx);
 
-            const noteRow = ui.panel.createDiv({ cls: "sm-row" });
+            const noteRow = ui.panel.createDiv({ cls: "sm-cartographer__panel-row" });
             noteRow.createEl("label", { text: "Notiz:" });
             ui.note = noteRow.createEl("textarea", { attr: { rows: "6" } }) as HTMLTextAreaElement;
             ui.note.disabled = true;

--- a/src/apps/map-editor/MapEditorOverview.txt
+++ b/src/apps/map-editor/MapEditorOverview.txt
@@ -20,8 +20,8 @@ src/apps/map-editor/
 
 ## Features & Verantwortlichkeiten
 
-- **Wrapper-View:** `index.ts` mountet den Cartographer und schaltet direkt in den Editor-Modus. Der View bleibt kompatibel mit bestehenden Commands/States, leitet aber sämtliche Karten-Interaktionen an die gemeinsame Shell weiter.
-- **Tool-Schnittstelle:** `tools-api.ts` definiert den Kontext (`getHandles`, `getOptions`, `setStatus` …) für Editier-Tools. Der Cartographer-Editor erzeugt Instanzen dieses Kontextes und triggert `onActivate`, `onMapRendered` sowie `onHexClick`.
+- **Wrapper-View:** `index.ts` mountet den Cartographer (`sm-cartographer`-Shell) und schaltet direkt in den Editor-Modus. Der View bleibt kompatibel mit bestehenden Commands/States, leitet aber sämtliche Karten-Interaktionen an die gemeinsame Shell weiter.
+- **Tool-Schnittstelle:** `tools-api.ts` definiert den Kontext (`getHandles`, `getOptions`, `setStatus` …) für Editier-Tools. Der Cartographer-Editor erzeugt Instanzen dieses Kontextes, triggert `onActivate`, `onMapRendered` sowie `onHexClick` und montiert Tool-UIs im geteilten Sidebar-Panel (`.sm-cartographer__panel--editor`).
 - **Brush-Infrastruktur:** `terrain-brush/*` stellt UI, Mathematik und Persistenz (Tiles schreiben/löschen) für das Terrain-Brush-Tool bereit. `brush-circle.ts` visualisiert den aktiven Radius direkt auf dem SVG.
 - **Inspector-Verlagerung:** Der Terrain-/Notiz-Inspector lebt nun als eigener Cartographer-Modus (`modes/inspector.ts`) und nutzt dort die gemeinsamen Render-/Persistenz-Hooks.
 

--- a/src/apps/travel-guide/TravelGuideOverview.txt
+++ b/src/apps/travel-guide/TravelGuideOverview.txt
@@ -53,6 +53,7 @@ src/apps/travel-guide/
 ## Featureliste
 
 - **Kartenverwaltung & Persistenz:** Karten lassen sich öffnen, erstellen und speichern; Terrain-Geschwindigkeiten werden beim Mount geladen und Token-Positionen (`token_travel`) automatisch aus den Hex-Notes gelesen bzw. dorthin zurückgeschrieben.
+- **Cartographer-Integration:** Der Modus läuft identisch im Cartographer-View und in der Legacy-Travel-Guide-Shell. Beide mounten die `sm-cartographer`-Struktur (Header, Map-Stage, Sidebar), sodass CSS, Header-Slots und Map-Management (`createMapManager`) geteilt werden.
 - **Routenaufbau durch Hex-Klicks:** Hex-Klicks erzeugen Nutzeranker, ergänzen automatische Zwischenpunkte entlang der Linie und aktualisieren Highlight & Route-Rendering unmittelbar.
 - **Präzise Drag-Interaktionen:** Nutzeranker und Token können mit Ghost-Vorschau verschoben werden; während aktiver Drags werden Hex-Klick-Events vollständig unterdrückt, damit keine zusätzlichen Wegpunkte entstehen.
 - **Token-Steuerung & Playback:** Token lassen sich manuell positionieren oder über Play/Stop/Reset animieren; der Playback-Loop berücksichtigt Terrain-Speed, Token-Speed und persistiert Fortschritte pro Tile.
@@ -137,7 +138,7 @@ export type TravelLogic = {
 
 ## Playback-Steuerung & Reset
 
-- Oberhalb der Sidebar-Zeilen liegt `sm-tg-sidebar__controls`; `ui/controls.ts` montiert seine Buttons in diesem Host, damit Play/Stop/Reset direkt neben Speed-Regler und Statuswerten sitzen, während der Map-Header wieder den Dateinamen im Standardslot anzeigt.
+- Oberhalb der Sidebar-Zeilen liegt `sm-cartographer__travel-controls`; `ui/controls.ts` montiert seine Buttons in diesem Host, damit Play/Stop/Reset direkt neben Speed-Regler und Statuswerten sitzen, während der Map-Header wieder den Dateinamen im Standardslot anzeigt.
 - Buttons verwenden weiterhin `applyMapButtonStyle`, zeigen „Start“, „Stopp“ und „Reset“ (Icons: Play, Square, Rotate) und rufen ausschließlich die übergebenen Callbacks (`logic.play()`, `logic.pause()`, `logic.reset()`) auf.
 - `handleStateChange` liefert `playing` und `route.length` an `setState`, damit „Start“ nur mit vorhandener Route aktiv ist, „Stopp“ ausschließlich während des Playbacks verfügbar bleibt und „Reset“ die Route leert, auch wenn Playback noch läuft.
 - `logic.reset()` ruft immer zuerst `logic.pause()` (sofortiges Abbrechen inkl. Token-Stop), leert Route/Edit-Index/`currentTile` und initialisiert das Token über `initTokenFromTiles()` neu, wodurch Position & Persistenz auf den Kartendaten aktualisiert werden.
@@ -161,7 +162,7 @@ export type TravelLogic = {
 - **Auto-Punkte (`.tg-route-dot--auto`):** kühles Blau (`--tg-color-auto-point`, fallback `#3b82f6`) mit reduzierter Deckkraft (55 %), um ergänzte Zwischenknoten subtiler zu halten.
 - **Highlight (`.is-highlighted`):** Domain-Highlighting erhöht weiterhin Radius + Border; zusätzlich hebt CSS die Deckkraft auf 100 % (User) bzw. 90 % (Auto), damit der aktuelle Fokus sofort sichtbar ist.
 
-Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben und nehmen vorhandene Obsidian-Theme-Variablen als bevorzugte Quelle.
+Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben und nehmen vorhandene Obsidian-Theme-Variablen als bevorzugte Quelle. Die Defaults werden auf `.sm-cartographer--travel` gesetzt, damit sowohl Cartographer-View als auch Legacy-Shell identisch aussehen.
 
 ---
 
@@ -173,7 +174,7 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - `activateTravelGuide(file?)` holt oder erstellt das Leaf, setzt den View-State aktiv und reicht optional eine Map-Datei durch.
 - `getOrCreateLeaf()` bevorzugt vorhandene oder rechte Splits (Obsidian API).
 
-- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-travel-guide`, erzeugt Header + Body (Map-/Sidebar-Container) und instanziiert `createTravelGuideMode()`.
+- `mountTravelGuide(app, host, file)` setzt den Host auf `.sm-cartographer` + `.sm-cartographer--travel`, erzeugt Header + Body (Map-/Sidebar-Container) und instanziiert `createTravelGuideMode()`.
 - Baut einen `CartographerModeContext` (Hosts, File-Getter, Map-Layer-Getter), ruft `mode.onEnter` auf und serialisiert Dateiladevorgänge über `enqueueLoad`.
 - Lädt Karten via `createMapLayer`, reicht `RenderHandles` an `mode.onFileChange` weiter und leitet `hex:click`-Events an `mode.onHexClick` durch.
 - Koppelt den Map-Header (`createMapHeader`) mit dem Modus (`onSave`) und führt Standard-Speicherlogik (`saveMap`/`saveMapAs`) aus, falls der Modus das Speichern nicht vollständig übernimmt.
@@ -202,7 +203,7 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - Lässt Pointer-Events aktiv (`cursor: grab`) für Drag-Start.
 
 ### `ui/controls.ts`
-- Rendert Start/Stopp/Reset-Buttons im von der Sidebar bereitgestellten Controls-Host (`.sm-tg-sidebar__controls`), nutzt `applyMapButtonStyle` und Obsidian-Icons (`play`, `square`, `rotate-ccw`).
+- Rendert Start/Stopp/Reset-Buttons im von der Sidebar bereitgestellten Controls-Host (`.sm-cartographer__travel-controls`), nutzt `applyMapButtonStyle` und Obsidian-Icons (`play`, `square`, `rotate-ccw`).
 - `setState` aktiviert „Start“ nur mit Route, „Stopp“ nur beim laufenden Playback und „Reset“ sobald entweder Route existiert oder abgespielt wird.
 - Klicks lösen ausschließlich die übergebenen Callbacks aus; der Helper hält keinen eigenen Zustand und lässt sich über `destroy()` vollständig entfernen.
 
@@ -222,7 +223,7 @@ Alle Farbwerte lassen sich über die jeweiligen Custom Properties überschreiben
 - Ruft bei `user`-Dots `logic.deleteUserAt(idx)` und stoppt Event-Bubbling.
 
 ### `ui/sidebar.ts`
-- Rendert eine kompakte Sidebar mit vorgelagertem `controlsHost` (Klasse `.sm-tg-sidebar__controls`) und zwei Status-Zeilen (aktuelles Hex, Token-Speed) inklusive Styles für Label/Value/Input.
+- Rendert eine kompakte Sidebar mit vorgelagertem `controlsHost` (Klasse `.sm-cartographer__travel-controls`) und zwei Status-Zeilen (aktuelles Hex, Token-Speed) inklusive Styles für Label/Value/Input.
 - `controlsHost` dient dem Travel-Mode als Mount-Punkt für die Playback-Buttons; `setTile`, `setSpeed` aktualisieren Werte, `setTitle` hinterlegt den Dateinamen als `data-map-title` auf dem Host (für Tooltips/Debug) und validiert Eingaben (>0).
 - `onSpeedChange` registriert den externen Callback, `destroy()` leert den Host und entfernt das Daten-Attribut. Wird vom Travel-Mode genutzt.
 

--- a/src/apps/travel-guide/ui/controls.ts
+++ b/src/apps/travel-guide/ui/controls.ts
@@ -18,10 +18,10 @@ export type PlaybackControlsHandle = {
 };
 
 export function createPlaybackControls(host: HTMLElement, callbacks: PlaybackControlsCallbacks): PlaybackControlsHandle {
-    const root = host.createDiv({ cls: "sm-tg-controls" });
+    const root = host.createDiv({ cls: "sm-cartographer__travel-buttons" });
 
     const playBtn = root.createEl("button", {
-        cls: "sm-tg-controls__btn sm-tg-controls__btn--play",
+        cls: "sm-cartographer__travel-button sm-cartographer__travel-button--play",
         text: "Start",
     });
     setIcon(playBtn, "play");
@@ -33,7 +33,7 @@ export function createPlaybackControls(host: HTMLElement, callbacks: PlaybackCon
     });
 
     const stopBtn = root.createEl("button", {
-        cls: "sm-tg-controls__btn sm-tg-controls__btn--stop",
+        cls: "sm-cartographer__travel-button sm-cartographer__travel-button--stop",
         text: "Stopp",
     });
     setIcon(stopBtn, "square");
@@ -45,7 +45,7 @@ export function createPlaybackControls(host: HTMLElement, callbacks: PlaybackCon
     });
 
     const resetBtn = root.createEl("button", {
-        cls: "sm-tg-controls__btn sm-tg-controls__btn--reset",
+        cls: "sm-cartographer__travel-button sm-cartographer__travel-button--reset",
         text: "Reset",
     });
     setIcon(resetBtn, "rotate-ccw");

--- a/src/apps/travel-guide/ui/sidebar.ts
+++ b/src/apps/travel-guide/ui/sidebar.ts
@@ -10,21 +10,24 @@ export type Sidebar = {
 
 export function createSidebar(host: HTMLElement): Sidebar {
     host.empty();
-    host.classList.add("sm-tg-sidebar");
+    host.classList.add("sm-cartographer__sidebar--travel");
 
-    const root = host.createDiv({ cls: "sm-tg-sidebar__inner" });
+    const root = host.createDiv({ cls: "sm-cartographer__travel" });
 
-    const controlsHost = root.createDiv({ cls: "sm-tg-sidebar__controls" });
+    const controlsHost = root.createDiv({ cls: "sm-cartographer__travel-controls" });
 
-    const tileRow = root.createDiv({ cls: "sm-tg-sidebar__row" });
-    tileRow.createSpan({ cls: "sm-tg-sidebar__label", text: "Aktuelles Hex" });
-    const tileValue = tileRow.createSpan({ cls: "sm-tg-sidebar__value", text: "—" });
+    const tileRow = root.createDiv({ cls: "sm-cartographer__travel-row" });
+    tileRow.createSpan({ cls: "sm-cartographer__travel-label", text: "Aktuelles Hex" });
+    const tileValue = tileRow.createSpan({
+        cls: "sm-cartographer__travel-value",
+        text: "—",
+    });
 
-    const speedRow = root.createDiv({ cls: "sm-tg-sidebar__row" });
-    speedRow.createSpan({ cls: "sm-tg-sidebar__label", text: "Token-Speed" });
+    const speedRow = root.createDiv({ cls: "sm-cartographer__travel-row" });
+    speedRow.createSpan({ cls: "sm-cartographer__travel-label", text: "Token-Speed" });
     const speedInput = speedRow.createEl("input", {
         type: "number",
-        cls: "sm-tg-sidebar__speed-input",
+        cls: "sm-cartographer__travel-input",
         attr: { step: "0.1", min: "0.1", value: "1" },
     }) as HTMLInputElement;
 
@@ -60,6 +63,7 @@ export function createSidebar(host: HTMLElement): Sidebar {
         onSpeedChange: (fn) => (onChange = fn),
         destroy: () => {
             host.empty();
+            host.classList.remove("sm-cartographer__sidebar--travel");
             delete host.dataset.mapTitle;
         },
     };

--- a/src/apps/travel-guide/ui/view-shell.ts
+++ b/src/apps/travel-guide/ui/view-shell.ts
@@ -26,13 +26,15 @@ export async function mountTravelGuide(
     file: TFile | null
 ): Promise<TravelGuideController | undefined> {
     host.empty();
-    host.classList.add("sm-travel-guide");
+    host.classList.add("sm-cartographer", "sm-cartographer--travel");
 
-    const headerHost = host.createDiv({ cls: "sm-travel-guide__header" });
-    const body = host.createDiv({ cls: "sm-travel-guide__body" });
+    const headerHost = host.createDiv({ cls: "sm-cartographer__header" });
+    const body = host.createDiv({ cls: "sm-cartographer__body" });
 
-    const mapHost = body.createDiv({ cls: "sm-tg-map" });
-    const sidebarHost = body.createDiv({ cls: "sm-tg-sidebar" });
+    const mapHost = body.createDiv({ cls: "sm-cartographer__map" });
+    const sidebarHost = body.createDiv({
+        cls: "sm-cartographer__sidebar sm-cartographer__sidebar--travel",
+    });
 
     const travelMode = createTravelGuideMode();
 
@@ -155,7 +157,7 @@ export async function mountTravelGuide(
             await travelMode.onExit();
             headerHandle?.destroy();
             headerHandle = null;
-            host.classList.remove("sm-travel-guide");
+            host.classList.remove("sm-cartographer", "sm-cartographer--travel");
             host.empty();
         },
     };


### PR DESCRIPTION
## Summary
- refactor the shared CSS to expose the `sm-cartographer` shell and travel specific sidebar controls while removing gallery styling
- update the legacy travel guide shell, sidebar and controls to use the cartographer classes and cleanup hooks
- align inspector tooling and documentation to the new mode layout and responsibilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d139f21ea08325a055f78c98ab6992