### PR TITLE
Refine layout editor element base classes

### DIFF
--- a/plugins/layout-editor/src/LayoutEditorOverview.txt
+++ b/plugins/layout-editor/src/LayoutEditorOverview.txt
@@ -23,7 +23,7 @@ plugins/layout-editor/
    │  ├─ base.ts           # Gemeinsame Interfaces für Komponenten (Preview/Inspector)
    │  ├─ registry.ts       # Lädt automatisch alle Komponenten aus ./components
    │  ├─ shared/
-   │  │  ├─ component-bases.ts # Abstrakte Basiskomponenten für Container & Selektoren
+   │  │  ├─ component-bases.ts # Abstrakte Basiskomponenten für Container-, Feld- & Select-Elemente
    │  │  └─ container-preview.ts # Gemeinsamer Preview-Renderer für Container
    │  └─ components/       # Drop-in-Komponenten pro Elementtyp (Preview, Inspector, Defaults)
    ├─ element-preview.ts   # Canvas-Vorschau delegiert an Element-Komponenten
@@ -47,7 +47,7 @@ plugins/layout-editor/
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Panning, Zoom und Panel-Resizer halten Bounds-Clamping und Fokusverhalten konsistent.
 - **Struktur-Überblick:** Interaktiver Baum mit Drag & Drop zur Container-Neuzuordnung (inkl. Root-Drop-Zone) und zyklusgesicherter Elternwahl. Inspector- und Baum-Breiten lassen sich über Trenner anpassen.
 - **Palette & Registry:** Element-Palette horcht auf Registry-Änderungen und liest Gruppen direkt aus den Komponentendefinitionen. Neue Element-Typen müssen nur als Datei in `src/elements/components/` landen – Palette und Inspector-Menüs greifen sie automatisch auf.
-- **Komponentenbasierte Elemente:** `elements/` bündelt Preview-, Inspector- und Default-Logik je Elementtyp und reduziert Redundanz bei neuen UI-Elementen. Gemeinsame Eigenschaften (z. B. Container-Layout oder Select-Verhalten) liegen nun in `shared/component-bases.ts` und werden von konkreten Komponenten geerbt.
+- **Komponentenbasierte Elemente:** `elements/` bündelt Preview-, Inspector- und Default-Logik je Elementtyp und reduziert Redundanz bei neuen UI-Elementen. Gemeinsame Eigenschaften (z. B. Container-Layout, Select- oder Textfeld-Verhalten) liegen nun in `shared/component-bases.ts` und werden von konkreten Komponenten geerbt.
 - **Container-Layout:** Box-, VBox- und HBox-Container verwalten Gap, Padding und Align sowie verschachtelte Kinder. Inspector und Baum unterstützen das schnelle Hinzufügen und Neuzuordnen von Elementen.
 - **Direkte Bearbeitung & Inspector:** Canvas rendert echte UI-Elemente. Freie Texte lassen sich inline editieren, alle Meta-Informationen pflegst du im Inspector (Labels, Placeholder, Optionen, Layout-Werte).
 - **Vorschau & Inline-Editing:** `element-preview.ts` erzeugt realistische Vorschauen; `inline-edit.ts` kapselt ContentEditable inklusive Placeholder/Trim-Logik.
@@ -96,12 +96,14 @@ plugins/layout-editor/
 - Lädt zur Build-Zeit automatisch alle Komponenten unter `elements/components/` und stellt Lookup-Helfer bereit.
 
 ### `elements/components/*`
-- Eine Datei pro UI-Element (Label, Textfeld, Container usw.). Enthält Definition, Preview-Renderer, Inspector-Logik und Default-Werte. Container- und Select-Elemente erweitern die abstrakten Basisklassen aus `shared/component-bases.ts` und erben so Layout- bzw. Optionslogik.
+- Eine Datei pro UI-Element (Label, Textfeld, Container usw.). Enthält Definition, Preview-Renderer, Inspector-Logik und Default-Werte. Container-, Select- und Textfeld-Elemente erweitern die abstrakten Basisklassen aus `shared/component-bases.ts` und erben so Layout-, Optionen- bzw. Value-Handling.
 
 ### `elements/shared/component-bases.ts`
 - Stellt abstrakte Basisklassen für generische UI-Komponenten bereit.
+- `FieldComponent` bündelt gemeinsames Label-/Placeholder-Verhalten für Feld-Elemente.
+- `TextFieldComponent` erweitert `FieldComponent` um Text-/Textarea-Steuerung inklusive Value-Sync.
 - `ContainerComponent` kapselt Preview, Inspector und Default-Layout-Initialisierung für Container.
-- `SelectComponent` teilt das Verhalten für Dropdown-Elemente (mit/ohne Suche) inklusive Placeholder- und Optionen-Handling.
+- `SelectComponent` erweitert `FieldComponent` und teilt das Verhalten für Dropdown-Elemente (mit/ohne Suche) inklusive Placeholder- und Optionen-Handling.
 
 ### `layout-library.ts`
 - Persistiert Layouts als JSON-Dateien im Vault-Ordner `LayoutEditor/Layouts`.

--- a/plugins/layout-editor/src/elements/ElementsOverview.txt
+++ b/plugins/layout-editor/src/elements/ElementsOverview.txt
@@ -1,0 +1,62 @@
+# Elements – Overview
+
+## Struktur
+```
+plugins/layout-editor/src/elements/
+├─ ElementsOverview.txt     # Diese Übersicht über Struktur & Vererbung
+├─ base.ts                  # Gemeinsame Interfaces für Preview/Inspector-Kontexte
+├─ component-manifest.ts    # Auto-generierte Komponentenliste (Build-Artefakt)
+├─ registry.ts              # Registriert Komponenten & liefert Lookup-Helfer
+├─ shared/
+│  ├─ component-bases.ts    # Abstrakte Basisklassen (Container, Field, TextField, Select)
+│  └─ container-preview.ts  # Gemeinsamer Preview-Renderer für Containerlayouts
+└─ components/
+   ├─ box-container.ts      # Vertikale Container-Komponente mit Standardlayout
+   ├─ dropdown.ts           # Einfaches Auswahlfeld (SelectComponent ohne Suche)
+   ├─ hbox-container.ts     # Horizontaler Container mit Zentrierung
+   ├─ label.ts              # Überschrift mit Inline-Editing & Autoscaling
+   ├─ search-dropdown.ts    # Auswahlfeld mit integrierter Suchfunktion
+   ├─ separator.ts          # Überschrift + Trennlinie
+   ├─ text-input.ts         # Freistehendes einzeiliges Texteingabefeld
+   ├─ textarea.ts           # Mehrzeiliges Texteingabefeld mit Placeholder
+   └─ vbox-container.ts     # Vertikaler Container mit Stretch-Align
+```
+
+## Vererbungsstruktur
+```
+ElementComponentBase
+├─ ContainerComponent
+├─ FieldComponent
+│  ├─ TextFieldComponent
+│  │  ├─ text-input
+│  │  └─ textarea
+│  └─ SelectComponent
+│     ├─ dropdown
+│     └─ search-dropdown
+└─ (spezialisierte Objekte)
+   ├─ label (Inline-Editing)
+   └─ separator (Divider + Titel)
+```
+
+## Features & Verantwortlichkeiten
+- **Zentrale Schnittstellen:** `base.ts` definiert, wie Komponenten Preview- und Inspector-Hooks konsumieren.
+- **Basisklassen für Felder:** `FieldComponent` bündelt Label/Placeholder-Handling; `TextFieldComponent` kapselt Input-Value-Logik für Text- und Textarea-Komponenten.
+- **Optionale Suche in Selects:** `SelectComponent` erweitert `FieldComponent` um Options-Rendering sowie Search-Integration.
+- **Container-Verhalten:** `ContainerComponent` stellt Standardlayout, Preview und Inspector-Einträge für Container sicher; `container-preview.ts` zeichnet die Vorschau konsistent.
+- **Manifest & Registry:** `component-manifest.ts` und `registry.ts` verbinden sämtliche Komponenten mit Palette und Inspector.
+
+## Datei-Referenz
+- **`base.ts`:** Typisiert Preview-/Inspector-Kontexte, Factory-Signaturen und Komponentenschnittstellen.
+- **`component-manifest.ts`:** Wird beim Build erstellt und exportiert das Komponenten-Array für die Registry.
+- **`registry.ts`:** Baut Lookup-Maps auf, liefert Komponentenlisten und generiert Default-Definitionen.
+- **`shared/component-bases.ts`:** Enthält `ElementComponentBase`, `FieldComponent`, `TextFieldComponent`, `ContainerComponent` und `SelectComponent` inklusive gemeinsamer Preview-/Inspector-Implementierungen.
+- **`shared/container-preview.ts`:** Rendert die Containerfläche und platziert Kinder-Previews nach Layout.
+- **`components/box-container.ts`:** Instanziiert `ContainerComponent` für Box-Layouts mit vertikaler Orientierung.
+- **`components/hbox-container.ts`:** Variante des Containers mit horizontaler Ausrichtung und zentrierten Items.
+- **`components/vbox-container.ts`:** Vertikale Container-Variante mit Stretch-Alignment und Beschreibung.
+- **`components/dropdown.ts`:** Erstellt eine `SelectComponent` ohne Suchfunktion mit Standardoptionen.
+- **`components/search-dropdown.ts`:** Aktiviert Suchfunktionalität innerhalb der `SelectComponent`.
+- **`components/text-input.ts`:** Nutzt `TextFieldComponent` für ein freies Eingabefeld ohne Inspector-Felder.
+- **`components/textarea.ts`:** Konfiguriert `TextFieldComponent` für mehrzeilige Eingaben inkl. Placeholder-Steuerung.
+- **`components/label.ts`:** Realisiert Inline-Editing für Überschriften samt dynamischer Schriftgrößenanpassung.
+- **`components/separator.ts`:** Rendert optionale Überschrift plus Trennlinie ohne zusätzliche Basisklasse.

--- a/plugins/layout-editor/src/elements/components/text-input.ts
+++ b/plugins/layout-editor/src/elements/components/text-input.ts
@@ -1,35 +1,33 @@
-import type { LayoutElementComponent } from "../base";
+import type { ElementInspectorContext } from "../base";
+import { TextFieldComponent } from "../shared/component-bases";
 
-const textInputComponent: LayoutElementComponent = {
-    definition: {
-        type: "text-input",
-        buttonLabel: "Textfeld",
-        defaultLabel: "",
-        category: "element",
-        paletteGroup: "input",
-        width: 260,
-        height: 140,
-    },
-    renderPreview({ preview, element, finalize }) {
-        const field = preview.createDiv({ cls: "sm-le-preview__input-only" });
-        const input = field.createEl("input", { attr: { type: "text" }, cls: "sm-le-preview__input" }) as HTMLInputElement;
-        input.value = element.defaultValue ?? "";
-        input.placeholder = "";
-        let lastValue = input.value;
-        input.addEventListener("input", () => {
-            element.defaultValue = input.value ? input.value : undefined;
-        });
-        input.addEventListener("blur", () => {
-            const next = input.value;
-            if (next === lastValue) return;
-            lastValue = next;
-            element.defaultValue = next ? next : undefined;
-            finalize(element);
-        });
-        if (element.placeholder) {
-            element.placeholder = undefined;
-        }
-    },
-};
+class TextInputComponent extends TextFieldComponent {
+    constructor() {
+        super(
+            {
+                type: "text-input",
+                buttonLabel: "Textfeld",
+                defaultLabel: "",
+                category: "element",
+                paletteGroup: "input",
+                width: 260,
+                height: 140,
+            },
+            {
+                wrapperTag: "div",
+                wrapperClass: "sm-le-preview__input-only",
+                inputClass: "sm-le-preview__input",
+                showLabelInPreview: false,
+                supportsPlaceholder: false,
+            },
+        );
+    }
+
+    renderInspector(_context: ElementInspectorContext): void {
+        // Intentionally left blank – das Textfeld besitzt keine zusätzlichen Inspector-Felder.
+    }
+}
+
+const textInputComponent = new TextInputComponent();
 
 export default textInputComponent;

--- a/plugins/layout-editor/src/elements/components/textarea.ts
+++ b/plugins/layout-editor/src/elements/components/textarea.ts
@@ -1,7 +1,7 @@
-import type { LayoutElementComponent } from "../base";
+import { TextFieldComponent } from "../shared/component-bases";
 
-const textareaComponent: LayoutElementComponent = {
-    definition: {
+const textareaComponent = new TextFieldComponent(
+    {
         type: "textarea",
         buttonLabel: "Mehrzeiliges Feld",
         defaultLabel: "",
@@ -11,36 +11,13 @@ const textareaComponent: LayoutElementComponent = {
         width: 320,
         height: 180,
     },
-    renderPreview({ preview, element, finalize }) {
-        const field = preview.createEl("label", { cls: "sm-le-preview__field" });
-        const labelHost = field.createSpan({ cls: "sm-le-preview__label" });
-        const labelText = element.label?.trim() ?? "";
-        if (labelText) {
-            labelHost.setText(labelText);
-        } else {
-            labelHost.style.display = "none";
-        }
-
-        const textarea = field.createEl("textarea", { cls: "sm-le-preview__textarea" }) as HTMLTextAreaElement;
-        textarea.value = element.defaultValue ?? "";
-        textarea.placeholder = element.placeholder ?? "";
-        textarea.rows = 4;
-        let lastValue = textarea.value;
-        textarea.addEventListener("input", () => {
-            element.defaultValue = textarea.value ? textarea.value : undefined;
-        });
-        textarea.addEventListener("blur", () => {
-            const next = textarea.value;
-            if (next === lastValue) return;
-            lastValue = next;
-            element.defaultValue = next ? next : undefined;
-            finalize(element);
-        });
+    {
+        inputClass: "sm-le-preview__textarea",
+        supportsPlaceholder: true,
+        multiline: true,
+        rows: 4,
+        placeholderInspectorLabel: "Platzhalter",
     },
-    renderInspector({ renderLabelField, renderPlaceholderField }) {
-        renderLabelField({ label: "Bezeichnung" });
-        renderPlaceholderField({ label: "Platzhalter" });
-    },
-};
+);
 
 export default textareaComponent;


### PR DESCRIPTION
## Summary
- add FieldComponent and TextFieldComponent abstractions to centralize label, placeholder and value handling for layout editor elements
- refactor text input and textarea components to use the new base classes while keeping existing inspector behaviour
- refresh layout editor overviews and add an ElementsOverview that documents the updated inheritance structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51ae7c2548325b45688d27e2e262b