### PR TITLE
Polish damage type editor and docs

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -90,9 +90,38 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-cc-chips { display:flex; gap:.35rem; flex-wrap:wrap; margin:.25rem 0 .5rem; }
 .sm-cc-chip { display:inline-flex; align-items:center; gap:.25rem; border:1px solid var(--background-modifier-border); border-radius:999px; padding:.1rem .4rem; background: var(--background-secondary); }
+.sm-cc-damage-row { align-items:center; }
+.sm-cc-damage-type { display:inline-flex; align-items:center; gap:.35rem; flex-wrap:wrap; justify-content:flex-start; }
+.sm-cc-damage-type__label { font-size:.85em; color: var(--text-muted); }
+.sm-cc-damage-type__buttons { display:inline-flex; border:1px solid var(--background-modifier-border); border-radius:999px; overflow:hidden; background: var(--background-primary); }
+.sm-cc-damage-type__btn { border:none; background:transparent; padding:.2rem .75rem; font-size:.85em; color: var(--text-muted); cursor:pointer; transition: background 120ms ease, color 120ms ease; }
+.sm-cc-damage-type__btn:hover { color: var(--text-normal); }
+.sm-cc-damage-type__btn.is-active { background: var(--interactive-accent); color: var(--text-on-accent, #fff); }
+.sm-cc-damage-type__btn.is-active:hover { color: var(--text-on-accent, #fff); }
+.sm-cc-damage-chips { margin-top:.25rem; }
+.sm-cc-damage-chip { align-items:center; gap:.4rem; padding-right:.5rem; }
+.sm-cc-damage-chip__name { font-weight:500; }
+.sm-cc-damage-chip__badge { font-size:.75em; font-weight:600; border-radius:999px; padding:.1rem .45rem; text-transform:uppercase; letter-spacing:.03em; }
+.sm-cc-damage-chip--res { border-color: rgba(37,99,235,.45); background-color: rgba(37,99,235,.08); }
+.sm-cc-damage-chip--res { border-color: color-mix(in srgb, var(--interactive-accent) 45%, transparent); background-color: color-mix(in srgb, var(--interactive-accent) 12%, var(--background-secondary)); }
+.sm-cc-damage-chip--res .sm-cc-damage-chip__badge { background-color: rgba(37,99,235,.18); color:#2563eb; }
+.sm-cc-damage-chip--res .sm-cc-damage-chip__badge { background-color: color-mix(in srgb, var(--interactive-accent) 22%, transparent); color: var(--interactive-accent); }
+.sm-cc-damage-chip--imm { border-color: rgba(124,58,237,.45); background-color: rgba(124,58,237,.08); }
+.sm-cc-damage-chip--imm { border-color: color-mix(in srgb, var(--color-purple, #7c3aed) 45%, transparent); background-color: color-mix(in srgb, var(--color-purple, #7c3aed) 12%, var(--background-secondary)); }
+.sm-cc-damage-chip--imm .sm-cc-damage-chip__badge { background-color: rgba(124,58,237,.18); color:#7c3aed; }
+.sm-cc-damage-chip--imm .sm-cc-damage-chip__badge { background-color: color-mix(in srgb, var(--color-purple, #7c3aed) 22%, transparent); color: var(--color-purple, #7c3aed); }
+.sm-cc-damage-chip--vuln { border-color: rgba(234,88,12,.45); background-color: rgba(234,88,12,.08); }
+.sm-cc-damage-chip--vuln { border-color: color-mix(in srgb, var(--color-orange, #ea580c) 45%, transparent); background-color: color-mix(in srgb, var(--color-orange, #ea580c) 12%, var(--background-secondary)); }
+.sm-cc-damage-chip--vuln .sm-cc-damage-chip__badge { background-color: rgba(234,88,12,.18); color:#ea580c; }
+.sm-cc-damage-chip--vuln .sm-cc-damage-chip__badge { background-color: color-mix(in srgb, var(--color-orange, #ea580c) 22%, transparent); color: var(--color-orange, #ea580c); }
 .sm-cc-skill-editor { display:flex; flex-direction:column; gap:.35rem; }
 .sm-cc-skill-search { align-items:center; }
+.sm-cc-skill-search label { flex: 0 0 auto; }
 .sm-cc-skill-search select { min-width:220px; }
+.sm-cc-senses-search { align-items:center; }
+.sm-cc-senses-search label { flex: 0 0 auto; }
+.sm-cc-senses-search .sm-sd { flex: 1 1 220px; min-width: 200px; }
+.sm-cc-senses-search button { flex: 0 0 auto; }
 .sm-cc-skill-chips { gap:.45rem; }
 .sm-cc-skill-chip { align-items:center; gap:.4rem; padding-right:.5rem; }
 .sm-cc-skill-chip__name { font-weight:500; }
@@ -109,6 +138,10 @@ export const HEX_PLUGIN_CSS = `
 .sm-cc-create-modal .sm-cc-skill-group { width: 100%; box-sizing: border-box; }
 .sm-cc-create-modal .sm-cc-searchbar { flex-wrap: wrap; }
 .sm-cc-create-modal .sm-cc-searchbar > * { flex: 1 1 160px; min-width: 140px; }
+.sm-cc-create-modal .sm-cc-damage-row > label,
+.sm-cc-create-modal .sm-cc-damage-row .sm-cc-damage-type,
+.sm-cc-create-modal .sm-cc-damage-row .sm-cc-damage-add { flex:0 0 auto; min-width:auto; }
+.sm-cc-create-modal .sm-cc-damage-row .sm-cc-damage-select { flex:1 1 240px; min-width:200px; }
 .sm-cc-create-modal .sm-cc-entry-grid { grid-template-columns: max-content 1fr max-content 1fr; column-gap: .75rem; row-gap: .35rem; align-items: center; }
 .sm-cc-create-modal .sm-cc-entry-grid input, .sm-cc-create-modal .sm-cc-entry-grid select { width: 100%; max-width: 220px; box-sizing: border-box; }
 .sm-cc-create-modal .sm-cc-entry-grid input[type="number"] { max-width: 100px; }
@@ -140,13 +173,27 @@ export const HEX_PLUGIN_CSS = `
 .sm-cc-create-modal .sm-cc-entry-head select { width: auto; }
 .sm-cc-create-modal .sm-cc-entry-name { width: 100%; min-width: 0; }
 
-/* Table-like layout for Stats and Skills */
+/* Table-like layout for Skills */
 .sm-cc-create-modal .sm-cc-table { display: grid; gap: .35rem .5rem; align-items: center; }
 .sm-cc-create-modal .sm-cc-row { display: contents; }
 .sm-cc-create-modal .sm-cc-cell { align-self: center; }
 .sm-cc-create-modal .sm-cc-header .sm-cc-cell { font-weight: 600; color: var(--text-muted); }
-.sm-cc-create-modal .sm-cc-stats-table { grid-template-columns: 100px 90px 80px 60px 90px; }
-.sm-cc-create-modal .sm-cc-stats-table input[type="number"] { width: 100%; }
+
+/* Ability score cards */
+.sm-cc-create-modal .sm-cc-stats-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .5rem; margin-top: .35rem; }
+.sm-cc-create-modal .sm-cc-stat { border: 1px solid var(--background-modifier-border); border-radius: 8px; padding: .5rem; background: var(--background-primary); display: flex; flex-direction: column; gap: .35rem; }
+.sm-cc-create-modal .sm-cc-stat__header { display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-weight: 600; }
+.sm-cc-create-modal .sm-cc-stat__header span:first-child { color: var(--text-normal); }
+.sm-cc-create-modal .sm-cc-stat__mod { display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-size: .95em; color: var(--text-muted); }
+.sm-cc-create-modal .sm-cc-stat__mod-value { font-weight: 600; color: var(--text-normal); }
+.sm-cc-create-modal .sm-cc-stat__save { display: flex; flex-direction: column; gap: .25rem; }
+.sm-cc-create-modal .sm-cc-stat__save-label { font-size: .85em; font-weight: 600; text-transform: uppercase; letter-spacing: .02em; color: var(--text-muted); }
+.sm-cc-create-modal .sm-cc-stat__save-controls { display: flex; align-items: center; gap: .35rem; }
+.sm-cc-create-modal .sm-cc-stat__save-controls input[type="checkbox"] { margin: 0; }
+.sm-cc-create-modal .sm-cc-stat__save-value { font-weight: 600; }
+@media (max-width: 700px) {
+    .sm-cc-create-modal .sm-cc-stats-grid { grid-template-columns: minmax(0, 1fr); }
+}
 
 /* Compact inline number controls */
 .sm-inline-number { display: inline-flex; align-items: center; gap: .25rem; }

--- a/src/apps/library/LibraryOverview.txt
+++ b/src/apps/library/LibraryOverview.txt
@@ -19,8 +19,8 @@ src/apps/library/
 │  ├─ creature/
 │  │  ├─ index.ts             # Re-exports Modal & Creature-Sections für externe Zugriffe
 │  │  ├─ modal.ts             # Modal zum Anlegen von Creatures (koordiniert die Abschnitte)
-│  │  ├─ presets.ts           # Zentralisierte Auswahllisten (Größe, Typ, Skills, Bewegungen …)
-│  │  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen
+│  │  ├─ presets.ts           # Zentralisierte Auswahllisten (Größe, Typ, Skills, Bewegungen, Sinne, Sprachen …)
+│  │  ├─ section-core-stats.ts   # Abschnitt für Identität, Kernwerte, Saves & Sinne/Sprachen (Preset-Suche)
 │  │  ├─ section-entries.ts      # Abschnitt für Traits/Aktionen/Legendäre Einträge mit Presets
 │  │  └─ section-spells-known.ts # Abschnitt für bekannte Zauber inkl. Typeahead-Suche
 │  ├─ spell/
@@ -42,8 +42,8 @@ src/apps/library/
   - Terrains: legt neuen Eintrag mit Defaultwerten an (`#888888`, `speed: 1`).
   - Regionen: legt neuen Eintrag ohne Terrain/Encounter an.
   - Creatures/Spells: öffnet ein Modal, erzeugt eine `.md`‑Datei im passenden Ordner und öffnet sie im Editor.
-- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/creature/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Gemeinsame Optionslisten (Größen, Typen, Gesinnung, Skills, Bewegungsarten) werden aus `create/creature/presets.ts` gespeist, sodass alle Segmente denselben Kanon verwenden.
-  - `creature/section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen.
+- Creature-Modal (`create/creature/modal.ts`) zerlegt das Formular in modulare Abschnitte (`create/creature/section-*.ts`) und orchestriert Mounting, State-Passing und Persistenz-Trigger. Gemeinsame Optionslisten (Größen, Typen, Gesinnung, Skills, Bewegungsarten, Sinne, Sprachen) werden aus `create/creature/presets.ts` gespeist, sodass alle Segmente denselben Kanon verwenden.
+  - `creature/section-core-stats`: Steuert Identität, Ability Scores, Saves/Skills mit Inline-Label-Suchzeile sowie Sinnes- und Sprachfelder inklusive Automatik-Berechnungen und nutzt Preset-gestützte Such-Dropdowns für Sinne/Sprachen.
   - `creature/section-entries`: Verwaltet Traits, Aktionen, legendäre Optionen und Presets für Treffer-/Schadenswerte.
   - `creature/section-spells-known`: Liefert eine Typeahead-gestützte Spell-Liste mit Grad- und Nutzungskonfiguration, die auf den live gehaltenen Spell-Getter des Modals hört.
 - Geteilte Stat-Utilities (`create/shared/stat-utils.ts`) bündeln Parsing, Modifikator-Logik und Vorzeichenformatierung für alle Abschnitte – nutzbar auch für zukünftige Modals (z. B. Items oder NPC-Varianten).
@@ -80,7 +80,7 @@ src/apps/library/
 - Warum: Hält den Workflow zentral und delegiert UI-Details an spezialisierte Sektionen, sodass Erweiterungen (z. B. neue Abschnitte) gebündelt erfolgen.
 
 ### `create/creature/presets.ts`
-- Kapselt alle Konstanten/Typen für Dropdowns und Automatisierungen (Größen, Typen, Gesinnungsteile, Ability-Definitionen, Skill-Mappings, Entry-Kategorien, Bewegungsarten).
+- Kapselt alle Konstanten/Typen für Dropdowns und Automatisierungen (Größen, Typen, Gesinnungsteile, Ability-Definitionen, Skill-Mappings, Entry-Kategorien, Bewegungsarten, Sinne, Sprachen).
 - Warum: Statt mehrfacher Inline-Listen verwenden alle Sektionen dieselben Presets, was Pflegeaufwand reduziert und Erweiterungen an einer Stelle bündelt.
 
 ### `create/creature/index.ts`
@@ -90,8 +90,8 @@ src/apps/library/
 - Fasst die Modal-Exports (`CreateCreatureModal`, `CreateSpellModal`) zusammen. `view.ts` bindet beide über einen Import, was Importketten vereinfacht und die Ordnerstruktur vor Außenstehenden kapselt.
 
 ### `create/creature/section-core-stats.ts`
-- Rendert Identität, Kernwerte, Saves/Skills sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
-- Nutzt den gemeinsamen Token-Editor (`shared/token-editor`) für Sinne/Sprachen, damit Chips-UX und Add/Remove-Verhalten identisch mit anderen Formularteilen bleibt.
+- Rendert Identität, Kernwerte, Saves/Skills mit Inline-Label in der Suchzeile sowie Sinne und Sprachen inklusive automatischer Modifikator- und Proficiency-Berechnung.
+- Nutzt Preset-gestützte Search-Dropdowns für Sinne/Sprachen (Freitext bleibt möglich) und spiegelt die Chip-UX des Skill-Editors inklusive Entfernen-Buttons; Token-Editoren bleiben für freie Listen wie Gear im Einsatz.
 - Zieht Berechnungshelfer (`shared/stat-utils`) für Ability-Modifikatoren und Vorzeichenformatierung heran, sodass dieselben Regeln wie in Eintragssektionen gelten.
 - Warum: Bündelt alle abhängigen Formeln (z. B. PB, Ability Mods) und sorgt dafür, dass Änderungen an Attributen sofort in allen Feldern sichtbar werden.
 
@@ -114,8 +114,7 @@ src/apps/library/
 - Verwendet `shared/token-editor`, um die Klassenliste als Chip-Liste zu bearbeiten und dieselbe UX wie in Creature-Abschnitten zu bieten.
 - Warum: Dedizierte UI für Spell-Erstellung; bleibt unabhängig vom Creature-Flow.
 
-### `create/shared/token-editor.ts`
-- Kapselt Setting-Aufbau, Input-Handling und Chip-Rendering für freie Listen (z. B. Klassen, Sinne, Sprachen).
+- Kapselt Setting-Aufbau, Input-Handling und Chip-Rendering für freie Listen (z. B. Klassen oder Gear) und ergänzt Sense-/Language-Workflows, wenn Felder ohne Preset-Suche benötigt werden.
 - Bietet optionale Add/Remove-Callbacks und einen Refresh-Hook, um konsistente Token-Editoren in allen Formularen zu gewährleisten.
 
 ### `create/spell/index.ts`

--- a/src/apps/library/create/creature/overview.txt
+++ b/src/apps/library/create/creature/overview.txt
@@ -5,8 +5,8 @@
 src/apps/library/create/creature/
 ├── index.ts                # Barrel-Exports für den Creator-Dialog
 ├── modal.ts                # Einstiegspunkt, verwaltet Lebenszyklus des Modals
-├── presets.ts              # Vordefinierte Auswahlwerte (Größen, Typen, Skills …)
-├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute & Skills, Sinne/Sprachen & Defensivlisten
+├── presets.ts              # Vordefinierte Auswahlwerte (Größen, Typen, Skills, Sinne, Sprachen …)
+├── section-core-stats.ts   # UI-Abschnitt für Identität, Kernwerte, Attribute & Skills, Sinne/Sprachen (Preset) & Defensivlisten
 ├── section-entries.ts      # UI-Abschnitt für strukturierte Einträge (Traits, Aktionen …)
 └── section-spells-known.ts # UI-Abschnitt für bekannte Zauber und Auswahl-Logik
 ```
@@ -34,16 +34,18 @@ Um laut „Monsters“-Regelwerk und den vorhandenen Beispielstatblocks vollstä
 
 ## Features & Zuständigkeiten
 - **Modulares Abschnitts-System:** Jede logische Eingabegruppe (Kernwerte, Einträge, Zauber) besitzt eigene Mount-Funktionen mit State-Management und Utility-Hooks.【F:src/apps/library/create/creature/modal.ts†L24-L103】
-- **Dynamische Berechnungen:** Core-Stats und Entry-Module berechnen Modifikatoren, Saves und Schadens-/Trefferwerte automatisch aus Attributen und PB, inklusive Unterstützung für „best of STR/DEX“ Fälle.【F:src/apps/library/create/creature/section-core-stats.ts†L60-L150】【F:src/apps/library/create/creature/section-entries.ts†L69-L148】
+- **Dynamische Berechnungen:** Core-Stats und Entry-Module berechnen Modifikatoren, Saves und Schadens-/Trefferwerte automatisch aus Attributen und PB, inklusive Unterstützung für „best of STR/DEX“ Fälle.【F:src/apps/library/create/creature/section-core-stats.ts†L60-L208】【F:src/apps/library/create/creature/section-entries.ts†L69-L148】
+- **Kartenbasierter Ability-Block:** Ability Scores werden als zweispaltiges Grid von Karten mit Score-Controls, Mod-Zeile und gemeinsamem Save-Mod-Bereich (Checkbox + Ergebnis) gerendert, was mobile Layouts und schnelle Erfassung unterstützt.【F:src/apps/library/create/creature/section-core-stats.ts†L147-L208】【F:src/app/css.ts†L97-L118】
 - **Typeahead-Auswahl:** Selects und Zaubersuche verwenden Search-Dropdowns bzw. Typeahead-Menüs, um große Datenmengen (Bewegungstypen, Fähigkeiten, Zauberliste, Defensivlisten) handhabbar zu halten.【F:src/apps/library/create/creature/modal.ts†L37-L88】【F:src/apps/library/create/creature/section-core-stats.ts†L26-L229】【F:src/apps/library/create/creature/section-spells-known.ts†L14-L45】
-- **Skill-Chip-Workflow:** Fertigkeiten werden über ein Such-Dropdown hinzugefügt, als Chips mit entfernbarem Button und Expertise-Checkbox angezeigt und synchronisieren `skillsProf`/`skillsExpertise` inklusive Mod-Neuberechnung.【F:src/apps/library/create/creature/section-core-stats.ts†L186-L289】
-- **Defensiv-Listenverwaltung:** Schadenstypen, Zustandsimmunitäten, passive Werte und Gear werden über Chip-basierte Editoren mit Such-Dropdowns gepflegt; freie Eingaben laufen jetzt direkt über das Search-Feld und landen strukturiert im `StatblockData`.【F:src/apps/library/create/creature/section-core-stats.ts†L313-L349】【F:src/apps/library/core/creature-files.ts†L15-L115】
+- **Skill-Chip-Workflow:** Fertigkeiten werden über ein Such-Dropdown mit Inline-Label in derselben Row hinzugefügt; Chips mit Entfernen-Button erscheinen darunter, inklusive Expertise-Checkbox und Sync von `skillsProf`/`skillsExpertise` plus Mod-Neuberechnung.【F:src/apps/library/create/creature/section-core-stats.ts†L186-L289】
+- **Sinne & Sprachen via Presets:** Ein Search-Dropdown greift auf die neuen Sense-/Language-Listen zu, erlaubt zusätzliche Freitexteinträge und zeigt Chips mit Remove-Button analog zum Skill-Editor.【F:src/apps/library/create/creature/section-core-stats.ts†L292-L344】
+- **Defensiv-Listenverwaltung:** Schadenstypen nutzen einen kombinierten Editor mit Search-Dropdown und Status-Schalter (Resistenz/Immunität/Verwundbarkeit), der Mehrfacheingaben verhindert und alle drei Listen über eine Zeile pflegt; Zustandsimmunitäten, passive Werte und Gear bleiben Chip-basiert mit frei editierbarem Search-Feld.【F:src/apps/library/create/creature/section-core-stats.ts†L301-L370】【F:src/apps/library/core/creature-files.ts†L15-L115】
 - **Strukturierte Ausgabe:** Einträge werden strukturiert im `StatblockData` gespeichert und ermöglichen später die Generierung formatierter Markdown-Abschnitte aus JSON-Daten.【F:src/apps/library/create/creature/section-entries.ts†L14-L175】【F:src/apps/library/core/creature-files.ts†L64-L119】
 
 ## Skript-Details
 - **`index.ts`:** Bündelt alle öffentlichen Einhängepunkte des Creature Creators (Modal & Mounting-Funktionen) für externe Nutzung.【F:src/apps/library/create/creature/index.ts†L1-L6】
 - **`modal.ts`:** Implementiert den Obsidian-Modal, orchestriert Abschnitt-Mounting, Geschwindigkeitserfassung, Spell-Ladeprozess und Submit-Handling.【F:src/apps/library/create/creature/modal.ts†L11-L105】
-- **`presets.ts`:** Enthält Konstanten für Auswahloptionen (Größen, Typen, Gesinnung, Skills, Eintragskategorien, Bewegungsarten sowie Schadenstyp-/Zustands-/Passive-Presets) zur zentralen Pflege von Listenwerten.【F:src/apps/library/create/creature/presets.ts†L1-L115】
-- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, Attributtabellen, den neuen Skill-Editor mit Search-Dropdown + Chips + Expertise-Toggles sowie Token-Editoren für Sinne/Sprachen und Defensivlisten; alle Änderungen halten `StatblockData` und Mod-Berechnungen synchron.【F:src/apps/library/create/creature/section-core-stats.ts†L86-L349】
+- **`presets.ts`:** Enthält Konstanten für Auswahloptionen (Größen, Typen, Gesinnung, Skills, Eintragskategorien, Bewegungsarten sowie Schadenstyp-/Zustands-/Passive-/Sense-/Language-Presets) zur zentralen Pflege von Listenwerten.【F:src/apps/library/create/creature/presets.ts†L1-L183】
+- **`section-core-stats.ts`:** Rendert Identitätsfelder, Kernwerte, den zweispaltigen Ability-Kartenblock mit gebündelten Save-Mod-Kontrollen, den Skill-Editor mit Inline-Label in der Suchzeile, Dropdown & Add-Button sowie Chips + Expertise-Toggles darunter, plus Token-Editoren für Sinne/Sprachen und den kombinierten Schadenstyp-Editor; alle Änderungen halten `StatblockData` und Mod-Berechnungen synchron.【F:src/apps/library/create/creature/section-core-stats.ts†L26-L353】
 - **`section-entries.ts`:** Verwalten der strukturierten Statblock-Einträge inkl. Kategorieauswahl, Auto-Berechnungen für To-Hit/Schaden, Save- und Recharge-Felder sowie Markdown-Detailtexten.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】
 - **`section-spells-known.ts`:** Bietet Typeahead-Auswahl für Zauber, Felder für Grad/Nutzung/Notizen und Listenpflege für die gespeicherten Spells mit Refresh-Hook für asynchrones Nachladen.【F:src/apps/library/create/creature/section-spells-known.ts†L5-L68】

--- a/src/apps/library/create/creature/presets.ts
+++ b/src/apps/library/create/creature/presets.ts
@@ -162,9 +162,45 @@ export const CREATURE_CONDITION_PRESETS = [
 ] as const;
 export type CreatureConditionPreset = (typeof CREATURE_CONDITION_PRESETS)[number];
 
+export const CREATURE_SENSE_PRESETS = [
+  "Blindsight",
+  "Darkvision",
+  "Tremorsense",
+  "Truesight",
+  "Passive Perception",
+  "Telepathy",
+] as const;
+export type CreatureSensePreset = (typeof CREATURE_SENSE_PRESETS)[number];
+
 export const CREATURE_PASSIVE_PRESETS = [
   "Passive Perception",
   "Passive Insight",
   "Passive Investigation",
 ] as const;
 export type CreaturePassivePreset = (typeof CREATURE_PASSIVE_PRESETS)[number];
+
+export const CREATURE_LANGUAGE_PRESETS = [
+  "Common",
+  "Dwarvish",
+  "Elvish",
+  "Giant",
+  "Gnomish",
+  "Goblin",
+  "Halfling",
+  "Orc",
+  "Abyssal",
+  "Celestial",
+  "Draconic",
+  "Deep Speech",
+  "Infernal",
+  "Primordial",
+  "Aquan",
+  "Auran",
+  "Ignan",
+  "Terran",
+  "Sylvan",
+  "Undercommon",
+  "Druidic",
+  "Thieves' Cant",
+] as const;
+export type CreatureLanguagePreset = (typeof CREATURE_LANGUAGE_PRESETS)[number];

--- a/src/apps/library/create/creature/section-core-stats.ts
+++ b/src/apps/library/create/creature/section-core-stats.ts
@@ -10,7 +10,9 @@ import {
   CREATURE_ALIGNMENT_LAW_CHAOS,
   CREATURE_CONDITION_PRESETS,
   CREATURE_DAMAGE_PRESETS,
+  CREATURE_LANGUAGE_PRESETS,
   CREATURE_PASSIVE_PRESETS,
+  CREATURE_SENSE_PRESETS,
   CREATURE_SIZES,
   CREATURE_SKILLS,
   CREATURE_TYPES,
@@ -23,29 +25,64 @@ interface PresetSelectModel {
   remove(index: number): void;
 }
 
+interface PresetSelectEditorOptions {
+  placeholder?: string;
+  inlineLabel?: string;
+  rowClass?: string;
+}
+
+type PresetSelectEditorConfig = string | PresetSelectEditorOptions | undefined;
+
+type DamageResponseKind = "res" | "imm" | "vuln";
+
+interface DamageResponseConfig {
+  kind: DamageResponseKind;
+  label: string;
+  list: string[];
+  chipClass: string;
+}
+
 function mountPresetSelectEditor(
   parent: HTMLElement,
   title: string,
   options: readonly string[],
   model: PresetSelectModel,
-  customPlaceholder?: string,
+  config?: PresetSelectEditorConfig,
 ) {
+  const resolved: PresetSelectEditorOptions =
+    typeof config === "string" ? { placeholder: config } : config ?? {};
+  const { placeholder, inlineLabel, rowClass } = resolved;
   const setting = new Setting(parent).setName(title);
-  const row = setting.controlEl.createDiv({ cls: "sm-cc-searchbar" });
-  const select = row.createEl("select") as HTMLSelectElement;
+  const rowClasses = ["sm-cc-searchbar"];
+  if (rowClass) rowClasses.push(rowClass);
+  const row = setting.controlEl.createDiv({ cls: rowClasses.join(" ") });
+  let labelEl: HTMLLabelElement | undefined;
+  let controlId: string | undefined;
+  if (inlineLabel) {
+    controlId = `sm-cc-select-${Math.random().toString(36).slice(2)}`;
+    labelEl = row.createEl("label", { text: inlineLabel, attr: { for: controlId } });
+  }
+  const select = row.createEl(
+    "select",
+    controlId ? { attr: { id: controlId } } : undefined,
+  ) as HTMLSelectElement;
   const blank = select.createEl("option", { text: "Auswahl…" }) as HTMLOptionElement;
   blank.value = "";
   for (const option of options) {
     const opt = select.createEl("option", { text: option }) as HTMLOptionElement;
     opt.value = option;
   }
-  try { enhanceSelectToSearch(select, "Such-dropdown…"); } catch {}
+  try { enhanceSelectToSearch(select, placeholder ?? "Such-dropdown…"); } catch {}
   const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-  if (customPlaceholder && searchInput) {
-    searchInput.placeholder = customPlaceholder;
+  if (searchInput) {
+    if (placeholder) searchInput.placeholder = placeholder;
+    if (!searchInput.id) {
+      searchInput.id = controlId ?? `sm-cc-input-${Math.random().toString(36).slice(2)}`;
+    }
+    if (labelEl) labelEl.htmlFor = searchInput.id;
   }
 
-  const addBtn = row.createEl("button", { text: "+ Hinzufügen" });
+  const addBtn = row.createEl("button", { text: "+ Hinzufügen", attr: { type: "button" } });
   const chips = setting.controlEl.createDiv({ cls: "sm-cc-chips" });
 
   const renderChips = () => {
@@ -53,7 +90,11 @@ function mountPresetSelectEditor(
     model.get().forEach((txt, index) => {
       const chip = chips.createDiv({ cls: "sm-cc-chip" });
       chip.createSpan({ text: txt });
-      const removeBtn = chip.createEl("button", { text: "×" });
+      const removeBtn = chip.createEl("button", {
+        cls: "sm-cc-chip__remove",
+        text: "×",
+        attr: { type: "button", "aria-label": `${txt} entfernen` },
+      });
       removeBtn.onclick = () => {
         model.remove(index);
         renderChips();
@@ -79,6 +120,137 @@ function mountPresetSelectEditor(
     if (searchInput) searchInput.value = "";
     renderChips();
   };
+
+  renderChips();
+}
+
+function mountDamageResponseEditor(
+  parent: HTMLElement,
+  damageLists: { resistances: string[]; immunities: string[]; vulnerabilities: string[] },
+) {
+  const configs: DamageResponseConfig[] = [
+    {
+      kind: "res",
+      label: "Resistenz",
+      list: damageLists.resistances,
+      chipClass: "sm-cc-damage-chip--res",
+    },
+    {
+      kind: "imm",
+      label: "Immunität",
+      list: damageLists.immunities,
+      chipClass: "sm-cc-damage-chip--imm",
+    },
+    {
+      kind: "vuln",
+      label: "Verwundbarkeit",
+      list: damageLists.vulnerabilities,
+      chipClass: "sm-cc-damage-chip--vuln",
+    },
+  ];
+
+  const setting = new Setting(parent).setName("Schadenstyp-Reaktionen");
+  const row = setting.controlEl.createDiv({ cls: "sm-cc-searchbar sm-cc-damage-row" });
+  row.createEl("label", { cls: "sm-cc-damage-label", text: "Schadenstyp" });
+
+  const select = row.createEl("select", { cls: "sm-cc-damage-select" }) as HTMLSelectElement;
+  const blank = select.createEl("option", { text: "Auswahl…" }) as HTMLOptionElement;
+  blank.value = "";
+  for (const option of CREATURE_DAMAGE_PRESETS) {
+    const opt = select.createEl("option", { text: option }) as HTMLOptionElement;
+    opt.value = option;
+  }
+  try { enhanceSelectToSearch(select, "Schadenstyp suchen…"); } catch {}
+  const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
+
+  const typeWrap = row.createDiv({ cls: "sm-cc-damage-type" });
+  typeWrap.createSpan({ cls: "sm-cc-damage-type__label", text: "Status" });
+  const btnWrap = typeWrap.createDiv({ cls: "sm-cc-damage-type__buttons" });
+
+  let activeConfig = configs[0];
+  const buttons = new Map<DamageResponseKind, HTMLButtonElement>();
+  for (const config of configs) {
+    const btn = btnWrap.createEl("button", {
+      cls: "sm-cc-damage-type__btn",
+      text: config.label,
+      attr: { type: "button" },
+    }) as HTMLButtonElement;
+    buttons.set(config.kind, btn);
+    btn.onclick = () => {
+      activeConfig = config;
+      for (const [kind, button] of buttons) {
+        if (kind === config.kind) button.addClass("is-active");
+        else button.removeClass("is-active");
+      }
+    };
+  }
+  buttons.get(activeConfig.kind)?.addClass("is-active");
+
+  const addBtn = row.createEl("button", {
+    cls: "sm-cc-damage-add",
+    text: "+ Hinzufügen",
+    attr: { type: "button" },
+  });
+
+  const chips = setting.controlEl.createDiv({ cls: "sm-cc-chips sm-cc-damage-chips" });
+
+  const normalize = (value: string) => value.trim().toLowerCase();
+
+  const renderChips = () => {
+    chips.empty();
+    for (const config of configs) {
+      config.list.forEach((entry, index) => {
+        const chip = chips.createDiv({ cls: `sm-cc-chip sm-cc-damage-chip ${config.chipClass}` });
+        chip.createSpan({ cls: "sm-cc-damage-chip__name", text: entry });
+        chip.createSpan({ cls: "sm-cc-damage-chip__badge", text: config.label });
+        const removeBtn = chip.createEl("button", {
+          cls: "sm-cc-chip__remove",
+          text: "×",
+          attr: { type: "button", "aria-label": `${config.label} entfernen` },
+        });
+        removeBtn.onclick = () => {
+          config.list.splice(index, 1);
+          renderChips();
+        };
+      });
+    }
+  };
+
+  const addEntry = () => {
+    const selectedValue = select.value.trim();
+    const typedValue = searchInput?.value.trim() ?? "";
+    let value = selectedValue;
+    if (!value && typedValue) {
+      const match = Array.from(select.options).find(
+        (opt) => opt.text.trim().toLowerCase() === typedValue.toLowerCase(),
+      );
+      value = match ? match.value.trim() : typedValue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      select.value = "";
+      if (searchInput) searchInput.value = "";
+      return;
+    }
+    const list = activeConfig.list;
+    if (list.some((entry) => normalize(entry) === normalize(trimmed))) {
+      return;
+    }
+    list.push(trimmed);
+    select.value = "";
+    if (searchInput) searchInput.value = "";
+    renderChips();
+  };
+
+  addBtn.addEventListener("click", addEntry);
+  if (searchInput) {
+    searchInput.addEventListener("keydown", (evt) => {
+      if (evt.key === "Enter") {
+        evt.preventDefault();
+        addEntry();
+      }
+    });
+  }
 
   renderChips();
 }
@@ -144,10 +316,6 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   // Abilities + Saves
   const abilitySection = root.createDiv({ cls: "sm-cc-skills" });
   abilitySection.createEl("h4", { text: "Stats" });
-  const statsTbl = abilitySection.createDiv({ cls: "sm-cc-table sm-cc-stats-table" });
-  const header = statsTbl.createDiv({ cls: "sm-cc-row sm-cc-header" });
-  ;["Name","Wert","Mod","Save","Save Mod"].forEach(h => header.createDiv({ cls: "sm-cc-cell", text: h }));
-
   const abilityElems = new Map<CreatureAbilityKey, { score: HTMLInputElement; mod: HTMLElement; save: HTMLInputElement; saveMod: HTMLElement }>();
 
   const ensureSets = () => {
@@ -156,13 +324,17 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
     if (!data.skillsExpertise) data.skillsExpertise = [];
   };
 
+  const statsGrid = abilitySection.createDiv({ cls: "sm-cc-stats-grid" });
+
   for (const s of CREATURE_ABILITIES) {
-    const rowEl = statsTbl.createDiv({ cls: "sm-cc-row" });
-    rowEl.createDiv({ cls: "sm-cc-cell", text: s.label });
-    const scoreCell = rowEl.createDiv({ cls: "sm-cc-cell sm-inline-number" });
-    const score = scoreCell.createEl("input", { attr: { type: "number", placeholder: "10", min: "0", step: "1" } }) as HTMLInputElement;
-    const dec = scoreCell.createEl("button", { text: "−", cls: "btn-compact" });
-    const inc = scoreCell.createEl("button", { text: "+", cls: "btn-compact" });
+    const statEl = statsGrid.createDiv({ cls: "sm-cc-stat" });
+
+    const header = statEl.createDiv({ cls: "sm-cc-stat__header" });
+    header.createSpan({ text: s.label });
+    const scoreWrap = header.createDiv({ cls: "sm-inline-number sm-cc-stat__score" });
+    const score = scoreWrap.createEl("input", { attr: { type: "number", placeholder: "10", min: "0", step: "1" } }) as HTMLInputElement;
+    const dec = scoreWrap.createEl("button", { text: "−", cls: "btn-compact" });
+    const inc = scoreWrap.createEl("button", { text: "+", cls: "btn-compact" });
     score.value = (data as any)[s.key] || "";
     const step = (d: number) => {
       const cur = parseInt(score.value, 10) || 0;
@@ -174,10 +346,19 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
     dec.onclick = () => step(-1);
     inc.onclick = () => step(1);
     score.addEventListener("input", () => { (data as any)[s.key] = score.value.trim(); updateMods(); });
-    const modOut = rowEl.createDiv({ cls: "sm-cc-cell", text: "+0" });
-    const saveCb = rowEl.createEl("input", { cls: "sm-cc-cell", attr: { type: "checkbox" } }) as HTMLInputElement;
-    const saveOut = rowEl.createDiv({ cls: "sm-cc-cell", text: "+0" });
-    ensureSets(); saveCb.checked = !!(data.saveProf as any)[s.key];
+
+    const modRow = statEl.createDiv({ cls: "sm-cc-stat__mod" });
+    modRow.createSpan({ text: "Mod" });
+    const modOut = modRow.createSpan({ cls: "sm-cc-stat__mod-value", text: "+0" });
+
+    const saveRow = statEl.createDiv({ cls: "sm-cc-stat__save" });
+    saveRow.createSpan({ cls: "sm-cc-stat__save-label", text: "Save mod" });
+    const saveControls = saveRow.createDiv({ cls: "sm-cc-stat__save-controls" });
+    const saveCb = saveControls.createEl("input", { attr: { type: "checkbox", "aria-label": `${s.label} Save Proficiency` } }) as HTMLInputElement;
+    const saveOut = saveControls.createSpan({ cls: "sm-cc-stat__save-value", text: "+0" });
+
+    ensureSets();
+    saveCb.checked = !!(data.saveProf as any)[s.key];
     saveCb.addEventListener("change", () => { (data.saveProf as any)[s.key] = saveCb.checked; updateMods(); });
     abilityElems.set(s.key, { score, mod: modOut, save: saveCb, saveMod: saveOut });
   }
@@ -189,8 +370,12 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   const skillsControl = skillsSetting.controlEl;
   skillsControl.addClass("sm-cc-skill-editor");
 
+  skillsSetting.nameEl.empty();
+
   const skillsRow = skillsControl.createDiv({ cls: "sm-cc-searchbar sm-cc-skill-search" });
-  const skillsSelect = skillsRow.createEl("select") as HTMLSelectElement;
+  const skillsSelectId = "sm-cc-skill-select";
+  const skillsLabel = skillsRow.createEl("label", { text: "Fertigkeiten", attr: { for: skillsSelectId } });
+  const skillsSelect = skillsRow.createEl("select", { attr: { id: skillsSelectId } }) as HTMLSelectElement;
   const blankSkill = skillsSelect.createEl("option", { text: "Fertigkeit wählen…" }) as HTMLOptionElement;
   blankSkill.value = "";
   for (const [name] of CREATURE_SKILLS) {
@@ -199,7 +384,11 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   }
   try { enhanceSelectToSearch(skillsSelect, "Fertigkeit suchen…"); } catch {}
   const skillsSearchInput = (skillsSelect as any)._smSearchInput as HTMLInputElement | undefined;
-  if (skillsSearchInput) skillsSearchInput.placeholder = "Fertigkeit suchen…";
+  if (skillsSearchInput) {
+    skillsSearchInput.placeholder = "Fertigkeit suchen…";
+    if (!skillsSearchInput.id) skillsSearchInput.id = `${skillsSelectId}-search`;
+    skillsLabel.htmlFor = skillsSearchInput.id;
+  }
 
   const addSkillBtn = skillsRow.createEl("button", { text: "+ Hinzufügen" });
   const skillChips = skillsControl.createDiv({ cls: "sm-cc-chips sm-cc-skill-chips" });
@@ -288,19 +477,6 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
   };
   renderSkillChips();
 
-  if (!data.sensesList) data.sensesList = [];
-  if (!data.languagesList) data.languagesList = [];
-  mountTokenEditor(root, "Sinne", {
-    getItems: () => data.sensesList!,
-    add: (value) => data.sensesList!.push(value),
-    remove: (index) => data.sensesList!.splice(index, 1),
-  });
-  mountTokenEditor(root, "Sprachen", {
-    getItems: () => data.languagesList!,
-    add: (value) => data.languagesList!.push(value),
-    remove: (index) => data.languagesList!.splice(index, 1),
-  });
-
   const ensureStringList = (key: keyof StatblockData & string): string[] => {
     const current = (data as any)[key];
     if (Array.isArray(current)) return current as string[];
@@ -320,17 +496,35 @@ export function mountCoreStatsSection(parent: HTMLElement, data: StatblockData) 
     },
   });
 
+  const senses = ensureStringList("sensesList");
+  mountPresetSelectEditor(
+    root,
+    "Sinne",
+    CREATURE_SENSE_PRESETS,
+    makeModel(senses),
+    { placeholder: "Sinn suchen oder eingeben…", inlineLabel: "Eintrag", rowClass: "sm-cc-senses-search" },
+  );
+
+  const languages = ensureStringList("languagesList");
+  mountPresetSelectEditor(
+    root,
+    "Sprachen",
+    CREATURE_LANGUAGE_PRESETS,
+    makeModel(languages),
+    { placeholder: "Sprache suchen oder eingeben…", inlineLabel: "Eintrag", rowClass: "sm-cc-senses-search" },
+  );
+
   const passives = ensureStringList("passivesList");
   mountPresetSelectEditor(root, "Passive Werte", CREATURE_PASSIVE_PRESETS, makeModel(passives), "Passiven Wert suchen oder eingeben…");
 
   const vulnerabilities = ensureStringList("damageVulnerabilitiesList");
-  mountPresetSelectEditor(root, "Verwundbarkeiten", CREATURE_DAMAGE_PRESETS, makeModel(vulnerabilities), "Verwundbarkeit suchen oder eingeben…");
-
   const resistances = ensureStringList("damageResistancesList");
-  mountPresetSelectEditor(root, "Resistenzen", CREATURE_DAMAGE_PRESETS, makeModel(resistances), "Resistenz suchen oder eingeben…");
-
   const immunities = ensureStringList("damageImmunitiesList");
-  mountPresetSelectEditor(root, "Immunitäten (Schaden)", CREATURE_DAMAGE_PRESETS, makeModel(immunities), "Schadensimmunität suchen oder eingeben…");
+  mountDamageResponseEditor(root, {
+    vulnerabilities,
+    resistances,
+    immunities,
+  });
 
   const conditionImmunities = ensureStringList("conditionImmunitiesList");
   mountPresetSelectEditor(root, "Zustandsimmunitäten", CREATURE_CONDITION_PRESETS, makeModel(conditionImmunities), "Zustandsimmunität suchen oder eingeben…");


### PR DESCRIPTION
## Summary
- add styling hooks for the new damage response chip controls and align the create modal layout
- extend the core stats section with a shared damage response editor that avoids duplicates and groups status toggles
- document the combined damage editor in the library and creature creator overviews
- introduce preset-backed sense and language selectors plus labelled skill search rows for better accessibility
- describe the new preset catalogs and search UX updates across the overview documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3edd8af788325ab61b24e9e7f92f5