### PR TITLE
Organize library create modals into scoped directories

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -79,8 +79,9 @@ Salt-Marcher/
 - `view.ts`: Zentrale Library-View mit Tab-Leiste (Terrains, Regionen, Kreaturen), Suchleiste, Ergebnisliste und Event-Delegation
   an Bereichs-spezifische Controller.
 - `core/*`: Gemeinsame Logik für Library-Daten (Laden/Speichern der Sammeldateien, Parsing, Suche, Filter, Eventing).
-- `create-modal.ts`: Modal zum Anlegen von Terrains/Regionen mit Validierung und Ergebnis-Rückgabe an den View.
-- `create-spell-modal.ts`: Spezialisierter Dialog zum Erfassen von Zaubern innerhalb einer Kreatur.
+- `create/creature/modal.ts`: Modal zum Anlegen von Creatures; orchestriert die Formular-Sektionen und persistiert neue Statblocks.
+- `create/spell/modal.ts`: Dediziertes Spell-Modal mit Dropdown-Komfort und Markdown-Feldern.
+- `create/index.ts`: Re-exportiert beide Modals, sodass `view.ts` die Create-Flows aus einem Bündel importiert.
 - `create/*`: Komponenten zum Erstellen/Bearbeiten von Library-Einträgen (z. B. Formularbaugruppen, Presets, Helpers).
 - `LibraryOverview.txt`: Struktur- und Verantwortlichkeitsdokument für den Library-Bereich.
 

--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -16,11 +16,16 @@ src/apps/library/
 │  ├─ creature-files.ts     # FS‑Utilities für Creatures (ensure/list/watch/create)
 │  └─ spell-files.ts        # FS‑Utilities für Spells (ensure/list/watch/create)
 ├─ create/
-│  ├─ section-core-stats.ts    # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
-│  ├─ section-entries.ts       # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
-│  └─ section-spells-known.ts  # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
-├─ create-modal.ts          # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
-├─ create-spell-modal.ts    # Modal zum Anlegen von Spells
+│  ├─ creature/
+│  │  ├─ index.ts             # Re-export für externe Zugriffe auf das Creature-Modal
+│  │  └─ modal.ts             # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
+│  ├─ spell/
+│  │  ├─ index.ts             # Re-export für externe Zugriffe auf das Spell-Modal
+│  │  └─ modal.ts             # Modal zum Anlegen von Spells
+│  ├─ index.ts                # Bündelt die Modal-Exporte für `view.ts`
+│  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
+│  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
+│  └─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
 ├─ view.ts                  # Obsidian-View mit Modus‑Tabs, Suche, Liste
 └─ LibraryOverview.txt      # Dieses Dokument
 ```
@@ -33,7 +38,7 @@ src/apps/library/
   - Terrains: legt neuen Eintrag mit Defaultwerten an (`#888888`, `speed: 1`).
   - Regionen: legt neuen Eintrag ohne Terrain/Encounter an.
   - Creatures/Spells: öffnet ein Modal, erzeugt eine `.md`‑Datei im passenden Ordner und öffnet sie im Editor.
-- Creature-Modal zerlegt das Formular in modulare Abschnitte (`create/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Dadurch lassen sich neue Segmente ergänzen, ohne das Modal selbst aufzublähen.
+- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Dadurch lassen sich neue Segmente ergänzen, ohne das Modal selbst aufzublähen.
   - `section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
   - `section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
   - `section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
@@ -64,10 +69,16 @@ src/apps/library/
 - `ensureSpellDir`, `listSpellFiles`, `watchSpellDir`, `createSpellFile`.
 - Analog zu Creatures, eigener Ordner.
 
-### `create-modal.ts`
+### `create/creature/modal.ts`
 - Orchestriert den gesamten Creature-Erstellungsfluss: setzt das Modal auf, lädt verfügbare Zauber, mountet die Abschnitts-Module und verarbeitet Bewegung sowie Speichern.
 - Reicht die Zauber-Liste als Getter weiter und stößt nach dem Async-Laden ein Refresh der Spell-Sektion an, damit neue Dateien ohne erneutes Öffnen sichtbar werden.
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
+
+### `create/creature/index.ts`
+- Re-exportiert das Modal für externe Consumer. Dadurch bleibt die Pfadstruktur (`create/creature/modal`) intern, während Aufrufer (`view.ts`) nur `create/creature` adressieren müssen.
+
+### `create/index.ts`
+- Fasst die Modal-Exports (`CreateCreatureModal`, `CreateSpellModal`) zusammen. `view.ts` bindet beide über einen Import, was Importketten vereinfacht und die Ordnerstruktur vor Außenstehenden kapselt.
 
 ### `create/section-core-stats.ts`
 - Rendert Identität, Kernwerte, Saves/Skills sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
@@ -81,9 +92,12 @@ src/apps/library/
 - Stellt den Zauber-Selector mit Typeahead, Grad/Nutzungsfeldern und Ergebnisliste bereit und liest Treffer bei jedem Rendern per Getter, sodass asynchron geladene Zauber sofort verfügbar sind.
 - Warum: Entkoppelt die Such-/Listenlogik von der Modal-Hülle und ermöglicht Wiederverwendung bzw. gezielte Anpassungen am Spell-UX. Die Sektion reagiert auf Refresh-Signale des Modals, sobald neue Spell-Dateien auftauchen.
 
-### `create-spell-modal.ts`
+### `create/spell/modal.ts`
 - Modal zum Anlegen neuer Zauberdateien mit Komfortfeldern und direktem Aufruf von `createSpellFile`.
 - Warum: Dedizierte UI für Spell-Erstellung; bleibt unabhängig vom Creature-Flow.
+
+### `create/spell/index.ts`
+- Exportiert `CreateSpellModal` mit kurzem Pfad und erlaubt konsistente Aggregation über `create/index.ts`.
 
 ## Interaktion mit Core & UI
 

--- a/src/apps/library/create/creature/index.ts
+++ b/src/apps/library/create/creature/index.ts
@@ -1,0 +1,2 @@
+// src/apps/library/create/creature/index.ts
+export { CreateCreatureModal } from "./modal";

--- a/src/apps/library/create/creature/modal.ts
+++ b/src/apps/library/create/creature/modal.ts
@@ -1,11 +1,11 @@
-// src/apps/library/create-modal.ts
+// src/apps/library/create/creature/modal.ts
 import { App, Modal, Setting } from "obsidian";
-import type { StatblockData } from "./core/creature-files";
-import { listSpellFiles } from "./core/spell-files";
-import { enhanceSelectToSearch } from "../../ui/search-dropdown";
-import { mountCoreStatsSection } from "./create/section-core-stats";
-import { mountEntriesSection } from "./create/section-entries";
-import { mountSpellsKnownSection } from "./create/section-spells-known";
+import type { StatblockData } from "../../core/creature-files";
+import { listSpellFiles } from "../../core/spell-files";
+import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
+import { mountCoreStatsSection } from "../section-core-stats";
+import { mountEntriesSection } from "../section-entries";
+import { mountSpellsKnownSection } from "../section-spells-known";
 
 export class CreateCreatureModal extends Modal {
     private data: StatblockData;

--- a/src/apps/library/create/index.ts
+++ b/src/apps/library/create/index.ts
@@ -1,0 +1,3 @@
+// src/apps/library/create/index.ts
+export { CreateCreatureModal } from "./creature";
+export { CreateSpellModal } from "./spell";

--- a/src/apps/library/create/spell/index.ts
+++ b/src/apps/library/create/spell/index.ts
@@ -1,0 +1,2 @@
+// src/apps/library/create/spell/index.ts
+export { CreateSpellModal } from "./modal";

--- a/src/apps/library/create/spell/modal.ts
+++ b/src/apps/library/create/spell/modal.ts
@@ -1,7 +1,7 @@
-// src/apps/library/create-spell-modal.ts
+// src/apps/library/create/spell/modal.ts
 import { App, Modal, Setting } from "obsidian";
-import { enhanceSelectToSearch } from "../../ui/search-dropdown";
-import type { SpellData } from "./core/spell-files";
+import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
+import type { SpellData } from "../../core/spell-files";
 
 export class CreateSpellModal extends Modal {
     private data: SpellData;

--- a/src/apps/library/view.ts
+++ b/src/apps/library/view.ts
@@ -4,9 +4,8 @@ import { ensureCreatureDir, listCreatureFiles, watchCreatureDir, createCreatureF
 import { enhanceSelectToSearch } from "../../ui/search-dropdown";
 import { ensureTerrainFile, loadTerrains, saveTerrains, watchTerrains, TERRAIN_FILE } from "../../core/terrain-store";
 import { ensureRegionsFile, loadRegions, saveRegions, watchRegions, REGIONS_FILE, type Region } from "../../core/regions-store";
-import { CreateCreatureModal } from "./create-modal";
 import { ensureSpellDir, listSpellFiles, watchSpellDir, createSpellFile } from "./core/spell-files";
-import { CreateSpellModal } from "./create-spell-modal";
+import { CreateCreatureModal, CreateSpellModal } from "./create";
 
 export const VIEW_LIBRARY = "salt-library";
 


### PR DESCRIPTION
## Summary
- move the creature and spell creation modals into dedicated subfolders with updated relative imports
- add index re-exports for the create module and point the library view at the new entry points
- refresh the library and plugin overview documentation to match the new folder structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2784a6440832587ab6f2c1c5dbc6d