### PR TITLE
Fix view container preview sizing

### DIFF
--- a/layout-editor/main.js
+++ b/layout-editor/main.js
@@ -4745,6 +4745,7 @@ var LAYOUT_EDITOR_CSS = `
     flex-direction: column;
     gap: 0.25rem;
     padding: 0.15rem;
+    box-sizing: border-box;
 }
 
 .sm-le-preview--view-container {

--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -48,7 +48,7 @@ plugins/layout-editor/
 ## Features & Verantwortlichkeiten
 
 - **Plugin-Einstieg (`main.ts`):** Registriert den `LayoutEditorView`, richtet Ribbon-Icon und Command ein, injiziert die Styles aus `css.ts` und stellt über `getApi()` ein `LayoutEditorPluginApi` bereit (Open-View, Registry-Hooks, Layout-Library-Funktionen).
-- **Eigenes Styling (`css.ts`):** Enthält das komplette Layout-Editor-CSS. Wird ausschließlich vom Layout-Editor-Plugin injiziert und kollidiert somit nicht länger mit SaltMarcher-spezifischem Styling.
+- **Eigenes Styling (`css.ts`):** Enthält das komplette Layout-Editor-CSS. Wird ausschließlich vom Layout-Editor-Plugin injiziert und kollidiert somit nicht länger mit SaltMarcher-spezifischem Styling. Die View-Container-Vorschau nutzt nun `box-sizing: border-box`, damit das Canvas-Clamping trotz Padding exakt an der sichtbaren Kante greift.
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Panning, Zoom und Panel-Resizer halten Bounds-Clamping und Fokusverhalten konsistent.
 - **Struktur-Überblick:** Interaktiver Baum mit Drag & Drop zur Container-Neuzuordnung (inkl. Root-Drop-Zone) und zyklusgesicherter Elternwahl. Inspector- und Baum-Breiten lassen sich über Trenner anpassen.
 - **Elementbibliothek & Registry:** Der „+ Element“-Trigger öffnet den `ElementPickerModal`, der alle Definitionen als einklappbare Baumstruktur darstellt. Registry-Änderungen aktualisieren die Baumansicht live, neue Komponenten landen weiterhin nur unter `src/elements/components/`.

--- a/layout-editor/src/css.ts
+++ b/layout-editor/src/css.ts
@@ -586,6 +586,7 @@ export const LAYOUT_EDITOR_CSS = `
     flex-direction: column;
     gap: 0.25rem;
     padding: 0.15rem;
+    box-sizing: border-box;
 }
 
 .sm-le-preview--view-container {

--- a/layout-editor/src/elements/ElementsOverview.txt
+++ b/layout-editor/src/elements/ElementsOverview.txt
@@ -64,5 +64,5 @@ ElementComponentBase
 - **`components/textarea.ts`:** Konfiguriert `TextFieldComponent` für mehrzeilige Eingaben inkl. Placeholder-Steuerung.
 - **`components/label.ts`:** Realisiert Inline-Editing für Überschriften samt dynamischer Schriftgrößenanpassung.
 - **`components/separator.ts`:** Rendert optionale Überschrift plus Trennlinie ohne zusätzliche Basisklasse.
-- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese per `ResizeObserver` (Fallback: RAF-Loop) dauerhaft an die aktuelle Elementgröße aus, bereinigt Observer/RAF bei Re-Renders und zeigt den gewählten Binding-Namen/ID an.
+- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese per `ResizeObserver` (Fallback: RAF-Loop) dauerhaft an die aktuelle Elementgröße aus, bereinigt Observer/RAF bei Re-Renders, setzt via `box-sizing: border-box` auf exakte Außenmaße und zeigt den gewählten Binding-Namen/ID an.
 - **`ui.ts`:** Bündelt allgemeine UI-Bausteine (Buttons, Formularfelder, Selects, Statusanzeigen, Stacks), damit der Editor komplett auf Elements-Komponenten basiert.


### PR DESCRIPTION
## Summary
- ensure the view container preview uses border-box sizing so padding no longer increases the external width
- rebuild the bundled plugin output after the style adjustment
- document the corrected preview sizing in the layout editor and elements overviews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d620a7634c8325bcf12eded88ed10a