### PR TITLE
Centralize creature creation presets

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -80,6 +80,7 @@ Salt-Marcher/
   an Bereichs-spezifische Controller.
 - `core/*`: Gemeinsame Logik für Library-Daten (Laden/Speichern der Sammeldateien, Parsing, Suche, Filter, Eventing).
 - `create/creature/modal.ts`: Modal zum Anlegen von Creatures; orchestriert die Formular-Sektionen und persistiert neue Statblocks.
+- `create/creature/presets.ts`: Zentraler Pool an Konstanten & Typen für Creature-Dropdowns (Größe, Typ, Gesinnung, Skills, Bewegungen).
 - `create/spell/modal.ts`: Dediziertes Spell-Modal mit Dropdown-Komfort und Markdown-Feldern.
 - `create/index.ts`: Re-exportiert beide Modals, sodass `view.ts` die Create-Flows aus einem Bündel importiert.
 - `create/*`: Komponenten zum Erstellen/Bearbeiten von Library-Einträgen (z. B. Formularbaugruppen, Presets, Helpers).

--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -19,6 +19,7 @@ src/apps/library/
 │  ├─ creature/
 │  │  ├─ index.ts             # Re-exports Modal & Creature-Sections für externe Zugriffe
 │  │  ├─ modal.ts             # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
+│  │  ├─ presets.ts           # Zentralisierte Auswahllisten (Größe, Typ, Skills, Bewegungen …)
 │  │  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
 │  │  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
 │  │  └─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
@@ -41,7 +42,7 @@ src/apps/library/
   - Terrains: legt neuen Eintrag mit Defaultwerten an (`#888888`, `speed: 1`).
   - Regionen: legt neuen Eintrag ohne Terrain/Encounter an.
   - Creatures/Spells: öffnet ein Modal, erzeugt eine `.md`‑Datei im passenden Ordner und öffnet sie im Editor.
-- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/creature/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Dadurch lassen sich neue Segmente ergänzen, ohne das Modal selbst aufzublähen.
+- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/creature/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Gemeinsame Optionslisten (Größen, Typen, Gesinnung, Skills, Bewegungsarten) werden aus `create/creature/presets.ts` gespeist, sodass alle Segmente denselben Kanon verwenden.
   - `creature/section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
   - `creature/section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
   - `creature/section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
@@ -77,6 +78,10 @@ src/apps/library/
 - Orchestriert den gesamten Creature-Erstellungsfluss: setzt das Modal auf, lädt verfügbare Zauber, mountet die Abschnitts-Module und verarbeitet Bewegung sowie Speichern.
 - Reicht die Zauber-Liste als Getter weiter und stößt nach dem Async-Laden ein Refresh der Spell-Sektion an, damit neue Dateien ohne erneutes Öffnen sichtbar werden.
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
+
+### `create/creature/presets.ts`
+- Kapselt alle Konstanten/Typen für Dropdowns und Automatisierungen (Größen, Typen, Gesinnungsteile, Ability-Definitionen, Skill-Mappings, Entry-Kategorien, Bewegungsarten).
+- Warum: Statt mehrfacher Inline-Listen verwenden alle Sektionen dieselben Presets, was Pflegeaufwand reduziert und Erweiterungen an einer Stelle bündelt.
 
 ### `create/creature/index.ts`
 - Re-exportiert das Modal sowie die Creature-Sections für externe Consumer. Dadurch bleibt die Pfadstruktur (`create/creature/modal` & `create/creature/section-*`) intern, während Aufrufer (`view.ts` oder Tests) nur `create/creature` adressieren müssen.

--- a/src/apps/library/create/creature/index.ts
+++ b/src/apps/library/create/creature/index.ts
@@ -3,3 +3,4 @@ export { CreateCreatureModal } from "./modal";
 export { mountCoreStatsSection } from "./section-core-stats";
 export { mountEntriesSection } from "./section-entries";
 export { mountSpellsKnownSection } from "./section-spells-known";
+export * from "./presets";

--- a/src/apps/library/create/creature/modal.ts
+++ b/src/apps/library/create/creature/modal.ts
@@ -6,6 +6,7 @@ import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
 import { mountCoreStatsSection } from "./section-core-stats";
 import { mountEntriesSection } from "./section-entries";
 import { mountSpellsKnownSection } from "./section-spells-known";
+import { CREATURE_MOVEMENT_TYPES, type CreatureMovementType } from "./presets";
 
 export class CreateCreatureModal extends Modal {
     private data: StatblockData;
@@ -51,20 +52,13 @@ export class CreateCreatureModal extends Modal {
         const speedCtl = speedWrap.createDiv({ cls: "setting-item-control sm-cc-move-ctl" });
         const addRow = speedCtl.createDiv({ cls: "sm-cc-searchbar sm-cc-move-row" });
         const typeSel = addRow.createEl("select") as HTMLSelectElement;
-        const types = [
-            ["walk","Gehen"],
-            ["climb","Klettern"],
-            ["fly","Fliegen"],
-            ["swim","Schwimmen"],
-            ["burrow","Graben"],
-        ] as const;
-        for (const [v,l] of types) { const o = typeSel.createEl("option", { text: l }); o.value = v; }
+        for (const [value, label] of CREATURE_MOVEMENT_TYPES) { const option = typeSel.createEl("option", { text: label }); option.value = value; }
         enhanceSelectToSearch(typeSel, 'Such-dropdown…');
         // hover option only for fly
         const hoverWrap = addRow.createDiv();
         const hoverCb = hoverWrap.createEl("input", { attr: { type: "checkbox", id: "cb-hover" } }) as HTMLInputElement;
         hoverWrap.createEl("label", { text: "Hover", attr: { for: "cb-hover" } });
-        const updateHover = () => { const isFly = typeSel.value === 'fly'; hoverWrap.style.display = isFly ? '' : 'none'; if (!isFly) hoverCb.checked = false; };
+        const updateHover = () => { const cur = typeSel.value as CreatureMovementType; const isFly = cur === 'fly'; hoverWrap.style.display = isFly ? '' : 'none'; if (!isFly) hoverCb.checked = false; };
         updateHover(); typeSel.onchange = updateHover;
         // inline number with +/- controls (5ft steps) – placed after hover
         const numWrap = addRow.createDiv({ cls: "sm-inline-number" });

--- a/src/apps/library/create/creature/presets.ts
+++ b/src/apps/library/create/creature/presets.ts
@@ -1,0 +1,114 @@
+// src/apps/library/create/creature/presets.ts
+
+export const CREATURE_SIZES = [
+  "Tiny",
+  "Small",
+  "Medium",
+  "Large",
+  "Huge",
+  "Gargantuan",
+] as const;
+export type CreatureSize = (typeof CREATURE_SIZES)[number];
+
+export const CREATURE_TYPES = [
+  "Aberration",
+  "Beast",
+  "Celestial",
+  "Construct",
+  "Dragon",
+  "Elemental",
+  "Fey",
+  "Fiend",
+  "Giant",
+  "Humanoid",
+  "Monstrosity",
+  "Ooze",
+  "Plant",
+  "Undead",
+] as const;
+export type CreatureType = (typeof CREATURE_TYPES)[number];
+
+export const CREATURE_ALIGNMENT_LAW_CHAOS = [
+  "Lawful",
+  "Neutral",
+  "Chaotic",
+] as const;
+export type CreatureAlignmentLawChaos = (typeof CREATURE_ALIGNMENT_LAW_CHAOS)[number];
+
+export const CREATURE_ALIGNMENT_GOOD_EVIL = [
+  "Good",
+  "Neutral",
+  "Evil",
+] as const;
+export type CreatureAlignmentGoodEvil = (typeof CREATURE_ALIGNMENT_GOOD_EVIL)[number];
+
+export const CREATURE_ABILITY_KEYS = ["str", "dex", "con", "int", "wis", "cha"] as const;
+export type CreatureAbilityKey = (typeof CREATURE_ABILITY_KEYS)[number];
+
+export const CREATURE_ABILITY_LABELS = ["STR", "DEX", "CON", "INT", "WIS", "CHA"] as const;
+export type CreatureAbilityLabel = (typeof CREATURE_ABILITY_LABELS)[number];
+
+export type CreatureAbilityDefinition = Readonly<{ key: CreatureAbilityKey; label: CreatureAbilityLabel }>;
+export const CREATURE_ABILITIES = [
+  { key: "str", label: "STR" },
+  { key: "dex", label: "DEX" },
+  { key: "con", label: "CON" },
+  { key: "int", label: "INT" },
+  { key: "wis", label: "WIS" },
+  { key: "cha", label: "CHA" },
+] as const satisfies readonly CreatureAbilityDefinition[];
+export type CreatureAbilityDef = (typeof CREATURE_ABILITIES)[number];
+
+export const CREATURE_SKILLS = [
+  ["Athletics", "str"],
+  ["Acrobatics", "dex"],
+  ["Sleight of Hand", "dex"],
+  ["Stealth", "dex"],
+  ["Arcana", "int"],
+  ["History", "int"],
+  ["Investigation", "int"],
+  ["Nature", "int"],
+  ["Religion", "int"],
+  ["Animal Handling", "wis"],
+  ["Insight", "wis"],
+  ["Medicine", "wis"],
+  ["Perception", "wis"],
+  ["Survival", "wis"],
+  ["Deception", "cha"],
+  ["Intimidation", "cha"],
+  ["Performance", "cha"],
+  ["Persuasion", "cha"],
+] as const satisfies readonly (readonly [string, CreatureAbilityKey])[];
+export type CreatureSkillEntry = (typeof CREATURE_SKILLS)[number];
+export type CreatureSkillName = CreatureSkillEntry[0];
+
+export const CREATURE_ENTRY_CATEGORIES = [
+  ["trait", "Eigenschaft"],
+  ["action", "Aktion"],
+  ["bonus", "Bonusaktion"],
+  ["reaction", "Reaktion"],
+  ["legendary", "Legendäre Aktion"],
+] as const;
+export type CreatureEntryCategory = (typeof CREATURE_ENTRY_CATEGORIES)[number][0];
+
+export const CREATURE_ABILITY_SELECTIONS = [
+  "",
+  "best_of_str_dex",
+  ...CREATURE_ABILITY_KEYS,
+] as const;
+export type CreatureAbilitySelection = (typeof CREATURE_ABILITY_SELECTIONS)[number];
+
+export const CREATURE_SAVE_OPTIONS = [
+  "",
+  ...CREATURE_ABILITY_LABELS,
+] as const;
+export type CreatureSaveOption = (typeof CREATURE_SAVE_OPTIONS)[number];
+
+export const CREATURE_MOVEMENT_TYPES = [
+  ["walk", "Gehen"],
+  ["climb", "Klettern"],
+  ["fly", "Fliegen"],
+  ["swim", "Schwimmen"],
+  ["burrow", "Graben"],
+] as const;
+export type CreatureMovementType = (typeof CREATURE_MOVEMENT_TYPES)[number][0];

--- a/src/apps/library/create/creature/section-core-stats.ts
+++ b/src/apps/library/create/creature/section-core-stats.ts
@@ -4,6 +4,15 @@ import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
 import { mountTokenEditor } from "../shared/token-editor";
 import { abilityMod, formatSigned, parseIntSafe } from "../shared/stat-utils";
 import type { StatblockData } from "../../core/creature-files";
+import {
+  CREATURE_ABILITIES,
+  CREATURE_ALIGNMENT_GOOD_EVIL,
+  CREATURE_ALIGNMENT_LAW_CHAOS,
+  CREATURE_SIZES,
+  CREATURE_SKILLS,
+  CREATURE_TYPES,
+  type CreatureAbilityKey,
+} from "./presets";
 
 export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) {
   const root = parent.createDiv();
@@ -18,7 +27,7 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const sizeSetting = new Setting(root).setName("Größe");
   sizeSetting.addDropdown((dd) => {
     dd.addOption("", "");
-    ["Tiny","Small","Medium","Large","Huge","Gargantuan"].forEach((s) => dd.addOption(s, s));
+    for (const option of CREATURE_SIZES) dd.addOption(option, option);
     dd.onChange((v: string) => (data.size = v));
     try { enhanceSelectToSearch(dd.selectEl, 'Such-dropdown…'); } catch {}
   });
@@ -26,7 +35,7 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const typeSetting = new Setting(root).setName("Typ");
   typeSetting.addDropdown((dd) => {
     dd.addOption("", "");
-    ["Aberration","Beast","Celestial","Construct","Dragon","Elemental","Fey","Fiend","Giant","Humanoid","Monstrosity","Ooze","Plant","Undead"].forEach((s) => dd.addOption(s, s));
+    for (const option of CREATURE_TYPES) dd.addOption(option, option);
     dd.onChange((v: string) => (data.type = v));
     try { enhanceSelectToSearch(dd.selectEl, 'Such-dropdown…'); } catch {}
   });
@@ -34,13 +43,13 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const alignSetting = new Setting(root).setName("Gesinnung");
   alignSetting.addDropdown((dd) => {
     dd.addOption("", "");
-    ["Lawful","Neutral","Chaotic"].forEach((s) => dd.addOption(s, s));
+    for (const option of CREATURE_ALIGNMENT_LAW_CHAOS) dd.addOption(option, option);
     dd.onChange((v: string) => (data.alignmentLawChaos = v));
     try { const el = dd.selectEl; el.dataset.sdOpenAll = '0'; enhanceSelectToSearch(el, 'Such-dropdown…'); } catch {}
   });
   alignSetting.addDropdown((dd) => {
     dd.addOption("", "");
-    ["Good","Neutral","Evil"].forEach((s) => dd.addOption(s, s));
+    for (const option of CREATURE_ALIGNMENT_GOOD_EVIL) dd.addOption(option, option);
     dd.onChange((v: string) => (data.alignmentGoodEvil = v));
     try { const el = dd.selectEl; el.dataset.sdOpenAll = '0'; enhanceSelectToSearch(el, 'Such-dropdown…'); } catch {}
   });
@@ -70,12 +79,7 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const header = statsTbl.createDiv({ cls: "sm-cc-row sm-cc-header" });
   ;["Name","Wert","Mod","Save","Save Mod"].forEach(h => header.createDiv({ cls: "sm-cc-cell", text: h }));
 
-  const abDefs = [
-    { key: 'str', label: 'STR' }, { key: 'dex', label: 'DEX' }, { key: 'con', label: 'CON' },
-    { key: 'int', label: 'INT' }, { key: 'wis', label: 'WIS' }, { key: 'cha', label: 'CHA' },
-  ] as const;
-
-  const abilityElems = new Map<string, { score: HTMLInputElement; mod: HTMLElement; save: HTMLInputElement; saveMod: HTMLElement }>();
+  const abilityElems = new Map<CreatureAbilityKey, { score: HTMLInputElement; mod: HTMLElement; save: HTMLInputElement; saveMod: HTMLElement }>();
 
   const ensureSets = () => {
     if (!data.saveProf) data.saveProf = {} as any;
@@ -83,7 +87,7 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
     if (!data.skillsExpertise) data.skillsExpertise = [];
   };
 
-  for (const s of abDefs) {
+  for (const s of CREATURE_ABILITIES) {
     const rowEl = statsTbl.createDiv({ cls: "sm-cc-row" });
     rowEl.createDiv({ cls: "sm-cc-cell", text: s.label });
     const scoreCell = rowEl.createDiv({ cls: "sm-cc-cell sm-inline-number" });
@@ -116,16 +120,8 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const skillsHeader = skillsTbl.createDiv({ cls: "sm-cc-row sm-cc-header" });
   ;["Name","Prof","Expertise","Mod"].forEach(h => skillsHeader.createDiv({ cls: "sm-cc-cell", text: h }));
 
-  const skills: Array<[string,string]> = [
-    ['Athletics','str'],
-    ['Acrobatics','dex'],['Sleight of Hand','dex'],['Stealth','dex'],
-    ['Arcana','int'],['History','int'],['Investigation','int'],['Nature','int'],['Religion','int'],
-    ['Animal Handling','wis'],['Insight','wis'],['Medicine','wis'],['Perception','wis'],['Survival','wis'],
-    ['Deception','cha'],['Intimidation','cha'],['Performance','cha'],['Persuasion','cha'],
-  ];
-
-  const skillElems: Array<{ ability: string; prof: HTMLInputElement; exp: HTMLInputElement; out: HTMLElement }> = [];
-  for (const [name, abil] of skills) {
+  const skillElems: Array<{ ability: CreatureAbilityKey; prof: HTMLInputElement; exp: HTMLInputElement; out: HTMLElement }> = [];
+  for (const [name, abil] of CREATURE_SKILLS) {
     const rowEl = skillsTbl.createDiv({ cls: "sm-cc-row" });
     rowEl.createDiv({ cls: "sm-cc-cell", text: name });
     const cbP = rowEl.createEl("input", { cls: "sm-cc-cell", attr: { type: "checkbox" } }) as HTMLInputElement;

--- a/src/apps/library/create/creature/section-entries.ts
+++ b/src/apps/library/create/creature/section-entries.ts
@@ -2,6 +2,7 @@
 import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
 import type { StatblockData } from "../../core/creature-files";
 import { abilityMod, formatSigned, parseIntSafe } from "../shared/stat-utils";
+import { CREATURE_ABILITY_SELECTIONS, CREATURE_ENTRY_CATEGORIES, CREATURE_SAVE_OPTIONS } from "./presets";
 
 export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
   if (!data.entries) data.entries = [] as any;
@@ -12,8 +13,10 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
 
   const addBar = ctl.createDiv({ cls: "sm-cc-searchbar" });
   const catSel = addBar.createEl("select") as HTMLSelectElement;
-  const catMap = [["trait","Eigenschaft"],["action","Aktion"],["bonus","Bonusaktion"],["reaction","Reaktion"],["legendary","Legendäre Aktion"]] as const;
-  for (const [v,l] of catMap) { const o = catSel.createEl("option", { text: l }); (o as HTMLOptionElement).value = v; }
+  for (const [value, label] of CREATURE_ENTRY_CATEGORIES) {
+    const option = catSel.createEl("option", { text: label });
+    (option as HTMLOptionElement).value = value;
+  }
   try { enhanceSelectToSearch(catSel, 'Such-dropdown…'); } catch {}
   const addEntryBtn = addBar.createEl("button", { text: "+ Eintrag" });
 
@@ -26,7 +29,11 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
       const box = host.createDiv({ cls: "sm-cc-skill-group" });
       const head = box.createDiv({ cls: "sm-cc-skill sm-cc-entry-head" });
       const c = head.createEl("select") as HTMLSelectElement;
-      for (const [v,l] of catMap) { const o=c.createEl("option",{ text:l }); (o as HTMLOptionElement).value=v; if (v===e.category) (o as HTMLOptionElement).selected=true; }
+      for (const [value, label] of CREATURE_ENTRY_CATEGORIES) {
+        const option = c.createEl("option", { text: label });
+        (option as HTMLOptionElement).value = value;
+        if (value === e.category) (option as HTMLOptionElement).selected = true;
+      }
       c.onchange = () => e.category = c.value as any;
       try { enhanceSelectToSearch(c, 'Such-dropdown…'); } catch {}
 
@@ -54,7 +61,10 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
       const hitGroup = autoRow.createDiv({ cls: 'sm-auto-group' });
       hitGroup.createSpan({ text: 'To hit:' });
       const toHitAbil = hitGroup.createEl('select') as HTMLSelectElement;
-      ['','best_of_str_dex','str','dex','con','int','wis','cha'].forEach(v=>{ const o=toHitAbil.createEl('option',{ text: v||'(von)' }); (o as HTMLOptionElement).value=v; });
+      for (const value of CREATURE_ABILITY_SELECTIONS) {
+        const option = toHitAbil.createEl('option', { text: value || '(von)' });
+        (option as HTMLOptionElement).value = value;
+      }
       try { enhanceSelectToSearch(toHitAbil, 'Such-dropdown…'); } catch {}
       const toHitProf = hitGroup.createEl('input', { attr: { type: 'checkbox', id: `hit-prof-${i}` } }) as HTMLInputElement;
       hitGroup.createEl('label', { text: 'Prof', attr: { for: `hit-prof-${i}` } });
@@ -64,7 +74,11 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
       const dmgGroup = autoRow.createDiv({ cls: 'sm-auto-group' });
       dmgGroup.createSpan({ text: 'Damage:' });
       const dmgDice = dmgGroup.createEl('input', { attr: { type: 'text', placeholder: '1d8', 'aria-label': 'Würfel' } }) as HTMLInputElement; (dmgDice.style as any).width = '10ch';
-      const dmgAbil = dmgGroup.createEl('select') as HTMLSelectElement; ['','best_of_str_dex','str','dex','con','int','wis','cha'].forEach(v=>{ const o=dmgAbil.createEl('option',{ text: v||'(von)' }); (o as HTMLOptionElement).value=v; });
+      const dmgAbil = dmgGroup.createEl('select') as HTMLSelectElement;
+      for (const value of CREATURE_ABILITY_SELECTIONS) {
+        const option = dmgAbil.createEl('option', { text: value || '(von)' });
+        (option as HTMLOptionElement).value = value;
+      }
       try { enhanceSelectToSearch(dmgAbil, 'Such-dropdown…'); } catch {}
       const dmgBonus = dmgGroup.createEl('input', { attr: { type: 'text', placeholder: 'piercing / slashing …', 'aria-label': 'Art' } }) as HTMLInputElement; (dmgBonus.style as any).width = '12ch';
       const dmg = dmgGroup.createEl('input', { cls: 'sm-auto-dmg', attr: { type: 'text', placeholder: '1d8 +3 piercing', 'aria-label': 'Schaden' } }) as HTMLInputElement; (dmg.style as any).width = '20ch';
@@ -96,7 +110,13 @@ export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
 
       const misc = box.createDiv({ cls: "sm-cc-grid sm-cc-entry-grid" });
       misc.createEl('label', { text: 'Save' });
-      const saveAb = misc.createEl("select") as HTMLSelectElement; ["","STR","DEX","CON","INT","WIS","CHA"].forEach(x=>{ const o=saveAb.createEl("option", { text: x||"(kein)" }); (o as HTMLOptionElement).value=x; if (x===(e.save_ability||"")) (o as HTMLOptionElement).selected=true; }); saveAb.onchange = () => e.save_ability = saveAb.value || undefined;
+      const saveAb = misc.createEl("select") as HTMLSelectElement;
+      for (const value of CREATURE_SAVE_OPTIONS) {
+        const option = saveAb.createEl("option", { text: value || "(kein)" });
+        (option as HTMLOptionElement).value = value;
+        if (value === (e.save_ability || "")) (option as HTMLOptionElement).selected = true;
+      }
+      saveAb.onchange = () => e.save_ability = saveAb.value || undefined;
       misc.createEl('label', { text: 'DC' });
       const saveDc = misc.createEl("input", { attr: { type: "number", placeholder: "DC", 'aria-label': 'DC' } }) as HTMLInputElement; saveDc.value = e.save_dc ? String(e.save_dc) : ""; saveDc.oninput = () => e.save_dc = saveDc.value ? parseInt(saveDc.value,10) : undefined as any; (saveDc.style as any).width = '4ch';
       misc.createEl('label', { text: 'Save-Effekt' });


### PR DESCRIPTION
## Summary
- add a dedicated presets module for creature creation constants and literal types
- refactor the core stats, entries and modal sections to consume the shared presets
- document the new presets module in the library and plugin overviews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d28392c238832587e3fdc848002d50