### PR TITLE
Simplify Cartographer registration

### DIFF
--- a/salt-marcher/PluginOverview.txt
+++ b/salt-marcher/PluginOverview.txt
@@ -1,11 +1,11 @@
 # Salt Marcher – Plugin Overview
 
-Salt Marcher liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen. Der Code ist nun klar vom Layout Editor getrennt – letzterer lebt als eigenes Plugin unter `plugins/layout-editor` und wird nicht mehr automatisch mitgeladen.
+Salt Marcher liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen. Der Code ist klar vom Layout Editor getrennt – letzterer lebt als eigenes Plugin im Repository (`layout-editor/`) und wird nicht mehr automatisch mitgeladen.
 
 ## Struktur
 
 ```
-plugins/
+Salt-Marcher/
 ├─ salt-marcher/
 │  ├─ manifest.json          # Obsidian-Manifest (lädt das gebündelte main.js im Plugin-Stamm)
 │  ├─ esbuild.config.mjs     # Build-Pipeline (bundelt src/app/main.ts → main.js)
@@ -29,7 +29,7 @@ plugins/
 
 ## Features & Verantwortlichkeiten
 
-- **Plugin-Bootstrap (`src/app/main.ts`):** Registriert Cartographer-, Encounter- und Library-Views, injiziert das Salt-Marcher-CSS und hält Terrain-Daten aktuell. Layout-bezogene Ribbons/Commands entfallen – diese liefert nun das unabhängige Layout-Editor-Plugin.
+- **Plugin-Bootstrap (`src/app/main.ts`):** Registriert Cartographer-, Encounter- und Library-Views, injiziert das Salt-Marcher-CSS, hält Terrain-Daten aktuell und nutzt die Cartographer-Helfer (`openCartographer`, `detachCartographerLeaves`) als einzige Entry-Points für Kommandos/Ribbons.
 - **Cartographer-Workspace:** Map-Stage mit Editor-, Inspector- und Travel-Modi inklusive Renderer-Synchronisierung, Dateioperationen und Modusverwaltung.
 - **Library-View:** Einheitliche Verwaltung von Terrains, Regionen und Kreaturen mit Suche, Create-Workflows und Persistenz.
 - **Encounter-View:** Schlanke Ansicht für Encounter-Notizen.
@@ -52,7 +52,7 @@ plugins/
 - `css.ts`: Enthält das Styling für Cartographer, Library und Encounter. Layout-Editor-spezifische Klassen wurden entfernt.
 
 ### `src/apps/cartographer`
-- `index.ts`: Meldet `CartographerView` bei Obsidian an, verwaltet Ribbon/Command-Anbindung und mountet `view-shell.ts` in einem `cartographer-host`-Element.
+- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`), die von `main.ts` genutzt werden, um den View zentral zu registrieren und zu öffnen.
 - `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap` und delegiert Hex-Events an Modi.
 - `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap`, nutzt den gemeinsamen `view-container` als Map-Host und delegiert Hex-Events an Modi.
 - `modes/editor.ts`: Sidebar für den Editor-Modus. Bindet Tool-Infrastruktur aus `editor/`, synchronisiert Brush-Vorschau und persistiert Terrain-Änderungen über `RenderHandles`.
@@ -85,6 +85,6 @@ plugins/
 
 ## Zusammenarbeit mit dem Layout-Editor
 
-- Das Layout-Editor-Plugin liegt unter `plugins/layout-editor/` und bringt eigenes Manifest, Build und CSS mit.
+- Das Layout-Editor-Plugin liegt unter `layout-editor/` und bringt eigenes Manifest, Build und CSS mit.
 - Falls benötigt, kann Salt Marcher über Obsidian den Layout Editor parallel laden und über dessen öffentliches API (`getApi()` aus `layout-editor`-Plugin) Layout-Definitionen registrieren oder Layouts laden – ohne direkte Code-Abhängigkeit im Salt-Marcher-Build.
 - `layout-editor-bridge.ts` registriert – sobald verfügbar – das Cartographer-Mapping als `viewBindingId` beim Layout Editor, sodass dessen View Container die Karte als Feature anbietet.

--- a/salt-marcher/src/app/main.ts
+++ b/salt-marcher/src/app/main.ts
@@ -2,11 +2,10 @@
 import { Plugin, WorkspaceLeaf } from "obsidian";
 // Legacy views removed (consolidated into Library)
 import { EncounterView, VIEW_ENCOUNTER } from "../apps/encounter/view";
-import { VIEW_CARTOGRAPHER, CartographerView } from "../apps/cartographer";
+import { VIEW_CARTOGRAPHER, CartographerView, openCartographer, detachCartographerLeaves } from "../apps/cartographer";
 import { VIEW_LIBRARY, LibraryView } from "../apps/library/view";
 import { ensureTerrainFile, loadTerrains, watchTerrains } from "../core/terrain-store";
 import { setTerrains } from "../core/terrain";
-import { getCenterLeaf } from "../core/layout";
 import { HEX_PLUGIN_CSS } from "./css";
 import { setupLayoutEditorBridge } from "./layout-editor-bridge";
 
@@ -26,9 +25,7 @@ export default class SaltMarcherPlugin extends Plugin {
 
         // Ribbons
         this.addRibbonIcon("compass", "Open Cartographer", async () => {
-            const leaf = getCenterLeaf(this.app);
-            await leaf.setViewState({ type: VIEW_CARTOGRAPHER, active: true });
-            this.app.workspace.revealLeaf(leaf);
+            await openCartographer(this.app);
         });
         this.addRibbonIcon("book", "Open Library", async () => {
             const leaf = this.app.workspace.getLeaf(true);
@@ -41,9 +38,7 @@ export default class SaltMarcherPlugin extends Plugin {
             id: "open-cartographer",
             name: "Cartographer öffnen",
             callback: async () => {
-                const leaf = getCenterLeaf(this.app);
-                await leaf.setViewState({ type: VIEW_CARTOGRAPHER, active: true });
-                this.app.workspace.revealLeaf(leaf);
+                await openCartographer(this.app);
             },
         });
         this.addCommand({
@@ -61,9 +56,10 @@ export default class SaltMarcherPlugin extends Plugin {
         this.teardownLayoutBridge = setupLayoutEditorBridge(this);
     }
 
-    onunload() {
+    async onunload() {
         this.unwatchTerrains?.();
         this.teardownLayoutBridge?.();
+        await detachCartographerLeaves(this.app);
         this.removeCss();
     }
 


### PR DESCRIPTION
## Summary
- remove the unused CartographerPlugin class and expose helper functions for reusing its leaf-handling logic
- update SaltMarcherPlugin to rely on the shared helpers for commands, ribbons, and unloading
- refresh the Salt Marcher plugin overview to describe the single entry point and new helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d63cd9ca2883258e996db416dff13a