### PR TITLE
Fix layout library lookup for manually imported files

### DIFF
--- a/plugins/layout-editor/main.js
+++ b/plugins/layout-editor/main.js
@@ -1859,9 +1859,11 @@ async function readLayoutMeta(app, file) {
     }
     const fallbackCreated = new Date(file.stat.ctime || Date.now()).toISOString();
     const fallbackUpdated = new Date(file.stat.mtime || Date.now()).toISOString();
+    const fileId = file.basename;
+    const resolvedName = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : fileId;
     return {
-      id: parsed.id ?? file.basename,
-      name: typeof parsed.name === "string" ? parsed.name : file.basename,
+      id: fileId,
+      name: resolvedName,
       canvasWidth: parsed.canvasWidth,
       canvasHeight: parsed.canvasHeight,
       elements: parsed.elements ?? [],

--- a/plugins/layout-editor/src/LayoutEditorOverview.txt
+++ b/plugins/layout-editor/src/LayoutEditorOverview.txt
@@ -58,7 +58,7 @@ plugins/layout-editor/
 - **Vorschau & Inline-Editing:** `element-preview.ts` erzeugt realistische Vorschauen; `inline-edit.ts` kapselt ContentEditable inklusive Placeholder/Trim-Logik.
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet Öffnen, Positionierung und Callbacks, sodass Inspector, Canvas und Historie synchron bleiben.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` bindet sie an Shortcuts (Strg+Z / Umschalt+Strg+Z) und automatische Pushes bei Mutationen.
-- **Export & Layout-Library:** `view.ts` erstellt JSON-Exporte; `layout-library.ts` persistiert Layouts unter `LayoutEditor/Layouts/<id>.json`, listet vorhandene Layouts und lädt sie erneut. `seed-layouts.ts` sorgt beim Plugin-Start dafür, dass ein Standardlayout („Layout Editor – Kreaturenvorlage“) als JSON im Vault vorhanden ist.
+- **Export & Layout-Library:** `view.ts` erstellt JSON-Exporte; `layout-library.ts` persistiert Layouts unter `LayoutEditor/Layouts/<id>.json`, listet vorhandene Layouts und lädt sie erneut. Die IDs werden dabei konsequent aus dem Dateinamen abgeleitet, sodass auch manuell importierte oder umbenannte Layout-Dateien gefunden werden. `seed-layouts.ts` sorgt beim Plugin-Start dafür, dass ein Standardlayout („Layout Editor – Kreaturenvorlage“) als JSON im Vault vorhanden ist.
 - **Layout-Bibliothek Import:** `layout-picker-modal.ts` und `view.ts` öffnen gespeicherte Layouts aus der Bibliothek und setzen Canvas/Einstellungen entsprechend zurück.
 
 ## Datenfluss
@@ -118,6 +118,7 @@ plugins/layout-editor/
 ### `layout-library.ts`
 - Persistiert Layouts als JSON-Dateien im Vault-Ordner `LayoutEditor/Layouts`.
 - Liefert `saveLayoutToLibrary`, `listSavedLayouts`, `loadSavedLayout` für wiederverwendbare Layout-Bibliotheken.
+- Erzwingt, dass die Layout-ID dem Dateinamen entspricht, damit der Import auch bei manuell hinzugefügten oder umbenannten Dateien zuverlässig funktioniert.
 
 ### `name-input-modal.ts`
 - Stellt einen schlanken Modal zur Verfügung, um Layout-Namen einzutippen (inkl. Enter-Shortcut und CTA-Button).

--- a/plugins/layout-editor/src/layout-library.ts
+++ b/plugins/layout-editor/src/layout-library.ts
@@ -62,9 +62,11 @@ async function readLayoutMeta(app: App, file: TFile): Promise<SavedLayout | null
         }
         const fallbackCreated = new Date(file.stat.ctime || Date.now()).toISOString();
         const fallbackUpdated = new Date(file.stat.mtime || Date.now()).toISOString();
+        const fileId = file.basename;
+        const resolvedName = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : fileId;
         return {
-            id: parsed.id ?? file.basename,
-            name: typeof parsed.name === "string" ? parsed.name : file.basename,
+            id: fileId,
+            name: resolvedName,
             canvasWidth: parsed.canvasWidth,
             canvasHeight: parsed.canvasHeight,
             elements: (parsed.elements ?? []) as LayoutElement[],


### PR DESCRIPTION
## Summary
- derive saved layout identifiers from the vault file name so manually imported or renamed layouts can be opened again
- document the updated lookup behaviour in the layout editor overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d534acb6c88325bef3672a485dbd6b