### PR TITLE
Tighten creature ability score input width

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -276,7 +276,12 @@ export const HEX_PLUGIN_CSS = `
 .sm-inline-number { display: inline-flex; align-items: center; gap: .2rem; }
 .sm-inline-number input[type="number"] { width: 84px; }
 .sm-cc-create-modal .sm-cc-stat-row .sm-inline-number { gap: .12rem; }
-.sm-cc-create-modal .sm-cc-stat-row__score-input { width: 2.2ch; min-width: 2.2ch; text-align: center; padding-inline: 0; }
+.sm-cc-create-modal .sm-cc-stat-row .sm-inline-number input[type="number"].sm-cc-stat-row__score-input {
+    width: 2.2ch;
+    min-width: 2.2ch;
+    text-align: center;
+    padding-inline: 0;
+}
 .btn-compact { padding: 0 .4rem; min-width: 1.5rem; height: 1.6rem; line-height: 1.2; }
 
 /* Movement row should not overflow; children stay compact */


### PR DESCRIPTION
## Summary
- scope the creature ability score input width rule to override the generic inline-number width
- shrink the ability score inputs so only two digits fit comfortably while keeping alignment and padding intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d430e8e49c8325b7650ff1dfa55ec1