### PR TITLE
Fix view container scaling in layout editor

### DIFF
--- a/layout-editor/main.js
+++ b/layout-editor/main.js
@@ -789,6 +789,8 @@ function onViewBindingsChanged(listener) {
 // src/elements/components/view-container.ts
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 3;
+var SURFACE_WIDTH = 960;
+var SURFACE_HEIGHT = 640;
 var ViewContainerComponent = class extends ElementComponentBase {
   constructor() {
     super({
@@ -826,6 +828,22 @@ var ViewContainerComponent = class extends ElementComponentBase {
       surface.style.transform = `translate(${camera.x}px, ${camera.y}px) scale(${camera.scale})`;
     };
     applyCamera();
+    const fitCameraToViewport = () => {
+      const rect = viewport.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      const baseScale = Math.min(rect.width / SURFACE_WIDTH, rect.height / SURFACE_HEIGHT);
+      if (!isFinite(baseScale) || baseScale <= 0) return;
+      const nextScale = Math.min(MAX_SCALE, baseScale);
+      const contentWidth = SURFACE_WIDTH * nextScale;
+      const contentHeight = SURFACE_HEIGHT * nextScale;
+      camera = {
+        scale: nextScale,
+        x: Math.round((rect.width - contentWidth) / 2),
+        y: Math.round((rect.height - contentHeight) / 2)
+      };
+      applyCamera();
+    };
+    window.requestAnimationFrame(fitCameraToViewport);
     let panPointer = null;
     let startX = 0;
     let startY = 0;

--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -61,7 +61,7 @@ plugins/layout-editor/
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` bindet sie an Shortcuts (Strg+Z / Umschalt+Strg+Z) und automatische Pushes bei Mutationen.
 - **Export & Layout-Library:** `view.ts` erstellt JSON-Exporte nun inklusive Metadaten (`id`, `name`, `createdAt`, `updatedAt`) im exakt gleichen Format wie die Bibliothek sie speichert (`canvasWidth`, `canvasHeight`, `elements`). Dadurch lassen sich Layouts ohne Nachbearbeitung wieder importieren oder direkt im Vault bearbeiten; `layout-library.ts` persistiert Layouts unter `LayoutEditor/Layouts/<id>.json`, listet vorhandene Layouts und lädt sie erneut. Die IDs werden dabei konsequent aus dem Dateinamen abgeleitet, sodass auch manuell importierte oder umbenannte Layout-Dateien gefunden werden. Beim Speichern validiert die Library IDs gegen Pfadtrenner, rundet Canvas-Maße auf Ganzzahlen, klont alle Elemente strikt und meldet bei ungültigen Feldern verständliche Fehler. Beim Einlesen werden Maße, Layout-Configs sowie Options-/Attribute-Listen tolerant geparst (Strings, Objekt-Mappings, frühere Align-Werte wie `flex-start`), sodass auch ältere oder handbearbeitete Dateien sicher geladen werden. Für Nutzer mit Bestandsdateien berücksichtigt die Library zusätzlich den Legacy-Pfad `Layout Editor/Layouts`, damit alte Layouts weiterhin erscheinen und importiert werden können. `seed-layouts.ts` sorgt beim Plugin-Start dafür, dass ein Standardlayout („Layout Editor – Kreaturenvorlage“) als JSON im Vault vorhanden ist.
 - **Layout-Bibliothek Import:** `layout-picker-modal.ts` und `view.ts` öffnen gespeicherte Layouts aus der Bibliothek, setzen Canvas/Einstellungen entsprechend zurück und initialisieren die Undo/Redo-Historie direkt auf dem geladenen Stand.
-- **View-Bindings & externe Features:** `view-registry.ts` hält registrierte Visualisierungen externer Plugins synchron und informiert Inspector/Preview. Die neue `view-container`-Komponente nutzt die Registry, um Feature-Dropdowns und Kamera-Demos (MMB-Pan, Wheel-Zoom) bereitzustellen und die gewählte `viewBindingId` im Layout zu speichern.
+- **View-Bindings & externe Features:** `view-registry.ts` hält registrierte Visualisierungen externer Plugins synchron und informiert Inspector/Preview. Die neue `view-container`-Komponente nutzt die Registry, um Feature-Dropdowns und Kamera-Demos (MMB-Pan, Wheel-Zoom) bereitzustellen, richtet die Demo-Fläche automatisch an der aktuellen Elementgröße aus und speichert die gewählte `viewBindingId` im Layout.
 
 ## Layout-Library Workflow (Speichern, Öffnen & API-Nutzung)
 
@@ -167,7 +167,7 @@ plugins/layout-editor/
 ### `elements/components/view-container.ts`
 - Spezialisiertes Element für externe Renderflächen.
 - Inspector bietet ein Dropdown der registrierten View-Bindings und speichert die Auswahl in `element.viewBindingId`.
-- Preview demonstriert eine Kamera (Mittlere Maustaste zum Pannen, Mausrad zum Zoomen) und blendet gewählte Feature-Namen/IDs ein.
+- Preview demonstriert eine Kamera (Mittlere Maustaste zum Pannen, Mausrad zum Zoomen), passt die Demo-Fläche automatisch an die Boxgröße in der Arbeitsfläche an und blendet gewählte Feature-Namen/IDs ein.
 
 ### `layout-library.ts`
 - Persistiert Layouts als JSON-Dateien im Vault-Ordner `LayoutEditor/Layouts`.

--- a/layout-editor/src/elements/ElementsOverview.txt
+++ b/layout-editor/src/elements/ElementsOverview.txt
@@ -47,7 +47,7 @@ ElementComponentBase
 - **Container-Verhalten:** `ContainerComponent` stellt Standardlayout, Preview und Inspector-Einträge für Container sicher; `container-preview.ts` zeichnet die Vorschau konsistent.
 - **Manifest & Registry:** `component-manifest.ts` und `registry.ts` verbinden sämtliche Komponenten mit Palette und Inspector.
 - **UI-Komponenten (`ui.ts`):** Stellt generische Controls für Buttons, Felder, Inputs und Statusanzeigen bereit, die in View, Inspector und Modals verwendet werden.
-- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom) und spiegelt gewählte Bindings wider.
+- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom), passt die Demo-Oberfläche automatisch an die Boxgröße an und spiegelt gewählte Bindings wider.
 
 ## Datei-Referenz
 - **`base.ts`:** Typisiert Preview-/Inspector-Kontexte, Factory-Signaturen und Komponentenschnittstellen.
@@ -64,5 +64,5 @@ ElementComponentBase
 - **`components/textarea.ts`:** Konfiguriert `TextFieldComponent` für mehrzeilige Eingaben inkl. Placeholder-Steuerung.
 - **`components/label.ts`:** Realisiert Inline-Editing für Überschriften samt dynamischer Schriftgrößenanpassung.
 - **`components/separator.ts`:** Rendert optionale Überschrift plus Trennlinie ohne zusätzliche Basisklasse.
-- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, die den gewählten Binding-Namen/ID anzeigt.
+- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese beim Rendern an die aktuelle Elementgröße aus und zeigt den gewählten Binding-Namen/ID an.
 - **`ui.ts`:** Bündelt allgemeine UI-Bausteine (Buttons, Formularfelder, Selects, Statusanzeigen, Stacks), damit der Editor komplett auf Elements-Komponenten basiert.

--- a/layout-editor/src/elements/components/view-container.ts
+++ b/layout-editor/src/elements/components/view-container.ts
@@ -16,6 +16,8 @@ type CameraState = {
 
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 3;
+const SURFACE_WIDTH = 960;
+const SURFACE_HEIGHT = 640;
 
 class ViewContainerComponent extends ElementComponentBase {
     constructor() {
@@ -60,6 +62,24 @@ class ViewContainerComponent extends ElementComponentBase {
             surface.style.transform = `translate(${camera.x}px, ${camera.y}px) scale(${camera.scale})`;
         };
         applyCamera();
+
+        const fitCameraToViewport = () => {
+            const rect = viewport.getBoundingClientRect();
+            if (!rect.width || !rect.height) return;
+            const baseScale = Math.min(rect.width / SURFACE_WIDTH, rect.height / SURFACE_HEIGHT);
+            if (!isFinite(baseScale) || baseScale <= 0) return;
+            const nextScale = Math.min(MAX_SCALE, baseScale);
+            const contentWidth = SURFACE_WIDTH * nextScale;
+            const contentHeight = SURFACE_HEIGHT * nextScale;
+            camera = {
+                scale: nextScale,
+                x: Math.round((rect.width - contentWidth) / 2),
+                y: Math.round((rect.height - contentHeight) / 2),
+            };
+            applyCamera();
+        };
+
+        window.requestAnimationFrame(fitCameraToViewport);
 
         let panPointer: number | null = null;
         let startX = 0;


### PR DESCRIPTION
## Summary
- auto-fit the view container demo surface to the element viewport so previews resize cleanly on the canvas
- document the automatic fitting behaviour in the layout editor overview files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d59a5b30188325a92d4d57ef1f09f3