### PR TITLE
Document cartographer travel UI controllers

### DIFF
--- a/Notes/cartographer-travel-ui-review.md
+++ b/Notes/cartographer-travel-ui-review.md
@@ -1,0 +1,29 @@
+# Cartographer Travel UI – Controller Review
+
+## Ziel & Vorgehen
+Audit der Travel-UI-Controller hinsichtlich Ereignisverwaltung, Benennungskonsistenz und Adapter-Erwartungen. Fokus auf Drag-Steuerung, Kontextmenü sowie Token- und Routen-Layer. Ergebnisse dienen als Grundlage für gezielte Refactorings und Tests.
+
+## Drag-Controller (`drag.controller.ts`)
+- **Event-Kaskade & Pointer-Capture:** Verwendet globale `pointerdown`-Capture-Listener zur Klickunterdrückung und bindet `pointermove`/`pointerup` am `window`, wodurch Abmeldungen zwingend über `unbind()` erfolgen müssen. Während aktiver Drags wird `pointerEvents` für die Routen-Layer deaktiviert; ein früher `unbind()`-Call während eines laufenden Drags würde `disableLayerHit(false)` nicht aufrufen und damit Hover/Click dauerhaft sperren.
+- **Release-Pfade:** `endDrag()` verlässt sich auf implizites Pointer-Capture-Release durch `pointerup`. Es existiert kein expliziter `releasePointerCapture`, was bei verlorenen `pointerup`-Events (z. B. Fensterwechsel) zu hängendem Capture führen kann.
+- **Adapter-Annahmen:** Erwartet, dass `RenderAdapter.ensurePolys` synchron Polygone materialisiert und dass `adapter.centerOf()` für jede Koordinate einen Mittelpunkt liefert, sonst brechen Ghost-Updates stillschweigend ab. Ghost-Move aktualisiert DOM-Attribute direkt ohne Fallback auf Presenter- oder Layer-Abgleich.
+- **State-Guards:** `consumeClickSuppression()` unterdrückt Folgeklicks, aber `suppressNextHexClick` wird an mehreren Stellen gesetzt (global pointerdown, Drag-Start, Commit). Ohne zusätzliche Logging/Tests lässt sich schwer validieren, ob Klicks in Race-Szenarien (z. B. schneller Doppelklick) fälschlich blockiert werden.
+
+## Kontextmenü (`contextmenue.ts`)
+- **Benennungsabweichung:** Dateiname und Export (`contextmenue`) verwenden ein „e“ zu viel. Das erschwert Suchvorgänge und konsistente Benennung im gesamten UI-Stack.
+- **Event-Härtung:** Bindet `contextmenu` mit Capture-Phase, verhindert Standardmenü aber ruft `stopPropagation()` nur beim Löschen. Bei nicht-löschbaren Punkten (`kind !== "user"`) propagiert das Event weiter und verhindert lediglich das Browser-Menü – Seiteneffekte anderer Listener sind unklar.
+- **State-Annahme:** Vertraut darauf, dass `logic.getState().route[idx]` existiert und `deleteUserAt` robust gegen Paralleländerungen ist. Es gibt keinen Abgleich mit `editIdx`/Drag-State, wodurch Lösch- und Drag-Operationen kollidieren könnten.
+
+## Token-Layer (`token-layer.ts`)
+- **Pointer-Policy:** Layer aktiviert Pointer-Events (`pointerEvents = "auto"`) und Cursor-Feedback für Drag, verlässt sich darauf, dass der Drag-Controller die tatsächliche Interaktion übernimmt. Fehlende eigene Listener vermeiden Doppelzuständigkeit, erfordern aber klare Dokumentation zum Pointer-Capture-Besitz.
+- **Animationssteuerung:** `moveTo()` nutzt `requestAnimationFrame` mit Abbruchlogik; laufende Animationen werden bei `setPos`, `moveTo` und `destroy` über `cancelActiveAnimation()` abgeräumt. Fehlerfall-Handling (`TokenMoveCancelled`) wird nirgendwo gefangen – Tests sollten sicherstellen, dass Aufrufer Rejections handhaben.
+
+## Routen-Layer (`route-layer.ts`)
+- **Render-Delegation:** Layer kapselt lediglich DOM-Erzeugung und delegiert `draw`/`highlight` an `drawRoute` bzw. `updateHighlight`. Erwartet, dass `drawRoute` Marker mitsamt Hitboxen erzeugt und `polyToCoord`-Map aktuell gehalten wird; Layer selbst synchronisiert keine Hitbox-Attribute.
+- **Lifecycle-Verantwortung:** `destroy()` entfernt nur das `<g>`-Element. Wenn externe Controller noch Referenzen (z. B. `routeLayerEl`) halten, verbleiben Event-Listener (`contextmenu`, Pointer) aktiv. Erfordert klare Ownership-Vereinbarung im Adapter/Presenter.
+
+## Empfohlene Prüfungen
+- Tests oder Logging für Drag-Abbruchpfade (Fensterwechsel, Pointercancel), um Pointer-Capture-Hänger zu erkennen.
+- Abklärung, ob Kontextmenü-Events an weiteren Stellen verarbeitet werden und ob zusätzliche `stopPropagation()` notwendig ist.
+- Verifizieren, dass Token-Animation-Rejections von aufrufenden Services behandelt werden, um unhandled promise rejections zu vermeiden.
+- Sicherstellen, dass Routen-Layer-Destroy zeitlich mit `unbind()` der Controller gekoppelt wird, um Event-Leaks zu verhindern.

--- a/salt-marcher/docs/cartographer/travel-ui/README.md
+++ b/salt-marcher/docs/cartographer/travel-ui/README.md
@@ -1,0 +1,36 @@
+# Cartographer Travel UI Documentation
+
+## Überblick
+Dieser Ordner beschreibt die UI-spezifischen Controller und Layer des Travel-Modus im Cartographer. Fokus: Event-Management, Pointer-Capture-Strategie sowie Zusammenspiel zwischen Drag-, Kontextmenü- und Layer-Adaptern.
+
+## Struktur
+```
+docs/cartographer/travel-ui/
+└─ README.md
+```
+
+## Module & Zuständigkeiten
+- `src/apps/cartographer/travel/ui/drag.controller.ts` – Globale Pointer-Event-Verwaltung für Dot- und Token-Drags inklusive Ghost-Preview.
+- `src/apps/cartographer/travel/ui/contextmenue.ts` – Rechtsklick-Löschen von nutzerdefinierten Routenpunkten.
+- `src/apps/cartographer/travel/ui/token-layer.ts` – Rendering und Animation des Travel-Tokens, stellt `TokenCtl` für den Drag-Controller.
+- `src/apps/cartographer/travel/ui/route-layer.ts` – Wrapper über `drawRoute`/`updateHighlight`, verwaltet das SVG-Routen-Layer.
+- `src/apps/cartographer/travel/ui/controls.ts` & `sidebar.ts` – UI-Komponenten für Playback/Inspect (nicht Teil dieser Analyse, hier nur zur Vollständigkeit aufgeführt).
+
+## Kern-Workflows
+1. **Drag-Workflow:** `drag.controller` bindet Pointer-Events an Route-Dots und das Token. Während des Drags deaktiviert es die Hitbox der Routen-Layer, bewegt Ghost-Dots/Token über `adapter.centerOf()` und committed Koordinaten via `logic.moveSelectedTo` bzw. `logic.moveTokenTo` nach Loslassen.
+2. **Kontextmenü-Löschen:** `contextmenue` interceptiert das Browser-Kontextmenü auf Route-Dots, validiert `RouteNode.kind === "user"` und delegiert Löschvorgänge an `logic.deleteUserAt`.
+3. **Token-Animation:** `token-layer` erzeugt das Token-`<g>` im SVG-Baum, kapselt `setPos`/`moveTo`/`stop` und blendet das Token auf Anfrage ein oder aus. Drag-Controller nutzt `setPos`/`show`, während Presenter/Playback `moveTo` für animiertes Reisen verwenden.
+
+## Standards & Policies
+- **Namenskonvention:** Module mit UI-spezifischen Events verwenden durchgängig das Suffix `.controller.ts` bzw. `.layer.ts`. Kontextmenü-Dateien sollen `context-menu`-Schreibweise übernehmen (siehe To-Do).
+- **Pointer-Capture-Policy:** Nur der Drag-Controller ruft `setPointerCapture` auf (`drag.controller.ts`). Andere Module interagieren nicht mit Pointer-Capture und respektieren damit eine zentrale Besitzregelung.
+- **Layer-Lifecycle:** `route-layer` und `token-layer` stellen ein `destroy()` bereit, das beim Moduswechsel gemeinsam mit `unbind()` der Controller aufzurufen ist, um Event-Leaks und hängende Pointer-Capture-Zustände zu vermeiden.
+- **Event-Suppression:** `drag.controller.consumeClickSuppression()` muss von Hex-Click-Handlern abgefragt werden, um Ghost-Klicks nach Drags abzufangen.
+
+## Weiterführende Ressourcen
+- Analyse & Audit-Notizen: [Notes/cartographer-travel-ui-review.md](../../../Notes/cartographer-travel-ui-review.md)
+- Travel-Mode-Überblick: [../travel-mode-overview.md](../travel-mode-overview.md)
+- Cartographer-Grundlagen: [../README.md](../README.md)
+
+## To-Do
+- [Cartographer travel UI review](../../../../todo/cartographer-travel-ui-review.md) – Sammlung konkreter Refactoring- und Testaufgaben basierend auf der Audit-Notiz.

--- a/todo/cartographer-travel-ui-review.md
+++ b/todo/cartographer-travel-ui-review.md
@@ -1,0 +1,23 @@
+# Cartographer Travel UI Review
+
+## Kontext
+Audit aus [Notes/cartographer-travel-ui-review.md](../Notes/cartographer-travel-ui-review.md) deckt Event- und Lifecycle-Risiken der Travel-spezifischen UI-Controller auf. To-Do bündelt Folgearbeiten für Drag-Steuerung, Kontextmenü und Layer.
+
+## Betroffene Module
+- `src/apps/cartographer/travel/ui/drag.controller.ts`
+- `src/apps/cartographer/travel/ui/contextmenue.ts`
+- `src/apps/cartographer/travel/ui/token-layer.ts`
+- `src/apps/cartographer/travel/ui/route-layer.ts`
+
+## Aufgaben
+1. **Naming bereinigen:** Datei `contextmenue.ts` in `context-menu.controller.ts` umbenennen, Exporte anpassen und Dokumentation aktualisieren.
+2. **Typisierung schärfen:** `LogicPort`-Definitionen in Drag- und Kontextmenü-Controller auf zentrale Domain-Typen refaktorieren (keine Inline-Strukturen). Optional generische Ports/Interfaces im `infra`-Layer einführen.
+3. **Pointer-Capture absichern:** Drag-Controller erweitern, um `releasePointerCapture` bei `unbind()` oder `pointercancel` aufzurufen; Tests für Fensterwechsel/Abort-Szenarien ergänzen.
+4. **Event-Propagation prüfen:** Kontextmenü-Handler um konsistentes `stopPropagation()` ergänzen und Integrationstests schreiben, die Konflikte mit anderen Listenern ausschließen.
+5. **Token-Animation testen:** Unit-/Integrationstests erstellen, die `TokenCtl.moveTo()`-Abbrüche abdecken und sicherstellen, dass Aufrufer `TokenMoveCancelled` behandeln.
+6. **Lifecycle-Kopplung dokumentieren:** Sicherstellen, dass Presenter beim Moduswechsel `destroy()` der Layer und `unbind()` der Controller konsistent aufruft; falls fehlend, Follow-up-Refactoring planen.
+
+## Lösungsideen & Hinweise
+- Tests bevorzugt mit jsdom + PointerEvent-Mocks oder Playwright-E2E für Drag/Drop.
+- Naming-Änderungen sollten Style-Guide-Erweiterungen (Kontextmenü-Schreibweise) dokumentieren.
+- Bei Typverfeinerungen zuerst Adapter-Signaturen aus `infra/adapter.ts` analysieren, um Doppelnamen zu vermeiden.


### PR DESCRIPTION
## Summary
- capture findings from the travel UI controller review in Notes, covering drag, context menu, token, and route layers
- add a travel UI documentation entry under docs/cartographer outlining modules, workflows, and standards
- record follow-up remediation tasks in a dedicated To-Do and link it from the documentation

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d6f45e8288832580686e5e87888073