### PR TITLE
Reorganize documentation hub and update references

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,12 +6,12 @@ This hub orients contributors, technical writers, and support staff to every maj
 ## Directory Map
 | Path | Description | Primary Docs |
 | --- | --- | --- |
-| `../README.md` | Repository-level overview for maintainers and cross-team coordination. | [`../README.md`](../README.md) |
+| `README.md` | Repository-level overview for maintainers and cross-team coordination. | [`README.md`](README.md) |
 | `repository-overview.md` | Cross-repository responsibilities and coordination touchpoints. | [`repository-overview.md`](repository-overview.md) |
-| `../salt-marcher/overview.md` | High-level summary of repository responsibilities and collaboration touchpoints. | [`../salt-marcher/overview.md`](../salt-marcher/overview.md) |
-| `../salt-marcher/` | Plugin source, build system, and subsystem documentation. | [`../salt-marcher/overview.md`](../salt-marcher/overview.md) |
-| `../salt-marcher/docs/` | Deep dives for Cartographer, Encounter, Library, Core, and UI modules. | [`../salt-marcher/docs/README.md`](../salt-marcher/docs/README.md) |
-| `../wiki/` | Offline mirror of the GitHub wiki for user-facing articles. | [`../wiki/README.md`](../wiki/README.md) |
+| `salt-marcher/overview.md` | High-level summary of repository responsibilities and collaboration touchpoints. | [`salt-marcher/overview.md`](salt-marcher/overview.md) |
+| `salt-marcher/` | Plugin source, build system, and subsystem documentation. | [`salt-marcher/overview.md`](salt-marcher/overview.md) |
+| `salt-marcher/docs/` | Deep dives for Cartographer, Encounter, Library, Core, and UI modules. | [`salt-marcher/docs/README.md`](salt-marcher/docs/README.md) |
+| `wiki/` | Offline mirror of the GitHub wiki for user-facing articles. | [`wiki/README.md`](wiki/README.md) |
 | `style-guide.md` | Mandatory template and formatting rules for all Salt Marcher documentation. | [`style-guide.md`](style-guide.md) |
 | `architecture-critique.md` | Repository-wide architecture health log and follow-up tracker. | [`architecture-critique.md`](architecture-critique.md) |
 
@@ -21,18 +21,18 @@ This hub orients contributors, technical writers, and support staff to every maj
 - **Review and update docs:** When code or workflows change, update both the technical references (e.g., subsystem docs) and user-facing wiki entries linked here to keep guidance aligned.
 
 ## Linked Docs
-- [Root README](../README.md) – maintainer-facing repository summary and workflows.
-- [Salt Marcher plugin overview](../salt-marcher/overview.md) – architecture and build information for the plugin package.
+- [Root README](README.md) – maintainer-facing repository summary and workflows.
+- [Salt Marcher plugin overview](salt-marcher/overview.md) – architecture and build information for the plugin package.
 - [Architecture critique](architecture-critique.md) – repository-wide assessment of technical risks and follow-ups.
 - [Documentation style guide](style-guide.md) – template and formatting requirements.
-- [GitHub project wiki](../wiki/README.md) – canonical end-user guides and troubleshooting articles.
+- [GitHub project wiki](wiki/README.md) – canonical end-user guides and troubleshooting articles.
 
 ## To-Do
-- [Cartographer presenter respects abort signals](../todo/cartographer-presenter-abort-handling.md) – Presenter muss Abort-Signale honorieren.
-- [Cartographer mode registry](../todo/cartographer-mode-registry.md) – Modi deklarativ konfigurierbar machen.
-- [UI terminology consistency](../todo/ui-terminology-consistency.md) – UI-Sprache vereinheitlichen.
+- [Cartographer presenter respects abort signals](todo/cartographer-presenter-abort-handling.md) – Presenter muss Abort-Signale honorieren.
+- [Cartographer mode registry](todo/cartographer-mode-registry.md) – Modi deklarativ konfigurierbar machen.
+- [UI terminology consistency](todo/ui-terminology-consistency.md) – UI-Sprache vereinheitlichen.
 
 ## Standards & Conventions
 - Maintain this index whenever documentation locations change so all teams share an accurate map.
 - Ensure every linked document complies with the [documentation style guide](style-guide.md) and uses relative links where possible.
-- Capture unresolved documentation issues or backlog items im [`todo/`](../todo/README.md)-Backlog und verweise auf passende Detaildokumente.
+- Capture unresolved documentation issues or backlog items im [`todo/`](todo/README.md)-Backlog und verweise auf passende Detaildokumente.

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ Salt Marcher is an Obsidian community plugin that helps game masters run hexcraw
 ## Directory Map
 | Path | Description | Primary Docs |
 | --- | --- | --- |
-| `docs/` | Project-wide documentation hub and shared standards for all contributors. | [`docs/README.md`](docs/README.md) |
+| `DOCUMENTATION.md` | Project-wide documentation hub and shared standards for all contributors. | [`DOCUMENTATION.md`](DOCUMENTATION.md) |
 | `salt-marcher/` | Source, build pipeline, and packaged artifacts for the Obsidian plugin. | [`salt-marcher/overview.md`](salt-marcher/overview.md) |
 | `wiki/` | Offline export of the end-user wiki for reference and contributions. | [`wiki/README.md`](wiki/README.md) |
 | `References, do not delete!/` | External SRD references preserved for licensing compliance. | [`References, do not delete!/README.md`]("References, do not delete!"/README.md) |
 
 ## Key Workflows
 - **Install the plugin for testing:** Follow the packaging and enablement steps in the [Salt Marcher README](salt-marcher/README.md) to load the plugin in Obsidian and verify workspace views.
-- **Update documentation consistently:** Use the shared [documentation style guide](docs/style-guide.md) and cross-reference folder-specific docs listed in the directory map before committing changes.
+- **Update documentation consistently:** Use the shared [documentation style guide](style-guide.md) and cross-reference folder-specific docs listed in the directory map before committing changes.
 - **Coordinate releases and support:** Review the project [wiki](wiki/README.md) for user-facing guides, and keep changelogs or troubleshooting entries aligned with the latest plugin features.
 
 ## Linked Docs
-- [Repository documentation hub](docs/README.md) – entry point into contributor, architecture, and user-facing docs.
-- [Repository overview](docs/repository-overview.md) – cross-team responsibilities and release coordination map.
+- [Repository documentation hub](DOCUMENTATION.md) – entry point into contributor, architecture, and user-facing docs.
+- [Repository overview](repository-overview.md) – cross-team responsibilities and release coordination map.
 - [Salt Marcher plugin overview](salt-marcher/overview.md) – architectural breakdown of the plugin package.
 - [Developer documentation set](salt-marcher/docs/README.md) – deep dives for individual subsystems.
 - [Project wiki](wiki/README.md) – canonical end-user guides hosted on GitHub.
@@ -29,6 +29,6 @@ Salt Marcher is an Obsidian community plugin that helps game masters run hexcraw
 - [UI terminology consistency](todo/ui-terminology-consistency.md) – Einheitliche Sprache für UI-Texte und Kommentare herstellen.
 
 ## Standards & Conventions
-- All new or updated docs must follow the mandatory template defined in the [documentation style guide](docs/style-guide.md).
+- All new or updated docs must follow the mandatory template defined in the [documentation style guide](style-guide.md).
 - Synchronize repository docs with the user-focused wiki to keep workflows and terminology consistent for referees and contributors alike.
 - Record outstanding architectural or quality concerns in the [`todo/`](todo/README.md) backlog and cross-link the relevant documentation sections.

--- a/architecture-critique.md
+++ b/architecture-critique.md
@@ -6,10 +6,10 @@ Diese Strukturanalyse richtet sich an Maintainer:innen und Architekt:innen, die 
 ## Directory Map
 | Path | Description | Primary Docs |
 | --- | --- | --- |
-| `../salt-marcher/overview.md` | Gesamtüberblick über Aufbau, Build-Pipeline und Integrationen des Plugins. | [`../salt-marcher/overview.md`](../salt-marcher/overview.md) |
-| `../salt-marcher/docs/README.md` | Einstiegspunkt für alle Bereichsdokumente (Cartographer, Core, Library, UI). | [`../salt-marcher/docs/README.md`](../salt-marcher/docs/README.md) |
-| `../salt-marcher/docs/cartographer/README.md` | Detaildokumentation zu Presenter, View-Shell und Travel-Modus. | [`../salt-marcher/docs/cartographer/README.md`](../salt-marcher/docs/cartographer/README.md) |
-| `../salt-marcher/docs/core/README.md` | Übersicht über Persistenz-, Hex- und Terrain-Services. | [`../salt-marcher/docs/core/README.md`](../salt-marcher/docs/core/README.md) |
+| `salt-marcher/overview.md` | Gesamtüberblick über Aufbau, Build-Pipeline und Integrationen des Plugins. | [`salt-marcher/overview.md`](salt-marcher/overview.md) |
+| `salt-marcher/docs/README.md` | Einstiegspunkt für alle Bereichsdokumente (Cartographer, Core, Library, UI). | [`salt-marcher/docs/README.md`](salt-marcher/docs/README.md) |
+| `salt-marcher/docs/cartographer/README.md` | Detaildokumentation zu Presenter, View-Shell und Travel-Modus. | [`salt-marcher/docs/cartographer/README.md`](salt-marcher/docs/cartographer/README.md) |
+| `salt-marcher/docs/core/README.md` | Übersicht über Persistenz-, Hex- und Terrain-Services. | [`salt-marcher/docs/core/README.md`](salt-marcher/docs/core/README.md) |
 
 ## Key Workflows
 1. **Bewertung aktualisieren:** Prüfe nach jedem Merge die betroffenen Abschnitte und markiere erledigte Punkte mit einem ✅-Hinweis sowie Quellenangaben.
@@ -17,9 +17,9 @@ Diese Strukturanalyse richtet sich an Maintainer:innen und Architekt:innen, die 
 3. **Quellen verlinken:** Ergänze bei neuen Feststellungen direkte Referenzen zu Code-Dateien oder Detail-Docs, damit Leser:innen Änderungen schnell nachvollziehen können.
 
 ## Linked Docs
-- [Repository documentation hub](README.md) – Navigationsübersicht über alle Projektdokumente.
+- [Repository documentation hub](DOCUMENTATION.md) – Navigationsübersicht über alle Projektdokumente.
 - [Repository overview](repository-overview.md) – Koordination und Verantwortlichkeiten auf Repo-Ebene.
-- [Salt Marcher plugin overview](../salt-marcher/overview.md) – Architektur, Integrationen und Build-Schritte des Plugins.
+- [Salt Marcher plugin overview](salt-marcher/overview.md) – Architektur, Integrationen und Build-Schritte des Plugins.
 
 ## Standards & Conventions
 - Halte Sprache und Status-Markierungen konsistent (✅ für erledigt, ungekennzeichnet für offen, nummerierte Maßnahmenliste am Ende).
@@ -35,7 +35,7 @@ Diese Strukturanalyse richtet sich an Maintainer:innen und Architekt:innen, die 
 
 #### 1.2 Cartographer-Shell
 - ✅ Behoben (2024-05-07): State-Logik liegt nun im `CartographerPresenter`, während `view-shell.ts` ausschließlich DOM-Komposition + Callback-Wiring übernimmt. Presenter-Tests decken Mode-Wechsel & File-Reaktionen ab.【F:salt-marcher/src/apps/cartographer/presenter.ts†L1-L254】【F:salt-marcher/src/apps/cartographer/view-shell.ts†L1-L146】【F:salt-marcher/tests/cartographer/presenter.test.ts†L1-L139】
-- Die Modi werden im Presenter über `provideModes` fest verdrahtet (`createTravelGuideMode`, `createEditorMode`, `createInspectorMode`). Erweiterungen oder Konfigurationen erfordern weiterhin Codeänderungen statt deklarativer Registrierung.【F:salt-marcher/src/apps/cartographer/presenter.ts†L60-L70】【F:salt-marcher/src/apps/cartographer/presenter.ts†L89-L94】 → [TODO: Cartographer mode registry](../todo/cartographer-mode-registry.md)
+- Die Modi werden im Presenter über `provideModes` fest verdrahtet (`createTravelGuideMode`, `createEditorMode`, `createInspectorMode`). Erweiterungen oder Konfigurationen erfordern weiterhin Codeänderungen statt deklarativer Registrierung.【F:salt-marcher/src/apps/cartographer/presenter.ts†L60-L70】【F:salt-marcher/src/apps/cartographer/presenter.ts†L89-L94】 → [TODO: Cartographer mode registry](todo/cartographer-mode-registry.md)
 - ✅ Behoben (2025-09-26): `CartographerPresenter` orchestriert Modewechsel über eine explizite State-Machine (`idle → exiting → entering`) inklusive eigenem `AbortController`. Supersedierende Wechsel aborten laufende Phasen, Fehler werden zentral geloggt und Cleanup läuft deterministisch.【F:salt-marcher/src/apps/cartographer/presenter.ts†L86-L125】【F:salt-marcher/src/apps/cartographer/presenter.ts†L233-L328】【F:salt-marcher/tests/cartographer/presenter.test.ts†L64-L146】
 
 #### 1.3 Map-Layer-Adapter
@@ -63,15 +63,15 @@ Diese Strukturanalyse richtet sich an Maintainer:innen und Architekt:innen, die 
 - ✅ Behoben (2024-05-31): Das Encounter-Gateway lädt Module vorab und zeigt Notices bei Fehlern, statt Encounter-Events stumm zu verlieren.【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L1-L36】
 
 ### 3. Robustheit & Fehlertoleranz
-- `CartographerPresenter` ignoriert das vom Shell-Controller übergebene `ModeSelectContext`/`AbortSignal`. Selbst wenn der Mode-Wechsel vom UI abgebrochen wird, laufen `setMode` und asynchrone Aufräum-/Enter-Schritte weiter und riskieren Race-Conditions.【F:salt-marcher/src/apps/cartographer/presenter.ts†L112-L205】【F:salt-marcher/src/apps/cartographer/view-shell.ts†L77-L119】【F:salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts†L1-L37】 → [TODO: Cartographer presenter respects abort signals](../todo/cartographer-presenter-abort-handling.md)
+- `CartographerPresenter` ignoriert das vom Shell-Controller übergebene `ModeSelectContext`/`AbortSignal`. Selbst wenn der Mode-Wechsel vom UI abgebrochen wird, laufen `setMode` und asynchrone Aufräum-/Enter-Schritte weiter und riskieren Race-Conditions.【F:salt-marcher/src/apps/cartographer/presenter.ts†L112-L205】【F:salt-marcher/src/apps/cartographer/view-shell.ts†L77-L119】【F:salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts†L1-L37】 → [TODO: Cartographer presenter respects abort signals](todo/cartographer-presenter-abort-handling.md)
 - ✅ Behoben (2024-05-31): Standard-Klicks lassen sich nun über das Interaction-Delegate blockieren; `saveTile` wird nur bei explizitem `"default"`-Outcome ausgeführt.【F:salt-marcher/src/core/hex-mapper/hex-render.ts†L138-L183】【F:salt-marcher/src/core/hex-mapper/render/interactions.ts†L45-L114】
 - ✅ Behoben (2024-05-31): `MapManager.deleteCurrent` fängt `deleteMapAndTiles`-Fehler ab und informiert den Nutzer via Notice.【F:salt-marcher/src/ui/map-manager.ts†L77-L93】
 
 ### 4. Sauberkeit & Codequalität
-- Namensgebung und Kommentare wechseln zwischen Englisch und Deutsch (z. B. englische Fehlermeldungen neben deutschsprachigen Notices), was Konsistenz und Lesbarkeit beeinträchtigt.【F:salt-marcher/src/ui/map-manager.ts†L1-L93】【F:salt-marcher/src/apps/library/view.ts†L46-L140】 → [TODO: UI terminology consistency](../todo/ui-terminology-consistency.md)
+- Namensgebung und Kommentare wechseln zwischen Englisch und Deutsch (z. B. englische Fehlermeldungen neben deutschsprachigen Notices), was Konsistenz und Lesbarkeit beeinträchtigt.【F:salt-marcher/src/ui/map-manager.ts†L1-L93】【F:salt-marcher/src/apps/library/view.ts†L46-L140】 → [TODO: UI terminology consistency](todo/ui-terminology-consistency.md)
 - ✅ Behoben (2024-07-01): `renderHexMap` fungiert nur noch als Orchestrator; Tile-Bootstrap, Koordinaten-Mapping und Interaktionsadapter leben in eigenen Modulen. Kamera- und Interaktionscontroller nutzen typsichere Interfaces (`HexCameraController`, `HexInteractionController`).【F:salt-marcher/src/core/hex-mapper/hex-render.ts†L1-L86】【F:salt-marcher/src/core/hex-mapper/render/bootstrap.ts†L1-L74】【F:salt-marcher/src/core/hex-mapper/render/coordinates.ts†L1-L47】【F:salt-marcher/src/core/hex-mapper/render/interaction-adapter.ts†L1-L39】【F:salt-marcher/src/core/hex-mapper/render/types.ts†L1-L43】
 
 ### 5. Empfohlene Maßnahmen
-1. **Presenter abort-aware machen:** `CartographerPresenter.setMode` sollte das `ModeSelectContext`-Signal respektieren, um abgebrochene Modewechsel deterministisch zu stoppen.【F:salt-marcher/src/apps/cartographer/presenter.ts†L112-L205】【F:salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts†L1-L37】 → [TODO](../todo/cartographer-presenter-abort-handling.md)
-2. **Mode-System modularisieren:** Eine deklarative Registry/API für `provideModes` einführen, damit zusätzliche Modi ohne Core-Änderung ladbar sind.【F:salt-marcher/src/apps/cartographer/presenter.ts†L60-L94】 → [TODO](../todo/cartographer-mode-registry.md)
-3. **Terminologie vereinheitlichen:** UI-Texte und Kommentare sollten konsequent in einer Sprache gehalten werden, um Mischformen wie in `MapManager` und `LibraryView` zu vermeiden.【F:salt-marcher/src/ui/map-manager.ts†L1-L93】【F:salt-marcher/src/apps/library/view.ts†L46-L140】 → [TODO](../todo/ui-terminology-consistency.md)
+1. **Presenter abort-aware machen:** `CartographerPresenter.setMode` sollte das `ModeSelectContext`-Signal respektieren, um abgebrochene Modewechsel deterministisch zu stoppen.【F:salt-marcher/src/apps/cartographer/presenter.ts†L112-L205】【F:salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts†L1-L37】 → [TODO](todo/cartographer-presenter-abort-handling.md)
+2. **Mode-System modularisieren:** Eine deklarative Registry/API für `provideModes` einführen, damit zusätzliche Modi ohne Core-Änderung ladbar sind.【F:salt-marcher/src/apps/cartographer/presenter.ts†L60-L94】 → [TODO](todo/cartographer-mode-registry.md)
+3. **Terminologie vereinheitlichen:** UI-Texte und Kommentare sollten konsequent in einer Sprache gehalten werden, um Mischformen wie in `MapManager` und `LibraryView` zu vermeiden.【F:salt-marcher/src/ui/map-manager.ts†L1-L93】【F:salt-marcher/src/apps/library/view.ts†L46-L140】 → [TODO](todo/ui-terminology-consistency.md)

--- a/repository-overview.md
+++ b/repository-overview.md
@@ -6,25 +6,25 @@ This overview introduces contributors to the structure and responsibilities of t
 ## Directory Map
 | Path | Description | Primary Docs |
 | --- | --- | --- |
-| `docs/` | Repository-wide hub describing documentation hierarchy, contributor workflows, and standards. | [`docs/README.md`](docs/README.md) |
+| `DOCUMENTATION.md` | Repository-wide hub describing documentation hierarchy, contributor workflows, and standards. | [`DOCUMENTATION.md`](DOCUMENTATION.md) |
 | `salt-marcher/` | Complete Obsidian plugin package including source, build scripts, tests, and subsystem overviews. | [`salt-marcher/overview.md`](salt-marcher/overview.md) |
 | `wiki/` | Local mirror of the GitHub wiki for offline edits and reviews. | [`wiki/README.md`](wiki/README.md) |
 | `architecture-critique.md` | Architektur-Review mit offenen Maßnahmen und Referenzen. | [`architecture-critique.md`](architecture-critique.md) |
 | `References, do not delete!/` | Required SRD reference material maintained verbatim for licensing compliance. | [`References, do not delete!/README.md`]("References, do not delete!"/README.md) |
 
 ## Key Workflows
-- **Plan cross-cutting changes:** Start with the [repository documentation hub](docs/README.md) to understand where detailed subsystem docs live before editing code.
+- **Plan cross-cutting changes:** Start with the [repository documentation hub](DOCUMENTATION.md) to understand where detailed subsystem docs live before editing code.
 - **Coordinate plugin development:** Drill into [`salt-marcher/overview.md`](salt-marcher/overview.md) for architectural responsibilities, and reference the nested docs for cartographer, library, encounter, and UI modules.
 - **Maintain compliance assets:** Verify updates against the SRD references and ensure acknowledgements stay current in top-level docs.
 
 ## Linked Docs
-- [Documentation hub](docs/README.md) – maps all README, overview, and wiki entry points.
+- [Documentation hub](DOCUMENTATION.md) – maps all README, overview, and wiki entry points.
 - [Salt Marcher plugin documentation](salt-marcher/docs/README.md) – subsystem-specific guides for developers.
-- [Project wiki](../wiki/README.md) – authoritative end-user walkthroughs.
+- [Project wiki](wiki/README.md) – authoritative end-user walkthroughs.
 - [Architecture critique](architecture-critique.md) – open risks and resolved measures across the plugin.
-- [Documentation style guide](docs/style-guide.md) – mandatory template and formatting rules.
+- [Documentation style guide](style-guide.md) – mandatory template and formatting rules.
 
 ## Standards & Conventions
-- Every new overview or README must adopt the sections defined in the shared [documentation style guide](docs/style-guide.md).
+- Every new overview or README must adopt the sections defined in the shared [documentation style guide](style-guide.md).
 - Update this overview whenever repository-level folders, workflows, or coordination touchpoints change.
 - Capture architectural risks or follow-up work items in [`architecture-critique.md`](architecture-critique.md) to maintain shared visibility.

--- a/salt-marcher/README.md
+++ b/salt-marcher/README.md
@@ -46,6 +46,7 @@ Weitere Nutzer-Workflows, Schritt-für-Schritt-Anleitungen und FAQ-Einträge sin
 - [UI terminology consistency](../todo/ui-terminology-consistency.md) – UI-Terminologie vereinheitlichen.
 
 ## Dokumentations- und Beitragshinweise
-Die technische Dokumentation dieses Plugins folgt dem [Documentation Index](docs/README.md). Bitte richte neue Beiträge am
-[Style Guide](../docs/style-guide.md) des Projekts aus und verlinke zusätzliche Detaildokumente innerhalb des bestehenden
+Die technische Dokumentation dieses Plugins orientiert sich am übergeordneten [Documentation Hub](../DOCUMENTATION.md) und dem
+bereichsspezifischen [Docs-Index](docs/README.md). Bitte richte neue Beiträge am
+[Style Guide](../style-guide.md) des Projekts aus und verlinke zusätzliche Detaildokumente innerhalb des bestehenden
 Dokumentationsnetzes.

--- a/salt-marcher/docs/README.md
+++ b/salt-marcher/docs/README.md
@@ -23,5 +23,5 @@ auf weiterführende Ressourcen.
 - [UI](ui/README.md) – Wiederverwendbare UI-Bausteine, Shell-Komponenten und Map-spezifische Workflows.
 
 ## Standards & Pflege
-Alle neuen oder aktualisierten Dokumente müssen dem [Documentation Style Guide](../../docs/style-guide.md) entsprechen. Ergänze
+Alle neuen oder aktualisierten Dokumente müssen dem [Documentation Style Guide](../../style-guide.md) entsprechen. Ergänze
 Querverlinkungen zwischen den Bereichen, sobald sich Verantwortlichkeiten überschneiden, und halte die Strukturdiagramme aktuell.

--- a/salt-marcher/docs/cartographer/README.md
+++ b/salt-marcher/docs/cartographer/README.md
@@ -21,7 +21,7 @@ docs/cartographer/
 
 ## Weiterführende Ressourcen
 - Nutzerperspektive im [Cartographer-Wiki-Eintrag](../../../wiki/Cartographer.md).
-- Dokumentationsstandards gemäß [Style Guide](../../../docs/style-guide.md).
+- Dokumentationsstandards gemäß [Style Guide](../../../style-guide.md).
 
 ## State-Machine
 Der `CartographerPresenter` verfolgt jeden Modewechsel als eigene State-Machine-Instanz mit Phasen `idle`, `exiting` und `entering`. Jeder Wechsel erhält einen dedizierten `AbortController`, der sowohl UI-Abbrüche (`ModeSelectContext.signal`) als auch supersedierende Wechsel zusammenführt. Dadurch räumt `onExit` deterministisch auf, `onEnter`/`onFileChange` laufen nur, solange das Signal nicht abgebrochen wurde, und parallele Wechsel zerstören keine bereits erstellten Layer mehr.【F:salt-marcher/src/apps/cartographer/presenter.ts†L86-L125】【F:salt-marcher/src/apps/cartographer/presenter.ts†L233-L328】

--- a/salt-marcher/docs/core/README.md
+++ b/salt-marcher/docs/core/README.md
@@ -18,7 +18,7 @@ docs/core/
 
 ## Weiterführende Ressourcen
 - Nutzung im Kontext der Workspaces siehe [Cartographer](../cartographer/README.md) und [Library](../library/README.md).
-- Richtlinien zur Dokumentation: [Style Guide](../../../docs/style-guide.md).
+- Richtlinien zur Dokumentation: [Style Guide](../../../style-guide.md).
 
 ## To-Do
 - Keine offenen Core-spezifischen Punkte. Siehe das zentrale [`todo/`](../../../todo/README.md) für bereichsübergreifende Backlog-Einträge.

--- a/salt-marcher/docs/library/README.md
+++ b/salt-marcher/docs/library/README.md
@@ -16,7 +16,7 @@ docs/library/
 
 ## Weiterführende Ressourcen
 - Anwenderdokumentation im [Library-Wiki-Eintrag](../../../wiki/Library.md).
-- Dokumentationsrichtlinien: [Style Guide](../../../docs/style-guide.md).
+- Dokumentationsrichtlinien: [Style Guide](../../../style-guide.md).
 
 ## To-Do
 - [UI terminology consistency](../../../todo/ui-terminology-consistency.md) – UI-Labels und Kommentare vereinheitlichen.

--- a/salt-marcher/docs/ui/README.md
+++ b/salt-marcher/docs/ui/README.md
@@ -18,7 +18,7 @@ docs/ui/
 ## Weiterführende Ressourcen
 - Verwendungsbeispiele findest du in den README-Dateien der Bereiche [Cartographer](../cartographer/README.md) und
   [Library](../library/README.md).
-- Dokumentationsrichtlinien: [Style Guide](../../../docs/style-guide.md).
+- Dokumentationsrichtlinien: [Style Guide](../../../style-guide.md).
 
 ## To-Do
 - [UI terminology consistency](../../../todo/ui-terminology-consistency.md) – UI-Texte und Kommentare sprachlich vereinheitlichen.

--- a/salt-marcher/overview.md
+++ b/salt-marcher/overview.md
@@ -44,8 +44,9 @@ salt-marcher/
    (`src/ui/*`) konsistente Dialoge und Header bereitstellen.
 
 ## Dokumentation & Standards
-Die Bereichsdokumente unter [`docs/`](docs/README.md) werden nach jedem Feature-Update gepflegt. Für neue Beiträge
-bitte den projektspezifischen [Style Guide](../docs/style-guide.md) beachten und Querverlinkungen zu bestehenden Overviews setzen.
+Die Bereichsdokumente unter [`docs/`](docs/README.md) werden nach jedem Feature-Update gepflegt. Der repository-weite Einstieg steht im
+[Documentation Hub](../DOCUMENTATION.md). Für neue Beiträge
+bitte den projektspezifischen [Style Guide](../style-guide.md) beachten und Querverlinkungen zu bestehenden Overviews setzen.
 
 ## To-Do
 - [Cartographer presenter respects abort signals](../todo/cartographer-presenter-abort-handling.md) – Presenter muss Abort-Signale in allen Lifecycle-Phasen respektieren.

--- a/style-guide.md
+++ b/style-guide.md
@@ -6,8 +6,8 @@ This guide defines the mandatory structure and formatting standards for READMEs,
 ## Directory Map
 | Path | Description | Primary Docs |
 | --- | --- | --- |
-| `docs/README.md` | Repository documentation hub that links every major knowledge area. | [`docs/README.md`](README.md) |
-| `docs/style-guide.md` | This style guide describing required sections and formatting rules. | _This document_ |
+| `DOCUMENTATION.md` | Repository documentation hub that links every major knowledge area. | [`DOCUMENTATION.md`](DOCUMENTATION.md) |
+| `style-guide.md` | This style guide describing required sections and formatting rules. | _This document_ |
 
 ## Key Workflows
 1. **Plan the document scope:** Identify the audience (contributors, users, or stakeholders) and determine which folders or features the document covers.
@@ -17,9 +17,9 @@ This guide defines the mandatory structure and formatting standards for READMEs,
 5. **Document standards:** Capture naming conventions, coding guidelines, testing expectations, or workflow agreements that apply to the scope of the document.
 
 ## Linked Docs
-- [Repository documentation hub](README.md) – overview of all documentation entry points.
-- [Salt Marcher plugin overview](../salt-marcher/overview.md) – example of the template applied to the plugin package.
-- [Root README](../README.md) – repository-level application of this style guide.
+- [Repository documentation hub](DOCUMENTATION.md) – overview of all documentation entry points.
+- [Salt Marcher plugin overview](salt-marcher/overview.md) – example of the template applied to the plugin package.
+- [Root README](README.md) – repository-level application of this style guide.
 
 ## Standards & Conventions
 Every README, overview, or wiki page must include the following sections in the listed order:

--- a/todo/cartographer-mode-registry.md
+++ b/todo/cartographer-mode-registry.md
@@ -5,7 +5,7 @@
 >
 > **Empfohlene Maßnahme:** Eine deklarative Registry/API für `provideModes` einführen, damit zusätzliche Modi ohne Core-Änderung ladbar sind.
 
-Quelle: [`docs/architecture-critique.md`](../docs/architecture-critique.md).
+Quelle: [`architecture-critique.md`](../architecture-critique.md).
 
 ## Kontext
 - **Betroffene Module:** `salt-marcher/src/apps/cartographer/presenter.ts`, Mode-Fabriken unter `salt-marcher/src/apps/cartographer/modes/`.

--- a/todo/cartographer-presenter-abort-handling.md
+++ b/todo/cartographer-presenter-abort-handling.md
@@ -5,7 +5,7 @@
 >
 > **Empfohlene Maßnahme:** `CartographerPresenter.setMode` sollte das `ModeSelectContext`-Signal respektieren, um abgebrochene Modewechsel deterministisch zu stoppen.
 
-Quelle: [`docs/architecture-critique.md`](../docs/architecture-critique.md).
+Quelle: [`architecture-critique.md`](../architecture-critique.md).
 
 ## Kontext
 - **Betroffene Module:** `salt-marcher/src/apps/cartographer/presenter.ts`, `salt-marcher/src/apps/cartographer/view-shell.ts`, `salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts`.

--- a/todo/ui-terminology-consistency.md
+++ b/todo/ui-terminology-consistency.md
@@ -5,7 +5,7 @@
 >
 > **Empfohlene Maßnahme:** UI-Texte und Kommentare sollten konsequent in einer Sprache gehalten werden, um Mischformen wie in `MapManager` und `LibraryView` zu vermeiden.
 
-Quelle: [`docs/architecture-critique.md`](../docs/architecture-critique.md).
+Quelle: [`architecture-critique.md`](../architecture-critique.md).
 
 ## Kontext
 - **Betroffene Module:** `salt-marcher/src/ui/map-manager.ts`, `salt-marcher/src/apps/library/view.ts` sowie verbundene UI-Komponenten.


### PR DESCRIPTION
## Summary
- move the documentation hub and related overview, style, and critique files to the repository root
- refresh README files and plugin docs to reference the new DOCUMENTATION.md and root style guide
- update todo sources to the relocated architecture critique and remove the obsolete docs directory

## Testing
- rg "docs/" -n

------
https://chatgpt.com/codex/tasks/task_e_68d6c78db11c832595eb027679243c3c