### PR TITLE
Document encounter workspace gaps

### DIFF
--- a/Notes/encounter-workspace-review.md
+++ b/Notes/encounter-workspace-review.md
@@ -1,0 +1,32 @@
+# Encounter Workspace – Technische Standortbestimmung
+
+## Ausgangspunkt & Artefakte
+- **Codebasis:** `salt-marcher/src/apps/encounter/view.ts` implementiert `EncounterView` als Obsidian-`ItemView` mit minimalem DOM.
+- **Erwartung:** Laut [Wiki](../wiki/Encounter.md) soll der Workspace Begegnungen aus dem Travel-Modus entgegennehmen, Kontextmaterial bündeln und nach Abschluss die Weiterreise ermöglichen.
+- **Anbindung:** Cartographer ruft `openEncounter(app)` innerhalb von `travel-guide/encounter-gateway.ts` auf; das Gateway lädt lediglich das Encounter-Modul vor und öffnet ein Leaf, sobald `EncounterView` registriert ist.
+
+## Beobachtetes Verhalten (Ist)
+1. `EncounterView.onOpen` leert das Content-Element, setzt die CSS-Klasse `sm-encounter-view`, rendert eine `<h2>`-Überschrift und einen leeren `<div class="desc">` ohne Text oder Interaktionen.【F:salt-marcher/src/apps/encounter/view.ts†L12-L17】
+2. `EncounterView.onClose` entfernt ausschließlich den gerenderten DOM und die CSS-Klasse; es existieren keine weiteren Aufräumarbeiten (Event-Listener, Stores, Controller).【F:salt-marcher/src/apps/encounter/view.ts†L19-L21】
+3. Es gibt keinerlei Persistenz-Hooks (`getViewData`, `setViewData`, `serializeState`) oder Pane-Menü-Einträge, sodass die View im Obsidian-Lifecycle nicht rekonstruierbar ist und keine eigenen Kommandos bereitstellt.【F:salt-marcher/src/apps/encounter/view.ts†L6-L21】
+4. In `src/app/css.ts` oder anderen Stylesheets existiert kein Styling für `sm-encounter-view`; der CSS-Hook bleibt wirkungslos, das Layout entspricht Obsidian-Defaults.
+
+## Abgleich mit Soll-Erwartungen (aus Wiki & Architektur)
+- **Kontextdarstellung:** Wiki erwartet, dass Encounter-Informationen (Gegnerlisten, Notizen, Hand-offs) sichtbar sind. Aktuell fehlt jegliche Datenbindung zu Library-, Regions- oder Travel-Stores; selbst Basisfelder (Titel, Beschreibung) werden nicht geladen.
+- **Interaktionsfluss:** Travel pausiert Playback und ruft `openEncounter`. Die Encounter-View signalisiert jedoch nicht, wann ein Encounter beendet ist oder ob Informationen bestätigt wurden. Es gibt keinen Rückkanal zum Travel-Controller (z. B. via Events oder Services).
+- **Session-Stabilität:** Ohne `setViewState` kann Obsidian die View beim Workspace-Restore nicht rekonstruieren. Ein Reload würde die Encounter-View ohne Inhalt wiederherstellen, wodurch laufende Encounter-Kontexte verloren gehen.
+- **Lifecycle-Hooks:** Standardisierte Hooks wie `onPaneMenu`, `onResize`, `load`/`unload` werden nicht genutzt. Das erschwert Erweiterungen (z. B. eigene Menübefehle, responsive Layouts) und verhindert deterministisches Cleanup, sollte später State hinzukommen.
+- **UX-Konsistenz:** Die View bietet keine Handlungsaufforderung (Buttons, Hinweise) und widerspricht dem Nutzer-Wiki, das die Encounter-View als zentrale Steuerfläche beschreibt. Selbst minimale UX-Elemente (Placeholder-Text, CTA zur Vorbereitung) fehlen.
+
+## Risiken & Auswirkungen
+- **Produktivbetrieb:** Encounter-Trigger landen auf einer leeren Seite; Spielleiter:innen verlieren Kontext und müssen auf externe Notizen ausweichen.
+- **Architektur:** Ohne definierte Schnittstelle zwischen Encounter-View und Domain-Services kann keine weitere Funktionalität inkrementell ergänzt werden; jeder Schritt erfordert grundlegendes Refactoring.
+- **Testing & Automation:** Es existiert kein Einstiegspunkt für Tests (keine separaten Controller oder Services). UI-Logik wäre aktuell nur über DOM-Snaphots testbar.
+
+## Offene Fragen & Folgeaufgaben (siehe TODO)
+1. Welche Datenquelle(n) sollen Encounter-Daten liefern (Regions, Library, externe YAML)?
+2. Benötigt der Workspace einen Presenter/Controller analog zu Cartographer, um Travel-Callbacks sauber zu verarbeiten?
+3. Welche UX-Grundbausteine gelten als Minimalversion (Encounter-Zusammenfassung, Aktionen, Buttons)?
+4. Wie werden Encounter-Zustände persistiert, damit ein Obsidian-Restart keine laufenden Szenen zerstört?
+
+Diese Punkte sind im Detail im To-Do [`todo/encounter-workspace-review.md`](../todo/encounter-workspace-review.md) zu verfolgen.

--- a/salt-marcher/docs/encounter/README.md
+++ b/salt-marcher/docs/encounter/README.md
@@ -1,0 +1,36 @@
+# Encounter Workspace Documentation
+
+## Purpose & Audience
+Dieses Dokument fasst den aktuellen technischen Stand des Encounter-Workspaces zusammen. Es richtet sich an Entwickler:innen, die den Travel→Encounter-Hand-off warten oder zukünftige Encounter-Tools planen. Nutzerorientierte Guides findest du im [Projekt-Wiki](../../../wiki/Encounter.md).
+
+## Strukturübersicht
+```
+docs/encounter/
+└─ README.md
+
+src/apps/encounter/
+└─ view.ts            # Obsidian-ItemView, aktuell nur Platzhalter-Markup
+```
+Der Workspace wird ausschließlich durch `EncounterView` bereitgestellt. Weitere Module (State-Management, Presenter, Styles) fehlen derzeit vollständig.
+
+## Workspace-Komponenten & Verantwortlichkeiten
+- **`EncounterView` (`src/apps/encounter/view.ts`)** – registriert als `salt-encounter`-ItemView. Öffnet beim Travel-Hand-off einen Pane mit Titel "Encounter", fügt `sm-encounter-view` als CSS-Hook hinzu und rendert statisches Header-Markup.
+- **Travel-Anbindung** – Cartographer ruft `openEncounter(app)` aus `travel-guide/encounter-gateway.ts` auf, um die View zu öffnen. Das Gateway erwartet, dass `EncounterView` beim Laden bereit ist, übernimmt jedoch selbst keinerlei UI-Initialisierung.
+
+## Soll-Workflows & Ist-Lücken
+1. **Encounter durch Travel-Events öffnen.** Travel pausiert Playback und fokussiert den Encounter-Workspace. _Ist:_ View rendert nur leeren Placeholder, es existiert kein Zustand oder Rendering der Encounter-Daten.
+2. **Encounter-Kontext anzeigen und bearbeiten.** Erwartet werden Listen von Gegnern, Aktionen oder Notizen gemäß [Encounter-Wiki](../../../wiki/Encounter.md). _Ist:_ Keine UI-Elemente außer Überschrift; keine Verbindung zu Library-/Regions-Daten.
+3. **Encounter schließen und Travel fortsetzen.** Nach Auflösung sollte Travel wiederaufgenommen werden. _Ist:_ View besitzt keine Hooks für Abschlussaktionen oder Kommunikation zurück an Travel.
+
+Die vollständige Gap-Analyse befindet sich in [Notes/encounter-workspace-review.md](../../../Notes/encounter-workspace-review.md).
+
+## Verwandte Dokumente & offene Punkte
+- Travel-Integration: [`docs/cartographer/travel-mode-overview.md`](../cartographer/travel-mode-overview.md)
+- Nutzerworkflows: [`wiki/Encounter.md`](../../../wiki/Encounter.md)
+- Architekturkritik & TODO: [`todo/encounter-workspace-review.md`](../../../todo/encounter-workspace-review.md)
+
+## Standards & Erwartungen
+- Encounter-spezifische Views müssen Obsidian-Lifecycle-Hooks (`onOpen`, `onClose`, perspektivisch `onPaneMenu`, `onload`) nutzen, um DOM- und Event-Listener deterministisch zu verwalten.
+- Datenquellen für Encounter (Regions, Library, Travel-Events) sind strikt voneinander zu entkoppeln. Verwende Stores/Services statt direkten DOM-Zugriffen.
+- Styles für `sm-encounter-view` sind zentral zu bündeln (vgl. `src/app/css.ts`), damit Theme-Anpassungen konsistent bleiben.
+- Erweiterungen oder Refactorings sind im passenden To-Do zu dokumentieren und dort gegen getestete Akzeptanzkriterien abzunehmen.

--- a/todo/encounter-workspace-review.md
+++ b/todo/encounter-workspace-review.md
@@ -1,0 +1,30 @@
+# Encounter workspace review
+
+## Problem Statement
+Travel-triggered Encounter-Events landen in einer Obsidian-View, die nur statisches Placeholder-Markup rendert. Es existiert weder Datenanbindung noch UX, obwohl das Nutzer-Wiki die View als zentrale Steuerfläche beschreibt.
+
+## Betroffene Module
+- `salt-marcher/src/apps/encounter/view.ts` – minimaler `ItemView` ohne State oder Hooks.
+- `salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts` – öffnet Encounter-Leaf, kann derzeit keine Fehler abfedern oder Statusmeldungen austauschen.
+- `salt-marcher/src/app/main.ts` – registriert die Encounter-View, stellt aber keine zusätzlichen Services oder Stores bereit.
+- Dokumentation: [`docs/encounter/README.md`](../salt-marcher/docs/encounter/README.md), [Notes/encounter-workspace-review.md](../Notes/encounter-workspace-review.md), [wiki/Encounter.md](../wiki/Encounter.md).
+
+## Beobachtungen & Gaps
+1. **Lifecycle & Persistenz** – `EncounterView` implementiert ausschließlich `onOpen`/`onClose`. Es fehlen `getViewData`/`setViewState`, Menü-Hooks und Events für Travel-Rückmeldungen. Damit gehen Encounter-Kontexte nach einem Workspace-Restore verloren.
+2. **UI/UX** – Keine Inhalte außer Überschrift + leerem `div.desc`. Erwartete Komponenten (Encounter-Zusammenfassung, Aktionen) existieren nicht; CSS-Hooks bleiben ungenutzt.
+3. **State-Management** – Kein Store oder Service, der Encounter-Daten verwaltet. Travel-Gateway kann keine Daten übergeben oder Fehler anzeigen.
+4. **Testbarkeit** – Mangels Presenter/Controller gibt es keinen Test-Harness. Jede Erweiterung müsste DOM-Tests oder Integrationstests über Obsidian hinaus aufsetzen.
+
+## Offene Fragen & Investigations
+- **Datenfluss definieren:** Welche Quelle liefert Encounter-Details (Regions-Store, Library, dedizierte Encounter-Dateien)?
+- **Controller entwerfen:** Wird ein Presenter benötigt, der Travel-Events entgegennimmt, UI-State verwaltet und Aktionen (z. B. "Encounter abgeschlossen") an Travel zurückmeldet?
+- **UX-Roadmap klären:** Welche Minimalfunktionen (z. B. Gegnerliste, XP-Berechnung, Notiz-Templates) sollen zuerst entstehen, und wie greifen sie auf bestehende Module zu?
+- **Persistenzstrategie:** Wie werden Encounter-Zustände gespeichert, damit Obsidian-Restarts oder View-Schließungen keine Daten verlieren?
+- **Styling & Komponenten:** Müssen gemeinsame UI-Bausteine aus `docs/ui/` genutzt oder erweitert werden, um Encounter-spezifische Layouts konsistent zu halten?
+
+## Nächste Schritte
+1. Workshop mit Produkt- und UX-Verantwortlichen, um Mindestumfang für Encounter-UI festzulegen (Mockups, Akzeptanzkriterien).
+2. Architektur-RFC zur Definition eines Encounter-Presenters inkl. Lifecycle, Services und Persistenzmodell.
+3. Prototyp implementieren, der Travel-Event-Daten annimmt, Basisinformationen rendert und einen Abschluss-Button bereitstellt.
+4. Testsuite erweitern (Unit + Integration), um Encounter-Hand-off, View-Restore und Travel-Rückgabe abzudecken.
+5. Dokumentation aktualisieren (README, Wiki), sobald Architekturentscheidungen gefallen sind.


### PR DESCRIPTION
## Summary
- add encounter workspace documentation outlining structure, responsibilities, and known deficiencies
- capture a technical review of the current Encounter view in the Notes workspace
- register follow-up investigations and next steps in the todo backlog, linking documentation accordingly

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6f45c138083258591cd1718ca2ca1