### PR TITLE
Refactor layout editor components with shared bases

### DIFF
--- a/plugins/layout-editor/src/LayoutEditorOverview.txt
+++ b/plugins/layout-editor/src/LayoutEditorOverview.txt
@@ -22,6 +22,9 @@ plugins/layout-editor/
    ├─ elements/
    │  ├─ base.ts           # Gemeinsame Interfaces für Komponenten (Preview/Inspector)
    │  ├─ registry.ts       # Lädt automatisch alle Komponenten aus ./components
+   │  ├─ shared/
+   │  │  ├─ component-bases.ts # Abstrakte Basiskomponenten für Container & Selektoren
+   │  │  └─ container-preview.ts # Gemeinsamer Preview-Renderer für Container
    │  └─ components/       # Drop-in-Komponenten pro Elementtyp (Preview, Inspector, Defaults)
    ├─ element-preview.ts   # Canvas-Vorschau delegiert an Element-Komponenten
    ├─ history.ts           # Undo/Redo-Verwaltung für LayoutSnapshots
@@ -44,7 +47,7 @@ plugins/layout-editor/
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Panning, Zoom und Panel-Resizer halten Bounds-Clamping und Fokusverhalten konsistent.
 - **Struktur-Überblick:** Interaktiver Baum mit Drag & Drop zur Container-Neuzuordnung (inkl. Root-Drop-Zone) und zyklusgesicherter Elternwahl. Inspector- und Baum-Breiten lassen sich über Trenner anpassen.
 - **Palette & Registry:** Element-Palette horcht auf Registry-Änderungen und liest Gruppen direkt aus den Komponentendefinitionen. Neue Element-Typen müssen nur als Datei in `src/elements/components/` landen – Palette und Inspector-Menüs greifen sie automatisch auf.
-- **Komponentenbasierte Elemente:** `elements/` bündelt Preview-, Inspector- und Default-Logik je Elementtyp und reduziert Redundanz bei neuen UI-Elementen.
+- **Komponentenbasierte Elemente:** `elements/` bündelt Preview-, Inspector- und Default-Logik je Elementtyp und reduziert Redundanz bei neuen UI-Elementen. Gemeinsame Eigenschaften (z. B. Container-Layout oder Select-Verhalten) liegen nun in `shared/component-bases.ts` und werden von konkreten Komponenten geerbt.
 - **Container-Layout:** Box-, VBox- und HBox-Container verwalten Gap, Padding und Align sowie verschachtelte Kinder. Inspector und Baum unterstützen das schnelle Hinzufügen und Neuzuordnen von Elementen.
 - **Direkte Bearbeitung & Inspector:** Canvas rendert echte UI-Elemente. Freie Texte lassen sich inline editieren, alle Meta-Informationen pflegst du im Inspector (Labels, Placeholder, Optionen, Layout-Werte).
 - **Vorschau & Inline-Editing:** `element-preview.ts` erzeugt realistische Vorschauen; `inline-edit.ts` kapselt ContentEditable inklusive Placeholder/Trim-Logik.
@@ -93,7 +96,12 @@ plugins/layout-editor/
 - Lädt zur Build-Zeit automatisch alle Komponenten unter `elements/components/` und stellt Lookup-Helfer bereit.
 
 ### `elements/components/*`
-- Eine Datei pro UI-Element (Label, Textfeld, Container usw.). Enthält Definition, Preview-Renderer, Inspector-Logik und Default-Werte.
+- Eine Datei pro UI-Element (Label, Textfeld, Container usw.). Enthält Definition, Preview-Renderer, Inspector-Logik und Default-Werte. Container- und Select-Elemente erweitern die abstrakten Basisklassen aus `shared/component-bases.ts` und erben so Layout- bzw. Optionslogik.
+
+### `elements/shared/component-bases.ts`
+- Stellt abstrakte Basisklassen für generische UI-Komponenten bereit.
+- `ContainerComponent` kapselt Preview, Inspector und Default-Layout-Initialisierung für Container.
+- `SelectComponent` teilt das Verhalten für Dropdown-Elemente (mit/ohne Suche) inklusive Placeholder- und Optionen-Handling.
 
 ### `layout-library.ts`
 - Persistiert Layouts als JSON-Dateien im Vault-Ordner `LayoutEditor/Layouts`.

--- a/plugins/layout-editor/src/elements/components/box-container.ts
+++ b/plugins/layout-editor/src/elements/components/box-container.ts
@@ -1,38 +1,17 @@
-import type { LayoutElement } from "../../types";
-import type { LayoutElementComponent } from "../base";
-import { renderContainerPreview } from "../shared/container-preview";
+import { ContainerComponent } from "../shared/component-bases";
 
 const defaultLayout = { gap: 16, padding: 16, align: "stretch" as const };
 
-function ensureLayout(element: LayoutElement) {
-    if (!element.layout) {
-        element.layout = { ...defaultLayout };
-    }
-    if (!Array.isArray(element.children)) {
-        element.children = [];
-    }
-}
-
-const boxContainerComponent: LayoutElementComponent = {
-    definition: {
-        type: "box-container",
-        buttonLabel: "BoxContainer",
-        defaultLabel: "",
-        category: "container",
-        paletteGroup: "container",
-        layoutOrientation: "vertical",
-        width: 360,
-        height: 220,
-        defaultLayout,
-    },
-    renderPreview(context) {
-        renderContainerPreview(context);
-    },
-    renderInspector({ renderLabelField, renderContainerLayoutControls }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderContainerLayoutControls({});
-    },
-    ensureDefaults: ensureLayout,
-};
+const boxContainerComponent = new ContainerComponent({
+    type: "box-container",
+    buttonLabel: "BoxContainer",
+    defaultLabel: "",
+    category: "container",
+    paletteGroup: "container",
+    layoutOrientation: "vertical",
+    width: 360,
+    height: 220,
+    defaultLayout,
+});
 
 export default boxContainerComponent;

--- a/plugins/layout-editor/src/elements/components/dropdown.ts
+++ b/plugins/layout-editor/src/elements/components/dropdown.ts
@@ -1,86 +1,7 @@
-import { enhanceSelectToSearch } from "../../search-dropdown";
-import type { LayoutElement } from "../../types";
-import type { LayoutElementComponent } from "../base";
+import { SelectComponent } from "../shared/component-bases";
 
-function renderSelect(
-    element: LayoutElement,
-    preview: HTMLElement,
-    finalize: (element: LayoutElement) => void,
-    enableSearch: boolean,
-) {
-    const field = preview.createEl("label", { cls: "sm-le-preview__field" });
-    const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
-    const labelText = element.label?.trim() ?? "";
-    if (labelText) {
-        labelHost.setText(labelText);
-    } else {
-        labelHost.style.display = "none";
-    }
-
-    const select = field.createEl("select", { cls: "sm-le-preview__select" }) as HTMLSelectElement;
-    const defaultPlaceholder = enableSearch ? "Suchen…" : "Option wählen…";
-
-    const renderSelectOptions = () => {
-        select.innerHTML = "";
-        const placeholderText = element.placeholder ?? defaultPlaceholder;
-        const placeholderOption = select.createEl("option", { value: "", text: placeholderText });
-        placeholderOption.disabled = true;
-        if (!element.defaultValue) {
-            placeholderOption.selected = true;
-        }
-        const optionValues = element.options && element.options.length ? element.options : null;
-        if (!optionValues) {
-            select.createEl("option", { value: "opt-1", text: "Erste Option" });
-        } else {
-            for (const opt of optionValues) {
-                const optionEl = select.createEl("option", { value: opt, text: opt });
-                if (element.defaultValue && element.defaultValue === opt) {
-                    optionEl.selected = true;
-                }
-            }
-            if (element.defaultValue && !optionValues.includes(element.defaultValue)) {
-                element.defaultValue = undefined;
-                placeholderOption.selected = true;
-            }
-        }
-        if (enableSearch) {
-            const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-            if (searchInput) {
-                searchInput.value = element.defaultValue ?? "";
-                searchInput.placeholder = placeholderText;
-            }
-        }
-    };
-
-    renderSelectOptions();
-    if (enableSearch) {
-        enhanceSelectToSearch(select, element.placeholder ?? defaultPlaceholder);
-        const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-        if (searchInput) {
-            searchInput.addEventListener("blur", () => {
-                const next = searchInput.value;
-                element.defaultValue = next ? next : undefined;
-                finalize(element);
-            });
-        }
-    }
-
-    select.onchange = () => {
-        const value = select.value || undefined;
-        if (value === element.defaultValue) return;
-        element.defaultValue = value;
-        if (enableSearch) {
-            const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-            if (searchInput) {
-                searchInput.value = value ?? "";
-            }
-        }
-        finalize(element);
-    };
-}
-
-const dropdownComponent: LayoutElementComponent = {
-    definition: {
+const dropdownComponent = new SelectComponent(
+    {
         type: "dropdown",
         buttonLabel: "Dropdown",
         defaultLabel: "",
@@ -91,14 +12,7 @@ const dropdownComponent: LayoutElementComponent = {
         width: 260,
         height: 150,
     },
-    renderPreview({ preview, element, finalize }) {
-        renderSelect(element, preview, finalize, false);
-    },
-    renderInspector({ renderLabelField, renderPlaceholderField, renderOptionsEditor }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderPlaceholderField({ label: "Platzhalter" });
-        renderOptionsEditor({});
-    },
-};
+    { enableSearch: false },
+);
 
 export default dropdownComponent;

--- a/plugins/layout-editor/src/elements/components/hbox-container.ts
+++ b/plugins/layout-editor/src/elements/components/hbox-container.ts
@@ -1,39 +1,18 @@
-import type { LayoutElement } from "../../types";
-import type { LayoutElementComponent } from "../base";
-import { renderContainerPreview } from "../shared/container-preview";
+import { ContainerComponent } from "../shared/component-bases";
 
 const defaultLayout = { gap: 16, padding: 16, align: "center" as const };
 
-function ensureLayout(element: LayoutElement) {
-    if (!element.layout) {
-        element.layout = { ...defaultLayout };
-    }
-    if (!Array.isArray(element.children)) {
-        element.children = [];
-    }
-}
-
-const hboxContainerComponent: LayoutElementComponent = {
-    definition: {
-        type: "hbox-container",
-        buttonLabel: "HBoxContainer",
-        defaultLabel: "",
-        category: "container",
-        paletteGroup: "container",
-        layoutOrientation: "horizontal",
-        defaultDescription: "Ordnet verknüpfte Elemente automatisch nebeneinander an.",
-        width: 360,
-        height: 220,
-        defaultLayout,
-    },
-    renderPreview(context) {
-        renderContainerPreview(context);
-    },
-    renderInspector({ renderLabelField, renderContainerLayoutControls }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderContainerLayoutControls({});
-    },
-    ensureDefaults: ensureLayout,
-};
+const hboxContainerComponent = new ContainerComponent({
+    type: "hbox-container",
+    buttonLabel: "HBoxContainer",
+    defaultLabel: "",
+    category: "container",
+    paletteGroup: "container",
+    layoutOrientation: "horizontal",
+    defaultDescription: "Ordnet verknüpfte Elemente automatisch nebeneinander an.",
+    width: 360,
+    height: 220,
+    defaultLayout,
+});
 
 export default hboxContainerComponent;

--- a/plugins/layout-editor/src/elements/components/search-dropdown.ts
+++ b/plugins/layout-editor/src/elements/components/search-dropdown.ts
@@ -1,79 +1,7 @@
-import { enhanceSelectToSearch } from "../../search-dropdown";
-import type { LayoutElement } from "../../types";
-import type { LayoutElementComponent } from "../base";
+import { SelectComponent } from "../shared/component-bases";
 
-function renderSelect(
-    element: LayoutElement,
-    preview: HTMLElement,
-    finalize: (element: LayoutElement) => void,
-) {
-    const field = preview.createEl("label", { cls: "sm-le-preview__field" });
-    const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
-    const labelText = element.label?.trim() ?? "";
-    if (labelText) {
-        labelHost.setText(labelText);
-    } else {
-        labelHost.style.display = "none";
-    }
-
-    const select = field.createEl("select", { cls: "sm-le-preview__select" }) as HTMLSelectElement;
-    const defaultPlaceholder = "Suchen…";
-
-    const renderSelectOptions = () => {
-        select.innerHTML = "";
-        const placeholderText = element.placeholder ?? defaultPlaceholder;
-        const placeholderOption = select.createEl("option", { value: "", text: placeholderText });
-        placeholderOption.disabled = true;
-        if (!element.defaultValue) {
-            placeholderOption.selected = true;
-        }
-        const optionValues = element.options && element.options.length ? element.options : null;
-        if (!optionValues) {
-            select.createEl("option", { value: "opt-1", text: "Erste Option" });
-        } else {
-            for (const opt of optionValues) {
-                const optionEl = select.createEl("option", { value: opt, text: opt });
-                if (element.defaultValue && element.defaultValue === opt) {
-                    optionEl.selected = true;
-                }
-            }
-            if (element.defaultValue && !optionValues.includes(element.defaultValue)) {
-                element.defaultValue = undefined;
-                placeholderOption.selected = true;
-            }
-        }
-        const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-        if (searchInput) {
-            searchInput.value = element.defaultValue ?? "";
-            searchInput.placeholder = placeholderText;
-        }
-    };
-
-    renderSelectOptions();
-    enhanceSelectToSearch(select, element.placeholder ?? defaultPlaceholder);
-    const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-    if (searchInput) {
-        searchInput.addEventListener("blur", () => {
-            const next = searchInput.value;
-            element.defaultValue = next ? next : undefined;
-            finalize(element);
-        });
-    }
-
-    select.onchange = () => {
-        const value = select.value || undefined;
-        if (value === element.defaultValue) return;
-        element.defaultValue = value;
-        const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
-        if (searchInput) {
-            searchInput.value = value ?? "";
-        }
-        finalize(element);
-    };
-}
-
-const searchDropdownComponent: LayoutElementComponent = {
-    definition: {
+const searchDropdownComponent = new SelectComponent(
+    {
         type: "search-dropdown",
         buttonLabel: "Such-Dropdown",
         defaultLabel: "",
@@ -84,14 +12,7 @@ const searchDropdownComponent: LayoutElementComponent = {
         width: 280,
         height: 160,
     },
-    renderPreview({ preview, element, finalize }) {
-        renderSelect(element, preview, finalize);
-    },
-    renderInspector({ renderLabelField, renderPlaceholderField, renderOptionsEditor }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderPlaceholderField({ label: "Platzhalter" });
-        renderOptionsEditor({});
-    },
-};
+    { enableSearch: true },
+);
 
 export default searchDropdownComponent;

--- a/plugins/layout-editor/src/elements/components/vbox-container.ts
+++ b/plugins/layout-editor/src/elements/components/vbox-container.ts
@@ -1,39 +1,18 @@
-import type { LayoutElement } from "../../types";
-import type { LayoutElementComponent } from "../base";
-import { renderContainerPreview } from "../shared/container-preview";
+import { ContainerComponent } from "../shared/component-bases";
 
 const defaultLayout = { gap: 16, padding: 16, align: "stretch" as const };
 
-function ensureLayout(element: LayoutElement) {
-    if (!element.layout) {
-        element.layout = { ...defaultLayout };
-    }
-    if (!Array.isArray(element.children)) {
-        element.children = [];
-    }
-}
-
-const vboxContainerComponent: LayoutElementComponent = {
-    definition: {
-        type: "vbox-container",
-        buttonLabel: "VBoxContainer",
-        defaultLabel: "",
-        category: "container",
-        paletteGroup: "container",
-        layoutOrientation: "vertical",
-        defaultDescription: "Ordnet verknüpfte Elemente automatisch untereinander an.",
-        width: 340,
-        height: 260,
-        defaultLayout,
-    },
-    renderPreview(context) {
-        renderContainerPreview(context);
-    },
-    renderInspector({ renderLabelField, renderContainerLayoutControls }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderContainerLayoutControls({});
-    },
-    ensureDefaults: ensureLayout,
-};
+const vboxContainerComponent = new ContainerComponent({
+    type: "vbox-container",
+    buttonLabel: "VBoxContainer",
+    defaultLabel: "",
+    category: "container",
+    paletteGroup: "container",
+    layoutOrientation: "vertical",
+    defaultDescription: "Ordnet verknüpfte Elemente automatisch untereinander an.",
+    width: 340,
+    height: 260,
+    defaultLayout,
+});
 
 export default vboxContainerComponent;

--- a/plugins/layout-editor/src/elements/shared/component-bases.ts
+++ b/plugins/layout-editor/src/elements/shared/component-bases.ts
@@ -1,0 +1,163 @@
+import { enhanceSelectToSearch } from "../../search-dropdown";
+import type { LayoutElement, LayoutElementDefinition } from "../../types";
+import type { ElementInspectorContext, ElementPreviewContext, LayoutElementComponent } from "../base";
+import { renderContainerPreview } from "./container-preview";
+
+export type PreviewContext = ElementPreviewContext;
+
+export abstract class ElementComponentBase implements LayoutElementComponent {
+    readonly definition: LayoutElementDefinition;
+
+    protected constructor(definition: LayoutElementDefinition) {
+        this.definition = definition;
+    }
+
+    abstract renderPreview(context: PreviewContext): void;
+
+    renderInspector?(context: ElementInspectorContext): void;
+
+    ensureDefaults?(element: LayoutElement): void;
+}
+
+interface ContainerComponentOptions {
+    inspectorLabel?: string;
+}
+
+export class ContainerComponent extends ElementComponentBase {
+    private readonly defaultLayout: LayoutElementDefinition["defaultLayout"];
+    private readonly inspectorLabel: string;
+
+    constructor(definition: LayoutElementDefinition, options: ContainerComponentOptions = {}) {
+        super(definition);
+        if (!definition.defaultLayout) {
+            throw new Error(`Container component "${definition.type}" requires a default layout configuration.`);
+        }
+        this.defaultLayout = { ...definition.defaultLayout };
+        this.inspectorLabel = options.inspectorLabel ?? "Bezeichnung";
+    }
+
+    renderPreview(context: PreviewContext): void {
+        renderContainerPreview(context);
+    }
+
+    renderInspector({ renderLabelField, renderContainerLayoutControls }: ElementInspectorContext): void {
+        renderLabelField({ label: this.inspectorLabel });
+        renderContainerLayoutControls({});
+    }
+
+    ensureDefaults(element: LayoutElement): void {
+        if (!element.layout) {
+            element.layout = { ...this.defaultLayout };
+        }
+        if (!Array.isArray(element.children)) {
+            element.children = [];
+        }
+    }
+}
+
+interface SelectComponentOptions {
+    enableSearch?: boolean;
+    inspectorLabel?: string;
+    placeholderInspectorLabel?: string;
+}
+
+export class SelectComponent extends ElementComponentBase {
+    private readonly enableSearch: boolean;
+    private readonly inspectorLabel: string;
+    private readonly placeholderInspectorLabel: string;
+
+    constructor(definition: LayoutElementDefinition, options: SelectComponentOptions = {}) {
+        super(definition);
+        this.enableSearch = options.enableSearch ?? false;
+        this.inspectorLabel = options.inspectorLabel ?? "Bezeichnung";
+        this.placeholderInspectorLabel = options.placeholderInspectorLabel ?? "Platzhalter";
+    }
+
+    private getDefaultPlaceholder(): string {
+        if (this.definition.defaultPlaceholder) {
+            return this.definition.defaultPlaceholder;
+        }
+        return this.enableSearch ? "Suchen…" : "Option wählen…";
+    }
+
+    renderPreview({ preview, element, finalize }: PreviewContext): void {
+        const field = preview.createEl("label", { cls: "sm-le-preview__field" });
+        const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
+        const labelText = element.label?.trim() ?? "";
+        if (labelText) {
+            labelHost.setText(labelText);
+        } else {
+            labelHost.style.display = "none";
+        }
+
+        const select = field.createEl("select", { cls: "sm-le-preview__select" }) as HTMLSelectElement;
+        const fallbackPlaceholder = this.getDefaultPlaceholder();
+
+        const renderSelectOptions = () => {
+            select.innerHTML = "";
+            const placeholderText = element.placeholder ?? fallbackPlaceholder;
+            const placeholderOption = select.createEl("option", { value: "", text: placeholderText });
+            placeholderOption.disabled = true;
+            if (!element.defaultValue) {
+                placeholderOption.selected = true;
+            }
+
+            const optionValues = element.options && element.options.length ? element.options : null;
+            if (!optionValues) {
+                select.createEl("option", { value: "opt-1", text: "Erste Option" });
+            } else {
+                for (const opt of optionValues) {
+                    const optionEl = select.createEl("option", { value: opt, text: opt });
+                    if (element.defaultValue && element.defaultValue === opt) {
+                        optionEl.selected = true;
+                    }
+                }
+                if (element.defaultValue && !optionValues.includes(element.defaultValue)) {
+                    element.defaultValue = undefined;
+                    placeholderOption.selected = true;
+                }
+            }
+
+            if (this.enableSearch) {
+                const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
+                if (searchInput) {
+                    searchInput.value = element.defaultValue ?? "";
+                    searchInput.placeholder = placeholderText;
+                }
+            }
+        };
+
+        renderSelectOptions();
+
+        if (this.enableSearch) {
+            enhanceSelectToSearch(select, element.placeholder ?? fallbackPlaceholder);
+            const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
+            if (searchInput) {
+                searchInput.addEventListener("blur", () => {
+                    const next = searchInput.value;
+                    element.defaultValue = next ? next : undefined;
+                    finalize(element);
+                });
+            }
+        }
+
+        select.onchange = () => {
+            const value = select.value || undefined;
+            if (value === element.defaultValue) return;
+            element.defaultValue = value;
+            if (this.enableSearch) {
+                const searchInput = (select as any)._smSearchInput as HTMLInputElement | undefined;
+                if (searchInput) {
+                    searchInput.value = value ?? "";
+                }
+            }
+            finalize(element);
+        };
+    }
+
+    renderInspector({ renderLabelField, renderPlaceholderField, renderOptionsEditor }: ElementInspectorContext): void {
+        renderLabelField({ label: this.inspectorLabel });
+        renderPlaceholderField({ label: this.placeholderInspectorLabel });
+        renderOptionsEditor({});
+    }
+}


### PR DESCRIPTION
## Summary
- introduce shared base classes that centralize shared inspector, preview and default logic
- refactor container and dropdown components to inherit from the new bases
- document the updated component hierarchy in the layout editor overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51706c3148325992ee93b0bb65a14