### PR TITLE
Fix layout editor resizer and add structure drag drop

### DIFF
--- a/src/app/css.ts
+++ b/src/app/css.ts
@@ -866,6 +866,20 @@ export const HEX_PLUGIN_CSS = `
     opacity: 0.85;
 }
 
+.sm-le-structure__entry.is-drop-target {
+    background: var(--interactive-accent);
+    color: var(--text-on-accent, #ffffff);
+}
+
+.sm-le-structure__entry.is-drop-target .sm-le-structure__title,
+.sm-le-structure__entry.is-drop-target .sm-le-structure__meta {
+    color: inherit;
+}
+
+.sm-le-structure__entry.is-drop-target .sm-le-structure__meta {
+    opacity: 0.85;
+}
+
 .sm-le-structure__title {
     font-weight: 600;
     line-height: 1.2;
@@ -875,6 +889,32 @@ export const HEX_PLUGIN_CSS = `
     font-size: 0.75rem;
     color: var(--text-muted);
     line-height: 1.2;
+}
+
+.sm-le-structure__entry.is-draggable {
+    cursor: grab;
+}
+
+.sm-le-structure__entry.is-draggable:active {
+    cursor: grabbing;
+}
+
+.sm-le-structure__root-drop {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    padding: 0.35rem 0.5rem;
+    border: 1px dashed var(--background-modifier-border);
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    text-align: center;
+    background: rgba(0, 0, 0, 0.02);
+    transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.sm-le-structure__root-drop.is-active {
+    background: var(--interactive-accent);
+    color: var(--text-on-accent, #ffffff);
+    border-color: var(--interactive-accent);
 }
 
 .sm-le-resizer {

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -20,8 +20,8 @@ src/apps/layout/
 
 ## Features & Verantwortlichkeiten
 
-- **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Die Arbeitsfläche füllt automatisch den Raum zwischen den Panels, lässt sich mit mittlerer Maustaste verschieben und per Mausrad (mit Fokuspunkt) zoomen. Breite/Höhe-Controls bleiben erhalten, Bounds-Clamping schützt weiterhin vor Überlauf, Drag/Resize funktionieren auch bei veränderter Zoom-Stufe.
-- **Struktur-Überblick:** Ein interaktiver Baum listet alle Layout-Elemente analog zur Container-Hierarchie (inkl. Kinderreihenfolge aus `children`). Ein Klick wählt das Element aus und fokussiert es mittig im Canvas. Das Panel kann – genauso wie der Inspector – über Drag an den Trennern in der Breite angepasst werden.
+- **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Die Arbeitsfläche füllt automatisch den Raum zwischen den Panels, lässt sich mit mittlerer Maustaste verschieben und per Mausrad (mit Fokuspunkt) zoomen. Breite/Höhe-Controls bleiben erhalten, Bounds-Clamping schützt weiterhin vor Überlauf und die Panel-Trenner reagieren erwartungskonform – sowohl links als auch rechts.
+- **Struktur-Überblick:** Ein interaktiver Baum listet alle Layout-Elemente analog zur Container-Hierarchie (inkl. Kinderreihenfolge aus `children`) und zeigt die aktuelle Eltern-Zuordnung direkt im Eintrag an. Ein Klick wählt das Element aus und fokussiert es mittig im Canvas. Über Drag & Drop lassen sich Elemente in Container ziehen oder aus ihnen lösen (Root-Drop-Zone), während das Panel – genauso wie der Inspector – weiterhin über die Trenner in der Breite angepasst werden kann.
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
 - **Container-Layout:** VBox-/HBox-Container verteilen Kinder automatisch (Gap, Padding, Align) und synchronisieren bei manuellen Änderungen oder Größenanpassungen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt werden.
 - **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente (Labels, Inputs, Dropdowns usw.) und lassen sich dort inhaltlich editieren. Erweiterte Eigenschaften wie Platzhalter, Optionslisten oder Container-Layout werden ausschließlich im Inspector gepflegt.
@@ -45,6 +45,7 @@ src/apps/layout/
 - Baut Header (Palette, Import, Status), Struktur-Baum, resizable Stage mit Kamera (Pan/Zoom), Inspector, Exportbereich und Sandbox auf.
 - Verwaltet Element-State, Selection, Historie und ruft Hilfs-Module (Preview, Inspector, Popover, Import) orchestriert auf.
 - Synchronisiert alle Mutationen (Canvas, Inspector, Export, Status) und sorgt für Bounds-Clamping, Container-Auto-Layout, Shortcuts (Delete, Undo/Redo) sowie Panel-/Kamera-Steuerung.
+- Enthält Drag-&-Drop-Zuordnung im Strukturpanel (inkl. Root-Drop-Zone) und aktualisiert die Panel-Größen-Logik, damit der rechte Trenner der Erwartung folgt.
 
 ### `editor/definitions.ts`
 - Enthält Element-Definitionen inkl. Default-Texte, Größen, Layout-Voreinstellungen und Attribute-Gruppen.


### PR DESCRIPTION
## Summary
- fix the inspector-side panel resizer so it tracks the pointer and keeps the stage width constraints intact
- extend the structure panel with parent badges, a root drop target, and drag & drop reassignment into containers
- style the new interactions and document the updated behaviour in the layout overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e633652883259423d8b84a5ebddc