### PR TITLE
feat: support lair actions and usage controls

### DIFF
--- a/src/apps/library/create/creature/Overview.txt
+++ b/src/apps/library/create/creature/Overview.txt
@@ -6,7 +6,7 @@ creature/
 ├─ index.ts              – Exportiert die öffentlichen Mount-/Modal-Hooks.
 ├─ modal.ts              – Orchestriert den Dialog und bündelt die Sections.
 ├─ section-core-stats.ts – UI für Identität, Kernwerte, Attribute & Listen.
-├─ section-entries.ts    – Strukturierte Einträge (Traits/Aktionen/... ).
+├─ section-entries.ts    – Tab-basiertes Entry-Interface mit Usage-Badges & Auto-Werten.
 ├─ section-spells-known.ts – Verwaltung bekannter Zauber.
 └─ presets.ts            – Geteilte Konstanten für Dropdowns/Enums.
 ```
@@ -18,9 +18,9 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 - **Attribute & Fertigkeiten mit Autofill:** Tabelle für STR–CHA inkl. Save-Proficiencies und Skills, automatische Modifikatorberechnung über gemeinsame Utilities.【F:src/apps/library/create/creature/section-core-stats.ts†L42-L132】【F:src/apps/library/create/shared/stat-utils.ts†L1-L33】
 - **Freitext-Listen (Sinne/Sprachen/Speeds):** Token-Editor-Chips zur Verwaltung variabler Listenfelder.【F:src/apps/library/create/creature/section-core-stats.ts†L134-L149】
 - **Defensive Listen & Ausrüstung:** Chip-Editoren für Resistances, Immunities, Vulnerabilities sowie ein Equipment-&-Notes-Textarea befüllen die neuen Felder im Statblock-Datentyp.【F:src/apps/library/create/creature/modal.ts†L104-L165】
-- **Strukturierte Einträge für Traits/Aktionen:** Kategoriebezogene Karten mit Feldern für Art, Trefferwürfe, Schaden, Saves, Recharge und Markdown-Text, inkl. Auto-Berechnung aus Ability/Proficiency.【F:src/apps/library/create/creature/section-entries.ts†L8-L151】
+- **Strukturierte Einträge für Traits/Aktionen:** Tab-Navigation für Traits/Actions/Bonus/Reactions/Legendary/Lair, Usage-Dropdowns mit Recharge-/Limited-Use-Badges sowie Mehrfach-Schadenszeilen inklusive Auto-Berechnung aus Ability & PB.【F:src/apps/library/create/creature/section-entries.ts†L90-L409】
 - **Zauber-Verwaltung:** Typeahead-Auswahl bekannter Zauber mit Level-, Nutzungs- und Notizfeldern.【F:src/apps/library/create/creature/section-spells-known.ts†L8-L70】
-- **Export als Markdown/YAML:** `statblockToMarkdown` schreibt strukturierte JSON/YAML-Felder (inkl. Resistances/Immunities/Vulnerabilities und Equipment-Notizen) für Frontmatter und geordnete Abschnittsausgabe.【F:src/apps/library/core/creature-files.ts†L55-L157】
+- **Export als Markdown/YAML:** `statblockToMarkdown` schreibt strukturierte JSON/YAML-Felder (inkl. Resistances/Immunities/Vulnerabilities und Equipment-Notizen) für Frontmatter und geordnete Abschnittsausgabe.【F:src/apps/library/core/creature-files.ts†L179-L238】
 
 ## Statblock-Anforderungen (aus Referenzen)
 - **Meta & Kampf-Hauptdaten:** Name, Größe, Kreaturentyp(+Tags), Gesinnung, AC, Initiative, HP/Hit Dice, Speed-Varianten.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L5-L88】
@@ -31,9 +31,9 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 ## Was funktioniert bereits gut?
 - **Klares Navigationsgerüst:** Breadcrumb, Stepper und Spaltenfokus lassen schnell zwischen Grundwerten, Details und Aktionen springen und halten den Namen live präsent.【F:src/apps/library/create/creature/modal.ts†L44-L128】
 - **Wiederverwendbare UI-Hilfen:** Suche-fähige Dropdowns, Inline-Stepper und Token-Chips sorgen für schnelle Eingabe wiederkehrender Felder.【F:src/apps/library/create/creature/modal.ts†L118-L161】【F:src/apps/library/create/shared/token-editor.ts†L1-L63】
-- **Automatik für Würfelwerte:** Treffer- und Schadenswerte lassen sich aus Ability + PB berechnen, wodurch Inkonsistenzen reduziert werden.【F:src/apps/library/create/creature/section-entries.ts†L68-L142】
+- **Automatik für Würfelwerte:** Trefferbonus und mehrteilige Schadensstrings lassen sich aus Ability + PB ableiten; Änderungen aktualisieren die finalen Werte automatisch.【F:src/apps/library/create/creature/section-entries.ts†L318-L407】
 - **Footer-Feedback:** Zusammenfassungschips & Warn-Badges zeigen fehlende Pflichtfelder an und deaktivieren Speichern, bis Mindestanforderungen erfüllt sind.【F:src/apps/library/create/creature/modal.ts†L168-L204】
-- **Markdown-Ausgabe deckt Kernabschnitte ab:** Export generiert YAML, Tabellen und strukturierte Abschnittsgruppen gemäß Vorlage.【F:src/apps/library/core/creature-files.ts†L79-L157】
+- **Markdown-Ausgabe deckt Kernabschnitte ab:** Export generiert YAML, gruppiert Traits/Actions/Bonus/Reactions/Legendary/Lair und übernimmt Usage-Badges sowie mehrteilige Schadensteile ins Markdown.【F:src/apps/library/core/creature-files.ts†L179-L238】
 
 ## Optimierungspotenzial
 - **Condition Immunities & Sonderfelder ergänzen:** Referenz-Statblocks führen neben Damage-Resistances häufig Condition Immunities oder Traits wie „Damage Threshold“, die weiterhin fehlen.【F:References, do not delete!/rulebooks/Statblocks/11_Monsters.md†L98-L128】
@@ -84,6 +84,6 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 - **index.ts:** Bündelt Exporte für Modal und Section-Mounts, damit externe Aufrufer eine schlanke API nutzen.【F:src/apps/library/create/creature/index.ts†L1-L6】
 - **modal.ts:** Baut Header mit Breadcrumb & Stepper, richtet Dreispaltenlayout samt Speed-/Entries-/Spells-Sektionen ein, erweitert die Mittelspalte um Resistances/Immunities/Vulnerabilities-Chips plus Equipment-&-Notes-Textarea, lädt Spell-Liste, zeigt Footer-Chips/Validierungen und öffnet bei Bedarf eine JSON-Vorschau.【F:src/apps/library/create/creature/modal.ts†L28-L210】
 - **section-core-stats.ts:** Baut Identity-/Kernwerte-Form, Fähigkeitentabelle, Skill-Checkboxen und Token-Editoren für Sinne/Sprachen.【F:src/apps/library/create/creature/section-core-stats.ts†L19-L149】
-- **section-entries.ts:** Rendert wiederholbare Karten für strukturierte Statblock-Einträge inklusive Auto-Berechnung und Markdown-Textbox.【F:src/apps/library/create/creature/section-entries.ts†L8-L151】
+- **section-entries.ts:** Rendert Tab-Panels je Kategorie, Usage-Editoren (Passive/Recharges/Limited Use), Auto-Damage-Reihen und Markdown-Textfelder pro Eintrag.【F:src/apps/library/create/creature/section-entries.ts†L90-L409】
 - **section-spells-known.ts:** Stellt Typeahead-Input bereit, verwaltet die gespeicherten Zauberobjekte und erzeugt Listenansicht mit Entfernen-Buttons.【F:src/apps/library/create/creature/section-spells-known.ts†L8-L70】
 - **presets.ts:** Enthält Konstanten/Typen für Größen, Typen, Gesinnungen, Skills, Bewegungsarten und Dropdown-Befüllung, damit UI & Export konsistent bleiben.【F:src/apps/library/create/creature/presets.ts†L1-L67】

--- a/src/apps/library/create/creature/presets.ts
+++ b/src/apps/library/create/creature/presets.ts
@@ -88,6 +88,7 @@ export const CREATURE_ENTRY_CATEGORIES = [
   ["bonus", "Bonusaktion"],
   ["reaction", "Reaktion"],
   ["legendary", "Legendäre Aktion"],
+  ["lair", "Lair-Aktion"],
 ] as const;
 export type CreatureEntryCategory = (typeof CREATURE_ENTRY_CATEGORIES)[number][0];
 

--- a/src/apps/library/create/creature/section-entries.ts
+++ b/src/apps/library/create/creature/section-entries.ts
@@ -1,134 +1,545 @@
 // src/apps/library/create/creature/section-entries.ts
 import { enhanceSelectToSearch } from "../../../../ui/search-dropdown";
-import type { StatblockData } from "../../core/creature-files";
+import type {
+  CreatureEntry,
+  CreatureEntryDamagePart,
+  CreatureEntryUsage,
+  StatblockData,
+} from "../../core/creature-files";
+import { formatEntryUsage, resolveEntryAutoDamage } from "../../core/creature-files";
 import { abilityMod, formatSigned, parseIntSafe } from "../shared/stat-utils";
-import { CREATURE_ABILITY_SELECTIONS, CREATURE_ENTRY_CATEGORIES, CREATURE_SAVE_OPTIONS } from "./presets";
+import {
+  CREATURE_ABILITY_SELECTIONS,
+  CREATURE_ENTRY_CATEGORIES,
+  CREATURE_SAVE_OPTIONS,
+} from "./presets";
+
+type Entry = CreatureEntry;
+type Usage = CreatureEntryUsage;
+type UsageType = Usage["type"];
+type Category = Entry["category"];
+
+const USAGE_OPTIONS: Array<[UsageType, string]> = [
+  ["passive", "Passive"],
+  ["recharge", "Recharge"],
+  ["limited", "Limited Use"],
+];
+
+const CATEGORY_LABEL = new Map<string, string>(CREATURE_ENTRY_CATEGORIES);
+
+type AbilityOption = (typeof CREATURE_ABILITY_SELECTIONS)[number];
+
+function normalizeLegacyUsage(entry: Entry): void {
+  if (entry.usage) return;
+  const legacy = entry.recharge?.trim();
+  if (!legacy) return;
+  const match = legacy.match(/recharge\s*(\d+)(?:\s*[-–—]\s*(\d+))?/i);
+  if (match) {
+    const min = Number.parseInt(match[1] ?? "", 10);
+    const max = match[2] ? Number.parseInt(match[2], 10) : min;
+    entry.usage = {
+      type: "recharge",
+      min: Number.isFinite(min) ? min : undefined,
+      max: Number.isFinite(max) ? max : undefined,
+    };
+    return;
+  }
+  entry.usage = { type: "limited", charges: legacy };
+}
+
+function ensureUsage(entry: Entry): Usage {
+  normalizeLegacyUsage(entry);
+  if (!entry.usage) entry.usage = { type: "passive" };
+  return entry.usage;
+}
+
+function synchronizeUsage(entry: Entry): void {
+  if (!entry.usage) return;
+  entry.recharge = formatEntryUsage(entry) || undefined;
+}
+
+function usageBadgeText(entry: Entry): string {
+  if (!entry.usage) return entry.recharge?.trim() ?? "";
+  if (entry.usage.type === "passive") return "Passive";
+  return formatEntryUsage(entry) ?? "";
+}
+
+function parseRechargeValue(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function populateAbilitySelect(select: HTMLSelectElement, current?: AbilityOption | undefined) {
+  for (const value of CREATURE_ABILITY_SELECTIONS) {
+    const option = select.createEl("option", { text: value || "(von)" });
+    (option as HTMLOptionElement).value = value;
+  }
+  if (current) select.value = current;
+  try {
+    enhanceSelectToSearch(select, "Such-dropdown…");
+  } catch {}
+}
+
+function ensureDamageExtras(entry: Entry): CreatureEntryDamagePart[] {
+  if (!Array.isArray(entry.damage_extra)) entry.damage_extra = [];
+  return entry.damage_extra;
+}
 
 export function mountEntriesSection(parent: HTMLElement, data: StatblockData) {
-  if (!data.entries) data.entries = [] as any;
+  if (!Array.isArray(data.entries)) data.entries = [] as Entry[];
+
+  const entries = data.entries as Entry[];
+  let focusEntry: Entry | null = null;
 
   const wrap = parent.createDiv({ cls: "setting-item sm-cc-entries" });
   wrap.createDiv({ cls: "setting-item-info", text: "Einträge (Traits, Aktionen, …)" });
   const ctl = wrap.createDiv({ cls: "setting-item-control" });
 
-  const addBar = ctl.createDiv({ cls: "sm-cc-searchbar" });
-  const catSel = addBar.createEl("select") as HTMLSelectElement;
+  const tabBar = ctl.createDiv({ cls: "sm-cc-entry-tabs-nav" });
+  const panelsRoot = ctl.createDiv({ cls: "sm-cc-entry-tabs" });
+
+  const hosts = new Map<Category, { button: HTMLButtonElement; panel: HTMLDivElement }>();
   for (const [value, label] of CREATURE_ENTRY_CATEGORIES) {
-    const option = catSel.createEl("option", { text: label });
-    (option as HTMLOptionElement).value = value;
+    const btn = tabBar.createEl("button", { text: label, cls: "sm-cc-entry-tab" });
+    const panel = panelsRoot.createDiv({ cls: "sm-cc-entry-panel" });
+    hosts.set(value, { button: btn as HTMLButtonElement, panel });
   }
-  try { enhanceSelectToSearch(catSel, 'Such-dropdown…'); } catch {}
-  const addEntryBtn = addBar.createEl("button", { text: "+ Eintrag" });
 
-  const host = ctl.createDiv();
-  let focusIdx: number | null = null;
+  let activeTab = (entries[0]?.category ?? CREATURE_ENTRY_CATEGORIES[0][0]) as Category;
 
-  const render = () => {
-    host.empty();
-    (data.entries as any[]).forEach((e, i) => {
-      const box = host.createDiv({ cls: "sm-cc-skill-group" });
-      const head = box.createDiv({ cls: "sm-cc-skill sm-cc-entry-head" });
-      const c = head.createEl("select") as HTMLSelectElement;
-      for (const [value, label] of CREATURE_ENTRY_CATEGORIES) {
-        const option = c.createEl("option", { text: label });
-        (option as HTMLOptionElement).value = value;
-        if (value === e.category) (option as HTMLOptionElement).selected = true;
-      }
-      c.onchange = () => e.category = c.value as any;
-      try { enhanceSelectToSearch(c, 'Such-dropdown…'); } catch {}
-
-      head.createEl('label', { text: 'Name' });
-      const name = head.createEl("input", { cls: "sm-cc-entry-name", attr: { type: "text", placeholder: "Name (z. B. Multiattack)", 'aria-label': 'Name' } }) as HTMLInputElement;
-      name.value = e.name || ""; name.oninput = () => e.name = name.value.trim();
-      (name.style as any).width = '26ch';
-      if (focusIdx === i) { setTimeout(() => name.focus(), 0); focusIdx = null; }
-      const del = head.createEl("button", { text: "🗑" });
-      del.onclick = () => { (data.entries as any[]).splice(i,1); render(); };
-
-      const grid = box.createDiv({ cls: "sm-cc-grid sm-cc-entry-grid" });
-      grid.createEl('label', { text: 'Art' });
-      const kind = grid.createEl("input", { attr: { type: "text", placeholder: "Melee/Ranged …", 'aria-label': 'Art' } }) as HTMLInputElement;
-      kind.value = e.kind || ""; kind.oninput = () => e.kind = kind.value.trim() || undefined; (kind.style as any).width = '24ch';
-      grid.createEl('label', { text: 'Reichweite' });
-      const rng = grid.createEl("input", { attr: { type: "text", placeholder: "reach 5 ft. / range 30 ft.", 'aria-label': 'Reichweite' } }) as HTMLInputElement;
-      rng.value = e.range || ""; rng.oninput = () => e.range = rng.value.trim() || undefined; (rng.style as any).width = '30ch';
-      grid.createEl('label', { text: 'Ziel' });
-      const tgt = grid.createEl("input", { attr: { type: "text", placeholder: "one target", 'aria-label': 'Ziel' } }) as HTMLInputElement;
-      tgt.value = e.target || ""; tgt.oninput = () => e.target = tgt.value.trim() || undefined; (tgt.style as any).width = '16ch';
-
-      // Auto-compute helpers
-      const autoRow = box.createDiv({ cls: "sm-cc-auto" });
-      const hitGroup = autoRow.createDiv({ cls: 'sm-auto-group' });
-      hitGroup.createSpan({ text: 'To hit:' });
-      const toHitAbil = hitGroup.createEl('select') as HTMLSelectElement;
-      for (const value of CREATURE_ABILITY_SELECTIONS) {
-        const option = toHitAbil.createEl('option', { text: value || '(von)' });
-        (option as HTMLOptionElement).value = value;
-      }
-      try { enhanceSelectToSearch(toHitAbil, 'Such-dropdown…'); } catch {}
-      const toHitProf = hitGroup.createEl('input', { attr: { type: 'checkbox', id: `hit-prof-${i}` } }) as HTMLInputElement;
-      hitGroup.createEl('label', { text: 'Prof', attr: { for: `hit-prof-${i}` } });
-      const hit = hitGroup.createEl('input', { cls: 'sm-auto-tohit', attr: { type: 'text', placeholder: '+7', 'aria-label': 'To hit' } }) as HTMLInputElement; (hit.style as any).width = '6ch';
-      hit.value = e.to_hit || ''; hit.addEventListener('input', () => e.to_hit = hit.value.trim() || undefined);
-
-      const dmgGroup = autoRow.createDiv({ cls: 'sm-auto-group' });
-      dmgGroup.createSpan({ text: 'Damage:' });
-      const dmgDice = dmgGroup.createEl('input', { attr: { type: 'text', placeholder: '1d8', 'aria-label': 'Würfel' } }) as HTMLInputElement; (dmgDice.style as any).width = '10ch';
-      const dmgAbil = dmgGroup.createEl('select') as HTMLSelectElement;
-      for (const value of CREATURE_ABILITY_SELECTIONS) {
-        const option = dmgAbil.createEl('option', { text: value || '(von)' });
-        (option as HTMLOptionElement).value = value;
-      }
-      try { enhanceSelectToSearch(dmgAbil, 'Such-dropdown…'); } catch {}
-      const dmgBonus = dmgGroup.createEl('input', { attr: { type: 'text', placeholder: 'piercing / slashing …', 'aria-label': 'Art' } }) as HTMLInputElement; (dmgBonus.style as any).width = '12ch';
-      const dmg = dmgGroup.createEl('input', { cls: 'sm-auto-dmg', attr: { type: 'text', placeholder: '1d8 +3 piercing', 'aria-label': 'Schaden' } }) as HTMLInputElement; (dmg.style as any).width = '20ch';
-      dmg.value = e.damage || ''; dmg.addEventListener('input', () => e.damage = dmg.value.trim() || undefined);
-
-      const applyAuto = () => {
-        const pb = parseIntSafe(data.pb as any) || 0;
-        if (e.to_hit_from) {
-          const abil = e.to_hit_from.ability as any;
-          const abilMod = abil === 'best_of_str_dex' ? Math.max(abilityMod(data.str as any), abilityMod(data.dex as any)) : abilityMod((data as any)[abil]);
-          const total = abilMod + (e.to_hit_from.proficient ? pb : 0);
-          e.to_hit = formatSigned(total); hit.value = e.to_hit;
-        }
-        if (e.damage_from) {
-          const abil = e.damage_from.ability as any;
-          const abilMod = abil ? (abil === 'best_of_str_dex' ? Math.max(abilityMod(data.str as any), abilityMod(data.dex as any)) : abilityMod((data as any)[abil])) : 0;
-          const base = e.damage_from.dice;
-          const tail = (abilMod ? ` ${formatSigned(abilMod)}` : '') + (e.damage_from.bonus ? ` ${e.damage_from.bonus}` : '');
-          e.damage = `${base}${tail}`.trim(); dmg.value = e.damage;
-        }
-      };
-      if (e.to_hit_from) { toHitAbil.value = e.to_hit_from.ability as any; toHitProf.checked = !!e.to_hit_from.proficient; }
-      if (e.damage_from) { dmgDice.value = e.damage_from.dice; dmgAbil.value = (e.damage_from.ability as any) || ''; dmgBonus.value = e.damage_from.bonus || ''; }
-      toHitAbil.onchange = () => { e.to_hit_from = { ability: toHitAbil.value as any, proficient: toHitProf.checked }; applyAuto(); };
-      toHitProf.onchange = () => { e.to_hit_from = { ability: toHitAbil.value as any, proficient: toHitProf.checked }; applyAuto(); };
-      dmgDice.oninput = () => { e.damage_from = { dice: dmgDice.value.trim(), ability: (dmgAbil.value as any) || undefined, bonus: dmgBonus.value.trim() || undefined }; applyAuto(); };
-      dmgAbil.onchange = () => { e.damage_from = { dice: dmgDice.value.trim(), ability: (dmgAbil.value as any) || undefined, bonus: dmgBonus.value.trim() || undefined }; applyAuto(); };
-      dmgBonus.oninput = () => { e.damage_from = { dice: dmgDice.value.trim(), ability: (dmgAbil.value as any) || undefined, bonus: dmgBonus.value.trim() || undefined }; applyAuto(); };
-
-      const misc = box.createDiv({ cls: "sm-cc-grid sm-cc-entry-grid" });
-      misc.createEl('label', { text: 'Save' });
-      const saveAb = misc.createEl("select") as HTMLSelectElement;
-      for (const value of CREATURE_SAVE_OPTIONS) {
-        const option = saveAb.createEl("option", { text: value || "(kein)" });
-        (option as HTMLOptionElement).value = value;
-        if (value === (e.save_ability || "")) (option as HTMLOptionElement).selected = true;
-      }
-      saveAb.onchange = () => e.save_ability = saveAb.value || undefined;
-      misc.createEl('label', { text: 'DC' });
-      const saveDc = misc.createEl("input", { attr: { type: "number", placeholder: "DC", 'aria-label': 'DC' } }) as HTMLInputElement; saveDc.value = e.save_dc ? String(e.save_dc) : ""; saveDc.oninput = () => e.save_dc = saveDc.value ? parseInt(saveDc.value,10) : undefined as any; (saveDc.style as any).width = '4ch';
-      misc.createEl('label', { text: 'Save-Effekt' });
-      const saveFx = misc.createEl("input", { attr: { type: "text", placeholder: "half on save …", 'aria-label': 'Save-Effekt' } }) as HTMLInputElement; saveFx.value = e.save_effect || ""; saveFx.oninput = () => e.save_effect = saveFx.value.trim() || undefined; (saveFx.style as any).width = '18ch';
-      misc.createEl('label', { text: 'Recharge' });
-      const rech = misc.createEl("input", { attr: { type: "text", placeholder: "Recharge 5–6 / 1/day" } }) as HTMLInputElement; rech.value = e.recharge || ""; rech.oninput = () => e.recharge = rech.value.trim() || undefined;
-      box.createEl('label', { text: 'Details' });
-      const ta = box.createEl("textarea", { cls: "sm-cc-entry-text", attr: { placeholder: "Details (Markdown)" } }); ta.value = e.text || ""; ta.addEventListener("input", () => e.text = (ta as HTMLTextAreaElement).value);
-    });
+  const updateActive = () => {
+    for (const [value, { button, panel }] of hosts) {
+      const isActive = value === activeTab;
+      button.classList.toggle("is-active", isActive);
+      panel.toggleClass("is-active", isActive);
+      (panel.style as CSSStyleDeclaration).display = isActive ? "" : "none";
+    }
   };
 
-  addEntryBtn.onclick = () => { (data.entries as any[]).unshift({ category: catSel.value as any, name: "" }); focusIdx = 0; render(); };
+  const setActive = (category: Category) => {
+    activeTab = category;
+    updateActive();
+  };
+
+  for (const [value] of CREATURE_ENTRY_CATEGORIES) {
+    const host = hosts.get(value as Category);
+    if (!host) continue;
+    host.button.onclick = () => {
+      setActive(value as Category);
+    };
+  }
+
+  const renderUsageControls = (
+    entry: Entry,
+    usageBadge: HTMLElement,
+    container: HTMLElement,
+  ) => {
+    container.empty();
+    const usageRow = container.createDiv({ cls: "sm-cc-entry-usage-row" });
+    usageRow.createEl("label", { text: "Verwendung" });
+    const usageSelect = usageRow.createEl("select") as HTMLSelectElement;
+    for (const [value, label] of USAGE_OPTIONS) {
+      const option = usageSelect.createEl("option", { text: label });
+      (option as HTMLOptionElement).value = value;
+    }
+    try {
+      enhanceSelectToSearch(usageSelect, "Such-dropdown…");
+    } catch {}
+
+    const rechargeWrap = container.createDiv({ cls: "sm-cc-entry-usage-recharge" });
+    const minInput = rechargeWrap.createEl("input", {
+      attr: { type: "number", placeholder: "von", "aria-label": "Recharge von" },
+    }) as HTMLInputElement;
+    const dash = rechargeWrap.createSpan({ text: "–" });
+    dash.addClass("sm-cc-entry-usage-dash");
+    const maxInput = rechargeWrap.createEl("input", {
+      attr: { type: "number", placeholder: "bis", "aria-label": "Recharge bis" },
+    }) as HTMLInputElement;
+
+    const limitedWrap = container.createDiv({ cls: "sm-cc-entry-usage-limited" });
+    const chargesInput = limitedWrap.createEl("input", {
+      attr: { type: "text", placeholder: "Charges / 3/Day", "aria-label": "Charges" },
+    }) as HTMLInputElement;
+    const costInput = limitedWrap.createEl("input", {
+      attr: { type: "text", placeholder: "Kosten", "aria-label": "Kosten" },
+    }) as HTMLInputElement;
+
+    const updateBadge = () => {
+      synchronizeUsage(entry);
+      const label = usageBadgeText(entry);
+      usageBadge.setText(label);
+      usageBadge.toggleClass("is-hidden", !label);
+    };
+
+    const updateFields = () => {
+      const usage = ensureUsage(entry);
+      usageSelect.value = usage.type;
+      rechargeWrap.style.display = usage.type === "recharge" ? "" : "none";
+      limitedWrap.style.display = usage.type === "limited" ? "" : "none";
+      if (usage.type === "recharge") {
+        minInput.value = usage.min != null ? String(usage.min) : "";
+        maxInput.value = usage.max != null ? String(usage.max) : "";
+      }
+      if (usage.type === "limited") {
+        chargesInput.value = usage.charges ?? "";
+        costInput.value = usage.cost ?? "";
+      }
+      updateBadge();
+    };
+
+    usageSelect.onchange = () => {
+      const next = usageSelect.value as UsageType;
+      if (next === "passive") entry.usage = { type: "passive" };
+      else if (next === "recharge") entry.usage = { type: "recharge", min: 5, max: 6 };
+      else entry.usage = { type: "limited" };
+      updateFields();
+    };
+
+    minInput.oninput = () => {
+      const usage = ensureUsage(entry);
+      if (usage.type !== "recharge") return;
+      usage.min = parseRechargeValue(minInput.value);
+      updateBadge();
+    };
+    maxInput.oninput = () => {
+      const usage = ensureUsage(entry);
+      if (usage.type !== "recharge") return;
+      usage.max = parseRechargeValue(maxInput.value);
+      updateBadge();
+    };
+
+    chargesInput.oninput = () => {
+      const usage = ensureUsage(entry);
+      if (usage.type !== "limited") return;
+      usage.charges = chargesInput.value.trim() || undefined;
+      updateBadge();
+    };
+    costInput.oninput = () => {
+      const usage = ensureUsage(entry);
+      if (usage.type !== "limited") return;
+      usage.cost = costInput.value.trim() || undefined;
+      updateBadge();
+    };
+
+    updateFields();
+  };
+
+  const renderEntryCard = (panel: HTMLElement, entry: Entry, index: number) => {
+    ensureUsage(entry);
+    synchronizeUsage(entry);
+
+    const card = panel.createDiv({ cls: "sm-cc-skill-group sm-cc-entry-card" });
+    const head = card.createDiv({ cls: "sm-cc-skill sm-cc-entry-head" });
+
+    const catSelect = head.createEl("select") as HTMLSelectElement;
+    for (const [value, label] of CREATURE_ENTRY_CATEGORIES) {
+      const option = catSelect.createEl("option", { text: label });
+      (option as HTMLOptionElement).value = value;
+      if (value === entry.category) (option as HTMLOptionElement).selected = true;
+    }
+    catSelect.onchange = () => {
+      entry.category = catSelect.value as Category;
+      focusEntry = entry;
+      setActive(entry.category);
+      render();
+    };
+    try {
+      enhanceSelectToSearch(catSelect, "Such-dropdown…");
+    } catch {}
+
+    const usageBadge = head.createSpan({ cls: "sm-cc-entry-usage-badge" });
+
+    head.createEl("label", { text: "Name" });
+    const nameInput = head.createEl("input", {
+      cls: "sm-cc-entry-name",
+      attr: { type: "text", placeholder: "Name (z. B. Multiattack)", "aria-label": "Name" },
+    }) as HTMLInputElement;
+    nameInput.value = entry.name || "";
+    nameInput.oninput = () => {
+      entry.name = nameInput.value.trim();
+    };
+    (nameInput.style as CSSStyleDeclaration).width = "26ch";
+    if (focusEntry === entry) {
+      setTimeout(() => nameInput.focus(), 0);
+      focusEntry = null;
+    }
+
+    const del = head.createEl("button", { text: "🗑" });
+    del.onclick = () => {
+      entries.splice(index, 1);
+      render();
+    };
+
+    const usageContainer = card.createDiv({ cls: "sm-cc-entry-usage" });
+    renderUsageControls(entry, usageBadge, usageContainer);
+
+    const grid = card.createDiv({ cls: "sm-cc-grid sm-cc-entry-grid" });
+    grid.createEl("label", { text: "Art" });
+    const kind = grid.createEl("input", {
+      attr: { type: "text", placeholder: "Melee/Ranged …", "aria-label": "Art" },
+    }) as HTMLInputElement;
+    kind.value = entry.kind || "";
+    kind.oninput = () => {
+      entry.kind = kind.value.trim() || undefined;
+    };
+    (kind.style as CSSStyleDeclaration).width = "24ch";
+
+    grid.createEl("label", { text: "Reichweite" });
+    const rng = grid.createEl("input", {
+      attr: { type: "text", placeholder: "reach 5 ft. / range 30 ft.", "aria-label": "Reichweite" },
+    }) as HTMLInputElement;
+    rng.value = entry.range || "";
+    rng.oninput = () => {
+      entry.range = rng.value.trim() || undefined;
+    };
+    (rng.style as CSSStyleDeclaration).width = "30ch";
+
+    grid.createEl("label", { text: "Ziel" });
+    const tgt = grid.createEl("input", {
+      attr: { type: "text", placeholder: "one target", "aria-label": "Ziel" },
+    }) as HTMLInputElement;
+    tgt.value = entry.target || "";
+    tgt.oninput = () => {
+      entry.target = tgt.value.trim() || undefined;
+    };
+    (tgt.style as CSSStyleDeclaration).width = "16ch";
+
+    const autoRow = card.createDiv({ cls: "sm-cc-auto" });
+    const hitGroup = autoRow.createDiv({ cls: "sm-auto-group" });
+    hitGroup.createSpan({ text: "To hit:" });
+    const toHitAbil = hitGroup.createEl("select") as HTMLSelectElement;
+    populateAbilitySelect(toHitAbil, entry.to_hit_from?.ability as AbilityOption | undefined);
+
+    const toHitProf = hitGroup.createEl("input", {
+      attr: { type: "checkbox", id: `hit-prof-${index}` },
+    }) as HTMLInputElement;
+    toHitProf.checked = !!entry.to_hit_from?.proficient;
+    hitGroup.createEl("label", { text: "Prof", attr: { for: `hit-prof-${index}` } });
+
+    const hit = hitGroup.createEl("input", {
+      cls: "sm-auto-tohit",
+      attr: { type: "text", placeholder: "+7", "aria-label": "To hit" },
+    }) as HTMLInputElement;
+    (hit.style as CSSStyleDeclaration).width = "6ch";
+    hit.value = entry.to_hit || "";
+    hit.addEventListener("input", () => {
+      entry.to_hit = hit.value.trim() || undefined;
+    });
+
+    const dmgGroup = autoRow.createDiv({ cls: "sm-auto-group" });
+    dmgGroup.createSpan({ text: "Damage:" });
+    const dmgDice = dmgGroup.createEl("input", {
+      attr: { type: "text", placeholder: "1d8", "aria-label": "Würfel" },
+    }) as HTMLInputElement;
+    (dmgDice.style as CSSStyleDeclaration).width = "10ch";
+    dmgDice.value = entry.damage_from?.dice || "";
+
+    const dmgAbil = dmgGroup.createEl("select") as HTMLSelectElement;
+    populateAbilitySelect(dmgAbil, entry.damage_from?.ability as AbilityOption | undefined);
+
+    const dmgBonus = dmgGroup.createEl("input", {
+      attr: { type: "text", placeholder: "piercing / slashing …", "aria-label": "Art" },
+    }) as HTMLInputElement;
+    (dmgBonus.style as CSSStyleDeclaration).width = "12ch";
+    dmgBonus.value = entry.damage_from?.bonus || "";
+
+    const dmg = dmgGroup.createEl("input", {
+      cls: "sm-auto-dmg",
+      attr: { type: "text", placeholder: "1d8 +3 piercing", "aria-label": "Schaden" },
+    }) as HTMLInputElement;
+    (dmg.style as CSSStyleDeclaration).width = "20ch";
+    dmg.value = entry.damage || "";
+    dmg.addEventListener("input", () => {
+      entry.damage = dmg.value.trim() || undefined;
+    });
+
+    const extrasHost = card.createDiv({ cls: "sm-cc-entry-damage-extras" });
+
+    const applyAuto = () => {
+      const pb = parseIntSafe(data.pb as any) || 0;
+      if (entry.to_hit_from) {
+        const ability = entry.to_hit_from.ability as AbilityOption | undefined;
+        let abilMod = 0;
+        if (ability === "best_of_str_dex") {
+          abilMod = Math.max(abilityMod(data.str as any), abilityMod(data.dex as any));
+        } else if (ability) {
+          abilMod = abilityMod((data as any)[ability]) ?? 0;
+        }
+        const total = abilMod + (entry.to_hit_from.proficient ? pb : 0);
+        entry.to_hit = formatSigned(total);
+        hit.value = entry.to_hit;
+      }
+      const autoDamage = resolveEntryAutoDamage(entry, data);
+      if (autoDamage) {
+        entry.damage = autoDamage;
+        dmg.value = autoDamage;
+      }
+      synchronizeUsage(entry);
+      const label = usageBadgeText(entry);
+      usageBadge.setText(label);
+      usageBadge.toggleClass("is-hidden", !label);
+    };
+
+    const updateToHitSource = () => {
+      const ability = toHitAbil.value as AbilityOption | "";
+      if (ability) {
+        entry.to_hit_from = { ability: ability as AbilityOption, proficient: toHitProf.checked };
+      } else {
+        entry.to_hit_from = undefined;
+      }
+      applyAuto();
+    };
+    toHitAbil.onchange = updateToHitSource;
+    toHitProf.onchange = updateToHitSource;
+
+    const updateBaseDamage = () => {
+      const dice = dmgDice.value.trim();
+      const ability = (dmgAbil.value as AbilityOption) || undefined;
+      const bonus = dmgBonus.value.trim() || undefined;
+      if (!dice && !ability && !bonus) entry.damage_from = undefined;
+      else entry.damage_from = { dice, ability, bonus };
+      applyAuto();
+    };
+    dmgDice.oninput = updateBaseDamage;
+    dmgAbil.onchange = updateBaseDamage;
+    dmgBonus.oninput = updateBaseDamage;
+
+    const renderExtras = () => {
+      extrasHost.empty();
+      const extras = ensureDamageExtras(entry);
+      extras.forEach((part, idx) => {
+        const row = extrasHost.createDiv({ cls: "sm-auto-group sm-cc-entry-damage-extra-row" });
+        row.createSpan({ text: "+" });
+        const extraDice = row.createEl("input", {
+          attr: { type: "text", placeholder: "1d6", "aria-label": "Zusatzwürfel" },
+        }) as HTMLInputElement;
+        (extraDice.style as CSSStyleDeclaration).width = "10ch";
+        extraDice.value = part.dice || "";
+
+        const extraAbil = row.createEl("select") as HTMLSelectElement;
+        populateAbilitySelect(extraAbil, part.ability as AbilityOption | undefined);
+
+        const extraBonus = row.createEl("input", {
+          attr: { type: "text", placeholder: "z. B. poison", "aria-label": "Zusatz" },
+        }) as HTMLInputElement;
+        (extraBonus.style as CSSStyleDeclaration).width = "14ch";
+        extraBonus.value = part.bonus || "";
+
+        const remove = row.createEl("button", { text: "✕", cls: "sm-cc-entry-remove-dmg" });
+        remove.onclick = () => {
+          extras.splice(idx, 1);
+          renderExtras();
+          applyAuto();
+        };
+
+        const updatePart = () => {
+          part.dice = extraDice.value.trim();
+          part.ability = (extraAbil.value as AbilityOption) || undefined;
+          part.bonus = extraBonus.value.trim() || undefined;
+          applyAuto();
+        };
+        extraDice.oninput = updatePart;
+        extraAbil.onchange = updatePart;
+        extraBonus.oninput = updatePart;
+      });
+
+      const addBtn = extrasHost.createEl("button", {
+        text: "+ Zusatzschaden",
+        cls: "sm-cc-entry-add-dmg",
+      });
+      addBtn.onclick = () => {
+        ensureDamageExtras(entry).push({ dice: "", ability: undefined, bonus: undefined });
+        renderExtras();
+      };
+    };
+    renderExtras();
+
+    const misc = card.createDiv({ cls: "sm-cc-grid sm-cc-entry-grid" });
+    misc.createEl("label", { text: "Save" });
+    const saveAb = misc.createEl("select") as HTMLSelectElement;
+    for (const value of CREATURE_SAVE_OPTIONS) {
+      const option = saveAb.createEl("option", { text: value || "(kein)" });
+      (option as HTMLOptionElement).value = value;
+      if (value === (entry.save_ability || "")) (option as HTMLOptionElement).selected = true;
+    }
+    saveAb.onchange = () => {
+      entry.save_ability = saveAb.value || undefined;
+    };
+
+    misc.createEl("label", { text: "DC" });
+    const saveDc = misc.createEl("input", {
+      attr: { type: "number", placeholder: "DC", "aria-label": "DC" },
+    }) as HTMLInputElement;
+    (saveDc.style as CSSStyleDeclaration).width = "4ch";
+    saveDc.value = entry.save_dc != null ? String(entry.save_dc) : "";
+    saveDc.oninput = () => {
+      entry.save_dc = saveDc.value ? Number.parseInt(saveDc.value, 10) : undefined;
+    };
+
+    misc.createEl("label", { text: "Save-Effekt" });
+    const saveFx = misc.createEl("input", {
+      attr: { type: "text", placeholder: "half on save …", "aria-label": "Save-Effekt" },
+    }) as HTMLInputElement;
+    (saveFx.style as CSSStyleDeclaration).width = "18ch";
+    saveFx.value = entry.save_effect || "";
+    saveFx.oninput = () => {
+      entry.save_effect = saveFx.value.trim() || undefined;
+    };
+
+    card.createEl("label", { text: "Details" });
+    const ta = card.createEl("textarea", {
+      cls: "sm-cc-entry-text",
+      attr: { placeholder: "Details (Markdown)" },
+    }) as HTMLTextAreaElement;
+    ta.value = entry.text || "";
+    ta.addEventListener("input", () => {
+      entry.text = ta.value;
+    });
+
+    const badgeLabel = usageBadgeText(entry);
+    usageBadge.setText(badgeLabel);
+    usageBadge.toggleClass("is-hidden", !badgeLabel);
+  };
+
+  const renderCategory = (category: Category, panel: HTMLDivElement) => {
+    panel.empty();
+    const addBar = panel.createDiv({ cls: "sm-cc-entry-addbar" });
+    const label = CATEGORY_LABEL.get(category) ?? "Eintrag";
+    const addBtn = addBar.createEl("button", {
+      text: `+ ${label}`,
+      cls: "sm-cc-entry-add-btn",
+    });
+    addBtn.onclick = () => {
+      const next: Entry = { category, name: "", usage: { type: "passive" } };
+      entries.unshift(next);
+      focusEntry = next;
+      setActive(category);
+      render();
+    };
+
+    const list = panel.createDiv({ cls: "sm-cc-entry-list" });
+    const catEntries = entries
+      .map((entry, idx) => [entry, idx] as const)
+      .filter(([entry]) => entry.category === category);
+
+    if (!catEntries.length) {
+      list.createDiv({ cls: "sm-cc-entry-empty", text: "Noch keine Einträge" });
+      return;
+    }
+
+    for (const [entry, idx] of catEntries) {
+      renderEntryCard(list, entry, idx);
+    }
+  };
+
+  const render = () => {
+    for (const [value, host] of hosts) {
+      renderCategory(value, host.panel);
+    }
+    updateActive();
+  };
+
   render();
 }
-


### PR DESCRIPTION
## Summary
- add a lair entry category plus structured usage/damage metadata for creature entries and markdown export
- rebuild the creature entry editor into a tabbed interface with usage badges and multi-damage automation
- refresh the creature creation overview to document the new workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c1164ba883259fcc52e38b02a73b