### PR TITLE
feat: add skill chip editor to creature core stats

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -90,6 +90,17 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-cc-chips { display:flex; gap:.35rem; flex-wrap:wrap; margin:.25rem 0 .5rem; }
 .sm-cc-chip { display:inline-flex; align-items:center; gap:.25rem; border:1px solid var(--background-modifier-border); border-radius:999px; padding:.1rem .4rem; background: var(--background-secondary); }
+.sm-cc-skill-editor { display:flex; flex-direction:column; gap:.35rem; }
+.sm-cc-skill-search { align-items:center; }
+.sm-cc-skill-search select { min-width:220px; }
+.sm-cc-skill-chips { gap:.45rem; }
+.sm-cc-skill-chip { align-items:center; gap:.4rem; padding-right:.5rem; }
+.sm-cc-skill-chip__name { font-weight:500; }
+.sm-cc-skill-chip__mod { font-weight:600; color: var(--text-normal); }
+.sm-cc-skill-chip__exp { display:inline-flex; align-items:center; gap:.25rem; font-size:.85em; color: var(--text-muted); }
+.sm-cc-skill-chip__exp input { margin:0; }
+.sm-cc-chip__remove { background:none; border:none; cursor:pointer; font-size:1rem; line-height:1; padding:0; color: var(--text-muted); }
+.sm-cc-chip__remove:hover { color: var(--text-normal); }
 
 /* Creature modal layout improvements */
 .sm-cc-create-modal .setting-item-control { flex: 1 1 auto; min-width: 0; }
@@ -136,8 +147,6 @@ export const HEX_PLUGIN_CSS = `
 .sm-cc-create-modal .sm-cc-header .sm-cc-cell { font-weight: 600; color: var(--text-muted); }
 .sm-cc-create-modal .sm-cc-stats-table { grid-template-columns: 100px 90px 80px 60px 90px; }
 .sm-cc-create-modal .sm-cc-stats-table input[type="number"] { width: 100%; }
-.sm-cc-create-modal .sm-cc-skills-table { grid-template-columns: 160px 60px 90px 70px; }
-.sm-cc-create-modal .sm-cc-skills-table input[type="checkbox"] { justify-self: start; }
 
 /* Compact inline number controls */
 .sm-inline-number { display: inline-flex; align-items: center; gap: .25rem; }

--- a/src/apps/library/create/creature/overview.txt
+++ b/src/apps/library/create/creature/overview.txt
@@ -6,7 +6,7 @@ src/apps/library/create/creature/
 ├── index.ts                # Barrel-Exports für den Creator-Dialog
 ├── modal.ts                # Einstiegspunkt, verwaltet Lebenszyklus des Modals
 ├── presets.ts              # Vordefinierte Auswahlwerte (Größen, Typen, Skills …)
-├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute, Sinne/Sprachen & Defensivlisten
+├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute & Skills, Sinne/Sprachen & Defensivlisten
 ├── section-entries.ts      # UI-Abschnitt für strukturierte Einträge (Traits, Aktionen …)
 └── section-spells-known.ts # UI-Abschnitt für bekannte Zauber und Auswahl-Logik
 ```
@@ -35,14 +35,15 @@ Um laut „Monsters“-Regelwerk und den vorhandenen Beispielstatblocks vollstä
 ## Features & Zuständigkeiten
 - **Modulares Abschnitts-System:** Jede logische Eingabegruppe (Kernwerte, Einträge, Zauber) besitzt eigene Mount-Funktionen mit State-Management und Utility-Hooks.【F:src/apps/library/create/creature/modal.ts†L24-L103】
 - **Dynamische Berechnungen:** Core-Stats und Entry-Module berechnen Modifikatoren, Saves und Schadens-/Trefferwerte automatisch aus Attributen und PB, inklusive Unterstützung für „best of STR/DEX“ Fälle.【F:src/apps/library/create/creature/section-core-stats.ts†L60-L150】【F:src/apps/library/create/creature/section-entries.ts†L69-L148】
-- **Typeahead-Auswahl:** Selects und Zaubersuche verwenden Search-Dropdowns bzw. Typeahead-Menüs, um große Datenmengen (Bewegungstypen, Fähigkeiten, Zauberliste, Defensivlisten) handhabbar zu halten.【F:src/apps/library/create/creature/modal.ts†L37-L88】【F:src/apps/library/create/creature/section-core-stats.ts†L21-L205】【F:src/apps/library/create/creature/section-spells-known.ts†L14-L45】
-- **Defensiv-Listenverwaltung:** Schadenstypen, Zustandsimmunitäten, passive Werte und Gear werden über Chip-basierte Editoren mit Such-Dropdowns gepflegt; freie Eingaben laufen jetzt direkt über das Search-Feld und landen strukturiert im `StatblockData`.【F:src/apps/library/create/creature/section-core-stats.ts†L21-L214】【F:src/apps/library/core/creature-files.ts†L15-L115】
+- **Typeahead-Auswahl:** Selects und Zaubersuche verwenden Search-Dropdowns bzw. Typeahead-Menüs, um große Datenmengen (Bewegungstypen, Fähigkeiten, Zauberliste, Defensivlisten) handhabbar zu halten.【F:src/apps/library/create/creature/modal.ts†L37-L88】【F:src/apps/library/create/creature/section-core-stats.ts†L26-L229】【F:src/apps/library/create/creature/section-spells-known.ts†L14-L45】
+- **Skill-Chip-Workflow:** Fertigkeiten werden über ein Such-Dropdown hinzugefügt, als Chips mit entfernbarem Button und Expertise-Checkbox angezeigt und synchronisieren `skillsProf`/`skillsExpertise` inklusive Mod-Neuberechnung.【F:src/apps/library/create/creature/section-core-stats.ts†L186-L289】
+- **Defensiv-Listenverwaltung:** Schadenstypen, Zustandsimmunitäten, passive Werte und Gear werden über Chip-basierte Editoren mit Such-Dropdowns gepflegt; freie Eingaben laufen jetzt direkt über das Search-Feld und landen strukturiert im `StatblockData`.【F:src/apps/library/create/creature/section-core-stats.ts†L313-L349】【F:src/apps/library/core/creature-files.ts†L15-L115】
 - **Strukturierte Ausgabe:** Einträge werden strukturiert im `StatblockData` gespeichert und ermöglichen später die Generierung formatierter Markdown-Abschnitte aus JSON-Daten.【F:src/apps/library/create/creature/section-entries.ts†L14-L175】【F:src/apps/library/core/creature-files.ts†L64-L119】
 
 ## Skript-Details
 - **`index.ts`:** Bündelt alle öffentlichen Einhängepunkte des Creature Creators (Modal & Mounting-Funktionen) für externe Nutzung.【F:src/apps/library/create/creature/index.ts†L1-L6】
 - **`modal.ts`:** Implementiert den Obsidian-Modal, orchestriert Abschnitt-Mounting, Geschwindigkeitserfassung, Spell-Ladeprozess und Submit-Handling.【F:src/apps/library/create/creature/modal.ts†L11-L105】
 - **`presets.ts`:** Enthält Konstanten für Auswahloptionen (Größen, Typen, Gesinnung, Skills, Eintragskategorien, Bewegungsarten sowie Schadenstyp-/Zustands-/Passive-Presets) zur zentralen Pflege von Listenwerten.【F:src/apps/library/create/creature/presets.ts†L1-L115】
-- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, Attributtabellen, Skill-Grids sowie Token-Editoren für Sinne/Sprachen und Defensivlisten. Die Such-Dropdowns akzeptieren jetzt auch direkt eingegebene Freitexte ohne Zusatzfeld, während der Abschnitt weiterhin Modifikatoren & Saves automatisch aktualisiert.【F:src/apps/library/create/creature/section-core-stats.ts†L17-L214】
+- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, Attributtabellen, den neuen Skill-Editor mit Search-Dropdown + Chips + Expertise-Toggles sowie Token-Editoren für Sinne/Sprachen und Defensivlisten; alle Änderungen halten `StatblockData` und Mod-Berechnungen synchron.【F:src/apps/library/create/creature/section-core-stats.ts†L86-L349】
 - **`section-entries.ts`:** Verwalten der strukturierten Statblock-Einträge inkl. Kategorieauswahl, Auto-Berechnungen für To-Hit/Schaden, Save- und Recharge-Felder sowie Markdown-Detailtexten.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】
 - **`section-spells-known.ts`:** Bietet Typeahead-Auswahl für Zauber, Felder für Grad/Nutzung/Notizen und Listenpflege für die gespeicherten Spells mit Refresh-Hook für asynchrones Nachladen.【F:src/apps/library/create/creature/section-spells-known.ts†L5-L68】


### PR DESCRIPTION
## Summary
- replace the skills table in the creature core stats section with a searchable chip editor that keeps `skillsProf`/`skillsExpertise` in sync
- update modifier calculations to work with the chip UI and limit expertise to proficient skills
- add styling for the new editor elements and document the workflow in the creature overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cad4e33c83258dce4e22aea73732