### PR TITLE
Refactor hex renderer into modular scene, camera, and interaction layers

### DIFF
--- a/salt-marcher/docs/core/hex-render-overview.md
+++ b/salt-marcher/docs/core/hex-render-overview.md
@@ -1,0 +1,67 @@
+# Hex Renderer Architektur
+
+```
++------------------------------+
+| renderHexMap (hex-render.ts) |
++------------------------------+
+           | orchestriert
+           v
++---------------------+    +-------------------------+    +------------------------------+
+| render/scene.ts     |--> | render/camera-          |--> | render/interactions.ts       |
+| SVG, viewBox, Polys |    | controller.ts           |    | Pointer- & Click-Fluss       |
++---------------------+    +-------------------------+    +------------------------------+
+           ^                                                     |
+           | setInteractionDelegate                              |
+           +--------------------------- render/interaction-delegate.ts
+```
+
+## Aufgabenverteilung
+
+- **`hex-render.ts`** lädt Tiles, bestimmt das initiale Grid und verbindet die Teilmodule.
+  - Reicht `ensurePolys` und `setFill` als Teil der öffentlichen `RenderHandles` durch.
+  - Stellt `setInteractionDelegate` bereit, damit Editoren eine typsichere Delegate-Instanz injizieren können.
+  - Default-Verhalten für Klicks: erstellt bei Bedarf ein Tile (`saveTile`) und öffnet es im aktiven Leaf.
+- **`render/scene.ts`** kapselt den Aufbau der SVG-Szene.
+  - Verantwortlich für Polygone, Labels, Bounding-Box und die synchronisierte Aktualisierung von `viewBox` und Overlay-Abmessungen.
+  - `ensurePolys` erzeugt fehlende Hexes und erweitert bei neuen Koordinaten automatisch die sichtbare Fläche.
+- **`render/camera-controller.ts`** wickelt `attachCameraControls` ab und liefert ein Cleanup-Objekt, sodass `destroy()` alle Listener sicher entfernt.
+- **`render/interactions.ts`** verwaltet Klick- und Pointer-Logik (inkl. Drag-Painting) auf Basis eines `HexInteractionDelegate`.
+  - Sorgt für RequestAnimationFrame-Drosselung, Pointer-Capture sowie Reset von Zuständen innerhalb von `destroy()`.
+- **`render/interaction-delegate.ts`** stellt den Default-Delegate bereit, der weiterhin `hex:click`-Events emittiert, aber das Ergebnis als `HexInteractionOutcome` interpretiert.
+  - Externe Listener können über `detail.setOutcome(...)` ein explizites Ergebnis melden, statt `preventDefault` zu nutzen.
+
+## Datenfluss
+
+1. `renderHexMap` lädt Tiles (`hex-notes.ts`) und erzeugt basierend auf vorhandenen Koordinaten einen `HexScene`.
+2. `HexScene` baut SVG/Overlay und aktualisiert `viewBox` + Overlay-Area, sobald neue Polygone entstehen.
+3. `createCameraController` aktiviert Pan/Zoom, während `createInteractionController` Pointer-Eingaben verarbeitet.
+4. Interaktionen fragen den Delegate ab:
+   - `"default"` → Renderer führt Standardaktion (`handleDefaultClick`) aus.
+   - `"handled"` → keine weitere Aktion.
+   - `"start-paint"` → Pointer wird gecaptured, weitere Pointer-Moves laufen durch den Delegate.
+5. `RenderHandles.ensurePolys` kann von außen (z. B. TravelGuide) genutzt werden, um die Szene zu erweitern; Bounding-Box/Overlay wachsen automatisch mit.
+6. `destroy()` ruft Szene-, Kamera- und Interaktions-Cleanup auf und verhindert Event-Leaks.
+
+## Öffentliche API (`RenderHandles`)
+
+| Methode | Beschreibung |
+|---------|--------------|
+| `svg`, `contentG`, `overlay` | Direkter Zugriff für Overlays/Marker. |
+| `polyByCoord` | Map für Lookups (`"r,c" → SVGPolygonElement`). |
+| `setFill(coord, color)` | Aktualisiert Inline-Farben inkl. `data-painted`-Marker. |
+| `ensurePolys(coords)` | Ergänzt fehlende Hexes **und** passt `viewBox`/Overlay sofort an. |
+| `setInteractionDelegate(delegate)` | Ersetzt den aktiven Delegate; `null` reaktiviert den Event-basierten Default. |
+| `destroy()` | Entfernt SVG, löst Kamera-Listener, stoppt Pointer-Loops und leert Maps. |
+
+## Erweiterungspunkte
+
+- **Eigene Delegates:** Tools können `HexInteractionDelegate` implementieren und via `setInteractionDelegate` registrieren, um Ergebnisse explizit zu steuern (z. B. `"start-paint"`).
+- **Event-Bridge:** Bestehende Listener können weiterhin `hex:click` konsumieren. Zusätzlich ermöglicht `detail.setOutcome(...)` den Übergang zur neuen API, ohne `preventDefault` als Seiteneffekt zu missbrauchen.
+
+## Cleanup-Garantien
+
+- `render/camera-controller.ts`: entfernt alle Listener von `attachCameraControls` inkl. `window.blur`.
+- `render/interactions.ts`: löst Pointer-Capture, stoppt laufende RAF-Schleifen und leert interne Sets.
+- `render/scene.ts`: entfernt SVG aus dem DOM und gibt Maps frei.
+
+Diese Struktur trennt Rendering, Kamera und Interaktionslogik klar, erleichtert Tool-spezifische Delegates und verhindert Speicherlecks bei mehrfacher Montage.

--- a/salt-marcher/src/core/hex-mapper/hex-render.ts
+++ b/salt-marcher/src/core/hex-mapper/hex-render.ts
@@ -1,24 +1,29 @@
 // src/core/hex-mapper/hex-render.ts
 import { App, TFile } from "obsidian";
 import { getCenterLeaf } from "../layout";
-import { hexPolygonPoints } from "./hex-geom";
 import { listTilesForMap, saveTile, type TileCoord } from "./hex-notes";
 import type { HexOptions } from "../options";
-import { attachCameraControls } from "./camera";
 import { TERRAIN_COLORS } from "../terrain";
+import { createHexScene } from "./render/scene";
+import { createCameraController } from "./render/camera-controller";
+import { createInteractionController } from "./render/interactions";
+import { createEventBackedInteractionDelegate } from "./render/interaction-delegate";
+import type { HexCoord, HexInteractionDelegate } from "./render/types";
+export type { HexInteractionDelegate, HexInteractionOutcome } from "./render/types";
+export { createEventBackedInteractionDelegate } from "./render/interaction-delegate";
 
 export type RenderHandles = {
     svg: SVGSVGElement;
     contentG: SVGGElement;
     overlay: SVGRectElement;
-    polyByCoord: Map<string, SVGPolygonElement>; // key: "r,c"
-    setFill(coord: { r: number; c: number }, color: string): void;
-    /** Fügt fehlende Polygone für die angegebenen Koordinaten hinzu und erweitert bei Bedarf die viewBox/overlay. */
-    ensurePolys(coords: Array<{ r: number; c: number }>): void;
+    polyByCoord: Map<string, SVGPolygonElement>;
+    setFill(coord: HexCoord, color: string): void;
+    /** Fügt fehlende Polygone für die angegebenen Koordinaten hinzu und erweitert viewBox/Overlay. */
+    ensurePolys(coords: HexCoord[]): void;
+    /** Ersetzt den aktiven Interaktions-Delegate (z. B. für Editor-Tools). */
+    setInteractionDelegate(delegate: HexInteractionDelegate | null): void;
     destroy(): void;
 };
-
-const keyOf = (r: number, c: number) => `${r},${c}`;
 
 type Bounds = { minR: number; maxR: number; minC: number; maxC: number };
 
@@ -41,14 +46,13 @@ export async function renderHexMap(
     opts: HexOptions,
     mapPath: string
 ): Promise<RenderHandles> {
-    const R = opts.radius;
-    const hexW = Math.sqrt(3) * R;
-    const hexH = 2 * R;
+    const radius = opts.radius;
+    const hexW = Math.sqrt(3) * radius;
+    const hexH = 2 * radius;
     const hStep = hexW;
     const vStep = 0.75 * hexH;
     const pad = 12;
 
-    // Tiles laden → dynamische Bounds
     const mapFile = app.vault.getAbstractFileByPath(mapPath);
     let tiles: Array<{ coord: TileCoord; data: { terrain: string } }> = [];
     let bounds: Bounds | null = null;
@@ -61,287 +65,120 @@ export async function renderHexMap(
         }
     }
 
-    // Fallback 3×3 um (0..2, 0..2)
     const minR0 = bounds ? bounds.minR : 0;
     const maxR0 = bounds ? bounds.maxR : 2;
     const minC0 = bounds ? bounds.minC : 0;
     const maxC0 = bounds ? bounds.maxC : 2;
 
-    // Basis-Anchor (verschiebt sich NICHT bei späterer Erweiterung -> wir erweitern viewBox stattdessen)
-    const baseR = minR0;
-    const baseC = minC0;
+    const base: HexCoord = { r: minR0, c: minC0 };
 
-    // initiale Fläche
-    const rows0 = maxR0 - minR0 + 1;
-    const cols0 = maxC0 - minC0 + 1;
+    const initialCoords: HexCoord[] = tiles.length
+        ? tiles.map((t) => t.coord)
+        : (() => {
+              const fallback: HexCoord[] = [];
+              for (let r = minR0; r <= maxR0; r++) {
+                  for (let c = minC0; c <= maxC0; c++) {
+                      fallback.push({ r, c });
+                  }
+              }
+              return fallback;
+          })();
 
-    // etwas extra Breite wegen odd-r Offset (½ Hex)
-    const initW = pad * 2 + hexW * cols0 + hexW * 0.5;
-    const initH = pad * 2 + hexH + vStep * (rows0 - 1);
+    const scene = createHexScene({
+        host,
+        radius,
+        padding: pad,
+        base,
+        initialCoords,
+    });
 
-    const svgNS = "http://www.w3.org/2000/svg";
-    const svg = document.createElementNS(svgNS, "svg") as SVGSVGElement;
-    svg.setAttribute("class", "hex3x3-map");
-    svg.setAttribute("viewBox", `0 0 ${initW} ${initH}`);
-    svg.setAttribute("width", "100%");
-    (svg.style as any).touchAction = "none";
-
-    // Overlay fängt Pointer-Events ab (Pan/Zoom/Brush-Follow)
-    const overlay = document.createElementNS(svgNS, "rect") as SVGRectElement;
-    overlay.setAttribute("x", "0");
-    overlay.setAttribute("y", "0");
-    overlay.setAttribute("width", String(initW));
-    overlay.setAttribute("height", String(initH));
-    overlay.setAttribute("fill", "transparent");
-    overlay.setAttribute("pointer-events", "all");
-    (overlay as unknown as HTMLElement).style.touchAction = "none";
-
-    const contentG = document.createElementNS(svgNS, "g") as SVGGElement;
-
-    svg.appendChild(overlay);
-    svg.appendChild(contentG);
-    host.appendChild(svg);
-
-    // Kamera
-    attachCameraControls(
-        svg,
-        contentG,
-        { minScale: 0.15, maxScale: 16, zoomSpeed: 1.01 },
-        [overlay, host]
+    const camera = createCameraController(
+        scene.svg,
+        scene.contentG,
+        scene.overlay,
+        host,
+        { minScale: 0.15, maxScale: 16, zoomSpeed: 1.01 }
     );
 
-    // ---- Rendering-State
-    const polyByCoord = new Map<string, SVGPolygonElement>();
-    // aktuelle viewBox (wird bei Erweiterung angepasst)
-    let vb = { minX: 0, minY: 0, width: initW, height: initH };
+    const svgPt = scene.svg.createSVGPoint();
 
-    // Grid → Pixel-Zentrum
-    const centerOf = (r: number, c: number) => {
-        const cx = pad + (c - baseC) * hStep + (r % 2 ? hexW / 2 : 0);
-        const cy = pad + (r - baseR) * vStep + hexH / 2;
-        return { cx, cy };
-    };
-    // Bounding-Box eines Hex (rechteckig, ausreichend für viewBox-Erweiterungen)
-    const bboxOf = (r: number, c: number) => {
-        const { cx, cy } = centerOf(r, c);
-        return {
-            minX: cx - hexW / 2,
-            maxX: cx + hexW / 2,
-            minY: cy - R,
-            maxY: cy + R,
-        };
-    };
-
-    const setViewBox = (minX: number, minY: number, width: number, height: number) => {
-        vb = { minX, minY, width, height };
-        svg.setAttribute("viewBox", `${minX} ${minY} ${width} ${height}`);
-        overlay.setAttribute("x", String(minX));
-        overlay.setAttribute("y", String(minY));
-        overlay.setAttribute("width", String(width));
-        overlay.setAttribute("height", String(height));
-    };
-
-    // --- Screen→contentG→Hex (nur einmal definieren) -----------------------
-    const svgPt = svg.createSVGPoint();
-
-    function toContentPoint(ev: MouseEvent | PointerEvent) {
-        const m = contentG.getScreenCTM();
+    const toContentPoint = (ev: MouseEvent | PointerEvent) => {
+        const m = scene.contentG.getScreenCTM();
         if (!m) return null;
-        svgPt.x = ev.clientX; svgPt.y = ev.clientY;
+        svgPt.x = ev.clientX;
+        svgPt.y = ev.clientY;
         return svgPt.matrixTransform(m.inverse());
-    }
+    };
 
-    function pointToCoord(px: number, py: number): { r: number; c: number } {
-        const rFloat = (py - pad - hexH / 2) / vStep + baseR;
+    const pointToCoord = (px: number, py: number): HexCoord => {
+        const rFloat = (py - pad - hexH / 2) / vStep + base.r;
         let r = Math.round(rFloat);
         const isOdd = r % 2 !== 0;
-        let c = Math.round((px - pad - (isOdd ? hexW / 2 : 0)) / hStep + baseC);
+        let c = Math.round((px - pad - (isOdd ? hexW / 2 : 0)) / hStep + base.c);
 
-        let best = { r, c }, bestD2 = Infinity;
+        let best = { r, c };
+        let bestD2 = Infinity;
         for (let dr = -1; dr <= 1; dr++) {
             const rr = r + dr;
             const odd = rr % 2 !== 0;
-            const cc = Math.round((px - pad - (odd ? hexW / 2 : 0)) / hStep + baseC);
-            const { cx, cy } = centerOf(rr, cc);
-            const dx = px - cx, dy = py - cy, d2 = dx*dx + dy*dy;
-            if (d2 < bestD2) { bestD2 = d2; best = { r: rr, c: cc }; }
+            const cc = Math.round((px - pad - (odd ? hexW / 2 : 0)) / hStep + base.c);
+            const cx = pad + (cc - base.c) * hStep + (rr % 2 ? hexW / 2 : 0);
+            const cy = pad + (rr - base.r) * vStep + hexH / 2;
+            const dx = px - cx;
+            const dy = py - cy;
+            const d2 = dx * dx + dy * dy;
+            if (d2 < bestD2) {
+                bestD2 = d2;
+                best = { r: rr, c: cc };
+            }
         }
         return best;
-    }
-
-    function dispatchHexClick(r: number, c: number): boolean {
-        const evt: CustomEvent<{ r:number; c:number }> = new CustomEvent("hex:click", {
-            detail: { r, c }, bubbles: true, cancelable: true
-        }) as CustomEvent<{ r:number; c:number }>;
-        return host.dispatchEvent(evt);
-    }
-
-    // Live-Fill
-    const setFill = (coord: { r: number; c: number }, color: string) => {
-        const poly = polyByCoord.get(keyOf(coord.r, coord.c));
-        if (!poly) return;
-
-        const c = color ?? "transparent";
-
-        // Inline-Styles schlagen die CSS-Default-Regeln
-        (poly.style as any).fill = c;
-        (poly.style as any).fillOpacity = c !== "transparent" ? "0.25" : "0";
-
-        // Für CSS-Selektor :not([data-painted="1"])
-        if (c !== "transparent") {
-            poly.setAttribute("data-painted", "1");
-        } else {
-            poly.removeAttribute("data-painted");
-        }
     };
 
+    const defaultDelegate = createEventBackedInteractionDelegate(host);
+    const delegateRef = { current: defaultDelegate as HexInteractionDelegate };
 
-    // Polygon + Label + Click anlegen (falls nicht vorhanden)
-    const addHex = (r: number, c: number) => {
-        const k = keyOf(r, c);
-        if (polyByCoord.has(k)) return;
-
-        const { cx, cy } = centerOf(r, c);
-
-        const poly = document.createElementNS(svgNS, "polygon");
-        // Attribute korrekt setzen
-        poly.setAttribute("points", hexPolygonPoints(cx, cy, R));
-        poly.setAttribute("data-row", String(r));
-        poly.setAttribute("data-col", String(c));
-
-        // Sichtbarkeit unabhängig von CSS sicherstellen
-        (poly.style as any).fill = "transparent";
-        (poly.style as any).stroke = "var(--text-muted)";
-        (poly.style as any).strokeWidth = "2";
-        (poly.style as any).transition = "fill 120ms ease, fill-opacity 120ms ease, stroke 120ms ease";
-
-        contentG.appendChild(poly);
-        polyByCoord.set(k, poly);
-
-        const label = document.createElementNS(svgNS, "text");
-        label.setAttribute("x", String(cx));
-        label.setAttribute("y", String(cy + 4));
-        label.setAttribute("text-anchor", "middle");
-        label.setAttribute("pointer-events", "none");
-        label.setAttribute("fill", "var(--text-muted)");
-        label.textContent = `${r},${c}`;
-        contentG.appendChild(label);
-    };
-
-    // Initial render: nur echte Tiles (plus 3×3-Fallback für leere Karten)
-    if (!tiles.length) {
-        const fallback: Array<{ r: number; c: number }> = [];
-        for (let r = 0; r <= 2; r++) for (let c = 0; c <= 2; c++) fallback.push({ r, c });
-        for (const { r, c } of fallback) addHex(r, c);
-    } else {
-        const coords = tiles.map(t => t.coord);
-        for (const { r, c } of coords) addHex(r, c);
+    async function handleDefaultClick(coord: HexCoord) {
+        const file = app.vault.getAbstractFileByPath(mapPath);
+        if (!(file instanceof TFile)) return;
+        const tfile = await saveTile(app, file, coord, { terrain: "" });
+        const leaf = getCenterLeaf(app);
+        await leaf.openFile(tfile, { active: true });
     }
 
-    // vorhandene Tiles einfärben
+    const interactions = createInteractionController({
+        svg: scene.svg,
+        overlay: scene.overlay,
+        toContentPoint,
+        pointToCoord,
+        delegateRef,
+        onDefaultClick: (coord) => handleDefaultClick(coord),
+    });
+
     for (const { coord, data } of tiles) {
         const color = TERRAIN_COLORS[data.terrain] ?? "transparent";
-        setFill(coord, color);
+        scene.setFill(coord, color);
     }
 
-    // --- öffentliche API
-    // --- öffentliche API
-    const ensurePolys = (coords: Array<{ r: number; c: number }>) => {
-        const missing: Array<{ r: number; c: number }> = [];
-        for (const { r, c } of coords) if (!polyByCoord.has(`${r},${c}`)) missing.push({ r, c });
-        if (!missing.length) return;
-        for (const { r, c } of missing) addHex(r, c);
+    const ensurePolys = (coords: HexCoord[]) => {
+        if (!coords.length) return;
+        scene.ensurePolys(coords);
     };
 
-    /* NEU: zentraler SVG-Click → immer Koordinaten berechnen */
-    svg.addEventListener("click", async (ev) => {
-        ev.preventDefault();
-        const pt = toContentPoint(ev as MouseEvent);
-        if (!pt) return;
-        const { r, c } = pointToCoord(pt.x, pt.y);
-
-        // Editor/Tool übernimmt?
-        if (dispatchHexClick(r, c) === false) return;
-
-        // Default-Open (Viewer)
-        const file = app.vault.getAbstractFileByPath(mapPath);
-        if (file instanceof TFile) {
-            const tfile = await saveTile(app, file, { r, c }, { terrain: "" });
-            const leaf = getCenterLeaf(app);
-            await leaf.openFile(tfile, { active: true });
-        }
-    }, { passive: false });
-
-    // --- Drag-Malen ----------------------------------------------------------
-    let painting = false;
-    let visited: Set<string> | null = null;
-    let raf = 0;
-    let lastEvt: PointerEvent | null = null;
-
-    const keyRC = (r:number,c:number) => `${r},${c}`;
-
-    function paintStep(ev: PointerEvent): boolean {
-        const pt = toContentPoint(ev);
-        if (!pt) return false;
-        const { r, c } = pointToCoord(pt.x, pt.y);
-        const k = keyRC(r, c);
-        if (visited && visited.has(k)) return true; // schon gemalt → weiterziehen
-        const notCanceled = dispatchHexClick(r, c);
-        if (notCanceled === false) visited?.add(k); // Tool hat übernommen
-        return notCanceled === false;
-    }
-
-    // LMB down → nur dann in den Malmodus gehen, wenn der Editor cancelt
-    svg.addEventListener("pointerdown", (ev) => {
-        if (ev.button !== 0) return;
-        lastEvt = ev;
-
-        // erster Punkt: prüft gleichzeitig, ob Tool übernimmt
-        const willPaint = paintStep(ev);
-        if (!willPaint) return; // Viewer-Fall → kein Drag, Standardinteraktionen bleiben
-
-        painting = true;
-        visited = new Set<string>();
-        (svg as any).setPointerCapture?.(ev.pointerId);
-
-        ev.preventDefault(); // blockt Click/Default, Events dürfen weiter zum Kreis
-    }, { capture: true });
-
-    svg.addEventListener("pointermove", (ev) => {
-        if (!painting) return;
-        lastEvt = ev;
-        if (!raf) {
-            raf = requestAnimationFrame(() => {
-                raf = 0;
-                if (lastEvt) paintStep(lastEvt);
-            });
-        }
-        ev.preventDefault(); // keine Propagation-Blockade → Kreis-Listener bekommt Events
-    }, { capture: true });
-
-    function endPaint(ev: PointerEvent) {
-        if (!painting) return;
-        painting = false;
-        visited?.clear(); visited = null;
-        lastEvt = null;
-        (svg as any).releasePointerCapture?.(ev.pointerId);
-        ev.preventDefault();
-    }
-    svg.addEventListener("pointerup", endPaint, { capture: true });
-    svg.addEventListener("pointercancel", endPaint, { capture: true });
-
-
-    /* HIER ist das return, vor dem dein neuer Handler stehen muss */
     return {
-        svg,
-        contentG,
-        overlay,
-        polyByCoord,
-        setFill,
+        svg: scene.svg,
+        contentG: scene.contentG,
+        overlay: scene.overlay,
+        polyByCoord: scene.polyByCoord,
+        setFill: (coord, color) => scene.setFill(coord, color),
         ensurePolys,
+        setInteractionDelegate: (delegate) => {
+            delegateRef.current = delegate ?? defaultDelegate;
+        },
         destroy: () => {
-            svg.remove();
-            polyByCoord.clear();
+            interactions.destroy();
+            camera.destroy();
+            scene.destroy();
         },
     };
 }

--- a/salt-marcher/src/core/hex-mapper/render/camera-controller.ts
+++ b/salt-marcher/src/core/hex-mapper/render/camera-controller.ts
@@ -1,0 +1,24 @@
+// src/core/hex-mapper/render/camera-controller.ts
+import { attachCameraControls } from "../camera";
+import type { Destroyable } from "./types";
+
+type CameraOptions = { minScale: number; maxScale: number; zoomSpeed: number };
+
+export function createCameraController(
+    svg: SVGSVGElement,
+    contentG: SVGGElement,
+    overlay: SVGRectElement,
+    host: HTMLElement,
+    options: CameraOptions
+): Destroyable {
+    const detach = attachCameraControls(svg, contentG, options, [overlay, host]);
+    return {
+        destroy() {
+            try {
+                detach?.();
+            } catch (err) {
+                console.error("[hex-render] camera cleanup failed", err);
+            }
+        },
+    };
+}

--- a/salt-marcher/src/core/hex-mapper/render/interaction-delegate.ts
+++ b/salt-marcher/src/core/hex-mapper/render/interaction-delegate.ts
@@ -1,0 +1,58 @@
+// src/core/hex-mapper/render/interaction-delegate.ts
+import type {
+    HexCoord,
+    HexInteractionDelegate,
+    HexInteractionEventDetail,
+    HexInteractionOutcome,
+    HexInteractionPhase,
+} from "./types";
+
+const EVENT_NAME = "hex:click";
+
+type DispatchResult = HexInteractionOutcome;
+
+function dispatchInteraction(
+    host: HTMLElement,
+    coord: HexCoord,
+    phase: HexInteractionPhase,
+    nativeEvent: MouseEvent | PointerEvent
+): DispatchResult {
+    let outcome: HexInteractionOutcome | null = null;
+    const detail: HexInteractionEventDetail = {
+        r: coord.r,
+        c: coord.c,
+        phase,
+        nativeEvent,
+        setOutcome(next) {
+            outcome = next;
+        },
+    };
+    const evt = new CustomEvent<HexInteractionEventDetail>(EVENT_NAME, {
+        detail,
+        bubbles: true,
+        cancelable: true,
+    });
+    host.dispatchEvent(evt);
+    if (outcome) return outcome;
+    if (evt.defaultPrevented) {
+        if (phase === "paint" && nativeEvent instanceof PointerEvent) {
+            const pointer = nativeEvent as PointerEvent;
+            if (pointer.button === 0 || pointer.buttons === 1) {
+                return "start-paint";
+            }
+        }
+        return "handled";
+    }
+    return "default";
+}
+
+export function createEventBackedInteractionDelegate(host: HTMLElement): HexInteractionDelegate {
+    return {
+        onClick(coord, ev) {
+            return dispatchInteraction(host, coord, "click", ev);
+        },
+        onPaintStep(coord, ev) {
+            return dispatchInteraction(host, coord, "paint", ev);
+        },
+    };
+}

--- a/salt-marcher/src/core/hex-mapper/render/interactions.ts
+++ b/salt-marcher/src/core/hex-mapper/render/interactions.ts
@@ -1,0 +1,148 @@
+// src/core/hex-mapper/render/interactions.ts
+import type { HexCoord, HexInteractionDelegate, HexInteractionOutcome, Destroyable } from "./types";
+
+export type InteractionControllerConfig = {
+    svg: SVGSVGElement;
+    overlay: SVGRectElement;
+    toContentPoint(ev: MouseEvent | PointerEvent): DOMPoint | null;
+    pointToCoord(x: number, y: number): HexCoord;
+    delegateRef: { current: HexInteractionDelegate };
+    onDefaultClick(coord: HexCoord, ev: MouseEvent): void | Promise<void>;
+};
+
+const keyOf = (coord: HexCoord) => `${coord.r},${coord.c}`;
+
+type PaintStepResult = { outcome: HexInteractionOutcome; coord: HexCoord | null };
+
+export function createInteractionController(config: InteractionControllerConfig): Destroyable {
+    const { svg, overlay, toContentPoint, pointToCoord, delegateRef, onDefaultClick } = config;
+
+    let painting = false;
+    let visited: Set<string> | null = null;
+    let raf = 0;
+    let lastPointer: PointerEvent | null = null;
+
+    const getDelegate = () => delegateRef.current;
+
+    function convert(ev: MouseEvent | PointerEvent): HexCoord | null {
+        const pt = toContentPoint(ev);
+        if (!pt) return null;
+        return pointToCoord(pt.x, pt.y);
+    }
+
+    async function executePaintStep(ev: PointerEvent): Promise<PaintStepResult> {
+        const coord = convert(ev);
+        if (!coord) return { outcome: "handled", coord: null };
+        if (painting && visited?.has(keyOf(coord))) {
+            return { outcome: "handled", coord };
+        }
+        const handler = getDelegate().onPaintStep;
+        if (!handler) return { outcome: "default", coord };
+        const outcome = await handler(coord, ev);
+        return { outcome, coord };
+    }
+
+    const onClick = async (ev: MouseEvent) => {
+        ev.preventDefault();
+        const coord = convert(ev);
+        if (!coord) return;
+        const handler = getDelegate().onClick;
+        const outcome = handler ? await handler(coord, ev) : "default";
+        if (outcome === "default") {
+            await onDefaultClick(coord, ev);
+        }
+    };
+
+    const onPointerDown = (ev: PointerEvent) => {
+        if (ev.button !== 0) return;
+        if (!getDelegate().onPaintStep) return;
+        lastPointer = ev;
+        void (async () => {
+            const { outcome, coord } = await executePaintStep(ev);
+            if (outcome === "start-paint" && coord) {
+                painting = true;
+                visited = new Set<string>([keyOf(coord)]);
+                (svg as any).setPointerCapture?.(ev.pointerId);
+                ev.preventDefault();
+            } else if (outcome !== "default") {
+                ev.preventDefault();
+            }
+        })();
+    };
+
+    const runQueuedPaintStep = () => {
+        if (!painting || !lastPointer) return;
+        const ev = lastPointer;
+        void (async () => {
+            const { outcome, coord } = await executePaintStep(ev);
+            if (!painting) return;
+            if (coord && outcome !== "default") {
+                visited?.add(keyOf(coord));
+            }
+        })();
+    };
+
+    const onPointerMove = (ev: PointerEvent) => {
+        if (!painting) return;
+        lastPointer = ev;
+        if (!raf) {
+            raf = requestAnimationFrame(() => {
+                raf = 0;
+                runQueuedPaintStep();
+            });
+        }
+        ev.preventDefault();
+    };
+
+    const endPaint = (ev: PointerEvent) => {
+        if (!painting) return;
+        painting = false;
+        visited?.clear();
+        visited = null;
+        lastPointer = null;
+        if (raf) {
+            cancelAnimationFrame(raf);
+            raf = 0;
+        }
+        (svg as any).releasePointerCapture?.(ev.pointerId);
+        getDelegate().onPaintEnd?.();
+        ev.preventDefault();
+    };
+
+    const onPointerCancel = (ev: PointerEvent) => {
+        if (!painting) return;
+        endPaint(ev);
+    };
+
+    svg.addEventListener("click", onClick, { passive: false });
+    svg.addEventListener("pointerdown", onPointerDown, { capture: true });
+    svg.addEventListener("pointermove", onPointerMove, { capture: true });
+    svg.addEventListener("pointerup", endPaint, { capture: true });
+    svg.addEventListener("pointercancel", onPointerCancel, { capture: true });
+    overlay.addEventListener("pointerdown", onPointerDown, { capture: true });
+    overlay.addEventListener("pointermove", onPointerMove, { capture: true });
+    overlay.addEventListener("pointerup", endPaint, { capture: true });
+    overlay.addEventListener("pointercancel", onPointerCancel, { capture: true });
+
+    return {
+        destroy() {
+            svg.removeEventListener("click", onClick as EventListener);
+            svg.removeEventListener("pointerdown", onPointerDown as EventListener);
+            svg.removeEventListener("pointermove", onPointerMove as EventListener);
+            svg.removeEventListener("pointerup", endPaint as EventListener);
+            svg.removeEventListener("pointercancel", onPointerCancel as EventListener);
+            overlay.removeEventListener("pointerdown", onPointerDown as EventListener);
+            overlay.removeEventListener("pointermove", onPointerMove as EventListener);
+            overlay.removeEventListener("pointerup", endPaint as EventListener);
+            overlay.removeEventListener("pointercancel", onPointerCancel as EventListener);
+            if (raf) {
+                cancelAnimationFrame(raf);
+                raf = 0;
+            }
+            painting = false;
+            visited?.clear();
+            visited = null;
+            lastPointer = null;
+        },
+    };
+}

--- a/salt-marcher/src/core/hex-mapper/render/scene.ts
+++ b/salt-marcher/src/core/hex-mapper/render/scene.ts
@@ -1,0 +1,185 @@
+// src/core/hex-mapper/render/scene.ts
+import { hexPolygonPoints } from "../hex-geom";
+import type { HexCoord } from "./types";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+export type HexSceneConfig = {
+    host: HTMLElement;
+    radius: number;
+    padding: number;
+    base: HexCoord;
+    initialCoords: HexCoord[];
+};
+
+export type HexScene = {
+    svg: SVGSVGElement;
+    contentG: SVGGElement;
+    overlay: SVGRectElement;
+    polyByCoord: Map<string, SVGPolygonElement>;
+    ensurePolys(coords: HexCoord[]): void;
+    setFill(coord: HexCoord, color: string): void;
+    getViewBox(): { minX: number; minY: number; width: number; height: number };
+    destroy(): void;
+};
+
+const keyOf = (coord: HexCoord) => `${coord.r},${coord.c}`;
+
+type Rect = { minX: number; minY: number; maxX: number; maxY: number };
+
+type SceneInternals = {
+    bounds: Rect | null;
+    updateViewBox(): void;
+    centerOf(coord: HexCoord): { cx: number; cy: number };
+    bboxOf(coord: HexCoord): Rect;
+};
+
+export function createHexScene(config: HexSceneConfig): HexScene {
+    const { host, radius, padding, base, initialCoords } = config;
+
+    const hexW = Math.sqrt(3) * radius;
+    const hexH = 2 * radius;
+    const hStep = hexW;
+    const vStep = 0.75 * hexH;
+
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("class", "hex3x3-map");
+    svg.setAttribute("width", "100%");
+    (svg.style as any).touchAction = "none";
+
+    const overlay = document.createElementNS(SVG_NS, "rect") as SVGRectElement;
+    overlay.setAttribute("fill", "transparent");
+    overlay.setAttribute("pointer-events", "all");
+    (overlay as unknown as HTMLElement).style.touchAction = "none";
+
+    const contentG = document.createElementNS(SVG_NS, "g") as SVGGElement;
+
+    svg.appendChild(overlay);
+    svg.appendChild(contentG);
+    host.appendChild(svg);
+
+    const polyByCoord = new Map<string, SVGPolygonElement>();
+
+    const internals: SceneInternals = {
+        bounds: null,
+        updateViewBox() {
+            if (!internals.bounds) return;
+            const { minX, minY, maxX, maxY } = internals.bounds;
+            const paddedMinX = Math.floor(minX - padding);
+            const paddedMinY = Math.floor(minY - padding);
+            const paddedMaxX = Math.ceil(maxX + padding);
+            const paddedMaxY = Math.ceil(maxY + padding);
+            const width = Math.max(1, paddedMaxX - paddedMinX);
+            const height = Math.max(1, paddedMaxY - paddedMinY);
+            svg.setAttribute("viewBox", `${paddedMinX} ${paddedMinY} ${width} ${height}`);
+            overlay.setAttribute("x", String(paddedMinX));
+            overlay.setAttribute("y", String(paddedMinY));
+            overlay.setAttribute("width", String(width));
+            overlay.setAttribute("height", String(height));
+        },
+        centerOf(coord: HexCoord) {
+            const { r, c } = coord;
+            const cx = padding + (c - base.c) * hStep + (r % 2 ? hexW / 2 : 0);
+            const cy = padding + (r - base.r) * vStep + hexH / 2;
+            return { cx, cy };
+        },
+        bboxOf(coord: HexCoord) {
+            const { cx, cy } = internals.centerOf(coord);
+            return {
+                minX: cx - hexW / 2,
+                maxX: cx + hexW / 2,
+                minY: cy - radius,
+                maxY: cy + radius,
+            };
+        },
+    };
+
+    function mergeBounds(next: Rect): void {
+        if (!internals.bounds) {
+            internals.bounds = { ...next };
+            return;
+        }
+        const current = internals.bounds;
+        current.minX = Math.min(current.minX, next.minX);
+        current.minY = Math.min(current.minY, next.minY);
+        current.maxX = Math.max(current.maxX, next.maxX);
+        current.maxY = Math.max(current.maxY, next.maxY);
+    }
+
+    function addHex(coord: HexCoord): void {
+        if (polyByCoord.has(keyOf(coord))) return;
+        const { cx, cy } = internals.centerOf(coord);
+        const poly = document.createElementNS(SVG_NS, "polygon");
+        poly.setAttribute("points", hexPolygonPoints(cx, cy, radius));
+        poly.setAttribute("data-row", String(coord.r));
+        poly.setAttribute("data-col", String(coord.c));
+        (poly.style as any).fill = "transparent";
+        (poly.style as any).stroke = "var(--text-muted)";
+        (poly.style as any).strokeWidth = "2";
+        (poly.style as any).transition = "fill 120ms ease, fill-opacity 120ms ease, stroke 120ms ease";
+
+        contentG.appendChild(poly);
+        polyByCoord.set(keyOf(coord), poly);
+
+        const label = document.createElementNS(SVG_NS, "text");
+        label.setAttribute("x", String(cx));
+        label.setAttribute("y", String(cy + 4));
+        label.setAttribute("text-anchor", "middle");
+        label.setAttribute("pointer-events", "none");
+        label.setAttribute("fill", "var(--text-muted)");
+        label.textContent = `${coord.r},${coord.c}`;
+        contentG.appendChild(label);
+
+        mergeBounds(internals.bboxOf(coord));
+    }
+
+    function ensurePolys(coords: HexCoord[]): void {
+        let added = false;
+        for (const coord of coords) {
+            const key = keyOf(coord);
+            if (polyByCoord.has(key)) continue;
+            addHex(coord);
+            added = true;
+        }
+        if (added) internals.updateViewBox();
+    }
+
+    function setFill(coord: HexCoord, color: string): void {
+        const poly = polyByCoord.get(keyOf(coord));
+        if (!poly) return;
+        const fill = color ?? "transparent";
+        (poly.style as any).fill = fill;
+        (poly.style as any).fillOpacity = fill !== "transparent" ? "0.25" : "0";
+        if (fill !== "transparent") {
+            poly.setAttribute("data-painted", "1");
+        } else {
+            poly.removeAttribute("data-painted");
+        }
+    }
+
+    const initial = initialCoords.length ? initialCoords : [];
+    if (initial.length) {
+        for (const coord of initial) addHex(coord);
+        internals.updateViewBox();
+    }
+
+    return {
+        svg,
+        contentG,
+        overlay,
+        polyByCoord,
+        ensurePolys,
+        setFill,
+        getViewBox: () => {
+            if (!internals.bounds) {
+                return { minX: 0, minY: 0, width: 0, height: 0 };
+            }
+            const { minX, minY, maxX, maxY } = internals.bounds;
+            return { minX, minY, width: maxX - minX, height: maxY - minY };
+        },
+        destroy: () => {
+            polyByCoord.clear();
+            svg.remove();
+        },
+    };
+}

--- a/salt-marcher/src/core/hex-mapper/render/types.ts
+++ b/salt-marcher/src/core/hex-mapper/render/types.ts
@@ -1,0 +1,28 @@
+// src/core/hex-mapper/render/types.ts
+
+export type HexCoord = { r: number; c: number };
+
+export type HexInteractionOutcome = "default" | "handled" | "start-paint";
+
+export type HexInteractionPhase = "click" | "paint";
+
+export type HexInteractionEventDetail = {
+    r: number;
+    c: number;
+    /**
+     * Phase der Interaktion. "click" = diskretes Auslösen (Mouse/Touch),
+     * "paint" = kontinuierliches Ziehen über eine gedrückte Primärtaste.
+     */
+    phase: HexInteractionPhase;
+    nativeEvent: MouseEvent | PointerEvent;
+    /** Erlaubt Listenern, ein explizites Ergebnis zu liefern. */
+    setOutcome(outcome: HexInteractionOutcome): void;
+};
+
+export interface HexInteractionDelegate {
+    onClick?(coord: HexCoord, ev: MouseEvent): HexInteractionOutcome | Promise<HexInteractionOutcome>;
+    onPaintStep?(coord: HexCoord, ev: PointerEvent): HexInteractionOutcome | Promise<HexInteractionOutcome>;
+    onPaintEnd?(): void;
+}
+
+export type Destroyable = { destroy(): void };


### PR DESCRIPTION
## Summary
- split the hex renderer into scene, camera, and interaction modules with a typed delegate API
- update ensurePolys to grow the SVG viewBox/overlay and expose delegate swapping via RenderHandles
- document the new architecture in docs/core/hex-render-overview.md

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69609b100832588c18ef9bcb24a64