### PR TITLE
Enhance layout editor inline editing and history

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -869,14 +869,191 @@ export const HEX_PLUGIN_CSS = `
     color: var(--text-muted);
 }
 
-.sm-le-box__label {
-    font-weight: 600;
+.sm-le-box__content {
+    flex: 1;
+    display: flex;
 }
 
-.sm-le-box__details {
+.sm-le-preview {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
     font-size: 0.9rem;
+}
+
+.sm-le-preview__text {
+    font-size: 1rem;
+    line-height: 1.4;
+}
+
+.sm-le-preview__subtext,
+.sm-le-preview__description {
+    font-size: 0.85rem;
     color: var(--text-muted);
+    line-height: 1.4;
+}
+
+.sm-le-preview__title {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.sm-le-preview__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sm-le-preview__label {
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.sm-le-preview__input,
+.sm-le-preview__textarea,
+.sm-le-preview__select {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--background-modifier-border);
+    padding: 0.4rem 0.5rem;
+    background: var(--background-primary);
+    font: inherit;
+    color: inherit;
+}
+
+.sm-le-preview__textarea {
+    resize: vertical;
+}
+
+.sm-le-preview__meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.sm-le-inline-edit {
+    display: inline-block;
+    padding: 0.1rem 0.2rem;
+    border-radius: 6px;
+    cursor: text;
+    transition: box-shadow 120ms ease, background 120ms ease;
+    min-width: 0.6rem;
+}
+
+.sm-le-inline-edit--block {
+    display: block;
+}
+
+.sm-le-inline-edit--multiline {
+    min-height: 2.2rem;
     white-space: pre-wrap;
+}
+
+.sm-le-inline-edit:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--interactive-accent);
+    background: rgba(var(--interactive-accent-rgb), 0.08);
+}
+
+.sm-le-inline-edit:empty::before {
+    content: attr(data-placeholder);
+    color: var(--text-muted);
+    pointer-events: none;
+}
+
+.sm-le-inline-meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.sm-le-inline-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.sm-le-inline-options__empty {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.sm-le-inline-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--background-secondary);
+    border-radius: 999px;
+    padding: 0.15rem 0.35rem;
+}
+
+.sm-le-inline-option__label {
+    font-size: 0.8rem;
+}
+
+.sm-le-inline-option__remove {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.sm-le-inline-option__remove:hover {
+    color: var(--text-normal);
+}
+
+.sm-le-inline-add {
+    align-self: flex-start;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+}
+
+.sm-le-preview__container-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.sm-le-preview__layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.sm-le-inline-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.sm-le-inline-number,
+.sm-le-inline-select {
+    border-radius: 6px;
+    border: 1px solid var(--background-modifier-border);
+    padding: 0.25rem 0.35rem;
+    font: inherit;
+    background: var(--background-primary);
+    color: inherit;
+}
+
+.sm-le-preview__container-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.sm-le-container-chip {
+    background: var(--background-secondary);
+    border-radius: 999px;
+    padding: 0.25rem 0.6rem;
 }
 
 .sm-le-box__footer {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -16,6 +16,8 @@ src/apps/layout/
 - **Element-Verwaltung:** Unterstützt Auswählen, Verschieben und Skalieren per Drag & Drop oder numerische Eingaben, inklusive visueller Auswahlmarkierung; Container bewegen ihre Kinder mit und wenden nach dem Loslassen erneut ihre Auto-Layouts an.
 - **Inspector-Panel:** Ermöglicht das Anpassen von Texten, Beschreibungen, Platzhaltern, Default-Werten, Dropdown-Optionen und verknüpften Creature-Attributen; bietet zudem Container-spezifische Eingaben für Abstand, Innenabstand, Ausrichtung, Kinderverwaltung sowie eine schnelle Zuweisung/Abmeldung von Elementen aus Containern.
 - **Inline-Attributeditor:** Attribute lassen sich direkt am Canvas-Element über ein Popover pflegen; Inspector und Canvas bleiben dabei synchron.
+- **Inline-Bearbeitung auf der Canvas:** Labels, Beschreibungen, Platzhalter, Default-Werte und Dropdown-Optionen werden direkt am dargestellten UI-Element editiert; dafür rendert der Editor echte Eingabefelder statt abstrakter Platzhalter.
+- **Canvas-Kurzbefehle & Historie:** Elemente lassen sich per Entf-Taste löschen und über Strg+Z / Strg+Umschalt+Z rückgängig machen bzw. wiederherstellen; alle Änderungen fließen in eine Undo/Redo-Historie.
 - **Export für Layoutdaten:** Generiert jederzeit ein JSON-Snippet mit Canvas-Größe plus vollständigem Element-Metadatenpaket (Typ, Texte, Optionen, Attribute, Maße), damit Layouts reproduzierbar bleiben.
 - **Creature-Creator-Import:** Baut den DOM des Creature-Creator-Dialogs in einer Sandbox nach, analysiert Maße, weist passende Elementtypen zu und füllt die Canvas automatisch mit vorkonfigurierten UI-Bereichen.
 
@@ -26,6 +28,7 @@ src/apps/layout/
 - Baut Header (Element-Palette, Import, Status), Canvas und Inspector auf und hält DOM-Referenzen für performante Aktualisierungen.
 - Verwaltet Element-Modelle in einem Array, synchronisiert Position/Größe mit dem DOM und bedient Pointer-basierte Drag-/Resize-Interaktionen.
 - Stellt im Inspector Eingabefelder für Label, Beschreibung, Platzhalter, Default-Werte, Dropdown-Optionen sowie eine Attribut-Auswahl bereit, ergänzt um Container-spezifische Controls (Abstand, Padding, Ausrichtung, Child-Management) und eine Container-Zuweisung für klassische Elemente.
-- Synchronisiert den Inline-Attributeditor (Popover auf der Canvas) mit dem Inspector und aktualisiert beide Wege konsistent.
+- Synchronisiert neben dem Inline-Attributeditor (Popover auf der Canvas) auch alle Inline-Text- und Options-Editoren mit dem Inspector und aktualisiert beide Wege konsistent.
+- Rendert auf der Canvas echte UI-Kontrollen (Labels, Inputs, Textareas, Dropdowns, Suche, Container) inklusive Undo/Redo-Historie und Tastaturkürzeln zum schnellen Löschen und Wiederherstellen.
 - Rekonstruiert bei Bedarf das Creature-Creator-Layout über die Abschnitts-Mount-Funktionen (`mountCreatureBasicsSection`, `mountCreatureStatsAndSkillsSection`, …), erkennt simple Eingabe-Typen und projiziert die gemessenen Bounding-Boxes auf die Canvas.
 - Erstellt das Export-JSON inklusive Canvas- und Element-Metadaten (inklusive Container-Beziehungen, Layout-Konfiguration und Kinderlisten) und stellt eine Kopier-Schaltfläche bereit.


### PR DESCRIPTION
## Summary
- add an undo/redo history layer with keyboard shortcuts and delete support for layout elements
- render realistic UI previews on the canvas and enable inline editing for labels, placeholders, defaults and dropdown options
- refresh layout editor styling and overview documentation to describe inline editing behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4584cff808325b59487632ed99a95