### PR TITLE
Update wiki documentation links to new root files

### DIFF
--- a/wiki/Encounter.md
+++ b/wiki/Encounter.md
@@ -21,7 +21,7 @@ The Encounter workspace currently provides a dedicated pane for handling travel-
 | Manual pane creation (`Open view by type → salt-marcher-encounter`) | Opens the workspace without a travel trigger. | Useful for testing layouts or preparing upcoming encounter features. |
 
 - Keep the encounter workspace docked next to Cartographer to reduce window juggling when multiple encounters occur.
-- Document any desired encounter tooling in [`docs/architecture-critique.md`](../docs/architecture-critique.md) so the placeholder can evolve alongside feature work.
+- Document any desired encounter tooling in [`architecture-critique.md`](../architecture-critique.md) so the placeholder can evolve alongside feature work.
 - Use Obsidian's pane pinning to prevent the encounter view from being replaced by unrelated notes during sessions.
 
 ## Related Links

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -37,7 +37,7 @@ This guide walks Obsidian users through installing Salt Marcher, enabling its wo
 
 - Keep the release bundle and source tree aligned; mismatched versions may cause watcher errors or missing commands.
 - For development, re-run `npm run build` after TypeScript changes to refresh `main.js` before testing in Obsidian.
-- Record deviations between documentation and behaviour in [`docs/architecture-critique.md`](../docs/architecture-critique.md) so follow-up tasks can address them.
+- Record deviations between documentation and behaviour in [`architecture-critique.md`](../architecture-critique.md) so follow-up tasks can address them.
 
 ## Related Links
 - [Cartographer](./Cartographer.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -6,7 +6,7 @@ Salt Marcher documentation is organised around the daily workflows that game mas
 ## Prerequisites
 - Obsidian Desktop 1.5 or later with community plugins enabled.
 - Access to the Salt Marcher plugin build and the accompanying vault assets.
-- Familiarity with the repository's shared documentation style guide as summarised in the root README.
+- Familiarity with the repository's shared documentation [style guide](../style-guide.md) as summarised in the root README.
 
 ## Step-by-step Workflow
 1. Start with [Getting Started](./Getting-Started.md) to install, enable, and verify the plugin inside an Obsidian vault.
@@ -22,9 +22,9 @@ Salt Marcher documentation is organised around the daily workflows that game mas
 | [Encounter](./Encounter.md) | Travel-triggered encounter hand-offs. | Facilitating active encounters mid-session. |
 | [Data Management](./Data-Management.md) | Storage formats, watchers, and sync events. | Auditing or extending data pipelines. |
 
-- Root documentation hub: see the project [README](../README.md) and the curated [documentation hub](../docs/README.md) for repository-wide context and licensing.
+- Root documentation hub: see the project [README](../README.md) and the curated [documentation hub](../DOCUMENTATION.md) for repository-wide context and licensing.
 - Plugin documentation hub: consult the [Salt Marcher plugin README](../salt-marcher/README.md) and the specialised documents under [`salt-marcher/docs/`](../salt-marcher/docs/README.md) for architectural deep dives.
-- Contribution notes: follow the shared documentation style guidance captured in the repository root materials when proposing edits or screenshots.
+- Contribution notes: follow the shared documentation guidance captured in the [style guide](../style-guide.md) when proposing edits or screenshots.
 
 ## Related Links
 - [Project repository](../README.md)


### PR DESCRIPTION
## Summary
- update wiki prerequisites and contribution notes to point at the relocated style guide
- retarget root documentation links to DOCUMENTATION.md
- refresh Getting Started and Encounter references to architecture-critique.md

## Testing
- rg -F '../docs' wiki

------
https://chatgpt.com/codex/tasks/task_e_68d6c792b754832587ad11955f1862ba