### PR TITLE
Refine layout editor canvas interactions and inspector

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -811,6 +811,10 @@ export const HEX_PLUGIN_CSS = `
     transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
+.sm-le-box:hover {
+    border-color: var(--background-modifier-border);
+}
+
 .sm-le-box.is-container {
     border-style: dashed;
     border-color: var(--background-modifier-border);
@@ -825,61 +829,16 @@ export const HEX_PLUGIN_CSS = `
     border-color: var(--interactive-accent);
 }
 
+.sm-le-box.is-interacting {
+    cursor: grabbing;
+}
+
 .sm-le-box__content {
     flex: 1;
     display: flex;
     align-items: stretch;
     justify-content: stretch;
     padding: 0;
-}
-
-.sm-le-box__chrome {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.3rem;
-    padding: 0.3rem;
-}
-
-.sm-le-box__handle,
-.sm-le-box__attrs {
-    pointer-events: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: 999px;
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    color: var(--text-muted);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
-    user-select: none;
-    transition: border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
-}
-
-.sm-le-box__handle {
-    cursor: grab;
-    font-size: 0.9rem;
-}
-
-.sm-le-box__attrs {
-    cursor: pointer;
-    font-size: 0.85rem;
-}
-
-.sm-le-box__attrs.is-empty {
-    opacity: 0.7;
-}
-
-.sm-le-box.is-selected .sm-le-box__handle,
-.sm-le-box.is-selected .sm-le-box__attrs {
-    border-color: var(--interactive-accent);
-    color: var(--interactive-accent);
-    box-shadow: 0 8px 20px rgba(56, 189, 248, 0.25);
 }
 
 .sm-le-preview {
@@ -933,6 +892,35 @@ export const HEX_PLUGIN_CSS = `
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+}
+
+.sm-le-preview__container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border-radius: 10px;
+    background: var(--background-primary);
+    border: 1px dashed var(--background-modifier-border);
+}
+
+.sm-le-preview__container-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.4rem;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--interactive-accent) 6%, transparent);
+    min-height: 60px;
+}
+
+.sm-le-preview__container-placeholder {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 0.35rem 0;
 }
 
 .sm-le-preview__text {
@@ -1034,7 +1022,7 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-le-inline-options {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.35rem;
 }
 
@@ -1045,26 +1033,45 @@ export const HEX_PLUGIN_CSS = `
 }
 
 .sm-le-inline-option {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.35rem;
     background: var(--background-secondary);
-    border-radius: 999px;
-    padding: 0.15rem 0.35rem;
+    border-radius: 8px;
+    padding: 0.35rem 0.5rem;
 }
 
-.sm-le-inline-option__label {
-    font-size: 0.8rem;
+.sm-le-inline-option__input {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid transparent;
+    background: transparent;
+    padding: 0.15rem 0.25rem;
+    font: inherit;
+    color: inherit;
+}
+
+.sm-le-inline-option__input:focus {
+    outline: none;
+    border-color: var(--interactive-accent);
+    background: var(--background-primary);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.18);
 }
 
 .sm-le-inline-option__remove {
-    font-size: 0.8rem;
+    border: none;
+    background: transparent;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.85rem;
     color: var(--text-muted);
     cursor: pointer;
+    border-radius: 6px;
+    transition: color 120ms ease, background 120ms ease;
 }
 
 .sm-le-inline-option__remove:hover {
     color: var(--text-normal);
+    background: rgba(56, 189, 248, 0.12);
 }
 
 .sm-le-inline-add {
@@ -1075,17 +1082,6 @@ export const HEX_PLUGIN_CSS = `
 
 .sm-le-inline-add--menu {
     align-self: flex-start;
-}
-
-.sm-le-inline-add--ghost {
-    border: 1px dashed var(--background-modifier-border);
-    background: transparent;
-    color: var(--text-muted);
-}
-
-.sm-le-inline-add--ghost:hover {
-    background: var(--background-secondary);
-    color: var(--text-normal);
 }
 
 .sm-le-preview__divider {
@@ -1118,49 +1114,10 @@ export const HEX_PLUGIN_CSS = `
     color: inherit;
 }
 
-.sm-le-preview__container-summary {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    font-size: 0.7rem;
-    color: var(--text-muted);
-}
-
 .sm-le-container-chip {
     background: var(--background-secondary);
     border-radius: 999px;
     padding: 0.2rem 0.45rem;
-}
-
-.sm-le-preview__container-add {
-    display: flex;
-}
-
-.sm-le-box__resize {
-    position: absolute;
-    width: 18px;
-    height: 18px;
-    border-radius: 6px;
-    right: 0.3rem;
-    bottom: 0.3rem;
-    cursor: se-resize;
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    display: grid;
-    place-items: center;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
-}
-
-.sm-le-box__resize::after {
-    content: "";
-    width: 10px;
-    height: 10px;
-    border-right: 2px solid var(--text-muted);
-    border-bottom: 2px solid var(--text-muted);
-}
-
-.sm-le-box.is-selected .sm-le-box__resize {
-    border-color: var(--interactive-accent);
 }
 
 .sm-le-inspector {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -20,11 +20,11 @@ src/apps/layout/
 
 ## Features & Verantwortlichkeiten
 
-- **Layout-Arbeitsfläche:** Konfigurierbare Canvas mit Breite/Höhe-Controls; alle Elemente werden mit Bounds-Clamping gerendert und können per Drag/Resize manipuliert werden. Inspector und Arbeitsfläche bilden ein Zweispalten-Layout mit rechts angedocktem Eigenschaften-Panel.
+- **Layout-Arbeitsfläche:** Konfigurierbare Canvas mit Breite/Höhe-Controls; alle Elemente werden mit Bounds-Clamping gerendert und lassen sich direkt über ihren Rahmen bewegen (Drag) bzw. an den Ecken skalieren (Resize). Inspector und Arbeitsfläche bilden ein Zweispalten-Layout mit rechts angedocktem Eigenschaften-Panel.
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
-- **Container-Layout:** VBox-/HBox-Container verteilen Kinder automatisch (Gap, Padding, Align) und synchronisieren bei manuellen Änderungen oder Größenanpassungen. Eine Schnell-Hinzufügen-Aktion direkt in der Canvas erlaubt das Anlegen neuer Kinder ohne Umweg über den Inspector.
-- **Inspector & Inline-Editing:** `element-preview.ts` stellt sämtliche Texte, Platzhalter, Default-Werte und Optionen direkt in der Vorschau zur Bearbeitung bereit; `inspector-panel.ts` liefert ergänzend Meta-Steuerung (Container-Zuordnung, Attribute, Maße).
-- **Headline-Labels & Textfelder:** Label-Elemente bestehen aus einer einzigen Überschrift mit automatischer Schriftgrößenanpassung; einfache Textfelder zeigen nur noch das Eingabefeld und verzichten auf Label- und Placeholder-Bearbeitung.
+- **Container-Layout:** VBox-/HBox-Container verteilen Kinder automatisch (Gap, Padding, Align) und synchronisieren bei manuellen Änderungen oder Größenanpassungen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt werden.
+- **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente (Labels, Inputs, Dropdowns usw.) und lassen sich dort inhaltlich editieren. Erweiterte Eigenschaften wie Platzhalter, Optionslisten oder Container-Layout werden ausschließlich im Inspector gepflegt.
+- **Echte Vorschau:** Label-Elemente passen ihre Schriftgröße automatisch an, einfache Textfelder bestehen nur aus dem Eingabefeld und alle weiteren Controls spiegeln ihr finales Erscheinungsbild ohne zusätzliche Chrome-Elemente wider.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet das Popover (Öffnen, Positionierung, Synchronisation) und hält Inspector sowie Canvas konsistent.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` nutzt sie für Strg+Z / Strg+Umschalt+Z sowie automatisches Pushen nach Mutationen.
 - **Export & Status:** JSON-Export (Canvas + Elemente) sowie Statusleiste werden in `view.ts` gepflegt und auf jede Mutation aktualisiert.
@@ -61,12 +61,12 @@ src/apps/layout/
 - Bietet einen generischen ContentEditable-Editor (Trim, Multiline, Placeholder) für Preview-Komponenten.
 
 ### `editor/element-preview.ts`
-- Rendert Canvas-Vorschauen als minimalistische UI-Elemente (Labels, Inputs, Dropdowns etc.) inklusive Inline-Label-/Beschreibung-/Optionen-Editoren ohne Surrounding-Panel.
-- Delegiert Layout-spezifische Aktionen (z. B. Container-Layout, History-Push) über Callbacks an die View.
+- Rendert die Canvas als echte UI-Elemente (Labels, Inputs, Dropdowns etc.) und erlaubt dort nur inhaltliche Direktbearbeitung (z. B. Texte, Default-Werte).
+- Übergibt finale Änderungen über Callbacks an die View, damit Inspector, Export und Historie synchron bleiben.
 
 ### `editor/inspector-panel.ts`
-- Rendert einen kompakten Inspector mit Meta-Infos, Container-Zuordnung, Attribut-Anzeige, Positions-/Größensteuerung und Container-Kindverwaltung.
-- Delegiert Mutationen über `InspectorCallbacks` zurück an die View, öffnet Attribute-Popover und reicht Inline-Änderungen weiter.
+- Rendert einen kompakten Inspector mit Meta-Infos, Container-Zuordnung, Attribut-Anzeige, Positions-/Größensteuerung, Layout-Parametern und Container-Kindverwaltung.
+- Delegiert alle Mutationen (inkl. Platzhalter-, Optionen- und Layout-Änderungen) über `InspectorCallbacks` an die View und öffnet das Attribute-Popover.
 
 ### `editor/attribute-popover.ts`
 - Erstellt, positioniert und synchronisiert das Attribut-Popover.


### PR DESCRIPTION
## Summary
- enable dragging from element borders and resizing from corners while rendering real UI previews on the canvas
- move placeholder, option, and container layout editing into the inspector and simplify preview markup accordingly
- refresh layout editor styling/documentation to match the new interaction model

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4dd32ae848325ace39797e5f8c258