### PR TITLE
Update Salt Marcher overview docs

### DIFF
--- a/PluginOverview.txt
+++ b/PluginOverview.txt
@@ -1,46 +1,52 @@
 # Salt Marcher Repository Overview
 
-Dieses Repository enthält zwei vollständig getrennte Obsidian-Plugins:
-
-- **Salt Marcher (`plugins/salt-marcher`)** – liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen.
-- **Layout Editor (`plugins/layout-editor`)** – stellt einen eigenständigen visuellen Layout-Editor inklusive Layout-Bibliothek bereit.
-
-Beide Plugins besitzen eigene Build-Pipelines, Manifeste und Overview-Dokumente innerhalb ihrer Verzeichnisse.
+Dieses Repository liefert das **Salt Marcher** Obsidian-Plugin. Es kombiniert Kartographie-, Encounter- und Bibliothekswerkzeuge
+für hex-basierte Kampagnen und bringt sämtliche Build-, Dokumentations- und Testartefakte im Ordner `salt-marcher/` mit.
 
 ## Struktur
 
 ```
 Salt-Marcher/
-├─ AGENTS.md
-├─ README.md                     # Projektweite Hinweise (SRD-Credits)
-├─ plugins/
-│  ├─ salt-marcher/              # Hauptplugin (Cartographer, Library, Encounter)
-│  │  ├─ manifest.json
-│  │  ├─ esbuild.config.mjs
-│  │  ├─ package.json / package-lock.json
-│  │  ├─ tsconfig.json
-│  │  ├─ main.js                 # Build-Output
-│  │  ├─ PluginOverview.txt      # Detaillierte Dokumentation des Salt-Marcher-Plugins
-│  │  └─ src/…                   # TypeScript-Quellcode (app, apps, core, ui)
-│  └─ layout-editor/             # Eigenständiger Layout-Editor
-│     ├─ manifest.json
-│     ├─ esbuild.config.mjs
-│     ├─ package.json / package-lock.json
-│     ├─ tsconfig.json
-│     ├─ main.js                 # Build-Output
-│     └─ src/…                   # Layout-Editor-Code + Overview
-└─ "References, do not delete!/" # SRD-Referenzen (unverändert)
+├─ AGENTS.md                     # Projektweite Arbeitsanweisungen
+├─ Critique.txt                  # Offene Architektur- oder Qualitätshinweise
+├─ PluginOverview.txt            # Diese Gesamtübersicht
+├─ README.md                     # Projektweite Hinweise (z. B. SRD-Credits)
+├─ "References, do not delete!/"
+│  └─ README.md                  # SRD-Referenzen (unverändert)
+└─ salt-marcher/
+   ├─ manifest.json              # Obsidian-Manifest (lädt main.js aus dem Plugin-Stamm)
+   ├─ esbuild.config.mjs         # Build-Pipeline (bundelt TypeScript → main.js)
+   ├─ main.js                    # Gebündeltes Plugin-Artefakt
+   ├─ package.json
+   ├─ package-lock.json
+   ├─ tsconfig.json
+   ├─ PluginOverview.txt         # Detailübersicht des Plugins
+   ├─ README.md                  # Anwender-Hinweise zum Plugin
+   ├─ docs/                      # Bereichspezifische Overviews (cartographer/core/library/ui)
+   ├─ src/
+   │  ├─ app/
+   │  │  ├─ main.ts             # Plugin-Bootstrap
+   │  │  ├─ css.ts              # Zentrales Styling
+   │  │  └─ layout-editor-bridge.ts # Bindung an einen extern installierten Layout Editor
+   │  ├─ apps/
+   │  │  ├─ cartographer/
+   │  │  ├─ encounter/
+   │  │  └─ library/
+   │  ├─ core/
+   │  └─ ui/
+   └─ tests/
+      └─ cartographer/
 ```
 
 ## Features & Verantwortlichkeiten
 
-- **Salt Marcher Plugin:** Registriert Cartographer-, Encounter- und Library-Views, injiziert eigenes CSS und verwaltet Terrain-/Regions-Daten. Enthält alle Hex-Mapper-, Travel- und Library-Funktionen.
-- **Layout Editor Plugin:** Registriert den Layout-Editor als eigenständigen View, injiziert dediziertes Styling, stellt ein API (`getApi()`) für Registry-/Persistenz-Hooks bereit und verwaltet Layout-Dateien unter `LayoutEditor/Layouts`.
-- **Getrennte Builds:** Jedes Plugin wird über sein eigenes `esbuild.config.mjs` gebündelt. Die erzeugten `main.js`-Artefakte liegen direkt im jeweiligen Plugin-Ordner und werden durch die zugehörigen Manifeste geladen.
-- **Overview-Dokumente:** Detailinformationen zu Struktur, Datenfluss und Zuständigkeiten stehen in `plugins/salt-marcher/PluginOverview.txt` und `plugins/layout-editor/src/LayoutEditorOverview.txt`.
+- **Salt Marcher Plugin:** Registriert Cartographer-, Encounter- und Library-Views, injiziert eigenes CSS und verwaltet Terrain-/Regions-Daten. Enthält alle Hex-Mapper-, Travel- und Library-Funktionen des Projekts.
+- **Layout-Editor-Bridge:** `src/app/layout-editor-bridge.ts` verknüpft Salt Marcher mit einem extern installierten Layout-Editor-Plugin und meldet dort optional View-Bindings an.
+- **Build & Artefakte:** `esbuild.config.mjs` erzeugt `main.js`; Tests liegen unter `tests/`, und sämtliche Bereichsübersichten befinden sich unter `docs/`.
+- **Overview-Dokumente:** Detailinformationen zu Struktur, Datenfluss und Zuständigkeiten stehen in `salt-marcher/PluginOverview.txt` sowie den Bereichsübersichten unter `salt-marcher/docs/`.
 
 ## Hinweise zur Zusammenarbeit
 
-- Plugins sind bewusst entkoppelt: Es bestehen keine direkten Imports zwischen den Codebasen.
-- Gemeinsame Funktionalität sollte bei Bedarf als eigene Hilfen in beiden Plugins dupliziert oder neu konzipiert werden (kein Shared-Code-Verzeichnis vorhanden).
-- Beim Arbeiten an einem der Plugins immer die zugehörige Overview-Datei aktualisieren und das Build-Artefakt (`main.js`) neu erzeugen.
+- Salt Marcher kann optional mit einem externen Layout-Editor interagieren; die Brücke ist jedoch so gestaltet, dass Salt Marcher auch ohne das andere Plugin vollständig funktioniert.
+- Gemeinsame Funktionalität sollte in klar abgegrenzten Services (`src/core/…`, `src/ui/…`) umgesetzt werden.
+- Beim Arbeiten am Plugin immer die zugehörigen Overview-Dateien aktualisieren und das Build-Artefakt (`main.js`) neu erzeugen.

--- a/salt-marcher/PluginOverview.txt
+++ b/salt-marcher/PluginOverview.txt
@@ -1,30 +1,36 @@
 # Salt Marcher – Plugin Overview
 
-Salt Marcher liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen. Der Code ist klar vom Layout Editor getrennt – letzterer lebt als eigenes Plugin im Repository (`layout-editor/`) und wird nicht mehr automatisch mitgeladen.
+Salt Marcher liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen. Der Code konzentriert sich
+vollständig auf dieses Plugin; eine optionale Kopplung an einen extern installierten Layout Editor erfolgt ausschließlich über
+das Brückenskript `src/app/layout-editor-bridge.ts`.
 
 ## Struktur
 
 ```
 Salt-Marcher/
-├─ salt-marcher/
-│  ├─ manifest.json          # Obsidian-Manifest (lädt das gebündelte main.js im Plugin-Stamm)
-│  ├─ esbuild.config.mjs     # Build-Pipeline (bundelt src/app/main.ts → main.js)
-│  ├─ main.js                # Gebündeltes Plugin-Artefakt
-│  ├─ package.json           # Scripts & Dev-Abhängigkeiten (esbuild, TypeScript, Obsidian-Typen)
-│  ├─ package-lock.json      # Reproduzierbare Dependency-Auflösung
-│  ├─ tsconfig.json          # TypeScript-Konfiguration für das Build-Setup
-│  └─ src/
-│     ├─ app/
-│     │  ├─ main.ts          # Plugin-Bootstrap (Views, Commands, CSS, Terrain-Watcher)
-│     │  ├─ css.ts           # Zentrales Styling als Template-String
-│     │  └─ layout-editor-bridge.ts # Optionales Binding zum Layout-Editor (View-Registry)
-│     ├─ apps/
-│     │  ├─ cartographer/    # Hex-Map-Workspace mit Editor/Inspector/Travel-Modi
-│     │  ├─ encounter/       # Encounter-View
-│     │  └─ library/         # Library-View für Terrains, Regionen, Kreaturen
-│     ├─ core/               # Domain-Services (Hex-Geometrie, Dateien, Terrain, Optionen)
-│     └─ ui/                 # Geteilte Dialoge und Workflow-Helfer
-└─ layout-editor/            # Eigenständiges Layout-Editor-Plugin (separater Build & Manifest)
+└─ salt-marcher/
+   ├─ manifest.json          # Obsidian-Manifest (lädt das gebündelte main.js im Plugin-Stamm)
+   ├─ esbuild.config.mjs     # Build-Pipeline (bundelt src/app/main.ts → main.js)
+   ├─ main.js                # Gebündeltes Plugin-Artefakt
+   ├─ package.json           # Scripts & Dev-Abhängigkeiten (esbuild, TypeScript, Obsidian-Typen)
+   ├─ package-lock.json      # Reproduzierbare Dependency-Auflösung
+   ├─ tsconfig.json          # TypeScript-Konfiguration für das Build-Setup
+   ├─ PluginOverview.txt     # Diese Detailübersicht
+   ├─ README.md              # Anwender-orientierte Hinweise
+   ├─ docs/                  # Bereichsspezifische Overviews (cartographer/core/library/ui)
+   ├─ src/
+   │  ├─ app/
+   │  │  ├─ main.ts          # Plugin-Bootstrap (Views, Commands, CSS, Terrain-Watcher)
+   │  │  ├─ css.ts           # Zentrales Styling als Template-String
+   │  │  └─ layout-editor-bridge.ts # Optionales Binding zu einem externen Layout-Editor
+   │  ├─ apps/
+   │  │  ├─ cartographer/    # Hex-Map-Workspace mit Editor/Inspector/Travel-Modi
+   │  │  ├─ encounter/       # Encounter-View
+   │  │  └─ library/         # Library-View für Terrains, Regionen, Kreaturen
+   │  ├─ core/               # Domain-Services (Hex-Geometrie, Dateien, Terrain, Optionen)
+   │  └─ ui/                 # Geteilte Dialoge und Workflow-Helfer
+   └─ tests/
+      └─ cartographer/       # Vitest-Suite für den Presenter
 ```
 
 ## Features & Verantwortlichkeiten
@@ -35,7 +41,7 @@ Salt-Marcher/
 - **Encounter-View:** Schlanke Ansicht für Encounter-Notizen.
 - **Core-Services:** Hex-Geometrie, Map/Terrain/Regions-Persistenz sowie Workspace-Helfer als Single Source of Truth.
 - **Geteilte UI-Bausteine:** Modals, Header und Workflows für Map-Management und generische Dialoge.
-- **View Container & Layout-Editor-Bridge:** `ui/view-container.ts` kapselt einen renderbaren View-Host inkl. optionaler Kamera; `src/app/layout-editor-bridge.ts` meldet die Cartographer-Karte als View-Binding beim Layout Editor an.
+- **View Container & Layout-Editor-Bridge:** `ui/view-container.ts` kapselt einen renderbaren View-Host inkl. optionaler Kamera; `src/app/layout-editor-bridge.ts` meldet die Cartographer-Karte als View-Binding bei einem extern installierten Layout-Editor an.
 - **Build & Styling:** Esbuild erzeugt `main.js`; `css.ts` enthält ausschließlich Salt-Marcher-spezifisches Styling (Layout-Editor-CSS ist in das separate Plugin umgezogen).
 
 ## Datenfluss
@@ -50,7 +56,7 @@ Salt-Marcher/
 ### `src/app`
 - `main.ts`: Einstiegspunkt des Plugins. Registriert Views/Commands, lädt Terrain-Daten (`ensureTerrainFile`, `loadTerrains`, `watchTerrains`), injiziert CSS.
 - `css.ts`: Enthält das Styling für Cartographer, Library und Encounter. Layout-Editor-spezifische Klassen wurden entfernt.
-- `layout-editor-bridge.ts`: Bindet den Cartographer optional an den Layout Editor (View-Bindings).
+- `layout-editor-bridge.ts`: Bindet den Cartographer optional an einen externen Layout Editor (View-Bindings über dessen API).
 
 ### `src/apps/cartographer`
 - `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`); delegiert Lifecycle an den Presenter.
@@ -89,6 +95,6 @@ Salt-Marcher/
 
 ## Zusammenarbeit mit dem Layout-Editor
 
-- Das Layout-Editor-Plugin liegt unter `layout-editor/` und bringt eigenes Manifest, Build und CSS mit.
-- Falls benötigt, kann Salt Marcher über Obsidian den Layout Editor parallel laden und über dessen öffentliches API (`getApi()` aus `layout-editor`-Plugin) Layout-Definitionen registrieren oder Layouts laden – ohne direkte Code-Abhängigkeit im Salt-Marcher-Build.
+- Der Layout Editor wird als separates Obsidian-Plugin ausgeliefert und ist nicht Teil dieses Repositories.
+- Sobald der Layout Editor installiert und aktiviert ist, kann Salt Marcher über dessen öffentliches API (`getApi()`) Layout-Definitionen registrieren oder Layouts laden – ohne direkte Code-Abhängigkeit im Salt-Marcher-Build.
 - `layout-editor-bridge.ts` registriert – sobald verfügbar – das Cartographer-Mapping als `viewBindingId` beim Layout Editor, sodass dessen View Container die Karte als Feature anbietet.


### PR DESCRIPTION
## Summary
- refresh the repository-level overview to describe the current single-plugin layout
- document the salt-marcher directory structure and optional external layout-editor bridge
- update references to overview documents and layout-editor integration details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a0e647448325b4bd093377b04037