### PR TITLE
feat(layout-editor): add structure tree and camera controls

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -780,15 +780,168 @@ export const HEX_PLUGIN_CSS = `
 }
 
 .sm-le-body {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 280px;
-    gap: 1.25rem;
+    display: flex;
     align-items: stretch;
+    gap: 0.75rem;
+    min-height: 520px;
+}
+
+.sm-le-panel {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 0.75rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    box-sizing: border-box;
+    min-width: 200px;
+}
+
+.sm-le-panel h3 {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.sm-le-panel--structure {
+    flex-basis: 260px;
+}
+
+.sm-le-panel--inspector {
+    flex-basis: 320px;
+}
+
+.sm-le-structure {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.sm-le-structure__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.sm-le-structure__item {
+    display: block;
+}
+
+.sm-le-structure__item > .sm-le-structure__list {
+    margin-left: 0.85rem;
+    padding-left: 0.75rem;
+    border-left: 1px dashed var(--background-modifier-border);
+    margin-top: 0.35rem;
+}
+
+.sm-le-structure__entry {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    padding: 0.4rem 0.5rem;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease;
+}
+
+.sm-le-structure__entry:hover {
+    background: var(--background-modifier-hover);
+}
+
+.sm-le-structure__entry.is-selected {
+    background: var(--interactive-accent);
+    color: var(--text-on-accent, #ffffff);
+}
+
+.sm-le-structure__entry.is-selected .sm-le-structure__meta {
+    color: inherit;
+    opacity: 0.85;
+}
+
+.sm-le-structure__title {
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.sm-le-structure__meta {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    line-height: 1.2;
+}
+
+.sm-le-resizer {
+    flex: 0 0 6px;
+    border-radius: 999px;
+    background: var(--background-modifier-border);
+    cursor: col-resize;
+    align-self: stretch;
+    transition: background-color 120ms ease;
+}
+
+.sm-le-resizer:hover,
+.sm-le-resizer.is-active {
+    background: var(--interactive-accent);
 }
 
 .sm-le-stage {
+    flex: 1 1 auto;
+    min-width: 320px;
     display: flex;
-    justify-content: center;
+    align-items: stretch;
+    justify-content: stretch;
+}
+
+.sm-le-stage__viewport {
+    position: relative;
+    flex: 1;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--background-secondary);
+    min-height: 520px;
+    cursor: grab;
+}
+
+.sm-le-stage__viewport::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.035) 1px,
+            transparent 1px
+        ),
+        linear-gradient(
+            90deg,
+            rgba(0, 0, 0, 0.035) 1px,
+            transparent 1px
+        );
+    background-size: 40px 40px;
+}
+
+.sm-le-stage__viewport.is-panning {
+    cursor: grabbing;
+}
+
+.sm-le-stage__camera {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: top left;
+}
+
+.sm-le-stage__zoom {
+    transform-origin: top left;
 }
 
 .sm-le-canvas {
@@ -1121,18 +1274,12 @@ export const HEX_PLUGIN_CSS = `
 }
 
 .sm-le-inspector {
-    min-width: 240px;
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 10px;
-    padding: 0.6rem;
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-}
-
-.sm-le-inspector h3 {
-    margin: 0;
+    overflow-y: auto;
+    padding-right: 0.25rem;
 }
 
 .sm-le-field {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -20,7 +20,8 @@ src/apps/layout/
 
 ## Features & Verantwortlichkeiten
 
-- **Layout-Arbeitsfläche:** Konfigurierbare Canvas mit Breite/Höhe-Controls; alle Elemente werden mit Bounds-Clamping gerendert und lassen sich direkt über ihren Rahmen bewegen (Drag) bzw. an den Ecken skalieren (Resize). Inspector und Arbeitsfläche bilden ein Zweispalten-Layout mit rechts angedocktem Eigenschaften-Panel.
+- **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Die Arbeitsfläche füllt automatisch den Raum zwischen den Panels, lässt sich mit mittlerer Maustaste verschieben und per Mausrad (mit Fokuspunkt) zoomen. Breite/Höhe-Controls bleiben erhalten, Bounds-Clamping schützt weiterhin vor Überlauf, Drag/Resize funktionieren auch bei veränderter Zoom-Stufe.
+- **Struktur-Überblick:** Ein interaktiver Baum listet alle Layout-Elemente analog zur Container-Hierarchie (inkl. Kinderreihenfolge aus `children`). Ein Klick wählt das Element aus und fokussiert es mittig im Canvas. Das Panel kann – genauso wie der Inspector – über Drag an den Trennern in der Breite angepasst werden.
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
 - **Container-Layout:** VBox-/HBox-Container verteilen Kinder automatisch (Gap, Padding, Align) und synchronisieren bei manuellen Änderungen oder Größenanpassungen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt werden.
 - **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente (Labels, Inputs, Dropdowns usw.) und lassen sich dort inhaltlich editieren. Erweiterte Eigenschaften wie Platzhalter, Optionslisten oder Container-Layout werden ausschließlich im Inspector gepflegt.
@@ -41,9 +42,9 @@ src/apps/layout/
 
 ### `editor/view.ts`
 - Implementiert `LayoutEditorView` (`ItemView`).
-- Baut Header (Palette, Import, Status), Canvas, Inspector, Exportbereich und Sandbox auf.
+- Baut Header (Palette, Import, Status), Struktur-Baum, resizable Stage mit Kamera (Pan/Zoom), Inspector, Exportbereich und Sandbox auf.
 - Verwaltet Element-State, Selection, Historie und ruft Hilfs-Module (Preview, Inspector, Popover, Import) orchestriert auf.
-- Synchronisiert alle Mutationen (Canvas, Inspector, Export, Status) und sorgt für Bounds-Clamping, Container-Auto-Layout sowie Shortcuts (Delete, Undo/Redo).
+- Synchronisiert alle Mutationen (Canvas, Inspector, Export, Status) und sorgt für Bounds-Clamping, Container-Auto-Layout, Shortcuts (Delete, Undo/Redo) sowie Panel-/Kamera-Steuerung.
 
 ### `editor/definitions.ts`
 - Enthält Element-Definitionen inkl. Default-Texte, Größen, Layout-Voreinstellungen und Attribute-Gruppen.


### PR DESCRIPTION
## Summary
- add a structure sidebar, resizable split layout, and camera pan/zoom controls to the layout editor
- update layout editor styles for three-panel workspace, resizers, and viewport grid background
- refresh the layout overview documentation to capture the new workspace capabilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e276215483258496b9dbe614ef4a