### PR TITLE
Refine travel travel UI controllers and tests

### DIFF
--- a/salt-marcher/docs/cartographer/travel-ui/README.md
+++ b/salt-marcher/docs/cartographer/travel-ui/README.md
@@ -7,11 +7,22 @@ Dieser Ordner beschreibt die UI-spezifischen Controller und Layer des Travel-Mod
 ```
 docs/cartographer/travel-ui/
 └─ README.md
+
+src/apps/cartographer/travel/ui/
+├─ context-menu.controller.ts
+├─ contextmenue.ts               (Legacy Re-Export, wird entfernt)
+├─ controls.ts
+├─ drag.controller.ts
+├─ map-layer.ts
+├─ route-layer.ts
+├─ sidebar.ts
+├─ token-layer.ts
+└─ types.ts
 ```
 
 ## Module & Zuständigkeiten
 - `src/apps/cartographer/travel/ui/drag.controller.ts` – Globale Pointer-Event-Verwaltung für Dot- und Token-Drags inklusive Ghost-Preview.
-- `src/apps/cartographer/travel/ui/contextmenue.ts` – Rechtsklick-Löschen von nutzerdefinierten Routenpunkten.
+- `src/apps/cartographer/travel/ui/context-menu.controller.ts` – Rechtsklick-Löschen von nutzerdefinierten Routenpunkten (`contextmenue.ts` re-exportiert vorerst für Altimporte).
 - `src/apps/cartographer/travel/ui/token-layer.ts` – Rendering und Animation des Travel-Tokens, stellt `TokenCtl` für den Drag-Controller.
 - `src/apps/cartographer/travel/ui/route-layer.ts` – Wrapper über `drawRoute`/`updateHighlight`, verwaltet das SVG-Routen-Layer.
 - `src/apps/cartographer/travel/ui/controls.ts` & `sidebar.ts` – UI-Komponenten für Playback/Inspect (nicht Teil dieser Analyse, hier nur zur Vollständigkeit aufgeführt).
@@ -23,9 +34,14 @@ docs/cartographer/travel-ui/
 
 ## Standards & Policies
 - **Namenskonvention:** Module mit UI-spezifischen Events verwenden durchgängig das Suffix `.controller.ts` bzw. `.layer.ts`. Kontextmenü-Dateien sollen `context-menu`-Schreibweise übernehmen (siehe To-Do).
-- **Pointer-Capture-Policy:** Nur der Drag-Controller ruft `setPointerCapture` auf (`drag.controller.ts`). Andere Module interagieren nicht mit Pointer-Capture und respektieren damit eine zentrale Besitzregelung.
+- **Pointer-Capture-Policy:** Nur der Drag-Controller ruft `setPointerCapture` auf (`drag.controller.ts`). Er ist außerdem verpflichtet, Pointer-Capture bei jedem Ende (`pointerup`, `pointercancel`, Programm-Abbruch) wieder freizugeben.
 - **Layer-Lifecycle:** `route-layer` und `token-layer` stellen ein `destroy()` bereit, das beim Moduswechsel gemeinsam mit `unbind()` der Controller aufzurufen ist, um Event-Leaks und hängende Pointer-Capture-Zustände zu vermeiden.
 - **Event-Suppression:** `drag.controller.consumeClickSuppression()` muss von Hex-Click-Handlern abgefragt werden, um Ghost-Klicks nach Drags abzufangen.
+
+## Lifecycle & Cleanup
+- **Initialisierung:** `drag.controller.bind()` sowie `bindContextMenu()` werden nach dem Aufbau des `route-layer` aufgerufen. Beide setzen voraus, dass `types.ts`-Verträge (Ports) erfüllt sind.
+- **Drag-Ende:** Der Drag-Controller gibt Pointer-Capture immer frei (auch bei frühzeitigen Abbrüchen) und reaktiviert das Routen-Layer für Hit-Tests.
+- **Teardown:** Beim Verlassen des Travel-Modus sind `drag.controller.unbind()`, die Rückgabe von `bindContextMenu()` sowie `token-layer.destroy()` aufzurufen. Offene Animationen werden dadurch abgebrochen und Promises mit `TokenMoveCancelled` verworfen.
 
 ## Weiterführende Ressourcen
 - Analyse & Audit-Notizen: [Notes/cartographer-travel-ui-review.md](../../../Notes/cartographer-travel-ui-review.md)

--- a/salt-marcher/src/apps/cartographer/travel/ui/context-menu.controller.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/context-menu.controller.ts
@@ -1,0 +1,34 @@
+// Context-menu handling for removing user-created travel route dots.
+// UI-only module: delegates deletions to the travel logic port.
+
+import type { ContextMenuLogicPort } from "./types";
+
+export function bindContextMenu(routeLayerEl: SVGGElement, logic: ContextMenuLogicPort): () => void {
+    const onContextMenu = (ev: MouseEvent) => {
+        const target = ev.target;
+        if (!(target instanceof SVGCircleElement)) return;
+
+        const idxAttr = target.getAttribute("data-idx");
+        if (!idxAttr) return;
+
+        const idx = Number(idxAttr);
+        if (!Number.isFinite(idx) || idx < 0) return;
+
+        const route = logic.getState().route;
+        const node = route[idx];
+        if (!node) return;
+
+        // Only allow user-generated nodes to be removed via context menu.
+        if (node.kind !== "user") {
+            ev.preventDefault();
+            return;
+        }
+
+        ev.preventDefault();
+        ev.stopPropagation();
+        logic.deleteUserAt(idx);
+    };
+
+    routeLayerEl.addEventListener("contextmenu", onContextMenu, { capture: true });
+    return () => routeLayerEl.removeEventListener("contextmenu", onContextMenu as any, { capture: true } as any);
+}

--- a/salt-marcher/src/apps/cartographer/travel/ui/contextmenue.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/contextmenue.ts
@@ -1,38 +1,5 @@
-// RMB-Löschen: nur hier! UI-only, ruft deleteUserAt(idx) in der Logik.
+// Deprecated shim to keep legacy imports working while transitioning to the
+// correctly named controller module. Remove once all callers migrated.
 
-import type { RouteNode } from "../domain/types";
-
-type LogicPort = {
-    getState(): { route: RouteNode[] };
-    deleteUserAt(idx: number): void;
-};
-
-export function bindContextMenu(routeLayerEl: SVGGElement, logic: LogicPort): () => void {
-    const onContextMenu = (ev: MouseEvent) => {
-        const t = ev.target as Element | null;
-        if (!(t instanceof SVGCircleElement)) return;
-
-        const idxAttr = t.getAttribute("data-idx");
-        if (!idxAttr) return;
-
-        const idx = Number(idxAttr);
-        if (!Number.isFinite(idx) || idx < 0) return;
-
-        const route = logic.getState().route;
-        const node = route[idx];
-        if (!node) return;
-
-        // Nur user-Punkte dürfen gelöscht werden
-        if (node.kind !== "user") {
-            ev.preventDefault(); // blockiere Browser-Menü, aber keine Aktion
-            return;
-        }
-
-        ev.preventDefault();
-        ev.stopPropagation();
-        logic.deleteUserAt(idx);
-    };
-
-    routeLayerEl.addEventListener("contextmenu", onContextMenu, { capture: true });
-    return () => routeLayerEl.removeEventListener("contextmenu", onContextMenu as any, { capture: true } as any);
-}
+export { bindContextMenu } from "./context-menu.controller";
+export type { ContextMenuLogicPort } from "./types";

--- a/salt-marcher/src/apps/cartographer/travel/ui/types.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/types.ts
@@ -1,0 +1,37 @@
+// Shared UI-facing domain typings for the travel cartographer stack.
+// Keeps controller modules aligned with the logic contract.
+
+import type { Coord, RouteNode } from "../domain/types";
+
+/**
+ * Minimal state snapshot required by UI controllers that need to inspect
+ * the editable travel route. The drag controller additionally relies on the
+ * `editIdx` to determine which dot is under manipulation.
+ */
+export type RouteEditSnapshot = {
+    route: RouteNode[];
+    editIdx: number | null;
+};
+
+/**
+ * Contract for the context-menu controller: expose the current route snapshot
+ * and allow user-created dots to be removed.
+ */
+export type ContextMenuLogicPort = {
+    getState(): Pick<RouteEditSnapshot, "route">;
+    deleteUserAt(idx: number): void;
+};
+
+/**
+ * Contract for the drag controller: allow selecting dots, moving them and the
+ * travel token, and provide access to the editable route state.
+ */
+export type DragLogicPort = {
+    getState(): RouteEditSnapshot;
+    selectDot(idx: number | null): void;
+    moveSelectedTo(rc: Coord): void;
+    moveTokenTo(rc: Coord): void;
+};
+
+// Re-export the core domain coordinates to keep imports local to the UI layer.
+export type { Coord, RouteNode } from "../domain/types";

--- a/salt-marcher/tests/cartographer/travel/token-layer.test.ts
+++ b/salt-marcher/tests/cartographer/travel/token-layer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { createTokenLayer } from "../../../src/apps/cartographer/travel/ui/token-layer";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+describe("token-layer animations", () => {
+    let host: SVGGElement;
+    let rafQueue: Array<{ id: number; cb: FrameRequestCallback }>;
+    let rafId: number;
+    let now: number;
+    let performanceSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+    const flushRaf = (ms: number) => {
+        now += ms;
+        const callbacks = rafQueue.slice();
+        rafQueue = [];
+        for (const { cb } of callbacks) {
+            cb(now);
+        }
+    };
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        const svg = document.createElementNS(SVG_NS, "svg");
+        host = document.createElementNS(SVG_NS, "g");
+        svg.appendChild(host);
+        document.body.appendChild(svg);
+
+        now = 0;
+        rafQueue = [];
+        rafId = 1;
+
+        vi.useFakeTimers();
+        vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+            const id = rafId++;
+            rafQueue.push({ id, cb });
+            return id;
+        });
+        vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+            rafQueue = rafQueue.filter((entry) => entry.id !== id);
+        });
+        performanceSpy = vi.spyOn(performance, "now").mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        if (performanceSpy) {
+            performanceSpy.mockRestore();
+            performanceSpy = null;
+        }
+        rafQueue = [];
+        vi.useRealTimers();
+    });
+
+    it("animates towards the requested position over time", async () => {
+        const token = createTokenLayer(host);
+        expect(token.el.style.display).toBe("none");
+
+        const promise = token.moveTo(90, 45, 200);
+
+        flushRaf(100); // Halfway through the duration
+        expect(token.el.getAttribute("transform")).toBe("translate(45,22.5)");
+
+        flushRaf(100); // Finish animation
+        await promise;
+        expect(token.el.getAttribute("transform")).toBe("translate(90,45)");
+    });
+
+    it("cancels the previous animation when a new move starts", async () => {
+        const token = createTokenLayer(host);
+
+        const first = token.moveTo(60, 30, 400);
+        flushRaf(100);
+
+        const second = token.moveTo(100, 50, 200);
+        await expect(first).rejects.toMatchObject({ name: "TokenMoveCancelled" });
+
+        flushRaf(100);
+        flushRaf(100);
+        await second;
+        expect(token.el.getAttribute("transform")).toBe("translate(100,50)");
+    });
+
+    it("rejects the active animation promise when stopped manually", async () => {
+        const token = createTokenLayer(host);
+
+        const pending = token.moveTo(20, 10, 300);
+        flushRaf(100);
+
+        token.stop();
+        await expect(pending).rejects.toMatchObject({ name: "TokenMoveCancelled" });
+    });
+});


### PR DESCRIPTION
## Summary
- add shared travel UI logic port typings and migrate drag/context-menu controllers to use them
- move the context menu controller to the new `context-menu.controller.ts` module while keeping a temporary shim for legacy imports
- improve drag pointer capture cleanup and add token-layer animation tests alongside updated lifecycle documentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f76d0114832584ce0fe39243854a