### PR TITLE
Refactor cartographer view shell into modular controllers

### DIFF
--- a/salt-marcher/docs/cartographer/view-shell-overview.md
+++ b/salt-marcher/docs/cartographer/view-shell-overview.md
@@ -1,0 +1,49 @@
+# Cartographer View Shell – Overview
+
+## Strukturdiagramm
+```mermaid
+graph TD
+    Host[Host HTMLElement]
+    Shell[view-shell.ts]
+    Layout[view-shell/layout.ts]
+    MapSurface[view-shell/map-surface.ts]
+    ModeRegistry[view-shell/mode-registry.ts]
+    ModeController[view-shell/mode-controller.ts]
+    Header[ui/map-header]
+    Presenter[presenter.ts]
+
+    Presenter -->|CartographerShellOptions| Shell
+    Shell --> Layout
+    Shell --> MapSurface
+    Shell --> Header
+    Shell --> ModeRegistry
+    Shell --> ModeController
+    ModeRegistry -->|Mode selection| ModeController
+    Shell -->|handle events| Presenter
+    MapSurface -->|hex:click| Shell
+```
+
+## Verantwortlichkeiten
+- **`view-shell.ts`** – Orchestriert den Aufbau der Cartographer-Oberfläche. Verkabelt Layout, Map-Surface, Mode-Registry und Mode-Controller zu einem Handle, das der Presenter konsumiert. Kümmert sich ausschließlich um UI-Signale und delegiert Geschäftslogik an die Callbacks.
+- **`view-shell/layout.ts`** – Erzeugt die Grundstruktur des Cartographer-Shell-DOM (Header, Map-Bereich, Sidebar) und sorgt für das Aufräumen des Hosts.
+- **`view-shell/map-surface.ts`** – Baut den `ViewContainer` für die Karte, kapselt Overlay-Steuerung und stellt einen bereinigten Host für das Map-Rendering zur Verfügung.
+- **`view-shell/mode-registry.ts`** – Verwaltet die Mode-Dropdown-Darstellung. Unterstützt dynamisches Registrieren/Deregistrieren von Modi und aktualisiert den Trigger-Button sowie ARIA-Status.
+- **`view-shell/mode-controller.ts`** – Stellt einen Abort-gestützten Controller für Modewechsel bereit. Jeder Wechsel erzeugt einen frischen `AbortController`, wodurch laufende `onEnter`/`onFileChange`-Arbeit beim Presenter sauber abgebrochen werden kann.
+
+## Daten- & Ereignisfluss
+1. **Initialisierung**: Der Presenter ruft `createCartographerShell` und übergibt die initiale Mode-Liste. Die Shell erzeugt Layout, Map-Surface und registriert das Mode-Dropdown im Header.
+2. **Mode-Wechsel**: Benutzer-Interaktionen im Dropdown lösen `ModeRegistry.onSelect` aus. Der Mode-Controller triggert `callbacks.onModeSelect(modeId, { signal })`. Bereits laufende Umschaltungen werden per `AbortController.abort()` beendet.
+3. **Dateiwechsel**: Der Presenter aktualisiert `setFileLabel`, `setOverlay`, `clearMap` etc. Das Shell-Handle leitet diese Befehle an Header und Map-Surface weiter, ohne eigenen Status zu halten.
+4. **Hex-Interaktionen**: Das Map-Surface fängt `hex:click`-Events und delegiert sie an `callbacks.onHexClick`. UI-spezifische Präventionslogik (preventDefault/stopPropagation) bleibt in der Shell konzentriert.
+
+## Skript-Beschreibungen
+- **`view-shell.ts`** – Stellt `CartographerShellHandle` bereit, verwaltet Mode- und Layout-Zustände und sorgt für sauberes Aufräumen aller Teil-Services.
+- **`view-shell/layout.ts`** – Minimaler Helfer für Host-Setup & -Teardown.
+- **`view-shell/map-surface.ts`** – Wrapper um `createViewContainer`, inklusive Overlay- und Cleanup-Hilfen.
+- **`view-shell/mode-registry.ts`** – Dropdown-Manager mit Outside-Click-Handling, ARIA-Statuspflege und dynamischer Mode-Liste.
+- **`view-shell/mode-controller.ts`** – Abort-fähiger Mode-Workflow, der Mehrfach-Wechsel und Destroy-Aufrufe robust verarbeitet.
+
+## Besondere Hinweise
+- Der Mode-Controller reicht den `AbortSignal` direkt an die Presenter-Callbacks weiter. Presenter sollten laufende `onEnter`/`onFileChange`-Operationen auf den `signal.aborted`-Status prüfen und ggf. eigene Ressourcen räumen.
+- Dynamische Mode-Listen: Die Shell bietet `setModes`, `registerMode` und `deregisterMode`, um externe Registries zu unterstützen. Änderungen werden sofort ins Dropdown gespiegelt.
+- Das Layout räumt den Host konsequent auf (`empty()` & `removeClass`), wodurch wiederholtes Mounten/Unmounten keine Zombie-Knoten hinterlässt.

--- a/salt-marcher/src/apps/cartographer/view-shell/layout.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/layout.ts
@@ -1,0 +1,30 @@
+export type CartographerLayout = {
+    readonly host: HTMLElement;
+    readonly headerHost: HTMLElement;
+    readonly bodyHost: HTMLElement;
+    readonly mapWrapper: HTMLElement;
+    readonly sidebarHost: HTMLElement;
+    destroy(): void;
+};
+
+export function createCartographerLayout(host: HTMLElement): CartographerLayout {
+    host.empty();
+    host.addClass("sm-cartographer");
+
+    const headerHost = host.createDiv({ cls: "sm-cartographer__header" });
+    const bodyHost = host.createDiv({ cls: "sm-cartographer__body" });
+    const mapWrapper = bodyHost.createDiv({ cls: "sm-cartographer__map" });
+    const sidebarHost = bodyHost.createDiv({ cls: "sm-cartographer__sidebar" });
+
+    return {
+        host,
+        headerHost,
+        bodyHost,
+        mapWrapper,
+        sidebarHost,
+        destroy: () => {
+            host.empty();
+            host.removeClass("sm-cartographer");
+        },
+    };
+}

--- a/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
@@ -1,0 +1,31 @@
+import { createViewContainer, type ViewContainerHandle } from "../../../ui/view-container";
+
+export type MapSurfaceHandle = {
+    readonly containerEl: HTMLElement;
+    readonly view: ViewContainerHandle;
+    readonly mapHost: HTMLElement;
+    setOverlay(content: string | null): void;
+    clear(): void;
+    destroy(): void;
+};
+
+export function createMapSurface(container: HTMLElement): MapSurfaceHandle {
+    const view = createViewContainer(container, { camera: false });
+    const mapHost = view.stageEl;
+
+    return {
+        containerEl: container,
+        view,
+        mapHost,
+        setOverlay: (content) => {
+            view.setOverlay(content);
+        },
+        clear: () => {
+            mapHost.empty();
+        },
+        destroy: () => {
+            view.destroy();
+            container.empty();
+        },
+    };
+}

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
@@ -1,0 +1,62 @@
+export type ModeSwitchContext = {
+    readonly signal: AbortSignal;
+};
+
+export type ModeSwitchHandler = (modeId: string, ctx: ModeSwitchContext) => Promise<void> | void;
+
+export type ModeControllerHandle = {
+    requestMode(modeId: string): Promise<void>;
+    abortActive(): void;
+    destroy(): void;
+};
+
+export function createModeController(options: { onSwitch: ModeSwitchHandler }): ModeControllerHandle {
+    const { onSwitch } = options;
+    let currentController: AbortController | null = null;
+    let destroyed = false;
+    let sequence = 0;
+
+    const abortActive = () => {
+        if (currentController) {
+            currentController.abort();
+            currentController = null;
+        }
+    };
+
+    const requestMode = async (modeId: string): Promise<void> => {
+        if (destroyed) return;
+
+        sequence += 1;
+        const token = sequence;
+
+        if (currentController) {
+            currentController.abort();
+        }
+        const controller = new AbortController();
+        currentController = controller;
+
+        try {
+            await onSwitch(modeId, { signal: controller.signal });
+        } catch (error) {
+            if (!controller.signal.aborted) {
+                throw error;
+            }
+        } finally {
+            if (currentController === controller && token === sequence) {
+                currentController = null;
+            }
+        }
+    };
+
+    const destroy = () => {
+        if (destroyed) return;
+        destroyed = true;
+        abortActive();
+    };
+
+    return {
+        requestMode,
+        abortActive,
+        destroy,
+    };
+}

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
@@ -1,0 +1,169 @@
+import type { CartographerShellMode } from "../view-shell";
+
+export type ModeRegistryHandle = {
+    setModes(modes: CartographerShellMode[]): void;
+    registerMode(mode: CartographerShellMode): void;
+    deregisterMode(id: string): void;
+    setActiveMode(id: string | null): void;
+    setTriggerLabel(label: string): void;
+    destroy(): void;
+};
+
+export type ModeRegistryOptions = {
+    host: HTMLElement;
+    initialLabel?: string;
+    onSelect(modeId: string): void;
+};
+
+type ModeEntry = {
+    mode: CartographerShellMode;
+    button: HTMLButtonElement;
+};
+
+export function createModeRegistry(options: ModeRegistryOptions): ModeRegistryHandle {
+    const { host, onSelect } = options;
+    host.addClass("sm-cartographer__mode-switch");
+
+    const dropdown = host.createDiv({ cls: "sm-mode-dropdown" });
+    const trigger = dropdown.createEl("button", {
+        text: options.initialLabel ?? "Mode",
+        attr: { type: "button", "aria-haspopup": "listbox", "aria-expanded": "false" },
+    });
+    trigger.addClass("sm-mode-dropdown__trigger");
+
+    const menu = dropdown.createDiv({ cls: "sm-mode-dropdown__menu", attr: { role: "listbox" } });
+
+    const entries = new Map<string, ModeEntry>();
+    let activeId: string | null = null;
+    let unbindOutsideClick: (() => void) | null = null;
+    let destroyed = false;
+
+    const closeMenu = () => {
+        dropdown.removeClass("is-open");
+        trigger.setAttr("aria-expanded", "false");
+        if (unbindOutsideClick) {
+            unbindOutsideClick();
+            unbindOutsideClick = null;
+        }
+    };
+
+    const openMenu = () => {
+        dropdown.addClass("is-open");
+        trigger.setAttr("aria-expanded", "true");
+        const onDocClick = (event: MouseEvent) => {
+            if (!dropdown.contains(event.target as Node)) closeMenu();
+        };
+        document.addEventListener("mousedown", onDocClick);
+        unbindOutsideClick = () => document.removeEventListener("mousedown", onDocClick);
+    };
+
+    trigger.onclick = () => {
+        const isOpen = dropdown.classList.contains("is-open");
+        if (isOpen) closeMenu();
+        else openMenu();
+    };
+
+    const updateActive = () => {
+        for (const entry of entries.values()) {
+            const isActive = entry.mode.id === activeId;
+            entry.button.classList.toggle("is-active", isActive);
+            entry.button.ariaSelected = isActive ? "true" : "false";
+        }
+    };
+
+    const ensureEntry = (mode: CartographerShellMode): ModeEntry => {
+        const button = menu.createEl("button", {
+            text: mode.label,
+            attr: { role: "option", type: "button", "data-id": mode.id },
+        });
+        button.addClass("sm-mode-dropdown__item");
+        button.onclick = () => {
+            closeMenu();
+            onSelect(mode.id);
+        };
+        const entry: ModeEntry = { mode, button };
+        entries.set(mode.id, entry);
+        return entry;
+    };
+
+    const removeEntry = (id: string) => {
+        const entry = entries.get(id);
+        if (!entry) return;
+        entry.button.remove();
+        entries.delete(id);
+        if (activeId === id) {
+            activeId = null;
+        }
+    };
+
+    const setModes = (modes: CartographerShellMode[]) => {
+        const incoming = new Set<string>();
+        for (const mode of modes) {
+            incoming.add(mode.id);
+            const existing = entries.get(mode.id);
+            if (existing) {
+                existing.mode = mode;
+                existing.button.setText(mode.label);
+            } else {
+                ensureEntry(mode);
+            }
+        }
+        for (const id of Array.from(entries.keys())) {
+            if (!incoming.has(id)) {
+                removeEntry(id);
+            }
+        }
+        updateActive();
+    };
+
+    const registerMode = (mode: CartographerShellMode) => {
+        if (entries.has(mode.id)) {
+            setModes([mode]);
+            return;
+        }
+        ensureEntry(mode);
+        updateActive();
+    };
+
+    const deregisterMode = (id: string) => {
+        removeEntry(id);
+        updateActive();
+    };
+
+    const setActiveMode = (id: string | null) => {
+        activeId = id;
+        updateActive();
+        if (activeId) {
+            const entry = entries.get(activeId);
+            if (entry) {
+                trigger.setText(entry.mode.label);
+            }
+        }
+    };
+
+    const setTriggerLabel = (label: string) => {
+        trigger.setText(label);
+    };
+
+    const destroy = () => {
+        if (destroyed) return;
+        destroyed = true;
+        closeMenu();
+        trigger.onclick = null;
+        for (const entry of entries.values()) {
+            entry.button.onclick = null;
+            entry.button.remove();
+        }
+        entries.clear();
+        dropdown.remove();
+    };
+
+    return {
+        setModes,
+        registerMode,
+        deregisterMode,
+        setActiveMode,
+        setTriggerLabel,
+        destroy,
+    };
+}


### PR DESCRIPTION
## Summary
- split the cartographer shell into dedicated layout, map surface, mode registry, and mode controller helpers
- extend the shell handle with dynamic mode management and abort-aware mode selection callbacks
- document the refactored responsibilities in docs/cartographer/view-shell-overview.md

## Testing
- npm run build
- npm test *(fails: vitest binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d69606819483259de82315f5cf4fe4