### PR TITLE
Add Cartographer mode registry with lazy providers

### DIFF
--- a/salt-marcher/docs/cartographer/mode-registry.md
+++ b/salt-marcher/docs/cartographer/mode-registry.md
@@ -1,0 +1,58 @@
+# Cartographer Mode Registry
+
+## Struktur & Zweck
+
+```
+src/apps/cartographer/mode-registry/
+├─ index.ts                # Öffentliche Registry-API + Kern-Provider-Bootstrap
+├─ registry.ts             # Interne Registrierungslogik, Sortierung, Lazy-Wrapping
+└─ providers/
+   ├─ editor.ts            # Provider-Deklaration für den Editor-Modus
+   ├─ inspector.ts         # Provider-Deklaration für den Inspector-Modus
+   └─ travel-guide.ts      # Provider-Deklaration für den Travel-Guide-Modus
+```
+
+Ergänzende Tests liegen in [`tests/cartographer/mode-registry.test.ts`](../../tests/cartographer/mode-registry.test.ts) und sichern das Registrierungsverhalten ab. Die Registry verwaltet deklarative Provider, kapselt Lazy Loading und stellt dem Presenter eine sortierte, fehlertolerante Modusliste zur Verfügung.
+
+## Registrierungsprotokoll
+
+1. **Provider deklarieren:** Exportiere ein Objekt vom Typ `CartographerModeProvider` mit Metadaten und einer `load()`-Funktion.
+2. **Registrieren:** Rufe `registerModeProvider(provider)` oder `registerCartographerModeProvider(provider)` (direkt aus `registry.ts`) auf. Die Funktion liefert ein Dispose-Handle (`() => void`).
+3. **Konflikte:** Doppelregistrierungen mit identischer `metadata.id` werden mit einer aussagekräftigen Fehlermeldung abgelehnt.
+4. **Deregistrieren:** Nutze das Dispose-Handle oder `unregisterModeProvider(id)`, um einen Provider zu entfernen.
+5. **Snapshots erstellen:**
+   - `provideCartographerModes()` liefert eine Liste lazy-gekapselter `CartographerMode`-Instanzen (inkl. Kernmodi).
+   - `createCartographerModesSnapshot()` arbeitet auf dem aktuellen Registry-Zustand, ohne Kern-Provider automatisch nachzuladen (für Tests & Tools).
+6. **Reset:** `resetCartographerModeRegistry({ registerCoreProviders })` leert die Registry und registriert Kernmodi optional neu (`true` ist Standard).
+
+## Metadaten-Schema
+
+| Feld        | Typ                  | Pflicht | Beschreibung |
+|-------------|----------------------|---------|--------------|
+| `id`        | `string`              | ✅       | Eindeutiger, stabiler Identifier (UI & Persistenz). |
+| `label`     | `string`              | ✅       | Nutzerfreundlicher Anzeigename. |
+| `summary`   | `string`              | ✅       | Kurzbeschreibung (Tooltips, Docs). |
+| `keywords`  | `readonly string[]`   | ❌       | Suchbegriffe für Filter & Suche. |
+| `order`     | `number`              | ❌       | Sortier-Priorität (kleiner = weiter oben). |
+| `source`    | `string`              | ✅       | Herkunft (z. B. `core/cartographer/editor` oder Plugin-ID). |
+| `version`   | `string`              | ❌       | Version des Providers (SemVer empfohlen). |
+
+Metadaten werden beim Registrieren defensiv geklont und eingefroren, damit Konsumenten stabile Referenzen erhalten.
+
+## Lazy Loading & Fehlerbehandlung
+
+- Provider laden ihren Modus erst, wenn eine Lifecycle-Funktion (`onEnter`, `onFileChange`, …) aufgerufen wird.
+- Fehlschläge beim Laden werden geloggt (`console.error`) und an den Aufrufer propagiert.
+- Optional implementierte Hooks (`onHexClick`, `onSave`) werden nur aufgerufen, wenn der geladene Modus sie anbietet.
+- Ein Abgleich stellt sicher, dass die Mode-ID mit der Provider-ID übereinstimmt; Abweichungen werden als Warnung geloggt.
+
+## Migration für Drittanbieter-Modi
+
+1. **Metadaten definieren:** Wähle eine stabile `id`, sprechenden `label`, aussagekräftige `summary`, ordne `source` (z. B. deine Plugin-ID) zu.
+2. **Provider erstellen:** Kapsle deine bisherige Fabrik in eine `load()`-Funktion. Empfohlen: dynamischer Import (`await import(...)`) für echtes Lazy Loading.
+3. **Registrieren:** Im Plugin-Setup `registerModeProvider(provider)` aufrufen und das Dispose-Handle speichern.
+4. **Aufräumen:** Im Plugin-Teardown Dispose-Handle aus Schritt 3 aufrufen oder `unregisterModeProvider(id)` verwenden.
+5. **Tests & Qualität:** Validiere dein Registrierungsverhalten mit einer Variante der vorhandenen Vitest-Cases. Nutze `resetCartographerModeRegistry({ registerCoreProviders: false })`, um reproduzierbare Testzustände zu erhalten.
+
+> **Konvention:** Für `source` wird das Schema `namespace/module` empfohlen (`core/cartographer/<name>` für Kernfunktionen, `plugin/<id>/<feature>` für Erweiterungen).
+

--- a/salt-marcher/src/apps/cartographer/index.ts
+++ b/salt-marcher/src/apps/cartographer/index.ts
@@ -2,9 +2,21 @@
 import { ItemView, WorkspaceLeaf, TFile } from "obsidian";
 import type { App } from "obsidian";
 import { CartographerPresenter } from "./presenter";
+import { provideCartographerModes } from "./mode-registry";
 
 export const VIEW_TYPE_CARTOGRAPHER = "cartographer-view";
 export const VIEW_CARTOGRAPHER = VIEW_TYPE_CARTOGRAPHER;
+
+const createProvideModes = () => {
+    return () => {
+        try {
+            return provideCartographerModes();
+        } catch (error) {
+            console.error("[cartographer] Failed to resolve mode registry", error);
+            return [];
+        }
+    };
+};
 
 export class CartographerView extends ItemView {
     presenter: CartographerPresenter;
@@ -13,7 +25,9 @@ export class CartographerView extends ItemView {
 
     constructor(leaf: WorkspaceLeaf) {
         super(leaf);
-        this.presenter = new CartographerPresenter(this.app as App);
+        this.presenter = new CartographerPresenter(this.app as App, {
+            provideModes: createProvideModes(),
+        });
     }
 
     getViewType(): string {

--- a/salt-marcher/src/apps/cartographer/mode-registry/index.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/index.ts
@@ -1,0 +1,53 @@
+import {
+    clearCartographerModeRegistry,
+    createCartographerModesSnapshot,
+    getCartographerModeMetadataSnapshot,
+    registerCartographerModeProvider,
+    unregisterCartographerModeProvider,
+    type CartographerModeMetadata,
+    type CartographerModeProvider,
+} from "./registry";
+import { createEditorModeProvider } from "./providers/editor";
+import { createInspectorModeProvider } from "./providers/inspector";
+import { createTravelGuideModeProvider } from "./providers/travel-guide";
+import type { CartographerMode } from "../presenter";
+
+let coreProvidersRegistered = false;
+
+const ensureCoreProviders = (): void => {
+    if (coreProvidersRegistered) return;
+    registerCartographerModeProvider(createTravelGuideModeProvider());
+    registerCartographerModeProvider(createEditorModeProvider());
+    registerCartographerModeProvider(createInspectorModeProvider());
+    coreProvidersRegistered = true;
+};
+
+export const provideCartographerModes = (): CartographerMode[] => {
+    ensureCoreProviders();
+    return createCartographerModesSnapshot();
+};
+
+export const listCartographerModeMetadata = (): readonly CartographerModeMetadata[] => {
+    ensureCoreProviders();
+    return getCartographerModeMetadataSnapshot();
+};
+
+export const registerModeProvider = (provider: CartographerModeProvider): (() => void) => {
+    return registerCartographerModeProvider(provider);
+};
+
+export const unregisterModeProvider = (id: string): boolean => {
+    return unregisterCartographerModeProvider(id);
+};
+
+export const resetCartographerModeRegistry = (options?: { registerCoreProviders?: boolean }): void => {
+    clearCartographerModeRegistry();
+    coreProvidersRegistered = false;
+    if (options?.registerCoreProviders ?? true) {
+        ensureCoreProviders();
+    }
+};
+
+export { createCartographerModesSnapshot, getCartographerModeMetadataSnapshot };
+
+export type { CartographerModeMetadata, CartographerModeProvider };

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
@@ -1,0 +1,17 @@
+import type { CartographerModeProvider } from "../registry";
+
+export const createEditorModeProvider = (): CartographerModeProvider => ({
+    metadata: {
+        id: "editor",
+        label: "Editor",
+        summary: "Interaktiver Hex-Map Editor mit Werkzeugpalette und Live-Vorschau.",
+        keywords: ["map", "edit", "hex"],
+        order: 200,
+        source: "core/cartographer/editor",
+        version: "1.0.0",
+    },
+    async load() {
+        const { createEditorMode } = await import("../../modes/editor");
+        return createEditorMode();
+    },
+});

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
@@ -1,0 +1,17 @@
+import type { CartographerModeProvider } from "../registry";
+
+export const createInspectorModeProvider = (): CartographerModeProvider => ({
+    metadata: {
+        id: "inspector",
+        label: "Inspector",
+        summary: "Liest bestehende Karten und stellt Metadaten sowie Hex-Details dar.",
+        keywords: ["inspect", "metadata", "analyze"],
+        order: 300,
+        source: "core/cartographer/inspector",
+        version: "1.0.0",
+    },
+    async load() {
+        const { createInspectorMode } = await import("../../modes/inspector");
+        return createInspectorMode();
+    },
+});

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
@@ -1,0 +1,17 @@
+import type { CartographerModeProvider } from "../registry";
+
+export const createTravelGuideModeProvider = (): CartographerModeProvider => ({
+    metadata: {
+        id: "travel-guide",
+        label: "Travel Guide",
+        summary: "Präsentiert Kurzinformationen und Kartenabschnitte für Reisende.",
+        keywords: ["travel", "guide", "summary"],
+        order: 100,
+        source: "core/cartographer/travel-guide",
+        version: "1.0.0",
+    },
+    async load() {
+        const { createTravelGuideMode } = await import("../../modes/travel-guide");
+        return createTravelGuideMode();
+    },
+});

--- a/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
@@ -1,0 +1,177 @@
+import type {
+    CartographerMode,
+    CartographerModeContext,
+} from "../presenter";
+
+export interface CartographerModeMetadata {
+    readonly id: string;
+    readonly label: string;
+    readonly summary: string;
+    readonly keywords?: readonly string[];
+    readonly order?: number;
+    readonly source: string;
+    readonly version?: string;
+}
+
+export interface CartographerModeProvider {
+    readonly metadata: CartographerModeMetadata;
+    load(): Promise<CartographerMode>;
+}
+
+type RegisteredProvider = {
+    readonly provider: CartographerModeProvider;
+    readonly metadata: CartographerModeMetadata;
+};
+
+const providers = new Map<string, RegisteredProvider>();
+
+const cloneMetadata = (metadata: CartographerModeMetadata): CartographerModeMetadata => {
+    const keywords = metadata.keywords ? [...metadata.keywords] : undefined;
+    const normalized: CartographerModeMetadata = {
+        ...metadata,
+        keywords,
+    };
+    return Object.freeze(normalized);
+};
+
+const normalizeProvider = (provider: CartographerModeProvider): RegisteredProvider => {
+    if (!provider?.metadata?.id) {
+        throw new Error("[cartographer:mode-registry] provider metadata requires an id");
+    }
+    if (!provider.metadata.label) {
+        throw new Error(`[` + "cartographer:mode-registry" + `] provider '${provider.metadata.id}' requires a label`);
+    }
+    if (!provider.metadata.summary) {
+        throw new Error(`[` + "cartographer:mode-registry" + `] provider '${provider.metadata.id}' requires a summary`);
+    }
+    if (!provider.metadata.source) {
+        throw new Error(`[` + "cartographer:mode-registry" + `] provider '${provider.metadata.id}' requires a source identifier`);
+    }
+
+    return {
+        provider: {
+            ...provider,
+            metadata: cloneMetadata(provider.metadata),
+        },
+        metadata: cloneMetadata(provider.metadata),
+    } satisfies RegisteredProvider;
+};
+
+export const registerCartographerModeProvider = (
+    provider: CartographerModeProvider,
+): (() => void) => {
+    const entry = normalizeProvider(provider);
+    const existing = providers.get(entry.metadata.id);
+    if (existing) {
+        throw new Error(
+            `[cartographer:mode-registry] provider with id '${entry.metadata.id}' is already registered by '${existing.metadata.source}'`,
+        );
+    }
+    providers.set(entry.metadata.id, entry);
+    return () => {
+        const current = providers.get(entry.metadata.id);
+        if (current === entry) {
+            providers.delete(entry.metadata.id);
+        }
+    };
+};
+
+export const unregisterCartographerModeProvider = (id: string): boolean => {
+    return providers.delete(id);
+};
+
+const orderValue = (metadata: CartographerModeMetadata): number => {
+    if (metadata.order === undefined || Number.isNaN(metadata.order)) return Number.POSITIVE_INFINITY;
+    return metadata.order;
+};
+
+const getSortedProviders = (): RegisteredProvider[] => {
+    return Array.from(providers.values()).sort((a, b) => {
+        const orderDiff = orderValue(a.metadata) - orderValue(b.metadata);
+        if (orderDiff !== 0) return orderDiff;
+        return a.metadata.label.localeCompare(b.metadata.label, undefined, { sensitivity: "base" });
+    });
+};
+
+export const getCartographerModeMetadataSnapshot = (): readonly CartographerModeMetadata[] => {
+    return getSortedProviders().map((entry) => entry.metadata);
+};
+
+const createLazyModeWrapper = (entry: RegisteredProvider): CartographerMode => {
+    const { metadata, provider } = entry;
+    let cached: CartographerMode | null = null;
+    let loading: Promise<CartographerMode> | null = null;
+
+    const load = async (): Promise<CartographerMode> => {
+        if (cached) return cached;
+        if (!loading) {
+            loading = provider
+                .load()
+                .then((mode) => {
+                    if (!mode) {
+                        throw new Error(
+                            `[cartographer:mode-registry] provider '${metadata.id}' returned an invalid mode instance`,
+                        );
+                    }
+                    if (mode.id && mode.id !== metadata.id) {
+                        console.warn(
+                            `[cartographer:mode-registry] mode id '${mode.id}' does not match provider id '${metadata.id}'`,
+                        );
+                    }
+                    cached = mode;
+                    return mode;
+                })
+                .catch((error) => {
+                    console.error(
+                        `[cartographer:mode-registry] failed to load mode '${metadata.id}' from '${metadata.source}'`,
+                        error,
+                    );
+                    loading = null;
+                    throw error;
+                });
+        }
+        return loading;
+    };
+
+    const invoke = async <T>(fn: (mode: CartographerMode) => T | Promise<T>): Promise<T> => {
+        const mode = await load();
+        return await fn(mode);
+    };
+
+    const invokeOptional = async <T>(fn: (mode: CartographerMode) => T | Promise<T>): Promise<T | undefined> => {
+        if (!cached && !loading) {
+            await load();
+        }
+        if (!cached) return undefined;
+        return await fn(cached);
+    };
+
+    return {
+        id: metadata.id,
+        label: metadata.label,
+        async onEnter(ctx: CartographerModeContext) {
+            return await invoke((mode) => mode.onEnter(ctx));
+        },
+        async onExit() {
+            if (!cached) return;
+            await invokeOptional((mode) => mode.onExit());
+        },
+        async onFileChange(file, handles, ctx) {
+            return await invoke((mode) => mode.onFileChange(file, handles, ctx));
+        },
+        async onHexClick(coord, event, ctx) {
+            return await invokeOptional((mode) => mode.onHexClick?.(coord, event, ctx));
+        },
+        async onSave(mode, file, ctx) {
+            return await invokeOptional((loaded) => loaded.onSave?.(mode, file, ctx));
+        },
+    } satisfies CartographerMode;
+};
+
+export const createCartographerModesSnapshot = (): CartographerMode[] => {
+    return getSortedProviders().map(createLazyModeWrapper);
+};
+
+export const clearCartographerModeRegistry = (): void => {
+    providers.clear();
+};

--- a/salt-marcher/tests/cartographer/mode-registry.test.ts
+++ b/salt-marcher/tests/cartographer/mode-registry.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { CartographerMode, CartographerModeContext } from "../../src/apps/cartographer/presenter";
+import {
+    registerModeProvider,
+    unregisterModeProvider,
+    resetCartographerModeRegistry,
+    createCartographerModesSnapshot,
+    getCartographerModeMetadataSnapshot,
+    type CartographerModeProvider,
+} from "../../src/apps/cartographer/mode-registry";
+
+const createStubContext = (): CartographerModeContext => ({
+    app: {} as any,
+    host: {} as HTMLElement,
+    mapHost: {} as HTMLElement,
+    sidebarHost: {} as HTMLElement,
+    getFile: () => null,
+    getMapLayer: () => null,
+    getRenderHandles: () => null,
+    getOptions: () => null,
+});
+
+describe("cartographer mode registry", () => {
+    beforeEach(() => {
+        resetCartographerModeRegistry({ registerCoreProviders: false });
+    });
+
+    it("loads registered providers lazily", async () => {
+        const load = vi.fn(async () => ({
+            id: "test-mode",
+            label: "Test",
+            onEnter: vi.fn(),
+            onExit: vi.fn(),
+            onFileChange: vi.fn(),
+        }) satisfies CartographerMode);
+
+        const provider: CartographerModeProvider = {
+            metadata: {
+                id: "test-mode",
+                label: "Test",
+                summary: "Test provider",
+                keywords: ["test"],
+                order: 10,
+                source: "tests/mode",
+            },
+            load,
+        };
+
+        registerModeProvider(provider);
+
+        const snapshot = createCartographerModesSnapshot();
+        expect(snapshot).toHaveLength(1);
+        const mode = snapshot[0];
+        expect(mode.id).toBe("test-mode");
+        expect(load).not.toHaveBeenCalled();
+
+        const ctx = createStubContext();
+        await mode.onEnter(ctx);
+        expect(load).toHaveBeenCalledTimes(1);
+        await mode.onFileChange(null, null, ctx);
+        await mode.onExit();
+    });
+
+    it("rejects duplicate registrations", () => {
+        const provider: CartographerModeProvider = {
+            metadata: {
+                id: "dup",
+                label: "Dup",
+                summary: "first",
+                source: "tests/dup",
+            },
+            async load() {
+                return {
+                    id: "dup",
+                    label: "Dup",
+                    onEnter: vi.fn(),
+                    onExit: vi.fn(),
+                    onFileChange: vi.fn(),
+                } satisfies CartographerMode;
+            },
+        };
+
+        registerModeProvider(provider);
+
+        expect(() => registerModeProvider(provider)).toThrow(/already registered/i);
+    });
+
+    it("reflects registry updates in metadata and mode snapshots", () => {
+        const providerA: CartographerModeProvider = {
+            metadata: {
+                id: "a",
+                label: "A",
+                summary: "first",
+                order: 2,
+                source: "tests/a",
+            },
+            async load() {
+                return {
+                    id: "a",
+                    label: "A",
+                    onEnter: vi.fn(),
+                    onExit: vi.fn(),
+                    onFileChange: vi.fn(),
+                } satisfies CartographerMode;
+            },
+        };
+
+        const providerB: CartographerModeProvider = {
+            metadata: {
+                id: "b",
+                label: "B",
+                summary: "second",
+                order: 1,
+                source: "tests/b",
+            },
+            async load() {
+                return {
+                    id: "b",
+                    label: "B",
+                    onEnter: vi.fn(),
+                    onExit: vi.fn(),
+                    onFileChange: vi.fn(),
+                } satisfies CartographerMode;
+            },
+        };
+
+        const disposeA = registerModeProvider(providerA);
+        registerModeProvider(providerB);
+
+        let metadata = getCartographerModeMetadataSnapshot();
+        expect(metadata.map((m) => m.id)).toEqual(["b", "a"]);
+
+        disposeA();
+        unregisterModeProvider("b");
+
+        metadata = getCartographerModeMetadataSnapshot();
+        expect(metadata).toHaveLength(0);
+
+        const snapshot = createCartographerModesSnapshot();
+        expect(snapshot).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
- introduce a declarative Cartographer mode registry with metadata validation and lazy wrappers
- register the core mode providers and expose helper APIs plus documentation for integrators
- wire the Cartographer view to resolve its modes from the registry and add coverage for dynamic registration behaviour

## Testing
- npm test -- cartographer/mode-registry

------
https://chatgpt.com/codex/tasks/task_e_68d6d3b018dc83259e94490409d7558c