### PR TITLE
Add defensive details to creature statblocks

### DIFF
--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -46,6 +46,7 @@ src/apps/library/
   - `creature/section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
   - `creature/section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
   - `creature/section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
+- Defensive Zusatzerfassung: Chip-Editoren für Resistances, Immunities, Vulnerabilities sowie ein Equipment-&-Notes-Textarea erweitern die mittlere Spalte des Creature-Modals und schreiben direkt ins Statblock-Objekt.【F:src/apps/library/create/creature/modal.ts†L104-L165】
 - Geteilte Stat-Utilities (`create/shared/stat-utils.ts`) bündeln Parsing, Modifikator-Logik und Vorzeichenformatierung für alle Abschnitte – nutzbar auch für zukünftige Modals (z. B. Items oder NPC-Varianten).
 - Öffnen: Ein Button pro Eintrag öffnet die Quelle (Datei bzw. Sammeldatei) in Obsidian.
 - Live‑Updates: Nutzt Watcher für Ordner/Dateien, um die Liste bei Änderungen neu zu laden.
@@ -68,7 +69,7 @@ src/apps/library/
 
 ### `core/creature-files.ts`
 - `ensureCreatureDir`, `listCreatureFiles`, `watchCreatureDir`, `createCreatureFile`.
-- Verantwortlich für Verzeichnis‑Struktur und Dateibenennung.
+- Verantwortlich für Verzeichnis‑Struktur, Dateibenennung und den Markdown-Export inklusive YAML-Feldern für Resistances/Immunities/Vulnerabilities sowie eines optionalen Equipment-&-Notes-Abschnitts im Body.【F:src/apps/library/core/creature-files.ts†L7-L152】
 
 ### `core/spell-files.ts`
 - `ensureSpellDir`, `listSpellFiles`, `watchSpellDir`, `createSpellFile`.
@@ -76,6 +77,7 @@ src/apps/library/
 
 ### `create/creature/modal.ts`
 - Orchestriert den gesamten Creature-Erstellungsfluss: setzt das Modal auf, lädt verfügbare Zauber, mountet die Abschnitts-Module und verarbeitet Bewegung sowie Speichern.
+- Ergänzt die mittlere Spalte um Chip-Editoren für Resistances/Immunities/Vulnerabilities sowie ein Equipment-&-Notes-Textarea, damit defensive Daten konsistent mit dem Referenzstatblock gepflegt werden.【F:src/apps/library/create/creature/modal.ts†L104-L165】
 - Reicht die Zauber-Liste als Getter weiter und stößt nach dem Async-Laden ein Refresh der Spell-Sektion an, damit neue Dateien ohne erneutes Öffnen sichtbar werden.
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
 

--- a/src/apps/library/create/creature/Overview.txt
+++ b/src/apps/library/create/creature/Overview.txt
@@ -17,9 +17,10 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 - **Statblock-Basisdaten erfassen:** Größe, Typ, Gesinnung, AC, Initiative, HP, Hit Dice, Bewegungen, Proficiency Bonus, CR, XP.【F:src/apps/library/create/creature/section-core-stats.ts†L19-L74】【F:src/apps/library/core/creature-files.ts†L7-L74】
 - **Attribute & Fertigkeiten mit Autofill:** Tabelle für STR–CHA inkl. Save-Proficiencies und Skills, automatische Modifikatorberechnung über gemeinsame Utilities.【F:src/apps/library/create/creature/section-core-stats.ts†L42-L132】【F:src/apps/library/create/shared/stat-utils.ts†L1-L33】
 - **Freitext-Listen (Sinne/Sprachen/Speeds):** Token-Editor-Chips zur Verwaltung variabler Listenfelder.【F:src/apps/library/create/creature/section-core-stats.ts†L134-L149】
+- **Defensive Listen & Ausrüstung:** Chip-Editoren für Resistances, Immunities, Vulnerabilities sowie ein Equipment-&-Notes-Textarea befüllen die neuen Felder im Statblock-Datentyp.【F:src/apps/library/create/creature/modal.ts†L104-L165】
 - **Strukturierte Einträge für Traits/Aktionen:** Kategoriebezogene Karten mit Feldern für Art, Trefferwürfe, Schaden, Saves, Recharge und Markdown-Text, inkl. Auto-Berechnung aus Ability/Proficiency.【F:src/apps/library/create/creature/section-entries.ts†L8-L151】
 - **Zauber-Verwaltung:** Typeahead-Auswahl bekannter Zauber mit Level-, Nutzungs- und Notizfeldern.【F:src/apps/library/create/creature/section-spells-known.ts†L8-L70】
-- **Export als Markdown/YAML:** `statblockToMarkdown` schreibt strukturierte JSON/YAML-Felder für Frontmatter und geordnete Abschnittsausgabe.【F:src/apps/library/core/creature-files.ts†L55-L157】
+- **Export als Markdown/YAML:** `statblockToMarkdown` schreibt strukturierte JSON/YAML-Felder (inkl. Resistances/Immunities/Vulnerabilities und Equipment-Notizen) für Frontmatter und geordnete Abschnittsausgabe.【F:src/apps/library/core/creature-files.ts†L55-L157】
 
 ## Statblock-Anforderungen (aus Referenzen)
 - **Meta & Kampf-Hauptdaten:** Name, Größe, Kreaturentyp(+Tags), Gesinnung, AC, Initiative, HP/Hit Dice, Speed-Varianten.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L5-L88】
@@ -35,7 +36,7 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 - **Markdown-Ausgabe deckt Kernabschnitte ab:** Export generiert YAML, Tabellen und strukturierte Abschnittsgruppen gemäß Vorlage.【F:src/apps/library/core/creature-files.ts†L79-L157】
 
 ## Optimierungspotenzial
-- **Defensive Details ergänzen:** Resistances, Vulnerabilities, Immunities und Gear sind im Referenz-Statblock wichtig, fehlen jedoch noch in Datentyp & UI.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L98-L121】【F:src/apps/library/core/creature-files.ts†L15-L74】
+- **Condition Immunities & Sonderfelder ergänzen:** Referenz-Statblocks führen neben Damage-Resistances häufig Condition Immunities oder Traits wie „Damage Threshold“, die weiterhin fehlen.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L98-L128】
 - **Speed-Felder konsolidieren:** Sowohl einzelne `speedWalk/swim/...` als auch `speedList` existieren; ein einheitliches Modell würde UI-Logik vereinfachen.【F:src/apps/library/core/creature-files.ts†L19-L26】【F:src/apps/library/create/creature/modal.ts†L115-L162】
 - **Abschnittsgewichtung verbessern:** Lange Listen (Skills, Einträge, Zauber) scrollen vertikal; Accordion- oder Tabs für „Offense/Defense/Spellcasting“ könnten Übersicht erhöhen ohne Informationen zu verstecken.【F:src/apps/library/create/creature/modal.ts†L44-L168】
 - **Voreinstellungen & Presets ausbauen:** Beispielstatblocks zeigen konsistente Reihenfolge & Terminologie (z. B. Initiative in Klammern); UI könnte Templates/Preview nutzen.【F:References, do not delete!/rulebooks/Statblocks/12_MonstersA-Z.md†L5-L58】
@@ -81,7 +82,7 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 
 ## Datei-Details
 - **index.ts:** Bündelt Exporte für Modal und Section-Mounts, damit externe Aufrufer eine schlanke API nutzen.【F:src/apps/library/create/creature/index.ts†L1-L6】
-- **modal.ts:** Baut Header mit Breadcrumb & Stepper, richtet Dreispaltenlayout samt Speed-/Entries-/Spells-Sektionen ein, lädt Spell-Liste, zeigt Footer-Chips/Validierungen und öffnet bei Bedarf eine JSON-Vorschau.【F:src/apps/library/create/creature/modal.ts†L28-L210】
+- **modal.ts:** Baut Header mit Breadcrumb & Stepper, richtet Dreispaltenlayout samt Speed-/Entries-/Spells-Sektionen ein, erweitert die Mittelspalte um Resistances/Immunities/Vulnerabilities-Chips plus Equipment-&-Notes-Textarea, lädt Spell-Liste, zeigt Footer-Chips/Validierungen und öffnet bei Bedarf eine JSON-Vorschau.【F:src/apps/library/create/creature/modal.ts†L28-L210】
 - **section-core-stats.ts:** Baut Identity-/Kernwerte-Form, Fähigkeitentabelle, Skill-Checkboxen und Token-Editoren für Sinne/Sprachen.【F:src/apps/library/create/creature/section-core-stats.ts†L19-L149】
 - **section-entries.ts:** Rendert wiederholbare Karten für strukturierte Statblock-Einträge inklusive Auto-Berechnung und Markdown-Textbox.【F:src/apps/library/create/creature/section-entries.ts†L8-L151】
 - **section-spells-known.ts:** Stellt Typeahead-Input bereit, verwaltet die gespeicherten Zauberobjekte und erzeugt Listenansicht mit Entfernen-Buttons.【F:src/apps/library/create/creature/section-spells-known.ts†L8-L70】


### PR DESCRIPTION
## Summary
- add resistances, immunities, vulnerabilities and equipment notes to creature statblocks and markdown export
- expose chip editors and equipment text area in the creature creation modal for the new fields
- document the new defensive fields and export behaviour in the library overview files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ba16a5248325a32166ba87ca01f5