### PR TITLE
Refine terrain watcher recovery

### DIFF
--- a/salt-marcher/docs/core/terrain-store-overview.md
+++ b/salt-marcher/docs/core/terrain-store-overview.md
@@ -1,0 +1,36 @@
+# Terrain Store Overview
+
+## Module Purpose
+The terrain store encapsulates reading and writing the shared terrain palette that the Salt Marcher plugin keeps in `SaltMarcher/Terrains.md`. It exposes helpers to ensure the file exists with sensible defaults, parse and stringify the fenced code block that stores terrain definitions, and synchronise in-memory state (`setTerrains`) whenever the vault copy changes.
+
+## Structure Diagram
+```
++----------------------+      ensure/save/load      +----------------------------+
+|  Obsidian Vault API  | <-----------------------> |  terrain-store.ts helpers  |
++----------+-----------+                           +------------+---------------+
+           ^                                                          |
+           | modify/delete events                                     |
+           |                                                          v
+           |                                           +-------------------------+
+           +-------------------------------------------+ Global terrain registry |
+                                                       |   (setTerrains)         |
+                                                       +-------------------------+
+```
+
+## Key Functions
+- `ensureTerrainFile(app)` – Creates the terrain markdown file with default YAML frontmatter, headings, and a starter palette if it does not already exist.
+- `parseTerrainBlock(md)` / `stringifyTerrainBlock(map)` – Bidirectional conversion between the fenced code block format and a typed record of terrain metadata.
+- `loadTerrains(app)` – Ensures the file, reads the markdown, and parses the fenced block into an in-memory palette.
+- `saveTerrains(app, next)` – Persists palette updates by rewriting (or appending) the terrain code block in the markdown file.
+- `watchTerrains(app, onChange?)` – Subscribes to Obsidian vault events and keeps the global palette aligned with file changes.
+
+## Watcher Flow
+1. The watcher attaches to both `modify` and `delete` vault events through a shared dispatcher that filters for `SaltMarcher/Terrains.md`.
+2. On `delete` the handler first calls `ensureTerrainFile` to recreate the file with default content, guaranteeing a valid fenced block exists immediately after removal.
+3. Both `modify` and `delete` paths call a shared `update` routine that reloads the file via `loadTerrains`, pushes the palette into the in-memory registry with `setTerrains`, and only then emits the `salt:terrains-updated` workspace event followed by the optional `onChange` callback.
+4. The disposer returned by `watchTerrains` tears down every registered `EventRef` exactly once, ensuring no lingering listeners remain if the watcher is disposed repeatedly.
+
+## Data Flow Notes
+- The parsing layer always injects an empty-name entry with a transparent colour and speed `1` to provide a default terrain for unpainted hexes.
+- Serialisation sorts the transparent default first and all remaining entries alphabetically, keeping diffs predictable when the palette is edited.
+- Consumers outside this module should rely on the workspace event or the optional callback from `watchTerrains` instead of re-reading the file manually.

--- a/salt-marcher/src/core/terrain-store.ts
+++ b/salt-marcher/src/core/terrain-store.ts
@@ -1,5 +1,5 @@
 // src/core/terrain-store.ts
-import { App, TFile, normalizePath } from "obsidian";
+import { App, EventRef, TAbstractFile, TFile, normalizePath } from "obsidian";
 import { setTerrains } from "./terrain";
 
 export const TERRAIN_FILE = "SaltMarcher/Terrains.md";
@@ -73,18 +73,31 @@ export async function saveTerrains(app: App, next: Record<string, { color: strin
     await app.vault.modify(f, replaced);
 }
 
-export function watchTerrains(app: App, onChange: () => void): () => void {
-    const handler = async (file: TFile) => {
-        if (file.path !== TERRAIN_FILE) return;
+export function watchTerrains(app: App, onChange?: () => void): () => void {
+    const update = async (reason: "modify" | "delete") => {
+        if (reason === "delete") {
+            await ensureTerrainFile(app);
+        }
         const map = await loadTerrains(app);
         setTerrains(map); // Farben + Speed global setzen
         (app.workspace as any).trigger?.("salt:terrains-updated");
         onChange?.();
     };
-    app.vault.on("modify", handler);
-    app.vault.on("delete", handler);
+
+    function maybeUpdate(reason: "modify" | "delete", file: TAbstractFile) {
+        if (!(file instanceof TFile) || file.path !== TERRAIN_FILE) return;
+        void update(reason);
+    }
+
+    const refs: EventRef[] = (["modify", "delete"] as const).map((event) =>
+        app.vault.on(event, (file) => maybeUpdate(event, file))
+    );
+    let disposed = false;
     return () => {
-        app.vault.off("modify", handler);
-        app.vault.off("delete", handler);
+        if (disposed) return;
+        disposed = true;
+        for (const ref of refs) {
+            app.vault.offref(ref);
+        }
     };
 }


### PR DESCRIPTION
## Summary
- ensure the terrain watcher recreates the deleted file, reloads defaults, and refreshes the global store before publishing workspace events
- consolidate watcher wiring so modify/delete share the same filter and dispose reliably via stored EventRefs
- document the terrain store responsibilities and the updated watcher flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69609f7088325be9bea99b7ce2036