### PR TITLE
Update Salt Marcher documentation structure

### DIFF
--- a/salt-marcher/PluginOverview.txt
+++ b/salt-marcher/PluginOverview.txt
@@ -1,100 +1,48 @@
 # Salt Marcher – Plugin Overview
 
-Salt Marcher liefert Kartographie-, Encounter- und Bibliothekswerkzeuge für hex-basierte Kampagnen. Der Code konzentriert sich
-vollständig auf dieses Plugin; eine optionale Kopplung an einen extern installierten Layout Editor erfolgt ausschließlich über
-das Brückenskript `src/app/layout-editor-bridge.ts`.
+## Purpose & Scope
+Dieses Dokument fasst die technische Struktur des Salt-Marcher-Plugins für Obsidian zusammen. Es dient Entwickler:innen als
+Einstieg in die Codebasis, verweist auf Detaildokumente unter `docs/` und beschreibt die wichtigsten Integrationspunkte.
 
-## Struktur
-
+## Repository Layout
 ```
-Salt-Marcher/
-└─ salt-marcher/
-   ├─ manifest.json          # Obsidian-Manifest (lädt das gebündelte main.js im Plugin-Stamm)
-   ├─ esbuild.config.mjs     # Build-Pipeline (bundelt src/app/main.ts → main.js)
-   ├─ main.js                # Gebündeltes Plugin-Artefakt
-   ├─ package.json           # Scripts & Dev-Abhängigkeiten (esbuild, TypeScript, Obsidian-Typen)
-   ├─ package-lock.json      # Reproduzierbare Dependency-Auflösung
-   ├─ tsconfig.json          # TypeScript-Konfiguration für das Build-Setup
-   ├─ PluginOverview.txt     # Diese Detailübersicht
-   ├─ README.md              # Anwender-orientierte Hinweise
-   ├─ docs/                  # Bereichsspezifische Overviews (cartographer/core/library/ui)
-   ├─ src/
-   │  ├─ app/
-   │  │  ├─ main.ts          # Plugin-Bootstrap (Views, Commands, CSS, Terrain-Watcher)
-   │  │  ├─ css.ts           # Zentrales Styling als Template-String
-   │  │  └─ layout-editor-bridge.ts # Optionales Binding zu einem externen Layout-Editor
-   │  ├─ apps/
-   │  │  ├─ cartographer/    # Hex-Map-Workspace mit Editor/Inspector/Travel-Modi
-   │  │  ├─ encounter/       # Encounter-View
-   │  │  └─ library/         # Library-View für Terrains, Regionen, Kreaturen
-   │  ├─ core/               # Domain-Services (Hex-Geometrie, Dateien, Terrain, Optionen)
-   │  └─ ui/                 # Geteilte Dialoge und Workflow-Helfer
-   └─ tests/
-      └─ cartographer/       # Vitest-Suite für den Presenter
+salt-marcher/
+├─ manifest.json          # Obsidian-Manifest (lädt main.js)
+├─ main.js                # Gebündeltes Plugin-Artefakt
+├─ README.md              # Produkt- & Architekturüberblick
+├─ docs/                  # Bereichsdokumentation (siehe unten)
+│  ├─ index.md            # Navigationsübersicht
+│  ├─ cartographer/       # Karten-Workspace (README + Overviews)
+│  ├─ core/               # Domain- und Persistenzdienste
+│  ├─ library/            # Verwaltungs- und Datenbank-Flows
+│  └─ ui/                 # Geteilte UI-Komponenten
+├─ src/
+│  ├─ app/                # Plugin-Bootstrap, CSS, Integrationen
+│  ├─ apps/               # Feature-Workspaces (Cartographer, Encounter, Library)
+│  ├─ core/               # Hex- und Daten-Services
+│  └─ ui/                 # Wiederverwendbare UI-Bausteine
+└─ tests/                 # Vitest-Suites (Presenter, Mocks)
 ```
 
-## Features & Verantwortlichkeiten
+## Kernbereiche
+- **Cartographer Workspace:** Hex-Map-Stage mit Editor-, Inspector- und Travel-Modi, orchestriert durch Presenter und View-Shell.
+  Struktur und Komponenten sind im [`docs/cartographer/`](docs/cartographer/README.md) beschrieben.
+- **Library Workspace:** Verwaltungsoberfläche für Terrains, Regionen, Kreaturen und Zauber. Architekturüberblick unter
+  [`docs/library/`](docs/library/README.md).
+- **Encounter Workspace:** Fokus-View für Begegnungen, die aus Cartographer- oder Library-Events gestartet werden. Ergänzende
+  Hinweise liegen im Projekt-Wiki ([Encounter-Guide](../wiki/Encounter.md)).
+- **Core Services:** Hex-Geometrie, Kartenpersistenz, Terrain-/Regions-Stores und Dateihilfen, dokumentiert in
+  [`docs/core/`](docs/core/README.md).
+- **Geteilte UI:** View-Container, Dialoge und Map-Workflows für alle Workspaces, siehe [`docs/ui/`](docs/ui/README.md).
 
-- **Plugin-Bootstrap (`src/app/main.ts`):** Registriert Cartographer-, Encounter- und Library-Views, injiziert das Salt-Marcher-CSS, hält Terrain-Daten aktuell und nutzt die Cartographer-Helfer (`openCartographer`, `detachCartographerLeaves`) als einzige Entry-Points für Kommandos/Ribbons – es existiert kein zweites Plugin-Objekt mehr.
-- **Cartographer-Workspace:** Map-Stage mit Editor-, Inspector- und Travel-Modi inklusive Renderer-Synchronisierung, Dateioperationen und Modusverwaltung.
-- **Library-View:** Einheitliche Verwaltung von Terrains, Regionen und Kreaturen mit Suche, Create-Workflows und Persistenz.
-- **Encounter-View:** Schlanke Ansicht für Encounter-Notizen.
-- **Core-Services:** Hex-Geometrie, Map/Terrain/Regions-Persistenz sowie Workspace-Helfer als Single Source of Truth.
-- **Geteilte UI-Bausteine:** Modals, Header und Workflows für Map-Management und generische Dialoge.
-- **View Container & Layout-Editor-Bridge:** `ui/view-container.ts` kapselt einen renderbaren View-Host inkl. optionaler Kamera; `src/app/layout-editor-bridge.ts` meldet die Cartographer-Karte als View-Binding bei einem extern installierten Layout-Editor an.
-- **Build & Styling:** Esbuild erzeugt `main.js`; `css.ts` enthält ausschließlich Salt-Marcher-spezifisches Styling (Layout-Editor-CSS ist in das separate Plugin umgezogen).
+## Daten- & Kontrollfluss
+1. **Bootstrap (`src/app/main.ts`):** Registriert Views, Commands und Ribbon-Icons, initialisiert Terrain-Daten und CSS.
+2. **Datenhaltung:** `core/terrain-store.ts`, `core/regions-store.ts` sowie Map-Helfer synchronisieren Vault-Dateien mit den Views.
+3. **Workspaces:** Cartographer-, Library- und Encounter-Apps beobachten die Stores, aktualisieren UI-Zustand und lösen Aktionen
+   wie Encounter-Starts oder Map-Saves aus.
+4. **Integrationen:** Die optionale `layout-editor-bridge.ts` bindet den Cartographer an den Layout Editor, während UI-Komponenten
+   (`src/ui/*`) konsistente Dialoge und Header bereitstellen.
 
-## Datenfluss
-
-1. **Plugin-Load (`main.ts`):** Registriert Views, richtet Ribbons/Commands ein und lädt Terrain-Daten.
-2. **Terrain-Store:** `ensureTerrainFile` und `loadTerrains` initialisieren den Speicher; `watchTerrains` broadcastet Änderungen.
-3. **Views:** Cartographer, Library und Encounter abonnieren die entsprechenden Stores/Services und aktualisieren ihre UI.
-4. **UI-Layer:** Gemeinsame Dialoge (z. B. Map-Workflows) orchestrieren Vault-Zugriffe, Renderer-Updates und Benutzerinteraktionen.
-
-## Skript-Referenz
-
-### `src/app`
-- `main.ts`: Einstiegspunkt des Plugins. Registriert Views/Commands, lädt Terrain-Daten (`ensureTerrainFile`, `loadTerrains`, `watchTerrains`), injiziert CSS.
-- `css.ts`: Enthält das Styling für Cartographer, Library und Encounter. Layout-Editor-spezifische Klassen wurden entfernt.
-- `layout-editor-bridge.ts`: Bindet den Cartographer optional an einen externen Layout Editor (View-Bindings über dessen API).
-
-### `src/apps/cartographer`
-- `index.ts`: Exportiert `CartographerView` sowie Hilfsfunktionen (`openCartographer`, `getOrCreateCartographerLeaf`, `detachCartographerLeaves`); delegiert Lifecycle an den Presenter.
-- `presenter.ts`: Kapselt Datei-/Mode-State, Map-Rendering und Hex-Ereignisse; koordiniert Map-Manager, Modi und View-Shell.
-- `view-shell.ts`: Rendert Header, Map-Stage und Sidebar-Hosts, liefert ein Handle zur UI-Aktualisierung und ruft Presenter-Callbacks (Open/Create/Delete/Save, Mode-Wahl, `hex:click`) auf.
-- `modes/editor.ts`: Sidebar für den Editor-Modus. Bindet Tool-Infrastruktur aus `editor/`, synchronisiert Brush-Vorschau und persistiert Terrain-Änderungen über `RenderHandles`.
-- `modes/inspector.ts`: Inspector-Sidebar zum Bearbeiten von Terrain/Notizen eines ausgewählten Hex. Nutzt `hex-notes` für Dateioperationen und aktualisiert Renderer-Fills live.
-- `modes/travel-guide.ts`: Verknüpft Travel-Logik (Playback, Token, Routen) mit dem Cartographer, verwaltet UI-Sidebar und Persistenz über `travel/domain`.
-- `editor/tools/*`: Tool-API und konkrete Tools (Terrain-Brush etc.).
-- `travel/*`: Domain-, Render- und UI-Bausteine für den Travel-Modus.
-- `CartographerOverview.txt`, `travel/TravelGuideOverview.txt`: Detaildokumentationen der Teilbereiche.
-
-### `src/apps/library`
-- `view.ts`: Tab-basierte Library-View für Terrains, Regionen, Kreaturen inkl. Suche, Inline-Editing und Persistenz.
-- `core/*`: Laden/Speichern der Sammeldateien, Parsing, Filterung und Eventing.
-- `create/*`: Modals und Helfer für Creatures/Spells inkl. Presets und Token-Editoren.
-- `LibraryOverview.txt`: Struktur- und Verantwortlichkeitsübersicht.
-
-### `src/apps/encounter`
-- `view.ts`: Implementiert `EncounterView` (ItemView). Rendert eine Encounter-Seite mit Titel/Platzhaltertext und räumt beim Schließen das DOM auf.
-
-### `src/core`
-- `CoreOverview.txt`: Überblick über Aufbau und Verantwortlichkeiten der Core-Schicht.
-- `options.ts`, `layout.ts`: Parser & Workspace-Helfer.
-- `hex-mapper/*`: Renderer, Geometrie und Camera-Logik.
-- `map-*.ts`: Erstellen, Löschen, Listen von Karten.
-- `terrain.ts`, `terrain-store.ts`, `regions-store.ts`: Verwaltung und Persistenz der Terrain/Regions-Daten.
-- `save.ts`: Gemeinsame Save-Helfer.
-
-### `src/ui`
-- `UiOverview.txt`: Übersicht über Struktur und Verantwortlichkeiten der UI-Bausteine.
-- `modals.ts`, `map-workflows.ts`, `map-manager.ts`, `map-header.ts`, `confirm-delete.ts`, `search-dropdown.ts`, `view-container.ts`: Geteilte UI- und Workflow-Komponenten.
-
-### `tests`
-- `cartographer/presenter.test.ts`: Vitest-Suite, die Presenter-Mode-Wechsel und Dateireaktionen ohne DOM-Verknüpfung prüft (inkl. Obsidian-Mocks).
-
-## Zusammenarbeit mit dem Layout-Editor
-
-- Der Layout Editor wird als separates Obsidian-Plugin ausgeliefert und ist nicht Teil dieses Repositories.
-- Sobald der Layout Editor installiert und aktiviert ist, kann Salt Marcher über dessen öffentliches API (`getApi()`) Layout-Definitionen registrieren oder Layouts laden – ohne direkte Code-Abhängigkeit im Salt-Marcher-Build.
-- `layout-editor-bridge.ts` registriert – sobald verfügbar – das Cartographer-Mapping als `viewBindingId` beim Layout Editor, sodass dessen View Container die Karte als Feature anbietet.
+## Dokumentation & Standards
+Die Bereichsdokumente unter [`docs/`](docs/index.md) werden nach jedem Feature-Update gepflegt. Für neue Beiträge
+bitte den projektspezifischen [Style Guide](../docs/style-guide.md) beachten und Querverlinkungen zu bestehenden Overviews setzen.

--- a/salt-marcher/README.md
+++ b/salt-marcher/README.md
@@ -1,53 +1,46 @@
 # Salt Marcher Plugin
 
-## Überblick
-Salt Marcher erweitert Obsidian um einen Arbeitsbereich für hexbasierte Kampagnenkarten, Reiserouten und bestandsgeführte Referenzen. Beim Laden registriert das Plugin spezialisierte Workspaces für Kartographie, Begegnungen und eine bibliotheksartige Verwaltung, lädt automatisch die Terrain-Palette und hält sie per Dateiwächter aktuell. Zusätzlich werden Schnellzugriffssymbole im Ribbon sowie Befehle bereitgestellt, um die wichtigsten Ansichten direkt zu öffnen.
+## Purpose & Audience
+Salt Marcher erweitert Obsidian um spezialisierte Workspaces für hexcrawl-orientierte Kampagnen. Dieses Dokument richtet sich an
+Entwickler:innen und Power-User, die das Plugin verstehen, erweitern oder in eigene Toolchains integrieren möchten. Für reine
+Anwenderthemen verweisen wir auf die Projekt-Wiki-Seiten in diesem Repository.
 
-## Kernbereiche und Funktionen
+## Systemüberblick
+Das Plugin registriert beim Laden die Cartographer-, Library- und Encounter-Workspaces, erstellt fehlende Datenquellen (z. B.
+Terrains) und hält sie über Dateiwächter synchron. Gemeinsame UI-Bausteine sorgen dafür, dass Karten, Reiserouten und Nachschlage-
+Einträge dieselben Datenmodelle teilen. Ergänzende Detaildokumente zu Architektur und Abläufen befinden sich im Ordner
+[`docs/`](docs/index.md).
 
-### Cartographer Workspace
-Der Cartographer-Workspace folgt einer Presenter/Shell-Aufteilung: `CartographerPresenter` mountet die Shell, koordiniert `MapManager`, Map-Layer und Mode-Lifecycle und hält Datei- sowie Options-Status synchron. Die `createCartographerShell`-Schicht rendert Header, Map-Bühne und Sidebar-Hosts, während das `MapHeader`-Layout Dateiaktionen bündelt und die Mode-Auswahl als Dropdown bereitstellt. Nutzer-Workflows sind im [Wiki: Cartographer-Workspace](../../wiki/Cartographer-Workspace) beschrieben.【F:salt-marcher/src/apps/cartographer/presenter.ts†L1-L210】【F:salt-marcher/src/apps/cartographer/view-shell.ts†L1-L141】【F:salt-marcher/src/ui/map-header.ts†L1-L120】【F:salt-marcher/src/ui/map-manager.ts†L1-L88】
+## Verzeichnisstruktur
+```
+salt-marcher/
+├─ manifest.json            # Obsidian-Manifest (zeigt auf main.js)
+├─ main.js                  # Gebündeltes Plugin-Artefakt
+├─ docs/                    # Architektur- und Workflow-Dokumentation
+│  ├─ index.md              # Einstiegspunkt für die Plugin-Dokumentation
+│  ├─ cartographer/         # Cartographer-spezifische Overviews
+│  ├─ core/                 # Kernservices & Datenhaltung
+│  ├─ library/              # Verwaltungs- und Datenbank-Flows
+│  └─ ui/                   # Geteilte UI-Komponenten & Shells
+├─ src/
+│  ├─ app/                  # Plugin-Bootstrap, CSS und Integrationen
+│  ├─ apps/                 # Feature-Workspaces (Cartographer, Encounter, Library)
+│  ├─ core/                 # Domain-Services & Persistenzlogik
+│  └─ ui/                   # View-Container, Dialoge und Workflows
+├─ tests/                   # Vitest-Suites (aktuell Cartographer-Presenter)
+└─ package.json             # Build- und Development-Skripte
+```
 
-#### Travel-Modus
-* initialisiert die Terrain-Palette aus `SaltMarcher/Terrains.md`, hält sie per Vault-Event aktuell und scoped das Layout (`sm-cartographer--travel`).
-* koppelt Routen- und Token-Ebene an `createTravelLogic` und synchronisiert Wiedergabe, Tempo und Uhrzeit über den `TravelPlaybackController`.
-* bindet Drag-&-Drop sowie Kontextmenüs über den `TravelInteractionController`, wodurch Route-Punkte und Token-Positionen im Map-Layer gepflegt werden.
-* persistiert Token-Positionen in die Karte und nutzt das Encounter-Gateway, um bei Zufallsereignissen automatisch den Encounter-View auf der rechten Seite zu öffnen.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L1-L242】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts†L1-L56】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts†L1-L64】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L1-L52】
+## Arbeitsbereiche & Ressourcen
+- **Cartographer:** Hex-Karten bearbeiten, Reisen visualisieren und Begegnungen auslösen. Siehe [Cartographer-Guide](../wiki/Cartographer.md)
+  sowie die technischen Overviews unter [`docs/cartographer/`](docs/cartographer/README.md).
+- **Library:** Terrains, Regionen, Kreaturen und Zauber verwalten. Nutzungsanleitung im [Library-Guide](../wiki/Library.md) und ergänzende
+  Architekturhinweise unter [`docs/library/`](docs/library/README.md).
+- **Encounter:** Begegnungen verwalten, die aus dem Travel-Modus oder der Library gestartet werden. Grundlagen im [Encounter-Guide](../wiki/Encounter.md).
 
-#### Editor-Modus
-* liefert eine erweiterbare Werkzeugleiste (aktuell: Terrain/Region-Brush) mit Such-Dropdowns.
-* die Brush-Optionen bieten Radiuswahl, Regionszuweisung und Mal-/Lösch-Modus; die Regionen werden aus der Regionsliste geladen und live aktualisiert.
-* Hex-Klicks schreiben Terrain- und Regionsdaten in die Karte, erzeugen fehlende Polygone und färben das Rendering unmittelbar ein.【F:salt-marcher/src/apps/cartographer/modes/editor.ts†L1-L161】【F:salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/brush-options.ts†L1-L167】
+Weitere Nutzer-Workflows, Schritt-für-Schritt-Anleitungen und FAQ-Einträge sind im [Projekt-Wiki](../wiki/Home.md) gesammelt.
 
-#### Inspector-Modus
-* blendet eine Informations- und Bearbeitungsleiste ein, sobald eine Karte geladen ist.
-* erlaubt die Auswahl einzelner Hexfelder, das Bearbeiten von Terrainzuweisung und Notiztexten und speichert Änderungen zeitverzögert ins Markdown, inklusive Aktualisierung der Kartenfarben.【F:salt-marcher/src/apps/cartographer/modes/inspector.ts†L1-L168】
-
-### Library View
-Die Library dient als zentrales Verwaltungswerkzeug für Kreaturen, Zauber, Terrains und Regionen. Anwender-Tipps finden sich im [Wiki: Library-View](../../wiki/Library-View).
-* Beim Öffnen werden sämtliche Quellordner/-dateien garantiert angelegt und einmalig geladen, anschließend halten Dateiwächter alle Listen synchron.
-* Eine Kopfleiste schaltet zwischen den Modi, darunter erlaubt eine Such- und Erstellen-Leiste sowohl Fuzzy-Suche als auch das direkte Anlegen neuer Einträge.
-* **Creatures & Spells:** Listen Markdown-Dateien, öffnen sie bei Bedarf und nutzen modale Dialoge zum Erstellen neuer Dateien.
-* **Terrains:** Bearbeitbare Tabelle mit Name, Farbe (per Color-Picker) und Bewegungsgeschwindigkeit; Mutationen laufen lokal, werden nach 500 ms Debounce gespeichert und beim Destroy der View zuverlässig geflusht.【F:salt-marcher/src/apps/library/view/terrains.ts†L10-L114】
-* **Regions:** Pflegt Regionen mit Terrainreferenz (Dropdown mit Suche) und optionalen Encounter-Wahrscheinlichkeiten; Änderungen werden persistiert und können gelöscht werden.【F:salt-marcher/src/apps/library/view.ts†L1-L249】
-
-### Encounter View
-Der Encounter-View liefert aktuell eine strukturierte Platzhalteroberfläche und steht im Fokus, sobald der Travel-Modus über das Encounter-Gateway einen Zufallsfund meldet. Das Gateway lädt Encounter-Modul & Layout-Helfer on demand, holt sich die rechte Workspace-Spalte und aktiviert den View für Nutzer. Mehr Details fasst das [Wiki: Encounter-View](../../wiki/Encounter-View) zusammen.【F:salt-marcher/src/apps/encounter/view.ts†L1-L20】【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L132-L203】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L1-L52】
-
-### Datenhaltung & Synchronisation
-* **Terrain-Datei:** `ensureTerrainFile` legt bei Bedarf `SaltMarcher/Terrains.md` mit Beispielpalette an, `watchTerrains` lädt Änderungen, aktualisiert globale Farben (`setTerrains`) und triggert Plugin-Events für UI-Komponenten.【F:salt-marcher/src/core/terrain-store.ts†L1-L86】
-* **Regionen:** Analog verwaltet `ensureRegionsFile` (nicht gezeigt) die Regionsliste; Library-Updates lösen `salt:regions-updated` aus (siehe Brush-Tool).
-* **Map-Daten:** `MapManager` und `MapHeader` kapseln die Dateiauswahl, `renderMap` im Cartographer lädt den ersten `hex3x3`-Block, montiert das SVG-Layering und informiert aktive Modi über Dateiwechsel.【F:salt-marcher/src/apps/cartographer/view-shell.ts†L96-L210】
-
-### Layout-Editor-Integration
-Bei installiertem „Layout Editor“-Plugin registriert Salt Marcher automatisch ein View-Binding, sodass die Cartographer-Karte innerhalb dieses Layout-Systems als Modul auswählbar ist. Aktivierung und Deaktivierung des Fremd-Plugins werden überwacht, um die Registrierung stabil zu halten.【F:salt-marcher/src/app/layout-editor-bridge.ts†L1-L83】
-
-### Befehle & Ribbon-Einträge
-Beim Laden registriert das Plugin die Cartographer-, Library- und Encounter-Views, richtet Ribbon-Icons (Kompass, Buch) ein und stellt Kommandos zum Öffnen der beiden wichtigsten Bereiche bereit. Alle Aktionen verwenden die zentrale Leaf-Verwaltung, um Ansichten im aktiven Workspace zu platzieren.【F:salt-marcher/src/app/main.ts†L1-L73】
-
-## Zusammenspiel der Komponenten
-* `SaltMarcherPlugin` initialisiert Terrains, setzt sie global und hält sie aktuell, sodass Cartographer-Modi und die Library konsistente Farbinformationen teilen.
-* Die Cartographer-Modi greifen über `CartographerModeContext` auf gemeinsame Infrastruktur zu (App, Host-Container, MapLayer, RenderHandles, Hex-Optionen) und reagieren auf Dateiwechsel, wodurch UI-Elemente automatisch zwischen Karten synchronisiert werden.【F:salt-marcher/src/apps/cartographer/view-shell.ts†L52-L193】
-* Library-Änderungen an Terrains oder Regionen feuern Events, die Editor-Tools (z. B. der Brush) abonnieren und dadurch Dropdowns aktuell halten.【F:salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/brush-options.ts†L36-L111】
-
-Gemeinsam entsteht so ein zusammenhängender Arbeitsbereich: Karten lassen sich erstellen, bearbeiten, inspizieren und für Reisen nutzen, während Bibliotheksdaten die Terrain- und Regionslogik unterstützen und Begegnungen direkt angebunden sind.
+## Dokumentations- und Beitragshinweise
+Die technische Dokumentation dieses Plugins folgt dem [Documentation Index](docs/index.md). Bitte richte neue Beiträge am
+[Style Guide](../docs/style-guide.md) des Projekts aus und verlinke zusätzliche Detaildokumente innerhalb des bestehenden
+Dokumentationsnetzes.

--- a/salt-marcher/docs/cartographer/README.md
+++ b/salt-marcher/docs/cartographer/README.md
@@ -1,0 +1,23 @@
+# Cartographer Documentation
+
+## Überblick
+Dieser Ordner beschreibt den Cartographer-Workspace – die Hex-Kartenbühne mit Editor-, Inspector- und Travel-Modi. Die Inhalte
+richten sich an Entwickler:innen, die Rendering, Interaktionen oder Datenflüsse anpassen möchten.
+
+## Struktur
+```
+docs/cartographer/
+├─ README.md
+├─ map-layer-overview.md
+├─ travel-mode-overview.md
+└─ view-shell-overview.md
+```
+
+## Inhalte
+- [view-shell-overview.md](view-shell-overview.md) – Aufbau der Cartographer-Shell, Presenter-Anbindung und Lifecycle-Hooks.
+- [map-layer-overview.md](map-layer-overview.md) – Rendering-Pipeline, Layer-Architektur und Datenquellen der Hex-Map.
+- [travel-mode-overview.md](travel-mode-overview.md) – Travel-spezifische Controller, Playback-Logik und Encounter-Anbindung.
+
+## Weiterführende Ressourcen
+- Nutzerperspektive im [Cartographer-Wiki-Eintrag](../../../wiki/Cartographer.md).
+- Dokumentationsstandards gemäß [Style Guide](../../../docs/style-guide.md).

--- a/salt-marcher/docs/core/README.md
+++ b/salt-marcher/docs/core/README.md
@@ -1,0 +1,21 @@
+# Core Documentation
+
+## Überblick
+Der Core-Bereich bündelt zentrale Services: Hex-Geometrie, Persistenz und Dateioperationen. Diese README hilft Entwickler:innen,
+schnell passende Module für Daten- und Rechenlogik zu finden.
+
+## Struktur
+```
+docs/core/
+├─ README.md
+├─ hex-render-overview.md
+└─ terrain-store-overview.md
+```
+
+## Inhalte
+- [hex-render-overview.md](hex-render-overview.md) – Renderer-Architektur, Kamera-Logik und Hex-Koordinatensystem.
+- [terrain-store-overview.md](terrain-store-overview.md) – Laden, Beobachten und Synchronisieren der Terrain-Daten.
+
+## Weiterführende Ressourcen
+- Nutzung im Kontext der Workspaces siehe [Cartographer](../cartographer/README.md) und [Library](../library/README.md).
+- Richtlinien zur Dokumentation: [Style Guide](../../../docs/style-guide.md).

--- a/salt-marcher/docs/index.md
+++ b/salt-marcher/docs/index.md
@@ -1,0 +1,27 @@
+# Salt Marcher Documentation Index
+
+## Purpose & Audience
+Diese Indexseite verknüpft die Bereichsdokumente des Plugins. Sie richtet sich an Entwickler:innen, die Architekturentscheidungen
+nachvollziehen oder neue Features ergänzen wollen. Nutzerorientierte Guides findest du im [Projekt-Wiki](../../wiki/Home.md).
+
+## Struktur
+```
+docs/
+├─ index.md
+├─ cartographer/
+├─ core/
+├─ library/
+└─ ui/
+```
+Die Unterordner spiegeln die Hauptbereiche des Plugins wider. Jede README beschreibt die enthaltenen Detaildokumente und verweist
+auf weiterführende Ressourcen.
+
+## Bereiche
+- [Cartographer](cartographer/README.md) – Karten-Workspace mit Editor-, Inspector- und Travel-Modi sowie deren Infrastruktur.
+- [Core](core/README.md) – Persistenz, Hex-Geometrie und zentrale Services, die Workspaces mit Daten versorgen.
+- [Library](library/README.md) – Verwaltung von Kreaturen, Zaubern, Terrains und Regionen inklusive Event-Flows.
+- [UI](ui/README.md) – Wiederverwendbare UI-Bausteine, Shell-Komponenten und Map-spezifische Workflows.
+
+## Standards & Pflege
+Alle neuen oder aktualisierten Dokumente müssen dem [Documentation Style Guide](../../docs/style-guide.md) entsprechen. Ergänze
+Querverlinkungen zwischen den Bereichen, sobald sich Verantwortlichkeiten überschneiden, und halte die Strukturdiagramme aktuell.

--- a/salt-marcher/docs/library/README.md
+++ b/salt-marcher/docs/library/README.md
@@ -1,0 +1,19 @@
+# Library Documentation
+
+## Überblick
+Der Library-Bereich deckt die Verwaltungsoberfläche für Kreaturen, Zauber, Terrains und Regionen ab. Die Dokumente unterstützen
+Entwickler:innen dabei, Datenflüsse und UI-Strukturen nachzuvollziehen.
+
+## Struktur
+```
+docs/library/
+├─ README.md
+└─ Overview.md
+```
+
+## Inhalte
+- [Overview.md](Overview.md) – Gesamtaufbau der Library-View, inklusive Tab-Logik, Create-Workflows und Datensynchronisation.
+
+## Weiterführende Ressourcen
+- Anwenderdokumentation im [Library-Wiki-Eintrag](../../../wiki/Library.md).
+- Dokumentationsrichtlinien: [Style Guide](../../../docs/style-guide.md).

--- a/salt-marcher/docs/ui/README.md
+++ b/salt-marcher/docs/ui/README.md
@@ -1,0 +1,21 @@
+# UI Documentation
+
+## Überblick
+Der UI-Bereich fasst wiederverwendbare Komponenten, Dialoge und Infrastruktur zusammen, die von allen Workspaces genutzt werden.
+Er dient Entwickler:innen, die gemeinsame UX-Bausteine erweitern oder neue Workflows implementieren möchten.
+
+## Struktur
+```
+docs/ui/
+├─ README.md
+└─ map-manager-overview.md
+```
+
+## Inhalte
+- [map-manager-overview.md](map-manager-overview.md) – Zuständigkeiten des Map-Managers, Leaf-Verwaltung und Integration in die
+  Workspaces.
+
+## Weiterführende Ressourcen
+- Verwendungsbeispiele findest du in den README-Dateien der Bereiche [Cartographer](../cartographer/README.md) und
+  [Library](../library/README.md).
+- Dokumentationsrichtlinien: [Style Guide](../../../docs/style-guide.md).


### PR DESCRIPTION
## Summary
- restructure the plugin README with a purpose section, directory map, and canonical wiki links
- replace the PluginOverview with a concise scope description and references to the new documentation tree
- add a documentation index plus area READMEs for cartographer, core, library, and UI that link back to the style guide

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6ab82e6248325b3d49bd282783119