### PR TITLE
Refactor layout editor into standalone plugin with registry & layout library

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -19,8 +19,9 @@ Salt-Marcher/
 │  ├─ apps/
 │  │  ├─ cartographer/      # Hex-Map-Workspace mit Editor/Inspector/Travel-Modi
 │  │  ├─ encounter/         # Einfache Encounter-View
-│  │  ├─ layout/            # Layout-Editor für Boxen, Übersetzungen & Maßexport
 │  │  └─ library/           # Bibliothek für Terrains, Regionen und Kreaturen
+│  ├─ plugins/
+│  │  └─ layout-editor/     # Eigenständiges Layout-Editor-Plugin inkl. Element-Registry & Layout-Library
 │  ├─ core/                 # Domain-Services (Hex-Geometrie, Dateien, Terrain, Optionen)
 │  └─ ui/                   # Geteilte Dialoge und Workflow-Helfer
 └─ tsconfig.json            # TypeScript-Konfiguration für das Build-Setup
@@ -34,7 +35,7 @@ Salt-Marcher/
 - **Library-View:** Vereinheitlicht das Management von Terrains, Regionen und Kreaturen inklusive Suchleiste, Erstellung,
   Inline-Bearbeitung und Persistenz.
 - **Encounter-View:** Liefert eine leichtgewichtige Ansicht für Encounter-Notizen.
-- **Layout-Editor:** Bietet eine Drag-&-Drop-Arbeitsfläche mit gruppierter Elementpalette, zeigt Vorschauen ohne störende Eingabefelder an, verwaltet Benennungen im Inspector, übersetzt Texte in Zielsprachen und exportiert Abmessungen als JSON.
+- **Layout-Editor-Plugin:** Kapselt den Layout-Editor als eigenständiges Modul, stellt eine registrierbare Element-Palette bereit und speichert Layouts als JSON-Dateien für andere Features.
 - **Core-Services:** Stellen Hex-Geometrie, Map/Tile-Dateioperationen, Terrain- und Regions-Persistenz sowie Workspace-Helfer
   bereit und dienen als Single Source of Truth für die Apps.
 - **Geteilte UI-Bausteine:** Modals, Header- und Workflow-Helfer kapseln wiederkehrende Interaktionen (Map-Auswahl, Bestätigungen,
@@ -77,16 +78,18 @@ Salt-Marcher/
 - `view.ts`: Implementiert `EncounterView` (ItemView). Rendert eine einfache Encounter-Seite mit Titel und Platzhaltertext und
   räumt beim Schließen das DOM auf.
 
-### src/apps/layout
-- `editor/view.ts`: Zentraler `LayoutEditorView` (ItemView). Orchestriert Canvas, Inspector, Export, History sowie Attribute-Popover und bindet die übrigen Module ein.
-- `editor/definitions.ts`: Konstante Element-/Attribut-Definitionen inkl. Label-Helfer und Default-Layouts.
-- `editor/history.ts`: Undo/Redo-Snapshotverwaltung mit `LayoutHistory`.
-- `editor/element-preview.ts`: Rendert Canvas-Vorschauen als echte Obsidian-Settings samt Inline-Editoren.
-- `editor/inspector-panel.ts`: Baut den Inspector (Formfelder, Container-Controls, Attribute-Trigger) als Rendering-Modul.
-- `editor/attribute-popover.ts`: Verwaltet das Attribute-Popover (Öffnen, Position, Sync, Cleanup).
-- `editor/creature-import.ts`: Repliziert den Creature-Creator in einer Sandbox und erzeugt LayoutElemente inkl. Defaults.
-- `editor/utils.ts`, `editor/types.ts`, `editor/inline-edit.ts`: Gemeinsame Typen, Hilfsfunktionen und Inline-Editor-Infrastruktur.
-- `LayoutOverview.txt`: Struktur- und Verantwortlichkeitsübersicht des Layout-Editors.
+### src/plugins/layout-editor
+- `index.ts`: Öffentliche Plugin-API. Registriert den View bei Obsidian, exponiert Element-Registry-Helper (`registerElementDefinition`, `onDefinitionsChanged`) sowie Layout-Library-Funktionen.
+- `view.ts`: Zentraler `LayoutEditorView` (ItemView). Orchestriert Canvas, Inspector, Export, History, Attribute-Popover, Element-Palette und Layout-Speicherung.
+- `definitions.ts`: Element-/Attribut-Definitionen inkl. Registry, Label-Helfern und Default-Layouts.
+- `history.ts`: Undo/Redo-Snapshotverwaltung mit `LayoutHistory`.
+- `element-preview.ts`: Rendert Canvas-Vorschauen als echte Obsidian-Settings samt Inline-Editoren.
+- `inspector-panel.ts`: Baut den Inspector (Formfelder, Container-Controls, Attribute-Trigger) als Rendering-Modul.
+- `attribute-popover.ts`: Verwaltet das Attribute-Popover (Öffnen, Position, Sync, Cleanup).
+- `creature-import.ts`: Repliziert den Creature-Creator in einer Sandbox und erzeugt LayoutElemente inkl. Defaults.
+- `layout-library.ts`: Persistiert Layouts als JSON-Dateien (`SaltMarcher/Layouts/<id>.json`) und liefert Lade-/Liste-Funktionen für andere Features.
+- `utils.ts`, `types.ts`, `inline-edit.ts`: Gemeinsame Typen, Hilfsfunktionen und Inline-Editor-Infrastruktur.
+- `LayoutEditorOverview.txt`: Struktur- und Verantwortlichkeitsübersicht des Layout-Editor-Plugins.
 
 ### src/apps/library
 - `view.ts`: Zentrale Library-View mit Tab-Leiste (Terrains, Regionen, Kreaturen), Suchleiste, Ergebnisliste und Event-Delegation

--- a/src/plugins/layout-editor/LayoutEditorOverview.txt
+++ b/src/plugins/layout-editor/LayoutEditorOverview.txt
@@ -3,82 +3,93 @@
 ## Struktur
 
 ```
-src/apps/layout/
-├─ editor/
-│  ├─ attribute-popover.ts   # Verwaltet das Attribute-Popover inklusive Events & Synchronisation
-│  ├─ creature-import.ts     # Baut das Creature-Creator-Layout nach und erzeugt LayoutElemente
-│  ├─ definitions.ts         # Konstanten (Element- & Attribut-Definitionen) + Label-Helfer
-│  ├─ element-preview.ts     # Rendert Canvas-Vorschauen, blendet reine Anzeige-Controls ohne Inline-Editing ein
-│  ├─ history.ts             # Undo/Redo-Verwaltung für LayoutSnapshots
-│  ├─ inline-edit.ts         # Generischer ContentEditable-Editor für Inline-Bearbeitung
-│  ├─ inspector-panel.ts     # Inspector-Rendering (Formfelder, Container-Steuerung, Attribute-Trigger)
-│  ├─ types.ts               # Gemeinsame Typen für Elemente, Container & Snapshots
-│  ├─ utils.ts               # Hilfsfunktionen (clamp, Deep-Clones, Vergleichs-Utilities)
-│  └─ view.ts                # `LayoutEditorView` – orchestriert Canvas, Inspector, Export & Historie
-└─ LayoutOverview.txt        # Diese Übersicht
+src/plugins/layout-editor/
+├─ attribute-popover.ts   # Attribute-Popover inkl. Events & Sync
+├─ creature-import.ts     # Baut den Creature-Creator nach und erzeugt LayoutElemente
+├─ definitions.ts         # Element-/Attribut-Registry + Label-Helfer & Defaults
+├─ element-preview.ts     # Canvas-Vorschau als echte Settings inkl. Inline-Editing
+├─ history.ts             # Undo/Redo-Verwaltung für LayoutSnapshots
+├─ index.ts               # Öffentliche Plugin-API (View-Registrierung, Registry, Layout-Library)
+├─ inline-edit.ts         # Generischer ContentEditable-Editor für Inline-Bearbeitung
+├─ inspector-panel.ts     # Inspector-Rendering (Formfelder, Container-Steuerung, Attribute-Trigger)
+├─ layout-library.ts      # Persistenz-Layer für gespeicherte Layouts (Vault JSON)
+├─ types.ts               # Gemeinsame Typen für Elemente, Container & Snapshots
+├─ utils.ts               # Hilfsfunktionen (clamp, Deep-Clones, Vergleichs-Utilities)
+└─ view.ts                # `LayoutEditorView` – orchestriert Canvas, Inspector, Export, Historie & Persistenz
 ```
 
 ## Features & Verantwortlichkeiten
 
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Die Arbeitsfläche füllt automatisch den Raum zwischen den Panels, lässt sich mit mittlerer Maustaste verschieben und per Mausrad (mit Fokuspunkt) zoomen. Breite/Höhe-Controls bleiben erhalten, Bounds-Clamping schützt weiterhin vor Überlauf und die Panel-Trenner reagieren erwartungskonform – sowohl links als auch rechts.
 - **Struktur-Überblick:** Ein interaktiver Baum listet alle Layout-Elemente analog zur Container-Hierarchie (inkl. Kinderreihenfolge aus `children`) und zeigt die aktuelle Eltern-Zuordnung direkt im Eintrag an. Ein Klick wählt das Element aus und fokussiert es mittig im Canvas. Über Drag & Drop lassen sich Elemente in Container ziehen oder aus ihnen lösen (Root-Drop-Zone), während das Panel – genauso wie der Inspector – weiterhin über die Trenner in der Breite angepasst werden kann.
-- **Palette & Nesting:** BoxContainer-, VBoxContainer- und HBoxContainer-Definitionen liegen gebündelt im „Container“-Dropdown der Palette, während Textfeld, Mehrzeiliges Feld, Dropdown und Such-Dropdown unter „Eingabefelder“ gruppiert sind. Alle Container lassen sich beliebig ineinander verschachteln; Inspector, Strukturbaum und Drag & Drop verhindern Zyklen und erlauben das Neuzuordnen sowie Verschieben kompletter Container-Hierarchien.
-- **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu.
+- **Palette & Registry:** Die Element-Palette lauscht auf Registry-Änderungen aus `definitions.ts`. Container erscheinen gesammelt im „Container“-Menü, Eingabefelder im „Eingabefelder“-Dropdown; zusätzliche Definitionen können Plugins zur Laufzeit registrieren und erscheinen sofort in Palette und Inspector-Quick-Add.
+- **Modulare Element-Hilfen:** Element-Definitionen (Buttons, Defaults, Layout-Standards) liegen zentral in `definitions.ts`; Canvas-Rendering und Inspector greifen auf dieselben Strukturen zu. Über `registerLayoutElementDefinition` lassen sich zusätzliche Komponenten ohne Core-Anpassungen einbinden.
 - **Container-Layout:** BoxContainer, VBoxContainer und HBoxContainer verwalten ihre Kinder inklusive Gap, Padding und Align automatisch und reagieren auch auf verschachtelte Konstellationen. Neue Kinder können weiterhin über den Inspector schnell hinzugefügt oder per Struktur-Baum in andere Container gezogen werden. Im Canvas erscheinen Container nur noch mit Rahmen, ohne zusätzliche Textchips für ihre Inhalte.
 - **Direkte Bearbeitung & Inspector:** Auf der Arbeitsfläche erscheinen echte UI-Elemente. Nur freie Texte (z. B. Überschriften) werden dort inline bearbeitet; Bezeichnungen für Container, Felder und Trenner pflegst du im Inspector zusammen mit Platzhaltern, Optionslisten und Layout-Eigenschaften.
 - **Echte Vorschau:** Label-Elemente passen ihre Schriftgröße automatisch an, einfache Textfelder bestehen nur aus dem Eingabefeld und alle weiteren Controls spiegeln ihr finales Erscheinungsbild ohne zusätzliche Chrome-Elemente wider. Standard-Elemente starten ohne automatisch gesetzte Label-Texte und zeigen lediglich Platzhalter, bis Redakteur:innen eigene Beschriftungen vergeben.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet das Popover (Öffnen, Positionierung, Synchronisation) und hält Inspector sowie Canvas konsistent.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` nutzt sie für Strg+Z / Strg+Umschalt+Z sowie automatisches Pushen nach Mutationen.
-- **Export & Status:** JSON-Export (Canvas + Elemente) sowie Statusleiste werden in `view.ts` gepflegt und auf jede Mutation aktualisiert.
+- **Export, Speicherung & Status:** JSON-Export (Canvas + Elemente) sowie Statusleiste werden in `view.ts` gepflegt. Zusätzlich speichert der Editor Layouts über `layout-library.ts` als Vault-Dateien und meldet Erfolg/Fehler via Notice.
 - **Creature-Import:** `creature-import.ts` mountet den Creature-Creator in einer Sandbox, liest Maße/Defaults aus und erzeugt passende LayoutElemente.
+- **Layout-Library:** `layout-library.ts` persistiert Layouts (`SaltMarcher/Layouts/<id>.json`), liefert Listen-/Load-Hilfen und erlaubt „Speichern unter“-Flows (neuer Name => neue Datei, gleicher Name => Update).
+- **Öffentliche Plugin-API:** `index.ts` stellt `createLayoutEditorPlugin` bereit, registriert den Obsidian-View und exponiert Registry-/Persistenz-Hooks für andere Features.
 
 ## Datenfluss
 
 1. **Interaktion** (Drag, Resize, Inspector, Inline): löst Mutationen an `LayoutElement`-Objekten aus.
 2. **`view.ts`** synchronisiert DOM (`syncElementElement`) und ruft `renderInspectorPanel` / `renderElementPreview` auf.
 3. **`history.ts`** erstellt Snapshots; Undo/Redo ruft `restoreSnapshot` in der View auf, die wiederum Canvas/Inspector/Export aktualisiert.
-4. **Attribute-Popover** sendet Änderungen zurück an `view.ts`, welches Export, Status & Historie aktualisiert.
+4. **Registry-Events** (`definitions.ts`) triggern Palette/Inspector-Refreshs in der View.
+5. **Attribute-Popover** sendet Änderungen zurück an `view.ts`, welches Export, Status & Historie aktualisiert.
+6. **Layout-Speicherung** (`layout-library.ts`) erhält per View den aktuellen Blueprint, schreibt JSON-Dateien und liefert Metadaten für Folgeaktionen.
 
 ## Dateibeschreibungen
 
-### `editor/view.ts`
+### `view.ts`
 - Implementiert `LayoutEditorView` (`ItemView`).
-- Baut Header (Palette mit Container-Dropdown, Import, Status), Struktur-Baum, resizable Stage mit Kamera (Pan/Zoom), Inspector, Exportbereich und Sandbox auf.
-- Verwaltet Element-State, Selection, Historie und ruft Hilfs-Module (Preview, Inspector, Popover, Import) orchestriert auf.
+- Baut Header (Palette mit Registry-Hooks, Import, Status), Struktur-Baum, resizable Stage mit Kamera (Pan/Zoom), Inspector, Exportbereich, Layout-Speicher-Controls und Sandbox auf.
+- Verwaltet Element-State, Selection, Historie und ruft Hilfs-Module (Preview, Inspector, Popover, Import, Layout-Library) orchestriert auf.
 - Synchronisiert alle Mutationen (Canvas, Inspector, Export, Status) und sorgt für Bounds-Clamping, Container-Auto-Layout, Shortcuts (Delete, Undo/Redo) sowie Panel-/Kamera-Steuerung.
 - Enthält Drag-&-Drop-Zuordnung im Strukturpanel (inkl. Root-Drop-Zone) mit Zyklus-Schutz und aktualisiert die Panel-Größen-Logik, damit der rechte Trenner der Erwartung folgt.
 
-### `editor/definitions.ts`
+### `definitions.ts`
 - Enthält Element-Definitionen inkl. Default-Texte, Größen, Layout-Voreinstellungen und Attribute-Gruppen.
-- Setzt für strukturgebende Elemente leere Default-Labels, damit im Canvas keine redundanten Überschriften erscheinen.
-- Stellt Label-/Summary-Helfer (`getElementTypeLabel`, `getAttributeSummary`, `getContainerAlignLabel`) bereit.
+- Stellt Registry-API (`registerLayoutElementDefinition`, `unregisterLayoutElementDefinition`, `onLayoutElementDefinitionsChanged`) bereit, sodass weitere Plugins neue UI-Bausteine einspeisen können.
+- Liefert Label-/Summary-Helfer (`getElementTypeLabel`, `getAttributeSummary`, `getContainerAlignLabel`).
 
-### `editor/types.ts`
+### `layout-library.ts`
+- Persistiert Layouts als JSON-Dateien in `SaltMarcher/Layouts`.
+- Liefert `saveLayoutToLibrary`, `listSavedLayouts`, `loadSavedLayout` für wiederverwendbare Layout-Bibliotheken.
+
+### `index.ts`
+- Öffentliche Einstiegstelle für andere Module/Plugins. Registriert den View über `createLayoutEditorPlugin` und gibt Registry-/Persistenz-Hooks gebündelt zurück.
+
+### `types.ts`
 - Typisiert Layout-Elemente, Container-Konfigurationen, Snapshots sowie Inline-Editor-Optionen.
-- Wird von allen Teilmodulen genutzt, um konsistente Datenmodelle zu garantieren.
+- Erweitert `LayoutElementDefinition` um Palette-/Kategorie-Metadaten, damit Registry-Zugänge korrekt gruppiert werden.
 
-### `editor/history.ts`
+### `history.ts`
 - Kapselt Undo/Redo mit Snapshot-Array, Index-Verwaltung und Restore-Callback.
 - Bewahrt `isRestoring`-State, damit View-Mutationen keine erneuten History-Einträge erzeugen.
 
-### `editor/inline-edit.ts`
+### `inline-edit.ts`
 - Bietet einen generischen ContentEditable-Editor (Trim, Multiline, Placeholder) für Preview-Komponenten.
 
-### `editor/element-preview.ts`
+### `element-preview.ts`
 - Rendert die Canvas als echte UI-Elemente (Labels, Inputs, Dropdowns etc.) und zeigt Container-/Labelbereiche ohne Inline-Eingabefelder an.
 - Übergibt finale Änderungen über Callbacks an die View, damit Inspector, Export und Historie synchron bleiben.
 
-### `editor/inspector-panel.ts`
+### `inspector-panel.ts`
 - Rendert einen kompakten Inspector mit Meta-Infos, Benennung, Container-Zuordnung (Dropdown inkl. Verschachtelungs-Schutz), Attribut-Anzeige, Positions-/Größensteuerung, Layout-Parametern und Container-Kindverwaltung.
-- Delegiert alle Mutationen (inkl. Platzhalter-, Optionen-, Benennungs- und Layout-Änderungen) über `InspectorCallbacks` an die View und öffnet das Attribute-Popover.
+- Bindet Registry-Definitionen für Quick-Add-Menüs ein und öffnet das Attribute-Popover.
 
-### `editor/attribute-popover.ts`
+### `attribute-popover.ts`
 - Erstellt, positioniert und synchronisiert das Attribut-Popover.
 - Ruft über Callbacks View-Aktionen (Sync, Export, Inspector, History) auf und kapselt Event-Cleanup.
 
-### `editor/utils.ts`
+### `utils.ts`
 - Enthält Utility-Funktionen (`clamp`, Deep-Clones, Equality-Checks, Container-/Ancestry-Erkennung) für View & History.
 
-### `editor/creature-import.ts`
+### `creature-import.ts`
 - Baut den Creature-Creator in einer Sandbox auf, extrahiert Maße/Defaults und erstellt LayoutElemente.
 - Aktualisiert Canvas- & Element-State über den bereitgestellten Kontext.

--- a/src/plugins/layout-editor/attribute-popover.ts
+++ b/src/plugins/layout-editor/attribute-popover.ts
@@ -1,4 +1,4 @@
-// src/apps/layout/editor/attribute-popover.ts
+// src/plugins/layout-editor/attribute-popover.ts
 import { ATTRIBUTE_GROUPS } from "./definitions";
 import type { AttributePopoverState, LayoutElement } from "./types";
 

--- a/src/plugins/layout-editor/creature-import.ts
+++ b/src/plugins/layout-editor/creature-import.ts
@@ -1,4 +1,4 @@
-// src/apps/layout/editor/creature-import.ts
+// src/plugins/layout-editor/creature-import.ts
 import { Notice } from "obsidian";
 import type { StatblockData } from "../../library/core/creature-files";
 import {
@@ -7,7 +7,7 @@ import {
     mountCreatureStatsAndSkillsSection,
     mountEntriesSection,
     mountSpellsKnownSection,
-} from "../../library/create/creature";
+} from "../../apps/library/create/creature";
 import { MIN_ELEMENT_SIZE } from "./definitions";
 import type { LayoutElement, LayoutElementType } from "./types";
 

--- a/src/plugins/layout-editor/element-preview.ts
+++ b/src/plugins/layout-editor/element-preview.ts
@@ -1,5 +1,5 @@
-// src/apps/layout/editor/element-preview.ts
-import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
+// src/plugins/layout-editor/element-preview.ts
+import { enhanceSelectToSearch } from "../../ui/search-dropdown";
 import { isContainerType } from "./definitions";
 import { createInlineEditor } from "./inline-edit";
 import { LayoutElement, LayoutElementType } from "./types";

--- a/src/plugins/layout-editor/history.ts
+++ b/src/plugins/layout-editor/history.ts
@@ -1,4 +1,4 @@
-// src/apps/layout/editor/history.ts
+// src/plugins/layout-editor/history.ts
 import { LayoutEditorSnapshot } from "./types";
 import { cloneLayoutElement, snapshotsAreEqual } from "./utils";
 

--- a/src/plugins/layout-editor/index.ts
+++ b/src/plugins/layout-editor/index.ts
@@ -1,0 +1,60 @@
+// src/plugins/layout-editor/index.ts
+import { Plugin, WorkspaceLeaf } from "obsidian";
+import { LayoutEditorView, VIEW_LAYOUT_EDITOR } from "./view";
+import {
+    getElementDefinitions,
+    onLayoutElementDefinitionsChanged,
+    registerLayoutElementDefinition,
+    unregisterLayoutElementDefinition,
+    resetLayoutElementDefinitions,
+    DEFAULT_ELEMENT_DEFINITIONS,
+} from "./definitions";
+import { listSavedLayouts, loadSavedLayout, saveLayoutToLibrary } from "./layout-library";
+import type {
+    LayoutBlueprint,
+    LayoutElementDefinition,
+    LayoutElementType,
+    SavedLayout,
+} from "./types";
+
+export interface LayoutEditorPluginApi {
+    viewType: string;
+    registerView: () => void;
+    registerElementDefinition(definition: LayoutElementDefinition): void;
+    unregisterElementDefinition(type: LayoutElementType): void;
+    resetElementDefinitions(definitions?: LayoutElementDefinition[]): void;
+    getElementDefinitions(): LayoutElementDefinition[];
+    onDefinitionsChanged(listener: (definitions: LayoutElementDefinition[]) => void): () => void;
+    saveLayout(payload: LayoutBlueprint & { name: string; id?: string }): Promise<SavedLayout>;
+    listLayouts(): Promise<SavedLayout[]>;
+    loadLayout(id: string): Promise<SavedLayout | null>;
+}
+
+export function createLayoutEditorPlugin(plugin: Plugin): LayoutEditorPluginApi {
+    const registerView = () => {
+        plugin.registerView(VIEW_LAYOUT_EDITOR, (leaf: WorkspaceLeaf) => new LayoutEditorView(leaf));
+    };
+    return {
+        viewType: VIEW_LAYOUT_EDITOR,
+        registerView,
+        registerElementDefinition,
+        unregisterElementDefinition,
+        resetElementDefinitions: definitions => {
+            if (definitions && definitions.length) {
+                resetLayoutElementDefinitions(definitions);
+            } else {
+                resetLayoutElementDefinitions(DEFAULT_ELEMENT_DEFINITIONS);
+            }
+        },
+        getElementDefinitions,
+        onDefinitionsChanged: listener => onLayoutElementDefinitionsChanged(listener),
+        saveLayout: payload => saveLayoutToLibrary(plugin.app, payload),
+        listLayouts: () => listSavedLayouts(plugin.app),
+        loadLayout: id => loadSavedLayout(plugin.app, id),
+    };
+}
+
+export { LayoutEditorView, VIEW_LAYOUT_EDITOR };
+export * from "./types";
+export { DEFAULT_ELEMENT_DEFINITIONS } from "./definitions";
+export { listSavedLayouts, loadSavedLayout, saveLayoutToLibrary } from "./layout-library";

--- a/src/plugins/layout-editor/inline-edit.ts
+++ b/src/plugins/layout-editor/inline-edit.ts
@@ -1,4 +1,4 @@
-// src/apps/layout/editor/inline-edit.ts
+// src/plugins/layout-editor/inline-edit.ts
 import type { InlineEditOptions } from "./types";
 
 export function createInlineEditor(options: InlineEditOptions): HTMLElement {

--- a/src/plugins/layout-editor/layout-library.ts
+++ b/src/plugins/layout-editor/layout-library.ts
@@ -1,0 +1,102 @@
+// src/plugins/layout-editor/layout-library.ts
+import { App, TFile, TFolder, normalizePath } from "obsidian";
+import { LayoutBlueprint, LayoutElement, SavedLayout } from "./types";
+
+const LAYOUT_FOLDER = "SaltMarcher/Layouts";
+
+async function ensureLayoutFolder(app: App): Promise<void> {
+    const folderPath = normalizePath(LAYOUT_FOLDER);
+    const folder = app.vault.getAbstractFileByPath(folderPath);
+    if (folder) return;
+    await app.vault.createFolder(folderPath).catch(() => {});
+}
+
+function createFileName(id: string): string {
+    return `${id}.json`;
+}
+
+function sanitizeName(name: string): string {
+    return name.trim() || "Unbenanntes Layout";
+}
+
+function createId(): string {
+    const globalCrypto = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (globalCrypto?.randomUUID) {
+        return globalCrypto.randomUUID();
+    }
+    return `layout-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+}
+
+export async function saveLayoutToLibrary(app: App, payload: LayoutBlueprint & { name: string; id?: string }): Promise<SavedLayout> {
+    await ensureLayoutFolder(app);
+    const id = payload.id ?? createId();
+    const fileName = createFileName(id);
+    const path = normalizePath(`${LAYOUT_FOLDER}/${fileName}`);
+    const existing = app.vault.getAbstractFileByPath(path);
+    const now = new Date().toISOString();
+    const entry: SavedLayout = {
+        id,
+        name: sanitizeName(payload.name),
+        canvasWidth: payload.canvasWidth,
+        canvasHeight: payload.canvasHeight,
+        elements: payload.elements,
+        createdAt: existing instanceof TFile ? (await readLayoutMeta(app, existing))?.createdAt ?? now : now,
+        updatedAt: now,
+    };
+    const body = JSON.stringify(entry, null, 2);
+    if (existing instanceof TFile) {
+        await app.vault.modify(existing, body);
+    } else {
+        await app.vault.create(path, body);
+    }
+    return entry;
+}
+
+async function readLayoutMeta(app: App, file: TFile): Promise<SavedLayout | null> {
+    try {
+        const raw = await app.vault.read(file);
+        const parsed = JSON.parse(raw) as Partial<SavedLayout>;
+        if (!parsed || typeof parsed !== "object") return null;
+        if (!Array.isArray(parsed.elements) || typeof parsed.canvasWidth !== "number" || typeof parsed.canvasHeight !== "number") {
+            return null;
+        }
+        const fallbackCreated = new Date(file.stat.ctime || Date.now()).toISOString();
+        const fallbackUpdated = new Date(file.stat.mtime || Date.now()).toISOString();
+        return {
+            id: parsed.id ?? file.basename,
+            name: typeof parsed.name === "string" ? parsed.name : file.basename,
+            canvasWidth: parsed.canvasWidth,
+            canvasHeight: parsed.canvasHeight,
+            elements: (parsed.elements ?? []) as LayoutElement[],
+            createdAt: typeof parsed.createdAt === "string" ? parsed.createdAt : fallbackCreated,
+            updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : fallbackUpdated,
+        };
+    } catch (error) {
+        console.error("Failed to read layout file", error);
+        return null;
+    }
+}
+
+export async function listSavedLayouts(app: App): Promise<SavedLayout[]> {
+    await ensureLayoutFolder(app);
+    const folder = app.vault.getAbstractFileByPath(normalizePath(LAYOUT_FOLDER));
+    if (!(folder instanceof TFolder)) {
+        return [];
+    }
+    const files = folder.children.filter((child): child is TFile => child instanceof TFile && child.extension === "json");
+    const out: SavedLayout[] = [];
+    for (const file of files) {
+        const meta = await readLayoutMeta(app, file);
+        if (meta) out.push(meta);
+    }
+    out.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return out;
+}
+
+export async function loadSavedLayout(app: App, id: string): Promise<SavedLayout | null> {
+    await ensureLayoutFolder(app);
+    const path = normalizePath(`${LAYOUT_FOLDER}/${createFileName(id)}`);
+    const file = app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) return null;
+    return await readLayoutMeta(app, file);
+}

--- a/src/plugins/layout-editor/types.ts
+++ b/src/plugins/layout-editor/types.ts
@@ -1,18 +1,9 @@
-// src/apps/layout/editor/types.ts
+// src/plugins/layout-editor/types.ts
 import type { Setting } from "obsidian";
 
-export type LayoutElementType =
-    | "label"
-    | "text-input"
-    | "textarea"
-    | "box-container"
-    | "separator"
-    | "dropdown"
-    | "search-dropdown"
-    | "vbox-container"
-    | "hbox-container";
+export type LayoutElementType = string;
 
-export type LayoutContainerType = "box-container" | "vbox-container" | "hbox-container";
+export type LayoutContainerType = LayoutElementType;
 
 export type LayoutContainerAlign = "start" | "center" | "end" | "stretch";
 
@@ -62,6 +53,9 @@ export interface LayoutElementDefinition {
     type: LayoutElementType;
     buttonLabel: string;
     defaultLabel: string;
+    category?: "element" | "container";
+    layoutOrientation?: "vertical" | "horizontal";
+    paletteGroup?: "element" | "input" | "container";
     defaultPlaceholder?: string;
     defaultValue?: string;
     defaultDescription?: string;
@@ -81,6 +75,19 @@ export interface AttributePopoverState {
     container: HTMLElement;
     anchor: HTMLElement;
     dispose: () => void;
+}
+
+export interface LayoutBlueprint {
+    canvasWidth: number;
+    canvasHeight: number;
+    elements: LayoutElement[];
+}
+
+export interface SavedLayout extends LayoutBlueprint {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface CreateSettingOptions {

--- a/src/plugins/layout-editor/utils.ts
+++ b/src/plugins/layout-editor/utils.ts
@@ -1,4 +1,4 @@
-// src/apps/layout/editor/utils.ts
+// src/plugins/layout-editor/utils.ts
 import { LayoutEditorSnapshot, LayoutElement } from "./types";
 import { isContainerType } from "./definitions";
 

--- a/src/ui/modals.ts
+++ b/src/ui/modals.ts
@@ -8,14 +8,26 @@ import { App, Modal, Setting, FuzzySuggestModal, TFile } from "obsidian";
 /** Modal zur Eingabe eines neuen Kartennamens */
 export class NameInputModal extends Modal {
     private value = "";
-    private placeholder = "Neue Hex Map";
-    constructor(app: App, private onSubmit: (val: string) => void) {
+    private placeholder: string;
+    private title: string;
+    private ctaLabel: string;
+    constructor(
+        app: App,
+        private onSubmit: (val: string) => void,
+        options?: { placeholder?: string; title?: string; cta?: string; initialValue?: string },
+    ) {
         super(app);
+        this.placeholder = options?.placeholder ?? "Neue Hex Map";
+        this.title = options?.title ?? "Name der neuen Karte";
+        this.ctaLabel = options?.cta ?? "Erstellen";
+        if (options?.initialValue) {
+            this.value = options.initialValue.trim();
+        }
     }
     onOpen() {
         const { contentEl } = this;
         contentEl.empty();
-        contentEl.createEl("h3", { text: "Name der neuen Karte" });
+        contentEl.createEl("h3", { text: this.title });
 
         let inputEl: HTMLInputElement | undefined;
 
@@ -24,9 +36,12 @@ export class NameInputModal extends Modal {
             t.setPlaceholder(this.placeholder).onChange((v) => (this.value = v.trim()));
             // @ts-ignore – Obsidian hält das Input-Element intern
             inputEl = (t as any).inputEl as HTMLInputElement;
+            if (this.value) {
+                inputEl.value = this.value;
+            }
         })
         .addButton((b) =>
-        b.setButtonText("Erstellen").setCta().onClick(() => this.submit()),
+        b.setButtonText(this.ctaLabel).setCta().onClick(() => this.submit()),
         );
 
         // Enter-Shortcut


### PR DESCRIPTION
## Summary
- move the layout editor into `src/plugins/layout-editor` and expose a reusable plugin API with element registry hooks
- add a vault-backed layout library plus in-editor save flow and configurable NameInputModal
- update main plugin bootstrap and documentation to reflect the new plugin structure and features

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d50169480083258c45f472ceb767be