### PR TITLE
Add Salt Marcher wiki docs

### DIFF
--- a/wiki/Cartographer.md
+++ b/wiki/Cartographer.md
@@ -1,0 +1,38 @@
+# Cartographer Workspace
+
+The Cartographer workspace combines the map shell, map header, and presenter-driven mode lifecycle to manage every aspect of your hex maps. The presenter constructs the shell, wires callbacks to the header, and coordinates the map manager so every action remains in sync with the loaded file.【F:salt-marcher/src/apps/cartographer/presenter.ts†L59-L136】
+
+## Map header actions
+The header shown above the map is powered by `createMapHeader` and `createMapManager`. Together they provide:
+- **Open map** – prompts you to pick an existing hex map file and broadcasts the selection to all active components.【F:salt-marcher/src/ui/map-header.ts†L88-L112】【F:salt-marcher/src/ui/map-manager.ts†L47-L68】
+- **Create map** – launches the create workflow and automatically loads the new file into the presenter.【F:salt-marcher/src/ui/map-header.ts†L114-L134】【F:salt-marcher/src/ui/map-manager.ts†L69-L87】
+- **Delete map** – (when enabled) triggers the confirmation modal and, on success, clears the current state so the UI stays consistent.【F:salt-marcher/src/ui/map-header.ts†L136-L159】【F:salt-marcher/src/ui/map-manager.ts†L88-L117】
+- **Save / Save As** – exposes a dropdown plus trigger button so you can persist the current map directly or via "Save As", falling back to presenter-provided hooks when available.【F:salt-marcher/src/ui/map-header.ts†L161-L218】
+
+## Mode switcher
+The dropdown on the right side of the header delegates to the presenter, which maintains the active mode and ensures lifecycle methods (`onEnter`, `onExit`, `onFileChange`) run serially. Switching modes always cleans up the previous mode before mounting the next, preventing leaked listeners or lingering DOM state.【F:salt-marcher/src/apps/cartographer/presenter.ts†L101-L214】 See the sections below for details on each mode.
+
+## Travel mode
+Travel mode focuses on route playback and encounter hand-offs.
+- **Terrain bootstrapping** – on entry the mode reloads the shared terrain palette and subscribes to `salt:terrains-updated`, keeping the travel palette synchronized with the Library view.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L19-L88】
+- **Route and token layers** – `createRouteLayer` and `createTokenLayer` draw current routes, highlights, and the traveling token. Map interactions (drag, context menus, suppression) are coordinated through the interaction controller so the presenter can stay stateless.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L89-L173】
+- **Playback controls** – the sidebar mounts the playback controller with play, pause, reset, and tempo actions that mutate the travel logic state.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L41-L83】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts†L1-L120】
+- **Encounter hand-off** – whenever `onEncounter` fires, travel mode pauses the logic and calls `openEncounter`, prompting Obsidian to show the encounter view. Travel automatically re-opens the encounter pane if the module is available.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L174-L222】
+
+## Editor mode
+Editor mode equips you with the terrain brush and any future tools.
+- **Tool lifecycle** – the sidebar renders a tool selector and panel body. Changing tools deactivates the previous tool, mounts the new panel, and calls `onActivate`/`onMapRendered` hooks as soon as render handles are ready.【F:salt-marcher/src/apps/cartographer/modes/editor.ts†L9-L120】
+- **Terrain brush** – the default tool lets you paint terrain/region assignments with search-enabled dropdowns. It receives map handles from the presenter and updates both the rendered hexes and underlying markdown data; see [Library](./Library.md) for how terrains and regions feed this tool.【F:salt-marcher/src/apps/cartographer/modes/editor.ts†L121-L182】【F:salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/brush-options.ts†L1-L167】
+- **Hex interactions** – `onHexClick` forwards coordinates to the active tool, allowing contextual editing per selection.【F:salt-marcher/src/apps/cartographer/modes/editor.ts†L183-L199】
+
+## Inspector mode
+Inspector mode surfaces per-hex metadata for quick adjustments.
+- **Selection workflow** – clicking a hex loads its terrain and note via `loadTile` and keeps the sidebar message in sync with the active selection.【F:salt-marcher/src/apps/cartographer/modes/inspector.ts†L1-L120】
+- **Buffered saves** – edits queue a 250 ms timeout before calling `saveTile`, preventing excessive disk writes while still keeping the renderer colourised through `setFill`.【F:salt-marcher/src/apps/cartographer/modes/inspector.ts†L121-L204】
+- **Terrain palette** – inspector uses the global `TERRAIN_COLORS` map, so any change propagated by the Library or travel mode applies immediately when the watcher signals an update.【F:salt-marcher/src/apps/cartographer/modes/inspector.ts†L13-L24】【F:salt-marcher/src/core/terrain-store.ts†L65-L86】
+
+## Related articles
+- [Getting Started](./Getting-Started.md) – opening the Cartographer view for the first time.
+- [Library](./Library.md) – how terrain and region data stay in sync with editor and inspector modes.
+- [Encounter](./Encounter.md) – what happens after travel mode triggers `openEncounter`.
+- [Data Management](./Data-Management.md) – file formats and watcher behaviour referenced in the modes above.

--- a/wiki/Data-Management.md
+++ b/wiki/Data-Management.md
@@ -1,0 +1,32 @@
+# Data Management
+
+This article describes how Salt Marcher stores shared terrain and region data, how watchers broadcast changes, and which components consume those signals. For usage guidance, see [Library](./Library.md) and [Cartographer](./Cartographer.md).
+
+## Terrain palette (`SaltMarcher/Terrains.md`)
+- **Bootstrap:** `ensureTerrainFile` creates the Markdown file with YAML frontmatter, a `# Terrains` heading, and a seeded palette if it does not already exist.【F:salt-marcher/src/core/terrain-store.ts†L1-L33】
+- **Format:** Terrains live inside a fenced `terrain` code block. Each line follows `Name: #aabbcc, speed: 0.8`. The empty name (`:`) always exists and resolves to `transparent` with speed `1`, ensuring hexes can fall back to a default.【F:salt-marcher/src/core/terrain-store.ts†L34-L63】
+- **Persistence:** `saveTerrains` rewrites the fenced block in place (or appends one) and resorts entries so the empty key stays first and remaining names are alphabetical.【F:salt-marcher/src/core/terrain-store.ts†L64-L83】
+- **Watcher:** `watchTerrains` listens to Obsidian vault `modify` and `delete` events. On delete it recreates the file, reloads the palette, updates the global renderer state via `setTerrains`, and emits the `salt:terrains-updated` workspace event before invoking any optional callback.【F:salt-marcher/src/core/terrain-store.ts†L84-L122】
+- **Consumers:**
+  - Library terrains mode refreshes its table when `watchTerrains` fires.【F:salt-marcher/src/apps/library/view/terrains.ts†L15-L36】
+  - Regions mode re-queries terrain names to keep dropdowns current.【F:salt-marcher/src/apps/library/view/regions.ts†L16-L41】
+  - Cartographer travel mode subscribes to `salt:terrains-updated` to keep playback palettes synchronised.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L41-L88】
+  - Cartographer inspector mode relies on the global `TERRAIN_COLORS` map that the watcher updates.【F:salt-marcher/src/apps/cartographer/modes/inspector.ts†L13-L24】
+
+## Regions list (`SaltMarcher/Regions.md`)
+- **Bootstrap:** `ensureRegionsFile` mirrors the terrain bootstrap by creating the Markdown file with YAML frontmatter, heading, and commented usage hints if absent.【F:salt-marcher/src/core/regions-store.ts†L1-L28】
+- **Format:** Regions appear in a fenced `regions` code block. Each line follows `Name: Terrain, encounter: 1/n` where the encounter clause is optional. Parsing accepts bare integers (`encounter: 6`) but serialisation always normalises back to `1/n`.【F:salt-marcher/src/core/regions-store.ts†L29-L58】
+- **Persistence:** `saveRegions` rewrites or appends the code block like terrains, ensuring external edits are preserved while the block stays canonical.【F:salt-marcher/src/core/regions-store.ts†L59-L83】
+- **Watcher:** `watchRegions` subscribes to `modify` and `delete` events for the regions file and triggers the `salt:regions-updated` workspace event before calling the supplied callback. Unlike terrains, it does not recreate the file—Library mode already guards creation on init.【F:salt-marcher/src/core/regions-store.ts†L84-L101】
+- **Consumers:**
+  - Library regions mode refreshes the list when the watcher fires and reuses the same disposer pattern as terrains.【F:salt-marcher/src/apps/library/view/regions.ts†L16-L41】
+  - Cartographer editor tools call `loadRegions` to populate dropdowns and rely on `salt:regions-updated` to stay up to date.【F:salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/brush-options.ts†L1-L120】
+
+## Synchronisation tips
+- Watcher callbacks run asynchronously; avoid triggering heavy work directly inside them. Instead, schedule UI updates or reloads the way existing modes do.
+- After external edits (e.g. vault sync), re-open the Library modes to confirm watchers picked up changes. The debounced save logic ensures manual edits never flood the disk, but watchers still fire for every persisted batch.
+
+## Cross-links
+- [Getting Started](./Getting-Started.md) – explains how the terrain bootstrap is triggered during plugin activation.
+- [Library](./Library.md) – documents the editing workflows built on top of these storage formats.
+- [Cartographer](./Cartographer.md) – shows how travel, editor, and inspector modes react to watcher events.

--- a/wiki/Encounter.md
+++ b/wiki/Encounter.md
@@ -1,0 +1,18 @@
+# Encounter Workspace
+
+The Encounter workspace currently functions as a dedicated placeholder view so the travel experience can hand off encounters without leaving Obsidian. When the view opens it renders a simple heading and reserves space for future encounter tooling while applying encounter-specific styling hooks.【F:salt-marcher/src/apps/encounter/view.ts†L1-L20】
+
+## How encounters launch
+- **Travel mode integration:** Whenever the travel logic signals `onEncounter`, the mode pauses playback and calls `openEncounter`, which opens (or reveals) the encounter workspace in a neighbouring pane.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L174-L222】
+- **Preloading:** Entering travel mode preloads the encounter module to reduce the delay between triggering an encounter and seeing the workspace appear.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L41-L83】
+
+## Manual access
+The encounter view is not yet exposed via a ribbon icon or command. To open it manually, create a new pane (e.g. with **Ctrl/Cmd+P → Open view by type**) and select `salt-encounter`. Once a route triggers another encounter, the existing pane will be reused automatically.
+
+## Roadmap notes
+- Capture a screenshot once the dedicated encounter UI lands and replace this note with the image reference.
+- Expand this article with encounter editing/management instructions as features ship.
+
+## Related articles
+- [Cartographer](./Cartographer.md) – explains how travel mode orchestrates the encounter hand-off.
+- [Getting Started](./Getting-Started.md) – outlines how to open the workspace manually if needed.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+This guide walks you through installing Salt Marcher, activating the plugin inside Obsidian, bootstrapping the shared terrain data, and opening every workspace that ships with the project. For a conceptual overview of features, start at the [Home](./Home.md) page.
+
+## 1. Install the plugin
+1. Download the latest release bundle or build it locally (see repository instructions).
+2. Copy the compiled plugin folder (containing `manifest.json`, `main.js`, and `styles.css` if present) into your vault under `.obsidian/plugins/salt-marcher`.
+3. Restart or reload Obsidian so it discovers the new plugin.
+
+> 💡 **Development build:** Run `npm install` followed by `npm run build` inside `salt-marcher/`. The build outputs `main.js` alongside the existing `manifest.json` for manual deployment.
+
+## 2. Enable Salt Marcher in Obsidian
+1. Open **Settings → Community plugins**.
+2. Toggle **Salt Marcher** on. The plugin registers the Cartographer, Library, and Encounter views, injects its stylesheet, and starts watching terrain data immediately.【F:salt-marcher/src/app/main.ts†L15-L59】
+3. Optional: pin the "Open Cartographer" (compass) and "Open Library" (book) ribbon icons to the sidebar for quicker access.
+
+## 3. Bootstrap shared terrains
+Salt Marcher maintains a shared terrain palette in `SaltMarcher/Terrains.md`. On first load the plugin ensures the file exists with default entries, reads it, and pushes the palette into the global renderer state.【F:salt-marcher/src/core/terrain-store.ts†L5-L64】
+
+If you prefer to prepare the vault ahead of time, run the **Command Palette → Salt Marcher: Cartographer öffnen** command once after enabling the plugin; this triggers the same bootstrap path.
+
+## 4. Open each workspace
+Salt Marcher exposes three dedicated workspaces. All can be opened via the ribbon buttons or the command palette unless otherwise noted.
+
+### Cartographer
+- Use **Command Palette → Salt Marcher: Cartographer öffnen** or click the compass icon.
+- The view mounts the map shell, map header, and the default mode. Travel, Editor, and Inspector modes can be switched via the header dropdown; see [Cartographer](./Cartographer.md) for details.
+
+### Library
+- Use **Command Palette → Salt Marcher: Library öffnen** or click the book icon.
+- When the view loads it ensures creature, spell, terrain, and region sources exist, attaches file watchers, and displays the mode switcher tabs; see [Library](./Library.md).
+
+### Encounter
+- The encounter workspace is primarily opened automatically by the travel mode when a route triggers an encounter hand-off. Manual access requires creating a new pane (`Ctrl/Cmd+P → Open view by type`) and selecting `salt-marcher-encounter`.
+- The view currently focuses on providing a dedicated layout placeholder; see [Encounter](./Encounter.md) for the present state.
+
+## 5. Next steps
+- Review the [Cartographer](./Cartographer.md) guide to learn how each mode behaves.
+- Visit the [Library](./Library.md) article for data management workflows and watcher expectations.
+- Inspect [Data Management](./Data-Management.md) if you need precise format specifications for terrains and regions.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,20 @@
+# Salt Marcher Knowledge Base
+
+Welcome to the Salt Marcher wiki. It complements the [project README](../README.md) with practitioner-focused guides for campaign cartography, travel support, and vault data stewardship.
+
+## Audience & Purpose
+- **Game masters using Obsidian** who need a reliable reference while preparing or running hex-crawl campaigns.
+- **Contributors and maintainers** who extend the plugin and require a concise description of runtime behaviour and expectations.
+- **Playtest facilitators** who must communicate current capabilities and gaps to stakeholders.
+
+Each article documents the current implementation state. If you spot a mismatch between documentation and behaviour, please update the relevant page and leave a note in `Critique.txt`.
+
+## Navigation
+- [Getting Started](./Getting-Started.md) – Installation, activation, first bootstraps, and workspace entry points.
+- [Cartographer](./Cartographer.md) – Detailed rundown of map modes, presenter hand-offs, and header actions.
+- [Library](./Library.md) – Managing creatures, spells, terrains, and regions with debounced saves.
+- [Encounter](./Encounter.md) – Current feature set and how travel auto-launches encounters.
+- [Data Management](./Data-Management.md) – Terrain/region storage formats, watchers, and sync signals.
+
+## Screenshots
+Screenshots are currently pending. Capture up-to-date views after UI polish passes and replace this note with the image references.

--- a/wiki/Library.md
+++ b/wiki/Library.md
@@ -1,0 +1,34 @@
+# Library Workspace
+
+The Library workspace centralises data sources for creatures, spells, terrains, and regions. It ensures every repository exists before rendering, attaches dedicated watchers per mode, and cleans up resources whenever you switch contexts.【F:salt-marcher/src/apps/library/view.ts†L1-L120】
+
+## Layout primer
+1. **Mode buttons** switch between Creatures, Spells, Terrains, and Regions. Only the active renderer stays mounted; previous renderers are destroyed, taking their watchers with them.【F:salt-marcher/src/apps/library/view.ts†L66-L118】
+2. **Search & create bar** filters the visible list and passes the search text to `handleCreate` so you can prefill new entries. The search string persists across mode changes.【F:salt-marcher/src/apps/library/view.ts†L90-L118】
+3. **Source description** displays the backing file or folder for the active mode, helping you verify watcher targets at a glance.【F:salt-marcher/src/apps/library/view.ts†L119-L145】
+
+## Creatures
+- Files live under `SaltMarcher/Creatures/`. The renderer loads the directory, lists entries with fuzzy scoring, and opens files with Obsidian’s native file opener.【F:salt-marcher/src/apps/library/view/creatures.ts†L1-L45】
+- Watcher behaviour: `watchCreatureDir` keeps the list in sync; switching away disposes the watcher via `registerCleanup`. No debounced saves are required because edits happen in Markdown files opened externally.【F:salt-marcher/src/apps/library/view/creatures.ts†L10-L33】
+- Creating entries invokes `CreateCreatureModal`, saves a new file, and reopens it in source mode for immediate editing.【F:salt-marcher/src/apps/library/view/creatures.ts†L35-L45】
+
+## Spells
+- Mirrors the creature workflow with `SaltMarcher/Spells/` as its backing directory.【F:salt-marcher/src/apps/library/view/spells.ts†L1-L45】
+- Watcher behaviour matches creatures via `watchSpellDir`, ensuring the UI refreshes whenever new spells are added externally.【F:salt-marcher/src/apps/library/view/spells.ts†L10-L33】
+- Creation uses `CreateSpellModal` and reopens the newly minted note just like creatures.【F:salt-marcher/src/apps/library/view/spells.ts†L35-L45】
+
+## Terrains
+- Data source: `SaltMarcher/Terrains.md`, maintained as a fenced `terrain` code block. The renderer guarantees an empty entry exists so the map always has a default terrain option.【F:salt-marcher/src/apps/library/view/terrains.ts†L1-L66】
+- Editing workflow: table rows let you rename, recolour, tweak speed, or delete terrains. Every change writes to an in-memory copy before re-rendering the list for immediate feedback.【F:salt-marcher/src/apps/library/view/terrains.ts†L67-L147】
+- **Debounced saves:** Terrain mutations call `scheduleSave`, bundling edits for 500 ms before persisting. After saving, the renderer reloads from disk to respect external updates.【F:salt-marcher/src/apps/library/view/terrains.ts†L148-L204】
+- **Watchers:** `watchTerrains` reloads the palette whenever the file changes elsewhere (including travel mode). The renderer registers the disposer so the watcher stops as soon as the mode is deactivated.【F:salt-marcher/src/apps/library/view/terrains.ts†L15-L36】
+
+## Regions
+- Data source: `SaltMarcher/Regions.md`, stored in a fenced `regions` code block that lists name, terrain link, and optional `encounter: 1/n` odds.【F:salt-marcher/src/apps/library/view/regions.ts†L1-L58】【F:salt-marcher/src/core/regions-store.ts†L5-L58】
+- Editing workflow: each row contains name, terrain dropdown (search-enhanced), encounter odds, and delete controls. Terrain names are re-populated dynamically whenever the shared palette changes.【F:salt-marcher/src/apps/library/view/regions.ts†L59-L129】
+- **Debounced saves:** Like terrains, region changes buffer for 500 ms before `saveRegions` writes the block back to disk and reloads it to avoid drift.【F:salt-marcher/src/apps/library/view/regions.ts†L130-L182】
+- **Watchers:** The renderer subscribes to both `watchRegions` and `watchTerrains`. Regions reload on direct edits, while terrain updates refresh the dropdown contents without losing unsaved changes.【F:salt-marcher/src/apps/library/view/regions.ts†L16-L41】
+
+## Cross-links
+- [Cartographer](./Cartographer.md) – the editor and inspector modes consume these terrain and region definitions.
+- [Data Management](./Data-Management.md) – explains the fenced block formats that Library persists and how watchers signal updates.


### PR DESCRIPTION
## Summary
- add a Salt Marcher wiki with a home page and navigation to detailed articles
- document getting started workflows, Cartographer and Library behaviours, and encounter hand-offs
- capture terrain/region data formats and watcher expectations for cross-feature synchronisation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a5633460832598612afc1ff8ec1a