### PR TITLE
Simplify layout editor element surfaces

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -804,74 +804,83 @@ export const HEX_PLUGIN_CSS = `
 .sm-le-box {
     position: absolute;
     display: flex;
-    flex-direction: column;
-    background: var(--background-primary);
+    align-items: stretch;
+    justify-content: stretch;
+    border: 1px solid transparent;
     border-radius: 12px;
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
-    border: 2px solid transparent;
     cursor: default;
-    transition: box-shadow 120ms ease, border-color 120ms ease;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.sm-le-box--container {
+.sm-le-box.is-container {
     border-style: dashed;
-    border-color: var(--interactive-accent);
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.05)), var(--background-primary);
-    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
-}
-
-.sm-le-box--container .sm-le-box__type {
-    color: var(--interactive-accent);
-}
-
-.sm-le-box--container .sm-le-box__footer {
-    color: var(--text-muted);
+    border-color: var(--background-modifier-border);
 }
 
 .sm-le-box.is-selected {
     border-color: var(--interactive-accent);
-    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.04), 0 0 0 4px rgba(56, 189, 248, 0.18);
 }
 
-.sm-le-box__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.35rem 0.5rem;
-    gap: 0.5rem;
-    border-bottom: 1px solid var(--background-modifier-border);
-    cursor: grab;
-    user-select: none;
-}
-
-.sm-le-box__handle {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-}
-
-.sm-le-box__dims {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-}
-
-.sm-le-box__body {
-    flex: 1;
-    padding: 0.5rem 0.6rem 0.6rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.sm-le-box__type {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--text-muted);
+.sm-le-box.is-selected.is-container {
+    border-color: var(--interactive-accent);
 }
 
 .sm-le-box__content {
     flex: 1;
     display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+    padding: 0;
+}
+
+.sm-le-box__chrome {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.3rem;
+    padding: 0.3rem;
+}
+
+.sm-le-box__handle,
+.sm-le-box__attrs {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 999px;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    color: var(--text-muted);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+    user-select: none;
+    transition: border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.sm-le-box__handle {
+    cursor: grab;
+    font-size: 0.9rem;
+}
+
+.sm-le-box__attrs {
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.sm-le-box__attrs.is-empty {
+    opacity: 0.7;
+}
+
+.sm-le-box.is-selected .sm-le-box__handle,
+.sm-le-box.is-selected .sm-le-box__attrs {
+    border-color: var(--interactive-accent);
+    color: var(--interactive-accent);
+    box-shadow: 0 8px 20px rgba(56, 189, 248, 0.25);
 }
 
 .sm-le-preview {
@@ -879,7 +888,17 @@ export const HEX_PLUGIN_CSS = `
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    font-size: 0.9rem;
+    padding: 0.25rem;
+}
+
+.sm-le-preview__text-block,
+.sm-le-preview__box,
+.sm-le-preview__field,
+.sm-le-preview__separator,
+.sm-le-preview__container-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
 }
 
 .sm-le-preview__text {
@@ -900,10 +919,17 @@ export const HEX_PLUGIN_CSS = `
 }
 
 .sm-le-preview__label {
-    font-size: 0.8rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    font-size: 0.85rem;
+    font-weight: 600;
     color: var(--text-muted);
+}
+
+.sm-le-preview__meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
 }
 
 .sm-le-preview__input,
@@ -912,14 +938,16 @@ export const HEX_PLUGIN_CSS = `
     width: 100%;
     border-radius: 8px;
     border: 1px solid var(--background-modifier-border);
-    padding: 0.4rem 0.5rem;
+    padding: 0.45rem 0.55rem;
     background: var(--background-primary);
     font: inherit;
     color: inherit;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
 .sm-le-preview__textarea {
     resize: vertical;
+    min-height: 120px;
 }
 
 .sm-le-inline-edit {
@@ -1003,55 +1031,10 @@ export const HEX_PLUGIN_CSS = `
     align-self: flex-start;
 }
 
-.sm-le-preview__setting {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 10px;
-    background: var(--background-primary);
-    padding: 0.6rem 0.7rem;
-    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
-}
-
-.sm-le-preview__setting .setting-item-info {
-    margin-right: 0;
-}
-
-.sm-le-preview__setting .setting-item-control {
-    margin-left: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-}
-
-.sm-le-preview__setting .setting-item-name {
-    font-weight: 600;
-    font-size: 0.95rem;
-}
-
-.sm-le-preview__setting .setting-item-description {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.sm-le-preview__setting--box .setting-item-name {
-    font-size: 1.05rem;
-}
-
 .sm-le-preview__divider {
     border: none;
     border-top: 1px solid var(--background-modifier-border);
     margin: 0.25rem 0 0;
-}
-
-.sm-le-preview__container-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
 }
 
 .sm-le-preview__layout {
@@ -1092,46 +1075,19 @@ export const HEX_PLUGIN_CSS = `
     padding: 0.25rem 0.6rem;
 }
 
-.sm-le-box__footer {
-    padding: 0 0.6rem 0.5rem;
-    font-size: 0.75rem;
-    color: var(--text-faint);
-    display: flex;
-    justify-content: flex-start;
-}
-
-.sm-le-box__attrs {
-    display: block;
-    white-space: normal;
-    width: 100%;
-}
-
-.sm-le-box__attrs.is-editable {
-    cursor: pointer;
-    transition: color 120ms ease;
-}
-
-.sm-le-box__attrs.is-editable:hover,
-.sm-le-box__attrs.is-editable:focus-visible {
-    color: var(--interactive-accent);
-}
-
-.sm-le-box__attrs.is-empty {
-    font-style: italic;
-    color: var(--text-muted);
-}
-
 .sm-le-box__resize {
     position: absolute;
     width: 18px;
     height: 18px;
     border-radius: 6px;
-    right: 0.25rem;
-    bottom: 0.25rem;
+    right: 0.3rem;
+    bottom: 0.3rem;
     cursor: se-resize;
-    background: rgba(0, 0, 0, 0.08);
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
     display: grid;
     place-items: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
 }
 
 .sm-le-box__resize::after {
@@ -1140,6 +1096,10 @@ export const HEX_PLUGIN_CSS = `
     height: 10px;
     border-right: 2px solid var(--text-muted);
     border-bottom: 2px solid var(--text-muted);
+}
+
+.sm-le-box.is-selected .sm-le-box__resize {
+    border-color: var(--interactive-accent);
 }
 
 .sm-le-inspector {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -23,7 +23,7 @@ src/apps/layout/
 - **Layout-Arbeitsfläche:** Konfigurierbare Canvas mit Breite/Höhe-Controls; alle Elemente werden mit Bounds-Clamping gerendert und können per Drag/Resize manipuliert werden.
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
 - **Container-Layout:** VBox-/HBox-Container verteilen Kinder automatisch (Gap, Padding, Align) und synchronisieren bei manuellen Änderungen oder Größenanpassungen.
-- **Inspector & Inline-Editing:** `inspector-panel.ts` erzeugt alle Formfelder, Container-Controls sowie Attribute-Trigger; `element-preview.ts` rendert auf der Canvas echte Obsidian-Settings mit Inline-Editoren.
+- **Inspector & Inline-Editing:** `inspector-panel.ts` erzeugt alle Formfelder, Container-Controls sowie Attribute-Trigger; `element-preview.ts` rendert auf der Canvas reduzierte UI-Elemente mit Inline-Editoren und ohne zusätzliche Panels.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet das Popover (Öffnen, Positionierung, Synchronisation) und hält Inspector sowie Canvas konsistent.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` nutzt sie für Strg+Z / Strg+Umschalt+Z sowie automatisches Pushen nach Mutationen.
 - **Export & Status:** JSON-Export (Canvas + Elemente) sowie Statusleiste werden in `view.ts` gepflegt und auf jede Mutation aktualisiert.
@@ -60,7 +60,7 @@ src/apps/layout/
 - Bietet einen generischen ContentEditable-Editor (Trim, Multiline, Placeholder) für Preview-Komponenten.
 
 ### `editor/element-preview.ts`
-- Rendert Canvas-Vorschauen als echte Obsidian-Settings, inklusive Inline-Label-/Beschreibung-/Optionen-Editoren.
+- Rendert Canvas-Vorschauen als minimalistische UI-Elemente (Labels, Inputs, Dropdowns etc.) inklusive Inline-Label-/Beschreibung-/Optionen-Editoren ohne Surrounding-Panel.
 - Delegiert Layout-spezifische Aktionen (z. B. Container-Layout, History-Push) über Callbacks an die View.
 
 ### `editor/inspector-panel.ts`

--- a/src/apps/layout/editor/view.ts
+++ b/src/apps/layout/editor/view.ts
@@ -378,18 +378,13 @@ export class LayoutEditorView extends ItemView {
         const el = this.canvasEl.createDiv({ cls: "sm-le-box" });
         el.dataset.id = element.id;
 
-        const header = el.createDiv({ cls: "sm-le-box__header" });
-        const handle = header.createSpan({ cls: "sm-le-box__handle", text: "⠿" });
+        const content = el.createDiv({ cls: "sm-le-box__content" });
+        content.dataset.role = "content";
+
+        const chrome = el.createDiv({ cls: "sm-le-box__chrome" });
+        const handle = chrome.createSpan({ cls: "sm-le-box__handle", text: "⠿" });
         handle.dataset.role = "move";
-        const dims = header.createSpan({ cls: "sm-le-box__dims", text: "" });
-        dims.dataset.role = "dims";
-
-        const body = el.createDiv({ cls: "sm-le-box__body" });
-        body.createDiv({ cls: "sm-le-box__type", text: "" }).dataset.role = "type";
-        body.createDiv({ cls: "sm-le-box__content" }).dataset.role = "content";
-
-        const footer = el.createDiv({ cls: "sm-le-box__footer" });
-        const attrs = footer.createSpan({ cls: "sm-le-box__attrs", text: "" }) as HTMLElement;
+        const attrs = chrome.createSpan({ cls: "sm-le-box__attrs", text: "⚙" }) as HTMLElement;
         attrs.dataset.role = "attrs";
 
         handle.addEventListener("pointerdown", ev => {
@@ -430,10 +425,7 @@ export class LayoutEditorView extends ItemView {
         el.style.top = `${Math.round(element.y)}px`;
         el.style.width = `${Math.round(element.width)}px`;
         el.style.height = `${Math.round(element.height)}px`;
-        const typeEl = el.querySelector<HTMLElement>('[data-role="type"]');
-        if (typeEl) typeEl.setText(getElementTypeLabel(element.type));
-        const dimsEl = el.querySelector<HTMLElement>('[data-role="dims"]');
-        if (dimsEl) dimsEl.setText(`${Math.round(element.width)} × ${Math.round(element.height)}px`);
+        el.classList.toggle("is-container", isContainerType(element.type));
         const contentEl = el.querySelector<HTMLElement>('[data-role="content"]');
         if (contentEl) {
             renderElementPreview({
@@ -447,7 +439,12 @@ export class LayoutEditorView extends ItemView {
             });
         }
         const attrsEl = el.querySelector<HTMLElement>('[data-role="attrs"]');
-        if (attrsEl) attrsEl.setText(getAttributeSummary(element.attributes));
+        if (attrsEl) {
+            const summary = getAttributeSummary(element.attributes);
+            attrsEl.setAttr("title", summary);
+            attrsEl.setAttr("aria-label", summary);
+            attrsEl.classList.toggle("is-empty", !element.attributes.length);
+        }
     }
 
     private selectElement(id: string | null) {


### PR DESCRIPTION
## Summary
- flatten layout editor canvas boxes so only the actual UI element plus minimal chrome remains
- rebuild the layout element preview renderers to output plain controls without surrounding panels
- update layout editor styling and overview documentation to match the simplified presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d57d903883259a9c96ced89954d7