### PR TITLE
Fix layout editor viewport flex sizing

### DIFF
--- a/layout-editor/main.js
+++ b/layout-editor/main.js
@@ -4776,6 +4776,8 @@ var LAYOUT_EDITOR_CSS = `
 .sm-view-container__viewport {
     position: relative;
     flex: 1;
+    min-width: 0;
+    min-height: 0;
     overflow: hidden;
     cursor: grab;
     touch-action: none;

--- a/layout-editor/src/LayoutEditorOverview.txt
+++ b/layout-editor/src/LayoutEditorOverview.txt
@@ -48,7 +48,7 @@ plugins/layout-editor/
 ## Features & Verantwortlichkeiten
 
 - **Plugin-Einstieg (`main.ts`):** Registriert den `LayoutEditorView`, richtet Ribbon-Icon und Command ein, injiziert die Styles aus `css.ts` und stellt über `getApi()` ein `LayoutEditorPluginApi` bereit (Open-View, Registry-Hooks, Layout-Library-Funktionen).
-- **Eigenes Styling (`css.ts`):** Enthält das komplette Layout-Editor-CSS. Wird ausschließlich vom Layout-Editor-Plugin injiziert und kollidiert somit nicht länger mit SaltMarcher-spezifischem Styling. Die View-Container-Vorschau nutzt nun `box-sizing: border-box`, damit das Canvas-Clamping trotz Padding exakt an der sichtbaren Kante greift.
+- **Eigenes Styling (`css.ts`):** Enthält das komplette Layout-Editor-CSS. Wird ausschließlich vom Layout-Editor-Plugin injiziert und kollidiert somit nicht länger mit SaltMarcher-spezifischem Styling. Die View-Container-Vorschau nutzt `box-sizing: border-box` und erzwingt mit `min-width/min-height: 0` auf dem flexiblen Viewport, dass die Demo-Fläche auch bei großen Surface-Inhalten innerhalb des 960 px-Frames bleibt und sauber schrumpfen kann.
 - **Layout-Arbeitsfläche & Kamera:** Dreigeteilte Arbeitsumgebung mit Strukturbaum links, Canvas in der Mitte und Inspector rechts. Panning, Zoom und Panel-Resizer halten Bounds-Clamping und Fokusverhalten konsistent.
 - **Struktur-Überblick:** Interaktiver Baum mit Drag & Drop zur Container-Neuzuordnung (inkl. Root-Drop-Zone) und zyklusgesicherter Elternwahl. Inspector- und Baum-Breiten lassen sich über Trenner anpassen.
 - **Elementbibliothek & Registry:** Der „+ Element“-Trigger öffnet den `ElementPickerModal`, der alle Definitionen als einklappbare Baumstruktur darstellt. Registry-Änderungen aktualisieren die Baumansicht live, neue Komponenten landen weiterhin nur unter `src/elements/components/`.
@@ -125,6 +125,7 @@ plugins/layout-editor/
 ### `css.ts`
 - Kapselt das komplette Layout-Editor-Styling als Template-String.
 - Wird nur vom Layout-Editor-Plugin geladen, um Konflikte mit anderen Plugins zu vermeiden.
+- Setzt im View-Container-Viewport `min-width`/`min-height` auf 0, damit das Flex-Item unabhängig von der Surface-Größe innerhalb des Rahmens bleiben kann.
 
 ### `index.ts`
 - Re-exportiert Plugin-Klasse, API-Typ, Registry- und Library-Hilfen für Drittcode.

--- a/layout-editor/src/css.ts
+++ b/layout-editor/src/css.ts
@@ -617,6 +617,8 @@ export const LAYOUT_EDITOR_CSS = `
 .sm-view-container__viewport {
     position: relative;
     flex: 1;
+    min-width: 0;
+    min-height: 0;
     overflow: hidden;
     cursor: grab;
     touch-action: none;

--- a/layout-editor/src/elements/ElementsOverview.txt
+++ b/layout-editor/src/elements/ElementsOverview.txt
@@ -47,7 +47,7 @@ ElementComponentBase
 - **Container-Verhalten:** `ContainerComponent` stellt Standardlayout, Preview und Inspector-Einträge für Container sicher; `container-preview.ts` zeichnet die Vorschau konsistent.
 - **Manifest & Registry:** `component-manifest.ts` und `registry.ts` verbinden sämtliche Komponenten mit Palette und Inspector.
 - **UI-Komponenten (`ui.ts`):** Stellt generische Controls für Buttons, Felder, Inputs und Statusanzeigen bereit, die in View, Inspector und Modals verwendet werden.
-- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom), hält die Demo-Oberfläche via `ResizeObserver`/RAF-Fallback lückenlos an die Boxgröße angepasst und spiegelt gewählte Bindings wider.
+- **View-Bindings:** `view-container.ts` bringt eine experimentelle View-Fläche inklusive Inspector-Feld für registrierte Features. Die Preview demonstriert Kamerasteuerung (MMB-Pan, Wheel-Zoom), hält die Demo-Oberfläche via `ResizeObserver`/RAF-Fallback lückenlos an die Boxgröße angepasst, setzt `min-width/min-height: 0` auf dem flexiblen Viewport und spiegelt gewählte Bindings wider.
 
 ## Datei-Referenz
 - **`base.ts`:** Typisiert Preview-/Inspector-Kontexte, Factory-Signaturen und Komponentenschnittstellen.
@@ -64,5 +64,5 @@ ElementComponentBase
 - **`components/textarea.ts`:** Konfiguriert `TextFieldComponent` für mehrzeilige Eingaben inkl. Placeholder-Steuerung.
 - **`components/label.ts`:** Realisiert Inline-Editing für Überschriften samt dynamischer Schriftgrößenanpassung.
 - **`components/separator.ts`:** Rendert optionale Überschrift plus Trennlinie ohne zusätzliche Basisklasse.
-- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese per `ResizeObserver` (Fallback: RAF-Loop) dauerhaft an die aktuelle Elementgröße aus, bereinigt Observer/RAF bei Re-Renders, setzt via `box-sizing: border-box` auf exakte Außenmaße und zeigt den gewählten Binding-Namen/ID an.
+- **`components/view-container.ts`:** Koppelt Layout-Elemente an die View-Registry. Inspector bietet eine Feature-Auswahl, Preview stellt eine panning-/zoomfähige Demo-Fläche bereit, richtet diese per `ResizeObserver` (Fallback: RAF-Loop) dauerhaft an die aktuelle Elementgröße aus, bereinigt Observer/RAF bei Re-Renders, setzt via `box-sizing: border-box` und `min-width`/`min-height: 0` auf exakte, frei schrumpfbare Außenmaße und zeigt den gewählten Binding-Namen/ID an.
 - **`ui.ts`:** Bündelt allgemeine UI-Bausteine (Buttons, Formularfelder, Selects, Statusanzeigen, Stacks), damit der Editor komplett auf Elements-Komponenten basiert.


### PR DESCRIPTION
## Summary
- allow the view container viewport flex item to shrink freely by enforcing `min-width` and `min-height` of 0 in the stylesheet
- document the updated flex configuration in the layout editor and elements overview notes
- rebuild the plugin bundle so the shipped CSS contains the fix

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d624fdec608325b550162ff1a778eb