### PR TITLE
Refresh spells list dynamically in creature creation modal

### DIFF
--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -33,7 +33,7 @@ src/apps/library/
   - Terrains: legt neuen Eintrag mit Defaultwerten an (`#888888`, `speed: 1`).
   - Regionen: legt neuen Eintrag ohne Terrain/Encounter an.
   - Creatures/Spells: öffnet ein Modal, erzeugt eine `.md`‑Datei im passenden Ordner und öffnet sie im Editor.
-- Creature-Modal gliedert die Eingabe in wiederverwendbare Abschnitte (Core Stats, Einträge, Zauber) für klare Zuständigkeiten.
+- Creature-Modal gliedert die Eingabe in wiederverwendbare Abschnitte (Core Stats, Einträge, Zauber) für klare Zuständigkeiten und aktualisiert die Spell-Auswahl live nach dem Laden der Dateien.
 - Öffnen: Ein Button pro Eintrag öffnet die Quelle (Datei bzw. Sammeldatei) in Obsidian.
 - Live‑Updates: Nutzt Watcher für Ordner/Dateien, um die Liste bei Änderungen neu zu laden.
 
@@ -63,6 +63,7 @@ src/apps/library/
 
 ### `create-modal.ts`
 - Orchestriert den gesamten Creature-Erstellungsfluss: setzt das Modal auf, lädt verfügbare Zauber, mountet die Abschnitts-Module und verarbeitet Bewegung sowie Speichern.
+- Reicht die Zauber-Liste als Getter weiter und stößt nach dem Async-Laden ein Refresh der Spell-Sektion an, damit neue Dateien ohne erneutes Öffnen sichtbar werden.
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
 
 ### `create/section-core-stats.ts`
@@ -74,7 +75,7 @@ src/apps/library/
 - Warum: Die komplexeste Sektion des Modals bleibt isoliert wartbar; Presets und Logik lassen sich hier ergänzen, ohne den Modal-Controller aufzublähen.
 
 ### `create/section-spells-known.ts`
-- Stellt den Zauber-Selector mit Typeahead, Grad/Nutzungsfeldern und Ergebnisliste bereit.
+- Stellt den Zauber-Selector mit Typeahead, Grad/Nutzungsfeldern und Ergebnisliste bereit und liest Treffer bei jedem Rendern per Getter, sodass asynchron geladene Zauber sofort verfügbar sind.
 - Warum: Entkoppelt die Such-/Listenlogik von der Modal-Hülle und ermöglicht Wiederverwendung bzw. gezielte Anpassungen am Spell-UX.
 
 ### `create-spell-modal.ts`

--- a/src/apps/library/create-modal.ts
+++ b/src/apps/library/create-modal.ts
@@ -32,10 +32,12 @@ export class CreateCreatureModal extends Modal {
 
         contentEl.createEl("h3", { text: "Neuen Statblock erstellen" });
         // Asynchron: verfügbare Zauber laden (best effort)
+        let spellsSectionControls: ReturnType<typeof mountSpellsKnownSection> | null = null;
         void (async () => {
             try {
                 const spells = (await listSpellFiles(this.app)).map(f => f.basename).sort((a,b)=>a.localeCompare(b));
                 this.availableSpells.splice(0, this.availableSpells.length, ...spells);
+                spellsSectionControls?.refreshSpellMatches();
             }
             catch {}
         })();
@@ -105,7 +107,7 @@ export class CreateCreatureModal extends Modal {
         mountEntriesSection(contentEl, this.data);
 
         // Known spells section
-        mountSpellsKnownSection(contentEl, this.data, this.availableSpells);
+        spellsSectionControls = mountSpellsKnownSection(contentEl, this.data, () => this.availableSpells);
 
         // Buttons
         new Setting(contentEl)

--- a/src/apps/library/create/section-spells-known.ts
+++ b/src/apps/library/create/section-spells-known.ts
@@ -1,7 +1,11 @@
 // src/apps/library/create/section-spells-known.ts
 import type { StatblockData } from "../core/creature-files";
 
-export function mountSpellsKnownSection(parent: HTMLElement, data: StatblockData, availableSpells: string[]) {
+export function mountSpellsKnownSection(
+  parent: HTMLElement,
+  data: StatblockData,
+  getAvailableSpells: () => readonly string[] | null | undefined,
+) {
   if (!data.spellsKnown) (data as any).spellsKnown = [] as any[];
   const wrap = parent.createDiv({ cls: "setting-item sm-cc-spells" });
   wrap.createDiv({ cls: "setting-item-info", text: "Bekannte Zauber" });
@@ -17,7 +21,9 @@ export function mountSpellsKnownSection(parent: HTMLElement, data: StatblockData
   const renderSpellMenu = () => {
     const q = (spellInput.value || '').toLowerCase();
     spellMenu.empty();
-    const matches = (availableSpells || []).filter(n => !q || n.toLowerCase().includes(q)).slice(0, 24);
+    const matches = (getAvailableSpells()?.slice() || [])
+      .filter(n => !q || n.toLowerCase().includes(q))
+      .slice(0, 24);
     if (matches.length === 0) { spellBox.removeClass('is-open'); return; }
     for (const name of matches) {
       const it = spellMenu.createDiv({ cls: 'sm-preset-item', text: name });
@@ -56,5 +62,13 @@ export function mountSpellsKnownSection(parent: HTMLElement, data: StatblockData
     });
   };
   renderList();
+
+  const refreshSpellMatches = () => {
+    if (document.activeElement === spellInput || spellBox.hasClass('is-open')) {
+      renderSpellMenu();
+    }
+  };
+
+  return { refreshSpellMatches };
 }
 


### PR DESCRIPTION
## Summary
- make the spells-known section read available spells through a getter and expose a refresh helper
- pass a getter from the creature creation modal and refresh the section after asynchronous spell loading
- update the library overview to document the live spell refresh in the modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27535e1c48325a1b89888b816033e