### PR TITLE
feat: upgrade layout editor with containers and inline editing

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -813,6 +813,21 @@ export const HEX_PLUGIN_CSS = `
     transition: box-shadow 120ms ease, border-color 120ms ease;
 }
 
+.sm-le-box--container {
+    border-style: dashed;
+    border-color: var(--interactive-accent);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.05)), var(--background-primary);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
+}
+
+.sm-le-box--container .sm-le-box__type {
+    color: var(--interactive-accent);
+}
+
+.sm-le-box--container .sm-le-box__footer {
+    color: var(--text-muted);
+}
+
 .sm-le-box.is-selected {
     border-color: var(--interactive-accent);
     box-shadow: 0 14px 32px rgba(0, 0, 0, 0.25);
@@ -878,6 +893,21 @@ export const HEX_PLUGIN_CSS = `
     width: 100%;
 }
 
+.sm-le-box__attrs.is-editable {
+    cursor: pointer;
+    transition: color 120ms ease;
+}
+
+.sm-le-box__attrs.is-editable:hover,
+.sm-le-box__attrs.is-editable:focus-visible {
+    color: var(--interactive-accent);
+}
+
+.sm-le-box__attrs.is-empty {
+    font-style: italic;
+    color: var(--text-muted);
+}
+
 .sm-le-box__resize {
     position: absolute;
     width: 18px;
@@ -938,6 +968,10 @@ export const HEX_PLUGIN_CSS = `
     gap: 0.5rem;
 }
 
+.sm-le-field--stack {
+    gap: 0.6rem;
+}
+
 .sm-le-attributes {
     display: flex;
     flex-direction: column;
@@ -973,6 +1007,56 @@ export const HEX_PLUGIN_CSS = `
     margin: 0;
 }
 
+.sm-le-container-add {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.sm-le-container-add select {
+    flex: 1;
+}
+
+.sm-le-container-add button {
+    white-space: nowrap;
+}
+
+.sm-le-container-children {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 200px;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.sm-le-container-child {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.35rem 0.45rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    background: var(--background-secondary);
+}
+
+.sm-le-container-child__label {
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.sm-le-container-child__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.sm-le-container-child__actions button {
+    padding: 0.1rem 0.4rem;
+    font-size: 0.75rem;
+}
+
 .sm-le-field--grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -994,6 +1078,65 @@ export const HEX_PLUGIN_CSS = `
 .sm-le-meta {
     font-size: 0.85rem;
     color: var(--text-muted);
+}
+
+.sm-le-attr-popover {
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 240px;
+}
+
+.sm-le-attr-popover__heading {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.sm-le-attr-popover__hint {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.sm-le-attr-popover__clear {
+    align-self: flex-end;
+    font-size: 0.75rem;
+}
+
+.sm-le-attr-popover__scroll {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 220px;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.sm-le-attr-popover__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.35rem 0.45rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+}
+
+.sm-le-attr-popover__group-title {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+
+.sm-le-attr-popover__option {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
 }
 
 .sm-le-export {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -11,9 +11,11 @@ src/apps/layout/
 ## Features & Verantwortlichkeiten
 
 - **Layout-Arbeitsfläche:** Stellt eine konfigurierbare Canvas (Breite/Höhe) bereit, auf der beliebig viele UI-Elemente platziert werden können.
-- **Element-Palette:** Fügt per Klick Labels, Textfelder, Mehrzeiler, Container-Boxen, Trennlinien, Dropdowns und Such-Dropdowns hinzu – jedes neue Element landet direkt auf der Canvas und kann sofort bearbeitet werden.
-- **Element-Verwaltung:** Unterstützt Auswählen, Verschieben und Skalieren per Drag & Drop oder numerische Eingaben, inklusive visueller Auswahlmarkierung.
-- **Inspector-Panel:** Ermöglicht das Anpassen von Texten, Beschreibungen, Platzhaltern, Default-Werten, Dropdown-Optionen und verknüpften Creature-Attributen; bietet zudem Löschaktionen sowie exakte Positions-/Größenangaben.
+- **Layout-Hilfen & Container:** Neue VBox-/HBox-Container gruppieren mehrere Elemente, verteilen sie automatisch gleichmäßig (inkl. Abstand, Innenabstand und Ausrichtung) und halten die Kinder bei Größen- oder Positionsänderungen synchron. Container lassen sich über den Inspector bestücken, sortieren und räumen ihre Einträge automatisch nach.
+- **Element-Palette:** Fügt per Klick Labels, Textfelder, Mehrzeiler, Container-Boxen, Trennlinien, Dropdowns und Such-Dropdowns hinzu – jedes neue Element landet direkt auf der Canvas und kann sofort bearbeitet werden. Wird beim Erstellen ein Container ausgewählt, landet das neue Element direkt darin und übernimmt dessen Layout-Einstellungen.
+- **Element-Verwaltung:** Unterstützt Auswählen, Verschieben und Skalieren per Drag & Drop oder numerische Eingaben, inklusive visueller Auswahlmarkierung; Container bewegen ihre Kinder mit und wenden nach dem Loslassen erneut ihre Auto-Layouts an.
+- **Inspector-Panel:** Ermöglicht das Anpassen von Texten, Beschreibungen, Platzhaltern, Default-Werten, Dropdown-Optionen und verknüpften Creature-Attributen; bietet zudem Container-spezifische Eingaben für Abstand, Innenabstand, Ausrichtung, Kinderverwaltung sowie eine schnelle Zuweisung/Abmeldung von Elementen aus Containern.
+- **Inline-Attributeditor:** Attribute lassen sich direkt am Canvas-Element über ein Popover pflegen; Inspector und Canvas bleiben dabei synchron.
 - **Export für Layoutdaten:** Generiert jederzeit ein JSON-Snippet mit Canvas-Größe plus vollständigem Element-Metadatenpaket (Typ, Texte, Optionen, Attribute, Maße), damit Layouts reproduzierbar bleiben.
 - **Creature-Creator-Import:** Baut den DOM des Creature-Creator-Dialogs in einer Sandbox nach, analysiert Maße, weist passende Elementtypen zu und füllt die Canvas automatisch mit vorkonfigurierten UI-Bereichen.
 
@@ -23,6 +25,7 @@ src/apps/layout/
 - Implementiert `LayoutEditorView` als `ItemView`-Ableitung.
 - Baut Header (Element-Palette, Import, Status), Canvas und Inspector auf und hält DOM-Referenzen für performante Aktualisierungen.
 - Verwaltet Element-Modelle in einem Array, synchronisiert Position/Größe mit dem DOM und bedient Pointer-basierte Drag-/Resize-Interaktionen.
-- Stellt im Inspector Eingabefelder für Label, Beschreibung, Platzhalter, Default-Werte, Dropdown-Optionen sowie eine Attribut-Auswahl bereit und synchronisiert Änderungen direkt mit der Canvas.
+- Stellt im Inspector Eingabefelder für Label, Beschreibung, Platzhalter, Default-Werte, Dropdown-Optionen sowie eine Attribut-Auswahl bereit, ergänzt um Container-spezifische Controls (Abstand, Padding, Ausrichtung, Child-Management) und eine Container-Zuweisung für klassische Elemente.
+- Synchronisiert den Inline-Attributeditor (Popover auf der Canvas) mit dem Inspector und aktualisiert beide Wege konsistent.
 - Rekonstruiert bei Bedarf das Creature-Creator-Layout über die Abschnitts-Mount-Funktionen (`mountCreatureBasicsSection`, `mountCreatureStatsAndSkillsSection`, …), erkennt simple Eingabe-Typen und projiziert die gemessenen Bounding-Boxes auf die Canvas.
-- Erstellt das Export-JSON inklusive Canvas- und Element-Metadaten und stellt eine Kopier-Schaltfläche bereit.
+- Erstellt das Export-JSON inklusive Canvas- und Element-Metadaten (inklusive Container-Beziehungen, Layout-Konfiguration und Kinderlisten) und stellt eine Kopier-Schaltfläche bereit.

--- a/src/apps/layout/view.ts
+++ b/src/apps/layout/view.ts
@@ -18,7 +18,19 @@ type LayoutElementType =
     | "box"
     | "separator"
     | "dropdown"
-    | "search-dropdown";
+    | "search-dropdown"
+    | "vbox"
+    | "hbox";
+
+type LayoutContainerType = "vbox" | "hbox";
+
+type LayoutContainerAlign = "start" | "center" | "end" | "stretch";
+
+interface LayoutContainerConfig {
+    gap: number;
+    padding: number;
+    align: LayoutContainerAlign;
+}
 
 interface LayoutElement {
     id: string;
@@ -33,6 +45,9 @@ interface LayoutElement {
     defaultValue?: string;
     options?: string[];
     attributes: string[];
+    parentId?: string;
+    layout?: LayoutContainerConfig;
+    children?: string[];
 }
 
 const MIN_ELEMENT_SIZE = 60;
@@ -47,6 +62,7 @@ const ELEMENT_DEFINITIONS: Array<{
     options?: string[];
     width: number;
     height: number;
+    defaultLayout?: LayoutContainerConfig;
 }> = [
     {
         type: "label",
@@ -104,6 +120,24 @@ const ELEMENT_DEFINITIONS: Array<{
         options: ["Erster Eintrag", "Zweiter Eintrag"],
         width: 280,
         height: 160,
+    },
+    {
+        type: "vbox",
+        buttonLabel: "VBox-Container",
+        defaultLabel: "VBox",
+        defaultDescription: "Ordnet verknüpfte Elemente automatisch untereinander an.",
+        width: 340,
+        height: 260,
+        defaultLayout: { gap: 16, padding: 16, align: "stretch" },
+    },
+    {
+        type: "hbox",
+        buttonLabel: "HBox-Container",
+        defaultLabel: "HBox",
+        defaultDescription: "Ordnet verknüpfte Elemente automatisch nebeneinander an.",
+        width: 360,
+        height: 220,
+        defaultLayout: { gap: 16, padding: 16, align: "center" },
     },
 ];
 
@@ -211,6 +245,13 @@ const ATTRIBUTE_LABEL_LOOKUP = new Map(
     ATTRIBUTE_GROUPS.flatMap(group => group.options.map(opt => [opt.value, opt.label] as const)),
 );
 
+interface AttributePopover {
+    elementId: string;
+    container: HTMLElement;
+    anchor: HTMLElement;
+    dispose: () => void;
+}
+
 export class LayoutEditorView extends ItemView {
     private elements: LayoutElement[] = [];
     private selectedElementId: string | null = null;
@@ -228,6 +269,7 @@ export class LayoutEditorView extends ItemView {
     private sandboxEl?: HTMLElement;
 
     private elementElements = new Map<string, HTMLElement>();
+    private activeAttributePopover: AttributePopover | null = null;
 
     getViewType() { return VIEW_LAYOUT_EDITOR; }
     getDisplayText() { return "Layout Editor"; }
@@ -360,14 +402,20 @@ export class LayoutEditorView extends ItemView {
             element.height = clamp(element.height, MIN_ELEMENT_SIZE, maxHeight);
             this.syncElementElement(element);
         }
+        for (const element of this.elements) {
+            if (isContainerType(element.type)) {
+                this.applyContainerLayout(element, { silent: true });
+            }
+        }
     }
 
     private createElement(type: LayoutElementType) {
         const def = ELEMENT_DEFINITION_LOOKUP.get(type);
         const width = def ? def.width : Math.min(240, Math.max(160, Math.round(this.canvasWidth * 0.25)));
         const height = def ? def.height : Math.min(160, Math.max(120, Math.round(this.canvasHeight * 0.25)));
+        const id = `element-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         const element: LayoutElement = {
-            id: `element-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+            id,
             type,
             x: Math.max(0, Math.round((this.canvasWidth - width) / 2)),
             y: Math.max(0, Math.round((this.canvasHeight - height) / 2)),
@@ -380,7 +428,30 @@ export class LayoutEditorView extends ItemView {
             options: def?.options ? [...def.options] : undefined,
             attributes: [],
         };
+
+        if (def?.defaultLayout) {
+            element.layout = { ...def.defaultLayout };
+            element.children = [];
+        }
+
+        const selected = this.selectedElementId ? this.elements.find(el => el.id === this.selectedElementId) : null;
+        const parentContainer = selected && isContainerElement(selected) && !isContainerType(type) ? selected : null;
+        if (parentContainer) {
+            element.parentId = parentContainer.id;
+            const padding = parentContainer.layout.padding;
+            element.x = parentContainer.x + padding;
+            element.y = parentContainer.y + padding;
+            element.width = Math.min(parentContainer.width - padding * 2, element.width);
+            element.height = Math.min(parentContainer.height - padding * 2, element.height);
+        }
+
         this.elements.push(element);
+
+        if (parentContainer) {
+            this.addChildToContainer(parentContainer, element.id);
+            this.applyContainerLayout(parentContainer);
+        }
+
         this.renderElements();
         this.selectElement(element.id);
         this.refreshExport();
@@ -390,6 +461,9 @@ export class LayoutEditorView extends ItemView {
         if (!this.canvasEl) return;
         const seen = new Set<string>();
         for (const element of this.elements) {
+            if (isContainerType(element.type)) {
+                this.ensureContainerDefaults(element);
+            }
             seen.add(element.id);
             let el = this.elementElements.get(element.id);
             if (!el) {
@@ -408,6 +482,302 @@ export class LayoutEditorView extends ItemView {
         this.updateStatus();
     }
 
+    private ensureContainerDefaults(element: LayoutElement) {
+        if (!isContainerType(element.type)) return;
+        if (!element.layout) {
+            const def = ELEMENT_DEFINITION_LOOKUP.get(element.type);
+            element.layout = def?.defaultLayout ? { ...def.defaultLayout } : { gap: 16, padding: 16, align: "stretch" };
+        }
+        if (!Array.isArray(element.children)) {
+            element.children = [];
+        }
+    }
+
+    private addChildToContainer(container: LayoutElement, childId: string) {
+        if (!isContainerType(container.type)) return;
+        this.ensureContainerDefaults(container);
+        if (!container.children!.includes(childId)) {
+            container.children!.push(childId);
+        }
+    }
+
+    private removeChildFromContainer(container: LayoutElement, childId: string) {
+        if (!isContainerType(container.type) || !Array.isArray(container.children)) return;
+        container.children = container.children.filter(id => id !== childId);
+    }
+
+    private moveChildInContainer(container: LayoutElement, childId: string, delta: number) {
+        if (!isContainerType(container.type) || !Array.isArray(container.children)) return;
+        const index = container.children.indexOf(childId);
+        if (index === -1) return;
+        const nextIndex = clamp(index + delta, 0, container.children.length - 1);
+        if (nextIndex === index) return;
+        const [id] = container.children.splice(index, 1);
+        container.children.splice(nextIndex, 0, id);
+        this.applyContainerLayout(container);
+    }
+
+    private assignElementToContainer(elementId: string, containerId: string | null) {
+        const element = this.elements.find(el => el.id === elementId);
+        if (!element) return;
+        const previousParent = element.parentId ? this.elements.find(el => el.id === element.parentId) : null;
+        if (previousParent) {
+            this.removeChildFromContainer(previousParent, element.id);
+        }
+        element.parentId = undefined;
+
+        const nextParent = containerId ? this.elements.find(el => el.id === containerId) : null;
+        if (nextParent) {
+            this.addChildToContainer(nextParent, element.id);
+            element.parentId = nextParent.id;
+        }
+
+        if (previousParent) {
+            this.applyContainerLayout(previousParent);
+        }
+        if (nextParent) {
+            this.applyContainerLayout(nextParent);
+        }
+        this.syncElementElement(element);
+        this.refreshExport();
+        this.renderInspector();
+    }
+
+    private applyContainerLayout(container: LayoutElement, options?: { silent?: boolean }) {
+        if (!isContainerType(container.type)) return;
+        this.ensureContainerDefaults(container);
+        const layout = container.layout!;
+        const gap = Math.max(0, layout.gap);
+        const padding = Math.max(0, layout.padding);
+        const align = layout.align;
+        const childIds = Array.isArray(container.children) ? container.children.slice() : [];
+        const children: LayoutElement[] = [];
+        const validIds: string[] = [];
+        for (const id of childIds) {
+            if (id === container.id) continue;
+            const child = this.elements.find(el => el.id === id);
+            if (child) {
+                children.push(child);
+                validIds.push(id);
+            }
+        }
+        container.children = validIds;
+        if (!children.length) {
+            if (!options?.silent) {
+                this.refreshExport();
+                this.renderInspector();
+            }
+            return;
+        }
+
+        const innerWidth = Math.max(MIN_ELEMENT_SIZE, container.width - padding * 2);
+        const innerHeight = Math.max(MIN_ELEMENT_SIZE, container.height - padding * 2);
+        const gapCount = Math.max(0, children.length - 1);
+
+        if (container.type === "vbox") {
+            const availableHeight = innerHeight - gap * gapCount;
+            const slotHeight = Math.max(MIN_ELEMENT_SIZE, Math.floor(availableHeight / children.length));
+            let y = container.y + padding;
+            for (const child of children) {
+                child.parentId = container.id;
+                child.height = slotHeight;
+                child.y = y;
+                let width = innerWidth;
+                if (align === "stretch") {
+                    child.x = container.x + padding;
+                } else {
+                    width = Math.min(child.width, innerWidth);
+                    if (align === "center") {
+                        child.x = container.x + padding + Math.round((innerWidth - width) / 2);
+                    } else if (align === "end") {
+                        child.x = container.x + padding + (innerWidth - width);
+                    } else {
+                        child.x = container.x + padding;
+                    }
+                }
+                child.width = width;
+                y += slotHeight + gap;
+                this.syncElementElement(child);
+            }
+        } else {
+            const availableWidth = innerWidth - gap * gapCount;
+            const slotWidth = Math.max(MIN_ELEMENT_SIZE, Math.floor(availableWidth / children.length));
+            let x = container.x + padding;
+            for (const child of children) {
+                child.parentId = container.id;
+                child.width = slotWidth;
+                child.x = x;
+                let height = innerHeight;
+                if (align === "stretch") {
+                    child.y = container.y + padding;
+                } else {
+                    height = Math.min(child.height, innerHeight);
+                    if (align === "center") {
+                        child.y = container.y + padding + Math.round((innerHeight - height) / 2);
+                    } else if (align === "end") {
+                        child.y = container.y + padding + (innerHeight - height);
+                    } else {
+                        child.y = container.y + padding;
+                    }
+                }
+                child.height = height;
+                x += slotWidth + gap;
+                this.syncElementElement(child);
+            }
+        }
+
+        this.syncElementElement(container);
+        if (!options?.silent) {
+            this.refreshExport();
+            this.renderInspector();
+        }
+        this.refreshAttributePopover();
+    }
+
+    private openAttributePopover(element: LayoutElement, anchor: HTMLElement) {
+        this.closeAttributePopover();
+        const container = document.createElement("div");
+        container.className = "sm-le-attr-popover";
+        container.style.position = "absolute";
+        container.style.zIndex = "1000";
+        container.style.visibility = "hidden";
+        container.addEventListener("pointerdown", ev => ev.stopPropagation());
+
+        const heading = document.createElement("div");
+        heading.className = "sm-le-attr-popover__heading";
+        heading.textContent = "Attribute";
+        container.appendChild(heading);
+
+        const hint = document.createElement("div");
+        hint.className = "sm-le-attr-popover__hint";
+        hint.textContent = "Mehrfachauswahl möglich.";
+        container.appendChild(hint);
+
+        const scroll = document.createElement("div");
+        scroll.className = "sm-le-attr-popover__scroll";
+        container.appendChild(scroll);
+
+        const clearBtn = document.createElement("button");
+        clearBtn.className = "sm-le-attr-popover__clear";
+        clearBtn.textContent = "Alle entfernen";
+        clearBtn.addEventListener("click", ev => {
+            ev.preventDefault();
+            if (element.attributes.length === 0) return;
+            element.attributes = [];
+            this.syncElementElement(element);
+            this.refreshExport();
+            this.renderInspector();
+            this.refreshAttributePopover();
+        });
+        container.appendChild(clearBtn);
+
+        for (const group of ATTRIBUTE_GROUPS) {
+            const groupEl = document.createElement("div");
+            groupEl.className = "sm-le-attr-popover__group";
+            const title = document.createElement("div");
+            title.className = "sm-le-attr-popover__group-title";
+            title.textContent = group.label;
+            groupEl.appendChild(title);
+            for (const option of group.options) {
+                const optionLabel = document.createElement("label");
+                optionLabel.className = "sm-le-attr-popover__option";
+                const checkbox = document.createElement("input");
+                checkbox.type = "checkbox";
+                checkbox.dataset.attr = option.value;
+                checkbox.checked = element.attributes.includes(option.value);
+                checkbox.addEventListener("change", () => {
+                    if (checkbox.checked) {
+                        if (!element.attributes.includes(option.value)) {
+                            element.attributes = [...element.attributes, option.value];
+                        }
+                    } else {
+                        element.attributes = element.attributes.filter(v => v !== option.value);
+                    }
+                    this.syncElementElement(element);
+                    this.refreshExport();
+                    this.renderInspector();
+                    this.refreshAttributePopover();
+                });
+                const labelText = document.createElement("span");
+                labelText.textContent = option.label;
+                optionLabel.appendChild(checkbox);
+                optionLabel.appendChild(labelText);
+                groupEl.appendChild(optionLabel);
+            }
+            scroll.appendChild(groupEl);
+        }
+
+        const onPointerDown = (ev: PointerEvent) => {
+            if (!(ev.target instanceof Node)) return;
+            if (!container.contains(ev.target) && ev.target !== anchor && !anchor.contains(ev.target as Node)) {
+                this.closeAttributePopover();
+            }
+        };
+        const onKeyDown = (ev: KeyboardEvent) => {
+            if (ev.key === "Escape") {
+                this.closeAttributePopover();
+            }
+        };
+        document.body.appendChild(container);
+        const state: AttributePopover = {
+            elementId: element.id,
+            container,
+            anchor,
+            dispose: () => {
+                document.removeEventListener("pointerdown", onPointerDown, true);
+                document.removeEventListener("keydown", onKeyDown, true);
+                container.remove();
+            },
+        };
+        document.addEventListener("pointerdown", onPointerDown, true);
+        document.addEventListener("keydown", onKeyDown, true);
+
+        this.activeAttributePopover = state;
+        this.positionAttributePopover(state);
+        container.style.visibility = "visible";
+    }
+
+    private closeAttributePopover() {
+        if (!this.activeAttributePopover) return;
+        this.activeAttributePopover.dispose();
+        this.activeAttributePopover = null;
+    }
+
+    private refreshAttributePopover() {
+        if (!this.activeAttributePopover) return;
+        const element = this.elements.find(el => el.id === this.activeAttributePopover!.elementId);
+        if (!element) {
+            this.closeAttributePopover();
+            return;
+        }
+        const checkboxes = this.activeAttributePopover.container.querySelectorAll<HTMLInputElement>("input[type='checkbox'][data-attr]");
+        checkboxes.forEach(checkbox => {
+            const attr = checkbox.dataset.attr;
+            if (!attr) return;
+            checkbox.checked = element.attributes.includes(attr);
+        });
+    }
+
+    private positionAttributePopover(state: AttributePopover) {
+        const anchorRect = state.anchor.getBoundingClientRect();
+        const popRect = state.container.getBoundingClientRect();
+        const margin = 8;
+        let left = anchorRect.left + window.scrollX;
+        let top = anchorRect.bottom + window.scrollY + margin;
+        const viewportWidth = window.innerWidth + window.scrollX;
+        const viewportHeight = window.innerHeight + window.scrollY;
+        if (left + popRect.width > viewportWidth - margin) {
+            left = viewportWidth - popRect.width - margin;
+        }
+        if (left < margin) left = margin;
+        if (top + popRect.height > viewportHeight - margin) {
+            top = anchorRect.top + window.scrollY - popRect.height - margin;
+        }
+        if (top < margin) top = margin;
+        state.container.style.left = `${Math.round(left)}px`;
+        state.container.style.top = `${Math.round(top)}px`;
+    }
+
     private createElementNode(element: LayoutElement) {
         const el = this.canvasEl.createDiv({ cls: "sm-le-box" });
         el.dataset.id = element.id;
@@ -423,7 +793,14 @@ export class LayoutEditorView extends ItemView {
         body.createDiv({ cls: "sm-le-box__label", text: "(Label)" }).dataset.role = "label";
         body.createDiv({ cls: "sm-le-box__details", text: "" }).dataset.role = "details";
         const footer = el.createDiv({ cls: "sm-le-box__footer" });
-        footer.createSpan({ cls: "sm-le-box__attrs", text: "" }).dataset.role = "attrs";
+        const attrs = footer.createSpan({ cls: "sm-le-box__attrs", text: "" }) as HTMLElement;
+        attrs.dataset.role = "attrs";
+        attrs.addClass("is-editable");
+        attrs.onclick = (ev: MouseEvent) => {
+            ev.stopPropagation();
+            this.selectElement(element.id);
+            this.openAttributePopover(element, attrs);
+        };
 
         const resize = el.createDiv({ cls: "sm-le-box__resize" });
         resize.dataset.role = "resize";
@@ -455,6 +832,7 @@ export class LayoutEditorView extends ItemView {
         el.style.top = `${element.y}px`;
         el.style.width = `${element.width}px`;
         el.style.height = `${element.height}px`;
+        el.classList.toggle("sm-le-box--container", isContainerType(element.type));
 
         const typeEl = el.querySelector('[data-role="type"]') as HTMLElement | null;
         const labelEl = el.querySelector('[data-role="label"]') as HTMLElement | null;
@@ -470,6 +848,11 @@ export class LayoutEditorView extends ItemView {
         }
         if (attrsEl) {
             attrsEl.setText(this.getAttributeSummary(element.attributes));
+            attrsEl.classList.toggle("is-empty", element.attributes.length === 0);
+        }
+        if (this.activeAttributePopover?.elementId === element.id) {
+            this.refreshAttributePopover();
+            this.positionAttributePopover(this.activeAttributePopover);
         }
     }
 
@@ -478,6 +861,17 @@ export class LayoutEditorView extends ItemView {
         const startY = event.clientY;
         const originX = element.x;
         const originY = element.y;
+        const isContainer = isContainerType(element.type);
+        const parent = element.parentId ? this.elements.find(el => el.id === element.parentId) : null;
+        const childOrigins: Array<{ child: LayoutElement; x: number; y: number }> = [];
+        if (isContainer && Array.isArray(element.children)) {
+            for (const childId of element.children) {
+                const child = this.elements.find(el => el.id === childId);
+                if (child) {
+                    childOrigins.push({ child, x: child.x, y: child.y });
+                }
+            }
+        }
 
         const onMove = (ev: PointerEvent) => {
             const dx = ev.clientX - startX;
@@ -489,6 +883,15 @@ export class LayoutEditorView extends ItemView {
             element.x = clamp(nextX, 0, maxX);
             element.y = clamp(nextY, 0, maxY);
             this.syncElementElement(element);
+            if (isContainer) {
+                for (const entry of childOrigins) {
+                    const childMaxX = Math.max(0, this.canvasWidth - entry.child.width);
+                    const childMaxY = Math.max(0, this.canvasHeight - entry.child.height);
+                    entry.child.x = clamp(entry.x + dx, 0, childMaxX);
+                    entry.child.y = clamp(entry.y + dy, 0, childMaxY);
+                    this.syncElementElement(entry.child);
+                }
+            }
             this.refreshExport();
             this.renderInspector();
         };
@@ -496,6 +899,11 @@ export class LayoutEditorView extends ItemView {
         const onUp = () => {
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onUp);
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parent && isContainerType(parent.type)) {
+                this.applyContainerLayout(parent);
+            }
         };
 
         window.addEventListener("pointermove", onMove);
@@ -507,6 +915,8 @@ export class LayoutEditorView extends ItemView {
         const startY = event.clientY;
         const originW = element.width;
         const originH = element.height;
+        const isContainer = isContainerType(element.type);
+        const parent = element.parentId ? this.elements.find(el => el.id === element.parentId) : null;
 
         const onMove = (ev: PointerEvent) => {
             const dx = ev.clientX - startX;
@@ -518,6 +928,9 @@ export class LayoutEditorView extends ItemView {
             element.width = nextW;
             element.height = nextH;
             this.syncElementElement(element);
+            if (isContainer) {
+                this.applyContainerLayout(element, { silent: true });
+            }
             this.refreshExport();
             this.renderInspector();
         };
@@ -525,6 +938,11 @@ export class LayoutEditorView extends ItemView {
         const onUp = () => {
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onUp);
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parent && isContainerType(parent.type)) {
+                this.applyContainerLayout(parent);
+            }
         };
 
         window.addEventListener("pointermove", onMove);
@@ -532,6 +950,7 @@ export class LayoutEditorView extends ItemView {
     }
 
     private selectElement(id: string | null) {
+        this.closeAttributePopover();
         this.selectedElementId = id;
         this.updateSelectionStyles();
         this.renderInspector();
@@ -555,6 +974,12 @@ export class LayoutEditorView extends ItemView {
             return;
         }
 
+        const isContainer = isContainerType(element.type);
+        if (isContainer) {
+            this.ensureContainerDefaults(element);
+        }
+        const parentContainer = !isContainer && element.parentId ? this.elements.find(el => el.id === element.parentId) : null;
+
         host.createDiv({ cls: "sm-le-meta", text: `Typ: ${getElementTypeLabel(element.type)}` });
 
         const labelField = host.createDiv({ cls: "sm-le-field" });
@@ -567,6 +992,25 @@ export class LayoutEditorView extends ItemView {
             this.syncElementElement(element);
             this.refreshExport();
         };
+
+        if (!isContainer) {
+            const containers = this.elements.filter(el => isContainerType(el.type));
+            if (containers.length) {
+                const containerField = host.createDiv({ cls: "sm-le-field" });
+                containerField.createEl("label", { text: "Container" });
+                const parentSelect = containerField.createEl("select") as HTMLSelectElement;
+                parentSelect.createEl("option", { value: "", text: "Kein Container" });
+                for (const container of containers) {
+                    const label = container.label || getElementTypeLabel(container.type);
+                    const option = parentSelect.createEl("option", { value: container.id, text: label });
+                    if (element.parentId === container.id) option.selected = true;
+                }
+                parentSelect.onchange = () => {
+                    const value = parentSelect.value || null;
+                    this.assignElementToContainer(element.id, value);
+                };
+            }
+        }
 
         if (element.type === "label" || element.type === "box") {
             const descField = host.createDiv({ cls: "sm-le-field" });
@@ -652,8 +1096,118 @@ export class LayoutEditorView extends ItemView {
                     }
                     this.syncElementElement(element);
                     this.refreshExport();
+                    this.refreshAttributePopover();
                 };
                 row.createEl("label", { text: option.label, attr: { for: optionId } });
+            }
+        }
+
+        if (isContainerElement(element)) {
+            const layoutField = host.createDiv({ cls: "sm-le-field sm-le-field--grid" });
+            layoutField.createEl("label", { text: "Abstand (px)" });
+            const gapInput = layoutField.createEl("input", { attr: { type: "number", min: "0" } }) as HTMLInputElement;
+            gapInput.value = String(Math.round(element.layout.gap));
+            gapInput.onchange = () => {
+                const next = Math.max(0, parseInt(gapInput.value, 10) || 0);
+                element.layout!.gap = next;
+                gapInput.value = String(next);
+                this.applyContainerLayout(element);
+            };
+            layoutField.createEl("label", { text: "Innenabstand (px)" });
+            const paddingInput = layoutField.createEl("input", { attr: { type: "number", min: "0" } }) as HTMLInputElement;
+            paddingInput.value = String(Math.round(element.layout.padding));
+            paddingInput.onchange = () => {
+                const next = Math.max(0, parseInt(paddingInput.value, 10) || 0);
+                element.layout!.padding = next;
+                paddingInput.value = String(next);
+                this.applyContainerLayout(element);
+            };
+
+            const alignField = host.createDiv({ cls: "sm-le-field" });
+            alignField.createEl("label", { text: element.type === "vbox" ? "Horizontale Ausrichtung" : "Vertikale Ausrichtung" });
+            const alignSelect = alignField.createEl("select") as HTMLSelectElement;
+            const alignOptions: Array<[LayoutContainerAlign, string]> =
+                element.type === "vbox"
+                    ? [
+                          ["start", "Links"],
+                          ["center", "Zentriert"],
+                          ["end", "Rechts"],
+                          ["stretch", "Breite strecken"],
+                      ]
+                    : [
+                          ["start", "Oben"],
+                          ["center", "Zentriert"],
+                          ["end", "Unten"],
+                          ["stretch", "Höhe strecken"],
+                      ];
+            for (const [value, label] of alignOptions) {
+                const option = alignSelect.createEl("option", { value, text: label });
+                if (element.layout.align === value) option.selected = true;
+            }
+            alignSelect.onchange = () => {
+                const next = (alignSelect.value as LayoutContainerAlign) ?? element.layout!.align;
+                element.layout!.align = next;
+                this.applyContainerLayout(element);
+            };
+
+            const childField = host.createDiv({ cls: "sm-le-field sm-le-field--stack" });
+            childField.createEl("label", { text: "Zugeordnete Elemente" });
+            const addRow = childField.createDiv({ cls: "sm-le-container-add" });
+            const addSelect = addRow.createEl("select") as HTMLSelectElement;
+            addSelect.createEl("option", { value: "", text: "Element auswählen…" });
+            const candidates = this.elements.filter(el => el.id !== element.id && !isContainerType(el.type));
+            for (const candidate of candidates) {
+                const textBase = candidate.label || getElementTypeLabel(candidate.type);
+                let optionText = textBase;
+                if (candidate.parentId && candidate.parentId !== element.id) {
+                    const parentElement = this.elements.find(el => el.id === candidate.parentId);
+                    if (parentElement) {
+                        const parentName = parentElement.label || getElementTypeLabel(parentElement.type);
+                        optionText = `${textBase} (in ${parentName})`;
+                    }
+                }
+                addSelect.createEl("option", { value: candidate.id, text: optionText });
+            }
+            const addButton = addRow.createEl("button", { text: "Hinzufügen" });
+            addButton.onclick = ev => {
+                ev.preventDefault();
+                const target = addSelect.value;
+                if (target) {
+                    this.assignElementToContainer(target, element.id);
+                }
+            };
+
+            const childList = childField.createDiv({ cls: "sm-le-container-children" });
+            const children = Array.isArray(element.children)
+                ? element.children
+                      .map(childId => this.elements.find(el => el.id === childId))
+                      .filter((child): child is LayoutElement => !!child)
+                : [];
+            if (!children.length) {
+                childList.createDiv({ cls: "sm-le-empty", text: "Keine Elemente verknüpft." });
+            } else {
+                for (const [idx, child] of children.entries()) {
+                    const row = childList.createDiv({ cls: "sm-le-container-child" });
+                    row.createSpan({ cls: "sm-le-container-child__label", text: child.label || getElementTypeLabel(child.type) });
+                    const controls = row.createDiv({ cls: "sm-le-container-child__actions" });
+                    const upBtn = controls.createEl("button", { text: "↑", attr: { title: "Nach oben" } });
+                    upBtn.disabled = idx === 0;
+                    upBtn.onclick = ev => {
+                        ev.preventDefault();
+                        this.moveChildInContainer(element, child.id, -1);
+                    };
+                    const downBtn = controls.createEl("button", { text: "↓", attr: { title: "Nach unten" } });
+                    downBtn.disabled = idx === children.length - 1;
+                    downBtn.onclick = ev => {
+                        ev.preventDefault();
+                        this.moveChildInContainer(element, child.id, 1);
+                    };
+                    const removeBtn = controls.createEl("button", { text: "✕", attr: { title: "Entfernen" } });
+                    removeBtn.onclick = ev => {
+                        ev.preventDefault();
+                        this.assignElementToContainer(child.id, null);
+                    };
+                }
             }
         }
 
@@ -673,6 +1227,11 @@ export class LayoutEditorView extends ItemView {
             widthInput.value = String(next);
             this.syncElementElement(element);
             this.refreshExport();
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parentContainer && isContainerType(parentContainer.type)) {
+                this.applyContainerLayout(parentContainer);
+            }
         };
         dimsField.createEl("label", { text: "Höhe (px)" });
         const heightInput = dimsField.createEl("input", { attr: { type: "number", min: String(MIN_ELEMENT_SIZE) } }) as HTMLInputElement;
@@ -684,6 +1243,11 @@ export class LayoutEditorView extends ItemView {
             heightInput.value = String(next);
             this.syncElementElement(element);
             this.refreshExport();
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parentContainer && isContainerType(parentContainer.type)) {
+                this.applyContainerLayout(parentContainer);
+            }
         };
 
         const posField = host.createDiv({ cls: "sm-le-field sm-le-field--grid" });
@@ -697,6 +1261,11 @@ export class LayoutEditorView extends ItemView {
             posXInput.value = String(next);
             this.syncElementElement(element);
             this.refreshExport();
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parentContainer && isContainerType(parentContainer.type)) {
+                this.applyContainerLayout(parentContainer);
+            }
         };
         posField.createEl("label", { text: "Y-Position" });
         const posYInput = posField.createEl("input", { attr: { type: "number", min: "0" } }) as HTMLInputElement;
@@ -708,6 +1277,11 @@ export class LayoutEditorView extends ItemView {
             posYInput.value = String(next);
             this.syncElementElement(element);
             this.refreshExport();
+            if (isContainer) {
+                this.applyContainerLayout(element);
+            } else if (parentContainer && isContainerType(parentContainer.type)) {
+                this.applyContainerLayout(parentContainer);
+            }
         };
 
         const meta = host.createDiv({ cls: "sm-le-meta" });
@@ -717,10 +1291,33 @@ export class LayoutEditorView extends ItemView {
     private deleteElement(id: string) {
         const index = this.elements.findIndex(b => b.id === id);
         if (index === -1) return;
+        const element = this.elements[index];
         this.elements.splice(index, 1);
+
+        if (isContainerType(element.type) && Array.isArray(element.children)) {
+            for (const childId of element.children) {
+                const child = this.elements.find(el => el.id === childId);
+                if (child) {
+                    child.parentId = undefined;
+                    this.syncElementElement(child);
+                }
+            }
+        }
+
+        if (element.parentId) {
+            const parent = this.elements.find(el => el.id === element.parentId);
+            if (parent) {
+                this.removeChildFromContainer(parent, element.id);
+                this.applyContainerLayout(parent);
+            }
+        }
+
         const el = this.elementElements.get(id);
         el?.remove();
         this.elementElements.delete(id);
+        if (this.activeAttributePopover?.elementId === id) {
+            this.closeAttributePopover();
+        }
         if (this.selectedElementId === id) {
             this.selectedElementId = null;
         }
@@ -731,6 +1328,16 @@ export class LayoutEditorView extends ItemView {
 
     private getElementDetails(element: LayoutElement): string {
         const parts: string[] = [];
+        if (isContainerType(element.type)) {
+            const layout = element.layout;
+            const gap = layout ? Math.round(layout.gap) : 0;
+            const alignLabel = layout ? getContainerAlignLabel(element.type, layout.align) : null;
+            const count = element.children?.length ?? 0;
+            parts.push(element.type === "vbox" ? "Vertikale Verteilung" : "Horizontale Verteilung");
+            parts.push(`Abstand ${gap}px`);
+            if (alignLabel) parts.push(alignLabel);
+            parts.push(`${count} Elemente`);
+        }
         if ((element.type === "label" || element.type === "box") && element.description) {
             parts.push(element.description);
         }
@@ -754,7 +1361,7 @@ export class LayoutEditorView extends ItemView {
     }
 
     private getAttributeSummary(attributes: string[]): string {
-        if (!attributes.length) return "Keine Attribute verknüpft";
+        if (!attributes.length) return "Attribute wählen…";
         return attributes.map(attr => ATTRIBUTE_LABEL_LOOKUP.get(attr) ?? attr).join(", ");
     }
 
@@ -830,6 +1437,19 @@ export class LayoutEditorView extends ItemView {
                 if (element.placeholder) node.placeholder = element.placeholder;
                 if (element.defaultValue) node.defaultValue = element.defaultValue;
                 if (element.options && element.options.length) node.options = [...element.options];
+                if (element.parentId) node.parentId = element.parentId;
+                if (isContainerType(element.type)) {
+                    if (element.layout) {
+                        node.layout = {
+                            gap: Math.round(element.layout.gap),
+                            padding: Math.round(element.layout.padding),
+                            align: element.layout.align,
+                        } satisfies LayoutContainerConfig;
+                    }
+                    if (element.children && element.children.length) {
+                        node.children = [...element.children];
+                    }
+                }
                 return node;
             }),
         };
@@ -976,4 +1596,43 @@ function clamp(value: number, min: number, max: number) {
 
 function getElementTypeLabel(type: LayoutElementType): string {
     return ELEMENT_DEFINITION_LOOKUP.get(type)?.buttonLabel ?? type;
+}
+
+function isContainerType(type: LayoutElementType): type is LayoutContainerType {
+    return type === "vbox" || type === "hbox";
+}
+
+function isContainerElement(element: LayoutElement): element is LayoutElement & {
+    type: LayoutContainerType;
+    layout: LayoutContainerConfig;
+    children: string[];
+} {
+    return isContainerType(element.type) && !!element.layout && Array.isArray(element.children);
+}
+
+function getContainerAlignLabel(type: LayoutContainerType, align: LayoutContainerAlign): string {
+    if (type === "vbox") {
+        switch (align) {
+            case "start":
+                return "Links ausgerichtet";
+            case "center":
+                return "Zentriert";
+            case "end":
+                return "Rechts ausgerichtet";
+            case "stretch":
+                return "Breite gestreckt";
+        }
+    } else {
+        switch (align) {
+            case "start":
+                return "Oben ausgerichtet";
+            case "center":
+                return "Vertikal zentriert";
+            case "end":
+                return "Unten ausgerichtet";
+            case "stretch":
+                return "Höhe gestreckt";
+        }
+    }
+    return "";
 }


### PR DESCRIPTION
## Summary
- add VBox/HBox container types with auto-layout management and container-aware element creation
- expose inline attribute editing and container controls inside the layout inspector
- refresh layout editor styling and documentation to cover the new workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44e97f0e08325a45c07d6c10dc324