### PR TITLE
Move creature creation sections into creature namespace

### DIFF
--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -17,15 +17,15 @@ src/apps/library/
 │  └─ spell-files.ts        # FS‑Utilities für Spells (ensure/list/watch/create)
 ├─ create/
 │  ├─ creature/
-│  │  ├─ index.ts             # Re-export für externe Zugriffe auf das Creature-Modal
-│  │  └─ modal.ts             # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
+│  │  ├─ index.ts             # Re-exports Modal & Creature-Sections für externe Zugriffe
+│  │  ├─ modal.ts             # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
+│  │  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
+│  │  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
+│  │  └─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
 │  ├─ spell/
 │  │  ├─ index.ts             # Re-export für externe Zugriffe auf das Spell-Modal
 │  │  └─ modal.ts             # Modal zum Anlegen von Spells
 │  ├─ index.ts                # Bündelt die Modal-Exporte für `view.ts`
-│  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
-│  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
-│  ├─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
 │  └─ shared/
 │     ├─ stat-utils.ts        # Gemeinsame Berechnungshelfer für Ability-Mods & Vorzeichenformatierung
 │     └─ token-editor.ts      # Gemeinsame Token-Editor-Utility für Chips-Eingaben
@@ -41,10 +41,10 @@ src/apps/library/
   - Terrains: legt neuen Eintrag mit Defaultwerten an (`#888888`, `speed: 1`).
   - Regionen: legt neuen Eintrag ohne Terrain/Encounter an.
   - Creatures/Spells: öffnet ein Modal, erzeugt eine `.md`‑Datei im passenden Ordner und öffnet sie im Editor.
-- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Dadurch lassen sich neue Segmente ergänzen, ohne das Modal selbst aufzublähen.
-  - `section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
-  - `section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
-  - `section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
+- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/creature/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Dadurch lassen sich neue Segmente ergänzen, ohne das Modal selbst aufzublähen.
+  - `creature/section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
+  - `creature/section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
+  - `creature/section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
 - Geteilte Stat-Utilities (`create/shared/stat-utils.ts`) bündeln Parsing, Modifikator-Logik und Vorzeichenformatierung für alle Abschnitte – nutzbar auch für zukünftige Modals (z. B. Items oder NPC-Varianten).
 - Öffnen: Ein Button pro Eintrag öffnet die Quelle (Datei bzw. Sammeldatei) in Obsidian.
 - Live‑Updates: Nutzt Watcher für Ordner/Dateien, um die Liste bei Änderungen neu zu laden.
@@ -79,23 +79,23 @@ src/apps/library/
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
 
 ### `create/creature/index.ts`
-- Re-exportiert das Modal für externe Consumer. Dadurch bleibt die Pfadstruktur (`create/creature/modal`) intern, während Aufrufer (`view.ts`) nur `create/creature` adressieren müssen.
+- Re-exportiert das Modal sowie die Creature-Sections für externe Consumer. Dadurch bleibt die Pfadstruktur (`create/creature/modal` & `create/creature/section-*`) intern, während Aufrufer (`view.ts` oder Tests) nur `create/creature` adressieren müssen.
 
 ### `create/index.ts`
 - Fasst die Modal-Exports (`CreateCreatureModal`, `CreateSpellModal`) zusammen. `view.ts` bindet beide über einen Import, was Importketten vereinfacht und die Ordnerstruktur vor Außenstehenden kapselt.
 
-### `create/section-core-stats.ts`
+### `create/creature/section-core-stats.ts`
 - Rendert Identität, Kernwerte, Saves/Skills sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
 - Nutzt den gemeinsamen Token-Editor (`shared/token-editor`) für Sinne/Sprachen, damit Chips-UX und Add/Remove-Verhalten identisch mit anderen Formularteilen bleibt.
 - Zieht Berechnungshelfer (`shared/stat-utils`) für Ability-Modifikatoren und Vorzeichenformatierung heran, sodass dieselben Regeln wie in Eintragssektionen gelten.
 - Warum: Bündelt alle abhängigen Formeln (z. B. PB, Ability Mods) und sorgt dafür, dass Änderungen an Attributen sofort in allen Feldern sichtbar werden.
 
-### `create/section-entries.ts`
+### `create/creature/section-entries.ts`
 - Verwaltet Trait/Aktion/Legendär-Einträge inkl. Preset-Formeln, Auto-Berechnung von Treffer- und Schadenswerten sowie zusätzlichen Feldern (Saves, Recharge, Text).
 - Greift auf `shared/stat-utils` zurück, um Treffer- und Schadenswerte konsistent mit den Kernwerten zu berechnen.
 - Warum: Die komplexeste Sektion des Modals bleibt isoliert wartbar; Presets und Logik lassen sich hier ergänzen, ohne den Modal-Controller aufzublähen. Unterstützt Rückmeldungen an das Modal (z. B. Dirty-State), ohne dass andere Abschnitte davon beeinflusst werden.
 
-### `create/section-spells-known.ts`
+### `create/creature/section-spells-known.ts`
 - Stellt den Zauber-Selector mit Typeahead, Grad/Nutzungsfeldern und Ergebnisliste bereit und liest Treffer bei jedem Rendern per Getter, sodass asynchron geladene Zauber sofort verfügbar sind.
 - Warum: Entkoppelt die Such-/Listenlogik von der Modal-Hülle und ermöglicht Wiederverwendung bzw. gezielte Anpassungen am Spell-UX. Die Sektion reagiert auf Refresh-Signale des Modals, sobald neue Spell-Dateien auftauchen.
 

--- a/src/apps/library/create/creature/index.ts
+++ b/src/apps/library/create/creature/index.ts
@@ -1,2 +1,5 @@
 // src/apps/library/create/creature/index.ts
 export { CreateCreatureModal } from "./modal";
+export { mountCoreStatsSection } from "./section-core-stats";
+export { mountEntriesSection } from "./section-entries";
+export { mountSpellsKnownSection } from "./section-spells-known";

--- a/src/apps/library/create/creature/modal.ts
+++ b/src/apps/library/create/creature/modal.ts
@@ -3,9 +3,9 @@ import { App, Modal, Setting } from "obsidian";
 import type { StatblockData } from "../../core/creature-files";
 import { listSpellFiles } from "../../core/spell-files";
 import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
-import { mountCoreStatsSection } from "../section-core-stats";
-import { mountEntriesSection } from "../section-entries";
-import { mountSpellsKnownSection } from "../section-spells-known";
+import { mountCoreStatsSection } from "./section-core-stats";
+import { mountEntriesSection } from "./section-entries";
+import { mountSpellsKnownSection } from "./section-spells-known";
 
 export class CreateCreatureModal extends Modal {
     private data: StatblockData;

--- a/src/apps/library/create/creature/section-core-stats.ts
+++ b/src/apps/library/create/creature/section-core-stats.ts
@@ -1,9 +1,9 @@
-// src/apps/library/create/section-core-stats.ts
+// src/apps/library/create/creature/section-core-stats.ts
 import { Setting } from "obsidian";
-import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
-import { mountTokenEditor } from "./shared/token-editor";
-import { abilityMod, formatSigned, parseIntSafe } from "./shared/stat-utils";
-import type { StatblockData } from "../core/creature-files";
+import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
+import { mountTokenEditor } from "../shared/token-editor";
+import { abilityMod, formatSigned, parseIntSafe } from "../shared/stat-utils";
+import type { StatblockData } from "../../core/creature-files";
 
 export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) {
   const root = parent.createDiv();

--- a/src/apps/library/create/creature/section-entries.ts
+++ b/src/apps/library/create/creature/section-entries.ts
@@ -1,7 +1,7 @@
-// src/apps/library/create/section-entries.ts
-import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
-import type { StatblockData } from "../core/creature-files";
-import { abilityMod, formatSigned, parseIntSafe } from "./shared/stat-utils";
+// src/apps/library/create/creature/section-entries.ts
+import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
+import type { StatblockData } from "../../core/creature-files";
+import { abilityMod, formatSigned, parseIntSafe } from "../shared/stat-utils";
 
 export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
   if (!data.entries) data.entries = [] as any;

--- a/src/apps/library/create/creature/section-spells-known.ts
+++ b/src/apps/library/create/creature/section-spells-known.ts
@@ -1,5 +1,5 @@
-// src/apps/library/create/section-spells-known.ts
-import type { StatblockData } from "../core/creature-files";
+// src/apps/library/create/creature/section-spells-known.ts
+import type { StatblockData } from "../../core/creature-files";
 
 export function mountSpellsKnownSection(
   parent: HTMLElement,


### PR DESCRIPTION
## Summary
- relocate the creature creation sections into the creature namespace and fix relative imports
- re-export the creature section mount helpers via the creature index for easier downstream usage
- refresh LibraryOverview to match the new create/creature structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27d0b96148325aa009d01a29f8d73