### PR TITLE
Remove redundant layout editor headings

### DIFF
--- a/main.js
+++ b/main.js
@@ -5617,7 +5617,7 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "textarea",
     buttonLabel: "Mehrzeiliges Feld",
-    defaultLabel: "Beschreibung",
+    defaultLabel: "",
     defaultPlaceholder: "Text erfassen\u2026",
     width: 320,
     height: 180
@@ -5625,7 +5625,7 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "box-container",
     buttonLabel: "BoxContainer",
-    defaultLabel: "BoxContainer",
+    defaultLabel: "",
     width: 360,
     height: 220,
     defaultLayout: { gap: 16, padding: 16, align: "stretch" }
@@ -5633,14 +5633,14 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "separator",
     buttonLabel: "Trennstrich",
-    defaultLabel: "Trennlinie",
+    defaultLabel: "",
     width: 320,
     height: 80
   },
   {
     type: "dropdown",
     buttonLabel: "Dropdown",
-    defaultLabel: "Auswahl",
+    defaultLabel: "",
     defaultPlaceholder: "Option w\xE4hlen\u2026",
     options: ["Option A", "Option B"],
     width: 260,
@@ -5649,7 +5649,7 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "search-dropdown",
     buttonLabel: "Such-Dropdown",
-    defaultLabel: "Suchfeld",
+    defaultLabel: "",
     defaultPlaceholder: "Suchen\u2026",
     options: ["Erster Eintrag", "Zweiter Eintrag"],
     width: 280,
@@ -5658,7 +5658,7 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "vbox-container",
     buttonLabel: "VBoxContainer",
-    defaultLabel: "VBoxContainer",
+    defaultLabel: "",
     defaultDescription: "Ordnet verkn\xFCpfte Elemente automatisch untereinander an.",
     width: 340,
     height: 260,
@@ -5667,7 +5667,7 @@ var ELEMENT_DEFINITIONS = [
   {
     type: "hbox-container",
     buttonLabel: "HBoxContainer",
-    defaultLabel: "HBoxContainer",
+    defaultLabel: "",
     defaultDescription: "Ordnet verkn\xFCpfte Elemente automatisch nebeneinander an.",
     width: 360,
     height: 220,

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -26,7 +26,7 @@ src/apps/layout/
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
 - **Container-Layout:** BoxContainer, VBoxContainer und HBoxContainer verwalten ihre Kinder inklusive Gap, Padding und Align automatisch und reagieren auch auf verschachtelte Konstellationen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt oder per Struktur-Baum in andere Container gezogen werden.
 - **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente (Labels, Inputs, Dropdowns usw.) und lassen sich dort inhaltlich editieren. Erweiterte Eigenschaften wie Platzhalter, Optionslisten oder Container-Layout werden ausschließlich im Inspector gepflegt.
-- **Echte Vorschau:** Label-Elemente passen ihre Schriftgröße automatisch an, einfache Textfelder bestehen nur aus dem Eingabefeld und alle weiteren Controls spiegeln ihr finales Erscheinungsbild ohne zusätzliche Chrome-Elemente wider.
+- **Echte Vorschau:** Label-Elemente passen ihre Schriftgröße automatisch an, einfache Textfelder bestehen nur aus dem Eingabefeld und alle weiteren Controls spiegeln ihr finales Erscheinungsbild ohne zusätzliche Chrome-Elemente wider. Standard-Elemente starten ohne automatisch gesetzte Label-Texte und zeigen lediglich Platzhalter, bis Redakteur:innen eigene Beschriftungen vergeben.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet das Popover (Öffnen, Positionierung, Synchronisation) und hält Inspector sowie Canvas konsistent.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` nutzt sie für Strg+Z / Strg+Umschalt+Z sowie automatisches Pushen nach Mutationen.
 - **Export & Status:** JSON-Export (Canvas + Elemente) sowie Statusleiste werden in `view.ts` gepflegt und auf jede Mutation aktualisiert.
@@ -50,6 +50,7 @@ src/apps/layout/
 
 ### `editor/definitions.ts`
 - Enthält Element-Definitionen inkl. Default-Texte, Größen, Layout-Voreinstellungen und Attribute-Gruppen.
+- Setzt für strukturgebende Elemente leere Default-Labels, damit im Canvas keine redundanten Überschriften erscheinen.
 - Stellt Label-/Summary-Helfer (`getElementTypeLabel`, `getAttributeSummary`, `getContainerAlignLabel`) bereit.
 
 ### `editor/types.ts`

--- a/src/apps/layout/editor/definitions.ts
+++ b/src/apps/layout/editor/definitions.ts
@@ -22,7 +22,7 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "textarea",
         buttonLabel: "Mehrzeiliges Feld",
-        defaultLabel: "Beschreibung",
+        defaultLabel: "",
         defaultPlaceholder: "Text erfassen…",
         width: 320,
         height: 180,
@@ -30,7 +30,7 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "box-container",
         buttonLabel: "BoxContainer",
-        defaultLabel: "BoxContainer",
+        defaultLabel: "",
         width: 360,
         height: 220,
         defaultLayout: { gap: 16, padding: 16, align: "stretch" },
@@ -38,14 +38,14 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "separator",
         buttonLabel: "Trennstrich",
-        defaultLabel: "Trennlinie",
+        defaultLabel: "",
         width: 320,
         height: 80,
     },
     {
         type: "dropdown",
         buttonLabel: "Dropdown",
-        defaultLabel: "Auswahl",
+        defaultLabel: "",
         defaultPlaceholder: "Option wählen…",
         options: ["Option A", "Option B"],
         width: 260,
@@ -54,7 +54,7 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "search-dropdown",
         buttonLabel: "Such-Dropdown",
-        defaultLabel: "Suchfeld",
+        defaultLabel: "",
         defaultPlaceholder: "Suchen…",
         options: ["Erster Eintrag", "Zweiter Eintrag"],
         width: 280,
@@ -63,7 +63,7 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "vbox-container",
         buttonLabel: "VBoxContainer",
-        defaultLabel: "VBoxContainer",
+        defaultLabel: "",
         defaultDescription: "Ordnet verknüpfte Elemente automatisch untereinander an.",
         width: 340,
         height: 260,
@@ -72,7 +72,7 @@ export const ELEMENT_DEFINITIONS: LayoutElementDefinition[] = [
     {
         type: "hbox-container",
         buttonLabel: "HBoxContainer",
-        defaultLabel: "HBoxContainer",
+        defaultLabel: "",
         defaultDescription: "Ordnet verknüpfte Elemente automatisch nebeneinander an.",
         width: 360,
         height: 220,


### PR DESCRIPTION
## Summary
- drop default labels from layout editor definitions so new elements no longer render auto-generated headings
- document the placeholder-based preview behavior in the layout overview
- rebuild the compiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4efea7f6083258537805a620ca508