### PR TITLE
feat(library): extract shared token editor

### DIFF
--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -25,7 +25,9 @@ src/apps/library/
 │  ├─ index.ts                # Bündelt die Modal-Exporte für `view.ts`
 │  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
 │  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
-│  └─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
+│  ├─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
+│  └─ shared/
+│     └─ token-editor.ts      # Gemeinsame Token-Editor-Utility für Chips-Eingaben
 ├─ view.ts                  # Obsidian-View mit Modus‑Tabs, Suche, Liste
 └─ LibraryOverview.txt      # Dieses Dokument
 ```
@@ -82,6 +84,7 @@ src/apps/library/
 
 ### `create/section-core-stats.ts`
 - Rendert Identität, Kernwerte, Saves/Skills sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
+- Nutzt den gemeinsamen Token-Editor (`shared/token-editor`) für Sinne/Sprachen, damit Chips-UX und Add/Remove-Verhalten identisch mit anderen Formularteilen bleibt.
 - Warum: Bündelt alle abhängigen Formeln (z. B. PB, Ability Mods) und sorgt dafür, dass Änderungen an Attributen sofort in allen Feldern sichtbar werden.
 
 ### `create/section-entries.ts`
@@ -94,7 +97,12 @@ src/apps/library/
 
 ### `create/spell/modal.ts`
 - Modal zum Anlegen neuer Zauberdateien mit Komfortfeldern und direktem Aufruf von `createSpellFile`.
+- Verwendet `shared/token-editor`, um die Klassenliste als Chip-Liste zu bearbeiten und dieselbe UX wie in Creature-Abschnitten zu bieten.
 - Warum: Dedizierte UI für Spell-Erstellung; bleibt unabhängig vom Creature-Flow.
+
+### `create/shared/token-editor.ts`
+- Kapselt Setting-Aufbau, Input-Handling und Chip-Rendering für freie Listen (z. B. Klassen, Sinne, Sprachen).
+- Bietet optionale Add/Remove-Callbacks und einen Refresh-Hook, um konsistente Token-Editoren in allen Formularen zu gewährleisten.
 
 ### `create/spell/index.ts`
 - Exportiert `CreateSpellModal` mit kurzem Pfad und erlaubt konsistente Aggregation über `create/index.ts`.

--- a/src/apps/library/create/section-core-stats.ts
+++ b/src/apps/library/create/section-core-stats.ts
@@ -1,6 +1,7 @@
 // src/apps/library/create/section-core-stats.ts
 import { Setting } from "obsidian";
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
+import { mountTokenEditor } from "./shared/token-editor";
 import type { StatblockData } from "../core/creature-files";
 
 export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) {
@@ -167,30 +168,17 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   };
   updateMods();
 
-  // Senses & Languages token editors
-  const makeTokenEditor = (host: HTMLElement, title: string, items: () => string[], onAdd: (v: string) => void, onRemove: (i: number) => void) => {
-    new Setting(host).setName(title).addText((t) => {
-      t.setPlaceholder("Begriff eingeben…");
-      const input = t.inputEl;
-      t.inputEl.style.minWidth = '260px';
-      t.inputEl.addEventListener('keydown', (e: KeyboardEvent) => { if (e.key === 'Enter') { const v = input.value.trim(); if (v) { onAdd(v); input.value = ''; renderChips(); } }});
-    }).addButton((b) => b.setButtonText("+").onClick(() => { const inp = b.buttonEl.parentElement?.querySelector('input') as HTMLInputElement | null; const v = inp?.value?.trim(); if (v) { onAdd(v); inp.value=''; renderChips(); } }));
-    const chips = host.createDiv({ cls: 'sm-cc-chips' });
-    const renderChips = () => {
-      chips.empty();
-      items().forEach((txt, i) => {
-        const chip = chips.createDiv({ cls: 'sm-cc-chip' });
-        chip.createSpan({ text: txt });
-        const x = chip.createEl('button', { text: '×' });
-        x.onclick = () => { onRemove(i); renderChips(); };
-      });
-    };
-    renderChips();
-  };
-
   if (!data.sensesList) data.sensesList = [];
   if (!data.languagesList) data.languagesList = [];
-  makeTokenEditor(root, "Sinne", () => data.sensesList!, (v) => data.sensesList!.push(v), (i) => data.sensesList!.splice(i, 1));
-  makeTokenEditor(root, "Sprachen", () => data.languagesList!, (v) => data.languagesList!.push(v), (i) => data.languagesList!.splice(i, 1));
+  mountTokenEditor(root, "Sinne", {
+    getItems: () => data.sensesList!,
+    add: (value) => data.sensesList!.push(value),
+    remove: (index) => data.sensesList!.splice(index, 1),
+  });
+  mountTokenEditor(root, "Sprachen", {
+    getItems: () => data.languagesList!,
+    add: (value) => data.languagesList!.push(value),
+    remove: (index) => data.languagesList!.splice(index, 1),
+  });
 }
 

--- a/src/apps/library/create/shared/token-editor.ts
+++ b/src/apps/library/create/shared/token-editor.ts
@@ -1,0 +1,87 @@
+// src/apps/library/create/shared/token-editor.ts
+import { Setting } from "obsidian";
+
+export interface TokenEditorModel {
+  getItems(): string[];
+  add(value: string): void;
+  remove(index: number): void;
+}
+
+export interface TokenEditorCallbacks {
+  onAdd?: (value: string) => void;
+  onRemove?: (value: string, index: number) => void;
+}
+
+export interface TokenEditorOptions extends TokenEditorCallbacks {
+  placeholder?: string;
+  addButtonLabel?: string;
+}
+
+export interface TokenEditorHandle {
+  setting: Setting;
+  chipsEl: HTMLElement;
+  refresh: () => void;
+}
+
+export function mountTokenEditor(
+  parent: HTMLElement,
+  title: string,
+  model: TokenEditorModel,
+  options: TokenEditorOptions = {}
+): TokenEditorHandle {
+  const placeholder = options.placeholder ?? "Begriff eingeben…";
+  const addLabel = options.addButtonLabel ?? "+";
+
+  const setting = new Setting(parent).setName(title);
+  let inputEl: HTMLInputElement | undefined;
+  let renderChips: () => void = () => {};
+
+  const commitValue = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    model.add(trimmed);
+    options.onAdd?.(trimmed);
+    renderChips();
+  };
+
+  setting.addText((t) => {
+    t.setPlaceholder(placeholder);
+    inputEl = t.inputEl;
+    t.inputEl.style.minWidth = "260px";
+    t.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        commitValue((inputEl?.value ?? "").trim());
+        if (inputEl) inputEl.value = "";
+      }
+    });
+  });
+
+  setting.addButton((b) =>
+    b
+      .setButtonText(addLabel)
+      .onClick(() => {
+        commitValue((inputEl?.value ?? "").trim());
+        if (inputEl) inputEl.value = "";
+      })
+  );
+
+  const chips = parent.createDiv({ cls: "sm-cc-chips" });
+  renderChips = () => {
+    chips.empty();
+    const items = model.getItems();
+    items.forEach((txt, index) => {
+      const chip = chips.createDiv({ cls: "sm-cc-chip" });
+      chip.createSpan({ text: txt });
+      const removeBtn = chip.createEl("button", { text: "×" });
+      removeBtn.onclick = () => {
+        model.remove(index);
+        options.onRemove?.(txt, index);
+        renderChips();
+      };
+    });
+  };
+
+  renderChips();
+
+  return { setting, chipsEl: chips, refresh: renderChips };
+}

--- a/src/apps/library/create/spell/modal.ts
+++ b/src/apps/library/create/spell/modal.ts
@@ -1,6 +1,7 @@
 // src/apps/library/create/spell/modal.ts
 import { App, Modal, Setting } from "obsidian";
 import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
+import { mountTokenEditor } from "../shared/token-editor";
 import type { SpellData } from "../../core/spell-files";
 
 export class CreateSpellModal extends Modal {
@@ -92,7 +93,11 @@ export class CreateSpellModal extends Modal {
 
         // Classes (as chips)
         if (!this.data.classes) this.data.classes = [];
-        this.makeTokenEditor(contentEl, "Klassen", (v) => this.data.classes!.push(v), () => this.data.classes!, (i) => this.data.classes!.splice(i,1));
+        mountTokenEditor(contentEl, "Klassen", {
+            getItems: () => this.data.classes!,
+            add: (value) => this.data.classes!.push(value),
+            remove: (index) => this.data.classes!.splice(index, 1),
+        });
 
         // Text
         this.addTextArea(contentEl, "Beschreibung", "Beschreibung (Markdown)", v => this.data.description = v);
@@ -113,30 +118,6 @@ export class CreateSpellModal extends Modal {
         const ctl = wrap.createDiv({ cls: "setting-item-control" });
         const ta = ctl.createEl("textarea", { attr: { placeholder } });
         ta.addEventListener("input", () => onChange(ta.value));
-    }
-
-    private makeTokenEditor(parent: HTMLElement, title: string, onAdd: (v: string) => void, itemsProvider: () => string[], onRemove: (idx: number) => void) {
-        new Setting(parent).setName(title).addText(t => {
-            t.setPlaceholder("Begriff eingeben…");
-            // @ts-ignore
-            const input = (t as any).inputEl as HTMLInputElement;
-            t.inputEl.style.minWidth = '260px';
-            t.inputEl.addEventListener('keydown', (e: KeyboardEvent) => {
-                if (e.key === 'Enter') { const v = input.value.trim(); if (v) { onAdd(v); input.value = ''; renderChips(); } }
-            });
-        }).addButton(b => b.setButtonText("+").onClick(() => { const inp = (b.buttonEl.parentElement?.querySelector('input') as HTMLInputElement); const v = inp?.value?.trim(); if (v) { onAdd(v); inp.value=''; renderChips(); } }));
-        const chips = parent.createDiv({ cls: 'sm-cc-chips' });
-        const renderChips = () => {
-            chips.empty();
-            const items = itemsProvider();
-            items.forEach((txt, i) => {
-                const chip = chips.createDiv({ cls: 'sm-cc-chip' });
-                chip.createSpan({ text: txt });
-                const x = chip.createEl('button', { text: '×' });
-                x.onclick = () => { onRemove(i); renderChips(); };
-            });
-        };
-        renderChips();
     }
 
     private submit() {


### PR DESCRIPTION
## Summary
- add a shared token-editor utility that encapsulates setting + chip rendering with optional callbacks
- reuse the helper for spell class chips and the creature senses/language editors to keep UX consistent
- document the shared helper in the library overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d279af66748325ab9b675dee5c1a01