### PR TITLE
Refine layout editor labeling UX

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -34,7 +34,7 @@ Salt-Marcher/
 - **Library-View:** Vereinheitlicht das Management von Terrains, Regionen und Kreaturen inklusive Suchleiste, Erstellung,
   Inline-Bearbeitung und Persistenz.
 - **Encounter-View:** Liefert eine leichtgewichtige Ansicht für Encounter-Notizen.
-- **Layout-Editor:** Bietet eine Drag-&-Drop-Arbeitsfläche mit direkter Inline-Bearbeitung für Labels, Defaults & Optionen, übersetzt Texte in Zielsprachen und exportiert Abmessungen als JSON.
+- **Layout-Editor:** Bietet eine Drag-&-Drop-Arbeitsfläche mit gruppierter Elementpalette, zeigt Vorschauen ohne störende Eingabefelder an, verwaltet Benennungen im Inspector, übersetzt Texte in Zielsprachen und exportiert Abmessungen als JSON.
 - **Core-Services:** Stellen Hex-Geometrie, Map/Tile-Dateioperationen, Terrain- und Regions-Persistenz sowie Workspace-Helfer
   bereit und dienen als Single Source of Truth für die Apps.
 - **Geteilte UI-Bausteine:** Modals, Header- und Workflow-Helfer kapseln wiederkehrende Interaktionen (Map-Auswahl, Bestätigungen,

--- a/src/apps/layout/LayoutOverview.txt
+++ b/src/apps/layout/LayoutOverview.txt
@@ -8,7 +8,7 @@ src/apps/layout/
 │  ├─ attribute-popover.ts   # Verwaltet das Attribute-Popover inklusive Events & Synchronisation
 │  ├─ creature-import.ts     # Baut das Creature-Creator-Layout nach und erzeugt LayoutElemente
 │  ├─ definitions.ts         # Konstanten (Element- & Attribut-Definitionen) + Label-Helfer
-│  ├─ element-preview.ts     # Rendert Canvas-Vorschauen inkl. Inline-Editoren
+│  ├─ element-preview.ts     # Rendert Canvas-Vorschauen, blendet reine Anzeige-Controls ohne Inline-Editing ein
 │  ├─ history.ts             # Undo/Redo-Verwaltung für LayoutSnapshots
 │  ├─ inline-edit.ts         # Generischer ContentEditable-Editor für Inline-Bearbeitung
 │  ├─ inspector-panel.ts     # Inspector-Rendering (Formfelder, Container-Steuerung, Attribute-Trigger)
@@ -22,10 +22,10 @@ src/apps/layout/
 
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Die Arbeitsfläche füllt automatisch den Raum zwischen den Panels, lässt sich mit mittlerer Maustaste verschieben und per Mausrad (mit Fokuspunkt) zoomen. Breite/Höhe-Controls bleiben erhalten, Bounds-Clamping schützt weiterhin vor Überlauf und die Panel-Trenner reagieren erwartungskonform – sowohl links als auch rechts.
 - **Struktur-Überblick:** Ein interaktiver Baum listet alle Layout-Elemente analog zur Container-Hierarchie (inkl. Kinderreihenfolge aus `children`) und zeigt die aktuelle Eltern-Zuordnung direkt im Eintrag an. Ein Klick wählt das Element aus und fokussiert es mittig im Canvas. Über Drag & Drop lassen sich Elemente in Container ziehen oder aus ihnen lösen (Root-Drop-Zone), während das Panel – genauso wie der Inspector – weiterhin über die Trenner in der Breite angepasst werden kann.
-- **Container-Palette & Nesting:** BoxContainer-, VBoxContainer- und HBoxContainer-Definitionen liegen gebündelt im neuen „Container“-Dropdown der Palette. Alle Container lassen sich beliebig ineinander verschachteln; Inspector, Strukturbaum und Drag & Drop verhindern Zyklen und erlauben das Neuzuordnen sowie Verschieben kompletter Container-Hierarchien.
+- **Palette & Nesting:** BoxContainer-, VBoxContainer- und HBoxContainer-Definitionen liegen gebündelt im „Container“-Dropdown der Palette, während Textfeld, Mehrzeiliges Feld, Dropdown und Such-Dropdown unter „Eingabefelder“ gruppiert sind. Alle Container lassen sich beliebig ineinander verschachteln; Inspector, Strukturbaum und Drag & Drop verhindern Zyklen und erlauben das Neuzuordnen sowie Verschieben kompletter Container-Hierarchien.
 - **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
 - **Container-Layout:** BoxContainer, VBoxContainer und HBoxContainer verwalten ihre Kinder inklusive Gap, Padding und Align automatisch und reagieren auch auf verschachtelte Konstellationen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt oder per Struktur-Baum in andere Container gezogen werden.
-- **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente (Labels, Inputs, Dropdowns usw.) und lassen sich dort inhaltlich editieren. Erweiterte Eigenschaften wie Platzhalter, Optionslisten oder Container-Layout werden ausschließlich im Inspector gepflegt.
+- **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente. Nur freie Texte (z. B. Überschriften) werden dort inline bearbeitet; Bezeichnungen für Container, Felder und Trenner pflegst du im Inspector zusammen mit Platzhaltern, Optionslisten und Layout-Eigenschaften.
 - **Echte Vorschau:** Label-Elemente passen ihre Schriftgröße automatisch an, einfache Textfelder bestehen nur aus dem Eingabefeld und alle weiteren Controls spiegeln ihr finales Erscheinungsbild ohne zusätzliche Chrome-Elemente wider. Standard-Elemente starten ohne automatisch gesetzte Label-Texte und zeigen lediglich Platzhalter, bis Redakteur:innen eigene Beschriftungen vergeben.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet das Popover (Öffnen, Positionierung, Synchronisation) und hält Inspector sowie Canvas konsistent.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` nutzt sie für Strg+Z / Strg+Umschalt+Z sowie automatisches Pushen nach Mutationen.
@@ -65,12 +65,12 @@ src/apps/layout/
 - Bietet einen generischen ContentEditable-Editor (Trim, Multiline, Placeholder) für Preview-Komponenten.
 
 ### `editor/element-preview.ts`
-- Rendert die Canvas als echte UI-Elemente (Labels, Inputs, Dropdowns etc.) und erlaubt dort nur inhaltliche Direktbearbeitung (z. B. Texte, Default-Werte).
+- Rendert die Canvas als echte UI-Elemente (Labels, Inputs, Dropdowns etc.) und zeigt Container-/Labelbereiche ohne Inline-Eingabefelder an.
 - Übergibt finale Änderungen über Callbacks an die View, damit Inspector, Export und Historie synchron bleiben.
 
 ### `editor/inspector-panel.ts`
-- Rendert einen kompakten Inspector mit Meta-Infos, Container-Zuordnung (Dropdown inkl. Verschachtelungs-Schutz), Attribut-Anzeige, Positions-/Größensteuerung, Layout-Parametern und Container-Kindverwaltung.
-- Delegiert alle Mutationen (inkl. Platzhalter-, Optionen- und Layout-Änderungen) über `InspectorCallbacks` an die View und öffnet das Attribute-Popover.
+- Rendert einen kompakten Inspector mit Meta-Infos, Benennung, Container-Zuordnung (Dropdown inkl. Verschachtelungs-Schutz), Attribut-Anzeige, Positions-/Größensteuerung, Layout-Parametern und Container-Kindverwaltung.
+- Delegiert alle Mutationen (inkl. Platzhalter-, Optionen-, Benennungs- und Layout-Änderungen) über `InspectorCallbacks` an die View und öffnet das Attribute-Popover.
 
 ### `editor/attribute-popover.ts`
 - Erstellt, positioniert und synchronisiert das Attribut-Popover.

--- a/src/apps/layout/editor/element-preview.ts
+++ b/src/apps/layout/editor/element-preview.ts
@@ -88,13 +88,12 @@ export function renderElementPreview(deps: ElementPreviewDependencies) {
 
     if (element.type === "separator") {
         const header = preview.createDiv({ cls: "sm-le-preview__separator" });
-        const label = createInlineEditor({
-            parent: header,
-            value: element.label,
-            placeholder: "Titel eingeben…",
-            onCommit: commitLabel,
-        });
-        label.addClass("sm-le-preview__label");
+        const title = element.label?.trim() ? element.label : "";
+        if (title) {
+            header.createSpan({ cls: "sm-le-preview__label", text: title });
+        } else {
+            header.style.display = "none";
+        }
         preview.createEl("hr", { cls: "sm-le-preview__divider" });
         return;
     }
@@ -124,12 +123,12 @@ export function renderElementPreview(deps: ElementPreviewDependencies) {
     if (element.type === "textarea") {
         const field = preview.createEl("label", { cls: "sm-le-preview__field" });
         const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
-        createInlineEditor({
-            parent: labelHost,
-            value: element.label,
-            placeholder: "Label eingeben…",
-            onCommit: commitLabel,
-        });
+        const labelText = element.label?.trim() ?? "";
+        if (labelText) {
+            labelHost.setText(labelText);
+        } else {
+            labelHost.style.display = "none";
+        }
 
         const textarea = field.createEl("textarea", { cls: "sm-le-preview__textarea" }) as HTMLTextAreaElement;
         textarea.value = element.defaultValue ?? "";
@@ -153,12 +152,12 @@ export function renderElementPreview(deps: ElementPreviewDependencies) {
     if (element.type === "dropdown" || element.type === "search-dropdown") {
         const field = preview.createEl("label", { cls: "sm-le-preview__field" });
         const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
-        createInlineEditor({
-            parent: labelHost,
-            value: element.label,
-            placeholder: "Label eingeben…",
-            onCommit: commitLabel,
-        });
+        const labelText = element.label?.trim() ?? "";
+        if (labelText) {
+            labelHost.setText(labelText);
+        } else {
+            labelHost.style.display = "none";
+        }
 
         const select = field.createEl("select", { cls: "sm-le-preview__select" }) as HTMLSelectElement;
         const defaultPlaceholder = element.type === "dropdown" ? "Option wählen…" : "Suchen…";
@@ -223,12 +222,12 @@ export function renderElementPreview(deps: ElementPreviewDependencies) {
         deps.ensureContainerDefaults(element);
         const frame = preview.createDiv({ cls: "sm-le-preview__container" });
         const header = frame.createDiv({ cls: "sm-le-preview__container-header" });
-        createInlineEditor({
-            parent: header,
-            value: element.label,
-            placeholder: "Container benennen…",
-            onCommit: commitLabel,
-        }).addClass("sm-le-preview__label");
+        const labelText = element.label?.trim() ?? "";
+        if (labelText) {
+            header.createSpan({ cls: "sm-le-preview__label", text: labelText });
+        } else {
+            header.style.display = "none";
+        }
         const body = frame.createDiv({ cls: "sm-le-preview__container-body" });
         const children = Array.isArray(element.children)
             ? element.children

--- a/src/apps/layout/editor/inspector-panel.ts
+++ b/src/apps/layout/editor/inspector-panel.ts
@@ -34,6 +34,16 @@ export interface InspectorDependencies {
     callbacks: InspectorCallbacks;
 }
 
+const LABEL_INSPECTOR_TYPES = new Set<LayoutElementType>([
+    "textarea",
+    "dropdown",
+    "search-dropdown",
+    "separator",
+    "box-container",
+    "vbox-container",
+    "hbox-container",
+]);
+
 export function renderInspectorPanel(deps: InspectorDependencies) {
     const { host, element } = deps;
     host.empty();
@@ -56,8 +66,13 @@ export function renderInspectorPanel(deps: InspectorDependencies) {
 
     host.createDiv({
         cls: "sm-le-hint",
-        text: "Texte bearbeitest du direkt im Arbeitsbereich. Platzhalter, Optionen und Layout findest du hier im Inspector.",
+        text: "Benennungen und Eigenschaften pflegst du hier im Inspector. Reine Textblöcke bearbeitest du direkt im Arbeitsbereich.",
     });
+
+    if (LABEL_INSPECTOR_TYPES.has(element.type)) {
+        const labelText = element.type === "separator" ? "Titel" : "Bezeichnung";
+        renderLabelField({ host, element, callbacks, label: labelText });
+    }
 
     const containers = elements.filter(el => isContainerType(el.type));
     if (containers.length) {
@@ -331,6 +346,22 @@ function renderPlaceholderField(options: {
         if (next === element.placeholder) return;
         element.placeholder = next;
         finalizeElementChange(element, callbacks);
+    };
+    input.onchange = commit;
+    input.onblur = commit;
+}
+
+function renderLabelField(options: { host: HTMLElement; element: LayoutElement; callbacks: InspectorCallbacks; label: string }) {
+    const { host, element, callbacks, label } = options;
+    const field = host.createDiv({ cls: "sm-le-field" });
+    field.createEl("label", { text: label });
+    const input = field.createEl("input", { attr: { type: "text" } }) as HTMLInputElement;
+    input.value = element.label ?? "";
+    const commit = () => {
+        const next = input.value ?? "";
+        if (next === element.label) return;
+        element.label = next;
+        finalizeElementChange(element, callbacks, { rerender: true });
     };
     input.onchange = commit;
     input.onblur = commit;

--- a/src/apps/layout/editor/view.ts
+++ b/src/apps/layout/editor/view.ts
@@ -191,9 +191,26 @@ export class LayoutEditorView extends ItemView {
         const addWrap = addGroup.createDiv({ cls: "sm-le-add" });
         const containerDefinitions = ELEMENT_DEFINITIONS.filter(def => isContainerType(def.type));
         const elementDefinitions = ELEMENT_DEFINITIONS.filter(def => !isContainerType(def.type));
-        for (const def of elementDefinitions) {
+        const inputFieldTypes = new Set<LayoutElementType>(["text-input", "textarea", "dropdown", "search-dropdown"]);
+        const inputDefinitions = elementDefinitions.filter(def => inputFieldTypes.has(def.type));
+        const otherElementDefinitions = elementDefinitions.filter(def => !inputFieldTypes.has(def.type));
+        for (const def of otherElementDefinitions) {
             const btn = addWrap.createEl("button", { text: def.buttonLabel });
             btn.onclick = () => this.createElement(def.type);
+        }
+        if (inputDefinitions.length) {
+            const inputBtn = addWrap.createEl("button", { text: "Eingabefelder" });
+            inputBtn.onclick = event => {
+                event.preventDefault();
+                const menu = new Menu();
+                for (const def of inputDefinitions) {
+                    menu.addItem(item => {
+                        item.setTitle(def.buttonLabel);
+                        item.onClick(() => this.createElement(def.type));
+                    });
+                }
+                menu.showAtMouseEvent(event);
+            };
         }
         if (containerDefinitions.length) {
             const containerBtn = addWrap.createEl("button", { text: "Container" });


### PR DESCRIPTION
## Summary
- hide inline rename inputs for containers, textarea, dropdown and separator previews
- add label editing fields to the layout inspector and regroup palette inputs under a shared menu
- refresh LayoutOverview and PluginOverview documentation to reflect the inspector workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f39fda588325bb9d8f790725b858