### PR TITLE
Fix layout editor API references

### DIFF
--- a/plugins/layout-editor/main.js
+++ b/plugins/layout-editor/main.js
@@ -175,6 +175,12 @@ function getElementDefinitions() {
 function getElementDefinition(type) {
   return registry.get(type);
 }
+function registerLayoutElementDefinition(definition) {
+  registry.register(definition);
+}
+function unregisterLayoutElementDefinition(type) {
+  registry.unregister(type);
+}
 function resetLayoutElementDefinitions(definitions) {
   registry.replaceAll(definitions);
 }
@@ -3908,8 +3914,8 @@ var LayoutEditorPlugin = class extends import_obsidian6.Plugin {
     this.api = {
       viewType: VIEW_LAYOUT_EDITOR,
       openView: () => this.openView(),
-      registerElementDefinition,
-      unregisterElementDefinition,
+      registerElementDefinition: registerLayoutElementDefinition,
+      unregisterElementDefinition: unregisterLayoutElementDefinition,
       resetElementDefinitions: (definitions) => {
         if (definitions && definitions.length) {
           resetLayoutElementDefinitions(definitions);

--- a/plugins/layout-editor/src/LayoutEditorOverview.txt
+++ b/plugins/layout-editor/src/LayoutEditorOverview.txt
@@ -60,6 +60,7 @@ plugins/layout-editor/
 ### `main.ts`
 - Bootstrap des Plugins: registriert View, Ribbon-Icon und Command.
 - Stellt `LayoutEditorPluginApi` bereit (Open-View, Registry- und Library-Methoden).
+- Die API-Weiterleitungen binden die Registry-Helfer (`registerLayoutElementDefinition`/`unregisterLayoutElementDefinition`) explizit ein, damit die gebündelte Ausgabe keine fehlenden Referenzen mehr enthält.
 - Integriert CSS-Injektion und sorgt beim Unload für Cleanup sowie Registry-Reset auf Default-Definitionen.
 
 ### `css.ts`

--- a/plugins/layout-editor/src/main.ts
+++ b/plugins/layout-editor/src/main.ts
@@ -5,9 +5,9 @@ import {
     DEFAULT_ELEMENT_DEFINITIONS,
     getElementDefinitions,
     onLayoutElementDefinitionsChanged,
-    registerLayoutElementDefinition,
+    registerLayoutElementDefinition as registerElementDefinition,
     resetLayoutElementDefinitions,
-    unregisterLayoutElementDefinition,
+    unregisterLayoutElementDefinition as unregisterElementDefinition,
 } from "./definitions";
 import { listSavedLayouts, loadSavedLayout, saveLayoutToLibrary } from "./layout-library";
 import type {


### PR DESCRIPTION
## Summary
- alias the registry helpers when exposing the layout editor plugin API so the bundled script can resolve them correctly
- refresh the layout editor overview to document the API forwarding fix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d509b4d864832582de816db8d4c5f8