### PR TITLE
Standardize UI terminology across map manager and library

### DIFF
--- a/salt-marcher/docs/ui/terminology.md
+++ b/salt-marcher/docs/ui/terminology.md
@@ -1,0 +1,43 @@
+# UI Terminology Reference
+
+## Purpose & Audience
+This reference defines the canonical English terms and phrases used across Salt Marcher's runtime UI and related tests. It targets developers, UX writers, and reviewers who introduce or review labels, notices, or comments inside UI-facing modules.
+
+## Directory Map
+| Path | Description | Primary Docs |
+| --- | --- | --- |
+| `docs/ui/terminology.md` | Central glossary for UI nouns, verbs, and example copy. | _This document_ |
+| `docs/ui/README.md` | Overview of shared UI components and governance. | [`README.md`](README.md) |
+| `../../style-guide.md` | Repository-wide documentation and language standards. | [`style-guide.md`](../../style-guide.md) |
+
+## Key Workflows
+1. **Confirm the target term.** Identify whether the change concerns maps, library resources, encounters, or shared system copy.
+2. **Select the approved phrase.** Use the glossary below to source the noun, verb, and sample UI sentence; adapt pluralization exactly as listed.
+3. **Update code and tests together.** Apply the phrase via the exported copy objects (`MAP_MANAGER_COPY`, `LIBRARY_COPY`, etc.) and adjust assertions to match.
+4. **Document new additions.** When introducing a new UI concept, extend this glossary and cross-link relevant modules before merging.
+
+## Linked Docs
+- [Documentation Style Guide](../../style-guide.md) – language policy and structural requirements.
+- [UI overview](README.md) – structure and responsibilities of UI components.
+- [Map manager overview](map-manager-overview.md) – deeper dive into map management workflows.
+
+## Standards & Conventions
+### Core Vocabulary
+| Concept | Preferred Term | Example Phrase |
+| --- | --- | --- |
+| Map lifecycle | Map / Maps | "Select a map before deleting." |
+| Resource library | Library | "Library" (view title) |
+| Creature records | Creatures | "Creatures" (library mode toggle) |
+| Spell records | Spells | "Spells" (library mode toggle) |
+| Terrain records | Terrain / Terrains | "No terrains available." |
+| Regional records | Region / Regions | "Regions" (library mode toggle) |
+| Adventure events | Encounter / Encounters | "Create encounter" (button label) |
+| Creation action | Create entry | "Create entry" (library action button) |
+| Search affordance | Search the library or enter a name… | Search bar placeholder |
+
+### Usage Guidelines
+- **Language:** Runtime UI copy, notices, and inline comments must use U.S. English. Avoid German loanwords and keep punctuation consistent with the examples above.
+- **Central copy objects:** Prefer the exported constants in code (`MAP_MANAGER_COPY` within `src/ui/map-manager.ts`, `LIBRARY_COPY` within `src/apps/library/view.ts`). Introducing new UI flows should follow the same pattern so tests can import a single source of truth.
+- **Pluralisation:** Use the plural forms supplied in the table (`Terrains`, `Regions`, `Encounters`). For dynamic messages, construct sentences from these exact tokens to prevent drift.
+- **Testing:** Assertions that validate UI text should import the relevant copy object rather than hard-coding literals, ensuring updates stay synchronized.
+- **Extending the glossary:** When a new term is approved, append it to the table above, include an example phrase, and link to the module where it is used.

--- a/salt-marcher/src/apps/library/view.ts
+++ b/salt-marcher/src/apps/library/view.ts
@@ -10,6 +10,28 @@ import { SpellsRenderer } from "./view/spells";
 import { TerrainsRenderer, describeTerrainsSource } from "./view/terrains";
 import { RegionsRenderer, describeRegionsSource } from "./view/regions";
 
+/**
+ * Authoritative UI copy for the library view. Keep aligned with `docs/ui/terminology.md`.
+ */
+export const LIBRARY_COPY = {
+    title: "Library",
+    searchPlaceholder: "Search the library or enter a name…",
+    createButton: "Create entry",
+    modes: {
+        creatures: "Creatures",
+        spells: "Spells",
+        terrains: "Terrains",
+        regions: "Regions",
+    },
+    sources: {
+        prefix: "Source: ",
+        creatures: "SaltMarcher/Creatures/",
+        spells: "SaltMarcher/Spells/",
+    },
+} as const;
+
+type ModeCopy = typeof LIBRARY_COPY.modes;
+
 export const VIEW_LIBRARY = "salt-library";
 
 export class LibraryView extends ItemView {
@@ -22,7 +44,7 @@ export class LibraryView extends ItemView {
     private searchInput?: HTMLInputElement;
 
     getViewType() { return VIEW_LIBRARY; }
-    getDisplayText() { return "Library"; }
+    getDisplayText() { return LIBRARY_COPY.title; }
     getIcon() { return "library" as any; }
 
     async onOpen() {
@@ -45,31 +67,31 @@ export class LibraryView extends ItemView {
 
     private renderShell() {
         const root = this.contentEl; root.empty();
-        root.createEl("h2", { text: "Library" });
+        root.createEl("h2", { text: LIBRARY_COPY.title });
 
         // Mode header
         const header = root.createDiv({ cls: "sm-lib-header" });
-        const mkBtn = (label: string, m: Mode) => {
+        const mkBtn = (label: ModeCopy[Mode], m: Mode) => {
             const b = header.createEl("button", { text: label });
             this.headerButtons.set(m, b);
             b.onclick = () => { void this.activateMode(m); };
             return b;
         };
-        mkBtn("Creatures", "creatures");
-        mkBtn("Spells", "spells");
-        mkBtn("Terrains", "terrains");
-        mkBtn("Regions", "regions");
+        mkBtn(LIBRARY_COPY.modes.creatures, "creatures");
+        mkBtn(LIBRARY_COPY.modes.spells, "spells");
+        mkBtn(LIBRARY_COPY.modes.terrains, "terrains");
+        mkBtn(LIBRARY_COPY.modes.regions, "regions");
 
         // Search + create
         const bar = root.createDiv({ cls: "sm-cc-searchbar" });
-        const search = bar.createEl("input", { attr: { type: "text", placeholder: "Search or type a name…" } }) as HTMLInputElement;
+        const search = bar.createEl("input", { attr: { type: "text", placeholder: LIBRARY_COPY.searchPlaceholder } }) as HTMLInputElement;
         search.value = this.query;
         search.oninput = () => {
             this.query = search.value;
             this.activeRenderer?.setQuery(this.query);
         };
         this.searchInput = search;
-        const createBtn = bar.createEl("button", { text: "Create" });
+        const createBtn = bar.createEl("button", { text: LIBRARY_COPY.createButton });
         createBtn.onclick = () => { void this.onCreate(search.value.trim()); };
 
         // Source description
@@ -126,10 +148,13 @@ export class LibraryView extends ItemView {
 
     private updateSourceDescription() {
         if (!this.descEl) return;
-        const text = this.mode === "creatures" ? "Source: SaltMarcher/Creatures/" :
-            this.mode === "spells" ? "Source: SaltMarcher/Spells/" :
-                this.mode === "terrains" ? describeTerrainsSource() :
-                    describeRegionsSource();
+        const text = this.mode === "creatures"
+            ? `${LIBRARY_COPY.sources.prefix}${LIBRARY_COPY.sources.creatures}`
+            : this.mode === "spells"
+                ? `${LIBRARY_COPY.sources.prefix}${LIBRARY_COPY.sources.spells}`
+                : this.mode === "terrains"
+                    ? describeTerrainsSource()
+                    : describeRegionsSource();
         this.descEl.setText(text);
     }
 

--- a/salt-marcher/src/ui/map-manager.ts
+++ b/salt-marcher/src/ui/map-manager.ts
@@ -11,6 +11,20 @@ import {
 import { ConfirmDeleteModal } from "./confirm-delete";
 import { deleteMapAndTiles } from "../core/map-delete";
 
+/**
+ * Authoritative UI copy for map-management notices.
+ * Keep the strings aligned with the terminology reference in `docs/ui/terminology.md`.
+ */
+export const MAP_MANAGER_COPY = {
+    notices: {
+        missingSelection: "Select a map before deleting.",
+        deleteFailed: "Unable to delete the map. Check the developer console for details.",
+    },
+    logs: {
+        deleteFailed: "Map deletion failed",
+    },
+} as const;
+
 export type MapManagerOptions = {
     /** Initial file tracked by the internal state. */
     initialFile?: TFile | null;
@@ -40,7 +54,9 @@ export type MapManagerHandle = {
 
 export function createMapManager(app: App, options: MapManagerOptions = {}): MapManagerHandle {
     const notices = {
-        missingSelection: options.notices?.missingSelection ?? "No map selected.",
+        missingSelection:
+            options.notices?.missingSelection ?? MAP_MANAGER_COPY.notices.missingSelection,
+        deleteFailed: MAP_MANAGER_COPY.notices.deleteFailed,
     } as const;
 
     let current: TFile | null = options.initialFile ?? null;
@@ -87,8 +103,8 @@ export function createMapManager(app: App, options: MapManagerOptions = {}): Map
                     await applyChange(null);
                 }
             } catch (error) {
-                console.error("Map deletion failed", error);
-                new Notice("Could not delete the map. Check the console for details.");
+                console.error(MAP_MANAGER_COPY.logs.deleteFailed, error);
+                new Notice(notices.deleteFailed);
             }
         }).open();
     };

--- a/salt-marcher/tests/library/view.test.ts
+++ b/salt-marcher/tests/library/view.test.ts
@@ -1,0 +1,167 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mode } from "../../src/apps/library/view/mode";
+import { LIBRARY_COPY, LibraryView } from "../../src/apps/library/view";
+import { App, WorkspaceLeaf } from "obsidian";
+
+vi.mock("../../src/apps/library/core/creature-files", () => ({
+    ensureCreatureDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/apps/library/core/spell-files", () => ({
+    ensureSpellDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/core/terrain-store", () => ({
+    ensureTerrainFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/core/regions-store", () => ({
+    ensureRegionsFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+const noop = () => {};
+
+function createRenderer(mode: Mode) {
+    return class {
+        readonly mode = mode;
+        constructor(public app: App, public container: HTMLElement) {
+            void this.app;
+            void this.container;
+        }
+        async init() {}
+        render() {}
+        setQuery = noop;
+        async handleCreate() {}
+        async destroy() {}
+    };
+}
+
+vi.mock("../../src/apps/library/view/creatures", () => ({
+    CreaturesRenderer: createRenderer("creatures" as Mode),
+}));
+
+vi.mock("../../src/apps/library/view/spells", () => ({
+    SpellsRenderer: createRenderer("spells" as Mode),
+}));
+
+const terrainsSource = "Source: SaltMarcher/Terrains/";
+const regionsSource = "Source: SaltMarcher/Regions.json";
+
+vi.mock("../../src/apps/library/view/terrains", () => ({
+    TerrainsRenderer: createRenderer("terrains" as Mode),
+    describeTerrainsSource: () => terrainsSource,
+}));
+
+vi.mock("../../src/apps/library/view/regions", () => ({
+    RegionsRenderer: createRenderer("regions" as Mode),
+    describeRegionsSource: () => regionsSource,
+}));
+
+const ensureObsidianDomHelpers = () => {
+    const proto = HTMLElement.prototype as any;
+    if (!proto.createEl) {
+        proto.createEl = function(tag: string, options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            const el = document.createElement(tag);
+            if (options?.text) el.textContent = options.text;
+            if (options?.cls) el.classList.add(options.cls);
+            if (options?.attr) {
+                for (const [key, value] of Object.entries(options.attr)) {
+                    el.setAttribute(key, value);
+                }
+            }
+            this.appendChild(el);
+            return el;
+        };
+    }
+    if (!proto.createDiv) {
+        proto.createDiv = function(options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            return this.createEl("div", options);
+        };
+    }
+    if (!proto.empty) {
+        proto.empty = function() {
+            while (this.firstChild) {
+                this.removeChild(this.firstChild);
+            }
+            return this;
+        };
+    }
+    if (!proto.setText) {
+        proto.setText = function(text: string) {
+            this.textContent = text;
+            return this;
+        };
+    }
+    if (!proto.addClass) {
+        proto.addClass = function(cls: string) {
+            this.classList.add(cls);
+            return this;
+        };
+    }
+    if (!proto.removeClass) {
+        proto.removeClass = function(cls: string) {
+            this.classList.remove(cls);
+            return this;
+        };
+    }
+};
+
+beforeAll(() => {
+    ensureObsidianDomHelpers();
+});
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe("LibraryView copy", () => {
+    let app: App;
+    let view: LibraryView;
+
+    beforeEach(() => {
+        app = new App();
+        const leaf = new WorkspaceLeaf();
+        view = new LibraryView(leaf as unknown as WorkspaceLeaf);
+        (view as unknown as { app: App }).app = app;
+        (view as unknown as { contentEl: HTMLElement }).contentEl = document.createElement("div");
+    });
+
+    it("renders the standard English labels", async () => {
+        await view.onOpen();
+        const root = (view as unknown as { contentEl: HTMLElement }).contentEl;
+
+        const heading = root.querySelector("h2");
+        expect(heading?.textContent).toBe(LIBRARY_COPY.title);
+
+        const buttons = Array.from(root.querySelectorAll(".sm-lib-header button"));
+        expect(buttons.map(b => b.textContent)).toEqual([
+            LIBRARY_COPY.modes.creatures,
+            LIBRARY_COPY.modes.spells,
+            LIBRARY_COPY.modes.terrains,
+            LIBRARY_COPY.modes.regions,
+        ]);
+
+        const search = root.querySelector("input[type=\"text\"]");
+        expect(search?.getAttribute("placeholder")).toBe(LIBRARY_COPY.searchPlaceholder);
+
+        const createBtn = root.querySelector(".sm-cc-searchbar button");
+        expect(createBtn?.textContent).toBe(LIBRARY_COPY.createButton);
+
+        const desc = root.querySelector(".desc");
+        expect(desc?.textContent).toBe(`${LIBRARY_COPY.sources.prefix}${LIBRARY_COPY.sources.creatures}`);
+    });
+
+    it("updates the source description when switching modes", async () => {
+        await view.onOpen();
+        const root = (view as unknown as { contentEl: HTMLElement }).contentEl;
+        const [_, __, terrainsButton, regionsButton] = Array.from(root.querySelectorAll(".sm-lib-header button"));
+
+        terrainsButton.dispatchEvent(new Event("click"));
+        await flush();
+        const descAfterTerrains = root.querySelector(".desc")?.textContent;
+        expect(descAfterTerrains).toBe(terrainsSource);
+
+        regionsButton.dispatchEvent(new Event("click"));
+        await flush();
+        const descAfterRegions = root.querySelector(".desc")?.textContent;
+        expect(descAfterRegions).toBe(regionsSource);
+    });
+});

--- a/salt-marcher/tests/ui/map-manager.test.ts
+++ b/salt-marcher/tests/ui/map-manager.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { createMapManager, MAP_MANAGER_COPY } from "../../src/ui/map-manager";
+import type { deleteMapAndTiles as DeleteMapAndTiles } from "../../src/core/map-delete";
+
+const notices: string[] = [];
+
+vi.mock("obsidian", async () => {
+    const actual = await vi.importActual<typeof import("obsidian")>("obsidian");
+
+    class Notice extends actual.Notice {
+        constructor(message?: string) {
+            super(message);
+            if (message) notices.push(message);
+        }
+    }
+
+    return {
+        ...actual,
+        Notice,
+    };
+});
+
+const confirmModals: { onConfirm: () => Promise<void> }[] = [];
+
+vi.mock("../../src/ui/confirm-delete", () => ({
+    ConfirmDeleteModal: class {
+        onConfirm: () => Promise<void>;
+        constructor(_app: App, _target: TFile, onConfirm: () => Promise<void>) {
+            this.onConfirm = onConfirm;
+            confirmModals.push({ onConfirm });
+        }
+        open() {
+            // Actual modal is interactive; tests trigger the confirmation explicitly.
+        }
+    },
+}));
+
+const deleteMapAndTiles = vi.fn<Parameters<DeleteMapAndTiles>, ReturnType<DeleteMapAndTiles>>();
+
+vi.mock("../../src/core/map-delete", () => ({
+    deleteMapAndTiles: (...args: Parameters<typeof deleteMapAndTiles>) => deleteMapAndTiles(...args),
+}));
+
+const appStub = { workspace: {} } as unknown as App;
+
+const createFile = (path: string): TFile => ({ path, basename: path.split("/").pop() ?? path }) as TFile;
+
+describe("createMapManager", () => {
+    beforeEach(() => {
+        notices.length = 0;
+        confirmModals.length = 0;
+        deleteMapAndTiles.mockReset();
+    });
+
+    it("uses the default notice when no map is selected", () => {
+        const manager = createMapManager(appStub);
+
+        manager.deleteCurrent();
+
+        expect(notices).toContain(MAP_MANAGER_COPY.notices.missingSelection);
+    });
+
+    it("shows the failure notice when deletion fails", async () => {
+        const file = createFile("maps/example.map");
+        const manager = createMapManager(appStub, { initialFile: file });
+        deleteMapAndTiles.mockRejectedValueOnce(new Error("boom"));
+
+        manager.deleteCurrent();
+        expect(confirmModals).toHaveLength(1);
+
+        const modal = confirmModals[0];
+        await modal.onConfirm().catch(() => undefined);
+
+        expect(notices).toContain(MAP_MANAGER_COPY.notices.deleteFailed);
+    });
+});

--- a/style-guide.md
+++ b/style-guide.md
@@ -35,4 +35,10 @@ Additional formatting rules:
 - Prefer relative links inside the repository to keep navigation consistent across forks and mirrors.
 - When referencing command sequences or configuration snippets, use fenced code blocks with language hints for readability.
 - Update directory tables and linked references whenever files move to prevent dead links.
-- Runtime UI copy (buttons, notices, placeholders) and accompanying code comments must use English to stay aligned with the Library and UI documentation. Quote the exact labels (e.g. "Create", "Open") when describing workflows.
+- Runtime UI copy (buttons, notices, placeholders) and accompanying code comments must follow the UI language policy below.
+
+### Runtime UI Copy
+- Use U.S. English for all runtime copy, developer-facing notices, and inline comments. Avoid mixing locales or borrowing untranslated German phrases.
+- Prefer the canonical phrases defined in the [UI terminology reference](salt-marcher/docs/ui/terminology.md); this includes example strings such as `"Select a map before deleting."`, `"Create entry"`, and `"Search the library or enter a name…"`.
+- When adding new UI flows, centralise labels in exported constants (e.g. `MAP_MANAGER_COPY`, `LIBRARY_COPY`) so production code and tests can import a single source of truth.
+- Reference the exact labels in documentation and commit messages to make reviews traceable against the glossary.


### PR DESCRIPTION
## Summary
- document a unified English UI language policy and reference glossary
- centralize copy constants for the map manager and library views to remove mixed-language notices
- add unit tests that assert the canonical copy used in both modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6d3b2e370832589fdc2574814b13a