### PR TITLE
refactor: share stat helpers across creature sections

### DIFF
--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -27,6 +27,7 @@ src/apps/library/
 │  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
 │  ├─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
 │  └─ shared/
+│     ├─ stat-utils.ts        # Gemeinsame Berechnungshelfer für Ability-Mods & Vorzeichenformatierung
 │     └─ token-editor.ts      # Gemeinsame Token-Editor-Utility für Chips-Eingaben
 ├─ view.ts                  # Obsidian-View mit Modus‑Tabs, Suche, Liste
 └─ LibraryOverview.txt      # Dieses Dokument
@@ -44,6 +45,7 @@ src/apps/library/
   - `section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
   - `section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
   - `section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
+- Geteilte Stat-Utilities (`create/shared/stat-utils.ts`) bündeln Parsing, Modifikator-Logik und Vorzeichenformatierung für alle Abschnitte – nutzbar auch für zukünftige Modals (z. B. Items oder NPC-Varianten).
 - Öffnen: Ein Button pro Eintrag öffnet die Quelle (Datei bzw. Sammeldatei) in Obsidian.
 - Live‑Updates: Nutzt Watcher für Ordner/Dateien, um die Liste bei Änderungen neu zu laden.
 
@@ -85,15 +87,22 @@ src/apps/library/
 ### `create/section-core-stats.ts`
 - Rendert Identität, Kernwerte, Saves/Skills sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
 - Nutzt den gemeinsamen Token-Editor (`shared/token-editor`) für Sinne/Sprachen, damit Chips-UX und Add/Remove-Verhalten identisch mit anderen Formularteilen bleibt.
+- Zieht Berechnungshelfer (`shared/stat-utils`) für Ability-Modifikatoren und Vorzeichenformatierung heran, sodass dieselben Regeln wie in Eintragssektionen gelten.
 - Warum: Bündelt alle abhängigen Formeln (z. B. PB, Ability Mods) und sorgt dafür, dass Änderungen an Attributen sofort in allen Feldern sichtbar werden.
 
 ### `create/section-entries.ts`
 - Verwaltet Trait/Aktion/Legendär-Einträge inkl. Preset-Formeln, Auto-Berechnung von Treffer- und Schadenswerten sowie zusätzlichen Feldern (Saves, Recharge, Text).
+- Greift auf `shared/stat-utils` zurück, um Treffer- und Schadenswerte konsistent mit den Kernwerten zu berechnen.
 - Warum: Die komplexeste Sektion des Modals bleibt isoliert wartbar; Presets und Logik lassen sich hier ergänzen, ohne den Modal-Controller aufzublähen. Unterstützt Rückmeldungen an das Modal (z. B. Dirty-State), ohne dass andere Abschnitte davon beeinflusst werden.
 
 ### `create/section-spells-known.ts`
 - Stellt den Zauber-Selector mit Typeahead, Grad/Nutzungsfeldern und Ergebnisliste bereit und liest Treffer bei jedem Rendern per Getter, sodass asynchron geladene Zauber sofort verfügbar sind.
 - Warum: Entkoppelt die Such-/Listenlogik von der Modal-Hülle und ermöglicht Wiederverwendung bzw. gezielte Anpassungen am Spell-UX. Die Sektion reagiert auf Refresh-Signale des Modals, sobald neue Spell-Dateien auftauchen.
+
+### `create/shared/stat-utils.ts`
+- Fasst `parseIntSafe`, `abilityMod` und `formatSigned` zusammen, damit UI-Sektionen identische Rechenregeln verwenden.
+- Geeignet für weitere Modals (z. B. Item- oder NPC-Editoren), die Trefferwürfe, Saves oder Schadensformeln automatisch ableiten möchten.
+- Warum: Reduziert Duplikate, verhindert auseinanderlaufende Formeln und erleichtert Tests für gemeinsames Verhalten.
 
 ### `create/spell/modal.ts`
 - Modal zum Anlegen neuer Zauberdateien mit Komfortfeldern und direktem Aufruf von `createSpellFile`.

--- a/src/apps/library/create/section-core-stats.ts
+++ b/src/apps/library/create/section-core-stats.ts
@@ -2,6 +2,7 @@
 import { Setting } from "obsidian";
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import { mountTokenEditor } from "./shared/token-editor";
+import { abilityMod, formatSigned, parseIntSafe } from "./shared/stat-utils";
 import type { StatblockData } from "../core/creature-files";
 
 export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) {
@@ -68,10 +69,6 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const statsTbl = abilitySection.createDiv({ cls: "sm-cc-table sm-cc-stats-table" });
   const header = statsTbl.createDiv({ cls: "sm-cc-row sm-cc-header" });
   ;["Name","Wert","Mod","Save","Save Mod"].forEach(h => header.createDiv({ cls: "sm-cc-cell", text: h }));
-
-  const parseIntSafe = (v?: string) => { const m = String(v ?? '').match(/-?\d+/); return m ? parseInt(m[0], 10) : NaN; };
-  const abilityMod = (score?: string) => { const n = parseIntSafe(score); if (Number.isNaN(n)) return 0; return Math.floor((n - 10) / 2); };
-  const fmt = (n: number) => (n>=0?'+':'')+n;
 
   const abDefs = [
     { key: 'str', label: 'STR' }, { key: 'dex', label: 'DEX' }, { key: 'con', label: 'CON' },
@@ -156,14 +153,14 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
     const pb = parseIntSafe(data.pb as any) || 0;
     for (const [key, refs] of abilityElems) {
       const mod = abilityMod((data as any)[key]);
-      refs.mod.textContent = fmt(mod);
+      refs.mod.textContent = formatSigned(mod);
       const saveBonus = (data.saveProf as any)?.[key] ? pb : 0;
-      refs.saveMod.textContent = fmt(mod + saveBonus);
+      refs.saveMod.textContent = formatSigned(mod + saveBonus);
     }
     for (const sk of skillElems) {
       const mod = abilityMod((data as any)[sk.ability]);
       const bonus = sk.exp.checked ? pb * 2 : sk.prof.checked ? pb : 0;
-      sk.out.textContent = fmt(mod + bonus);
+      sk.out.textContent = formatSigned(mod + bonus);
     }
   };
   updateMods();

--- a/src/apps/library/create/section-entries.ts
+++ b/src/apps/library/create/section-entries.ts
@@ -1,6 +1,7 @@
 // src/apps/library/create/section-entries.ts
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import type { StatblockData } from "../core/creature-files";
+import { abilityMod, formatSigned, parseIntSafe } from "./shared/stat-utils";
 
 export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
   if (!data.entries) data.entries = [] as any;
@@ -49,10 +50,6 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
       tgt.value = e.target || ""; tgt.oninput = () => e.target = tgt.value.trim() || undefined; (tgt.style as any).width = '16ch';
 
       // Auto-compute helpers
-      const parseIntSafe = (v?: string) => { const m = String(v ?? '').match(/-?\d+/); return m ? parseInt(m[0], 10) : NaN; };
-      const abilityMod = (score?: string) => { const n = parseIntSafe(score); if (Number.isNaN(n)) return 0; return Math.floor((n - 10) / 2); };
-      const fmt = (n: number) => (n>=0?'+':'')+n;
-
       const autoRow = box.createDiv({ cls: "sm-cc-auto" });
       const hitGroup = autoRow.createDiv({ cls: 'sm-auto-group' });
       hitGroup.createSpan({ text: 'To hit:' });
@@ -79,13 +76,13 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
           const abil = e.to_hit_from.ability as any;
           const abilMod = abil === 'best_of_str_dex' ? Math.max(abilityMod(data.str as any), abilityMod(data.dex as any)) : abilityMod((data as any)[abil]);
           const total = abilMod + (e.to_hit_from.proficient ? pb : 0);
-          e.to_hit = fmt(total); hit.value = e.to_hit;
+          e.to_hit = formatSigned(total); hit.value = e.to_hit;
         }
         if (e.damage_from) {
           const abil = e.damage_from.ability as any;
           const abilMod = abil ? (abil === 'best_of_str_dex' ? Math.max(abilityMod(data.str as any), abilityMod(data.dex as any)) : abilityMod((data as any)[abil])) : 0;
           const base = e.damage_from.dice;
-          const tail = (abilMod ? ` ${fmt(abilMod)}` : '') + (e.damage_from.bonus ? ` ${e.damage_from.bonus}` : '');
+          const tail = (abilMod ? ` ${formatSigned(abilMod)}` : '') + (e.damage_from.bonus ? ` ${e.damage_from.bonus}` : '');
           e.damage = `${base}${tail}`.trim(); dmg.value = e.damage;
         }
       };

--- a/src/apps/library/create/shared/stat-utils.ts
+++ b/src/apps/library/create/shared/stat-utils.ts
@@ -1,0 +1,31 @@
+// src/apps/library/create/shared/stat-utils.ts
+// Gemeinsame Hilfsfunktionen für Ability-Scores und formatierte Ausgaben.
+
+/**
+ * Extrahiert die erste ganzzahlige Zahl aus dem gegebenen Wert.
+ * Unterstützt Strings mit eingebetteten Zahlen (z.\u00a0B. "1d8 + 4").
+ */
+export function parseIntSafe(value?: string | number | null): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.trunc(value) : NaN;
+  }
+  const match = String(value ?? "").match(/-?\d+/);
+  return match ? parseInt(match[0], 10) : NaN;
+}
+
+/**
+ * Berechnet den Ability-Modifikator f\u00fcr einen gegebenen Score.
+ * Nicht parsebare Werte liefern `0`, um UI-Updates robust zu halten.
+ */
+export function abilityMod(score?: string | number | null): number {
+  const numeric = typeof score === "number" ? score : parseIntSafe(score);
+  if (Number.isNaN(numeric)) return 0;
+  return Math.floor((numeric - 10) / 2);
+}
+
+/**
+ * Formatiert eine Zahl mit explizitem Vorzeichen (z.\u00a0B. `+3` oder `-1`).
+ */
+export function formatSigned(value: number): string {
+  return `${value >= 0 ? "+" : ""}${value}`;
+}


### PR DESCRIPTION
## Summary
- add `stat-utils` module with shared parsing and formatting helpers
- replace duplicated helper logic in core stats and entry sections with the shared utilities
- document the reusable helpers in `LibraryOverview.txt` for future modal reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27acbd61883258b8f594d5b49218e