### PR TITLE
Refactor library view into per-mode renderers

### DIFF
--- a/salt-marcher/docs/library/Overview.md
+++ b/salt-marcher/docs/library/Overview.md
@@ -1,0 +1,56 @@
+# Library View – Struktur & Persistenz
+
+## Architektur auf einen Blick
+```mermaid
+graph TD
+    A[LibraryView] -->|instantiate| B[CreaturesRenderer]
+    A -->|instantiate| C[SpellsRenderer]
+    A -->|instantiate| D[TerrainsRenderer]
+    A -->|instantiate| E[RegionsRenderer]
+    A -->|delegates search/create| B
+    A -->|delegates search/create| C
+    A -->|delegates search/create| D
+    A -->|delegates search/create| E
+    D -->|debounced save| T[(Terrains.md)]
+    E -->|debounced save| R[(Regions.json)]
+    B -->|watch| BC[Creatures directory]
+    C -->|watch| SC[Spells directory]
+    D -->|watch| TT[Terrains store]
+    E -->|watch| RR[Regions store]
+    E -->|pull terrain names| TT
+```
+
+Der `LibraryView` reduziert sich auf die Shell-Aufgabe: Mode-Umschaltung, Suchfeld, Beschreibungstext und Einbindung der Renderer. Für jeden Modus existiert ein dedizierter Renderer, der UI, Watcher und Persistenzkabelung kapselt.
+
+## Module & Verantwortlichkeiten
+
+| Modul | Aufgabe |
+| --- | --- |
+| `view.ts` | Initialisiert die View-Shell, hält den aktuellen Modus & Query-String und delegiert an Mode-spezifische Renderer. |
+| `view/mode.ts` | Definiert das `ModeRenderer`-Interface, gemeinsame Hilfslogik (`scoreName`) sowie eine `BaseModeRenderer`-Klasse mit Cleanup-Handling. |
+| `view/creatures.ts` | Lädt & beobachtet Kreaturen-Dateien, rendert Trefferliste und öffnet Dateien über Obsidian. |
+| `view/spells.ts` | Analog zu `creatures`, jedoch für Zauber. |
+| `view/terrains.ts` | Stellt Terrain-Palette dar, verwaltet lokale Mutationen und speichert mit 500 ms Debounce in `Terrains.md`. |
+| `view/regions.ts` | Verwaltet Regionen inklusive Terrain-Auswahl, konsumiert Terrain-Liste und speichert Änderungen mit 500 ms Debounce. |
+
+## Datenfluss & Persistenz
+
+1. **Mode-Aktivierung:** `LibraryView.activateMode` zerstört ggf. den bisherigen Renderer (inkl. Watcher) und erzeugt eine neue Instanz. Anschließend wird die aktuelle Suchanfrage übergeben und die Liste gerendert.
+2. **Watcher-Management:** Jeder Renderer registriert die benötigten Datei-Watcher selbstständig über `BaseModeRenderer.registerCleanup`. Beim Destroy werden alle Listener aufgehoben und das Container-Element geleert.
+3. **Such- und Create-Fluss:** Der Suchstring wird zentral gehalten und per `setQuery` an den aktiven Renderer weitergereicht. Der „Erstellen“-Button ruft `handleCreate` des aktiven Renderers auf, wodurch Kreaturen/Zauber modale Workflows starten oder Terrains/Regionen direkt vorbereitet werden.
+4. **Terrains-Persistenz:** Terrain-Änderungen aktualisieren zunächst nur den lokalen Zustand. Ein Debounce (500 ms) bündelt alle Eingaben, bevor `saveTerrains` ausgeführt wird. Nach dem Persistieren werden Daten erneut geladen, um externe Änderungen zu berücksichtigen.
+5. **Regions-Persistenz:** Regionen verhalten sich identisch – Eingaben werden lokal gehalten und erst nach dem Debounce in `saveRegions` geschrieben. Terrain-Namen werden separat beobachtet, sodass Dropdowns automatisch neue Terrains anbieten.
+
+## Skriptbeschreibungen
+
+- **`view.ts`** – Komponiert die Library-Oberfläche, pflegt Modus-Buttons, Query und Quelle-Text, erzeugt Renderer instanziell und räumt sie sauber wieder auf.
+- **`view/mode.ts`** – Abstrakte Basisschicht für Renderer mit Cleanup-Registrierung und Namensscoring.
+- **`view/creatures.ts` / `view/spells.ts`** – Einfache Listenrenderer, die Obsidian-Dateien per Button öffnen und auf Verzeichnisänderungen reagieren.
+- **`view/terrains.ts`** – Enthält Terrain-spezifische UI mit Farbwähler, Geschwindigkeitsfeld, Debounce-Speichermechanismus und Sicherstellung des leeren Eintrags.
+- **`view/regions.ts`** – Rendert Regionen inklusive Terrain-Auswahl (mit Such-Dropdown) und debounced Persistenz plus Dropdown-Aktualisierung bei Terrain-Änderungen.
+
+## Feature-Notizen
+
+- **Debounced Saves:** Terrains und Regionen lösen keine direkten Vault-Schreibzugriffe pro Tastendruck mehr aus; Änderungen werden gesammelt und nach 500 ms Inaktivität geschrieben.
+- **Sauberer Lifecycle:** Renderer übernehmen ihre Watcher komplett selbst und geben sie beim Wechsel frei, wodurch `LibraryView` keine zentrale Cleanup-Liste mehr benötigt.
+- **Erweiterbarkeit:** Neue Modi können über zusätzliche Renderer eingeführt werden, ohne `LibraryView` mit Mode-spezifischer Logik zu füllen.

--- a/salt-marcher/src/apps/library/view.ts
+++ b/salt-marcher/src/apps/library/view.ts
@@ -1,27 +1,25 @@
 // src/apps/library/view.ts
-import { ItemView, TFile, WorkspaceLeaf } from "obsidian";
-import { ensureCreatureDir, listCreatureFiles, watchCreatureDir, createCreatureFile } from "./core/creature-files";
-import { enhanceSelectToSearch } from "../../ui/search-dropdown";
-import { ensureTerrainFile, loadTerrains, saveTerrains, watchTerrains, TERRAIN_FILE } from "../../core/terrain-store";
-import { ensureRegionsFile, loadRegions, saveRegions, watchRegions, REGIONS_FILE, type Region } from "../../core/regions-store";
-import { ensureSpellDir, listSpellFiles, watchSpellDir, createSpellFile } from "./core/spell-files";
-import { CreateCreatureModal, CreateSpellModal } from "./create";
+import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ensureCreatureDir } from "./core/creature-files";
+import { ensureSpellDir } from "./core/spell-files";
+import { ensureTerrainFile } from "../../core/terrain-store";
+import { ensureRegionsFile } from "../../core/regions-store";
+import type { ModeRenderer, Mode } from "./view/mode";
+import { CreaturesRenderer } from "./view/creatures";
+import { SpellsRenderer } from "./view/spells";
+import { TerrainsRenderer, describeTerrainsSource } from "./view/terrains";
+import { RegionsRenderer, describeRegionsSource } from "./view/regions";
 
 export const VIEW_LIBRARY = "salt-library";
 
-type Mode = "creatures" | "spells" | "terrains" | "regions";
-
 export class LibraryView extends ItemView {
     private mode: Mode = "creatures";
-    private cleanups: Array<() => void> = [];
-    private unwatch?: () => void;
     private query = "";
-
-    // data per mode
-    private creatureFiles: TFile[] = [];
-    private terrains: Record<string, { color: string; speed: number }> = {};
-    private spellFiles: TFile[] = [];
-    private regions: Region[] = [];
+    private headerButtons = new Map<Mode, HTMLButtonElement>();
+    private listEl?: HTMLElement;
+    private descEl?: HTMLElement;
+    private activeRenderer?: ModeRenderer;
+    private searchInput?: HTMLInputElement;
 
     getViewType() { return VIEW_LIBRARY; }
     getDisplayText() { return "Library"; }
@@ -29,50 +27,23 @@ export class LibraryView extends ItemView {
 
     async onOpen() {
         this.contentEl.addClass("sm-library");
-        await ensureCreatureDir(this.app);
-        await ensureTerrainFile(this.app);
-        await ensureSpellDir(this.app);
-        await ensureRegionsFile(this.app);
-        await this.reloadAll();
-        this.render();
-        this.attachWatcher();
+        await Promise.all([
+            ensureCreatureDir(this.app),
+            ensureSpellDir(this.app),
+            ensureTerrainFile(this.app),
+            ensureRegionsFile(this.app),
+        ]);
+        this.renderShell();
+        await this.activateMode(this.mode);
     }
 
     async onClose() {
-        this.unwatch?.();
-        this.cleanups.forEach(fn => { try { fn(); } catch {} });
-        this.cleanups = [];
+        await this.activeRenderer?.destroy();
+        this.activeRenderer = undefined;
         this.contentEl.removeClass("sm-library");
     }
 
-    private attachWatcher() {
-        this.unwatch?.();
-        const off: Array<() => void> = [];
-        off.push(watchCreatureDir(this.app, () => this.onSourceChanged("creatures")));
-        off.push(watchSpellDir(this.app, () => this.onSourceChanged("spells")));
-        off.push(watchTerrains(this.app, () => this.onSourceChanged("terrains")));
-        off.push(watchRegions(this.app, () => this.onSourceChanged("regions")));
-        this.unwatch = () => off.forEach(fn => fn());
-    }
-
-    private async onSourceChanged(which: Mode) {
-        if (which === "creatures") this.creatureFiles = await listCreatureFiles(this.app);
-        if (which === "spells") this.spellFiles = await listSpellFiles(this.app);
-        if (which === "terrains") this.terrains = await loadTerrains(this.app);
-        if (which === "regions") this.regions = await loadRegions(this.app);
-        this.renderList();
-    }
-
-    private async reloadAll() {
-        [this.creatureFiles, this.spellFiles, this.terrains, this.regions] = await Promise.all([
-            listCreatureFiles(this.app),
-            listSpellFiles(this.app),
-            loadTerrains(this.app),
-            loadRegions(this.app),
-        ]);
-    }
-
-    private render() {
+    private renderShell() {
         const root = this.contentEl; root.empty();
         root.createEl("h2", { text: "Library" });
 
@@ -80,9 +51,8 @@ export class LibraryView extends ItemView {
         const header = root.createDiv({ cls: "sm-lib-header" });
         const mkBtn = (label: string, m: Mode) => {
             const b = header.createEl("button", { text: label });
-            const update = () => b.classList.toggle("is-active", this.mode === m);
-            update();
-            b.onclick = () => { this.mode = m; updateAll(); };
+            this.headerButtons.set(m, b);
+            b.onclick = () => { void this.activateMode(m); };
             return b;
         };
         mkBtn("Creatures", "creatures");
@@ -94,213 +64,79 @@ export class LibraryView extends ItemView {
         const bar = root.createDiv({ cls: "sm-cc-searchbar" });
         const search = bar.createEl("input", { attr: { type: "text", placeholder: "Suche oder Name eingeben…" } }) as HTMLInputElement;
         search.value = this.query;
-        search.oninput = () => { this.query = search.value; this.renderList(); };
+        search.oninput = () => {
+            this.query = search.value;
+            this.activeRenderer?.setQuery(this.query);
+        };
+        this.searchInput = search;
         const createBtn = bar.createEl("button", { text: "Erstellen" });
-        createBtn.onclick = () => this.onCreate(search.value.trim());
+        createBtn.onclick = () => { void this.onCreate(search.value.trim()); };
 
         // Target source info
-        const desc = root.createDiv({ cls: "desc" });
-        const updateDesc = () => {
-            desc.setText(
-                this.mode === "creatures" ? "Quelle: SaltMarcher/Creatures/" :
-                this.mode === "spells" ? "Quelle: SaltMarcher/Spells/" :
-                this.mode === "terrains" ? `Quelle: ${TERRAIN_FILE}` :
-                `Quelle: ${REGIONS_FILE}`
-            );
-        };
-        updateDesc();
+        this.descEl = root.createDiv({ cls: "desc" });
 
         // List container
-        root.createDiv({ cls: "sm-cc-list" });
-
-        const updateAll = () => { updateDesc(); this.renderList(); header.querySelectorAll('button').forEach(b => b.classList.toggle('is-active', (b as HTMLButtonElement).innerText.toLowerCase().startsWith(this.mode.slice(0,3)))); };
-        this.renderList();
+        this.listEl = root.createDiv({ cls: "sm-cc-list" });
     }
 
-    private renderList() {
-        const root = this.contentEl;
-        const list = root.querySelector(".sm-cc-list") as HTMLElement;
-        if (!list) return;
-        list.empty();
-        const q = (this.query || "").toLowerCase();
-        const score = (name: string) => this.scoreName(name.toLowerCase(), q);
-
-        if (this.mode === "creatures") {
-            const items = this.creatureFiles.map(f => ({ name: f.basename, f, s: score(f.basename) }))
-                .filter(x => q ? x.s > -Infinity : true)
-                .sort((a, b) => b.s - a.s || a.name.localeCompare(b.name));
-            for (const it of items) {
-                const row = list.createDiv({ cls: "sm-cc-item" });
-                row.createDiv({ cls: "sm-cc-item__name", text: it.name });
-                const openBtn = row.createEl("button", { text: "Öffnen" });
-                openBtn.onclick = async () => this.app.workspace.openLinkText(it.f.path, it.f.path, true);
-            }
+    private async activateMode(mode: Mode) {
+        if (this.activeRenderer?.mode === mode) {
+            this.mode = mode;
+            this.updateHeaderButtons();
+            this.updateSourceDescription();
+            this.activeRenderer.setQuery(this.query);
+            this.activeRenderer.render();
             return;
         }
-
-        if (this.mode === "spells") {
-            const items = this.spellFiles.map(f => ({ name: f.basename, f, s: score(f.basename) }))
-                .filter(x => q ? x.s > -Infinity : true)
-                .sort((a, b) => b.s - a.s || a.name.localeCompare(b.name));
-            for (const it of items) {
-                const row = list.createDiv({ cls: "sm-cc-item" });
-                row.createDiv({ cls: "sm-cc-item__name", text: it.name });
-                const openBtn = row.createEl("button", { text: "Öffnen" });
-                openBtn.onclick = async () => this.app.workspace.openLinkText(it.f.path, it.f.path, true);
-            }
-            return;
+        if (this.activeRenderer) {
+            await this.activeRenderer.destroy();
+            this.activeRenderer = undefined;
         }
+        this.mode = mode;
+        this.updateHeaderButtons();
+        this.updateSourceDescription();
+        if (!this.listEl) return;
+        const renderer = this.createRenderer(mode, this.listEl);
+        this.activeRenderer = renderer;
+        await renderer.init();
+        renderer.setQuery(this.query);
+        renderer.render();
+    }
 
-        if (this.mode === "terrains") {
-            // include empty terrain always at top
-            const names = Object.keys(this.terrains || {});
-            const order = ["", ...names.filter(n => n !== "")];
-            const items = order
-                .map(name => ({ name, s: score(name || "") }))
-                .filter(x => x.name === "" || (q ? x.s > -Infinity : true))
-                .sort((a, b) => a.name === "" ? -1 : b.name === "" ? 1 : (b.s - a.s || a.name.localeCompare(b.name)));
-
-            for (const it of items) {
-                const row = list.createDiv({ cls: "sm-cc-item" });
-                const nameInp = row.createEl("input", { attr: { type: "text", placeholder: "(Name)" } }) as HTMLInputElement;
-                nameInp.value = it.name;
-                const colorInp = row.createEl("input", { attr: { type: "color" } }) as HTMLInputElement;
-                const speedInp = row.createEl("input", { attr: { type: "number", step: "0.1", min: "0" } }) as HTMLInputElement;
-                const delBtn = row.createEl("button", { text: "🗑" });
-
-                const v = this.terrains[it.name] || { color: "transparent", speed: 1 };
-                colorInp.value = /^#([0-9a-f]{6})$/i.test(v.color) ? v.color : "#999999";
-                speedInp.value = String(Number.isFinite(v.speed) ? v.speed : 1);
-
-                const commit = () => this.commitTerrains();
-                const upsert = () => {
-                    const k = nameInp.value;
-                    const color = colorInp.value;
-                    const speed = parseFloat(speedInp.value) || 1;
-                    this.upsertTerrain(it.name, k, color, speed);
-                };
-                nameInp.oninput = upsert;
-                colorInp.oninput = upsert;
-                speedInp.oninput = upsert;
-                delBtn.onclick = () => this.removeTerrain(nameInp.value);
-            }
-            return;
+    private createRenderer(mode: Mode, container: HTMLElement): ModeRenderer {
+        switch (mode) {
+            case "creatures":
+                return new CreaturesRenderer(this.app, container);
+            case "spells":
+                return new SpellsRenderer(this.app, container);
+            case "terrains":
+                return new TerrainsRenderer(this.app, container);
+            case "regions":
+                return new RegionsRenderer(this.app, container);
+            default:
+                throw new Error(`Unsupported mode: ${mode}`);
         }
+    }
 
-        // regions
-        const entries = this.regions.map((r, i) => ({ ...r, _i: i }))
-            .filter(r => (r.name || "").trim())
-            .map(r => ({ r, s: score(r.name) }))
-            .filter(x => q ? x.s > -Infinity : true)
-            .sort((a, b) => b.s - a.s || a.r.name.localeCompare(b.r.name));
-        for (const it of entries) {
-            const row = list.createDiv({ cls: "sm-cc-item" });
-            const nameInp = row.createEl("input", { attr: { type: "text", placeholder: "(Name)" } }) as HTMLInputElement;
-            nameInp.value = it.r.name;
-            const terrSel = row.createEl("select") as HTMLSelectElement;
-            enhanceSelectToSearch(terrSel, 'Such-dropdown…');
-            const terrNames = Object.keys(this.terrains || {});
-            for (const t of terrNames) {
-                const opt = terrSel.createEl("option", { text: t || "(leer)", value: t });
-                if (t === it.r.terrain) opt.selected = true;
-            }
-            const encInp = row.createEl("input", { attr: { type: "number", min: "1", step: "1", placeholder: "Encounter 1/n" } }) as HTMLInputElement;
-            encInp.value = it.r.encounterOdds && it.r.encounterOdds > 0 ? String(it.r.encounterOdds) : "";
-            const delBtn = row.createEl("button", { text: "🗑" });
-
-            const update = () => {
-                const n = parseInt(encInp.value, 10);
-                const odds = Number.isFinite(n) && n > 0 ? n : undefined;
-                this.upsertRegion(it.r._i as number, nameInp.value, terrSel.value, odds);
-            };
-            nameInp.oninput = update;
-            terrSel.onchange = update;
-            encInp.oninput = update;
-            delBtn.onclick = () => this.removeRegion(it.r._i as number);
+    private updateHeaderButtons() {
+        for (const [mode, btn] of this.headerButtons.entries()) {
+            btn.classList.toggle("is-active", this.mode === mode);
         }
+    }
+
+    private updateSourceDescription() {
+        if (!this.descEl) return;
+        const text = this.mode === "creatures" ? "Quelle: SaltMarcher/Creatures/" :
+            this.mode === "spells" ? "Quelle: SaltMarcher/Spells/" :
+                this.mode === "terrains" ? describeTerrainsSource() :
+                    describeRegionsSource();
+        this.descEl.setText(text);
     }
 
     private async onCreate(name: string) {
-        if (this.mode === "creatures") {
-            new CreateCreatureModal(this.app, name, async (data) => {
-                const f = await createCreatureFile(this.app, data);
-                await this.onSourceChanged("creatures");
-                await this.app.workspace.openLinkText(f.path, f.path, true, { state: { mode: "source" } });
-            }).open();
-            return;
-        }
-        if (this.mode === "spells") {
-            new CreateSpellModal(this.app, name, async (data) => {
-                const f = await createSpellFile(this.app, data);
-                await this.onSourceChanged("spells");
-                await this.app.workspace.openLinkText(f.path, f.path, true, { state: { mode: "source" } });
-            }).open();
-            return;
-        }
-        if (!name) return;
-        if (this.mode === "terrains") {
-            const map = { ...this.terrains };
-            if (!map[name]) map[name] = { color: "#888888", speed: 1 };
-            await saveTerrains(this.app, map);
-            this.terrains = await loadTerrains(this.app);
-            this.renderList();
-            return;
-        }
-        // regions
-        const exists = this.regions.some(r => (r.name || "").toLowerCase() === name.toLowerCase());
-        if (!exists) {
-            const next = [...this.regions, { name, terrain: "" }];
-            await saveRegions(this.app, next);
-            this.regions = await loadRegions(this.app);
-            this.renderList();
-        }
-    }
-
-    private scoreName(name: string, q: string): number {
-        if (!q) return 0.0001;
-        if (name === q) return 1000;
-        if (name.startsWith(q)) return 900 - (name.length - q.length);
-        const idx = name.indexOf(q);
-        if (idx >= 0) return 700 - idx;
-        const tokenIdx = name.split(/\s+|[-_]/).findIndex(t => t.startsWith(q));
-        if (tokenIdx >= 0) return 600 - tokenIdx * 5;
-        return -Infinity;
-    }
-
-    // --- Terrains helpers ---
-    private async commitTerrains() {
-        await saveTerrains(this.app, this.terrains);
-        // reload to normalize ordering and ensure empty terrain key present
-        this.terrains = await loadTerrains(this.app);
-    }
-    private upsertTerrain(oldKey: string, newKey: string, color: string, speed: number) {
-        if (!Number.isFinite(speed as any)) speed = 1;
-        const next = { ...this.terrains };
-        if (oldKey !== newKey) delete next[oldKey];
-        if (newKey === "") next[""] = { color: "transparent", speed: 1 };
-        else next[newKey] = { color, speed };
-        this.terrains = next;
-        void this.commitTerrains();
-    }
-    private removeTerrain(key: string) {
-        if (key === "") return;
-        const next = { ...this.terrains }; delete next[key]; this.terrains = next;
-        void this.commitTerrains(); this.renderList();
-    }
-
-    // --- Regions helpers ---
-    private async commitRegions() {
-        await saveRegions(this.app, this.regions);
-    }
-    private upsertRegion(idx: number, name: string, terrain: string, encounterOdds?: number) {
-        if (!this.regions[idx]) return;
-        this.regions[idx] = { name, terrain, encounterOdds } as Region;
-        void this.commitRegions();
-    }
-    private removeRegion(idx: number) {
-        if (!this.regions[idx]) return;
-        this.regions.splice(idx, 1);
-        void this.commitRegions();
-        this.renderList();
+        if (!name && this.mode !== "creatures" && this.mode !== "spells") return;
+        if (!this.activeRenderer) return;
+        await this.activeRenderer.handleCreate(name);
+        this.searchInput?.focus();
     }
 }

--- a/salt-marcher/src/apps/library/view/creatures.ts
+++ b/salt-marcher/src/apps/library/view/creatures.ts
@@ -1,0 +1,49 @@
+import type { TFile } from "obsidian";
+import type { ModeRenderer } from "./mode";
+import { BaseModeRenderer, scoreName } from "./mode";
+import { listCreatureFiles, watchCreatureDir, createCreatureFile } from "../core/creature-files";
+import { CreateCreatureModal } from "../create";
+
+export class CreaturesRenderer extends BaseModeRenderer implements ModeRenderer {
+    readonly mode = "creatures" as const;
+    private files: TFile[] = [];
+
+    async init(): Promise<void> {
+        this.files = await listCreatureFiles(this.app);
+        const stop = watchCreatureDir(this.app, async () => {
+            this.files = await listCreatureFiles(this.app);
+            if (!this.isDisposed()) this.render();
+        });
+        this.registerCleanup(stop);
+    }
+
+    render(): void {
+        if (this.isDisposed()) return;
+        const list = this.container;
+        list.empty();
+        const q = this.query;
+        const items = this.files.map(f => ({ name: f.basename, file: f, score: scoreName(f.basename.toLowerCase(), q) }))
+            .filter(x => q ? x.score > -Infinity : true)
+            .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+
+        for (const it of items) {
+            const row = list.createDiv({ cls: "sm-cc-item" });
+            row.createDiv({ cls: "sm-cc-item__name", text: it.name });
+            const openBtn = row.createEl("button", { text: "Öffnen" });
+            openBtn.onclick = async () => {
+                await this.app.workspace.openLinkText(it.file.path, it.file.path, true);
+            };
+        }
+    }
+
+    async handleCreate(name: string): Promise<void> {
+        new CreateCreatureModal(this.app, name, async (data) => {
+            const file = await createCreatureFile(this.app, data);
+            this.files = await listCreatureFiles(this.app);
+            if (!this.isDisposed()) {
+                this.render();
+                await this.app.workspace.openLinkText(file.path, file.path, true, { state: { mode: "source" } });
+            }
+        }).open();
+    }
+}

--- a/salt-marcher/src/apps/library/view/mode.ts
+++ b/salt-marcher/src/apps/library/view/mode.ts
@@ -1,0 +1,60 @@
+import type { App } from "obsidian";
+
+export type Mode = "creatures" | "spells" | "terrains" | "regions";
+
+export interface ModeRenderer {
+    readonly mode: Mode;
+    init(): Promise<void>;
+    render(): void;
+    setQuery(query: string): void;
+    handleCreate(name: string): Promise<void>;
+    destroy(): Promise<void>;
+}
+
+export function scoreName(name: string, q: string): number {
+    if (!q) return 0.0001;
+    if (name === q) return 1000;
+    if (name.startsWith(q)) return 900 - (name.length - q.length);
+    const idx = name.indexOf(q);
+    if (idx >= 0) return 700 - idx;
+    const tokenIdx = name.split(/\s+|[-_]/).findIndex(t => t.startsWith(q));
+    if (tokenIdx >= 0) return 600 - tokenIdx * 5;
+    return -Infinity;
+}
+
+export abstract class BaseModeRenderer implements ModeRenderer {
+    readonly abstract mode: Mode;
+    protected query = "";
+    private cleanups: Array<() => void> = [];
+    private disposed = false;
+
+    constructor(protected readonly app: App, protected readonly container: HTMLElement) {}
+
+    async init(): Promise<void> { /* optional */ }
+
+    setQuery(query: string): void {
+        this.query = (query || "").toLowerCase();
+        this.render();
+    }
+
+    abstract render(): void;
+
+    async handleCreate(_name: string): Promise<void> { /* optional */ }
+
+    async destroy(): Promise<void> {
+        if (this.disposed) return;
+        this.disposed = true;
+        for (const fn of this.cleanups.splice(0)) {
+            try { fn(); } catch { /* noop */ }
+        }
+        this.container.empty();
+    }
+
+    protected isDisposed(): boolean {
+        return this.disposed;
+    }
+
+    protected registerCleanup(fn: () => void): void {
+        this.cleanups.push(fn);
+    }
+}

--- a/salt-marcher/src/apps/library/view/regions.ts
+++ b/salt-marcher/src/apps/library/view/regions.ts
@@ -1,0 +1,151 @@
+import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
+import type { ModeRenderer } from "./mode";
+import { BaseModeRenderer, scoreName } from "./mode";
+import { ensureRegionsFile, loadRegions, saveRegions, watchRegions, REGIONS_FILE, type Region } from "../../../core/regions-store";
+import { loadTerrains, watchTerrains } from "../../../core/terrain-store";
+
+const SAVE_DEBOUNCE_MS = 500;
+
+export class RegionsRenderer extends BaseModeRenderer implements ModeRenderer {
+    readonly mode = "regions" as const;
+    private regions: Region[] = [];
+    private terrainNames: string[] = [];
+    private saveTimer: ReturnType<typeof setTimeout> | null = null;
+    private dirty = false;
+
+    async init(): Promise<void> {
+        await ensureRegionsFile(this.app);
+        [this.regions, this.terrainNames] = await Promise.all([
+            loadRegions(this.app),
+            this.loadTerrainNames(),
+        ]);
+
+        const stopRegions = watchRegions(this.app, async () => {
+            if (this.isDisposed()) return;
+            this.regions = await loadRegions(this.app);
+            this.render();
+        });
+        const stopTerrains = watchTerrains(this.app, async () => {
+            if (this.isDisposed()) return;
+            this.terrainNames = await this.loadTerrainNames();
+            this.render();
+        });
+        this.registerCleanup(stopRegions);
+        this.registerCleanup(stopTerrains);
+    }
+
+    render(): void {
+        if (this.isDisposed()) return;
+        const list = this.container;
+        list.empty();
+        const q = this.query;
+
+        const entries = this.regions
+            .map((region, index) => ({ region, index, score: scoreName((region.name || "").toLowerCase(), q) }))
+            .filter(item => (item.region.name || "").trim())
+            .filter(item => q ? item.score > -Infinity : true)
+            .sort((a, b) => b.score - a.score || (a.region.name || "").localeCompare(b.region.name || ""));
+
+        for (const entry of entries) {
+            const region = entry.region;
+            const row = list.createDiv({ cls: "sm-cc-item" });
+
+            const nameInp = row.createEl("input", { attr: { type: "text", placeholder: "(Name)" } }) as HTMLInputElement;
+            nameInp.value = region.name || "";
+            nameInp.addEventListener("input", () => {
+                region.name = nameInp.value;
+                this.scheduleSave();
+            });
+
+            const terrSel = row.createEl("select") as HTMLSelectElement;
+            enhanceSelectToSearch(terrSel, "Such-dropdown…");
+            this.populateTerrainOptions(terrSel, region.terrain || "");
+            terrSel.addEventListener("change", () => {
+                region.terrain = terrSel.value;
+                this.scheduleSave();
+            });
+
+            const encInp = row.createEl("input", { attr: { type: "number", min: "1", step: "1", placeholder: "Encounter 1/n" } }) as HTMLInputElement;
+            encInp.value = region.encounterOdds && region.encounterOdds > 0 ? String(region.encounterOdds) : "";
+            encInp.addEventListener("input", () => {
+                const val = parseInt(encInp.value, 10);
+                region.encounterOdds = Number.isFinite(val) && val > 0 ? val : undefined;
+                this.scheduleSave();
+            });
+
+            const delBtn = row.createEl("button", { text: "🗑" });
+            delBtn.onclick = () => {
+                this.removeRegion(entry.index);
+            };
+        }
+
+        if (!entries.length) {
+            list.createDiv({ cls: "sm-cc-item" }).setText("Keine Regionen hinterlegt.");
+        }
+    }
+
+    async handleCreate(name: string): Promise<void> {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        const exists = this.regions.some(r => (r.name || "").toLowerCase() === trimmed.toLowerCase());
+        if (exists) return;
+        this.regions.push({ name: trimmed, terrain: "" });
+        this.render();
+        this.scheduleSave();
+    }
+
+    async destroy(): Promise<void> {
+        await this.flushSave();
+        await super.destroy();
+    }
+
+    private populateTerrainOptions(select: HTMLSelectElement, selected: string): void {
+        select.empty();
+        const options = Array.from(new Set(["", ...this.terrainNames]));
+        for (const name of options) {
+            const option = select.createEl("option", { text: name || "(leer)", value: name });
+            option.selected = name === selected;
+        }
+    }
+
+    private async loadTerrainNames(): Promise<string[]> {
+        const terrains = await loadTerrains(this.app);
+        return Object.keys(terrains || {});
+    }
+
+    private removeRegion(index: number): void {
+        if (!this.regions[index]) return;
+        this.regions.splice(index, 1);
+        this.render();
+        this.scheduleSave();
+    }
+
+    private scheduleSave(): void {
+        if (this.isDisposed()) return;
+        this.dirty = true;
+        if (this.saveTimer) clearTimeout(this.saveTimer);
+        this.saveTimer = setTimeout(() => { void this.flushSave(); }, SAVE_DEBOUNCE_MS);
+    }
+
+    private async flushSave(): Promise<void> {
+        if (!this.dirty) {
+            if (this.saveTimer) {
+                clearTimeout(this.saveTimer);
+                this.saveTimer = null;
+            }
+            return;
+        }
+        this.dirty = false;
+        if (this.saveTimer) {
+            clearTimeout(this.saveTimer);
+            this.saveTimer = null;
+        }
+        await saveRegions(this.app, this.regions);
+        this.regions = await loadRegions(this.app);
+        if (!this.isDisposed()) this.render();
+    }
+}
+
+export function describeRegionsSource(): string {
+    return `Quelle: ${REGIONS_FILE}`;
+}

--- a/salt-marcher/src/apps/library/view/spells.ts
+++ b/salt-marcher/src/apps/library/view/spells.ts
@@ -1,0 +1,49 @@
+import type { TFile } from "obsidian";
+import type { ModeRenderer } from "./mode";
+import { BaseModeRenderer, scoreName } from "./mode";
+import { listSpellFiles, watchSpellDir, createSpellFile } from "../core/spell-files";
+import { CreateSpellModal } from "../create";
+
+export class SpellsRenderer extends BaseModeRenderer implements ModeRenderer {
+    readonly mode = "spells" as const;
+    private files: TFile[] = [];
+
+    async init(): Promise<void> {
+        this.files = await listSpellFiles(this.app);
+        const stop = watchSpellDir(this.app, async () => {
+            this.files = await listSpellFiles(this.app);
+            if (!this.isDisposed()) this.render();
+        });
+        this.registerCleanup(stop);
+    }
+
+    render(): void {
+        if (this.isDisposed()) return;
+        const list = this.container;
+        list.empty();
+        const q = this.query;
+        const items = this.files.map(f => ({ name: f.basename, file: f, score: scoreName(f.basename.toLowerCase(), q) }))
+            .filter(x => q ? x.score > -Infinity : true)
+            .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+
+        for (const it of items) {
+            const row = list.createDiv({ cls: "sm-cc-item" });
+            row.createDiv({ cls: "sm-cc-item__name", text: it.name });
+            const openBtn = row.createEl("button", { text: "Öffnen" });
+            openBtn.onclick = async () => {
+                await this.app.workspace.openLinkText(it.file.path, it.file.path, true);
+            };
+        }
+    }
+
+    async handleCreate(name: string): Promise<void> {
+        new CreateSpellModal(this.app, name, async (data) => {
+            const file = await createSpellFile(this.app, data);
+            this.files = await listSpellFiles(this.app);
+            if (!this.isDisposed()) {
+                this.render();
+                await this.app.workspace.openLinkText(file.path, file.path, true, { state: { mode: "source" } });
+            }
+        }).open();
+    }
+}

--- a/salt-marcher/src/apps/library/view/terrains.ts
+++ b/salt-marcher/src/apps/library/view/terrains.ts
@@ -1,0 +1,179 @@
+import type { ModeRenderer } from "./mode";
+import { BaseModeRenderer, scoreName } from "./mode";
+import { loadTerrains, saveTerrains, watchTerrains, ensureTerrainFile, TERRAIN_FILE } from "../../../core/terrain-store";
+
+interface TerrainConfig { color: string; speed: number; }
+
+type TerrainMap = Record<string, TerrainConfig>;
+
+const SAVE_DEBOUNCE_MS = 500;
+
+export class TerrainsRenderer extends BaseModeRenderer implements ModeRenderer {
+    readonly mode = "terrains" as const;
+    private terrains: TerrainMap = {};
+    private saveTimer: ReturnType<typeof setTimeout> | null = null;
+    private dirty = false;
+
+    async init(): Promise<void> {
+        await ensureTerrainFile(this.app);
+        this.terrains = await loadTerrains(this.app);
+        this.ensureEmptyKey();
+        const stop = watchTerrains(this.app, async () => {
+            if (this.isDisposed()) return;
+            this.terrains = await loadTerrains(this.app);
+            this.ensureEmptyKey();
+            this.render();
+        });
+        this.registerCleanup(stop);
+    }
+
+    render(): void {
+        if (this.isDisposed()) return;
+        const list = this.container;
+        list.empty();
+        const q = this.query;
+
+        const names = Object.keys(this.terrains);
+        const order = ["", ...names.filter(n => n !== "")];
+        const entries = order
+            .map(name => ({
+                name,
+                displayName: name || "",
+                score: scoreName(name.toLowerCase(), q),
+            }))
+            .filter(x => x.name === "" || (q ? x.score > -Infinity : true))
+            .sort((a, b) => a.name === "" ? -1 : b.name === "" ? 1 : (b.score - a.score || a.name.localeCompare(b.name)));
+
+        for (const entry of entries) {
+            let currentKey = entry.name;
+            const row = list.createDiv({ cls: "sm-cc-item" });
+            const nameInp = row.createEl("input", { attr: { type: "text", placeholder: "(Name)" } }) as HTMLInputElement;
+            nameInp.value = currentKey;
+            const colorInp = row.createEl("input", { attr: { type: "color" } }) as HTMLInputElement;
+            const speedInp = row.createEl("input", { attr: { type: "number", step: "0.1", min: "0" } }) as HTMLInputElement;
+            const delBtn = row.createEl("button", { text: "🗑" });
+
+            const base = this.terrains[currentKey] ?? { color: "transparent", speed: 1 };
+            colorInp.value = /^#([0-9a-f]{6})$/i.test(base.color) ? base.color : "#999999";
+            speedInp.value = String(Number.isFinite(base.speed) ? base.speed : 1);
+
+            const updateFromInputs = () => {
+                const nextKey = nameInp.value.trim();
+                const color = colorInp.value || "#999999";
+                const speed = parseFloat(speedInp.value);
+                const normalizedNext = nextKey || "";
+                const normalizedCurrent = currentKey || "";
+                this.writeTerrain(currentKey, nextKey, {
+                    color,
+                    speed: Number.isFinite(speed) ? speed : 1,
+                });
+                currentKey = normalizedNext;
+                if (normalizedNext !== normalizedCurrent) {
+                    this.render();
+                }
+            };
+
+            nameInp.addEventListener("change", updateFromInputs);
+            nameInp.addEventListener("blur", updateFromInputs);
+            nameInp.addEventListener("keydown", (evt) => {
+                if (evt.key === "Enter") {
+                    evt.preventDefault();
+                    updateFromInputs();
+                }
+            });
+            colorInp.addEventListener("input", () => {
+                const speed = parseFloat(speedInp.value);
+                const nextKey = nameInp.value.trim();
+                this.writeTerrain(currentKey, nextKey, {
+                    color: colorInp.value || "#999999",
+                    speed: Number.isFinite(speed) ? speed : 1,
+                });
+                currentKey = nextKey || "";
+            });
+            speedInp.addEventListener("change", updateFromInputs);
+            speedInp.addEventListener("blur", updateFromInputs);
+
+            delBtn.onclick = () => {
+                this.deleteTerrain(currentKey);
+                this.render();
+            };
+        }
+
+        if (!entries.length) {
+            list.createDiv({ cls: "sm-cc-item" }).setText("Keine Terrains vorhanden.");
+        }
+    }
+
+    async handleCreate(name: string): Promise<void> {
+        const key = name.trim();
+        if (!key) return;
+        if (!this.terrains[key]) {
+            this.terrains[key] = { color: "#888888", speed: 1 };
+            this.ensureEmptyKey();
+            this.render();
+            this.scheduleSave();
+        }
+    }
+
+    async destroy(): Promise<void> {
+        await this.flushSave();
+        await super.destroy();
+    }
+
+    private ensureEmptyKey(): void {
+        if (!this.terrains[""]) {
+            this.terrains[""] = { color: "transparent", speed: 1 };
+        }
+    }
+
+    private writeTerrain(oldKey: string, newKey: string, payload: TerrainConfig): void {
+        const next: TerrainMap = { ...this.terrains };
+        const normalizedOld = oldKey || "";
+        const normalizedNew = newKey || "";
+        delete next[normalizedOld];
+        next[normalizedNew] = payload;
+        this.terrains = next;
+        this.ensureEmptyKey();
+        this.scheduleSave();
+    }
+
+    private deleteTerrain(key: string): void {
+        const normalized = key || "";
+        if (normalized === "") return;
+        const next: TerrainMap = { ...this.terrains };
+        delete next[normalized];
+        this.terrains = next;
+        this.ensureEmptyKey();
+        this.scheduleSave();
+    }
+
+    private scheduleSave(): void {
+        if (this.isDisposed()) return;
+        this.dirty = true;
+        if (this.saveTimer) clearTimeout(this.saveTimer);
+        this.saveTimer = setTimeout(() => { void this.flushSave(); }, SAVE_DEBOUNCE_MS);
+    }
+
+    private async flushSave(): Promise<void> {
+        if (!this.dirty) {
+            if (this.saveTimer) {
+                clearTimeout(this.saveTimer);
+                this.saveTimer = null;
+            }
+            return;
+        }
+        this.dirty = false;
+        if (this.saveTimer) {
+            clearTimeout(this.saveTimer);
+            this.saveTimer = null;
+        }
+        await saveTerrains(this.app, this.terrains);
+        this.terrains = await loadTerrains(this.app);
+        this.ensureEmptyKey();
+        if (!this.isDisposed()) this.render();
+    }
+}
+
+export function describeTerrainsSource(): string {
+    return `Quelle: ${TERRAIN_FILE}`;
+}


### PR DESCRIPTION
## Summary
- refactor `LibraryView` into a thin shell that instantiates per-mode renderer classes
- add dedicated renderer modules for creatures, spells, terrains, and regions with self-managed watchers and debounced persistence
- document the new view architecture and save workflow in `docs/library/Overview.md`

## Testing
- npm run build
- npm test *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69608ff208325995878fa788ecfe8