### PR TITLE
Refine cartographer map layer typing

### DIFF
--- a/Critique.txt
+++ b/Critique.txt
@@ -11,7 +11,7 @@
 - `modeChange` verkettet Promises manuell, aber eine Fehlerblase kann den Zustand inkonsistent lassen (z. B. nach Throw bleibt `modeChange` ungelöst). Eine State-Machine oder Task-Queue mit finally-Block wäre robuster.【F:salt-marcher/src/apps/cartographer/view-shell.ts†L121-L147】
 
 ### 1.3 Map-Layer-Adapter
-- `createMapLayer` akzeptiert `opts: any` und greift mehrfach auf `handles` via `as any` zu.【F:salt-marcher/src/apps/cartographer/travel/ui/map-layer.ts†L21-L44】 Dadurch wird der Typschutz der `HexOptions` bzw. `RenderHandles` aufgehoben. Ein explizites Interface für die benötigten Methoden (inkl. `ensurePolys`) wäre nötig.
+- ✅ Behoben (2024-05-10): `createMapLayer` nutzt nun das typsichere `RenderLayerOptions`-Alias zu `HexOptions` und kapselt `ensurePolys` ohne `any`-Casts. Die Adapter-Übersicht dokumentiert das Protokoll.【F:salt-marcher/src/apps/cartographer/travel/ui/map-layer.ts†L5-L69】【F:salt-marcher/docs/cartographer/map-layer-overview.md†L1-L68】
 
 ### 1.4 Travel-Mode-Kapselung
 - `createTravelGuideMode` mischt UI-Aufbau, Domain-Logik und File-spezifische Lebenszyklen in einer Funktion. Mehrere interne Closures (`disposeInteractions`, `cleanupFile`) greifen auf geteilten Mutations-State zu, was Fehleranfälligkeit erhöht.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L20-L189】 Eine klarere Aufteilung (z. B. separate Controller-Klasse für Drag/Context-Menu) würde Seiteneffekte reduzieren.

--- a/salt-marcher/docs/cartographer/map-layer-overview.md
+++ b/salt-marcher/docs/cartographer/map-layer-overview.md
@@ -1,0 +1,47 @@
+# Map Layer Adapter Overview
+
+## Strukturdiagramm
+```
+CartographerPresenter
+    └─ TravelGuide UI
+         └─ Map-Layer Adapter (`createMapLayer`)
+              └─ Core Hex Renderer (`renderHexMap`)
+```
+
+## Verantwortlichkeiten & Datenfluss
+- **Presenter → Adapter:** übergibt Obsidian-App-Instanz, Host-Element, aktive Karten-Datei sowie `RenderLayerOptions` (Alias zu `HexOptions`). Die Optionen steuern Hex-Geometrie (Radius, Farben etc.).
+- **Adapter → Renderer:** ruft `renderHexMap` mit denselben Optionen auf und verwaltet das zurückgegebene `RenderHandles`-Objekt. Dadurch bleiben UI-spezifische Erweiterungen (Hit-Testing, Layer-Lifecycle) vom Renderer getrennt.
+- **Adapter → UI-Tools:** stellt eine `MapLayer`-API bereit, die Polygone nachlädt (`ensurePolys`), Koordinaten indiziert (`polyToCoord`) und Zentren für Cursor-Interaktionen liefert (`centerOf`).
+
+## Kern-Schnittstellen
+### `RenderLayerOptions`
+- Alias zu `HexOptions` aus `src/core/options.ts`.
+- Dient als zentrale Typdefinition für Rendering-Parameter (z. B. Hex-Radius, Farbpaletten).
+- Verhindert `any`-Parameter in `createMapLayer` und erlaubt zukünftige Adapter-spezifische Erweiterungen über Intersection-Types.
+
+### `MapLayer`
+| Feld             | Beschreibung |
+| ---------------- | ------------ |
+| `handles`        | Rohzugriff auf die `RenderHandles` des Renderers (SVG, Camera, Polygon-Map). |
+| `polyToCoord`    | `WeakMap` von SVG-Polygonen zu Raster-Koordinaten für Hit-Tests (`elementFromPoint`). |
+| `ensurePolys()`  | Lädt fehlende Hex-Polygone nach und aktualisiert anschließend den Index. Delegiert typgesichert an `RenderHandles.ensurePolys`. |
+| `centerOf()`     | Ermittelt das Zentrum eines Hex (BBox) und sorgt bei Bedarf für das Nachladen der Polygone. |
+| `destroy()`      | Bricht Rendering-Verknüpfungen ab (Renderer übernimmt internes Cleanup). |
+
+### `RenderHandles.ensurePolys`
+- Erwartet `Coord[]` (d. h. `{ r: number; c: number }`).
+- Fügt nur Polygone hinzu, die im Renderer noch fehlen, und erweitert intern die ViewBox/Overlay.
+- Wird im Adapter zu einer No-Op degradiert, falls ein Renderer ohne `ensurePolys` geliefert würde; dadurch bleiben historische Implementierungen kompatibel, ohne `any`-Casts zu benötigen.
+
+## Skriptbeschreibung
+### `src/apps/cartographer/travel/ui/map-layer.ts`
+- Initialisiert den Renderer über `renderHexMap` und baut den Polygon-Index (`WeakMap`) für schnelle Hit-Tests.
+- Exportiert `createMapLayer`, das `RenderLayerOptions` akzeptiert und die `MapLayer`-API kapselt.
+- Enthält ein internes Fallback (`ensureHandlesPolys`), das `RenderHandles.ensurePolys` typsicher aufruft und neu angelegte Polygone registriert.
+- Liefert Hilfsfunktionen wie `centerOf` und `destroy`, damit höhere UI-Schichten (Travel-Mode, Tools) nicht direkt mit Renderer-Details arbeiten müssen.
+
+## Feature-Highlights
+- **Typsichere Optionen:** Adapter übernimmt unverändert die Definition aus dem Core, wodurch UI-Konfigurationen mit IntelliSense und Compiler-Schutz versehen sind.
+- **Erweiterbares Protokoll:** `ensurePolys` ist klar dokumentiert; neue Renderer können dieselbe Signatur implementieren oder per Feature-Flag deaktivieren.
+- **Indexierte Hit-Tests:** Der Adapter hält Polygon→Koordinaten-Mapping synchron, auch wenn Polygone dynamisch entstehen.
+

--- a/salt-marcher/src/apps/cartographer/travel/ui/map-layer.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/map-layer.ts
@@ -3,6 +3,7 @@
 
 import type { App, TFile } from "obsidian";
 import { renderHexMap, type RenderHandles } from "../../../../core/hex-mapper/hex-render";
+import type { HexOptions } from "../../../../core/options";
 import type { Coord } from "../domain/types";
 
 export type MapLayer = {
@@ -18,11 +19,13 @@ export type MapLayer = {
 
 const keyOf = (r: number, c: number) => `${r},${c}`;
 
+export type RenderLayerOptions = HexOptions;
+
 export async function createMapLayer(
     app: App,
     host: HTMLElement,
     mapFile: TFile,
-    opts: any
+    opts: RenderLayerOptions
 ): Promise<MapLayer> {
     // render map
     const handles = await renderHexMap(app, host, opts, mapFile.path);
@@ -35,8 +38,12 @@ export async function createMapLayer(
         polyToCoord.set(poly as unknown as SVGElement, { r, c });
     }
 
+    const ensureHandlesPolys = typeof handles.ensurePolys === "function"
+        ? (coords: Coord[]) => handles.ensurePolys(coords)
+        : null;
+
     function ensurePolys(coords: Coord[]) {
-        (handles as any).ensurePolys?.(coords);
+        ensureHandlesPolys?.(coords);
         // Neu erzeugte Polys in den Index aufnehmen
         for (const rc of coords) {
             const poly = handles.polyByCoord.get(keyOf(rc.r, rc.c));


### PR DESCRIPTION
## Summary
- type the cartographer map-layer adapter options via a RenderLayerOptions alias to HexOptions
- wrap RenderHandles.ensurePolys so callers no longer rely on any-casts while keeping the polygon index in sync
- document the adapter contract and data flow in a dedicated map-layer overview

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6960722b483259630bea9e9d1a47f