### PR TITLE
Improve view container preview resizing

### DIFF
--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -61,7 +61,7 @@ plugins/layout-editor/
 - **Undo/Redo-Historie:** `history.ts` kapselt Snapshot-Verwaltung; `view.ts` bindet sie an Shortcuts (Strg+Z / Umschalt+Strg+Z) und automatische Pushes bei Mutationen.
 - **Export & Layout-Library:** `view.ts` erstellt JSON-Exporte nun inklusive Metadaten (`id`, `name`, `createdAt`, `updatedAt`) im exakt gleichen Format wie die Bibliothek sie speichert (`canvasWidth`, `canvasHeight`, `elements`). Dadurch lassen sich Layouts ohne Nachbearbeitung wieder importieren oder direkt im Vault bearbeiten; `layout-library.ts` persistiert Layouts unter `LayoutEditor/Layouts/<id>.json`, listet vorhandene Layouts und lädt sie erneut. Die IDs werden dabei konsequent aus dem Dateinamen abgeleitet, sodass auch manuell importierte oder umbenannte Layout-Dateien gefunden werden. Beim Speichern validiert die Library IDs gegen Pfadtrenner, rundet Canvas-Maße auf Ganzzahlen, klont alle Elemente strikt und meldet bei ungültigen Feldern verständliche Fehler. Beim Einlesen werden Maße, Layout-Configs sowie Options-/Attribute-Listen tolerant geparst (Strings, Objekt-Mappings, frühere Align-Werte wie `flex-start`), sodass auch ältere oder handbearbeitete Dateien sicher geladen werden. Für Nutzer mit Bestandsdateien berücksichtigt die Library zusätzlich den Legacy-Pfad `Layout Editor/Layouts`, damit alte Layouts weiterhin erscheinen und importiert werden können. `seed-layouts.ts` sorgt beim Plugin-Start dafür, dass ein Standardlayout („Layout Editor – Kreaturenvorlage“) als JSON im Vault vorhanden ist.
 - **Layout-Bibliothek Import:** `layout-picker-modal.ts` und `view.ts` öffnen gespeicherte Layouts aus der Bibliothek, setzen Canvas/Einstellungen entsprechend zurück und initialisieren die Undo/Redo-Historie direkt auf dem geladenen Stand.
-- **View-Bindings & externe Features:** `view-registry.ts` hält registrierte Visualisierungen externer Plugins synchron und informiert Inspector/Preview. Die neue `view-container`-Komponente nutzt die Registry, um Feature-Dropdowns und Kamera-Demos (MMB-Pan, Wheel-Zoom) bereitzustellen, richtet die Demo-Fläche automatisch an der aktuellen Elementgröße aus und speichert die gewählte `viewBindingId` im Layout.
+- **View-Bindings & externe Features:** `view-registry.ts` hält registrierte Visualisierungen externer Plugins synchron und informiert Inspector/Preview. Die neue `view-container`-Komponente nutzt die Registry, um Feature-Dropdowns und Kamera-Demos (MMB-Pan, Wheel-Zoom) bereitzustellen, richtet die Demo-Fläche mit einem `ResizeObserver` (Fallback: RAF-Loop) unmittelbar an der aktuellen Elementgröße aus und speichert die gewählte `viewBindingId` im Layout.
 
 ## Layout-Library Workflow (Speichern, Öffnen & API-Nutzung)
 
@@ -167,7 +167,7 @@ plugins/layout-editor/
 ### `elements/components/view-container.ts`
 - Spezialisiertes Element für externe Renderflächen.
 - Inspector bietet ein Dropdown der registrierten View-Bindings und speichert die Auswahl in `element.viewBindingId`.
-- Preview demonstriert eine Kamera (Mittlere Maustaste zum Pannen, Mausrad zum Zoomen), passt die Demo-Fläche automatisch an die Boxgröße in der Arbeitsfläche an und blendet gewählte Feature-Namen/IDs ein.
+- Preview demonstriert eine Kamera (Mittlere Maustaste zum Pannen, Mausrad zum Zoomen), beobachtet die Viewport-Größe per `ResizeObserver` (inkl. RAF-Fallback) für sofortiges Re-Fitting, räumt Observer/RAF beim Re-Render auf und blendet gewählte Feature-Namen/IDs ein.
 
 ### `layout-library.ts`
 - Persistiert Layouts als JSON-Dateien im Vault-Ordner `LayoutEditor/Layouts`.

--- a/layout-editor/src/element-preview.ts
+++ b/layout-editor/src/element-preview.ts
@@ -5,10 +5,21 @@ import { getLayoutElementComponent } from "./elements/registry";
 
 export function renderElementPreview(deps: ElementPreviewDependencies) {
     const { host, element } = deps;
+    const hostWithCleanup = host as HTMLElement & { __smPreviewCleanup__?: () => void };
+    if (hostWithCleanup.__smPreviewCleanup__) {
+        hostWithCleanup.__smPreviewCleanup__();
+        delete hostWithCleanup.__smPreviewCleanup__;
+    }
     host.empty();
     host.toggleClass("sm-le-box__content", true);
     const preview = host.createDiv({ cls: `sm-le-preview sm-le-preview--${element.type}` });
-    const context: ElementPreviewContext = { ...deps, preview, container: host };
+    const registerPreviewCleanup = (cleanup: () => void) => {
+        if (hostWithCleanup.__smPreviewCleanup__) {
+            hostWithCleanup.__smPreviewCleanup__();
+        }
+        hostWithCleanup.__smPreviewCleanup__ = cleanup;
+    };
+    const context: ElementPreviewContext = { ...deps, preview, container: host, registerPreviewCleanup };
 
     const component = getLayoutElementComponent(element.type);
     if (component) {

--- a/layout-editor/src/elements/ElementsOverview.txt
+++ b/layout-editor/src/elements/ElementsOverview.txt
@@ -21,7 +21,7 @@ plugins/layout-editor/src/elements/
    ├─ text-input.ts         # Freistehendes einzeiliges Texteingabefeld
    ├─ textarea.ts           # Mehrzeiliges Texteingabefeld mit Placeholder
    ├─ vbox-container.ts     # Vertikaler Container mit Stretch-Align
-   └─ view-container.ts     # Spezialfläche für externe Visualisierungen (Feature-Bindings + Kamera-Demo)
+   └─ view-container.ts     # Spezialfläche für externe Visualisierungen (Feature-Bindings + Kamera-Demo mit Live-Re-Fitting)
 ```
 
 ## Vererbungsstruktur
@@ -47,7 +47,7 @@ ElementComponentBase
 - **Container-Verhalten:** `ContainerComponent` stellt Standardlayout, Preview und Inspector-Einträge für Container sicher; `container-preview.ts` zeichnet die Vorschau konsistent.
 - **Manifest & Registry:** `component-manifest.ts` und `registry.ts` verbinden sämtliche Komponenten mit Palette und Inspector.
 - **UI-Komponenten (`ui.ts`):** Stellt generische Controls für Buttons, Felder, Inputs und Statusanzeigen bereit, die in View, Inspector und Modals verwendet werden.
-- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom), passt die Demo-Oberfläche automatisch an die Boxgröße an und spiegelt gewählte Bindings wider.
+- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom), hält die Demo-Oberfläche via `ResizeObserver`/RAF-Fallback lückenlos an die Boxgröße angepasst und spiegelt gewählte Bindings wider.
 
 ## Datei-Referenz
 - **`base.ts`:** Typisiert Preview-/Inspector-Kontexte, Factory-Signaturen und Komponentenschnittstellen.
@@ -64,5 +64,5 @@ ElementComponentBase
 - **`components/textarea.ts`:** Konfiguriert `TextFieldComponent` für mehrzeilige Eingaben inkl. Placeholder-Steuerung.
 - **`components/label.ts`:** Realisiert Inline-Editing für Überschriften samt dynamischer Schriftgrößenanpassung.
 - **`components/separator.ts`:** Rendert optionale Überschrift plus Trennlinie ohne zusätzliche Basisklasse.
-- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese beim Rendern an die aktuelle Elementgröße aus und zeigt den gewählten Binding-Namen/ID an.
+- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese per `ResizeObserver` (Fallback: RAF-Loop) dauerhaft an die aktuelle Elementgröße aus, bereinigt Observer/RAF bei Re-Renders und zeigt den gewählten Binding-Namen/ID an.
 - **`ui.ts`:** Bündelt allgemeine UI-Bausteine (Buttons, Formularfelder, Selects, Statusanzeigen, Stacks), damit der Editor komplett auf Elements-Komponenten basiert.

--- a/layout-editor/src/elements/base.ts
+++ b/layout-editor/src/elements/base.ts
@@ -15,6 +15,7 @@ export interface ElementPreviewDependencies {
 export interface ElementPreviewContext extends ElementPreviewDependencies {
     preview: HTMLElement;
     container: HTMLElement;
+    registerPreviewCleanup(cleanup: () => void): void;
 }
 
 export interface ElementInspectorSections {


### PR DESCRIPTION
## Summary
- add a cleanup-aware ResizeObserver/RAF loop to keep the view-container preview camera aligned with the viewport
- allow preview renderers to register cleanup handlers so observers and animation frames are disposed when previews are rebuilt
- document the new responsive behaviour in the layout editor overviews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a38d9d60832589bc46f9b504b42b