### PR TITLE
Refine creature creation modal layout and workflow

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -72,6 +72,230 @@ export const HEX_PLUGIN_CSS = `
 .sm-cc-item { display:flex; gap:.5rem; align-items:center; justify-content:space-between; padding:.35rem .5rem; border:1px solid var(--background-modifier-border); border-radius:8px; background: var(--background-primary); }
 .sm-cc-item__name { font-weight: 500; }
 
+/* Create Creature Modal layout */
+.sm-cc-create-modal {
+    width: min(96vw, 1240px);
+    max-height: min(88vh, 760px);
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.sm-cc-create-modal .sm-cc-create-wrapper {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem 1.5rem 1rem;
+    box-sizing: border-box;
+    height: 100%;
+    min-height: 0;
+}
+
+.sm-cc-create-modal .sm-cc-create-header {
+    position: sticky;
+    top: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: center;
+    background: var(--background-primary);
+    z-index: 5;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.sm-cc-create-breadcrumb {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    color: var(--text-muted);
+    font-size: 0.95em;
+}
+
+.sm-cc-create-breadcrumb .sm-cc-crumb + .sm-cc-crumb::before {
+    content: "›";
+    opacity: 0.6;
+    margin: 0 0.35rem;
+}
+
+.sm-cc-crumb--name {
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.sm-cc-create-stepper {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.sm-cc-stepper-btn {
+    border: 1px solid var(--background-modifier-border);
+    background: var(--background-secondary);
+    padding: 0.35rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.9em;
+    cursor: pointer;
+}
+
+.sm-cc-stepper-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.sm-cc-stepper-label {
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.sm-cc-create-body {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: 320px 360px minmax(0, 1fr);
+    gap: 1rem;
+    min-height: 0;
+}
+
+.sm-cc-create-column {
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    min-height: 0;
+}
+
+.sm-cc-create-column.is-active {
+    border-color: var(--interactive-accent);
+    box-shadow: 0 0 0 1px var(--interactive-accent);
+}
+
+.sm-cc-create-footer {
+    position: sticky;
+    bottom: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: center;
+    background: var(--background-primary);
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--background-modifier-border);
+    z-index: 5;
+}
+
+.sm-cc-footer-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.sm-cc-footer-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    font-size: 0.9em;
+}
+
+.sm-cc-footer-chip__label {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.sm-cc-footer-chip__value {
+    font-weight: 600;
+}
+
+.sm-cc-footer-status {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.sm-cc-footer-status__ok {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.sm-cc-footer-status__warnings {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.sm-cc-footer-warning {
+    background: rgba(255, 196, 0, 0.18);
+    border: 1px solid rgba(255, 196, 0, 0.45);
+    border-radius: 999px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85em;
+    color: var(--text-normal);
+}
+
+.sm-cc-footer-actions {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sm-cc-footer-btn {
+    border: 1px solid var(--background-modifier-border);
+    background: var(--background-secondary);
+    color: var(--text-normal);
+    padding: 0.45rem 1.1rem;
+    border-radius: 8px;
+    font-size: 0.9em;
+    cursor: pointer;
+}
+
+.sm-cc-footer-btn.is-primary {
+    background: var(--interactive-accent);
+    border-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+}
+
+.sm-cc-footer-btn.is-disabled,
+.sm-cc-footer-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.sm-cc-preview-modal {
+    min-width: 520px;
+}
+
+.sm-cc-preview {
+    max-height: 60vh;
+    overflow: auto;
+    padding: 0.75rem;
+    background: var(--background-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--background-modifier-border);
+    font-size: 0.85em;
+}
+
+@media (max-width: 1180px) {
+    .sm-cc-create-modal .sm-cc-create-body {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .sm-cc-create-modal .sm-cc-create-column {
+        max-height: 36vh;
+    }
+}
+
 /* Create Creature Modal helpers */
 .sm-cc-create-modal .sm-cc-grid {
     display: grid;

--- a/src/apps/library/create/creature/Overview.txt
+++ b/src/apps/library/create/creature/Overview.txt
@@ -13,6 +13,7 @@ creature/
 Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 
 ## Features & Hauptzuständigkeiten
+- **Geführtes Dreispalten-Layout mit Navigation:** Header-Breadcrumb & Stepper halten den Workflow linear, jede Spalte scrollt unabhängig und der Footer liefert AC/HP/Passive/CR-Chips plus Aktionen (Abbrechen/Speichern/Vorschau) samt Validierungsstatus.【F:src/apps/library/create/creature/modal.ts†L44-L204】【F:src/app/css.ts†L49-L176】
 - **Statblock-Basisdaten erfassen:** Größe, Typ, Gesinnung, AC, Initiative, HP, Hit Dice, Bewegungen, Proficiency Bonus, CR, XP.【F:src/apps/library/create/creature/section-core-stats.ts†L19-L74】【F:src/apps/library/core/creature-files.ts†L7-L74】
 - **Attribute & Fertigkeiten mit Autofill:** Tabelle für STR–CHA inkl. Save-Proficiencies und Skills, automatische Modifikatorberechnung über gemeinsame Utilities.【F:src/apps/library/create/creature/section-core-stats.ts†L42-L132】【F:src/apps/library/create/shared/stat-utils.ts†L1-L33】
 - **Freitext-Listen (Sinne/Sprachen/Speeds):** Token-Editor-Chips zur Verwaltung variabler Listenfelder.【F:src/apps/library/create/creature/section-core-stats.ts†L134-L149】
@@ -27,15 +28,16 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 - **Eingeteilte Aktionen:** Traits, Actions, Bonus Actions, Reactions, Legendary Actions sowie Nutzungs-/Recharge-Regeln und Spellcasting-Blocks.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L210-L272】【F:References, do not delete!/rulebooks/Statblocks/12_MonstersA-Z.md†L26-L158】
 
 ## Was funktioniert bereits gut?
-- **Geführter Datenfluss:** Der Modal baut Abschnitte sequentiell auf und hält den `StatblockData`-State zusammen, was den Export direkt speist.【F:src/apps/library/create/creature/modal.ts†L16-L104】
-- **Wiederverwendbare UI-Hilfen:** Suche-fähige Dropdowns, Inline-Stepper und Token-Chips sorgen für schnelle Eingabe wiederkehrender Felder.【F:src/apps/library/create/creature/modal.ts†L36-L103】【F:src/apps/library/create/shared/token-editor.ts†L1-L63】
+- **Klares Navigationsgerüst:** Breadcrumb, Stepper und Spaltenfokus lassen schnell zwischen Grundwerten, Details und Aktionen springen und halten den Namen live präsent.【F:src/apps/library/create/creature/modal.ts†L44-L128】
+- **Wiederverwendbare UI-Hilfen:** Suche-fähige Dropdowns, Inline-Stepper und Token-Chips sorgen für schnelle Eingabe wiederkehrender Felder.【F:src/apps/library/create/creature/modal.ts†L118-L161】【F:src/apps/library/create/shared/token-editor.ts†L1-L63】
 - **Automatik für Würfelwerte:** Treffer- und Schadenswerte lassen sich aus Ability + PB berechnen, wodurch Inkonsistenzen reduziert werden.【F:src/apps/library/create/creature/section-entries.ts†L68-L142】
+- **Footer-Feedback:** Zusammenfassungschips & Warn-Badges zeigen fehlende Pflichtfelder an und deaktivieren Speichern, bis Mindestanforderungen erfüllt sind.【F:src/apps/library/create/creature/modal.ts†L168-L204】
 - **Markdown-Ausgabe deckt Kernabschnitte ab:** Export generiert YAML, Tabellen und strukturierte Abschnittsgruppen gemäß Vorlage.【F:src/apps/library/core/creature-files.ts†L79-L157】
 
 ## Optimierungspotenzial
 - **Defensive Details ergänzen:** Resistances, Vulnerabilities, Immunities und Gear sind im Referenz-Statblock wichtig, fehlen jedoch noch in Datentyp & UI.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L98-L121】【F:src/apps/library/core/creature-files.ts†L15-L74】
-- **Speed-Felder konsolidieren:** Sowohl einzelne `speedWalk/swim/...` als auch `speedList` existieren; ein einheitliches Modell würde UI-Logik vereinfachen.【F:src/apps/library/core/creature-files.ts†L19-L26】【F:src/apps/library/create/creature/modal.ts†L44-L98】
-- **Abschnittsgewichtung verbessern:** Lange Listen (Skills, Einträge, Zauber) scrollen vertikal; Accordion- oder Tabs für „Offense/Defense/Spellcasting“ könnten Übersicht erhöhen ohne Informationen zu verstecken.【F:src/apps/library/create/creature/modal.ts†L36-L103】
+- **Speed-Felder konsolidieren:** Sowohl einzelne `speedWalk/swim/...` als auch `speedList` existieren; ein einheitliches Modell würde UI-Logik vereinfachen.【F:src/apps/library/core/creature-files.ts†L19-L26】【F:src/apps/library/create/creature/modal.ts†L115-L162】
+- **Abschnittsgewichtung verbessern:** Lange Listen (Skills, Einträge, Zauber) scrollen vertikal; Accordion- oder Tabs für „Offense/Defense/Spellcasting“ könnten Übersicht erhöhen ohne Informationen zu verstecken.【F:src/apps/library/create/creature/modal.ts†L44-L168】
 - **Voreinstellungen & Presets ausbauen:** Beispielstatblocks zeigen konsistente Reihenfolge & Terminologie (z. B. Initiative in Klammern); UI könnte Templates/Preview nutzen.【F:References, do not delete!/rulebooks/Statblocks/12_MonstersA-Z.md†L5-L58】
 
 ## Layout-Blueprint für den Creature-Dialog
@@ -79,7 +81,7 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 
 ## Datei-Details
 - **index.ts:** Bündelt Exporte für Modal und Section-Mounts, damit externe Aufrufer eine schlanke API nutzen.【F:src/apps/library/create/creature/index.ts†L1-L6】
-- **modal.ts:** Verantwortlich für Lebenszyklus des Modal-Dialogs, orchestriert Sections, lädt Spell-Liste und handhabt Submit/Cancel.【F:src/apps/library/create/creature/modal.ts†L16-L119】
+- **modal.ts:** Baut Header mit Breadcrumb & Stepper, richtet Dreispaltenlayout samt Speed-/Entries-/Spells-Sektionen ein, lädt Spell-Liste, zeigt Footer-Chips/Validierungen und öffnet bei Bedarf eine JSON-Vorschau.【F:src/apps/library/create/creature/modal.ts†L28-L210】
 - **section-core-stats.ts:** Baut Identity-/Kernwerte-Form, Fähigkeitentabelle, Skill-Checkboxen und Token-Editoren für Sinne/Sprachen.【F:src/apps/library/create/creature/section-core-stats.ts†L19-L149】
 - **section-entries.ts:** Rendert wiederholbare Karten für strukturierte Statblock-Einträge inklusive Auto-Berechnung und Markdown-Textbox.【F:src/apps/library/create/creature/section-entries.ts†L8-L151】
 - **section-spells-known.ts:** Stellt Typeahead-Input bereit, verwaltet die gespeicherten Zauberobjekte und erzeugt Listenansicht mit Entfernen-Buttons.【F:src/apps/library/create/creature/section-spells-known.ts†L8-L70】

--- a/src/apps/library/create/creature/section-core-stats.ts
+++ b/src/apps/library/create/creature/section-core-stats.ts
@@ -20,7 +20,10 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   // Identity: Name, Größe, Typ, Gesinnung (zweiteilig)
   const idSetting = new Setting(root).setName("Name");
   idSetting.addText((t) => {
-    t.setPlaceholder("Aboleth").setValue(data.name || "").onChange((v: string) => (data.name = v.trim()));
+    const updateName = (v: string) => { data.name = v.trim(); };
+    t.setPlaceholder("Aboleth").setValue(data.name || "").onChange((v: string) => updateName(v));
+    t.inputEl.dataset.role = "creature-name";
+    t.inputEl.addEventListener("input", () => updateName(t.inputEl.value));
     t.inputEl.style.width = '30ch';
   });
 


### PR DESCRIPTION
## Summary
- rebuild the creature creation modal around a breadcrumb header with stepper navigation, three scrollable columns, and a sticky footer that surfaces stat chips, validation, and preview actions
- extend the shared CSS with grid, sticky header/footer, responsive column, and footer styles used by the refreshed creature dialog
- wire the core stats section to emit live name updates and expand the creature overview documentation with the new navigation workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b4ed56b08325b9b694de73059e26