### PR TITLE
Ensure layout picker keeps selection when closing modal

### DIFF
--- a/layout-editor/main.js
+++ b/layout-editor/main.js
@@ -2195,9 +2195,10 @@ var LayoutPickerModal = class extends import_obsidian3.Modal {
     }
   }
   submit() {
-    if (!this.selectedId) return;
+    const layoutId = this.selectedId;
+    if (!layoutId) return;
     this.close();
-    this.onPick(this.selectedId);
+    this.onPick(layoutId);
   }
 };
 function formatTimestamp(value) {
@@ -3758,7 +3759,7 @@ var LayoutEditorView = class extends import_obsidian5.ItemView {
     this.renderInspector();
     this.refreshExport();
     this.updateStatus();
-    this.pushHistory();
+    this.history.reset(this.captureSnapshot());
   }
   nextFrame() {
     return new Promise((resolve) => requestAnimationFrame(() => resolve()));

--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -59,7 +59,7 @@ plugins/layout-editor/
 - **Attribute-Popover:** `attribute-popover.ts` verwaltet Öffnen, Positionierung und Callbacks, sodass Inspector, Canvas und Historie synchron bleiben.
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` bindet sie an Shortcuts (Strg+Z / Umschalt+Strg+Z) und automatische Pushes bei Mutationen.
 - **Export & Layout-Library:** `view.ts` erstellt JSON-Exporte nun inklusive Metadaten (`id`, `name`, `createdAt`, `updatedAt`) im exakt gleichen Format wie die Bibliothek sie speichert (`canvasWidth`, `canvasHeight`, `elements`). Dadurch lassen sich Layouts ohne Nachbearbeitung wieder importieren oder direkt im Vault bearbeiten; `layout-library.ts` persistiert Layouts unter `LayoutEditor/Layouts/<id>.json`, listet vorhandene Layouts und lädt sie erneut. Die IDs werden dabei konsequent aus dem Dateinamen abgeleitet, sodass auch manuell importierte oder umbenannte Layout-Dateien gefunden werden. Beim Einlesen werden Maße und Elemente tolerant geparst, sodass auch ältere/handbearbeitete Dateien mit Stringwerten oder Objekt-Mappings sicher geladen werden. Für Nutzer mit Bestandsdateien berücksichtigt die Library zusätzlich den Legacy-Pfad `Layout Editor/Layouts`, damit alte Layouts weiterhin erscheinen und importiert werden können. `seed-layouts.ts` sorgt beim Plugin-Start dafür, dass ein Standardlayout („Layout Editor – Kreaturenvorlage“) als JSON im Vault vorhanden ist.
-- **Layout-Bibliothek Import:** `layout-picker-modal.ts` und `view.ts` öffnen gespeicherte Layouts aus der Bibliothek und setzen Canvas/Einstellungen entsprechend zurück.
+- **Layout-Bibliothek Import:** `layout-picker-modal.ts` und `view.ts` öffnen gespeicherte Layouts aus der Bibliothek, setzen Canvas/Einstellungen entsprechend zurück und initialisieren die Undo/Redo-Historie direkt auf dem geladenen Stand.
 
 ## Datenfluss
 
@@ -94,7 +94,7 @@ plugins/layout-editor/
 - Implementiert `LayoutEditorView` (`ItemView`).
 - Baut Header („+ Element“-Button, Import, Status), Struktur-Baum, Stage mit Kamera, Inspector, Exportbereich und Sandbox auf – alle Controls basieren auf `elements/ui.ts`.
 - Verwaltet State (Selektion, Historie, Canvas) und orchestriert Hilfs-Module.
-- Öffnet gespeicherte Layouts über den `LayoutPickerModal` und setzt Canvas/Elemente inklusive Historie zurück.
+- Öffnet gespeicherte Layouts über den `LayoutPickerModal`, setzt Canvas/Elemente zurück und initialisiert die Historie auf den importierten Stand.
 
 ### `definitions.ts`
 - Enthält Element-Definitionen, Attribute-Gruppen und Registry-API (`registerLayoutElementDefinition`, `unregisterLayoutElementDefinition`, `onLayoutElementDefinitionsChanged`).
@@ -162,4 +162,4 @@ plugins/layout-editor/
 - Typisiert LayoutElemente, Container-Konfigurationen, Registry-Definitionen und gespeicherte Layouts.
 
 ### `layout-picker-modal.ts`
-- Stellt einen Modal mit Such-Dropdown bereit, um gespeicherte Layouts auszuwählen und die Auswahl an `view.ts` zurückzumelden – inklusive Elements-Buttons, -Selects und Statusmeldungen.
+- Stellt einen Modal mit Such-Dropdown bereit, um gespeicherte Layouts auszuwählen und die Auswahl an `view.ts` zurückzumelden – inklusive Elements-Buttons, -Selects und Statusmeldungen. Bewahrt die gewählte Layout-ID jetzt vor dem Schließen auf, damit `onPick` auch nach dem Modal-Cleanup stets eine gültige ID erhält.

--- a/layout-editor/src/layout-picker-modal.ts
+++ b/layout-editor/src/layout-picker-modal.ts
@@ -171,9 +171,10 @@ export class LayoutPickerModal extends Modal {
     }
 
     private submit() {
-        if (!this.selectedId) return;
+        const layoutId = this.selectedId;
+        if (!layoutId) return;
         this.close();
-        this.onPick(this.selectedId);
+        this.onPick(layoutId);
     }
 }
 

--- a/layout-editor/src/view.ts
+++ b/layout-editor/src/view.ts
@@ -1505,7 +1505,7 @@ export class LayoutEditorView extends ItemView {
         this.renderInspector();
         this.refreshExport();
         this.updateStatus();
-        this.pushHistory();
+        this.history.reset(this.captureSnapshot());
     }
 
     private nextFrame(): Promise<void> {


### PR DESCRIPTION
## Summary
- keep the selected layout id before closing the picker modal so `onPick` always receives a real id
- document the resilient selection handling in the Layout Editor overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d53f26adf883258efe46b1b54964af