### PR TITLE
Document single SaltMarcher plugin entry point

### DIFF
--- a/Critique.txt
+++ b/Critique.txt
@@ -2,7 +2,7 @@
 
 ## 1. Architektur & Modularität
 ### 1.1 Einstiegs- und Registrierungslogik
-- In `src/app/main.ts` wird das eigentliche Plugin registriert, gleichzeitig existiert in `src/apps/cartographer/index.ts` weiterhin eine komplette `CartographerPlugin`-Klasse inklusive eigener Ribbon- und Command-Registrierung.【F:salt-marcher/src/app/main.ts†L16-L74】【F:salt-marcher/src/apps/cartographer/index.ts†L54-L88】 Diese Dopplung erzeugt ein zweites (nicht verwendetes) Entry-Point-Objekt und verwirrt den Build. Sie sollte entfernt oder in dedizierte „feature module“-Funktionen zerlegt werden.
+- ✅ Behoben (2024-04-09): `SaltMarcherPlugin` ist der einzige Entry Point. `src/apps/cartographer/index.ts` exportiert nur noch View- und Leaf-Helfer; Ribbon/Command-Registrierung liegt vollständig in `src/app/main.ts`.
 - `CartographerView` kapselt sowohl View-API als auch Dateiauswahl, während `mountCartographer` erneut State hält. Eine klare Trennung (z. B. Presenter vs. View) fehlt, wodurch Testbarkeit und Erweiterbarkeit leiden.【F:salt-marcher/src/apps/cartographer/index.ts†L9-L52】
 
 ### 1.2 Cartographer-Shell

--- a/salt-marcher/PluginOverview.txt
+++ b/salt-marcher/PluginOverview.txt
@@ -29,7 +29,7 @@ Salt-Marcher/
 
 ## Features & Verantwortlichkeiten
 
-- **Plugin-Bootstrap (`src/app/main.ts`):** Registriert Cartographer-, Encounter- und Library-Views, injiziert das Salt-Marcher-CSS, hält Terrain-Daten aktuell und nutzt die Cartographer-Helfer (`openCartographer`, `detachCartographerLeaves`) als einzige Entry-Points für Kommandos/Ribbons.
+- **Plugin-Bootstrap (`src/app/main.ts`):** Registriert Cartographer-, Encounter- und Library-Views, injiziert das Salt-Marcher-CSS, hält Terrain-Daten aktuell und nutzt die Cartographer-Helfer (`openCartographer`, `detachCartographerLeaves`) als einzige Entry-Points für Kommandos/Ribbons – es existiert kein zweites Plugin-Objekt mehr.
 - **Cartographer-Workspace:** Map-Stage mit Editor-, Inspector- und Travel-Modi inklusive Renderer-Synchronisierung, Dateioperationen und Modusverwaltung.
 - **Library-View:** Einheitliche Verwaltung von Terrains, Regionen und Kreaturen mit Suche, Create-Workflows und Persistenz.
 - **Encounter-View:** Schlanke Ansicht für Encounter-Notizen.
@@ -51,8 +51,7 @@ Salt-Marcher/
 - `main.ts`: Einstiegspunkt des Plugins. Registriert Views/Commands, lädt Terrain-Daten (`ensureTerrainFile`, `loadTerrains`, `watchTerrains`), injiziert CSS.
 - `css.ts`: Enthält das Styling für Cartographer, Library und Encounter. Layout-Editor-spezifische Klassen wurden entfernt.
 
-### `src/apps/cartographer`
-- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`), die von `main.ts` genutzt werden, um den View zentral zu registrieren und zu öffnen.
+- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`); Registrierung & Befehle liegen ausschließlich im `SaltMarcherPlugin`.
 - `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap` und delegiert Hex-Events an Modi.
 - `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap`, nutzt den gemeinsamen `view-container` als Map-Host und delegiert Hex-Events an Modi.
 - `modes/editor.ts`: Sidebar für den Editor-Modus. Bindet Tool-Infrastruktur aus `editor/`, synchronisiert Brush-Vorschau und persistiert Terrain-Änderungen über `RenderHandles`.

--- a/salt-marcher/src/apps/cartographer/CartographerOverview.txt
+++ b/salt-marcher/src/apps/cartographer/CartographerOverview.txt
@@ -13,7 +13,7 @@ src/apps/cartographer/
 │        ├─ brush-options.ts # Brush-Tool (UI, Radius-/Terrainwahl, Statushandling)
 │        ├─ brush.ts         # Persistiert Terrain-Änderungen + Live-Fill
 │        └─ brush-math.ts    # Hex-Radius-Berechnungen im odd-r Grid
-├─ index.ts                 # Obsidian-View inkl. Ribbon/Command-Anbindung
+├─ index.ts                 # Obsidian-View + Leaf-Helfer (Registrierung via SaltMarcherPlugin)
 ├─ view-shell.ts            # Layout, Map-Stage und Modusverwaltung
 ├─ modes/
 │  ├─ editor.ts             # Map-Editor-Modus (Tools, Brush, Sidebar-Panel)
@@ -29,7 +29,7 @@ src/apps/cartographer/
 
 ## Features & Verantwortlichkeiten
 
-- **View-Registrierung:** `index.ts` meldet `VIEW_TYPE_CARTOGRAPHER` an, richtet Ribbon & Command ein und kümmert sich um Mount/Cleanup des Views.
+- **View-Registrierung:** `index.ts` meldet `VIEW_TYPE_CARTOGRAPHER` an, stellt `CartographerView` bereit und liefert Leaf-Helfer (`openCartographer`, `detachCartographerLeaves`). Ribbons/Commands werden ausschließlich im `SaltMarcherPlugin` registriert.
 - **Layout-Shell:** `view-shell.ts` übernimmt das Cartographer-Grundlayout (Header + Body mit Map/Sidebar), verwaltet den Moduswechsel, bindet `createMapManager` für Open/Create/Delete ein und stellt `CartographerModeContext` inkl. `getOptions()` bereit.
 - **Map-Stage:** Rendert Karten via `createMapLayer`/`renderHexMap`, verwaltet `RenderHandles`, Hex-Klick-Delegation sowie Options-Parsing (`getFirstHexBlock` → `parseOptions`) und zeigt sinnvolle Platzhalter, wenn kein File oder kein Hex-Block vorliegt.
 - **Modus-System:** Stellt das Mode-Interface (`onEnter`, `onExit`, `onFileChange`, `onHexClick`, `onSave`) bereit, schaltet über ein Dropdown im Header zwischen Travel/Editor/Inspector um, delegiert Events und räumt Ressourcen deterministisch auf.
@@ -42,8 +42,8 @@ src/apps/cartographer/
 ## Dateibeschreibungen
 
 ### `index.ts`
-- Exportiert `CartographerView` und `VIEW_TYPE_CARTOGRAPHER`.
-- Registriert Ribbon & Command, damit der View erreichbar ist.
+- Exportiert `CartographerView`, `VIEW_TYPE_CARTOGRAPHER` sowie Leaf-/Open-Helfer für den Plugin-Bootstrap.
+- Verzichtet bewusst auf eine eigene Plugin-Klasse; Registrierungen erfolgen über `SaltMarcherPlugin` (`src/app/main.ts`).
 - Erzeugt einen Host (`cartographer-host`), mountet `view-shell.ts`, reicht `setFile`-Aufrufe weiter und räumt beim Schließen auf.
 
 ### `view-shell.ts`


### PR DESCRIPTION
## Summary
- update the plugin and cartographer overviews to note that SaltMarcherPlugin is the sole entry point and commands/ribbons are registered there
- mark the resolved duplicate CartographerPlugin finding in Critique.txt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d68bdb1e48832599d1e0128914d135