### PR TITLE
Document library creature section helpers

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -81,9 +81,13 @@ Salt-Marcher/
 - `core/*`: Gemeinsame Logik für Library-Daten (Laden/Speichern der Sammeldateien, Parsing, Suche, Filter, Eventing).
 - `create/creature/modal.ts`: Modal zum Anlegen von Creatures; orchestriert die Formular-Sektionen und persistiert neue Statblocks.
 - `create/creature/presets.ts`: Zentraler Pool an Konstanten & Typen für Creature-Dropdowns (Größe, Typ, Gesinnung, Skills, Bewegungen).
+- `create/creature/section-core-stats.ts`: Rendert den Kernbereich des Statblocks (Identität, AC/HP-Zeile, Ability-/Skill-Tabellen) inkl. Token-/Dropdown-Helfer.
+- `create/creature/section-entries.ts`: Dynamischer Editor für Traits/Aktionen mit Auto-Berechnung von Treffer-/Schadenswerten und Save/Recharge-Optionen.
+- `create/creature/section-spells-known.ts`: Pflegt bekannte Zauber mit Suchfeld, Grad-/Nutzungsfeldern und removebaren Listeneinträgen.
 - `create/spell/modal.ts`: Dediziertes Spell-Modal mit Dropdown-Komfort und Markdown-Feldern.
 - `create/index.ts`: Re-exportiert beide Modals, sodass `view.ts` die Create-Flows aus einem Bündel importiert.
-- `create/*`: Komponenten zum Erstellen/Bearbeiten von Library-Einträgen (z. B. Formularbaugruppen, Presets, Helpers).
+- `create/shared/stat-utils.ts`: Geteilte Parser/Formatter für Ability-Scores (z. B. `abilityMod`, `parseIntSafe`) zur Berechnung von Modifikatoren.
+- `create/shared/token-editor.ts`: Wiederverwendbarer Chip-/Token-Editor für Texteingabenlisten (z. B. Sinne, Sprachen) mit Add/Remove-Callbacks.
 - `LibraryOverview.txt`: Struktur- und Verantwortlichkeitsdokument für den Library-Bereich.
 
 ### src/core


### PR DESCRIPTION
## Summary
- expand the library overview with dedicated bullets for the new creature form sections
- describe the shared stat utility and token editor helpers used by the creation modals
- remove the outdated catch-all create entry to keep the list aligned with the module layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d287a018448325b919ed0fba1849a6