### PR TITLE
Handle map deletion errors

### DIFF
--- a/salt-marcher/docs/ui/map-manager-overview.md
+++ b/salt-marcher/docs/ui/map-manager-overview.md
@@ -1,0 +1,21 @@
+# Map-Manager Overview
+
+## Strukturdiagramm
+```
+src/ui/
+└─ map-manager.ts      # Stellt `createMapManager` als zentrales Steuerobjekt bereit
+   ├─ map-workflows.ts # Prompt-Dialoge für Auswahl/Erstellung
+   ├─ confirm-delete.ts# Bestätigungsdialog vor dem Löschen
+   └─ ../core/map-delete.ts
+                      # Löscht Karten-Datei und assoziierte Tiles
+```
+
+## Aufgaben & Datenfluss
+- `createMapManager` kapselt den aktuellen Karten-State (`current`) und veröffentlicht die UI-Aktionen `open`, `create`, `setFile`, `deleteCurrent`.
+- Auswahl/Erstellung laufen jeweils über die Prompt-Helfer aus `map-workflows.ts`, das Ergebnis wird über `applyChange` synchronisiert.
+- Beim Löschen wird über `ConfirmDeleteModal` ein Dialog geöffnet. Nach der Bestätigung erfolgt der Aufruf von `deleteMapAndTiles`, der bei Erfolg den State leert.
+
+## Fehlerbehandlung beim Löschen
+- Die Delete-Callback-Logik ist in `try/catch` gekapselt. So bleiben Fehler beim Entfernen der Map/Tile-Dateien nicht stumm.
+- Schlägt `deleteMapAndTiles` fehl, protokolliert der Manager den Fehler via `console.error` und informiert Anwender:innen mit einem `Notice`.
+- Der `onChange(null)`-Callback wird nur nach erfolgreich abgeschlossenem Löschvorgang ausgeführt, wodurch externe Konsumenten keine inkonsistenten Zustände erhalten.

--- a/salt-marcher/src/ui/map-manager.ts
+++ b/salt-marcher/src/ui/map-manager.ts
@@ -81,9 +81,14 @@ export function createMapManager(app: App, options: MapManagerOptions = {}): Map
             return;
         }
         new ConfirmDeleteModal(app, target, async () => {
-            await deleteMapAndTiles(app, target);
-            if (current && current.path === target.path) {
-                await applyChange(null);
+            try {
+                await deleteMapAndTiles(app, target);
+                if (current && current.path === target.path) {
+                    await applyChange(null);
+                }
+            } catch (error) {
+                console.error("Map deletion failed", error);
+                new Notice("Karte konnte nicht gelöscht werden. Siehe Konsole für Details.");
             }
         }).open();
     };


### PR DESCRIPTION
## Summary
- wrap map deletion in the manager with try/catch to avoid inconsistent state and surface failures to users
- document the updated error handling behavior in the map manager overview

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6960b2a7c832595650d03956756e2