### PR TITLE
Harden layout editor bridge integration

### DIFF
--- a/salt-marcher/docs/app/layout-editor-bridge.md
+++ b/salt-marcher/docs/app/layout-editor-bridge.md
@@ -10,30 +10,38 @@ docs/app/
 └─ layout-editor-bridge.md    # Dieses Dokument
 
 src/app/
+├─ integration-telemetry.ts   # Gemeinsame Fehler-Telemetrie & Notices
 └─ layout-editor-bridge.ts    # Bridge-Implementierung
+
+tests/app/
+└─ layout-editor-bridge.test.ts  # Lifecycle- und Fehlerpfad-Tests
 ```
 
 ## Integrationsvertrag
-- **Registrierung**: `setupLayoutEditorBridge(plugin)` wird aus `main.ts` mit dem aktuellen Plugin-Objekt aufgerufen. Die Funktion sucht über `app.plugins.getPlugin("layout-editor")?.getApi?.()` nach dem Fremd-Plugin und erwartet ein API-Objekt mit `registerViewBinding` und `unregisterViewBinding`.
+- **Registrierung**: `setupLayoutEditorBridge(plugin)` wird aus `main.ts` mit dem aktuellen Plugin-Objekt aufgerufen. Die Funktion sucht über `app.plugins.getPlugin("layout-editor")?.getApi?.()` nach dem Fremd-Plugin. Das erwartete API-Objekt muss mindestens `registerViewBinding` bereitstellen; `unregisterViewBinding` wird genutzt, wenn vorhanden.
 - **View Binding**: Bei erfolgreichem Lookup registriert die Bridge ein Binding mit der Kennung `salt-marcher.cartographer-map`. Die ID ist Teil des Vertrags; Layout-Editor-Konfigurationen, die auf Salt Marcher verweisen, nutzen diesen Schlüssel.
-- **Lifecycle Hooks**: Die Bridge hört auf Obsidian-Events (`layout-ready`) sowie auf Plugin-Lifecycle (`plugin-enabled`/`plugin-disabled`) und führt `registerViewBinding` bzw. `unregisterViewBinding` deterministisch aus. Das von `setupLayoutEditorBridge` gelieferte Dispose-Callback räumt dieselben Bindings auf und entfernt die Event-Hooks wieder.
-- **Fehlerbild**: Fehlschläge beim Registrieren/ Deregistrieren werden in der Konsole protokolliert; der Bridge-Code bricht nicht ab, wenn das Layout-Editor-Plugin fehlt oder inkompatible APIs liefert.
+- **Lifecycle Hooks**: Die Bridge hört auf Obsidian-Events (`layout-ready`) sowie auf Plugin-Lifecycle (`plugin-enabled`/`plugin-disabled`). Die Listener sind jetzt streng typisiert (`PluginLifecycleEmitter`) und werden über das Rückgabecallback deterministisch abgeräumt.
+- **Fehlerbild & Telemetrie**: Fehlschläge bei API-Auflösung, Registrierung oder Deregistrierung werden über `reportIntegrationIssue` gemeldet. Das Hilfsmodul schreibt eine `console.error`-Spur und zeigt deduplizierte Notices mit konkretem Kontext an (Registrierung, Deregistrierung, inkompatible API).
 
 ## Abhängigkeiten & Erwartungen
-- **Layout Editor Plugin**: Muss einen synchronen `getApi()`-Zugriff bereitstellen. Alle Methoden sind optional, weshalb der Bridge-Code defensive Guards benötigt.
-- **Plugin-Manager-Emitter**: Wir verlassen uns darauf, dass `app.plugins.on/off` EventEmitter-ähnliche Methoden bereitstellen und ein Token zurückgeben, das später wiederverwendet werden kann. Dieses Verhalten ist nicht offiziell dokumentiert (siehe Review-Notizen).
+- **Layout Editor Plugin**: Muss einen synchronen `getApi()`-Zugriff bereitstellen. Gibt `getApi()` vorübergehend `null/undefined` zurück, wiederholt die Bridge den Versuch beim nächsten Lifecycle-Event. Eine inkompatible API (fehlendes `registerViewBinding`) führt zu einem deduplizierten Fehlerhinweis.
+- **Plugin-Manager-Emitter**: Wir kapseln `app.plugins.on/off` über `bindLifecycleEmitter`, sodass Listener automatisch mit dem korrekten Kontext verknüpft werden. Fallback: Wenn `off` fehlt oder `on` kein Token zurückgibt, verzichtet die Bridge auf das Abmelden.
+- **Telemetrie-Helfer**: `integration-telemetry.ts` stellt eine zentrale Schnittstelle für Integrationsprobleme bereit. Notices sind bewusst kurz gehalten und verweisen auf das Debug-Log für Details.
 - **Obsidian Lifecycle**: Die Bridge wird ausschließlich über das App-Bootstrap-Modul verwaltet. Andere Komponenten dürfen das Layout-Editor-API nicht direkt ansprechen, um die Verantwortung klar zu halten.
 
 ## Defensive Coding Standards
 - **Feature-Detection zuerst**: Jede neue Interaktion mit dem Layout-Editor muss optional bleiben (typeof-/in-Checks) und darf bei fehlender API still aussteigen.
 - **Idempotenz erzwingen**: Halte `tryRegister`/`unregister` reentrant, indem du Sentinels wie `unregister`-Closures oder Flag-States nutzt.
-- **Bound Context**: Wenn Methoden des Plugin-Managers (`on`/`off`) zwischengespeichert werden, müssen sie an den ursprünglichen Kontext gebunden (`bind`) werden, damit Obsidian-internes State-Handling nicht verloren geht.
-- **Fehlerlog sichtbar halten**: Catch-Blöcke müssen `console.error` nutzen und die Layout-Editor-ID nennen, damit Support-Fälle im Debug-Log auffindbar sind. Mittel- bis langfristig sind strukturierte Telemetrie und UI-Feedback geplant.
+- **Bound Context**: Lifecycle-Methoden des Plugin-Managers werden via `bind` an den ursprünglichen Kontext gebunden, damit Obsidian-internes State-Handling nicht verloren geht.
+- **Fehlerlog sichtbar halten**: `reportIntegrationIssue` liefert strukturierte Fehlermeldungen inklusive Notices. Zusätzliche Fehlerzweige müssen denselben Pfad nutzen, damit Nutzer:innen informiert bleiben.
 - **Isolierte Teardown-Signatur**: Das Dispose-Callback darf keine zusätzlichen Parameter erwarten. Es wird von `main.ts` direkt in `onunload` durchgereicht.
 
 ## Offene Punkte
-Anstehende Maßnahmen (typisierte APIs, Telemetrie, Tests) sind im [To-Do: Layout Editor Bridge Review](../../todo/layout-editor-bridge-review.md) dokumentiert.
+- Prüfen, ob das Layout-Editor-Plugin mittelfristig weitere Hooks (z. B. Status-Abfragen) bereitstellt, die wir spiegeln möchten.
+- `todo/layout-editor-bridge-review.md` hält den historischen Review-Kontext fest und sollte nach der nächsten Plugin-Version aktualisiert werden, falls sich der Integrationsvertrag erneut ändert.
 
 ## Weiterführende Ressourcen
 - Lifecycle-Analyse: [`Notes/layout-editor-bridge-review.md`](../../Notes/layout-editor-bridge-review.md)
 - Implementierung: [`src/app/layout-editor-bridge.ts`](../../salt-marcher/src/app/layout-editor-bridge.ts)
+- Telemetrie: [`src/app/integration-telemetry.ts`](../../salt-marcher/src/app/integration-telemetry.ts)
+- Tests: [`tests/app/layout-editor-bridge.test.ts`](../../salt-marcher/tests/app/layout-editor-bridge.test.ts)

--- a/salt-marcher/src/app/integration-telemetry.ts
+++ b/salt-marcher/src/app/integration-telemetry.ts
@@ -1,0 +1,45 @@
+import { Notice } from "obsidian";
+
+/** Identifies the bridge/integration that surfaced an operational issue. */
+export type IntegrationId = string;
+
+/** Supported failure modes emitted by layout/editor style integrations. */
+export type IntegrationOperation =
+    | "resolve-api"
+    | "register-view-binding"
+    | "unregister-view-binding";
+
+export interface IntegrationIssuePayload {
+    /** Stable integration identifier (e.g. the external plugin id). */
+    integrationId: IntegrationId;
+    /** The failing operation within the integration lifecycle. */
+    operation: IntegrationOperation;
+    /** Captured error/exception for diagnostic logging. */
+    error: unknown;
+    /** User-facing explanation shown as an Obsidian notice. */
+    userMessage: string;
+}
+
+const notifiedOperations = new Set<string>();
+
+/**
+ * Reports integration issues to both the developer console and the user.
+ * Repeated failures for the same integration & operation are deduplicated
+ * to avoid notice spam.
+ */
+export function reportIntegrationIssue(payload: IntegrationIssuePayload): void {
+    const { integrationId, operation, error, userMessage } = payload;
+    const logPrefix = `[salt-marcher] integration(${integrationId}) ${operation} failed`;
+    console.error(logPrefix, error);
+
+    const dedupeKey = `${integrationId}:${operation}`;
+    if (notifiedOperations.has(dedupeKey)) return;
+    notifiedOperations.add(dedupeKey);
+
+    new Notice(userMessage);
+}
+
+/** @internal - Test hook to clear deduplicated notice state. */
+export function __resetIntegrationIssueTelemetry(): void {
+    notifiedOperations.clear();
+}

--- a/salt-marcher/src/app/layout-editor-bridge.ts
+++ b/salt-marcher/src/app/layout-editor-bridge.ts
@@ -3,7 +3,11 @@
 // registrieren wir einen View-Binding-Eintrag, damit der neue View Container des
 // Layout Editors die Cartographer-Karte als Feature anbieten kann.
 
-import type { App, Plugin } from "obsidian";
+import type { App, EventRef, Plugin } from "obsidian";
+import {
+    reportIntegrationIssue,
+    type IntegrationIssuePayload,
+} from "./integration-telemetry";
 
 type LayoutEditorViewBinding = {
     id: string;
@@ -12,88 +16,184 @@ type LayoutEditorViewBinding = {
 };
 
 type LayoutEditorPluginApi = {
-    registerViewBinding?(definition: LayoutEditorViewBinding): void;
+    registerViewBinding(definition: LayoutEditorViewBinding): void;
     unregisterViewBinding?(id: string): void;
+};
+
+type LayoutEditorPlugin = {
+    getApi?: () => unknown;
 };
 
 type PluginLifecycleEvent = "plugin-enabled" | "plugin-disabled";
 type PluginEventRef = unknown;
+type PluginLifecycleHandler = (id: string) => void;
+
 type PluginLifecycleEmitter = {
-    on?(event: PluginLifecycleEvent, callback: (id: string) => void): PluginEventRef;
+    on(event: PluginLifecycleEvent, callback: PluginLifecycleHandler): PluginEventRef | void;
     off?(event: PluginLifecycleEvent, ref: PluginEventRef): void;
+};
+
+type BoundLifecycleEmitter = {
+    on: PluginLifecycleEmitter["on"];
+    off?: PluginLifecycleEmitter["off"];
 };
 
 const LAYOUT_EDITOR_PLUGIN_ID = "layout-editor";
 const MAP_VIEW_BINDING_ID = "salt-marcher.cartographer-map";
 
+const REGISTER_NOTICE =
+    "Salt Marcher konnte die Layout-Editor-Bridge nicht aktivieren. Prüfe das Debug-Log.";
+const UNREGISTER_NOTICE =
+    "Salt Marcher konnte die Layout-Editor-Bridge nicht sauber deaktivieren. Prüfe das Debug-Log.";
+const INVALID_API_NOTICE =
+    "Salt Marcher fand eine inkompatible Layout-Editor-API. Bitte Plugin-Version prüfen.";
+
+const VIEW_BINDING: LayoutEditorViewBinding = Object.freeze({
+    id: MAP_VIEW_BINDING_ID,
+    label: "Salt Marcher – Hex Map",
+    description: "Cartographer-View mit renderHexMap & Token-Workflow.",
+});
+
+function emitIntegrationIssue(
+    overrides: Pick<IntegrationIssuePayload, "operation" | "error" | "userMessage">
+): void {
+    reportIntegrationIssue({
+        integrationId: LAYOUT_EDITOR_PLUGIN_ID,
+        ...overrides,
+    });
+}
+
+function bindLifecycleEmitter(manager: App["plugins"]): BoundLifecycleEmitter | null {
+    const candidate = manager as Partial<PluginLifecycleEmitter>;
+    if (typeof candidate.on !== "function") {
+        return null;
+    }
+    return {
+        on: candidate.on.bind(candidate) as PluginLifecycleEmitter["on"],
+        off:
+            typeof candidate.off === "function"
+                ? (candidate.off.bind(candidate) as PluginLifecycleEmitter["off"])
+                : undefined,
+    };
+}
+
 function resolveLayoutEditorApi(app: App): LayoutEditorPluginApi | null {
-    const layoutEditor: unknown = app.plugins.getPlugin(LAYOUT_EDITOR_PLUGIN_ID);
-    if (!layoutEditor || typeof layoutEditor !== "object") return null;
-    const api: unknown = (layoutEditor as { getApi?: () => unknown }).getApi?.();
-    if (!api || typeof api !== "object") return null;
-    return api as LayoutEditorPluginApi;
+    const plugin = app.plugins.getPlugin(LAYOUT_EDITOR_PLUGIN_ID) as LayoutEditorPlugin | null;
+    if (!plugin) return null;
+
+    if (typeof plugin.getApi !== "function") {
+        emitIntegrationIssue({
+            operation: "resolve-api",
+            error: new Error("Missing getApi() on layout-editor plugin"),
+            userMessage: INVALID_API_NOTICE,
+        });
+        return null;
+    }
+
+    let apiCandidate: unknown;
+    try {
+        apiCandidate = plugin.getApi();
+    } catch (error) {
+        emitIntegrationIssue({
+            operation: "resolve-api",
+            error,
+            userMessage: INVALID_API_NOTICE,
+        });
+        return null;
+    }
+
+    if (!apiCandidate) {
+        // Plugin noch nicht initialisiert; später erneut versuchen.
+        return null;
+    }
+
+    if (!isLayoutEditorPluginApi(apiCandidate)) {
+        emitIntegrationIssue({
+            operation: "resolve-api",
+            error: new Error("Incompatible layout-editor API"),
+            userMessage: INVALID_API_NOTICE,
+        });
+        return null;
+    }
+
+    return apiCandidate;
+}
+
+function isLayoutEditorPluginApi(candidate: unknown): candidate is LayoutEditorPluginApi {
+    if (!candidate || typeof candidate !== "object") return false;
+    const api = candidate as LayoutEditorPluginApi;
+    return typeof api.registerViewBinding === "function";
 }
 
 export function setupLayoutEditorBridge(plugin: Plugin): () => void {
     const { app } = plugin;
-    let unregister: (() => void) | null = null;
+    let unregisterBinding: (() => void) | null = null;
 
     const tryRegister = () => {
-        if (unregister) return; // bereits registriert
-        const api = resolveLayoutEditorApi(app);
-        if (!api?.registerViewBinding) return;
-        try {
-            api.registerViewBinding({
-                id: MAP_VIEW_BINDING_ID,
-                label: "Salt Marcher – Hex Map",
-                description: "Cartographer-View mit renderHexMap & Token-Workflow.",
-            });
-            unregister = () => {
-                try {
-                    api.unregisterViewBinding?.(MAP_VIEW_BINDING_ID);
-                } catch (err) {
-                    console.error("[salt-marcher] failed to unregister layout binding", err);
-                }
-                unregister = null;
-            };
-        } catch (err) {
-            console.error("[salt-marcher] failed to register layout binding", err);
+        if (unregisterBinding) {
+            return;
         }
+        const api = resolveLayoutEditorApi(app);
+        if (!api) {
+            return;
+        }
+
+        try {
+            api.registerViewBinding(VIEW_BINDING);
+        } catch (error) {
+            emitIntegrationIssue({
+                operation: "register-view-binding",
+                error,
+                userMessage: REGISTER_NOTICE,
+            });
+            return;
+        }
+
+        unregisterBinding = () => {
+            if (typeof api.unregisterViewBinding !== "function") {
+                unregisterBinding = null;
+                return;
+            }
+            try {
+                api.unregisterViewBinding(MAP_VIEW_BINDING_ID);
+            } catch (error) {
+                emitIntegrationIssue({
+                    operation: "unregister-view-binding",
+                    error,
+                    userMessage: UNREGISTER_NOTICE,
+                });
+            } finally {
+                unregisterBinding = null;
+            }
+        };
     };
 
     tryRegister();
 
-    plugin.registerEvent(app.workspace.on("layout-ready", tryRegister));
+    const layoutReadyRef: EventRef = app.workspace.on("layout-ready", tryRegister);
+    plugin.registerEvent(layoutReadyRef);
 
-    const manager = app.plugins as App["plugins"] & PluginLifecycleEmitter;
-    const onLifecycle = typeof manager.on === "function" ? manager.on.bind(manager) : null;
-    const offLifecycle = typeof manager.off === "function" ? manager.off.bind(manager) : null;
+    const lifecycle = bindLifecycleEmitter(app.plugins);
 
-    let enabledRef: PluginEventRef | null = null;
-    let disabledRef: PluginEventRef | null = null;
+    const enabledRef = lifecycle?.on("plugin-enabled", (id) => {
+        if (id === LAYOUT_EDITOR_PLUGIN_ID) {
+            tryRegister();
+        }
+    }) ?? null;
 
-    if (onLifecycle) {
-        enabledRef = onLifecycle("plugin-enabled", (id: string) => {
-            if (id === LAYOUT_EDITOR_PLUGIN_ID) {
-                tryRegister();
-            }
-        }) ?? null;
-        disabledRef = onLifecycle("plugin-disabled", (id: string) => {
-            if (id === LAYOUT_EDITOR_PLUGIN_ID) {
-                unregister?.();
-            }
-        }) ?? null;
-    }
+    const disabledRef = lifecycle?.on("plugin-disabled", (id) => {
+        if (id === LAYOUT_EDITOR_PLUGIN_ID) {
+            unregisterBinding?.();
+        }
+    }) ?? null;
 
     return () => {
-        unregister?.();
-        if (offLifecycle && enabledRef) {
-            offLifecycle("plugin-enabled", enabledRef);
-            enabledRef = null;
+        unregisterBinding?.();
+        if (lifecycle?.off && enabledRef) {
+            lifecycle.off("plugin-enabled", enabledRef);
         }
-        if (offLifecycle && disabledRef) {
-            offLifecycle("plugin-disabled", disabledRef);
-            disabledRef = null;
+        if (lifecycle?.off && disabledRef) {
+            lifecycle.off("plugin-disabled", disabledRef);
         }
     };
 }

--- a/salt-marcher/tests/app/layout-editor-bridge.test.ts
+++ b/salt-marcher/tests/app/layout-editor-bridge.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, EventRef, Plugin } from "obsidian";
+
+vi.mock("../../src/app/integration-telemetry", () => ({
+    reportIntegrationIssue: vi.fn(),
+}));
+
+import { setupLayoutEditorBridge } from "../../src/app/layout-editor-bridge";
+import { reportIntegrationIssue } from "../../src/app/integration-telemetry";
+
+type LayoutEditorPluginApi = {
+    registerViewBinding: ReturnType<typeof vi.fn>;
+    unregisterViewBinding?: ReturnType<typeof vi.fn>;
+};
+
+type LifecycleEvent = "plugin-enabled" | "plugin-disabled";
+type LifecycleHandler = (id: string) => void;
+
+type TestContext = {
+    app: App;
+    plugin: Plugin;
+    pluginManager: {
+        getPlugin: ReturnType<typeof vi.fn>;
+        on: ReturnType<typeof vi.fn>;
+        off: ReturnType<typeof vi.fn>;
+    };
+    layoutReadyHandlers: Array<() => void>;
+    lifecycleHandlers: Partial<Record<LifecycleEvent, LifecycleHandler>>;
+    lifecycleRefs: Partial<Record<LifecycleEvent, unknown>>;
+    setLayoutEditorPlugin: (plugin: { getApi?: () => unknown } | null) => void;
+};
+
+const MOCKED_REPORT = vi.mocked(reportIntegrationIssue);
+
+function createTestContext(): TestContext {
+    const layoutReadyHandlers: Array<() => void> = [];
+    const lifecycleHandlers: Partial<Record<LifecycleEvent, LifecycleHandler>> = {};
+    const lifecycleRefs: Partial<Record<LifecycleEvent, unknown>> = {};
+
+    let layoutEditorPlugin: { getApi?: () => unknown } | null = null;
+
+    const getPlugin = vi.fn(() => layoutEditorPlugin);
+    const on = vi.fn((event: LifecycleEvent, handler: LifecycleHandler) => {
+        lifecycleHandlers[event] = handler;
+        const ref = Symbol(event);
+        lifecycleRefs[event] = ref;
+        return ref;
+    });
+    const off = vi.fn();
+
+    const workspaceOn = vi.fn((event: string, handler: () => void) => {
+        if (event === "layout-ready") {
+            layoutReadyHandlers.push(handler);
+        }
+        return { event } as unknown as EventRef;
+    });
+
+    const app = {
+        plugins: { getPlugin, on, off },
+        workspace: { on: workspaceOn },
+    } as unknown as App;
+
+    const plugin = {
+        app,
+        registerEvent: vi.fn((ref: EventRef) => ref),
+    } as unknown as Plugin;
+
+    return {
+        app,
+        plugin,
+        pluginManager: { getPlugin, on, off },
+        layoutReadyHandlers,
+        lifecycleHandlers,
+        lifecycleRefs,
+        setLayoutEditorPlugin: (pluginRef) => {
+            layoutEditorPlugin = pluginRef;
+        },
+    };
+}
+
+describe("setupLayoutEditorBridge", () => {
+    beforeEach(() => {
+        MOCKED_REPORT.mockReset();
+    });
+
+    it("registers the view binding and tears down listeners", () => {
+        const ctx = createTestContext();
+        const registerViewBinding = vi.fn();
+        const unregisterViewBinding = vi.fn();
+        ctx.setLayoutEditorPlugin({
+            getApi: () => ({ registerViewBinding, unregisterViewBinding }),
+        });
+
+        const dispose = setupLayoutEditorBridge(ctx.plugin);
+
+        expect(registerViewBinding).toHaveBeenCalledWith(
+            expect.objectContaining({ id: "salt-marcher.cartographer-map" })
+        );
+        expect(MOCKED_REPORT).not.toHaveBeenCalled();
+
+        dispose();
+
+        expect(unregisterViewBinding).toHaveBeenCalledWith("salt-marcher.cartographer-map");
+        expect(ctx.pluginManager.off).toHaveBeenCalledWith(
+            "plugin-enabled",
+            ctx.lifecycleRefs["plugin-enabled"]
+        );
+        expect(ctx.pluginManager.off).toHaveBeenCalledWith(
+            "plugin-disabled",
+            ctx.lifecycleRefs["plugin-disabled"]
+        );
+    });
+
+    it("registers once the layout editor becomes available", () => {
+        const ctx = createTestContext();
+        const registerViewBinding = vi.fn();
+        const api = { registerViewBinding } satisfies LayoutEditorPluginApi;
+        ctx.setLayoutEditorPlugin(null);
+
+        setupLayoutEditorBridge(ctx.plugin);
+
+        expect(registerViewBinding).not.toHaveBeenCalled();
+
+        ctx.setLayoutEditorPlugin({ getApi: () => api });
+        ctx.layoutReadyHandlers.forEach((handler) => handler());
+
+        expect(registerViewBinding).toHaveBeenCalledTimes(1);
+    });
+
+    it("unregisters when the layout editor plugin is disabled", () => {
+        const ctx = createTestContext();
+        const registerViewBinding = vi.fn();
+        const unregisterViewBinding = vi.fn();
+        ctx.setLayoutEditorPlugin({
+            getApi: () => ({ registerViewBinding, unregisterViewBinding }),
+        });
+
+        setupLayoutEditorBridge(ctx.plugin);
+        const disable = ctx.lifecycleHandlers["plugin-disabled"];
+        expect(disable).toBeTypeOf("function");
+
+        disable?.("layout-editor");
+
+        expect(unregisterViewBinding).toHaveBeenCalledWith("salt-marcher.cartographer-map");
+    });
+
+    it("reports a registration failure", () => {
+        const ctx = createTestContext();
+        const registerViewBinding = vi.fn(() => {
+            throw new Error("boom");
+        });
+        ctx.setLayoutEditorPlugin({ getApi: () => ({ registerViewBinding }) });
+
+        setupLayoutEditorBridge(ctx.plugin);
+
+        expect(MOCKED_REPORT).toHaveBeenCalledWith(
+            expect.objectContaining({ operation: "register-view-binding" })
+        );
+    });
+
+    it("reports an unregister failure", () => {
+        const ctx = createTestContext();
+        const unregisterViewBinding = vi.fn(() => {
+            throw new Error("boom");
+        });
+        ctx.setLayoutEditorPlugin({
+            getApi: () => ({
+                registerViewBinding: vi.fn(),
+                unregisterViewBinding,
+            }),
+        });
+
+        const dispose = setupLayoutEditorBridge(ctx.plugin);
+        MOCKED_REPORT.mockClear();
+
+        dispose();
+
+        expect(MOCKED_REPORT).toHaveBeenCalledWith(
+            expect.objectContaining({ operation: "unregister-view-binding" })
+        );
+    });
+
+    it("guards against incompatible APIs", () => {
+        const ctx = createTestContext();
+        ctx.setLayoutEditorPlugin({ getApi: () => ({}) });
+
+        setupLayoutEditorBridge(ctx.plugin);
+
+        expect(MOCKED_REPORT).toHaveBeenCalledWith(
+            expect.objectContaining({ operation: "resolve-api" })
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add a shared integration telemetry helper with deduplicated notice reporting
- tighten the layout editor bridge lifecycle handling with typed plugin hooks and error reporting
- cover registration/teardown flows with vitest and document the updated integration contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f76ed238832599fccd601a283ff4