### PR TITLE
Add shared Mod/Save header for creature stats

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -194,18 +194,23 @@ export const HEX_PLUGIN_CSS = `
 
 /* Ability score cards */
 .sm-cc-create-modal .sm-cc-stats-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 1fr; align-items: stretch; gap: .35rem 1rem; margin-top: .35rem; }
+.sm-cc-create-modal .sm-cc-stats-grid__header { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .35rem 1rem; align-items: center; padding: 0 .45rem; margin-bottom: .15rem; font-size: .85em; color: var(--text-muted); }
+.sm-cc-create-modal .sm-cc-stats-grid__header-cell { display: flex; align-items: center; justify-content: flex-end; gap: .35rem; font-weight: 600; }
+.sm-cc-create-modal .sm-cc-stats-grid__header-cell--save { gap: .45rem; }
+.sm-cc-create-modal .sm-cc-stats-grid__header-save-mod { font-size: .78em; letter-spacing: .06em; text-transform: uppercase; min-width: 2.5rem; text-align: right; }
+.sm-cc-create-modal .sm-cc-stats-grid__header-save-label { font-weight: 600; }
 .sm-cc-create-modal .sm-cc-stats-col { display: flex; flex-direction: column; gap: .35rem; }
 .sm-cc-create-modal .sm-cc-stat-row { display: flex; align-items: center; gap: .45rem; padding: .35rem .45rem; border-radius: 8px; border: 1px solid var(--background-modifier-border); background: var(--background-primary); }
 .sm-cc-create-modal .sm-cc-stat-row__label { flex: 0 0 2.5rem; font-weight: 600; color: var(--text-normal); }
 .sm-cc-create-modal .sm-cc-stat-row__score { flex: 0 0 auto; }
-.sm-cc-create-modal .sm-cc-stat-row__mod-label { font-size: .85em; color: var(--text-muted); }
-.sm-cc-create-modal .sm-cc-stat-row__mod-value { font-weight: 600; color: var(--text-normal); min-width: 2.5rem; text-align: right; }
-.sm-cc-create-modal .sm-cc-stat-row__save { margin-left: auto; display: inline-flex; align-items: center; gap: .35rem; }
-.sm-cc-create-modal .sm-cc-stat-row__save-prof { display: inline-flex; align-items: center; gap: .3rem; font-size: .85em; color: var(--text-muted); cursor: pointer; }
+.sm-cc-create-modal .sm-cc-stat-row__mod-value { font-weight: 600; color: var(--text-normal); min-width: 2.5rem; text-align: right; margin-left: auto; }
+.sm-cc-create-modal .sm-cc-stat-row__save { margin-left: .5rem; display: grid; grid-auto-flow: column; grid-auto-columns: max-content; align-items: center; gap: .35rem; }
+.sm-cc-create-modal .sm-cc-stat-row__save-prof { display: inline-flex; align-items: center; justify-content: center; width: 1.5rem; height: 1.5rem; font-size: .85em; color: var(--text-muted); cursor: pointer; }
 .sm-cc-create-modal .sm-cc-stat-row__save-prof input[type="checkbox"] { margin: 0; }
 .sm-cc-create-modal .sm-cc-stat-row__save-mod { font-weight: 600; color: var(--text-normal); min-width: 2.5rem; text-align: right; }
 @media (max-width: 700px) {
     .sm-cc-create-modal .sm-cc-stats-grid { grid-template-columns: minmax(0, 1fr); }
+    .sm-cc-create-modal .sm-cc-stats-grid__header { grid-template-columns: minmax(0, 1fr); justify-items: flex-end; row-gap: .25rem; }
 }
 
 /* Compact inline number controls */

--- a/src/apps/library/create/creature/overview.txt
+++ b/src/apps/library/create/creature/overview.txt
@@ -7,7 +7,7 @@ src/apps/library/create/creature/
 ├── modal.ts                  # Einstiegspunkt, orchestriert Abschnitte & Submit-Flow
 ├── presets.ts                # Vordefinierte Auswahlwerte (Größen, Typen, Skills, Sinne, Sprachen …)
 ├── section-basics.ts         # Identity-, Kernwert- und Bewegungs-Editor
-├── section-stats-and-skills.ts # Ability-Zweispalten-Layout, Save-Profs & Skill-Editor mit Mod-Neuberechnung
+├── section-stats-and-skills.ts # Ability-Zweispalten-Layout, gemeinsame Mod/Save-Kopfzeile & Skill-Editor mit Mod-Neuberechnung
 ├── section-senses-and-defenses.ts # Sinne, Sprachen, Passives, Schadenstyp-Antworten & Gear
 ├── section-utils.ts          # Geteilte Preset-/Damage-Editor-Helfer für Sections
 ├── section-entries.ts        # Strukturierte Einträge (Traits, Aktionen …)
@@ -18,14 +18,14 @@ src/apps/library/create/creature/
 1. **Initialisierung:** `CreateCreatureModal` legt ein frisches `StatblockData` an, verhindert Outside-Click-Closes und startet das asynchrone Laden der Zauberdateiliste.
 2. **Abschnitts-Mounting:** Das Modal ruft nacheinander `mountCreatureBasicsSection`, `mountCreatureStatsAndSkillsSection`, `mountCreatureSensesAndDefensesSection`, `mountEntriesSection` und `mountSpellsKnownSection` auf. Jede Section erhält das gemeinsame Datenobjekt und pflegt ihren Teilbereich eigenständig.
 3. **Grunddaten & Bewegung:** Die Basics-Section verwaltet Name, Größe, Typ, Gesinnung, Kernwerte sowie Bewegungsarten; die Bewegungsauswahl sitzt in einer einzeiligen Such-/Input-Leiste mit Hover-Toggle und kompaktem `+`-Button, neue Speed-Einträge landen als Chips in `speedList`.
-4. **Ability/Skill-Bereich:** Die Stats-&-Skills-Section rendert ein zweispaltiges Ability-Grid mit kompakten Save-Zeilen, verwaltet Skill-Chips samt Expertise-Toggle und berechnet Modifikatoren nach jeder Änderung automatisch.
+4. **Ability/Skill-Bereich:** Die Stats-&-Skills-Section rendert ein zweispaltiges Ability-Grid mit vorgelagerter Mod/Save-Kopfzeile, verwaltet Skill-Chips samt Expertise-Toggle und berechnet Modifikatoren nach jeder Änderung automatisch.
 5. **Sinne/Verteidigung:** Sinne/Sprachen/Passives nutzen Preset-Suchdropdowns mit rechtsbündigem Suchfeld, Schadenstyp-Reaktionen teilen sich einen Editor mit Status-Schaltern, Zustandsimmunitäten und Gear werden via Chips gepflegt.
 6. **Submission:** Buttons am Ende schließen das Modal oder reichen das `StatblockData` an den Callback weiter; `onClose`/`onunload` stellen Pointer-Events des Hintergrunds wieder her.
 
 ## Features & Zuständigkeiten
 - **Modulare Abschnittsstruktur:** Jede Eingabegruppe ist in ein eigenes Skript ausgelagert, wodurch UI-Logik, State-Hooks und Preset-Helfer getrennt wartbar bleiben.【F:src/apps/library/create/creature/modal.ts†L5-L55】
 - **Grunddaten & Movement-Chips:** Die Basics-Section kombiniert Identitätsfelder mit einem Movement-Editor, der Bewegungsarten in einer einzeiligen Suchleiste inkl. Hover-Toggle & `+`-Button verwaltet und Speed-Chips rendert.【F:src/apps/library/create/creature/section-basics.ts†L19-L146】
-- **Ability-Zeilen mit Live-Mods:** Ability Scores, Saves und Skill-Proficiencies sitzen in einem zweispaltigen Reihenlayout; Änderungen aktualisieren Modifikatoren, Save-Boni und Expertise-Synchronisation sofort.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
+- **Ability-Zeilen mit Live-Mods:** Ability Scores, Saves und Skill-Proficiencies sitzen in einem zweispaltigen Reihenlayout mit geteilter Mod/Save-Headerzeile; Änderungen aktualisieren Modifikatoren, Save-Boni und Expertise-Synchronisation sofort.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
 - **Suchbare Sinne/Sprachen & Schadenstyp-Editor:** Preset-gestützte Dropdowns ohne Inline-Labels decken Sinne, Sprachen und Passives jetzt mit gemeinsamem Rechtsausrichtungslayout samt kompaktem `+`-Button ab, während ein kombinierter Schadenstyp-Editor Resistenz/Immunität/Verwundbarkeit über Status-Schalter steuert.【F:src/apps/library/create/creature/section-senses-and-defenses.ts†L42-L100】【F:src/apps/library/create/creature/section-utils.ts†L24-L125】
 - **Geteilte Helfer:** `section-utils.ts` stellt `mountPresetSelectEditor` und `mountDamageResponseEditor` bereit, damit mehrere Abschnitte identische Chip-UX und Validierung nutzen können.【F:src/apps/library/create/creature/section-utils.ts†L1-L210】
 - **Strukturierte Einträge & Zauber:** Traits/Aktionen und Zauberlisten behalten ihre bestehenden Module mit Typeahead- und Berechnungslogik; sie hängen direkt an `StatblockData` und reagieren auf Refresh-Signale aus dem Modal.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】【F:src/apps/library/create/creature/section-spells-known.ts†L5-L68】
@@ -35,7 +35,7 @@ src/apps/library/create/creature/
 - **`modal.ts`:** Obsidian-Modal, das Lebenszyklus, Abschnitts-Mounting, Spell-Refresh und Submit-Handling koordiniert.【F:src/apps/library/create/creature/modal.ts†L1-L62】
 - **`presets.ts`:** Zentralisiert Auswahlwerte für Größen, Typen, Gesinnung, Bewegungsarten, Skills, Sinne, Sprachen, Passives, Schadenstypen und Zustände.【F:src/apps/library/create/creature/presets.ts†L1-L183】
 - **`section-basics.ts`:** Verwaltet Identität, Kernwerte und Movement-UX (einzeilige Dropdown-/Hover-Leiste + Chip-Liste) innerhalb eines Settings-Layouts.【F:src/apps/library/create/creature/section-basics.ts†L19-L146】
-- **`section-stats-and-skills.ts`:** Rendert das zweispaltige Ability-Grid mit Save-Reihen, eine rechtsbündige Skill-Suche mit Chips/Expertise und synchronisiert alle Modifikatoren via `shared/stat-utils`.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
+- **`section-stats-and-skills.ts`:** Rendert das zweispaltige Ability-Grid samt gemeinsamer Mod/Save-Headerleiste, eine rechtsbündige Skill-Suche mit Chips/Expertise und synchronisiert alle Modifikatoren via `shared/stat-utils`.【F:src/apps/library/create/creature/section-stats-and-skills.ts†L32-L217】
 - **`section-senses-and-defenses.ts`:** Kapselt Sinne/Sprachen/Passives über Preset-Dropdowns mit dem gleichen rechten Layout wie die Skills, setzt dort bewusst auf kompakte `+`-Buttons, kombiniert Schadenstypen mit Statusauswahl und deckt Gear + Zustandsimmunitäten über Chip-Editoren ab.【F:src/apps/library/create/creature/section-senses-and-defenses.ts†L1-L100】
 - **`section-utils.ts`:** Gemeinsame Helper zum Mounten von Preset-Suchdropdowns (inklusive konfigurierbarer Standard-Buttonbeschriftung) und Schadenstyp-Reaktionseditoren für mehrere Sections.【F:src/apps/library/create/creature/section-utils.ts†L1-L210】
 - **`section-entries.ts`:** Strukturierte Eingabemaske für Traits/Aktionen, inklusive Auto-Berechnungen für To-Hit, Saves und Schaden.【F:src/apps/library/create/creature/section-entries.ts†L12-L175】

--- a/src/apps/library/create/creature/section-stats-and-skills.ts
+++ b/src/apps/library/create/creature/section-stats-and-skills.ts
@@ -30,6 +30,24 @@ export function mountCreatureStatsAndSkillsSection(
   abilitySection.createEl("h4", { text: "Stats" });
 
   const statsGrid = abilitySection.createDiv({ cls: "sm-cc-stats-grid" });
+  const statsGridHeader = statsGrid.createDiv({
+    cls: "sm-cc-stats-grid__header",
+  });
+  statsGridHeader.createSpan({
+    cls: "sm-cc-stats-grid__header-cell sm-cc-stats-grid__header-cell--mod",
+    text: "Mod",
+  });
+  const statsGridSaveHead = statsGridHeader.createDiv({
+    cls: "sm-cc-stats-grid__header-cell sm-cc-stats-grid__header-cell--save",
+  });
+  statsGridSaveHead.createSpan({
+    cls: "sm-cc-stats-grid__header-save-label",
+    text: "Save",
+  });
+  statsGridSaveHead.createSpan({
+    cls: "sm-cc-stats-grid__header-save-mod",
+    text: "Mod",
+  });
 
   const abilityByKey = new Map<CreatureAbilityKey, (typeof CREATURE_ABILITIES)[number]>(
     CREATURE_ABILITIES.map((def) => [def.key, def]),
@@ -69,7 +87,6 @@ export function mountCreatureStatsAndSkillsSection(
         updateMods();
       });
 
-      row.createSpan({ cls: "sm-cc-stat-row__mod-label", text: "Mod" });
       const modOut = row.createSpan({
         cls: "sm-cc-stat-row__mod-value",
         text: "+0",
@@ -80,7 +97,6 @@ export function mountCreatureStatsAndSkillsSection(
       const saveCb = saveLabel.createEl("input", {
         attr: { type: "checkbox", "aria-label": `${ability.label} Save Proficiency` },
       }) as HTMLInputElement;
-      saveLabel.createSpan({ text: "Save" });
       const saveOut = saveWrap.createSpan({
         cls: "sm-cc-stat-row__save-mod",
         text: "+0",


### PR DESCRIPTION
## Summary
- add a shared Mod/Save header row to the creature stat grid and streamline the per-stat rendering logic
- tune the creature modal styles so the new header, checkbox, and save modifier align cleanly across breakpoints
- refresh the creature creator overview to note the shared Mod/Save header layout

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d41647cb848325933b598a511af60f