### PR TITLE
Add layout editor view with translation workflow

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -19,6 +19,7 @@ Salt-Marcher/
 │  ├─ apps/
 │  │  ├─ cartographer/      # Hex-Map-Workspace mit Editor/Inspector/Travel-Modi
 │  │  ├─ encounter/         # Einfache Encounter-View
+│  │  ├─ layout/            # Layout-Editor für Boxen, Übersetzungen & Maßexport
 │  │  └─ library/           # Bibliothek für Terrains, Regionen und Kreaturen
 │  ├─ core/                 # Domain-Services (Hex-Geometrie, Dateien, Terrain, Optionen)
 │  └─ ui/                   # Geteilte Dialoge und Workflow-Helfer
@@ -33,6 +34,7 @@ Salt-Marcher/
 - **Library-View:** Vereinheitlicht das Management von Terrains, Regionen und Kreaturen inklusive Suchleiste, Erstellung,
   Inline-Bearbeitung und Persistenz.
 - **Encounter-View:** Liefert eine leichtgewichtige Ansicht für Encounter-Notizen.
+- **Layout-Editor:** Bietet eine Drag-&-Drop-Arbeitsfläche zum Platzieren von Boxen, übersetzt Label-Texte in Zielsprachen und exportiert Abmessungen als JSON.
 - **Core-Services:** Stellen Hex-Geometrie, Map/Tile-Dateioperationen, Terrain- und Regions-Persistenz sowie Workspace-Helfer
   bereit und dienen als Single Source of Truth für die Apps.
 - **Geteilte UI-Bausteine:** Modals, Header- und Workflow-Helfer kapseln wiederkehrende Interaktionen (Map-Auswahl, Bestätigungen,
@@ -74,6 +76,11 @@ Salt-Marcher/
 ### src/apps/encounter
 - `view.ts`: Implementiert `EncounterView` (ItemView). Rendert eine einfache Encounter-Seite mit Titel und Platzhaltertext und
   räumt beim Schließen das DOM auf.
+
+### src/apps/layout
+- `view.ts`: Implementiert den `LayoutEditorView` mit Canvas, Inspector und Export. Unterstützt das Erstellen, Verschieben und
+  Skalieren von Boxen, nutzt `translateText` zur Sprachübersetzung von Labels und stellt JSON-Export inklusive Maße bereit.
+- `LayoutOverview.txt`: Struktur- und Verantwortlichkeitsübersicht des Layout-Editors.
 
 ### src/apps/library
 - `view.ts`: Zentrale Library-View mit Tab-Leiste (Terrains, Regionen, Kreaturen), Suchleiste, Ergebnisliste und Event-Delegation

--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -719,4 +719,257 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-cartographer--travel .hex3x3-map circle[data-token] { opacity: .95; }
 .sm-cartographer--travel .hex3x3-map polyline { pointer-events: none; }
+
+/* === Layout Editor === */
+.sm-layout-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0.75rem 1rem 1.5rem;
+}
+
+.sm-le-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sm-le-header h2 {
+    margin: 0;
+}
+
+.sm-le-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: flex-end;
+}
+
+.sm-le-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 120px;
+}
+
+.sm-le-control label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.sm-le-size {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.sm-le-status {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.sm-le-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.sm-le-stage {
+    flex: 1 1 520px;
+    display: flex;
+    justify-content: center;
+}
+
+.sm-le-canvas {
+    position: relative;
+    border: 1px dashed var(--background-modifier-border);
+    background: var(--background-secondary);
+    border-radius: 12px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+}
+
+.sm-le-box {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    background: var(--background-primary);
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+    border: 2px solid transparent;
+    cursor: default;
+    transition: box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.sm-le-box.is-selected {
+    border-color: var(--interactive-accent);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.25);
+}
+
+.sm-le-box__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.35rem 0.5rem;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--background-modifier-border);
+    cursor: grab;
+    user-select: none;
+}
+
+.sm-le-box__handle {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.sm-le-box__dims {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.sm-le-box__body {
+    flex: 1;
+    padding: 0.5rem 0.6rem 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sm-le-box__label {
+    font-weight: 600;
+}
+
+.sm-le-box__translation {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+}
+
+.sm-le-box__footer {
+    padding: 0 0.6rem 0.5rem;
+    font-size: 0.75rem;
+    color: var(--text-faint);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.sm-le-box__resize {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 6px;
+    right: 0.25rem;
+    bottom: 0.25rem;
+    cursor: se-resize;
+    background: rgba(0, 0, 0, 0.08);
+    display: grid;
+    place-items: center;
+}
+
+.sm-le-box__resize::after {
+    content: "";
+    width: 10px;
+    height: 10px;
+    border-right: 2px solid var(--text-muted);
+    border-bottom: 2px solid var(--text-muted);
+}
+
+.sm-le-inspector {
+    flex: 0 0 280px;
+    min-width: 260px;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sm-le-inspector h3 {
+    margin: 0;
+}
+
+.sm-le-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sm-le-field label {
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.sm-le-field textarea,
+.sm-le-field input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.sm-le-field--grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+    align-items: end;
+}
+
+.sm-le-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.sm-le-actions button:last-child {
+    margin-left: auto;
+}
+
+.sm-le-empty {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.sm-le-error {
+    color: var(--text-error);
+    font-size: 0.9rem;
+}
+
+.sm-le-meta {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.sm-le-export {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sm-le-export__controls {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.sm-le-export__textarea {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: var(--font-monospace);
+    min-height: 160px;
+}
+
+@media (max-width: 860px) {
+    .sm-le-inspector {
+        flex: 1 1 100%;
+    }
+
+    .sm-le-stage {
+        flex: 1 1 100%;
+    }
+}
+
 `;

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -4,6 +4,7 @@ import { Plugin, WorkspaceLeaf } from "obsidian";
 import { EncounterView, VIEW_ENCOUNTER } from "../apps/encounter/view";
 import { VIEW_CARTOGRAPHER, CartographerView } from "../apps/cartographer";
 import { VIEW_LIBRARY, LibraryView } from "../apps/library/view";
+import { VIEW_LAYOUT_EDITOR, LayoutEditorView } from "../apps/layout/view";
 import { ensureTerrainFile, loadTerrains, watchTerrains } from "../core/terrain-store";
 import { setTerrains } from "../core/terrain";
 import { getCenterLeaf } from "../core/layout";
@@ -17,6 +18,7 @@ export default class SaltMarcherPlugin extends Plugin {
         this.registerView(VIEW_CARTOGRAPHER,         (leaf: WorkspaceLeaf) => new CartographerView(leaf));
         this.registerView(VIEW_ENCOUNTER,            (leaf: WorkspaceLeaf) => new EncounterView(leaf));
         this.registerView(VIEW_LIBRARY,              (leaf: WorkspaceLeaf) => new LibraryView(leaf));
+        this.registerView(VIEW_LAYOUT_EDITOR,        (leaf: WorkspaceLeaf) => new LayoutEditorView(leaf));
 
         // Terrains initial laden & live halten
         await ensureTerrainFile(this.app);
@@ -32,6 +34,11 @@ export default class SaltMarcherPlugin extends Plugin {
         this.addRibbonIcon("book", "Open Library", async () => {
             const leaf = this.app.workspace.getLeaf(true);
             await leaf.setViewState({ type: VIEW_LIBRARY, active: true });
+            this.app.workspace.revealLeaf(leaf);
+        });
+        this.addRibbonIcon("layout-grid", "Open Layout Editor", async () => {
+            const leaf = getCenterLeaf(this.app);
+            await leaf.setViewState({ type: VIEW_LAYOUT_EDITOR, active: true });
             this.app.workspace.revealLeaf(leaf);
         });
 
@@ -51,6 +58,15 @@ export default class SaltMarcherPlugin extends Plugin {
             callback: async () => {
                 const leaf = this.app.workspace.getLeaf(true);
                 await leaf.setViewState({ type: VIEW_LIBRARY, active: true });
+                this.app.workspace.revealLeaf(leaf);
+            },
+        });
+        this.addCommand({
+            id: "open-layout-editor",
+            name: "Layout Editor öffnen",
+            callback: async () => {
+                const leaf = getCenterLeaf(this.app);
+                await leaf.setViewState({ type: VIEW_LAYOUT_EDITOR, active: true });
                 this.app.workspace.revealLeaf(leaf);
             },
         });

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -1,0 +1,26 @@
+# Layout Editor – Overview
+
+## Struktur
+
+```
+src/apps/layout/
+├─ view.ts             # Obsidian-ItemView für den visuellen Layout-Editor
+└─ LayoutOverview.txt  # Diese Übersicht
+```
+
+## Features & Verantwortlichkeiten
+
+- **Layout-Arbeitsfläche:** Stellt eine konfigurierbare Canvas (Breite/Höhe) bereit, auf der beliebig viele Boxen platziert werden können.
+- **Box-Verwaltung:** Ermöglicht das Hinzufügen, Auswählen, Verschieben und Skalieren von Boxen via Drag & Drop oder numerischen Eingaben.
+- **Label-Übersetzung:** Nutzt `translateText` aus `src/core/translator.ts`, um Box-Labels in eine wählbare Zielsprache zu übertragen. Unterstützt Einzel- und Sammelübersetzung inkl. Fehlerfeedback.
+- **Export für Abmessungen:** Generiert jederzeit ein JSON-Snippet mit Canvas-Größe, Positionen, Dimensionen und Übersetzungen aller Boxen, damit Layouts leicht weitergegeben werden können.
+- **Inspector-Panel:** Bietet ein Seitenpanel für detaillierte Bearbeitung (Label, Übersetzung, Maße, Position) sowie Kontextaktionen wie Löschen.
+
+## Dateibeschreibungen
+
+### `view.ts`
+- Implementiert `LayoutEditorView` als `ItemView`-Ableitung.
+- Baut Header (Steuerung, Sprachwahl, Status), Canvas und Inspector auf und hält DOM-Referenzen für effiziente Updates.
+- Verwaltet Box-Modelle in einem In-Memory-Array, synchronisiert Position/Größe mit dem DOM und kümmert sich um Pointer-basierte Drag-/Resize-Interaktionen.
+- Orchestriert Übersetzungen (Einzelbox oder alle Boxen) über `translateText`, zeigt Fortschritt/Fehler im UI und aktualisiert Exportdaten.
+- Erstellt das Export-JSON inklusive Canvas- und Box-Metadaten und stellt eine Kopier-Schaltfläche bereit.

--- a/src/apps/layout/view.ts
+++ b/src/apps/layout/view.ts
@@ -1,0 +1,594 @@
+// src/apps/layout/view.ts
+import { ItemView, Notice } from "obsidian";
+import { translateText } from "../../core/translator";
+
+export const VIEW_LAYOUT_EDITOR = "salt-layout-editor";
+
+interface LayoutBox {
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    label: string;
+    translationText: string;
+    translationSource?: string;
+    lastTranslatedAt?: number;
+    translationPending?: boolean;
+    translationError?: string | null;
+}
+
+const MIN_BOX_SIZE = 60;
+
+const LANG_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: "de", label: "Deutsch" },
+    { value: "en", label: "Englisch" },
+    { value: "fr", label: "Französisch" },
+    { value: "es", label: "Spanisch" },
+    { value: "it", label: "Italienisch" },
+    { value: "pl", label: "Polnisch" },
+    { value: "ja", label: "Japanisch" },
+];
+
+export class LayoutEditorView extends ItemView {
+    private boxes: LayoutBox[] = [];
+    private selectedBoxId: string | null = null;
+    private canvasWidth = 800;
+    private canvasHeight = 600;
+    private isTranslating = false;
+
+    private canvasEl!: HTMLElement;
+    private inspectorHost!: HTMLElement;
+    private exportEl!: HTMLTextAreaElement;
+    private languageSelect!: HTMLSelectElement;
+    private translateAllBtn!: HTMLButtonElement;
+    private statusEl!: HTMLElement;
+
+    private boxElements = new Map<string, HTMLElement>();
+
+    getViewType() { return VIEW_LAYOUT_EDITOR; }
+    getDisplayText() { return "Layout Editor"; }
+    getIcon() { return "layout-grid" as any; }
+
+    async onOpen() {
+        this.contentEl.addClass("sm-layout-editor");
+        this.render();
+        if (this.boxes.length === 0) {
+            this.createBox();
+        }
+        this.refreshExport();
+        this.updateStatus();
+    }
+
+    async onClose() {
+        this.boxElements.clear();
+        this.contentEl.empty();
+        this.contentEl.removeClass("sm-layout-editor");
+    }
+
+    private render() {
+        const root = this.contentEl;
+        root.empty();
+
+        const header = root.createDiv({ cls: "sm-le-header" });
+        header.createEl("h2", { text: "Layout Editor" });
+
+        const controls = header.createDiv({ cls: "sm-le-controls" });
+
+        const addBtn = controls.createEl("button", { text: "Box hinzufügen" });
+        addBtn.onclick = () => this.createBox();
+
+        const languageGroup = controls.createDiv({ cls: "sm-le-control" });
+        languageGroup.createEl("label", { text: "Zielsprache" });
+        this.languageSelect = languageGroup.createEl("select") as HTMLSelectElement;
+        for (const opt of LANG_OPTIONS) {
+            const option = this.languageSelect.createEl("option", { text: opt.label, attr: { value: opt.value } });
+            option.selected = opt.value === "en";
+        }
+        this.languageSelect.value = this.languageSelect.value || "en";
+        this.languageSelect.onchange = () => {
+            this.updateStatus();
+            this.refreshExport();
+            this.renderInspector();
+        };
+
+        const sizeGroup = controls.createDiv({ cls: "sm-le-control" });
+        sizeGroup.createEl("label", { text: "Arbeitsfläche" });
+        const sizeWrapper = sizeGroup.createDiv({ cls: "sm-le-size" });
+        const widthInput = sizeWrapper.createEl("input", { attr: { type: "number", min: "200", max: "2000" } }) as HTMLInputElement;
+        widthInput.value = String(this.canvasWidth);
+        widthInput.onchange = () => {
+            const next = clamp(parseInt(widthInput.value, 10) || this.canvasWidth, 200, 2000);
+            this.canvasWidth = next;
+            widthInput.value = String(next);
+            this.applyCanvasSize();
+            this.refreshExport();
+        };
+        sizeWrapper.createSpan({ text: "×" });
+        const heightInput = sizeWrapper.createEl("input", { attr: { type: "number", min: "200", max: "2000" } }) as HTMLInputElement;
+        heightInput.value = String(this.canvasHeight);
+        heightInput.onchange = () => {
+            const next = clamp(parseInt(heightInput.value, 10) || this.canvasHeight, 200, 2000);
+            this.canvasHeight = next;
+            heightInput.value = String(next);
+            this.applyCanvasSize();
+            this.refreshExport();
+        };
+        sizeWrapper.createSpan({ text: "px" });
+
+        this.translateAllBtn = controls.createEl("button", { text: "Alle übersetzen" });
+        this.translateAllBtn.onclick = () => { void this.translateAll(); };
+
+        this.statusEl = header.createDiv({ cls: "sm-le-status" });
+
+        const body = root.createDiv({ cls: "sm-le-body" });
+        const stage = body.createDiv({ cls: "sm-le-stage" });
+        this.canvasEl = stage.createDiv({ cls: "sm-le-canvas" });
+        this.canvasEl.style.width = `${this.canvasWidth}px`;
+        this.canvasEl.style.height = `${this.canvasHeight}px`;
+        this.registerDomEvent(this.canvasEl, "pointerdown", (ev: PointerEvent) => {
+            if (ev.target === this.canvasEl) {
+                this.selectBox(null);
+            }
+        });
+
+        this.inspectorHost = body.createDiv({ cls: "sm-le-inspector" });
+        this.renderInspector();
+
+        const exportWrap = root.createDiv({ cls: "sm-le-export" });
+        exportWrap.createEl("h3", { text: "Layout-Daten" });
+        const exportControls = exportWrap.createDiv({ cls: "sm-le-export__controls" });
+        const copyBtn = exportControls.createEl("button", { text: "JSON kopieren" });
+        copyBtn.onclick = async () => {
+            if (!this.exportEl.value) return;
+            try {
+                const clip = navigator.clipboard;
+                if (!clip || typeof clip.writeText !== "function") {
+                    throw new Error("Clipboard API nicht verfügbar");
+                }
+                await clip.writeText(this.exportEl.value);
+                new Notice("Layout kopiert");
+            } catch (error) {
+                console.error("Clipboard write failed", error);
+                new Notice("Konnte nicht in die Zwischenablage kopieren");
+            }
+        };
+        this.exportEl = exportWrap.createEl("textarea", { cls: "sm-le-export__textarea", attr: { rows: "10", readonly: "readonly" } }) as HTMLTextAreaElement;
+
+        this.renderBoxes();
+    }
+
+    private applyCanvasSize() {
+        if (!this.canvasEl) return;
+        this.canvasEl.style.width = `${this.canvasWidth}px`;
+        this.canvasEl.style.height = `${this.canvasHeight}px`;
+        for (const box of this.boxes) {
+            const maxX = Math.max(0, this.canvasWidth - box.width);
+            const maxY = Math.max(0, this.canvasHeight - box.height);
+            box.x = clamp(box.x, 0, maxX);
+            box.y = clamp(box.y, 0, maxY);
+            const maxWidth = Math.max(MIN_BOX_SIZE, this.canvasWidth - box.x);
+            const maxHeight = Math.max(MIN_BOX_SIZE, this.canvasHeight - box.y);
+            box.width = clamp(box.width, MIN_BOX_SIZE, maxWidth);
+            box.height = clamp(box.height, MIN_BOX_SIZE, maxHeight);
+            this.syncBoxElement(box);
+        }
+    }
+
+    private createBox() {
+        const width = Math.min(240, Math.max(160, Math.round(this.canvasWidth * 0.25)));
+        const height = Math.min(160, Math.max(120, Math.round(this.canvasHeight * 0.25)));
+        const box: LayoutBox = {
+            id: `box-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+            x: Math.max(0, Math.round((this.canvasWidth - width) / 2)),
+            y: Math.max(0, Math.round((this.canvasHeight - height) / 2)),
+            width,
+            height,
+            label: "", 
+            translationText: "",
+        };
+        this.boxes.push(box);
+        this.renderBoxes();
+        this.selectBox(box.id);
+        this.refreshExport();
+    }
+
+    private renderBoxes() {
+        if (!this.canvasEl) return;
+        const seen = new Set<string>();
+        for (const box of this.boxes) {
+            seen.add(box.id);
+            let el = this.boxElements.get(box.id);
+            if (!el) {
+                el = this.createBoxElement(box);
+                this.boxElements.set(box.id, el);
+            }
+            this.syncBoxElement(box);
+        }
+        for (const [id, el] of Array.from(this.boxElements.entries())) {
+            if (!seen.has(id)) {
+                el.remove();
+                this.boxElements.delete(id);
+            }
+        }
+        this.updateSelectionStyles();
+        this.updateStatus();
+    }
+
+    private createBoxElement(box: LayoutBox) {
+        const el = this.canvasEl.createDiv({ cls: "sm-le-box" });
+        el.dataset.id = box.id;
+
+        const header = el.createDiv({ cls: "sm-le-box__header" });
+        const handle = header.createSpan({ cls: "sm-le-box__handle", text: "⠿" });
+        handle.dataset.role = "move";
+        const dims = header.createSpan({ cls: "sm-le-box__dims", text: "" });
+        dims.dataset.role = "dims";
+
+        const body = el.createDiv({ cls: "sm-le-box__body" });
+        body.createDiv({ cls: "sm-le-box__label", text: "(Label)" }).dataset.role = "label";
+        body.createDiv({ cls: "sm-le-box__translation", text: "" }).dataset.role = "translation";
+        const footer = el.createDiv({ cls: "sm-le-box__footer" });
+        footer.createSpan({ cls: "sm-le-box__source", text: "" }).dataset.role = "source";
+
+        const resize = el.createDiv({ cls: "sm-le-box__resize" });
+        resize.dataset.role = "resize";
+
+        el.onclick = (ev: MouseEvent) => {
+            if (ev.target instanceof HTMLElement && ev.target.dataset.role === "resize") return;
+            this.selectBox(box.id);
+        };
+
+        handle.onpointerdown = (ev: PointerEvent) => {
+            ev.preventDefault();
+            this.selectBox(box.id);
+            this.beginDrag(box, ev);
+        };
+
+        resize.onpointerdown = (ev: PointerEvent) => {
+            ev.preventDefault();
+            this.selectBox(box.id);
+            this.beginResize(box, ev);
+        };
+
+        return el;
+    }
+
+    private syncBoxElement(box: LayoutBox) {
+        const el = this.boxElements.get(box.id);
+        if (!el) return;
+        el.style.left = `${box.x}px`;
+        el.style.top = `${box.y}px`;
+        el.style.width = `${box.width}px`;
+        el.style.height = `${box.height}px`;
+
+        const label = el.querySelector('[data-role="label"]') as HTMLElement | null;
+        const translation = el.querySelector('[data-role="translation"]') as HTMLElement | null;
+        const dims = el.querySelector('[data-role="dims"]') as HTMLElement | null;
+        const source = el.querySelector('[data-role="source"]') as HTMLElement | null;
+
+        label?.setText(box.label || "(Label)");
+        if (box.translationPending) {
+            translation?.setText("Übersetze…");
+        } else if (box.translationError) {
+            translation?.setText(`Fehler: ${box.translationError}`);
+        } else {
+            translation?.setText(box.translationText || "");
+        }
+        if (dims) {
+            dims.setText(`${Math.round(box.width)} × ${Math.round(box.height)} px`);
+        }
+        if (source) {
+            const meta = [] as string[];
+            if (box.translationSource) meta.push(`aus ${box.translationSource.toUpperCase()}`);
+            if (box.lastTranslatedAt) {
+                const date = new Date(box.lastTranslatedAt);
+                meta.push(date.toLocaleTimeString());
+            }
+            source.setText(meta.join(" · "));
+        }
+    }
+
+    private beginDrag(box: LayoutBox, event: PointerEvent) {
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const originX = box.x;
+        const originY = box.y;
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - startX;
+            const dy = ev.clientY - startY;
+            const nextX = originX + dx;
+            const nextY = originY + dy;
+            const maxX = Math.max(0, this.canvasWidth - box.width);
+            const maxY = Math.max(0, this.canvasHeight - box.height);
+            box.x = clamp(nextX, 0, maxX);
+            box.y = clamp(nextY, 0, maxY);
+            this.syncBoxElement(box);
+            this.refreshExport();
+            this.renderInspector();
+        };
+
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+    }
+
+    private beginResize(box: LayoutBox, event: PointerEvent) {
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const originW = box.width;
+        const originH = box.height;
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - startX;
+            const dy = ev.clientY - startY;
+            const maxWidth = Math.max(MIN_BOX_SIZE, this.canvasWidth - box.x);
+            const maxHeight = Math.max(MIN_BOX_SIZE, this.canvasHeight - box.y);
+            const nextW = clamp(originW + dx, MIN_BOX_SIZE, maxWidth);
+            const nextH = clamp(originH + dy, MIN_BOX_SIZE, maxHeight);
+            box.width = nextW;
+            box.height = nextH;
+            this.syncBoxElement(box);
+            this.refreshExport();
+            this.renderInspector();
+        };
+
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+    }
+
+    private selectBox(id: string | null) {
+        this.selectedBoxId = id;
+        this.updateSelectionStyles();
+        this.renderInspector();
+    }
+
+    private updateSelectionStyles() {
+        for (const [id, el] of this.boxElements) {
+            el.classList.toggle("is-selected", id === this.selectedBoxId);
+        }
+    }
+
+    private renderInspector() {
+        if (!this.inspectorHost) return;
+        const host = this.inspectorHost;
+        host.empty();
+        host.createEl("h3", { text: "Eigenschaften" });
+
+        const box = this.selectedBoxId ? this.boxes.find(b => b.id === this.selectedBoxId) : null;
+        if (!box) {
+            host.createDiv({ cls: "sm-le-empty", text: "Wähle eine Box, um Details anzupassen." });
+            return;
+        }
+
+        const labelField = host.createDiv({ cls: "sm-le-field" });
+        labelField.createEl("label", { text: "Label" });
+        const labelInput = labelField.createEl("textarea") as HTMLTextAreaElement;
+        labelInput.value = box.label;
+        labelInput.rows = 2;
+        labelInput.oninput = () => {
+            box.label = labelInput.value;
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+
+        const translationField = host.createDiv({ cls: "sm-le-field" });
+        translationField.createEl("label", { text: `Übersetzung (${this.languageSelect?.value?.toUpperCase() || "EN"})` });
+        const translationInput = translationField.createEl("textarea") as HTMLTextAreaElement;
+        translationInput.value = box.translationText;
+        translationInput.rows = 2;
+        translationInput.oninput = () => {
+            box.translationText = translationInput.value;
+            box.translationError = null;
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+
+        const translateControls = host.createDiv({ cls: "sm-le-actions" });
+        const translateBtn = translateControls.createEl("button", { text: "Label übersetzen" });
+        translateBtn.disabled = this.isTranslating || box.translationPending || !box.label.trim();
+        translateBtn.onclick = () => { void this.translateSingle(box); };
+
+        const deleteBtn = translateControls.createEl("button", { text: "Box löschen" });
+        deleteBtn.classList.add("mod-warning");
+        deleteBtn.onclick = () => this.deleteBox(box.id);
+
+        const dimsField = host.createDiv({ cls: "sm-le-field sm-le-field--grid" });
+        dimsField.createEl("label", { text: "Breite (px)" });
+        const widthInput = dimsField.createEl("input", { attr: { type: "number", min: String(MIN_BOX_SIZE) } }) as HTMLInputElement;
+        widthInput.value = String(Math.round(box.width));
+        widthInput.onchange = () => {
+            const maxWidth = Math.max(MIN_BOX_SIZE, this.canvasWidth - box.x);
+            const next = clamp(parseInt(widthInput.value, 10) || box.width, MIN_BOX_SIZE, maxWidth);
+            box.width = next;
+            widthInput.value = String(next);
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+        dimsField.createEl("label", { text: "Höhe (px)" });
+        const heightInput = dimsField.createEl("input", { attr: { type: "number", min: String(MIN_BOX_SIZE) } }) as HTMLInputElement;
+        heightInput.value = String(Math.round(box.height));
+        heightInput.onchange = () => {
+            const maxHeight = Math.max(MIN_BOX_SIZE, this.canvasHeight - box.y);
+            const next = clamp(parseInt(heightInput.value, 10) || box.height, MIN_BOX_SIZE, maxHeight);
+            box.height = next;
+            heightInput.value = String(next);
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+
+        const posField = host.createDiv({ cls: "sm-le-field sm-le-field--grid" });
+        posField.createEl("label", { text: "X-Position" });
+        const posXInput = posField.createEl("input", { attr: { type: "number", min: "0" } }) as HTMLInputElement;
+        posXInput.value = String(Math.round(box.x));
+        posXInput.onchange = () => {
+            const maxX = Math.max(0, this.canvasWidth - box.width);
+            const next = clamp(parseInt(posXInput.value, 10) || box.x, 0, maxX);
+            box.x = next;
+            posXInput.value = String(next);
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+        posField.createEl("label", { text: "Y-Position" });
+        const posYInput = posField.createEl("input", { attr: { type: "number", min: "0" } }) as HTMLInputElement;
+        posYInput.value = String(Math.round(box.y));
+        posYInput.onchange = () => {
+            const maxY = Math.max(0, this.canvasHeight - box.height);
+            const next = clamp(parseInt(posYInput.value, 10) || box.y, 0, maxY);
+            box.y = next;
+            posYInput.value = String(next);
+            this.syncBoxElement(box);
+            this.refreshExport();
+        };
+
+        if (box.translationError) {
+            host.createDiv({ cls: "sm-le-error", text: box.translationError });
+        }
+
+        const meta = host.createDiv({ cls: "sm-le-meta" });
+        meta.setText(`Fläche: ${Math.round(box.width * box.height)} px²`);
+    }
+
+    private async translateSingle(box: LayoutBox) {
+        if (!box.label.trim()) return;
+        box.translationPending = true;
+        box.translationError = null;
+        this.isTranslating = true;
+        this.syncBoxElement(box);
+        this.renderInspector();
+        this.updateStatus();
+        try {
+            const result = await translateText({
+                text: box.label,
+                target: this.languageSelect?.value || "en",
+                source: box.translationSource,
+            });
+            box.translationText = result.translatedText;
+            box.translationSource = result.detectedSourceLanguage;
+            box.lastTranslatedAt = Date.now();
+        } catch (error) {
+            console.error("translateSingle", error);
+            box.translationError = error instanceof Error ? error.message : String(error);
+        } finally {
+            box.translationPending = false;
+            this.isTranslating = false;
+            this.syncBoxElement(box);
+            this.renderInspector();
+            this.refreshExport();
+            this.updateStatus();
+        }
+    }
+
+    private async translateAll() {
+        if (!this.boxes.length || this.isTranslating) return;
+        this.isTranslating = true;
+        this.updateStatus();
+        this.translateAllBtn.disabled = true;
+        for (const box of this.boxes) {
+            if (!box.label.trim()) continue;
+            box.translationPending = true;
+            box.translationError = null;
+            this.syncBoxElement(box);
+        }
+        try {
+            for (const box of this.boxes) {
+                if (!box.label.trim()) {
+                    box.translationText = "";
+                    continue;
+                }
+                const result = await translateText({
+                    text: box.label,
+                    target: this.languageSelect?.value || "en",
+                    source: box.translationSource,
+                });
+                box.translationText = result.translatedText;
+                box.translationSource = result.detectedSourceLanguage;
+                box.lastTranslatedAt = Date.now();
+                box.translationPending = false;
+                this.syncBoxElement(box);
+                if (this.selectedBoxId === box.id) {
+                    this.renderInspector();
+                }
+                this.refreshExport();
+            }
+        } catch (error) {
+            console.error("translateAll", error);
+            const message = error instanceof Error ? error.message : String(error);
+            for (const box of this.boxes) {
+                if (box.translationPending) {
+                    box.translationError = message;
+                    box.translationPending = false;
+                    this.syncBoxElement(box);
+                }
+            }
+            new Notice("Übersetzung fehlgeschlagen");
+        } finally {
+            this.isTranslating = false;
+            this.translateAllBtn.disabled = false;
+            for (const box of this.boxes) {
+                box.translationPending = false;
+            }
+            this.updateStatus();
+            this.renderInspector();
+            this.refreshExport();
+        }
+    }
+
+    private deleteBox(id: string) {
+        const index = this.boxes.findIndex(b => b.id === id);
+        if (index === -1) return;
+        this.boxes.splice(index, 1);
+        const el = this.boxElements.get(id);
+        el?.remove();
+        this.boxElements.delete(id);
+        if (this.selectedBoxId === id) {
+            this.selectedBoxId = null;
+        }
+        this.renderInspector();
+        this.refreshExport();
+        this.updateStatus();
+    }
+
+    private refreshExport() {
+        if (!this.exportEl) return;
+        const payload = {
+            canvas: { width: Math.round(this.canvasWidth), height: Math.round(this.canvasHeight) },
+            targetLanguage: this.languageSelect?.value || "en",
+            boxes: this.boxes.map(box => ({
+                id: box.id,
+                label: box.label,
+                translation: box.translationText,
+                sourceLanguage: box.translationSource,
+                x: Math.round(box.x),
+                y: Math.round(box.y),
+                width: Math.round(box.width),
+                height: Math.round(box.height),
+            })),
+        };
+        this.exportEl.value = JSON.stringify(payload, null, 2);
+    }
+
+    private updateStatus() {
+        if (!this.statusEl) return;
+        const pending = this.boxes.filter(b => b.translationPending).length;
+        const info = `${this.boxes.length} Boxen · Zielsprache ${this.languageSelect?.value?.toUpperCase() || "EN"}`;
+        this.statusEl.setText(pending > 0 ? `${info} · Übersetzung läuft…` : info);
+        if (this.translateAllBtn) {
+            this.translateAllBtn.disabled = !this.boxes.length || this.isTranslating;
+        }
+    }
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}

--- a/src/core/CoreOverview.txt
+++ b/src/core/CoreOverview.txt
@@ -14,6 +14,7 @@ Der Core-Layer bündelt sämtliche fachlichen Services des Plugins, die unabhän
 | `save.ts` | Placeholder für Persistenz-Funktionen (`saveMap`, `saveMapAs`) – dient als Erweiterungspunkt. |
 | `terrain-store.ts` | Zentraler Dateiservice für `Terrains.md` (Ensure, Parser, Stringifier, Load/Save, Watcher + Workspace-Event). Legt die Datei mit `smList: true` an. |
 | `terrain.ts` | Verwaltet Standard- und Laufzeit-Terrainpaletten (Farben + Geschwindigkeiten) und bietet Mutatoren (`setTerrainPalette`, `setTerrains`). |
+| `translator.ts` | Stellt `translateText` bereit, ein schlankes Fetch-Utility für Google Translate (inkl. Fallback bei Fehlern). |
 
 ### Hex-Mapper Subsystem (`hex-mapper/`)
 

--- a/src/core/translator.ts
+++ b/src/core/translator.ts
@@ -1,0 +1,47 @@
+// src/core/translator.ts
+export interface TranslationRequest {
+    text: string;
+    target: string;
+    source?: string;
+}
+
+export interface TranslationResult {
+    translatedText: string;
+    detectedSourceLanguage?: string;
+}
+
+const GOOGLE_TRANSLATE_ENDPOINT = "https://translate.googleapis.com/translate_a/single";
+
+/**
+ * Übersetzt einen Text mithilfe des inoffiziellen Google-Translate-Endpunkts.
+ * Bei Fehlern wird der Originaltext zurückgegeben, damit der Nutzer weiterarbeiten kann.
+ */
+export async function translateText({ text, target, source }: TranslationRequest): Promise<TranslationResult> {
+    if (!text.trim()) {
+        return { translatedText: "", detectedSourceLanguage: source };
+    }
+
+    const params = new URLSearchParams({
+        client: "gtx",
+        sl: source || "auto",
+        tl: target,
+        dt: "t",
+        q: text,
+    });
+
+    try {
+        const response = await fetch(`${GOOGLE_TRANSLATE_ENDPOINT}?${params.toString()}`);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const body = await response.json();
+        const translated = Array.isArray(body?.[0])
+            ? body[0].map((chunk: any[]) => chunk?.[0] ?? "").join("")
+            : text;
+        const detected = typeof body?.[2] === "string" ? body[2] : source;
+        return { translatedText: translated, detectedSourceLanguage: detected };
+    } catch (error) {
+        console.error("translateText failed", error);
+        return { translatedText: text, detectedSourceLanguage: source };
+    }
+}


### PR DESCRIPTION
## Summary
- add a layout editor ItemView that manages draggable/resizable labeled boxes, translation helpers, and JSON export
- register the new view in the plugin bootstrap, provide styling, and expose a translator utility for Google Translate requests
- document the new feature in the project and core overviews and regenerate the bundled `main.js`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d438d934948325849ed986f8e9298d