### PR TITLE
Add encounter gateway documentation and roadmap

### DIFF
--- a/salt-marcher/docs/README.md
+++ b/salt-marcher/docs/README.md
@@ -10,6 +10,7 @@ docs/
 ├─ README.md
 ├─ cartographer/
 ├─ core/
+├─ encounter/
 ├─ library/
 └─ ui/
 ```
@@ -19,6 +20,7 @@ auf weiterführende Ressourcen.
 ## Bereiche
 - [Cartographer](cartographer/README.md) – Karten-Workspace mit Editor-, Inspector- und Travel-Modi sowie deren Infrastruktur.
 - [Core](core/README.md) – Persistenz, Hex-Geometrie und zentrale Services, die Workspaces mit Daten versorgen.
+- [Encounter](encounter/README.md) – Placeholder-Workspace für Begegnungen; analysiert die aktuelle Gateway-Implementierung und dokumentiert offene Arbeiten.
 - [Library](library/README.md) – Verwaltung von Kreaturen, Zaubern, Terrains und Regionen inklusive Event-Flows.
 - [UI](ui/README.md) – Wiederverwendbare UI-Bausteine, Shell-Komponenten und Map-spezifische Workflows.
 

--- a/salt-marcher/docs/encounter/README.md
+++ b/salt-marcher/docs/encounter/README.md
@@ -1,0 +1,19 @@
+# Encounter Workspace Documentation
+
+## Überblick
+Dieser Ordner bündelt technische Notizen zum Encounter-Workspace. Aktuell existiert nur ein minimaler View, der vom Travel-Modus geöffnet wird. Die Dokumente richten sich an Entwickler:innen, die die Gateway-Logik bewerten oder den Workspace weiter ausbauen möchten.
+
+## Struktur
+```
+docs/encounter/
+├─ README.md
+└─ overview.md
+```
+
+## Inhalte
+- [overview.md](overview.md) – Analyse der Gateway-Funktion `openEncounter`, der registrierten Obsidian-Views sowie der bestehenden Lücken.
+
+## Standards & Pflege
+- Dokumentiere alle Erweiterungen der Encounter-APIs (View-Registrierung, Datenübergaben, UI-Hooks) in diesem Ordner.
+- Halte Querverweise zum Travel-Mode aktuell, sobald sich Trigger oder Schnittstellen ändern.
+- Offene Arbeiten werden im To-Do [`../todo/encounter-workspace-roadmap.md`](../../todo/encounter-workspace-roadmap.md) gepflegt und aus den Encounter-Dokumenten verlinkt.

--- a/salt-marcher/docs/encounter/overview.md
+++ b/salt-marcher/docs/encounter/overview.md
@@ -1,0 +1,38 @@
+# Encounter Workspace – Gateway & Ist-Zustand
+
+## Strukturdiagramm
+```
+TravelGuideMode.onEncounter
+    └─ EncounterGateway.openEncounter (travel-guide/encounter-gateway.ts)
+         ├─ ensureEncounterModule()
+         │    └─ import core/layout → getRightLeaf()
+         │    └─ import apps/encounter/view → VIEW_ENCOUNTER
+         └─ WorkspaceLeaf.setViewState({ type: VIEW_ENCOUNTER })
+EncounterView (apps/encounter/view.ts)
+```
+
+## Ablauf `openEncounter`
+1. **Preload im Travel-Mode.** Während `onEnter` ruft der Travel-Mode `preloadEncounterModule()` auf, wodurch das Gateway `core/layout` und `apps/encounter/view` lazy importiert und zwischenspeichert.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L153-L158】【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L10-L35】
+2. **Encounter-Trigger.** `TravelLogic` meldet einen Encounter, sobald `createPlayback` in seiner Stundenuhr `checkEncounter()` mit einem Treffer beendet. Vor dem Gateway-Aufruf pausiert der Modus die aktive Logik.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L233-L246】【F:salt-marcher/src/apps/cartographer/travel/domain/playback.ts†L60-L166】
+3. **Leaf-Auflösung.** `openEncounter` wartet auf den Import, ruft `layout.getRightLeaf(app)` und erhält (oder erzeugt) den rechten Obsidian-Leaf.【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L12-L31】【F:salt-marcher/src/core/layout.ts†L7-L24】
+4. **View-Aktivierung.** Das Gateway setzt den View-State auf `VIEW_ENCOUNTER`, aktiviert den Leaf und ruft `app.workspace.revealLeaf` auf. Fehler im Importpfad werden via `Notice` gemeldet und führen zu `false` als Rückgabewert, der aktuell ignoriert wird.【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L17-L43】
+
+## Ist-Zustand des Encounter-Workspaces
+- **View-Registrierung:** `main.ts` registriert `EncounterView` unter `VIEW_ENCOUNTER = "salt-encounter"`; das View-Objekt ist ein nacktes `ItemView`, das beim Öffnen lediglich eine Überschrift und einen leeren Beschreibungstext erzeugt.【F:salt-marcher/src/app/main.ts†L4-L40】【F:salt-marcher/src/apps/encounter/view.ts†L1-L21】
+- **Datenfluss:** Weder `openEncounter` noch `EncounterView` akzeptieren Kontext zum auslösenden Encounter (Region, Tile, Odds, NPCs). Die Hand-off-Kette endet damit beim Öffnen des Pane ohne Nutzdaten.
+- **Steuerung im Travel-Mode:** Nach dem Pausieren der Logik wird der Rückgabewert (`boolean`) des Gateways verworfen, sodass Fehler nicht bis zur Playback-Steuerung propagieren.【F:salt-marcher/src/apps/cartographer/modes/travel-guide.ts†L239-L246】
+- **UI-Zustand:** Beim Schließen des Views wird ausschließlich der DOM geleert; es existieren keine weiteren Controller oder Store-Subscriptions.【F:salt-marcher/src/apps/encounter/view.ts†L11-L20】
+
+## Fehlende Soll-Funktionen
+- **Encounter-Kontext übergeben.** Travel-Mode liefert weder Encounter-Metadaten noch eine Callback-Schnittstelle in Richtung Encounter-Workspace. Erwartet wird perspektivisch mindestens die Übergabe von Region, Terrain, Uhrzeit und Würfelergebnis, damit Encounter-Tools entstehen können.
+- **Workspace-spezifische UI.** `EncounterView` bietet keine Controls (Initiative, Monsterliste, Logbuch). Ohne definierte API existiert kein Pfad, um den Encounter-Vorgang abzubilden oder zu dokumentieren.
+- **Fehlerpropagation.** `openEncounter` gibt zwar `false` bei fehlgeschlagenem Import zurück, doch der Travel-Modus ignoriert das Ergebnis. Dadurch bleibt der Modus in einem pausierten Zustand ohne Feedback oder Retry-Strategie.
+- **Lebenszyklus & Cleanup.** Es gibt keinen Mechanismus, um beim Schließen des Encounter-Panes den Travel-Modus zu informieren (z. B. um Playback wieder freizugeben) oder Encounter-spezifische Ressourcen zu entsorgen.
+
+## Offene Fragen für die Weiterentwicklung
+1. Wie soll der Encounter-Kontext modelliert werden (DTO, Vault-Referenzen, Live-Store)?
+2. Soll das Gateway Encounters stapeln (Queue) oder immer nur den neuesten Trigger anzeigen?
+3. Wie werden manuell gestartete Encounter (z. B. via Library) in dieselbe Infrastruktur integriert?
+4. Benötigt der Travel-Modus ein Recovery, falls das Öffnen des Views scheitert (z. B. Notice + Resume)?
+
+Weitere Recherche- und Planungsschritte sind im To-Do [Encounter Workspace Roadmap](../../todo/encounter-workspace-roadmap.md) gebündelt.

--- a/salt-marcher/overview.md
+++ b/salt-marcher/overview.md
@@ -14,6 +14,7 @@ salt-marcher/
 │  ├─ README.md           # Navigationsübersicht
 │  ├─ cartographer/       # Karten-Workspace (README + Overviews)
 │  ├─ core/               # Domain- und Persistenzdienste
+│  ├─ encounter/          # Encounter-Gateway & Workspace-Dokumentation
 │  ├─ library/            # Verwaltungs- und Datenbank-Flows
 │  └─ ui/                 # Geteilte UI-Komponenten
 ├─ src/
@@ -29,8 +30,9 @@ salt-marcher/
   Struktur und Komponenten sind im [`docs/cartographer/`](docs/cartographer/README.md) beschrieben.
 - **Library Workspace:** Verwaltungsoberfläche für Terrains, Regionen, Kreaturen und Zauber. Architekturüberblick unter
   [`docs/library/`](docs/library/README.md).
-- **Encounter Workspace:** Fokus-View für Begegnungen, die aus Cartographer- oder Library-Events gestartet werden. Ergänzende
-  Hinweise liegen im Projekt-Wiki ([Encounter-Guide](../wiki/Encounter.md)).
+- **Encounter Workspace:** Fokus-View für Begegnungen, die aus Cartographer- oder Library-Events gestartet werden. Technische
+  Analyse des Gateways unter [`docs/encounter/`](docs/encounter/README.md); Nutzer:innen-Workflows im Projekt-Wiki
+  ([Encounter-Guide](../wiki/Encounter.md)).
 - **Core Services:** Hex-Geometrie, Kartenpersistenz, Terrain-/Regions-Stores und Dateihilfen, dokumentiert in
   [`docs/core/`](docs/core/README.md).
 - **Geteilte UI:** View-Container, Dialoge und Map-Workflows für alle Workspaces, siehe [`docs/ui/`](docs/ui/README.md).
@@ -52,3 +54,4 @@ bitte den projektspezifischen [Style Guide](../style-guide.md) beachten und Quer
 - [Cartographer presenter respects abort signals](../todo/cartographer-presenter-abort-handling.md) – Presenter muss Abort-Signale in allen Lifecycle-Phasen respektieren.
 - [Cartographer mode registry](../todo/cartographer-mode-registry.md) – Modi deklarativ erfassen und laden.
 - [UI terminology consistency](../todo/ui-terminology-consistency.md) – Einheitliche UI-Sprache und Kommentare sicherstellen.
+- [Encounter Workspace Roadmap](../todo/encounter-workspace-roadmap.md) – Encounter-Hand-off mit Kontext-DTO, Workspace-UI und Travel-Rückkanal planen.

--- a/todo/encounter-workspace-roadmap.md
+++ b/todo/encounter-workspace-roadmap.md
@@ -1,0 +1,52 @@
+# Encounter Workspace Roadmap
+
+## Kontext
+- Travel-Mode löst über `createPlayback.checkEncounter()` stündliche Encounter-Prüfungen aus und pausiert die Reise, sobald `onEncounter` feuert.【F:salt-marcher/src/apps/cartographer/travel/domain/playback.ts†L60-L166】
+- Das Gateway `openEncounter` öffnet anschließend lediglich den registrierten Obsidian-View, ohne Metadaten aus dem Trigger zu übergeben.【F:salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts†L10-L43】
+- `EncounterView` ist derzeit ein Placeholder und stellt keine Interaktionen, Datenquellen oder Brücke zurück zum Travel-Mode bereit.【F:salt-marcher/src/apps/encounter/view.ts†L1-L21】
+
+## Betroffene Module
+- `salt-marcher/src/apps/cartographer/travel/domain/playback.ts`
+- `salt-marcher/src/apps/cartographer/modes/travel-guide.ts`
+- `salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts`
+- `salt-marcher/src/apps/encounter/view.ts`
+- Eventuelle neue Shared-Stores unter `salt-marcher/src/core/` oder `salt-marcher/src/ui/`
+
+## Zielbild
+1. Travel-Mode liefert Encounter-Kontext (Region, Würfelergebnis, Zeitstempel, ggf. vorbereitete Encounter-Notiz) strukturiert an das Gateway.
+2. Der Encounter-Workspace stellt Werkzeuge zum Auflösen des Encounter bereit (Initiative, Notiz-Linking, Log) und kann Ergebnisse wieder an Travel zurückmelden (z. B. "Encounter resolved").
+3. Fehler beim Öffnen oder Ausführen werden sauber propagiert, damit Travel-Playback nicht hängen bleibt.
+
+## Investigation & Implementierungsschritte
+1. **Anforderungsaufnahme**
+   - Stakeholder: Cartographer-Team, Encounter-Tooling, GM-UX.
+   - Review bestehende Wiki-Guides (`wiki/Encounter.md`) und validiere Soll-Szenarien.
+2. **Datenmodell entwerfen**
+   - Definiere Encounter-DTO (Region-ID, Tile, Odds, Uhrzeit, Trigger-Quelle).
+   - Kläre Persistenz: ephemerer Store vs. Vault-Datei.
+3. **Gateway erweitern**
+   - Ergänze `openEncounter(app, context)` und sichere Abwärtskompatibilität.
+   - Stelle sicher, dass Preload weiterhin funktioniert (Dynamic import bundling prüfen).
+4. **EncounterView aufbauen**
+   - MVP: Anzeige der Metadaten, Link auf relevante Notizen, Buttons für "Start Initiative" / "Encounter erledigt".
+   - Langfristig: Integration mit Library (Monster/Region-Tabellen) und Logging.
+5. **Rückkanal Travel**
+   - Definiere API, über die Encounter das Playback fortsetzen oder Token-Positionen anpassen.
+   - Ergänze Tests für Pause/Resume-Fluss.
+6. **Fehler- & UX-Handling**
+   - Nutzerfreundliche Notices bei Importfehlern oder fehlender Konfiguration.
+   - Telemetrie/Logging-Hooks für Encounter-Lifecycle evaluieren.
+
+## Nächste Schritte (Priorität ↓)
+1. **P0 – Discovery-Workshop** (Owner: Architektur)
+   - Workshop mit Travel- und Encounter-Verantwortlichen ansetzen, um Kontextfelder und UI-Erwartungen zu fixieren.
+   - Dokumentationsergebnis direkt im Encounter-Overview ergänzen.
+2. **P1 – Datenfluss-Prototyp** (Owner: Encounter-Entwicklung)
+   - Minimalen Context-DTO implementieren, Travel-Callback erweitern und Encounter-View die Daten rendern lassen.
+   - Akzeptanzkriterium: Encounter-Trigger zeigt Region & Uhrzeit an und erlaubt "Encounter beendet" als Dummy-Aktion.
+3. **P2 – UX/Tooling-Ausbau** (Owner: GM-UX)
+   - Initiative-Tracker und Verlinkung auf Library-Daten konzipieren.
+   - Ergebnisse als Folge-To-Dos splitten.
+
+## Referenzen
+- Detailanalyse im Dokument [Encounter Workspace – Gateway & Ist-Zustand](../salt-marcher/docs/encounter/overview.md).


### PR DESCRIPTION
## Summary
- add an Encounter documentation folder with an overview of the travel-mode gateway
- link the new encounter docs from the existing repository overviews and add a roadmap todo entry
- capture open questions and planned work for the encounter workspace in a dedicated todo file

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6f05d8e0c8325bf00080c39fd9c8b