### PR TITLE
Remove legacy hex map aggregator file

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -88,7 +88,6 @@ Salt-Marcher/
 - `CoreOverview.txt`: Übersicht über Aufbau und Verantwortlichkeiten der Core-Schicht.
 - `options.ts`: Parser für Hex-Codeblöcke (`hex3x3`) und freie Optionen (Folder, Prefix, Radius).
 - `layout.ts`: Workspace-Helfer (`getCenterLeaf`, `getRightLeaf`) zur gezielten Steuerung der Obsidian-Leaves.
-- `hex-mapper/hex-map.ts`: Erzeugt Karten-Modelle und hexagonale Koordinatenstrukturen.
 - `hex-mapper/hex-geom.ts`: Mathematische Hilfen für Hex-Koordinaten (odd-r/axial, Nachbarn, Distanz, Ring-Iterationen).
 - `hex-mapper/camera.ts`: Verwaltet Map-Viewport, Zoom und Pan-Logik.
 - `hex-mapper/hex-render.ts`: Rendert Hex-Karten in SVG und synchronisiert Füllfarben/Labels.

--- a/src/core/CoreOverview.txt
+++ b/src/core/CoreOverview.txt
@@ -23,7 +23,6 @@ Der Core-Layer bündelt sämtliche fachlichen Services des Plugins, die unabhän
 | `camera.ts` | Fügt SVG-Pan/Zoom-Kontrollen mit Wheel-Gesten und mittlerer Maustaste hinzu. |
 | `hex-notes.ts` | Organisiert Tile-Dateien: liest Optionen, erzeugt Folder/Dateinamen, migriert Legacy-Strukturen, liest/schreibt Frontmatter + Body. Schreibt `smHexTile: true` ins Frontmatter. Bietet High-Level-APIs (`listTilesForMap`, `loadTile`, `saveTile`, `deleteTile`, `initTilesForNewMap`). |
 | `hex-render.ts` | Rendert Hex-Karten in ein SVG, färbt Tiles anhand `TERRAIN_COLORS`, verdrahtet Kamera und User-Interaction (Click-Dispatch, Brush-Drag). Gibt Handles (`setFill`, `ensurePolys`, `destroy`) zur Laufzeitsteuerung zurück. |
-| `hex-map.ts` | Aggregiert Exporte (`parseOptions`, `renderHexMap`, `getAllMapFiles`, `getFirstHexBlock`) als Einstiegsmodul für Renderer/Feature-Layer. |
 
 ## Lebenszyklus & Zusammenspiel
 

--- a/src/core/hex-mapper/hex-map.ts
+++ b/src/core/hex-mapper/hex-map.ts
@@ -1,4 +1,0 @@
-// src/core/hex-mapper/hex-map.ts
-export { parseOptions } from "../options";
-export { renderHexMap } from "./hex-render";
-export { getAllMapFiles, getFirstHexBlock } from "../map-list";


### PR DESCRIPTION
## Summary
- remove the obsolete `hex-map.ts` aggregator from the core hex-mapper module
- refresh PluginOverview and CoreOverview so the structure and responsibilities no longer reference the deleted entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27389cc78832591c1e013eea690a5