### PR TITLE
Refactor travel mode controllers and terrain sync

### DIFF
--- a/salt-marcher/docs/cartographer/travel-mode-overview.md
+++ b/salt-marcher/docs/cartographer/travel-mode-overview.md
@@ -1,0 +1,37 @@
+# Cartographer – Travel Mode Architecture
+
+## Strukturdiagramm
+```
+CartographerPresenter
+    └─ createTravelGuideMode (travel-guide.ts)
+         ├─ TravelPlaybackController (playback-controller.ts)
+         ├─ TravelInteractionController (interaction-controller.ts)
+         ├─ EncounterGateway (encounter-gateway.ts)
+         ├─ RouteLayer / TokenLayer (travel/ui)
+         └─ TravelLogic (travel/domain)
+```
+
+## Funktionen & Verantwortlichkeiten
+- **`travel-guide.ts`** – orchestriert den Modus-Lifecycle. Baut Sidebar und Layer auf, koppelt Domain-Logik an UI-Controller und reagiert auf Dateiauswahl, Hex-Klicks sowie Speichern.
+- **`playback-controller.ts`** – kapselt die Verbindung zwischen Playback-UI und `TravelLogic`. Erstellt die Controls, synchronisiert deren Zustand und räumt beim Verlassen auf.
+- **`interaction-controller.ts`** – bündelt Drag-&-Drop sowie Kontextmenü der Route. Delegiert alle Operationen an `TravelLogic` und sorgt für sauberes Cleanup.
+- **`encounter-gateway.ts`** – lädt Encounter-Abhängigkeiten frühzeitig und öffnet die Encounter-Ansicht fehlertolerant. Stellt sicher, dass der Modus nutzbar bleibt, falls das Modul fehlt.
+
+## Datenfluss
+1. **Initialisierung** – `createTravelGuideMode.onEnter` lädt Terrains (`loadTerrains` → `setTerrains`), registriert ein Workspace-Event (`salt:terrains-updated`) und montiert Sidebar & Playback-Controller.
+2. **Datei-Wechsel** – `onFileChange` erzeugt Route- & Token-Layer, instanziiert `TravelLogic` und übergibt Render-Adapter sowie Callback-Hooks an die Controller.
+3. **State-Updates** – `TravelLogic` ruft `onChange`, worauf `travel-guide.ts` Layer, Sidebar und Playback synchronisiert.
+4. **Interaktion** – Drag- und Kontext-Events laufen über den Interaction-Controller und werden unmittelbar an `TravelLogic` delegiert; Hex-Klicks werden nach Suppression-Check ebenfalls an `TravelLogic` weitergereicht.
+5. **Encounter** – `TravelLogic` meldet Begegnungen über `onEncounter`. Das Gateway öffnet die Encounter-View; Fehler bei Importen werden per `Notice` angezeigt.
+6. **Terrain-Refresh** – Der Workspace-Listener lädt Terrains nach, sobald `salt:terrains-updated` ausgelöst wird (z. B. durch den File-Watcher).
+
+## Skript-Notizen
+- **`travel-guide.ts`** – Fokus auf Lifecycle-Steuerung: Terrain-Synchronisierung, Controller-Mounting, Cleanup. Hält keinerlei UI-spezifische Closures mehr.
+- **`playback-controller.ts`** – API: `mount`, `sync`, `reset`, `dispose`. Erwartet einen Driver mit `play`, `pause`, `reset`, `setTempo`.
+- **`interaction-controller.ts`** – API: `bind(env, logic)`, `consumeClickSuppression`, `dispose`. Stellt sicher, dass Drag und Kontextmenü atomar aufgeräumt werden.
+- **`encounter-gateway.ts`** – API: `preloadEncounterModule`, `openEncounter`. Nutzt `Promise.all` ohne `try/catch`-Wrapper und zeigt Fehler via `Notice`.
+
+## Feature-Zusammenfassung
+- Entkoppelte Controller reduzieren geteilten Mutable State im Modus.
+- Terrain-Änderungen werden über Workspace-Events erkannt und automatisch nachgeladen.
+- Encounter-Aufrufe sind vorab geladen und benachrichtigen bei Fehlern.

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
@@ -1,0 +1,44 @@
+import { Notice, type App, type WorkspaceLeaf } from "obsidian";
+
+interface EncounterModule {
+    getRightLeaf(app: App): WorkspaceLeaf;
+    VIEW_ENCOUNTER: string;
+}
+
+let encounterModule: Promise<EncounterModule | null> | null = null;
+
+function loadEncounterModule(): Promise<EncounterModule | null> {
+    return Promise.all([
+        import("../../../../core/layout"),
+        import("../../../encounter/view"),
+    ])
+        .then(([layout, encounter]) => ({
+            getRightLeaf: layout.getRightLeaf,
+            VIEW_ENCOUNTER: encounter.VIEW_ENCOUNTER,
+        }))
+        .catch((err) => {
+            console.error("[travel-mode] failed to load encounter module", err);
+            new Notice("Encounter-Modul konnte nicht geladen werden.");
+            return null;
+        });
+}
+
+function ensureEncounterModule(): Promise<EncounterModule | null> {
+    if (!encounterModule) {
+        encounterModule = loadEncounterModule();
+    }
+    return encounterModule;
+}
+
+export function preloadEncounterModule() {
+    void ensureEncounterModule();
+}
+
+export async function openEncounter(app: App): Promise<boolean> {
+    const mod = await ensureEncounterModule();
+    if (!mod) return false;
+    const leaf = mod.getRightLeaf(app);
+    await leaf.setViewState({ type: mod.VIEW_ENCOUNTER, active: true });
+    app.workspace.revealLeaf(leaf);
+    return true;
+}

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
@@ -1,0 +1,62 @@
+import { createDragController, type DragController } from "../travel/ui/drag.controller";
+import { bindContextMenu } from "../travel/ui/contextmenue";
+import type { RenderAdapter } from "../travel/infra/adapter";
+import type { LogicStateSnapshot } from "../travel/domain/types";
+
+export interface InteractionLogicPort {
+    getState(): LogicStateSnapshot;
+    selectDot(index: number): void;
+    moveSelectedTo(rc: { r: number; c: number }): void;
+    moveTokenTo(rc: { r: number; c: number }): void;
+    deleteUserAt(index: number): void;
+}
+
+export interface InteractionEnvironment {
+    routeLayerEl: SVGGElement;
+    tokenLayerEl: SVGGElement;
+    token: RenderAdapter["token"];
+    adapter: RenderAdapter;
+    polyToCoord: (poly: SVGPolygonElement) => { r: number; c: number };
+}
+
+export class TravelInteractionController {
+    private drag: DragController | null = null;
+    private unbindContext: (() => void) | null = null;
+
+    bind(env: InteractionEnvironment, logic: InteractionLogicPort) {
+        this.dispose();
+        this.drag = createDragController({
+            routeLayerEl: env.routeLayerEl,
+            tokenEl: env.tokenLayerEl,
+            token: env.token,
+            adapter: env.adapter,
+            logic: {
+                getState: () => logic.getState(),
+                selectDot: (idx) => logic.selectDot(idx),
+                moveSelectedTo: (rc) => logic.moveSelectedTo(rc),
+                moveTokenTo: (rc) => logic.moveTokenTo(rc),
+            },
+            polyToCoord: env.polyToCoord,
+        });
+        this.drag.bind();
+        this.unbindContext = bindContextMenu(env.routeLayerEl, {
+            getState: () => logic.getState(),
+            deleteUserAt: (idx) => logic.deleteUserAt(idx),
+        });
+    }
+
+    consumeClickSuppression(): boolean {
+        return this.drag?.consumeClickSuppression() ?? false;
+    }
+
+    dispose() {
+        if (this.drag) {
+            this.drag.unbind();
+            this.drag = null;
+        }
+        if (this.unbindContext) {
+            this.unbindContext();
+            this.unbindContext = null;
+        }
+    }
+}

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
@@ -1,0 +1,44 @@
+import type { Sidebar } from "../travel/ui/sidebar";
+import {
+    createPlaybackControls,
+    type PlaybackControlsHandle,
+} from "../travel/ui/controls";
+import type { LogicStateSnapshot, RouteNode } from "../travel/domain/types";
+
+export interface PlaybackDriver {
+    play(): Promise<void> | void;
+    pause(): Promise<void> | void;
+    reset(): Promise<void> | void;
+    setTempo?(value: number): void;
+}
+
+export class TravelPlaybackController {
+    private handle: PlaybackControlsHandle | null = null;
+
+    mount(host: Sidebar, driver: PlaybackDriver) {
+        this.dispose();
+        this.handle = createPlaybackControls(host.controlsHost, {
+            onPlay: () => void driver.play(),
+            onStop: () => void driver.pause(),
+            onReset: () => void driver.reset(),
+            onTempoChange: (value) => driver.setTempo?.(value),
+        });
+        this.reset();
+    }
+
+    sync(state: LogicStateSnapshot) {
+        if (!this.handle) return;
+        this.handle.setState({ playing: state.playing, route: state.route });
+        (this.handle as any)?.setClock?.(state.clockHours ?? 0);
+        (this.handle as any)?.setTempo?.(state.tempo ?? 1);
+    }
+
+    reset() {
+        this.handle?.setState({ playing: false, route: [] as RouteNode[] });
+    }
+
+    dispose() {
+        this.handle?.destroy();
+        this.handle = null;
+    }
+}


### PR DESCRIPTION
## Summary
- extract dedicated playback, drag, and context menu controllers for the travel mode lifecycle
- replace the terrain readiness flag with workspace event subscriptions and preload the encounter module safely
- document the updated travel mode architecture and event flow

## Testing
- npm run test *(fails: vitest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6960868d88325b7cd7076e7386143