### PR TITLE
Refactor layout editor to use internal UI components

### DIFF
--- a/plugins/layout-editor/src/LayoutEditorOverview.txt
+++ b/plugins/layout-editor/src/LayoutEditorOverview.txt
@@ -36,7 +36,8 @@ plugins/layout-editor/
    ├─ search-dropdown.ts   # Autocomplete-Helfer für Select-Elemente
    ├─ types.ts             # Gemeinsame Typen für Elemente, Container & Snapshots
    ├─ ui/
-   │  └─ add-palette.ts    # Rendert die Element-Palette gruppiert nach Palette-Gruppen
+   │  ├─ add-palette.ts    # Rendert die Element-Palette gruppiert nach Palette-Gruppen
+   │  └─ editor-menu.ts    # Kontextmenü-Komponente für Palette & Inspector
    └─ utils.ts             # Hilfsfunktionen (clamp, Deep-Clones, Vergleichs-Utilities)
 ```
 
@@ -46,7 +47,7 @@ plugins/layout-editor/
 - **Eigenes Styling (`css.ts`):** Enthält das komplette Layout-Editor-CSS. Wird ausschließlich vom Layout-Editor-Plugin injiziert und kollidiert somit nicht länger mit SaltMarcher-spezifischem Styling.
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Panning, Zoom und Panel-Resizer halten Bounds-Clamping und Fokusverhalten konsistent.
 - **Struktur-Überblick:** Interaktiver Baum mit Drag & Drop zur Container-Neuzuordnung (inkl. Root-Drop-Zone) und zyklusgesicherter Elternwahl. Inspector- und Baum-Breiten lassen sich über Trenner anpassen.
-- **Palette & Registry:** Element-Palette horcht auf Registry-Änderungen und liest Gruppen direkt aus den Komponentendefinitionen. Neue Element-Typen müssen nur als Datei in `src/elements/components/` landen – Palette und Inspector-Menüs greifen sie automatisch auf.
+- **Palette & Registry:** Element-Palette horcht auf Registry-Änderungen und liest Gruppen direkt aus den Komponentendefinitionen. Neue Element-Typen müssen nur als Datei in `src/elements/components/` landen – Palette und Inspector-Menüs greifen sie automatisch auf. Eigene Editor-Komponenten (Palette + Kontextmenüs) verzichten vollständig auf Obsidian-Menüs.
 - **Komponentenbasierte Elemente:** `elements/` bündelt Preview-, Inspector- und Default-Logik je Elementtyp und reduziert Redundanz bei neuen UI-Elementen. Gemeinsame Eigenschaften (z. B. Container-Layout, Select- oder Textfeld-Verhalten) liegen nun in `shared/component-bases.ts` und werden von konkreten Komponenten geerbt.
 - **Container-Layout:** Box-, VBox- und HBox-Container verwalten Gap, Padding und Align sowie verschachtelte Kinder. Inspector und Baum unterstützen das schnelle Hinzufügen und Neuzuordnen von Elementen.
 - **Direkte Bearbeitung & Inspector:** Canvas rendert echte UI-Elemente. Freie Texte lassen sich inline editieren, alle Meta-Informationen pflegst du im Inspector (Labels, Placeholder, Optionen, Layout-Werte).
@@ -111,6 +112,7 @@ plugins/layout-editor/
 
 ### `name-input-modal.ts`
 - Stellt einen schlanken Modal zur Verfügung, um Layout-Namen einzutippen (inkl. Enter-Shortcut und CTA-Button).
+- Nutzt jetzt ein eigenes Formular-Layout anstelle der Obsidian-`Setting`-Komponente, damit der Editor ausschließlich eigene UI-Bausteine verwendet.
 
 ### `search-dropdown.ts`
 - Verwandelt native `<select>`-Elemente in durchsuchbare Dropdowns (Suchfeld, Keyboard-Navigation, Menü-Rendering).
@@ -123,6 +125,11 @@ plugins/layout-editor/
 
 ### `ui/add-palette.ts`
 - Baut die gruppierte Element-Palette und öffnet Kontext-Menüs für Sammlungen (Inputs, Container, benutzerdefinierte Gruppen).
+- Verwendet das interne `editor-menu.ts`, um Dropdowns ohne Obsidian-`Menu` darzustellen.
+
+### `ui/editor-menu.ts`
+- Implementiert das kontextsensitive Menü des Layout-Editors.
+- Stellt Keyboard- und Pointer-Handling bereit (Escape, Outside-Click) und kapselt das Positioning relativ zum Auslöser.
 
 ### `element-preview.ts`
 - Delegiert das Rendering an die registrierten Komponenten und kapselt das gemeinsame Inline-Editing.

--- a/plugins/layout-editor/src/css.ts
+++ b/plugins/layout-editor/src/css.ts
@@ -549,6 +549,62 @@ export const LAYOUT_EDITOR_CSS = `
     align-self: flex-start;
 }
 
+.sm-le-menu {
+    position: absolute;
+    z-index: 10000;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 10px;
+    box-shadow: 0 8px 22px rgba(15, 23, 42, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.3rem;
+    min-width: 180px;
+}
+
+.sm-le-menu__item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    padding: 0.45rem 0.55rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: background-color 120ms ease, color 120ms ease;
+}
+
+.sm-le-menu__item:hover,
+.sm-le-menu__item:focus-visible {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.sm-le-menu__item.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.sm-le-menu__label {
+    font-weight: 600;
+}
+
+.sm-le-menu__description {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.sm-le-menu__separator {
+    height: 1px;
+    background: var(--background-modifier-border);
+    margin: 0.15rem 0.25rem;
+}
+
 .sm-le-preview__divider {
     border: none;
     border-top: 1px solid var(--background-modifier-border);
@@ -586,6 +642,47 @@ export const LAYOUT_EDITOR_CSS = `
     gap: 0.5rem;
     overflow-y: auto;
     padding-right: 0.25rem;
+}
+
+.sm-le-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.sm-le-modal__form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sm-le-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sm-le-modal__field label {
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.sm-le-modal__field input {
+    font: inherit;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+}
+
+.sm-le-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.sm-le-modal__actions .mod-cta {
+    min-width: 120px;
 }
 
 .sm-le-field {

--- a/plugins/layout-editor/src/name-input-modal.ts
+++ b/plugins/layout-editor/src/name-input-modal.ts
@@ -1,5 +1,5 @@
 // plugins/layout-editor/src/name-input-modal.ts
-import { App, Modal, Setting } from "obsidian";
+import { App, Modal } from "obsidian";
 
 export class NameInputModal extends Modal {
     private value = "";
@@ -24,28 +24,44 @@ export class NameInputModal extends Modal {
     onOpen() {
         const { contentEl } = this;
         contentEl.empty();
+        contentEl.addClass("sm-le-modal");
         contentEl.createEl("h3", { text: this.title });
 
-        let inputEl: HTMLInputElement | undefined;
+        const form = contentEl.createEl("form", { cls: "sm-le-modal__form" });
+        const field = form.createDiv({ cls: "sm-le-modal__field" });
+        const inputId = `sm-le-name-input-${Date.now()}`;
+        field.createEl("label", { text: "Name", attr: { for: inputId } });
+        const inputEl = field.createEl("input", {
+            attr: { type: "text", id: inputId, placeholder: this.placeholder },
+        }) as HTMLInputElement;
+        if (this.value) {
+            inputEl.value = this.value;
+        }
+        inputEl.addEventListener("input", () => {
+            this.value = inputEl.value.trim();
+        });
 
-        new Setting(contentEl)
-            .addText(text => {
-                text.setPlaceholder(this.placeholder).onChange(value => (this.value = value.trim()));
-                inputEl = (text as any).inputEl as HTMLInputElement;
-                if (this.value) {
-                    inputEl.value = this.value;
-                }
-            })
-            .addButton(button => {
-                button.setButtonText(this.ctaLabel).setCta().onClick(() => this.submit());
-            });
+        const actions = form.createDiv({ cls: "sm-le-modal__actions" });
+        const submitBtn = actions.createEl("button", { text: this.ctaLabel });
+        submitBtn.type = "submit";
+        submitBtn.addClass("mod-cta");
 
-        this.scope.register([], "Enter", () => this.submit());
-        queueMicrotask(() => inputEl?.focus());
+        form.onsubmit = ev => {
+            ev.preventDefault();
+            this.value = inputEl.value.trim();
+            this.submit();
+        };
+
+        this.scope.register([], "Enter", () => {
+            this.value = inputEl.value.trim();
+            this.submit();
+        });
+        queueMicrotask(() => inputEl.focus());
     }
 
     onClose() {
         this.contentEl.empty();
+        this.contentEl.removeClass("sm-le-modal");
     }
 
     private submit() {

--- a/plugins/layout-editor/src/types.ts
+++ b/plugins/layout-editor/src/types.ts
@@ -1,6 +1,4 @@
 // src/plugins/layout-editor/types.ts
-import type { Setting } from "obsidian";
-
 export type LayoutElementType = string;
 
 export type LayoutContainerType = LayoutElementType;
@@ -90,8 +88,3 @@ export interface SavedLayout extends LayoutBlueprint {
     updatedAt: string;
 }
 
-export interface CreateSettingOptions {
-    host: HTMLElement;
-    withDescription?: boolean;
-    prepare?: (setting: Setting) => void;
-}

--- a/plugins/layout-editor/src/ui/add-palette.ts
+++ b/plugins/layout-editor/src/ui/add-palette.ts
@@ -1,5 +1,5 @@
-import { Menu } from "obsidian";
 import type { LayoutElementDefinition, LayoutElementType } from "../types";
+import { openEditorMenu } from "./editor-menu";
 
 export interface PaletteRenderOptions {
     host: HTMLElement;
@@ -41,17 +41,15 @@ export function renderPalette(options: PaletteRenderOptions) {
         const button = host.createEl("button", { text: label });
         button.onclick = event => {
             event.preventDefault();
-            const menu = new Menu();
-            defs
+            const entries = defs
                 .slice()
                 .sort((a, b) => a.buttonLabel.localeCompare(b.buttonLabel, "de"))
-                .forEach(def => {
-                    menu.addItem(item => {
-                        item.setTitle(def.buttonLabel);
-                        item.onClick(() => onCreate(def.type));
-                    });
-                });
-            menu.showAtMouseEvent(event);
+                .map(def => ({
+                    type: "item" as const,
+                    label: def.buttonLabel,
+                    onSelect: () => onCreate(def.type),
+                }));
+            openEditorMenu({ anchor: button, entries, event });
         };
     }
 }

--- a/plugins/layout-editor/src/ui/editor-menu.ts
+++ b/plugins/layout-editor/src/ui/editor-menu.ts
@@ -1,0 +1,134 @@
+// plugins/layout-editor/src/ui/editor-menu.ts
+export type EditorMenuEntry =
+    | { type: "item"; label: string; description?: string; onSelect: () => void; disabled?: boolean }
+    | { type: "separator" };
+
+export interface EditorMenuOptions {
+    anchor: HTMLElement;
+    entries: EditorMenuEntry[];
+    event?: MouseEvent | PointerEvent;
+    onClose?: () => void;
+}
+
+interface EditorMenuHandle {
+    close(): void;
+}
+
+let activeMenu: EditorMenuHandle | null = null;
+
+export function openEditorMenu(options: EditorMenuOptions): EditorMenuHandle | null {
+    const { anchor, entries, event, onClose } = options;
+    if (!anchor || !entries.length) {
+        return null;
+    }
+
+    activeMenu?.close();
+
+    const menu = document.createElement("div");
+    menu.className = "sm-le-menu";
+
+    let isOpen = true;
+
+    const close = () => {
+        if (!isOpen) return;
+        isOpen = false;
+        menu.remove();
+        document.removeEventListener("pointerdown", handlePointerDown, true);
+        document.removeEventListener("keydown", handleKeyDown, true);
+        window.removeEventListener("blur", close);
+        if (activeMenu && activeMenu.close === close) {
+            activeMenu = null;
+        }
+        onClose?.();
+    };
+
+    const handlePointerDown = (ev: PointerEvent) => {
+        const target = ev.target as Node | null;
+        if (!target) {
+            close();
+            return;
+        }
+        if (!menu.contains(target) && !anchor.contains(target)) {
+            close();
+        }
+    };
+
+    const handleKeyDown = (ev: KeyboardEvent) => {
+        if (ev.key === "Escape") {
+            ev.preventDefault();
+            close();
+        }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown, true);
+    window.addEventListener("blur", close);
+
+    for (const entry of entries) {
+        if (entry.type === "separator") {
+            menu.createDiv({ cls: "sm-le-menu__separator" });
+            continue;
+        }
+        const item = menu.createEl("button", { cls: "sm-le-menu__item" });
+        item.type = "button";
+        item.createSpan({ cls: "sm-le-menu__label", text: entry.label });
+        if (entry.description) {
+            item.createSpan({ cls: "sm-le-menu__description", text: entry.description });
+        }
+        if (entry.disabled) {
+            item.setAttr("disabled", "disabled");
+            item.addClass("is-disabled");
+        }
+        item.onclick = ev => {
+            ev.preventDefault();
+            if (entry.disabled) return;
+            close();
+            entry.onSelect();
+        };
+        item.onkeydown = ev => {
+            if (ev.key === "Enter" || ev.key === " ") {
+                ev.preventDefault();
+                if (!entry.disabled) {
+                    close();
+                    entry.onSelect();
+                }
+            }
+        };
+    }
+
+    document.body.appendChild(menu);
+
+    // Position after appending so dimensions are available.
+    const anchorRect = anchor.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const offsetX = event ? event.clientX - anchorRect.left : 0;
+    let left = anchorRect.left + window.scrollX + offsetX;
+    let top = (event ? event.clientY : anchorRect.bottom) + window.scrollY;
+
+    const viewportRight = window.scrollX + window.innerWidth;
+    const viewportBottom = window.scrollY + window.innerHeight;
+
+    if (left + menuRect.width > viewportRight - 8) {
+        left = Math.max(8, viewportRight - menuRect.width - 8);
+    }
+    if (top + menuRect.height > viewportBottom - 8) {
+        const above = anchorRect.top + window.scrollY - menuRect.height;
+        if (above >= 8) {
+            top = above;
+        } else {
+            top = Math.max(8, viewportBottom - menuRect.height - 8);
+        }
+    }
+
+    menu.style.left = `${Math.round(left)}px`;
+    menu.style.top = `${Math.round(top)}px`;
+
+    const focusable = menu.querySelector<HTMLElement>(".sm-le-menu__item:not([disabled])");
+    if (focusable) {
+        focusable.focus();
+    }
+
+    const handle: EditorMenuHandle = { close };
+    activeMenu = handle;
+    return handle;
+}


### PR DESCRIPTION
## Summary
- add a reusable `openEditorMenu` helper so palette and inspector menus no longer depend on Obsidian's `Menu`
- replace the layout name modal with a custom form layout and add dedicated styles for menus and modals
- document the new editor menu component and UI refactor in the layout editor overview

## Testing
- `npm --prefix plugins/layout-editor run build`


------
https://chatgpt.com/codex/tasks/task_e_68d51de2ea948325aec7cc18500480e3