### PR TITLE
Ensure Cartographer lifecycle context flows across transitions

### DIFF
--- a/salt-marcher/docs/cartographer/mode-registry.md
+++ b/salt-marcher/docs/cartographer/mode-registry.md
@@ -45,6 +45,7 @@ Metadaten werden beim Registrieren defensiv geklont und eingefroren, damit Konsu
 - Fehlschläge beim Laden werden geloggt (`console.error`) und an den Aufrufer propagiert.
 - Optional implementierte Hooks (`onHexClick`, `onSave`) werden nur aufgerufen, wenn der geladene Modus sie anbietet.
 - Ein Abgleich stellt sicher, dass die Mode-ID mit der Provider-ID übereinstimmt; Abweichungen werden als Warnung geloggt.
+- Der Lazy-Wrapper reicht den vollständigen `CartographerModeLifecycleContext` (inkl. `AbortSignal`) an jeden Hook weiter und behält typsichere Signaturen bei.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L113-L165】
 
 ## Migration für Drittanbieter-Modi
 


### PR DESCRIPTION
## Summary
- strengthen the cartographer mode wrapper so all lifecycle hooks forward the abort-aware context with strict typings
- keep a stable lifecycle context per active mode inside the presenter, ensuring exits reuse the same object and rendering hooks share it
- add regression coverage for Travel→Editor→Travel switches and document the lifecycle guarantees for mode authors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6e51948b083259cdd8b2adf1ea7d7