### PR TITLE
Refactor cartographer UI to presenter/controller pattern

### DIFF
--- a/Critique.txt
+++ b/Critique.txt
@@ -3,10 +3,10 @@
 ## 1. Architektur & Modularität
 ### 1.1 Einstiegs- und Registrierungslogik
 - ✅ Behoben (2024-04-09): `SaltMarcherPlugin` ist der einzige Entry Point. `src/apps/cartographer/index.ts` exportiert nur noch View- und Leaf-Helfer; Ribbon/Command-Registrierung liegt vollständig in `src/app/main.ts`.
-- `CartographerView` kapselt sowohl View-API als auch Dateiauswahl, während `mountCartographer` erneut State hält. Eine klare Trennung (z. B. Presenter vs. View) fehlt, wodurch Testbarkeit und Erweiterbarkeit leiden.【F:salt-marcher/src/apps/cartographer/index.ts†L9-L52】
+- ✅ Behoben (2024-05-07): `CartographerView` delegiert Lifecycle & Dateiauswahl vollständig an `CartographerPresenter`; die View ist auf Obsidian-Wiring reduziert.【F:salt-marcher/src/apps/cartographer/index.ts†L1-L45】【F:salt-marcher/src/apps/cartographer/presenter.ts†L1-L254】
 
 ### 1.2 Cartographer-Shell
-- `mountCartographer` ist ein 300‑Zeilen-Monolith, der UI-Aufbau, Modusmanagement, Dateiladen, Render-Lifecycle und Dropdown-Interaktionen bündelt.【F:salt-marcher/src/apps/cartographer/view-shell.ts†L51-L218】 Diese Vermischung erschwert Wiederverwendung und erschafft komplexe Seiteneffekte. Empfohlen ist die Aufteilung in kleinere Services (ModeRegistry, MapLoader, HeaderController) mit klaren Verantwortlichkeiten.
+- ✅ Behoben (2024-05-07): State-Logik liegt nun im `CartographerPresenter`, während `view-shell.ts` ausschließlich DOM-Komposition + Callback-Wiring übernimmt. Presenter-Tests decken Mode-Wechsel & File-Reaktionen ab.【F:salt-marcher/src/apps/cartographer/presenter.ts†L1-L254】【F:salt-marcher/src/apps/cartographer/view-shell.ts†L1-L146】【F:salt-marcher/tests/cartographer/presenter.test.ts†L1-L139】
 - Die Modi sind hart im Shell-Code verdrahtet (`createTravelGuideMode`, `createEditorMode`, `createInspectorMode`).【F:salt-marcher/src/apps/cartographer/view-shell.ts†L92-L96】 Erweiterungen oder Konfigurationen erfordern Codeänderungen statt deklarativer Registrierung.
 - `modeChange` verkettet Promises manuell, aber eine Fehlerblase kann den Zustand inkonsistent lassen (z. B. nach Throw bleibt `modeChange` ungelöst). Eine State-Machine oder Task-Queue mit finally-Block wäre robuster.【F:salt-marcher/src/apps/cartographer/view-shell.ts†L121-L147】
 

--- a/salt-marcher/PluginOverview.txt
+++ b/salt-marcher/PluginOverview.txt
@@ -50,10 +50,12 @@ Salt-Marcher/
 ### `src/app`
 - `main.ts`: Einstiegspunkt des Plugins. Registriert Views/Commands, lädt Terrain-Daten (`ensureTerrainFile`, `loadTerrains`, `watchTerrains`), injiziert CSS.
 - `css.ts`: Enthält das Styling für Cartographer, Library und Encounter. Layout-Editor-spezifische Klassen wurden entfernt.
+- `layout-editor-bridge.ts`: Bindet den Cartographer optional an den Layout Editor (View-Bindings).
 
-- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`); Registrierung & Befehle liegen ausschließlich im `SaltMarcherPlugin`.
-- `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap` und delegiert Hex-Events an Modi.
-- `view-shell.ts`: Baut Layout (Header, Stage, Sidebar), hält aktiven Modus, lädt Karten via `createMapLayer`/`renderHexMap`, nutzt den gemeinsamen `view-container` als Map-Host und delegiert Hex-Events an Modi.
+### `src/apps/cartographer`
+- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`); delegiert Lifecycle an den Presenter.
+- `presenter.ts`: Kapselt Datei-/Mode-State, Map-Rendering und Hex-Ereignisse; koordiniert Map-Manager, Modi und View-Shell.
+- `view-shell.ts`: Rendert Header, Map-Stage und Sidebar-Hosts, liefert ein Handle zur UI-Aktualisierung und ruft Presenter-Callbacks (Open/Create/Delete/Save, Mode-Wahl, `hex:click`) auf.
 - `modes/editor.ts`: Sidebar für den Editor-Modus. Bindet Tool-Infrastruktur aus `editor/`, synchronisiert Brush-Vorschau und persistiert Terrain-Änderungen über `RenderHandles`.
 - `modes/inspector.ts`: Inspector-Sidebar zum Bearbeiten von Terrain/Notizen eines ausgewählten Hex. Nutzt `hex-notes` für Dateioperationen und aktualisiert Renderer-Fills live.
 - `modes/travel-guide.ts`: Verknüpft Travel-Logik (Playback, Token, Routen) mit dem Cartographer, verwaltet UI-Sidebar und Persistenz über `travel/domain`.
@@ -81,6 +83,9 @@ Salt-Marcher/
 ### `src/ui`
 - `UiOverview.txt`: Übersicht über Struktur und Verantwortlichkeiten der UI-Bausteine.
 - `modals.ts`, `map-workflows.ts`, `map-manager.ts`, `map-header.ts`, `confirm-delete.ts`, `search-dropdown.ts`, `view-container.ts`: Geteilte UI- und Workflow-Komponenten.
+
+### `tests`
+- `cartographer/presenter.test.ts`: Vitest-Suite, die Presenter-Mode-Wechsel und Dateireaktionen ohne DOM-Verknüpfung prüft (inkl. Obsidian-Mocks).
 
 ## Zusammenarbeit mit dem Layout-Editor
 

--- a/salt-marcher/package-lock.json
+++ b/salt-marcher/package-lock.json
@@ -10,9 +10,46 @@
       "devDependencies": {
         "@types/node": "^20.12.12",
         "esbuild": "^0.21.5",
+        "jsdom": "^27.0.0",
         "obsidian": "^1.6.0",
-        "typescript": "^5.5.4"
+        "typescript": "^5.5.4",
+        "vitest": "^1.6.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.6.tgz",
+      "integrity": "sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/state": {
       "version": "6.5.2",
@@ -37,6 +74,144 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -430,6 +605,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
@@ -437,6 +632,321 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -475,6 +985,198 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -482,6 +1184,125 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -522,6 +1343,310 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -530,6 +1655,61 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/obsidian": {
@@ -547,6 +1727,337 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
@@ -554,6 +2065,96 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.2",
@@ -569,12 +2170,168 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
@@ -583,6 +2340,151 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/salt-marcher/package.json
+++ b/salt-marcher/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
-    "build": "node esbuild.config.mjs"
+    "build": "node esbuild.config.mjs",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "esbuild": "^0.21.5",
-    "typescript": "^5.5.4",
     "@types/node": "^20.12.12",
-    "obsidian": "^1.6.0"
+    "esbuild": "^0.21.5",
+    "jsdom": "^27.0.0",
+    "obsidian": "^1.6.0",
+    "typescript": "^5.5.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/salt-marcher/src/apps/cartographer/CartographerOverview.txt
+++ b/salt-marcher/src/apps/cartographer/CartographerOverview.txt
@@ -14,7 +14,8 @@ src/apps/cartographer/
 │        ├─ brush.ts         # Persistiert Terrain-Änderungen + Live-Fill
 │        └─ brush-math.ts    # Hex-Radius-Berechnungen im odd-r Grid
 ├─ index.ts                 # Obsidian-View + Leaf-Helfer (Registrierung via SaltMarcherPlugin)
-├─ view-shell.ts            # Layout, Map-Stage und Modusverwaltung
+├─ presenter.ts             # Presenter orchestriert Mode-/File-State und Rendering
+├─ view-shell.ts            # DOM-Aufbau (Header, Stage, Sidebar) + UI-Callbacks
 ├─ modes/
 │  ├─ editor.ts             # Map-Editor-Modus (Tools, Brush, Sidebar-Panel)
 │  ├─ inspector.ts          # Inspector-Modus (Terrain & Notizen pro Hex bearbeiten)
@@ -30,7 +31,7 @@ src/apps/cartographer/
 ## Features & Verantwortlichkeiten
 
 - **View-Registrierung:** `index.ts` meldet `VIEW_TYPE_CARTOGRAPHER` an, stellt `CartographerView` bereit und liefert Leaf-Helfer (`openCartographer`, `detachCartographerLeaves`). Ribbons/Commands werden ausschließlich im `SaltMarcherPlugin` registriert.
-- **Layout-Shell:** `view-shell.ts` übernimmt das Cartographer-Grundlayout (Header + Body mit Map/Sidebar), verwaltet den Moduswechsel, bindet `createMapManager` für Open/Create/Delete ein und stellt `CartographerModeContext` inkl. `getOptions()` bereit.
+- **Presenter & View-Shell:** `presenter.ts` hält Datei-, Mode- und Renderer-State zusammen, orchestriert Map-Manager, Mode-Lifecycle und Hex-Klick-Delegation. `view-shell.ts` rendert ausschließlich den DOM (Header, Mode-Dropdown, Map-Stage, Sidebar) und koppelt UI-Aktionen zurück an den Presenter.
 - **Map-Stage:** Rendert Karten via `createMapLayer`/`renderHexMap`, verwaltet `RenderHandles`, Hex-Klick-Delegation sowie Options-Parsing (`getFirstHexBlock` → `parseOptions`) und zeigt sinnvolle Platzhalter, wenn kein File oder kein Hex-Block vorliegt.
 - **Modus-System:** Stellt das Mode-Interface (`onEnter`, `onExit`, `onFileChange`, `onHexClick`, `onSave`) bereit, schaltet über ein Dropdown im Header zwischen Travel/Editor/Inspector um, delegiert Events und räumt Ressourcen deterministisch auf.
 - **Editor-Tooling:** `editor/` beherbergt die wiederverwendbare Tool-Infrastruktur (Schnittstelle, Brush-Vorschau, Terrain-Brush). `modes/editor.ts` konsumiert diese Module und mountet sie in das gemeinsame Sidebar-Panel.
@@ -44,14 +45,17 @@ src/apps/cartographer/
 ### `index.ts`
 - Exportiert `CartographerView`, `VIEW_TYPE_CARTOGRAPHER` sowie Leaf-/Open-Helfer für den Plugin-Bootstrap.
 - Verzichtet bewusst auf eine eigene Plugin-Klasse; Registrierungen erfolgen über `SaltMarcherPlugin` (`src/app/main.ts`).
-- Erzeugt einen Host (`cartographer-host`), mountet `view-shell.ts`, reicht `setFile`-Aufrufe weiter und räumt beim Schließen auf.
+- Erzeugt den Host (`cartographer-host`) und delegiert Lifecycle (`onOpen`, `onClose`, `setFile`) vollständig an den `CartographerPresenter`.
+
+### `presenter.ts`
+- Definiert das Modus-Interface inkl. Kontext und kapselt die komplette Steuerlogik des Cartographers.
+- Bindet Map-Manager, lädt Hex-Optionen, erzeugt Map-Layer und informiert aktive Modi über Datei- und State-Änderungen.
+- Trennt asynchrone Vorgänge (Mode-Wechsel, Render-Reload) über Promise-Chaining, behandelt Fehler robust und säubert Ressourcen beim Schließen.
 
 ### `view-shell.ts`
-- Implementiert `CartographerMode` & `CartographerModeContext` (inkl. `getOptions`) als zentrale Schnittstelle für Modi.
-- Baut Header, Body, Map- und Sidebar-Container mit `sm-cartographer`-Klassen auf.
-- Nutzt `createMapLayer` + `renderHexMap` zum Laden der Karte, aktualisiert `currentOptions` und leitet `hex:click`-Events an den aktiven Modus weiter.
-- Bindet `createMapManager`, um Header-Buttons (`Open`, `Create`, `Delete`) zu teilen und den Stage-Reload nach jeder State-Änderung zu koordinieren.
-- Registriert Travel-, Editor-, Inspector- sowie Beispiel-Modi und sorgt für konsistente `onEnter`/`onExit`/`onFileChange`-Sequenzen.
+- Rendert Header, Body, Map- und Sidebar-Container mit `sm-cartographer`-Klassen und liefert ein Handle zur Aktualisierung (Mode-Label, Overlay, File-Label).
+- Delegiert UI-Events (Open/Create/Delete/Save, Mode-Wahl, `hex:click`) an den Presenter und hält selbst keinen Business-State.
+- Ermöglicht durch die schlanke Schnittstelle das Mocken in Tests, sodass DOM und State separat validiert werden können.
 
 ### `modes/editor.ts`
 - Erzeugt das Editor-Panel im Sidebar-Host, zeigt Dateiname & Tool-Auswahl (derzeit nur Brush) und liefert Statusmeldungen.

--- a/salt-marcher/src/apps/cartographer/modes/editor.ts
+++ b/salt-marcher/src/apps/cartographer/modes/editor.ts
@@ -1,5 +1,5 @@
 import type { TFile } from "obsidian";
-import type { CartographerMode, CartographerModeContext, HexCoord } from "../view-shell";
+import type { CartographerMode, CartographerModeContext, HexCoord } from "../presenter";
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import { createBrushTool } from "../editor/tools/terrain-brush/brush-options";
 import type { ToolModule, ToolContext } from "../editor/tools/tools-api";

--- a/salt-marcher/src/apps/cartographer/modes/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/modes/inspector.ts
@@ -3,7 +3,7 @@ import { loadTile, saveTile } from "../../../core/hex-mapper/hex-notes";
 import { TERRAIN_COLORS } from "../../../core/terrain";
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import type { RenderHandles } from "../../../core/hex-mapper/hex-render";
-import type { CartographerMode, CartographerModeContext, HexCoord } from "../view-shell";
+import type { CartographerMode, CartographerModeContext, HexCoord } from "../presenter";
 
 type InspectorUI = {
     panel: HTMLElement | null;

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
@@ -1,5 +1,5 @@
 import type { MapHeaderSaveMode } from "../../../ui/map-header";
-import type { CartographerMode, CartographerModeContext } from "../view-shell";
+import type { CartographerMode, CartographerModeContext } from "../presenter";
 import { loadTerrains } from "../../../core/terrain-store";
 import { setTerrains } from "../../../core/terrain";
 import { createSidebar, type Sidebar } from "../travel/ui/sidebar";

--- a/salt-marcher/src/apps/cartographer/presenter.ts
+++ b/salt-marcher/src/apps/cartographer/presenter.ts
@@ -1,0 +1,317 @@
+// src/apps/cartographer/presenter.ts
+// Presenter: Kapselt Statusverwaltung, Mode-Lifecycle und Map-Rendering für den Cartographer.
+
+import type { App, TFile } from "obsidian";
+import { parseOptions, type HexOptions } from "../../core/options";
+import { getFirstHexBlock } from "../../core/map-list";
+import type { RenderHandles } from "../../core/hex-mapper/hex-render";
+import { createMapLayer, type MapLayer } from "./travel/ui/map-layer";
+import { createMapManager, type MapManagerHandle } from "../../ui/map-manager";
+import { createTravelGuideMode } from "./modes/travel-guide";
+import { createEditorMode } from "./modes/editor";
+import { createInspectorMode } from "./modes/inspector";
+import {
+    createCartographerShell,
+    type CartographerShellHandle,
+    type CartographerShellMode,
+    type CartographerShellOptions,
+} from "./view-shell";
+import type { MapHeaderSaveMode } from "../../ui/map-header";
+
+export type HexCoord = { r: number; c: number };
+
+export type CartographerModeContext = {
+    readonly app: App;
+    readonly host: HTMLElement;
+    readonly mapHost: HTMLElement;
+    readonly sidebarHost: HTMLElement;
+    getFile(): TFile | null;
+    getMapLayer(): MapLayer | null;
+    getRenderHandles(): RenderHandles | null;
+    getOptions(): HexOptions | null;
+};
+
+export interface CartographerMode {
+    readonly id: string;
+    readonly label: string;
+    onEnter(ctx: CartographerModeContext): void | Promise<void>;
+    onExit(): void | Promise<void>;
+    onFileChange(
+        file: TFile | null,
+        handles: RenderHandles | null,
+        ctx: CartographerModeContext,
+    ): void | Promise<void>;
+    onHexClick?(
+        coord: HexCoord,
+        event: CustomEvent<HexCoord>,
+        ctx: CartographerModeContext,
+    ): void | Promise<void>;
+    onSave?(mode: MapHeaderSaveMode, file: TFile | null, ctx: CartographerModeContext): void | Promise<void | boolean> | boolean;
+}
+
+export interface CartographerPresenterDeps {
+    createShell(options: CartographerShellOptions): CartographerShellHandle;
+    createMapManager(app: App, options: Parameters<typeof createMapManager>[1]): MapManagerHandle;
+    createMapLayer(app: App, host: HTMLElement, file: TFile, opts: HexOptions): Promise<MapLayer>;
+    loadHexOptions(app: App, file: TFile): Promise<HexOptions | null>;
+    provideModes(): CartographerMode[];
+}
+
+const createDefaultDeps = (app: App): CartographerPresenterDeps => ({
+    createShell: (options) => createCartographerShell(options),
+    createMapManager: (appInstance, options) => createMapManager(appInstance, options),
+    createMapLayer: (appInstance, host, file, opts) => createMapLayer(appInstance, host, file, opts),
+    loadHexOptions: async (appInstance, file) => {
+        const block = await getFirstHexBlock(appInstance, file);
+        if (!block) return null;
+        return parseOptions(block);
+    },
+    provideModes: () => [createTravelGuideMode(), createEditorMode(), createInspectorMode()],
+});
+
+export class CartographerPresenter {
+    private readonly app: App;
+    private readonly deps: CartographerPresenterDeps;
+
+    private shell: CartographerShellHandle | null = null;
+    private mapManager: MapManagerHandle | null = null;
+    private currentFile: TFile | null = null;
+    private currentOptions: HexOptions | null = null;
+    private mapLayer: MapLayer | null = null;
+    private activeMode: CartographerMode | null = null;
+    private readonly modes: CartographerMode[];
+    private hostEl: HTMLElement | null = null;
+    private modeChange: Promise<void> = Promise.resolve();
+    private loadToken = 0;
+    private isMounted = false;
+    private requestedFile: TFile | null | undefined = undefined;
+
+    constructor(app: App, deps?: Partial<CartographerPresenterDeps>) {
+        this.app = app;
+        const defaults = createDefaultDeps(app);
+        this.deps = { ...defaults, ...deps } as CartographerPresenterDeps;
+        this.modes = this.deps.provideModes();
+    }
+
+    /** Öffnet den Presenter auf dem übergebenen Host. */
+    async onOpen(host: HTMLElement, fallbackFile: TFile | null): Promise<void> {
+        await this.onClose();
+
+        this.hostEl = host;
+        const initialFile = this.requestedFile ?? fallbackFile ?? null;
+        this.currentFile = initialFile;
+
+        const shellModes: CartographerShellMode[] = this.modes.map((mode) => ({ id: mode.id, label: mode.label }));
+
+        this.shell = this.deps.createShell({
+            app: this.app,
+            host,
+            initialFile,
+            modes: shellModes,
+            callbacks: {
+                onModeSelect: (id) => {
+                    void this.setMode(id);
+                },
+                onOpen: async (file) => {
+                    await this.mapManager?.setFile(file);
+                },
+                onCreate: async (file) => {
+                    await this.mapManager?.setFile(file);
+                },
+                onDelete: async () => {
+                    this.mapManager?.deleteCurrent();
+                },
+                onSave: async (mode, file) => {
+                    return await this.handleSave(mode, file);
+                },
+                onHexClick: async (coord, event) => {
+                    await this.handleHexClick(coord, event);
+                },
+            },
+        });
+
+        this.mapManager = this.deps.createMapManager(this.app, {
+            initialFile,
+            onChange: async (file) => {
+                await this.handleFileChange(file);
+            },
+        });
+
+        this.shell.setModeLabel(shellModes[0]?.label ?? "Mode");
+        this.shell.setModeActive(shellModes[0]?.id ?? "");
+        this.shell.setFileLabel(initialFile);
+
+        this.isMounted = true;
+        this.requestedFile = initialFile;
+
+        await this.setMode(shellModes[0]?.id ?? "");
+        await this.mapManager.setFile(initialFile);
+    }
+
+    /** Schließt den Presenter und räumt Ressourcen auf. */
+    async onClose(): Promise<void> {
+        if (!this.isMounted) {
+            this.shell?.destroy();
+            this.shell = null;
+            this.hostEl = null;
+            return;
+        }
+
+        this.isMounted = false;
+        await this.modeChange;
+        try {
+            await this.activeMode?.onExit();
+        } catch (err) {
+            console.error("[cartographer] mode exit failed", err);
+        }
+        this.activeMode = null;
+        await this.teardownLayer();
+        this.shell?.destroy();
+        this.shell = null;
+        this.hostEl = null;
+        this.mapManager = null;
+    }
+
+    /** Setzt (oder merkt) die gewünschte Karte. */
+    async setFile(file: TFile | null): Promise<void> {
+        this.requestedFile = file;
+        if (!this.isMounted || !this.mapManager) return;
+        await this.mapManager.setFile(file);
+    }
+
+    private get modeCtx(): CartographerModeContext {
+        if (!this.shell || !this.hostEl) {
+            throw new Error("CartographerPresenter is not mounted.");
+        }
+        return {
+            app: this.app,
+            host: this.hostEl,
+            mapHost: this.shell.mapHost,
+            sidebarHost: this.shell.sidebarHost,
+            getFile: () => this.currentFile,
+            getMapLayer: () => this.mapLayer,
+            getRenderHandles: () => this.mapLayer?.handles ?? null,
+            getOptions: () => this.currentOptions,
+        } satisfies CartographerModeContext;
+    }
+
+    private async handleFileChange(file: TFile | null): Promise<void> {
+        this.currentFile = file;
+        this.shell?.setFileLabel(file);
+        await this.refresh();
+    }
+
+    private async handleSave(mode: MapHeaderSaveMode, file: TFile | null): Promise<boolean> {
+        if (!this.activeMode?.onSave) return false;
+        try {
+            const handled = await this.activeMode.onSave(mode, file, this.modeCtx);
+            return handled === true;
+        } catch (err) {
+            console.error("[cartographer] mode onSave failed", err);
+            return false;
+        }
+    }
+
+    private async handleHexClick(coord: HexCoord, event: CustomEvent<HexCoord>): Promise<void> {
+        if (!this.activeMode?.onHexClick) return;
+        try {
+            await this.activeMode.onHexClick(coord, event, this.modeCtx);
+        } catch (err) {
+            console.error("[cartographer] mode onHexClick failed", err);
+        }
+    }
+
+    async setMode(id: string): Promise<void> {
+        const next = this.modes.find((mode) => mode.id === id) ?? this.modes[0];
+        if (!next) return;
+        if (this.activeMode?.id === next.id) {
+            this.shell?.setModeActive(next.id);
+            this.shell?.setModeLabel(next.label);
+            return;
+        }
+        const ctx = this.modeCtx;
+        this.modeChange = this.modeChange.then(async () => {
+            try {
+                await this.activeMode?.onExit();
+            } catch (err) {
+                console.error("[cartographer] mode exit failed", err);
+            }
+            this.activeMode = next;
+            this.shell?.setModeActive(next.id);
+            this.shell?.setModeLabel(next.label);
+            try {
+                await next.onEnter(ctx);
+                await next.onFileChange(this.currentFile, this.mapLayer?.handles ?? null, ctx);
+            } catch (err) {
+                console.error("[cartographer] mode enter failed", err);
+            }
+        });
+        await this.modeChange;
+    }
+
+    private async refresh(): Promise<void> {
+        const token = ++this.loadToken;
+        await this.renderMap(token);
+    }
+
+    private async renderMap(token: number): Promise<void> {
+        await this.teardownLayer();
+
+        if (!this.shell) return;
+        const ctx = this.modeCtx;
+
+        if (!this.currentFile) {
+            this.shell.clearMap();
+            this.shell.setOverlay("Keine Karte ausgewählt.");
+            this.currentOptions = null;
+            await this.activeMode?.onFileChange(null, null, ctx);
+            return;
+        }
+
+        let options: HexOptions | null = null;
+        try {
+            options = await this.deps.loadHexOptions(this.app, this.currentFile);
+        } catch (err) {
+            console.error("[cartographer] failed to parse map options", err);
+        }
+
+        if (!options) {
+            this.shell.clearMap();
+            this.shell.setOverlay("Kein hex3x3-Block in dieser Datei.");
+            this.currentOptions = null;
+            await this.activeMode?.onFileChange(this.currentFile, null, ctx);
+            return;
+        }
+
+        try {
+            const layer = await this.deps.createMapLayer(this.app, this.shell.mapHost, this.currentFile, options);
+            if (token !== this.loadToken || !this.shell) {
+                layer.destroy();
+                return;
+            }
+            this.mapLayer = layer;
+            this.currentOptions = options;
+            this.shell.setOverlay(null);
+            await this.activeMode?.onFileChange(this.currentFile, this.mapLayer.handles, ctx);
+        } catch (err) {
+            console.error("[cartographer] failed to render map", err);
+            this.shell.clearMap();
+            this.shell.setOverlay("Karte konnte nicht geladen werden.");
+            this.currentOptions = null;
+            await this.activeMode?.onFileChange(this.currentFile, null, ctx);
+        }
+    }
+
+    private async teardownLayer(): Promise<void> {
+        if (this.mapLayer) {
+            try {
+                this.mapLayer.destroy();
+            } catch (err) {
+                console.error("[cartographer] failed to destroy map layer", err);
+            }
+            this.mapLayer = null;
+        }
+        this.shell?.clearMap();
+        this.currentOptions = null;
+    }
+}

--- a/salt-marcher/src/apps/cartographer/view-shell.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell.ts
@@ -1,58 +1,49 @@
 // src/apps/cartographer/view-shell.ts
-// Shell: Layout + Mode-Wiring für den Cartographer-View.
+// View-Layer: rendert DOM-Struktur und leitet UI-Ereignisse an den Presenter weiter.
 
 import type { App, TFile } from "obsidian";
-import { parseOptions, type HexOptions } from "../../core/options";
-import { getFirstHexBlock } from "../../core/map-list";
-import type { RenderHandles } from "../../core/hex-mapper/hex-render";
-import { createMapLayer, type MapLayer } from "./travel/ui/map-layer";
-import { createMapHeader, type MapHeaderHandle, type MapHeaderSaveMode } from "../../ui/map-header";
-import { createMapManager } from "../../ui/map-manager";
-import { createTravelGuideMode } from "./modes/travel-guide";
-import { createEditorMode } from "./modes/editor";
-import { createInspectorMode } from "./modes/inspector";
+import type { HexCoord } from "./presenter";
+import { createMapHeader, type MapHeaderSaveMode } from "../../ui/map-header";
 import { createViewContainer } from "../../ui/view-container";
 
-export type HexCoord = { r: number; c: number };
+export type CartographerShellMode = { id: string; label: string };
 
-export type CartographerModeContext = {
-    readonly app: App;
+export interface CartographerShellCallbacks {
+    onModeSelect(id: string): void;
+    onOpen(file: TFile): void | Promise<void>;
+    onCreate(file: TFile): void | Promise<void>;
+    onDelete(file: TFile): void | Promise<void>;
+    onSave(mode: MapHeaderSaveMode, file: TFile | null): Promise<boolean> | boolean;
+    onHexClick(coord: HexCoord, event: CustomEvent<HexCoord>): void | Promise<void>;
+}
+
+export interface CartographerShellOptions {
+    app: App;
+    host: HTMLElement;
+    initialFile: TFile | null;
+    modes: CartographerShellMode[];
+    callbacks: CartographerShellCallbacks;
+}
+
+export interface CartographerShellHandle {
     readonly host: HTMLElement;
     readonly mapHost: HTMLElement;
     readonly sidebarHost: HTMLElement;
-    getFile(): TFile | null;
-    getMapLayer(): MapLayer | null;
-    getRenderHandles(): RenderHandles | null;
-    getOptions(): HexOptions | null;
-};
-
-export interface CartographerMode {
-    readonly id: string;
-    readonly label: string;
-    onEnter(ctx: CartographerModeContext): void | Promise<void>;
-    onExit(): void | Promise<void>;
-    onFileChange(
-        file: TFile | null,
-        handles: RenderHandles | null,
-        ctx: CartographerModeContext
-    ): void | Promise<void>;
-    onHexClick?(coord: HexCoord, event: CustomEvent<HexCoord>, ctx: CartographerModeContext): void | Promise<void>;
-    onSave?(mode: MapHeaderSaveMode, file: TFile | null, ctx: CartographerModeContext): void | Promise<void | boolean> | boolean;
+    setFileLabel(file: TFile | null): void;
+    setModeActive(id: string): void;
+    setModeLabel(label: string): void;
+    setOverlay(content: string | null): void;
+    clearMap(): void;
+    destroy(): void;
 }
 
-export type CartographerController = {
-    destroy(): Promise<void> | void;
-    setFile(file: TFile | null): Promise<void>;
-    setMode(id: string): Promise<void>;
-};
+type ModeMenuItem = { modeId: string; item: HTMLButtonElement };
 
-type ModeMenuItem = { mode: CartographerMode; item: HTMLButtonElement };
+type Cleanup = () => void;
 
-export async function mountCartographer(
-    app: App,
-    host: HTMLElement,
-    initialFile: TFile | null
-): Promise<CartographerController> {
+export function createCartographerShell(options: CartographerShellOptions): CartographerShellHandle {
+    const { app, host, initialFile, modes, callbacks } = options;
+
     host.empty();
     host.classList.add("sm-cartographer");
 
@@ -64,304 +55,129 @@ export async function mountCartographer(
     const mapHost = mapView.stageEl;
     const sidebarHost = body.createDiv({ cls: "sm-cartographer__sidebar" });
 
-    let currentFile: TFile | null = initialFile ?? null;
-    let headerHandle: MapHeaderHandle | null = null;
-    let mapLayer: MapLayer | null = null;
-    let destroyed = false;
-    let loadToken = 0;
-    let activeMode: CartographerMode | null = null;
-    let modeChange = Promise.resolve();
     const modeMenuItems: ModeMenuItem[] = [];
     let modeTriggerBtn: HTMLButtonElement | null = null;
-    let modeMenuEl: HTMLElement | null = null;
     let modeDropdownEl: HTMLElement | null = null;
-    let unbindOutsideClick: (() => void) | null = null;
-    let currentOptions: HexOptions | null = null;
+    let unbindOutsideClick: Cleanup | null = null;
 
-    const modeCtx: CartographerModeContext = {
-        app,
-        host,
-        mapHost,
-        sidebarHost,
-        getFile: () => currentFile,
-        getMapLayer: () => mapLayer,
-        getRenderHandles: () => mapLayer?.handles ?? null,
-        getOptions: () => currentOptions,
+    const closeMenu = () => {
+        if (!modeDropdownEl || !modeTriggerBtn) return;
+        modeDropdownEl.classList.remove("is-open");
+        modeTriggerBtn.setAttr("aria-expanded", "false");
+        if (unbindOutsideClick) {
+            unbindOutsideClick();
+            unbindOutsideClick = null;
+        }
     };
 
-    const modes: CartographerMode[] = [
-        createTravelGuideMode(),
-        createEditorMode(),
-        createInspectorMode(),
-    ];
-
-    const onHexClick = async (event: Event) => {
-        const ev = event as CustomEvent<HexCoord>;
-        if (ev.cancelable) ev.preventDefault();
-        ev.stopPropagation();
-        if (!activeMode?.onHexClick) return;
-        await activeMode.onHexClick(ev.detail, ev, modeCtx);
-    };
-    mapHost.addEventListener("hex:click", onHexClick as EventListener, { passive: false });
-
-    async function teardownLayer() {
-        if (mapLayer) {
-            try {
-                mapLayer.destroy();
-            } catch (err) {
-                console.error("[cartographer] failed to destroy map layer", err);
-            }
-            mapLayer = null;
-        }
-        mapHost.empty();
-        mapView.setOverlay(null);
-        currentOptions = null;
-    }
-
-    async function switchMode(id: string) {
-        const next = modes.find((m) => m.id === id) ?? modes[0];
-        if (activeMode?.id === next.id) return;
-        modeChange = modeChange.then(async () => {
-            if (destroyed) return;
-            try {
-                await activeMode?.onExit();
-            } catch (err) {
-                console.error("[cartographer] mode exit failed", err);
-            }
-            activeMode = next;
-            // Reflect active mode in dropdown UI
-            if (modeTriggerBtn) modeTriggerBtn.textContent = next.label;
-            for (const { mode, item } of modeMenuItems) {
-                const isActive = mode.id === next.id;
-                item.classList.toggle("is-active", isActive);
-                item.ariaSelected = isActive ? "true" : "false";
-            }
-            try {
-                await next.onEnter(modeCtx);
-                await next.onFileChange(currentFile, mapLayer?.handles ?? null, modeCtx);
-            } catch (err) {
-                console.error("[cartographer] mode enter failed", err);
-            }
-        });
-        await modeChange;
-    }
-
-    async function loadHexOptions(file: TFile): Promise<HexOptions | null> {
-        const block = await getFirstHexBlock(app, file);
-        if (!block) return null;
-        return parseOptions(block);
-    }
-
-    async function renderMap(token: number) {
-        await teardownLayer();
-
-        if (!currentFile) {
-            mapHost.empty();
-            mapView.setOverlay("Keine Karte ausgewählt.");
-            currentOptions = null;
-            await activeMode?.onFileChange(null, null, modeCtx);
-            return;
-        }
-
-        let opts: HexOptions | null = null;
-        try {
-            opts = await loadHexOptions(currentFile);
-        } catch (err) {
-            console.error("[cartographer] failed to parse map options", err);
-        }
-        if (!opts) {
-            mapHost.empty();
-            mapView.setOverlay("Kein hex3x3-Block in dieser Datei.");
-            currentOptions = null;
-            await activeMode?.onFileChange(currentFile, null, modeCtx);
-            return;
-        }
-
-        try {
-            const layer = await createMapLayer(app, mapHost, currentFile, opts);
-            if (destroyed || token !== loadToken) {
-                layer.destroy();
-                return;
-            }
-            mapLayer = layer;
-            currentOptions = opts;
-            mapView.setOverlay(null);
-            await activeMode?.onFileChange(currentFile, mapLayer.handles, modeCtx);
-        } catch (err) {
-            console.error("[cartographer] failed to render map", err);
-            mapHost.empty();
-            mapView.setOverlay("Karte konnte nicht geladen werden.");
-            currentOptions = null;
-            await activeMode?.onFileChange(currentFile, null, modeCtx);
-        }
-    }
-
-    async function refresh() {
-        const token = ++loadToken;
-        await renderMap(token);
-    }
-
-    const onManagerChange = async (file: TFile | null) => {
-        currentFile = file;
-        headerHandle?.setFileLabel(file);
-        await refresh();
+    const openMenu = () => {
+        if (!modeDropdownEl || !modeTriggerBtn) return;
+        modeDropdownEl.classList.add("is-open");
+        modeTriggerBtn.setAttr("aria-expanded", "true");
+        const onDocClick = (ev: MouseEvent) => {
+            if (!modeDropdownEl?.contains(ev.target as Node)) closeMenu();
+        };
+        document.addEventListener("mousedown", onDocClick);
+        unbindOutsideClick = () => document.removeEventListener("mousedown", onDocClick);
     };
 
-    const mapManager = createMapManager(app, {
-        initialFile: currentFile,
-        onChange: onManagerChange,
-    });
-
-    async function setFile(file: TFile | null) {
-        await mapManager.setFile(file);
-    }
-
-    headerHandle = createMapHeader(app, headerHost, {
+    const headerHandle = createMapHeader(app, headerHost, {
         title: "Cartographer",
         initialFile,
         onOpen: async (file) => {
-            await mapManager.setFile(file);
+            await callbacks.onOpen(file);
         },
         onCreate: async (file) => {
-            await mapManager.setFile(file);
+            await callbacks.onCreate(file);
         },
-        onDelete: async () => {
-            mapManager.deleteCurrent();
+        onDelete: async (file) => {
+            await callbacks.onDelete(file);
         },
         onSave: async (mode, file) => {
-            if (!activeMode?.onSave) return false;
-            try {
-                const handled = await activeMode.onSave(mode, file, modeCtx);
-                return handled === true;
-            } catch (err) {
-                console.error("[cartographer] mode onSave failed", err);
-                return false;
-            }
+            return await callbacks.onSave(mode, file);
         },
         titleRightSlot: (slot) => {
-            // Build dropdown for modes
             slot.classList.add("sm-cartographer__mode-switch");
             const dropdown = slot.createDiv({ cls: "sm-mode-dropdown" });
             modeDropdownEl = dropdown;
 
-            // Trigger button shows current mode label
             modeTriggerBtn = dropdown.createEl("button", {
                 text: modes[0]?.label ?? "Mode",
                 attr: { type: "button", "aria-haspopup": "listbox", "aria-expanded": "false" },
             });
             modeTriggerBtn.classList.add("sm-mode-dropdown__trigger");
-
-            // Menu list
-            modeMenuEl = dropdown.createDiv({ cls: "sm-mode-dropdown__menu", attr: { role: "listbox" } });
-
-            const closeMenu = () => {
-                if (!modeMenuEl || !modeTriggerBtn) return;
-                modeDropdownEl?.classList.remove("is-open");
-                modeTriggerBtn.setAttr("aria-expanded", "false");
-                if (unbindOutsideClick) {
-                    unbindOutsideClick();
-                    unbindOutsideClick = null;
-                }
-            };
-
-            const openMenu = () => {
-                if (!modeMenuEl || !modeTriggerBtn) return;
-                modeDropdownEl?.classList.add("is-open");
-                modeTriggerBtn.setAttr("aria-expanded", "true");
-                const onDocClick = (ev: MouseEvent) => {
-                    if (!dropdown.contains(ev.target as Node)) closeMenu();
-                };
-                document.addEventListener("mousedown", onDocClick);
-                unbindOutsideClick = () => document.removeEventListener("mousedown", onDocClick);
-            };
-
             modeTriggerBtn.onclick = () => {
-                if (!modeMenuEl) return;
-                const isOpen = modeDropdownEl?.classList.contains("is-open");
-                if (isOpen) closeMenu(); else openMenu();
+                if (!modeDropdownEl) return;
+                const isOpen = modeDropdownEl.classList.contains("is-open");
+                if (isOpen) closeMenu();
+                else openMenu();
             };
+
+            const menuEl = dropdown.createDiv({ cls: "sm-mode-dropdown__menu", attr: { role: "listbox" } });
 
             for (const mode of modes) {
-                const item = modeMenuEl.createEl("button", {
+                const item = menuEl.createEl("button", {
                     text: mode.label,
                     attr: { role: "option", type: "button", "data-id": mode.id },
                 });
                 item.classList.add("sm-mode-dropdown__item");
                 item.onclick = () => {
                     closeMenu();
-                    void switchMode(mode.id);
+                    callbacks.onModeSelect(mode.id);
                 };
-                modeMenuItems.push({ mode, item });
+                modeMenuItems.push({ modeId: mode.id, item });
             }
         },
     });
 
-    headerHandle.setFileLabel(currentFile);
+    const onHexClick = async (event: Event) => {
+        const ev = event as CustomEvent<HexCoord>;
+        if (ev.cancelable) ev.preventDefault();
+        ev.stopPropagation();
+        await callbacks.onHexClick(ev.detail, ev);
+    };
+    mapHost.addEventListener("hex:click", onHexClick as EventListener, { passive: false });
 
-    await switchMode(modes[0].id);
-    await mapManager.setFile(currentFile);
-
-    async function destroy() {
-        if (destroyed) return;
-        destroyed = true;
-        mapHost.removeEventListener("hex:click", onHexClick as EventListener);
-        await modeChange;
-        try {
-            await activeMode?.onExit();
-        } catch (err) {
-            console.error("[cartographer] mode exit during destroy failed", err);
+    const setModeActive = (id: string) => {
+        for (const entry of modeMenuItems) {
+            const isActive = entry.modeId === id;
+            entry.item.classList.toggle("is-active", isActive);
+            entry.item.ariaSelected = isActive ? "true" : "false";
         }
-        activeMode = null;
-        await teardownLayer();
+    };
+
+    const setModeLabel = (label: string) => {
+        if (modeTriggerBtn) {
+            modeTriggerBtn.textContent = label;
+        }
+    };
+
+    const destroy = () => {
+        closeMenu();
+        mapHost.removeEventListener("hex:click", onHexClick as EventListener);
+        headerHandle.destroy();
         mapView.destroy();
-        headerHandle?.destroy();
-        headerHandle = null;
-        if (unbindOutsideClick) { unbindOutsideClick(); unbindOutsideClick = null; }
         host.empty();
         host.removeClass("sm-cartographer");
-    }
+    };
 
-    return {
+    const handle: CartographerShellHandle = {
+        host,
+        mapHost,
+        sidebarHost,
+        setFileLabel: (file) => {
+            headerHandle.setFileLabel(file);
+        },
+        setModeActive,
+        setModeLabel,
+        setOverlay: (content) => {
+            mapView.setOverlay(content);
+        },
+        clearMap: () => {
+            mapHost.empty();
+        },
         destroy,
-        setFile,
-        setMode: async (id: string) => {
-            await switchMode(id);
-        },
     };
-}
 
-function createNotesMode(): CartographerMode {
-    let panel: HTMLElement | null = null;
-    let message: HTMLElement | null = null;
-    return {
-        id: "notes",
-        label: "Notes",
-        async onEnter(ctx) {
-            ctx.sidebarHost.empty();
-            panel = ctx.sidebarHost.createDiv({ cls: "sm-cartographer__panel" });
-            panel.createEl("h3", { text: "Notes" });
-            panel.createEl("p", {
-                text: "Dieser Modus ist ein Platzhalter für weitere Werkzeuge.",
-            });
-            message = panel.createEl("div", { cls: "sm-cartographer__panel-info" });
-        },
-        async onExit() {
-            panel?.remove();
-            panel = null;
-            message = null;
-        },
-        async onFileChange(file, handles, ctx) {
-            if (!panel) return;
-            panel.toggleClass("is-disabled", !file || !handles);
-            if (!file || !handles) {
-                message?.setText("Map-Modi benötigen eine geladene Karte.");
-            } else {
-                message?.setText("Hex auf der Karte anklicken, um Notizen zu sammeln.");
-            }
-        },
-        async onHexClick(coord, _event, ctx) {
-            if (!message) return;
-            message.setText(`Hex ausgewählt: r${coord.r}, c${coord.c}`);
-        },
-    };
+    return handle;
 }

--- a/salt-marcher/tests/cartographer/presenter.test.ts
+++ b/salt-marcher/tests/cartographer/presenter.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import {
+    CartographerPresenter,
+    type CartographerMode,
+    type CartographerModeContext,
+} from "../../src/apps/cartographer/presenter";
+import type {
+    CartographerShellHandle,
+    CartographerShellOptions,
+} from "../../src/apps/cartographer/view-shell";
+import type { MapManagerHandle } from "../../src/ui/map-manager";
+import type { HexOptions } from "../../src/core/options";
+import type { RenderHandles } from "../../src/core/hex-mapper/hex-render";
+import type { MapLayer } from "../../src/apps/cartographer/travel/ui/map-layer";
+
+function createShellStub() {
+    const host = document.createElement("div");
+    const mapHost = document.createElement("div");
+    const sidebarHost = document.createElement("div");
+    const setFileLabel = vi.fn();
+    const setModeActive = vi.fn();
+    const setModeLabel = vi.fn();
+    const setOverlay = vi.fn();
+    const clearMap = vi.fn();
+    const destroy = vi.fn();
+
+    let capturedOptions: CartographerShellOptions | null = null;
+
+    const handle: CartographerShellHandle = {
+        host,
+        mapHost,
+        sidebarHost,
+        setFileLabel,
+        setModeActive,
+        setModeLabel,
+        setOverlay,
+        clearMap,
+        destroy,
+    };
+
+    const factory = (options: CartographerShellOptions): CartographerShellHandle => {
+        capturedOptions = options;
+        return handle;
+    };
+
+    const getCallbacks = () => {
+        if (!capturedOptions) throw new Error("shell not initialised");
+        return capturedOptions.callbacks;
+    };
+
+    const getModes = () => {
+        if (!capturedOptions) throw new Error("shell not initialised");
+        return capturedOptions.modes;
+    };
+
+    return {
+        host,
+        mapHost,
+        sidebarHost,
+        factory,
+        handle,
+        getCallbacks,
+        getModes,
+        setFileLabel,
+        setModeActive,
+        setModeLabel,
+        setOverlay,
+        clearMap,
+        destroy,
+    };
+}
+
+type MapManagerOptions = {
+    initialFile?: TFile | null;
+    onChange?: (file: TFile | null) => void | Promise<void>;
+};
+
+function createStubMapManager(options: MapManagerOptions = {}): MapManagerHandle {
+    let current: TFile | null = options.initialFile ?? null;
+    const apply = async (file: TFile | null) => {
+        current = file;
+        await options.onChange?.(file);
+    };
+    return {
+        getFile: () => current,
+        setFile: async (file) => {
+            await apply(file ?? null);
+        },
+        open: vi.fn(),
+        create: vi.fn(),
+        deleteCurrent: () => {
+            void apply(null);
+        },
+    };
+}
+
+const createMapManagerFactory = () =>
+    (_app: App, opts?: MapManagerOptions): MapManagerHandle => createStubMapManager(opts ?? {});
+
+const appStub = { workspace: {} } as unknown as App;
+
+describe("CartographerPresenter", () => {
+    it("switches modes and performs lifecycle hooks", async () => {
+        const shell = createShellStub();
+        const events: string[] = [];
+
+        const modeA: CartographerMode = {
+            id: "a",
+            label: "Mode A",
+            onEnter: () => {
+                events.push("A:enter");
+            },
+            onExit: () => {
+                events.push("A:exit");
+            },
+            onFileChange: (file) => {
+                events.push(`A:file:${file ? file.path : "null"}`);
+            },
+        };
+
+        const modeB: CartographerMode = {
+            id: "b",
+            label: "Mode B",
+            onEnter: () => {
+                events.push("B:enter");
+            },
+            onExit: () => {
+                events.push("B:exit");
+            },
+            onFileChange: (file) => {
+                events.push(`B:file:${file ? file.path : "null"}`);
+            },
+        };
+
+        const presenter = new CartographerPresenter(appStub, {
+            createShell: shell.factory,
+            createMapManager: createMapManagerFactory(),
+            createMapLayer: vi.fn(async () => {
+                throw new Error("layer should not be created in this scenario");
+            }),
+            loadHexOptions: vi.fn(async () => null as HexOptions | null),
+            provideModes: () => [modeA, modeB],
+        });
+
+        await presenter.onOpen(shell.host, null);
+        events.length = 0;
+
+        await presenter.setMode("b");
+
+        expect(events).toEqual(["A:exit", "B:enter", "B:file:null"]);
+        expect(shell.setModeActive).toHaveBeenLastCalledWith("b");
+        expect(shell.setModeLabel).toHaveBeenLastCalledWith("Mode B");
+    });
+
+    it("loads map data when file changes and notifies active mode", async () => {
+        const shell = createShellStub();
+        const file: TFile = { path: "Maps/alpha.md", basename: "alpha" } as TFile;
+        const handles = { marker: "handles" } as unknown as RenderHandles;
+        const mapLayer: MapLayer = {
+            handles,
+            polyToCoord: new WeakMap(),
+            ensurePolys: vi.fn(),
+            centerOf: vi.fn(),
+            destroy: vi.fn(),
+        };
+
+        const mode: CartographerMode = {
+            id: "main",
+            label: "Main",
+            onEnter: vi.fn(),
+            onExit: vi.fn(),
+            onFileChange: vi.fn(),
+        };
+
+        const loadHexOptions = vi.fn(async () => ({ hexSize: 1 } as unknown as HexOptions));
+        const createLayer = vi.fn(async () => mapLayer);
+
+        const presenter = new CartographerPresenter(appStub, {
+            createShell: shell.factory,
+            createMapManager: createMapManagerFactory(),
+            createMapLayer: createLayer,
+            loadHexOptions,
+            provideModes: () => [mode],
+        });
+
+        await presenter.onOpen(shell.host, file);
+
+        expect(loadHexOptions).toHaveBeenCalledWith(appStub, file);
+        expect(createLayer).toHaveBeenCalled();
+
+        const calls = (mode.onFileChange as ReturnType<typeof vi.fn>).mock.calls;
+        expect(calls.length).toBeGreaterThan(0);
+        const [receivedFile, receivedHandles, ctx] = calls[calls.length - 1];
+        expect(receivedFile).toBe(file);
+        expect(receivedHandles).toBe(handles);
+        expect(typeof (ctx as CartographerModeContext).getOptions).toBe("function");
+        expect(shell.setOverlay).toHaveBeenLastCalledWith(null);
+    });
+});

--- a/salt-marcher/tests/mocks/obsidian.ts
+++ b/salt-marcher/tests/mocks/obsidian.ts
@@ -1,0 +1,56 @@
+export class Notice {
+    message: string | undefined;
+    constructor(message?: string) {
+        this.message = message;
+    }
+}
+
+export class TFile {
+    path = "";
+    basename = "";
+}
+
+export class WorkspaceLeaf {
+    view: unknown = null;
+    setViewState = async (_state: unknown) => {};
+    detach = async () => {};
+}
+
+export class ItemView {
+    containerEl: HTMLElement;
+    app: App | null = null;
+    constructor(public leaf: WorkspaceLeaf) {
+        this.containerEl = document.createElement("div");
+    }
+    getViewType(): string {
+        return "";
+    }
+}
+
+export class App {
+    workspace = {
+        getLeavesOfType: (_type: string) => [] as WorkspaceLeaf[],
+        getLeaf: (_create: boolean) => new WorkspaceLeaf(),
+        revealLeaf: (_leaf: WorkspaceLeaf) => {},
+        getActiveFile: () => null as TFile | null,
+    };
+}
+
+export function setIcon(_el: HTMLElement, _name: string): void {}
+
+export class Modal {
+    constructor(public app: App) {}
+    open() {}
+    close() {}
+}
+
+export class FuzzySuggestModal<T> extends Modal {
+    getItems(): T[] {
+        return [];
+    }
+    getItemText(_item: T): string {
+        return "";
+    }
+    renderSuggestion(_item: T, _el: HTMLElement): void {}
+    onChooseItem(_item: T, _evt: MouseEvent | KeyboardEvent): void {}
+}

--- a/salt-marcher/tsconfig.json
+++ b/salt-marcher/tsconfig.json
@@ -8,5 +8,5 @@
     "paths": { "*": ["./*", "./src/*"] },
     "types": ["obsidian", "node"]   // <- wichtig für die Typen
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/salt-marcher/vitest.config.ts
+++ b/salt-marcher/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+const resolvePath = (relative: string) =>
+    fileURLToPath(new URL(relative, import.meta.url));
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        globals: true,
+        setupFiles: [],
+    },
+    resolve: {
+        alias: {
+            obsidian: resolvePath("./tests/mocks/obsidian.ts"),
+        },
+    },
+});


### PR DESCRIPTION
## Summary
- extract a CartographerPresenter that owns map manager coordination, mode switching, and rendering state while keeping the view shell purely DOM-focused
- update CartographerView and related mode modules to consume the presenter abstraction and refresh the cartographer documentation/critique notes
- add a vitest suite with obsidian mocks to exercise presenter mode changes and file handling

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d68ce693a083258b29b67e09447e2e