### PR TITLE
Refine creature ability layout

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -193,17 +193,17 @@ export const HEX_PLUGIN_CSS = `
 .sm-cc-create-modal .sm-cc-header .sm-cc-cell { font-weight: 600; color: var(--text-muted); }
 
 /* Ability score cards */
-.sm-cc-create-modal .sm-cc-stats-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .5rem; margin-top: .35rem; }
-.sm-cc-create-modal .sm-cc-stat { border: 1px solid var(--background-modifier-border); border-radius: 8px; padding: .5rem; background: var(--background-primary); display: flex; flex-direction: column; gap: .35rem; }
-.sm-cc-create-modal .sm-cc-stat__header { display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-weight: 600; }
-.sm-cc-create-modal .sm-cc-stat__header span:first-child { color: var(--text-normal); }
-.sm-cc-create-modal .sm-cc-stat__mod { display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-size: .95em; color: var(--text-muted); }
-.sm-cc-create-modal .sm-cc-stat__mod-value { font-weight: 600; color: var(--text-normal); }
-.sm-cc-create-modal .sm-cc-stat__save { display: flex; flex-direction: column; gap: .25rem; }
-.sm-cc-create-modal .sm-cc-stat__save-label { font-size: .85em; font-weight: 600; text-transform: uppercase; letter-spacing: .02em; color: var(--text-muted); }
-.sm-cc-create-modal .sm-cc-stat__save-controls { display: flex; align-items: center; gap: .35rem; }
-.sm-cc-create-modal .sm-cc-stat__save-controls input[type="checkbox"] { margin: 0; }
-.sm-cc-create-modal .sm-cc-stat__save-value { font-weight: 600; }
+.sm-cc-create-modal .sm-cc-stats-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 1fr; align-items: stretch; gap: .35rem 1rem; margin-top: .35rem; }
+.sm-cc-create-modal .sm-cc-stats-col { display: flex; flex-direction: column; gap: .35rem; }
+.sm-cc-create-modal .sm-cc-stat-row { display: flex; align-items: center; gap: .45rem; padding: .35rem .45rem; border-radius: 8px; border: 1px solid var(--background-modifier-border); background: var(--background-primary); }
+.sm-cc-create-modal .sm-cc-stat-row__label { flex: 0 0 2.5rem; font-weight: 600; color: var(--text-normal); }
+.sm-cc-create-modal .sm-cc-stat-row__score { flex: 0 0 auto; }
+.sm-cc-create-modal .sm-cc-stat-row__mod-label { font-size: .85em; color: var(--text-muted); }
+.sm-cc-create-modal .sm-cc-stat-row__mod-value { font-weight: 600; color: var(--text-normal); min-width: 2.5rem; text-align: right; }
+.sm-cc-create-modal .sm-cc-stat-row__save { margin-left: auto; display: inline-flex; align-items: center; gap: .35rem; }
+.sm-cc-create-modal .sm-cc-stat-row__save-prof { display: inline-flex; align-items: center; gap: .3rem; font-size: .85em; color: var(--text-muted); cursor: pointer; }
+.sm-cc-create-modal .sm-cc-stat-row__save-prof input[type="checkbox"] { margin: 0; }
+.sm-cc-create-modal .sm-cc-stat-row__save-mod { font-weight: 600; color: var(--text-normal); min-width: 2.5rem; text-align: right; }
 @media (max-width: 700px) {
     .sm-cc-create-modal .sm-cc-stats-grid { grid-template-columns: minmax(0, 1fr); }
 }

--- a/src/apps/library/create/creature/overview.txt
+++ b/src/apps/library/create/creature/overview.txt
@@ -7,7 +7,7 @@ src/apps/library/create/creature/
 ├── modal.ts                  # Einstiegspunkt, orchestriert Abschnitte & Submit-Flow
 ├── presets.ts                # Vordefinierte Auswahlwerte (Größen, Typen, Skills, Sinne, Sprachen …)
 ├── section-basics.ts         # Identity-, Kernwert- und Bewegungs-Editor
-├── section-stats-and-skills.ts # Ability-, Save- und Skill-Editor mit Mod-Neuberechnung
+├── section-stats-and-skills.ts # Ability-Zweispalten-Layout, Save-Profs & Skill-Editor mit Mod-Neuberechnung
 ├── section-senses-and-defenses.ts # Sinne, Sprachen, Passives, Schadenstyp-Antworten & Gear
 ├── section-utils.ts          # Geteilte Preset-/Damage-Editor-Helfer für Sections
 ├── section-entries.ts        # Strukturierte Einträge (Traits, Aktionen …)
@@ -18,14 +18,14 @@ src/apps/library/create/creature/
 1. **Initialisierung:** `CreateCreatureModal` legt ein frisches `StatblockData` an, verhindert Outside-Click-Closes und startet das asynchrone Laden der Zauberdateiliste.
 2. **Abschnitts-Mounting:** Das Modal ruft nacheinander `mountCreatureBasicsSection`, `mountCreatureStatsAndSkillsSection`, `mountCreatureSensesAndDefensesSection`, `mountEntriesSection` und `mountSpellsKnownSection` auf. Jede Section erhält das gemeinsame Datenobjekt und pflegt ihren Teilbereich eigenständig.
 3. **Grunddaten & Bewegung:** Die Basics-Section verwaltet Name, Größe, Typ, Gesinnung, Kernwerte sowie Bewegungsarten; die Bewegungsauswahl sitzt in einer einzeiligen Such-/Input-Leiste mit Hover-Toggle und kompaktem `+`-Button, neue Speed-Einträge landen als Chips in `speedList`.
-4. **Ability/Skill-Bereich:** Die Stats-&-Skills-Section rendert Ability-Karten mit Save-Proficiencies, kümmert sich um Skill-Chips samt Expertise-Toggle und berechnet Modifikatoren nach jeder Änderung automatisch.
+4. **Ability/Skill-Bereich:** Die Stats-&-Skills-Section rendert ein zweispaltiges Ability-Grid mit kompakten Save-Zeilen, verwaltet Skill-Chips samt Expertise-Toggle und berechnet Modifikatoren nach jeder Änderung automatisch.
 5. **Sinne/Verteidigung:** Sinne/Sprachen/Passives nutzen Preset-Suchdropdowns mit rechtsbündigem Suchfeld, Schadenstyp-Reaktionen teilen sich einen Editor mit Status-Schaltern, Zustandsimmunitäten und Gear werden via Chips gepflegt.
 6. **Submission:** Buttons am Ende schließen das Modal oder reichen das `StatblockData` an den Callback weiter; `onClose`/`onunload` stellen Pointer-Events des Hintergrunds wieder her.
 
 ## Features & Zuständigkeiten
 - **Modulare Abschnittsstruktur:** Jede Eingabegruppe ist in ein eigenes Skript ausgelagert, wodurch UI-Logik, State-Hooks und Preset-Helfer getrennt wartbar bleiben.【F:src/apps/library/create/creature/modal.ts†L5-L55】
 - **Grunddaten & Movement-Chips:** Die Basics-Section kombiniert Identitätsfelder mit einem Movement-Editor, der Bewegungsarten in einer einzeiligen Suchleiste inkl. Hover-Toggle & `+`-Button verwaltet und Speed-Chips rendert.【F:src/apps/library/create/creature/section-basics.ts†L19-L146】
-- **Ability-Karten mit Live-Mods:** Ability Scores, Saves und Skill-Proficiencies sitzen in einem Kartengrid; Änderungen aktualisieren Modifikatoren, Save-Boni und Expertise-Synchronisation sofort.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L15-L143】
+- **Ability-Zeilen mit Live-Mods:** Ability Scores, Saves und Skill-Proficiencies sitzen in einem zweispaltigen Reihenlayout; Änderungen aktualisieren Modifikatoren, Save-Boni und Expertise-Synchronisation sofort.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
 - **Suchbare Sinne/Sprachen & Schadenstyp-Editor:** Preset-gestützte Dropdowns ohne Inline-Labels decken Sinne, Sprachen und Passives jetzt mit gemeinsamem Rechtsausrichtungslayout samt kompaktem `+`-Button ab, während ein kombinierter Schadenstyp-Editor Resistenz/Immunität/Verwundbarkeit über Status-Schalter steuert.【F:src/apps/library/create/creature/section-senses-and-defenses.ts†L42-L100】【F:src/apps/library/create/creature/section-utils.ts†L24-L125】
 - **Geteilte Helfer:** `section-utils.ts` stellt `mountPresetSelectEditor` und `mountDamageResponseEditor` bereit, damit mehrere Abschnitte identische Chip-UX und Validierung nutzen können.【F:src/apps/library/create/creature/section-utils.ts†L1-L210】
 - **Strukturierte Einträge & Zauber:** Traits/Aktionen und Zauberlisten behalten ihre bestehenden Module mit Typeahead- und Berechnungslogik; sie hängen direkt an `StatblockData` und reagieren auf Refresh-Signale aus dem Modal.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】【F:src/apps/library/create/creature/section-spells-known.ts†L5-L68】
@@ -35,7 +35,7 @@ src/apps/library/create/creature/
 - **`modal.ts`:** Obsidian-Modal, das Lebenszyklus, Abschnitts-Mounting, Spell-Refresh und Submit-Handling koordiniert.【F:src/apps/library/create/creature/modal.ts†L1-L62】
 - **`presets.ts`:** Zentralisiert Auswahlwerte für Größen, Typen, Gesinnung, Bewegungsarten, Skills, Sinne, Sprachen, Passives, Schadenstypen und Zustände.【F:src/apps/library/create/creature/presets.ts†L1-L183】
 - **`section-basics.ts`:** Verwaltet Identität, Kernwerte und Movement-UX (einzeilige Dropdown-/Hover-Leiste + Chip-Liste) innerhalb eines Settings-Layouts.【F:src/apps/library/create/creature/section-basics.ts†L19-L146】
-- **`section-stats-and-skills.ts`:** Rendert das zweispaltige Ability-Grid, Save-Proficiencies, eine rechtsbündige Skill-Suche mit Chips/Expertise und synchronisiert alle Modifikatoren via `shared/stat-utils`.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L15-L196】
+- **`section-stats-and-skills.ts`:** Rendert das zweispaltige Ability-Grid mit Save-Reihen, eine rechtsbündige Skill-Suche mit Chips/Expertise und synchronisiert alle Modifikatoren via `shared/stat-utils`.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
 - **`section-senses-and-defenses.ts`:** Kapselt Sinne/Sprachen/Passives über Preset-Dropdowns mit dem gleichen rechten Layout wie die Skills, setzt dort bewusst auf kompakte `+`-Buttons, kombiniert Schadenstypen mit Statusauswahl und deckt Gear + Zustandsimmunitäten über Chip-Editoren ab.【F:src/apps/library/create/creature/section-senses-and-defenses.ts†L1-L100】
 - **`section-utils.ts`:** Gemeinsame Helper zum Mounten von Preset-Suchdropdowns (inklusive konfigurierbarer Standard-Buttonbeschriftung) und Schadenstyp-Reaktionseditoren für mehrere Sections.【F:src/apps/library/create/creature/section-utils.ts†L1-L210】
 - **`section-entries.ts`:** Strukturierte Eingabemaske für Traits/Aktionen, inklusive Auto-Berechnungen für To-Hit, Saves und Schaden.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】


### PR DESCRIPTION
## Summary
- reorganize creature ability editor into two column rows with inline save controls
- update styles to match the row-based ability layout
- refresh creature creator overview to describe the new stats section structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d413c21f8c8325aaae9db0d2681626