### PR TITLE
Document plugin bootstrap responsibilities and follow-ups

### DIFF
--- a/salt-marcher/docs/README.md
+++ b/salt-marcher/docs/README.md
@@ -1,27 +1,26 @@
 # Salt Marcher Documentation Index
 
 ## Purpose & Audience
-Diese Indexseite verknüpft die Bereichsdokumente des Plugins. Sie richtet sich an Entwickler:innen, die Architekturentscheidungen
-nachvollziehen oder neue Features ergänzen wollen. Nutzerorientierte Guides findest du im [Projekt-Wiki](../../wiki/README.md).
+Diese Indexseite verknüpft die Bereichsdokumente des Plugins. Sie richtet sich an Entwickler:innen, die Architekturentscheidungen nachvollziehen oder neue Features ergänzen wollen. Nutzerorientierte Guides findest du im [Projekt-Wiki](../../wiki/README.md).
 
 ## Struktur
 ```
 docs/
 ├─ README.md
+├─ app/
 ├─ cartographer/
 ├─ core/
 ├─ library/
 └─ ui/
 ```
-Die Unterordner spiegeln die Hauptbereiche des Plugins wider. Jede README beschreibt die enthaltenen Detaildokumente und verweist
-auf weiterführende Ressourcen.
+Die Unterordner spiegeln die Hauptbereiche des Plugins wider. Jede README beschreibt die enthaltenen Detaildokumente und verweist auf weiterführende Ressourcen.
 
 ## Bereiche
+- [App Bootstrap](app/README.md) – Plugin-Lifecycle, View-Registrierung, Terrain-Watcher und Integrationen wie die Layout-Editor-Bridge.
 - [Cartographer](cartographer/README.md) – Karten-Workspace mit Editor-, Inspector- und Travel-Modi sowie deren Infrastruktur.
 - [Core](core/README.md) – Persistenz, Hex-Geometrie und zentrale Services, die Workspaces mit Daten versorgen.
 - [Library](library/README.md) – Verwaltung von Kreaturen, Zaubern, Terrains und Regionen inklusive Event-Flows.
 - [UI](ui/README.md) – Wiederverwendbare UI-Bausteine, Shell-Komponenten und Map-spezifische Workflows.
 
 ## Standards & Pflege
-Alle neuen oder aktualisierten Dokumente müssen dem [Documentation Style Guide](../../style-guide.md) entsprechen. Ergänze
-Querverlinkungen zwischen den Bereichen, sobald sich Verantwortlichkeiten überschneiden, und halte die Strukturdiagramme aktuell.
+Alle neuen oder aktualisierten Dokumente müssen dem [Documentation Style Guide](../../style-guide.md) entsprechen. Ergänze Querverlinkungen zwischen den Bereichen, sobald sich Verantwortlichkeiten überschneiden, und halte die Strukturdiagramme aktuell. Bootstrap-spezifische Standards (Lifecycle, optionale Integrationen, CSS-Injektion) sind im [App-Bootstrap-Dokument](app/README.md) festgehalten; offene Refactorings werden im [Plugin Bootstrap Review](../../todo/plugin-bootstrap-review.md) verfolgt.

--- a/salt-marcher/docs/app/README.md
+++ b/salt-marcher/docs/app/README.md
@@ -1,0 +1,44 @@
+# App Bootstrap
+
+## Purpose & Audience
+Dieses Dokument beschreibt das Bootstrap-Modul unter `src/app/`. Es richtet sich an Entwickler:innen, die verstehen möchten, wie das Plugin Views registriert, zentrale Datenflüsse initialisiert und Integrationen mit Obsidian oder Dritt-Plugins herstellt. Nutzerorientierte Workflows findest du im [Projekt-Wiki](../../wiki/README.md).
+
+## Struktur
+```
+docs/app/
+└─ README.md
+```
+Das Verzeichnis dokumentiert ausschließlich den Bootstrap-Layer. Detailentscheidungen zu Feature-Workspaces (Cartographer, Library, Encounter) werden in deren Bereichs-README behandelt.
+
+## Bootstrap-Modul (`src/app/`)
+```
+src/app/
+├─ main.ts                # Einstiegspunkt, registriert Views/Commands und orchestriert Dateninitialisierung
+├─ layout-editor-bridge.ts # Optionale Integration mit dem Layout-Editor-Plugin
+└─ css.ts                  # Gebündeltes Stylesheet, das zur Laufzeit injiziert wird
+```
+
+## Verantwortlichkeiten
+### View- und Command-Registration
+`main.ts` registriert Cartographer-, Encounter- und Library-Views sowie die zugehörigen Ribbon-Icons und Befehle. Dadurch bleibt der Einstieg in alle Workspaces konsistent und der Bootstrap kontrolliert, welche `WorkspaceLeaf`-Instanzen geöffnet oder wiederverwendet werden.
+
+### Terrain-Watcher & Initialisierung
+Der Bootstrap sorgt dafür, dass die Terrain-Datei existiert (`ensureTerrainFile`), initiale Daten geladen werden (`loadTerrains` + `setTerrains`) und Änderungen über `watchTerrains` beobachtet werden. Der Watcher ruft aktuell nur einen leeren Callback auf; die konkreten Views reagieren über Event-Listener auf Datensätze. Fehlerbehandlung und Wiederanbindung des Watchers im Fehlerfall sind offene Punkte, siehe [To-Do: Plugin Bootstrap Review](../../todo/plugin-bootstrap-review.md).
+
+### Layout-Editor-Bridge
+`layout-editor-bridge.ts` kapselt die optionale Integration zum "Layout Editor"-Plugin. Beim Laden versucht der Bootstrap, eine View-Binding-Registrierung anzulegen und hält Listener bereit, um bei Aktivierung/Deaktivierung des Fremd-Plugins korrekt aufzuräumen. Fehler werden geloggt, damit Layout-Probleme sichtbar bleiben.
+
+### CSS-Injektion
+`main.ts` injiziert das gebündelte Stylesheet (`HEX_PLUGIN_CSS`) als `<style id="hex-css">` ins Dokument und entfernt es beim Entladen. Dadurch bleiben die Hex-spezifischen Styles isoliert, ohne dass separate CSS-Dateien im Vault verwaltet werden müssen.
+
+## Offene Fragen: Bootstrap vs. Feature-Verantwortung
+- Wie robust soll das Error-Handling des Terrain-Watchers sein, bevor Events an die Workspaces weitergereicht werden?
+- Wann sollten Feature-spezifische Initialisierungen (z. B. Default-Layer-Konfigurationen) aus dem Bootstrap in die jeweiligen Workspaces verschoben werden?
+- Welche Standards gelten für Dritt-Plugin-Integrationen (Layout Editor, potenziell weitere), damit sie testbar bleiben?
+
+Diese Fragen werden im [To-Do: Plugin Bootstrap Review](../../todo/plugin-bootstrap-review.md) gebündelt und priorisiert.
+
+## Standards & Abhängigkeiten
+- Halte dich an den [Documentation Style Guide](../../style-guide.md) sowie die Obsidian-Plugin-Konventionen (Lifecycle `onload`/`onunload`).
+- Bootstrap-Code muss ohne optionale Plugins lauffähig bleiben; Integrationen dürfen nur defensive Abhängigkeiten aufrufen.
+- Asynchrone Initialisierung (Terrain-Laden) darf UI-Registrierungen nicht blockieren; langfristig sind Tests für die Bootstrapping-Sequenz zu ergänzen (siehe To-Do oben).

--- a/salt-marcher/overview.md
+++ b/salt-marcher/overview.md
@@ -1,8 +1,7 @@
 # Salt Marcher – Plugin Overview
 
 ## Purpose & Scope
-Dieses Dokument fasst die technische Struktur des Salt-Marcher-Plugins für Obsidian zusammen. Es dient Entwickler:innen als
-Einstieg in die Codebasis, verweist auf Detaildokumente unter `docs/` und beschreibt die wichtigsten Integrationspunkte.
+Dieses Dokument fasst die technische Struktur des Salt-Marcher-Plugins für Obsidian zusammen. Es dient Entwickler:innen als Einstieg in die Codebasis, verweist auf Detaildokumente unter `docs/` und beschreibt die wichtigsten Integrationspunkte.
 
 ## Repository Layout
 ```
@@ -12,6 +11,7 @@ salt-marcher/
 ├─ README.md              # Produkt- & Architekturüberblick
 ├─ docs/                  # Bereichsdokumentation (siehe unten)
 │  ├─ README.md           # Navigationsübersicht
+│  ├─ app/                # Plugin-Bootstrap, Integrationen, Standards
 │  ├─ cartographer/       # Karten-Workspace (README + Overviews)
 │  ├─ core/               # Domain- und Persistenzdienste
 │  ├─ library/            # Verwaltungs- und Datenbank-Flows
@@ -25,30 +25,24 @@ salt-marcher/
 ```
 
 ## Kernbereiche
-- **Cartographer Workspace:** Hex-Map-Stage mit Editor-, Inspector- und Travel-Modi, orchestriert durch Presenter und View-Shell.
-  Struktur und Komponenten sind im [`docs/cartographer/`](docs/cartographer/README.md) beschrieben.
-- **Library Workspace:** Verwaltungsoberfläche für Terrains, Regionen, Kreaturen und Zauber. Architekturüberblick unter
-  [`docs/library/`](docs/library/README.md).
-- **Encounter Workspace:** Fokus-View für Begegnungen, die aus Cartographer- oder Library-Events gestartet werden. Ergänzende
-  Hinweise liegen im Projekt-Wiki ([Encounter-Guide](../wiki/Encounter.md)).
-- **Core Services:** Hex-Geometrie, Kartenpersistenz, Terrain-/Regions-Stores und Dateihilfen, dokumentiert in
-  [`docs/core/`](docs/core/README.md).
+- **App Bootstrap:** Lifecycle-Management, View-Registrierung, Terrain-Watcher und Integrationen sind im [`docs/app/`](docs/app/README.md) dokumentiert.
+- **Cartographer Workspace:** Hex-Map-Stage mit Editor-, Inspector- und Travel-Modi, orchestriert durch Presenter und View-Shell. Struktur und Komponenten sind im [`docs/cartographer/`](docs/cartographer/README.md) beschrieben.
+- **Library Workspace:** Verwaltungsoberfläche für Terrains, Regionen, Kreaturen und Zauber. Architekturüberblick unter [`docs/library/`](docs/library/README.md).
+- **Encounter Workspace:** Fokus-View für Begegnungen, die aus Cartographer- oder Library-Events gestartet werden. Ergänzende Hinweise liegen im Projekt-Wiki ([Encounter-Guide](../wiki/Encounter.md)).
+- **Core Services:** Hex-Geometrie, Kartenpersistenz, Terrain-/Regions-Stores und Dateihilfen, dokumentiert in [`docs/core/`](docs/core/README.md).
 - **Geteilte UI:** View-Container, Dialoge und Map-Workflows für alle Workspaces, siehe [`docs/ui/`](docs/ui/README.md).
 
 ## Daten- & Kontrollfluss
-1. **Bootstrap (`src/app/main.ts`):** Registriert Views, Commands und Ribbon-Icons, initialisiert Terrain-Daten und CSS.
+1. **Bootstrap (`src/app/main.ts`):** Registriert Views, Commands und Ribbon-Icons, initialisiert Terrain-Daten und CSS. Detailstandards und offene Fragen findest du im [App-Bootstrap-Dokument](docs/app/README.md).
 2. **Datenhaltung:** `core/terrain-store.ts`, `core/regions-store.ts` sowie Map-Helfer synchronisieren Vault-Dateien mit den Views.
-3. **Workspaces:** Cartographer-, Library- und Encounter-Apps beobachten die Stores, aktualisieren UI-Zustand und lösen Aktionen
-   wie Encounter-Starts oder Map-Saves aus.
-4. **Integrationen:** Die optionale `layout-editor-bridge.ts` bindet den Cartographer an den Layout Editor, während UI-Komponenten
-   (`src/ui/*`) konsistente Dialoge und Header bereitstellen.
+3. **Workspaces:** Cartographer-, Library- und Encounter-Apps beobachten die Stores, aktualisieren UI-Zustand und lösen Aktionen wie Encounter-Starts oder Map-Saves aus.
+4. **Integrationen:** Die optionale `layout-editor-bridge.ts` bindet den Cartographer an den Layout Editor, während UI-Komponenten (`src/ui/*`) konsistente Dialoge und Header bereitstellen.
 
 ## Dokumentation & Standards
-Die Bereichsdokumente unter [`docs/`](docs/README.md) werden nach jedem Feature-Update gepflegt. Der repository-weite Einstieg steht im
-[Documentation Hub](../DOCUMENTATION.md). Für neue Beiträge
-bitte den projektspezifischen [Style Guide](../style-guide.md) beachten und Querverlinkungen zu bestehenden Overviews setzen.
+Die Bereichsdokumente unter [`docs/`](docs/README.md) werden nach jedem Feature-Update gepflegt. Der repository-weite Einstieg steht im [Documentation Hub](../DOCUMENTATION.md). Für neue Beiträge bitte den projektspezifischen [Style Guide](../style-guide.md) beachten und Querverlinkungen zu bestehenden Overviews setzen. Bootstrap-bezogene Refactorings sind im [Plugin Bootstrap Review](../todo/plugin-bootstrap-review.md) dokumentiert.
 
 ## To-Do
 - [Cartographer presenter respects abort signals](../todo/cartographer-presenter-abort-handling.md) – Presenter muss Abort-Signale in allen Lifecycle-Phasen respektieren.
 - [Cartographer mode registry](../todo/cartographer-mode-registry.md) – Modi deklarativ erfassen und laden.
 - [UI terminology consistency](../todo/ui-terminology-consistency.md) – Einheitliche UI-Sprache und Kommentare sicherstellen.
+- [Plugin Bootstrap Review](../todo/plugin-bootstrap-review.md) – Verantwortlichkeiten des Bootstraps präzisieren, Error-Handling und Tests evaluieren.

--- a/todo/plugin-bootstrap-review.md
+++ b/todo/plugin-bootstrap-review.md
@@ -1,0 +1,19 @@
+# Plugin Bootstrap Review
+
+## Kontext
+Der Plugin-Bootstrap (`src/app/`) bündelt derzeit View-Registrierung, Terrain-Dateninitialisierung, CSS-Injektion und optionale Integrationen. Die Verantwortlichkeiten verschwimmen teilweise mit den Feature-Workspaces, wodurch Fehlerszenarien schwer testbar sind. Diese Notiz sammelt Investigationspunkte, bevor Refactorings geplant werden.
+
+## Betroffene Module
+- `salt-marcher/src/app/main.ts`
+- `salt-marcher/src/app/layout-editor-bridge.ts`
+- `salt-marcher/src/core/terrain-store.ts`
+- `salt-marcher/src/core/terrain.ts`
+
+## Offene Fragen & Untersuchungen
+- **Watcher-Error-Handling:** Welche Fehlerzustände kann `watchTerrains` auslösen (z. B. gelöschte Dateien, Berechtigungen)? Wie werden Views informiert, und braucht es Retry-/Backoff-Strategien?
+- **Teststrategie:** Wie können wir Bootstrap-Sequenzen mit Vitest oder Integrationstests abdecken? Benötigen wir Mocks für Obsidian-`App` und Plugin-Manager, um die Layout-Bridge deterministisch zu testen?
+- **Plugin-Konfiguration:** Welche Teile der Bootstrap-Initialisierung sollten über Obsidian-Settings konfigurierbar sein (z. B. automatische Cartographer-Öffnung, CSS-Opt-Out)? Welche Persistenz ist dafür vorgesehen?
+- **Verantwortungsschnitt:** Welche Initialisierungen können in Feature-spezifische Module verschoben werden, damit der Bootstrap schlanker und wartbarer bleibt?
+
+## Nächste Schritte
+Erstelle Proof-of-Concept-Tests für den Terrain-Watcher und eine Mock-API für den Layout-Editor. Aus den Ergebnissen ableiten, ob der Bootstrap in Service-Klassen zerlegt werden sollte.


### PR DESCRIPTION
## Summary
- add an app bootstrap README that describes lifecycle responsibilities, integration points, and open questions
- update the documentation index and plugin overview to reference the bootstrap standards and link the new follow-up work
- capture bootstrap review investigation topics in the todo list for future refactoring

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6f05afe1c8325958eacfc6fe834f6