### PR TITLE
Align Library UI copy with English terminology

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -35,3 +35,4 @@ Additional formatting rules:
 - Prefer relative links inside the repository to keep navigation consistent across forks and mirrors.
 - When referencing command sequences or configuration snippets, use fenced code blocks with language hints for readability.
 - Update directory tables and linked references whenever files move to prevent dead links.
+- Runtime UI copy (buttons, notices, placeholders) and accompanying code comments must use English to stay aligned with the Library and UI documentation. Quote the exact labels (e.g. "Create", "Open") when describing workflows.

--- a/salt-marcher/docs/library/Overview.md
+++ b/salt-marcher/docs/library/Overview.md
@@ -37,7 +37,7 @@ Der `LibraryView` reduziert sich auf die Shell-Aufgabe: Mode-Umschaltung, Suchfe
 
 1. **Mode-Aktivierung:** `LibraryView.activateMode` zerstört ggf. den bisherigen Renderer (inkl. Watcher) und erzeugt eine neue Instanz. Anschließend wird die aktuelle Suchanfrage übergeben und die Liste gerendert.
 2. **Watcher-Management:** Jeder Renderer registriert die benötigten Datei-Watcher selbstständig über `BaseModeRenderer.registerCleanup`. Beim Destroy werden alle Listener aufgehoben und das Container-Element geleert.
-3. **Such- und Create-Fluss:** Der Suchstring wird zentral gehalten und per `setQuery` an den aktiven Renderer weitergereicht. Der „Erstellen“-Button ruft `handleCreate` des aktiven Renderers auf, wodurch Kreaturen/Zauber modale Workflows starten oder Terrains/Regionen direkt vorbereitet werden.
+3. **Such- und Create-Fluss:** Der Suchstring wird zentral gehalten und per `setQuery` an den aktiven Renderer weitergereicht. Der „Create“-Button ruft `handleCreate` des aktiven Renderers auf, wodurch Kreaturen/Zauber modale Workflows starten oder Terrains/Regionen direkt vorbereitet werden.
 4. **Terrains-Persistenz:** Terrain-Änderungen aktualisieren zunächst nur den lokalen Zustand. Ein Debounce (500 ms) bündelt alle Eingaben, bevor `saveTerrains` ausgeführt wird. Nach dem Persistieren werden Daten erneut geladen, um externe Änderungen zu berücksichtigen.
 5. **Regions-Persistenz:** Regionen verhalten sich identisch – Eingaben werden lokal gehalten und erst nach dem Debounce in `saveRegions` geschrieben. Terrain-Namen werden separat beobachtet, sodass Dropdowns automatisch neue Terrains anbieten.
 

--- a/salt-marcher/src/apps/library/view.ts
+++ b/salt-marcher/src/apps/library/view.ts
@@ -60,19 +60,19 @@ export class LibraryView extends ItemView {
         mkBtn("Terrains", "terrains");
         mkBtn("Regions", "regions");
 
-        // Search + Create
+        // Search + create
         const bar = root.createDiv({ cls: "sm-cc-searchbar" });
-        const search = bar.createEl("input", { attr: { type: "text", placeholder: "Suche oder Name eingeben…" } }) as HTMLInputElement;
+        const search = bar.createEl("input", { attr: { type: "text", placeholder: "Search or type a name…" } }) as HTMLInputElement;
         search.value = this.query;
         search.oninput = () => {
             this.query = search.value;
             this.activeRenderer?.setQuery(this.query);
         };
         this.searchInput = search;
-        const createBtn = bar.createEl("button", { text: "Erstellen" });
+        const createBtn = bar.createEl("button", { text: "Create" });
         createBtn.onclick = () => { void this.onCreate(search.value.trim()); };
 
-        // Target source info
+        // Source description
         this.descEl = root.createDiv({ cls: "desc" });
 
         // List container
@@ -126,8 +126,8 @@ export class LibraryView extends ItemView {
 
     private updateSourceDescription() {
         if (!this.descEl) return;
-        const text = this.mode === "creatures" ? "Quelle: SaltMarcher/Creatures/" :
-            this.mode === "spells" ? "Quelle: SaltMarcher/Spells/" :
+        const text = this.mode === "creatures" ? "Source: SaltMarcher/Creatures/" :
+            this.mode === "spells" ? "Source: SaltMarcher/Spells/" :
                 this.mode === "terrains" ? describeTerrainsSource() :
                     describeRegionsSource();
         this.descEl.setText(text);

--- a/salt-marcher/src/apps/library/view/creatures.ts
+++ b/salt-marcher/src/apps/library/view/creatures.ts
@@ -29,7 +29,7 @@ export class CreaturesRenderer extends BaseModeRenderer implements ModeRenderer 
         for (const it of items) {
             const row = list.createDiv({ cls: "sm-cc-item" });
             row.createDiv({ cls: "sm-cc-item__name", text: it.name });
-            const openBtn = row.createEl("button", { text: "Öffnen" });
+            const openBtn = row.createEl("button", { text: "Open" });
             openBtn.onclick = async () => {
                 await this.app.workspace.openLinkText(it.file.path, it.file.path, true);
             };

--- a/salt-marcher/src/apps/library/view/regions.ts
+++ b/salt-marcher/src/apps/library/view/regions.ts
@@ -58,7 +58,7 @@ export class RegionsRenderer extends BaseModeRenderer implements ModeRenderer {
             });
 
             const terrSel = row.createEl("select") as HTMLSelectElement;
-            enhanceSelectToSearch(terrSel, "Such-dropdown…");
+            enhanceSelectToSearch(terrSel, "Search options…");
             this.populateTerrainOptions(terrSel, region.terrain || "");
             terrSel.addEventListener("change", () => {
                 region.terrain = terrSel.value;
@@ -80,7 +80,7 @@ export class RegionsRenderer extends BaseModeRenderer implements ModeRenderer {
         }
 
         if (!entries.length) {
-            list.createDiv({ cls: "sm-cc-item" }).setText("Keine Regionen hinterlegt.");
+            list.createDiv({ cls: "sm-cc-item" }).setText("No regions available.");
         }
     }
 
@@ -103,7 +103,7 @@ export class RegionsRenderer extends BaseModeRenderer implements ModeRenderer {
         select.empty();
         const options = Array.from(new Set(["", ...this.terrainNames]));
         for (const name of options) {
-            const option = select.createEl("option", { text: name || "(leer)", value: name });
+            const option = select.createEl("option", { text: name || "(empty)", value: name });
             option.selected = name === selected;
         }
     }
@@ -147,5 +147,5 @@ export class RegionsRenderer extends BaseModeRenderer implements ModeRenderer {
 }
 
 export function describeRegionsSource(): string {
-    return `Quelle: ${REGIONS_FILE}`;
+    return `Source: ${REGIONS_FILE}`;
 }

--- a/salt-marcher/src/apps/library/view/spells.ts
+++ b/salt-marcher/src/apps/library/view/spells.ts
@@ -29,7 +29,7 @@ export class SpellsRenderer extends BaseModeRenderer implements ModeRenderer {
         for (const it of items) {
             const row = list.createDiv({ cls: "sm-cc-item" });
             row.createDiv({ cls: "sm-cc-item__name", text: it.name });
-            const openBtn = row.createEl("button", { text: "Öffnen" });
+            const openBtn = row.createEl("button", { text: "Open" });
             openBtn.onclick = async () => {
                 await this.app.workspace.openLinkText(it.file.path, it.file.path, true);
             };

--- a/salt-marcher/src/apps/library/view/terrains.ts
+++ b/salt-marcher/src/apps/library/view/terrains.ts
@@ -100,7 +100,7 @@ export class TerrainsRenderer extends BaseModeRenderer implements ModeRenderer {
         }
 
         if (!entries.length) {
-            list.createDiv({ cls: "sm-cc-item" }).setText("Keine Terrains vorhanden.");
+            list.createDiv({ cls: "sm-cc-item" }).setText("No terrains available.");
         }
     }
 
@@ -175,5 +175,5 @@ export class TerrainsRenderer extends BaseModeRenderer implements ModeRenderer {
 }
 
 export function describeTerrainsSource(): string {
-    return `Quelle: ${TERRAIN_FILE}`;
+    return `Source: ${TERRAIN_FILE}`;
 }

--- a/salt-marcher/src/ui/map-manager.ts
+++ b/salt-marcher/src/ui/map-manager.ts
@@ -1,5 +1,5 @@
 // src/ui/map-manager.ts
-// Gemeinsame Verwaltung für Map-Auswahl, Erstellung und Löschung.
+// Central manager that coordinates map selection, creation, and deletion flows.
 
 import { App, Notice, TFile } from "obsidian";
 import {
@@ -12,35 +12,35 @@ import { ConfirmDeleteModal } from "./confirm-delete";
 import { deleteMapAndTiles } from "../core/map-delete";
 
 export type MapManagerOptions = {
-    /** Startdatei für den internen State. */
+    /** Initial file tracked by the internal state. */
     initialFile?: TFile | null;
-    /** Überschriebene Texte für Notices. */
+    /** Optional overrides for notice copy. */
     notices?: {
         missingSelection?: string;
     };
-    /** Zusätzliche Optionen für die Auswahldialoge. */
+    /** Extra options for the selection dialogs. */
     selectOptions?: PromptMapSelectionOptions;
     createOptions?: PromptCreateMapOptions;
-    /** Callback nach jeder State-Änderung. */
+    /** Callback invoked after every state update. */
     onChange?: (file: TFile | null) => void | Promise<void>;
 };
 
 export type MapManagerHandle = {
-    /** Gibt die aktuell gemerkte Karte zurück. */
+    /** Returns the currently tracked map file. */
     getFile(): TFile | null;
-    /** Setzt den State (z. B. wenn extern ein File zugewiesen wurde). */
+    /** Updates the state (e.g. when a file is assigned externally). */
     setFile(file: TFile | null): Promise<void>;
-    /** Öffnet den Auswahl-Dialog und aktualisiert den State nach Auswahl. */
+    /** Opens the selection dialog and applies the chosen file. */
     open(): Promise<void>;
-    /** Startet den Create-Dialog und setzt den State auf die neue Karte. */
+    /** Launches the creation dialog and tracks the new map. */
     create(): void;
-    /** Öffnet den Delete-Dialog; bei Erfolg wird der State geleert. */
+    /** Opens the delete dialog; on success the state is cleared. */
     deleteCurrent(): void;
 };
 
 export function createMapManager(app: App, options: MapManagerOptions = {}): MapManagerHandle {
     const notices = {
-        missingSelection: options.notices?.missingSelection ?? "Keine Karte ausgewählt.",
+        missingSelection: options.notices?.missingSelection ?? "No map selected.",
     } as const;
 
     let current: TFile | null = options.initialFile ?? null;
@@ -88,7 +88,7 @@ export function createMapManager(app: App, options: MapManagerOptions = {}): Map
                 }
             } catch (error) {
                 console.error("Map deletion failed", error);
-                new Notice("Karte konnte nicht gelöscht werden. Siehe Konsole für Details.");
+                new Notice("Could not delete the map. Check the console for details.");
             }
         }).open();
     };


### PR DESCRIPTION
## Summary
- translate Library view controls, prompts, and notices to English and align the shared map manager messages
- refresh related documentation to reflect the new "Create" label and codify English UI copy in the style guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c50b8a788325b018e01d2cc417a2