### PR TITLE
Adjust creature creator modal dimensions

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -74,8 +74,9 @@ export const HEX_PLUGIN_CSS = `
 
 /* Create Creature Modal layout */
 .sm-cc-create-modal {
-    width: min(96vw, 1240px);
-    max-height: min(88vh, 760px);
+    width: clamp(1100px, 96vw, 1420px);
+    max-width: clamp(1100px, 96vw, 1420px);
+    max-height: min(90vh, 780px);
     padding: 0;
     display: flex;
     flex-direction: column;

--- a/src/apps/library/create/creature/Overview.txt
+++ b/src/apps/library/create/creature/Overview.txt
@@ -45,7 +45,7 @@ Unterstützende Utilities liegen in `shared/` (`token-editor`, `stat-utils`).
 ## Layout-Blueprint für den Creature-Dialog
 
 ### 1. Grid & Navigation
-- **Dialograhmen:** Fester Inhalt auf 1240 px Breite, 720 px Höhe; dreispaltiges CSS-Grid mit Spaltenbreiten 320 px · 360 px · flex (Rest). 24 px Innenabstand, 16 px Spaltengap für klare Blickführung.
+- **Dialograhmen:** Breite via Clamp auf 1100 – 1420 px (96 % Viewport-Limit) und Höhe bis 780 px bei 90 % vh; dreispaltiges CSS-Grid mit Spaltenbreiten 320 px · 360 px · flex (Rest). 24 px Innenabstand, 16 px Spaltengap für klare Blickführung.
 - **Sektionensteuerung:** Accordion auf Desktop standardmäßig ausgeklappt, „Zurück/Weiter“-Stepper oberhalb des Footers für linearen Workflow. Breadcrumb-Titel zeigt Kreaturenname (live aktualisiert) zur Orientierung.【F:References, do not delete!/rulebooks/Statblocks/Creatures/Monsters/ancient-black-dragon.md†L1-L8】
 - **Scrollverhalten:** Grid-Spalten scrollen unabhängig (overflow-y auto) mit Sticky-Section-Headern bei 48 px Höhe, damit lange Aktionslisten nicht Navigationselemente verdecken.【F:References, do not delete!/rulebooks/Statblocks/Creatures/Monsters/vampire.md†L45-L64】
 


### PR DESCRIPTION
## Summary
- widen the shared Create Modal styling so the creature dialog uses a clamp width of 1100–1420px and a taller viewport cap, avoiding cramped content
- refresh the creature creator overview blueprint to document the updated modal sizing envelope

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b20e67088325906dc4fbf8258c66