### PR TITLE
Add defensive data entry to creature creator dialog

### DIFF
--- a/src/apps/library/create/creature/overview.txt
+++ b/src/apps/library/create/creature/overview.txt
@@ -6,7 +6,7 @@ src/apps/library/create/creature/
 ├── index.ts                # Barrel-Exports für den Creator-Dialog
 ├── modal.ts                # Einstiegspunkt, verwaltet Lebenszyklus des Modals
 ├── presets.ts              # Vordefinierte Auswahlwerte (Größen, Typen, Skills …)
-├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute, Sinnes-/Sprachlisten
+├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute, Sinne/Sprachen & Defensivlisten
 ├── section-entries.ts      # UI-Abschnitt für strukturierte Einträge (Traits, Aktionen …)
 └── section-spells-known.ts # UI-Abschnitt für bekannte Zauber und Auswahl-Logik
 ```
@@ -35,13 +35,14 @@ Um laut „Monsters“-Regelwerk und den vorhandenen Beispielstatblocks vollstä
 ## Features & Zuständigkeiten
 - **Modulares Abschnitts-System:** Jede logische Eingabegruppe (Kernwerte, Einträge, Zauber) besitzt eigene Mount-Funktionen mit State-Management und Utility-Hooks.【F:src/apps/library/create/creature/modal.ts†L24-L103】
 - **Dynamische Berechnungen:** Core-Stats und Entry-Module berechnen Modifikatoren, Saves und Schadens-/Trefferwerte automatisch aus Attributen und PB, inklusive Unterstützung für „best of STR/DEX“ Fälle.【F:src/apps/library/create/creature/section-core-stats.ts†L60-L150】【F:src/apps/library/create/creature/section-entries.ts†L69-L148】
-- **Typeahead-Auswahl:** Selects und Zaubersuche verwenden Search-Dropdowns bzw. Typeahead-Menüs, um große Datenmengen (Bewegungstypen, Fähigkeiten, Zauberliste) handhabbar zu halten.【F:src/apps/library/create/creature/modal.ts†L37-L88】【F:src/apps/library/create/creature/section-spells-known.ts†L14-L45】
+- **Typeahead-Auswahl:** Selects und Zaubersuche verwenden Search-Dropdowns bzw. Typeahead-Menüs, um große Datenmengen (Bewegungstypen, Fähigkeiten, Zauberliste, Defensivlisten) handhabbar zu halten.【F:src/apps/library/create/creature/modal.ts†L37-L88】【F:src/apps/library/create/creature/section-core-stats.ts†L21-L205】【F:src/apps/library/create/creature/section-spells-known.ts†L14-L45】
+- **Defensiv-Listenverwaltung:** Schadenstypen, Zustandsimmunitäten, passive Werte und Gear werden über Chip-basierte Editoren mit Such-Dropdowns gepflegt und landen strukturiert im `StatblockData`.【F:src/apps/library/create/creature/section-core-stats.ts†L21-L214】【F:src/apps/library/core/creature-files.ts†L15-L115】
 - **Strukturierte Ausgabe:** Einträge werden strukturiert im `StatblockData` gespeichert und ermöglichen später die Generierung formatierter Markdown-Abschnitte aus JSON-Daten.【F:src/apps/library/create/creature/section-entries.ts†L14-L175】【F:src/apps/library/core/creature-files.ts†L64-L119】
 
 ## Skript-Details
 - **`index.ts`:** Bündelt alle öffentlichen Einhängepunkte des Creature Creators (Modal & Mounting-Funktionen) für externe Nutzung.【F:src/apps/library/create/creature/index.ts†L1-L6】
 - **`modal.ts`:** Implementiert den Obsidian-Modal, orchestriert Abschnitt-Mounting, Geschwindigkeitserfassung, Spell-Ladeprozess und Submit-Handling.【F:src/apps/library/create/creature/modal.ts†L11-L105】
-- **`presets.ts`:** Enthält Konstanten für Auswahloptionen (Größen, Typen, Gesinnung, Skills, Eintragskategorien, Bewegungsarten) zur zentralen Pflege von Listenwerten.【F:src/apps/library/create/creature/presets.ts†L1-L69】
-- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, Attributtabellen, Skill-Grids sowie Token-Editoren für Sinne/Sprachen und aktualisiert automatisch Modifikatoren & Saves.【F:src/apps/library/create/creature/section-core-stats.ts†L17-L140】
+- **`presets.ts`:** Enthält Konstanten für Auswahloptionen (Größen, Typen, Gesinnung, Skills, Eintragskategorien, Bewegungsarten sowie Schadenstyp-/Zustands-/Passive-Presets) zur zentralen Pflege von Listenwerten.【F:src/apps/library/create/creature/presets.ts†L1-L115】
+- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, Attributtabellen, Skill-Grids sowie Token-Editoren für Sinne/Sprachen und Defensivlisten. Zudem aktualisiert der Abschnitt automatisch Modifikatoren & Saves.【F:src/apps/library/create/creature/section-core-stats.ts†L17-L214】
 - **`section-entries.ts`:** Verwalten der strukturierten Statblock-Einträge inkl. Kategorieauswahl, Auto-Berechnungen für To-Hit/Schaden, Save- und Recharge-Felder sowie Markdown-Detailtexten.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】
 - **`section-spells-known.ts`:** Bietet Typeahead-Auswahl für Zauber, Felder für Grad/Nutzung/Notizen und Listenpflege für die gespeicherten Spells mit Refresh-Hook für asynchrones Nachladen.【F:src/apps/library/create/creature/section-spells-known.ts†L5-L68】

--- a/src/apps/library/create/creature/presets.ts
+++ b/src/apps/library/create/creature/presets.ts
@@ -112,3 +112,59 @@ export const CREATURE_MOVEMENT_TYPES = [
   ["burrow", "Graben"],
 ] as const;
 export type CreatureMovementType = (typeof CREATURE_MOVEMENT_TYPES)[number][0];
+
+export const CREATURE_DAMAGE_PRESETS = [
+  "Acid",
+  "Bludgeoning",
+  "Bludgeoning (magisch)",
+  "Bludgeoning (nichtmagisch)",
+  "Cold",
+  "Fire",
+  "Force",
+  "Lightning",
+  "Necrotic",
+  "Piercing",
+  "Piercing (magisch)",
+  "Piercing (nichtmagisch)",
+  "Poison",
+  "Psychic",
+  "Radiant",
+  "Slashing",
+  "Slashing (magisch)",
+  "Slashing (nichtmagisch)",
+  "Thunder",
+  "Alle außer Force",
+  "Alle außer Psychic",
+  "Nichtmagische Angriffe",
+  "Magische Angriffe",
+  "Nichtmagische Waffen",
+  "Nichtmagische Angriffe (nicht versilbert)",
+  "Nichtmagische Angriffe (nicht aus Adamantit)",
+] as const;
+export type CreatureDamagePreset = (typeof CREATURE_DAMAGE_PRESETS)[number];
+
+export const CREATURE_CONDITION_PRESETS = [
+  "Blinded",
+  "Charmed",
+  "Deafened",
+  "Exhaustion",
+  "Frightened",
+  "Grappled",
+  "Incapacitated",
+  "Invisible",
+  "Paralyzed",
+  "Petrified",
+  "Poisoned",
+  "Prone",
+  "Restrained",
+  "Stunned",
+  "Unconscious",
+] as const;
+export type CreatureConditionPreset = (typeof CREATURE_CONDITION_PRESETS)[number];
+
+export const CREATURE_PASSIVE_PRESETS = [
+  "Passive Perception",
+  "Passive Insight",
+  "Passive Investigation",
+] as const;
+export type CreaturePassivePreset = (typeof CREATURE_PASSIVE_PRESETS)[number];


### PR DESCRIPTION
## Summary
- add search-driven chip editors for passives, resistances, immunities and gear in the creature creator core stats section
- extend StatblockData serialization to persist the new defensive lists
- expand presets and overview documentation to cover the additional options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b7fb8c048325a81d58d607d28c01