### PR TITLE
Add observable cartographer modes and reactive presenter sync

### DIFF
--- a/salt-marcher/docs/cartographer/mode-registry.md
+++ b/salt-marcher/docs/cartographer/mode-registry.md
@@ -47,6 +47,13 @@ Metadaten werden beim Registrieren defensiv geklont und eingefroren, damit Konsu
 - Ein Abgleich stellt sicher, dass die Mode-ID mit der Provider-ID übereinstimmt; Abweichungen werden als Warnung geloggt.
 - Der Lazy-Wrapper reicht den vollständigen `CartographerModeLifecycleContext` (inkl. `AbortSignal`) an jeden Hook weiter und behält typsichere Signaturen bei.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L113-L165】
 
+## Beobachtung & UI-Synchronisation
+
+- `subscribeToModeRegistry(listener)` stellt ein Observable über den Registry-Zustand bereit. Jeder Listener erhält sofort ein `initial`-Event mit allen aktuell bekannten Modi (inklusive Kern-Providern) und im weiteren Verlauf gezielte `registered`-, `deregistered`- und `reset`-Events.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L63-L96】【F:salt-marcher/src/apps/cartographer/mode-registry/index.ts†L28-L56】
+- Event-Nutzlasten kombinieren Metadaten und lazy-gekapselte `CartographerMode`-Instanzen, sodass Konsumenten direkt mit stabilen Objekten weiterarbeiten können.
+- Der `CartographerPresenter` abonniert die Registry dauerhaft, aktualisiert seine interne Modusliste und synchronisiert die View-Shell inkrementell über `registerMode`, `deregisterMode` und `setModes`. Änderungen an Drittanbieter-Providern tauchen daher ohne Reload im Dropdown auf.【F:salt-marcher/src/apps/cartographer/presenter.ts†L102-L190】【F:salt-marcher/src/apps/cartographer/presenter.ts†L260-L299】
+- Wird der aktive Modus deregistriert, stößt der Presenter automatisch einen Fallback auf den zuerst verfügbaren Modus an – inklusive Lifecycle-Aufräumen und UI-Update der Shell.【F:salt-marcher/src/apps/cartographer/presenter.ts†L280-L299】
+
 ## Migration für Drittanbieter-Modi
 
 1. **Metadaten definieren:** Wähle eine stabile `id`, sprechenden `label`, aussagekräftige `summary`, ordne `source` (z. B. deine Plugin-ID) zu.

--- a/salt-marcher/src/apps/cartographer/mode-registry/index.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/index.ts
@@ -4,6 +4,9 @@ import {
     getCartographerModeMetadataSnapshot,
     registerCartographerModeProvider,
     unregisterCartographerModeProvider,
+    subscribeToCartographerModeRegistry,
+    type CartographerModeRegistryEvent,
+    type CartographerModeRegistryEntry,
     type CartographerModeMetadata,
     type CartographerModeProvider,
 } from "./registry";
@@ -40,6 +43,13 @@ export const unregisterModeProvider = (id: string): boolean => {
     return unregisterCartographerModeProvider(id);
 };
 
+export const subscribeToModeRegistry = (
+    listener: (event: CartographerModeRegistryEvent) => void,
+): (() => void) => {
+    ensureCoreProviders();
+    return subscribeToCartographerModeRegistry(listener);
+};
+
 export const resetCartographerModeRegistry = (options?: { registerCoreProviders?: boolean }): void => {
     clearCartographerModeRegistry();
     coreProvidersRegistered = false;
@@ -50,4 +60,9 @@ export const resetCartographerModeRegistry = (options?: { registerCoreProviders?
 
 export { createCartographerModesSnapshot, getCartographerModeMetadataSnapshot };
 
-export type { CartographerModeMetadata, CartographerModeProvider };
+export type {
+    CartographerModeMetadata,
+    CartographerModeProvider,
+    CartographerModeRegistryEvent,
+    CartographerModeRegistryEntry,
+};


### PR DESCRIPTION
## Summary
- add change notifications to the cartographer mode registry and expose a subscription helper
- hook the presenter into registry events to refresh shell modes, register/deregister entries, and handle fallback when the active mode is removed
- extend registry and presenter tests for late registration/deregistration and document the dynamic flow for extensions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6e83f14488325a0215f6b82ac14a3