### PR TITLE
Implement encounter presenter and travel hand-off

### DIFF
--- a/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
@@ -241,7 +241,9 @@ export function createTravelGuideMode(): CartographerMode {
                         activeLogic.pause();
                     } catch {}
                     if (!isAborted()) {
-                        void openEncounter(ctx.app);
+                        const mapFile = ctx.getFile?.() ?? null;
+                        const state = activeLogic.getState();
+                        void openEncounter(ctx.app, { mapFile, state });
                     }
                 },
             });

--- a/salt-marcher/src/apps/encounter/event-builder.ts
+++ b/salt-marcher/src/apps/encounter/event-builder.ts
@@ -1,0 +1,60 @@
+// src/apps/encounter/event-builder.ts
+// Translates travel mode context into encounter events that can be consumed by
+// the session store.
+
+import type { App, TFile } from "obsidian";
+import type { LogicStateSnapshot } from "../cartographer/travel/domain/types";
+import type { EncounterEvent } from "./session-store";
+
+export interface TravelEncounterContext {
+    mapFile: TFile | null;
+    state: LogicStateSnapshot | null;
+}
+
+export async function createEncounterEventFromTravel(app: App, ctx: TravelEncounterContext | null): Promise<EncounterEvent | null> {
+    const triggeredAt = new Date().toISOString();
+    const coord = ctx?.state?.currentTile ?? ctx?.state?.tokenRC ?? null;
+    const mapFile = ctx?.mapFile ?? null;
+    let regionName: string | undefined;
+    let encounterOdds: number | undefined;
+
+    if (mapFile && coord) {
+        try {
+            const { loadTile } = await import("../../core/hex-mapper/hex-notes");
+            const tile = await loadTile(app, mapFile, coord).catch(() => null);
+            const tileRegion = typeof tile?.region === "string" ? tile.region : undefined;
+            if (tileRegion) {
+                regionName = tileRegion;
+                try {
+                    const { loadRegions } = await import("../../core/regions-store");
+                    const regions = await loadRegions(app);
+                    const region = regions.find((r: any) => typeof r?.name === "string" && r.name.toLowerCase() === tileRegion.toLowerCase());
+                    const odds = region?.encounterOdds;
+                    if (typeof odds === "number" && Number.isFinite(odds) && odds > 0) {
+                        encounterOdds = odds;
+                    }
+                } catch (err) {
+                    console.error("[encounter] failed to resolve region odds", err);
+                }
+            }
+        } catch (err) {
+            console.error("[encounter] failed to read tile metadata", err);
+        }
+    }
+
+    const travelClock = ctx?.state?.clockHours;
+
+    const event: EncounterEvent = {
+        id: `travel-${Date.now()}`,
+        source: "travel",
+        triggeredAt,
+        coord,
+        regionName,
+        mapPath: mapFile?.path,
+        mapName: mapFile?.basename,
+        encounterOdds,
+        travelClockHours: typeof travelClock === "number" && Number.isFinite(travelClock) ? travelClock : undefined,
+    };
+
+    return event;
+}

--- a/salt-marcher/src/apps/encounter/presenter.ts
+++ b/salt-marcher/src/apps/encounter/presenter.ts
@@ -1,0 +1,149 @@
+// src/apps/encounter/presenter.ts
+// Presenter orchestrating encounter state, persistence and updates from the
+// session-store. It is intentionally UI-agnostic so it can be unit-tested and
+// reused by different view implementations (Obsidian ItemView, future mobile UI,
+// etc.).
+
+import { publishEncounterEvent, subscribeToEncounterEvents, type EncounterEvent } from "./session-store";
+
+export interface EncounterPersistedState {
+    session: EncounterSessionState | null;
+}
+
+export interface EncounterSessionState {
+    event: EncounterEvent;
+    notes: string;
+    status: EncounterResolutionStatus;
+    resolvedAt?: string | null;
+}
+
+export type EncounterResolutionStatus = "pending" | "resolved";
+
+export interface EncounterPresenterDeps {
+    now?(): string;
+}
+
+export interface EncounterViewState extends EncounterPersistedState {}
+
+export type EncounterStateListener = (state: EncounterViewState) => void;
+
+const defaultDeps: Required<EncounterPresenterDeps> = {
+    now: () => new Date().toISOString(),
+};
+
+export class EncounterPresenter {
+    private state: EncounterPersistedState;
+    private readonly deps: Required<EncounterPresenterDeps>;
+    private readonly listeners = new Set<EncounterStateListener>();
+    private unsubscribeStore?: () => void;
+
+    constructor(initial?: EncounterPersistedState | null, deps?: EncounterPresenterDeps) {
+        this.deps = { ...defaultDeps, ...deps };
+        this.state = EncounterPresenter.normalise(initial);
+        this.unsubscribeStore = subscribeToEncounterEvents((event) => this.applyEvent(event));
+    }
+
+    dispose() {
+        this.unsubscribeStore?.();
+        this.listeners.clear();
+    }
+
+    /** Restores persisted state (e.g. when `setViewData` fires before `onOpen`). */
+    restore(state: EncounterPersistedState | null) {
+        this.state = EncounterPresenter.normalise(state);
+        this.emit();
+    }
+
+    getState(): EncounterViewState {
+        return this.state;
+    }
+
+    subscribe(listener: EncounterStateListener): () => void {
+        this.listeners.add(listener);
+        listener(this.state);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    setNotes(notes: string) {
+        if (!this.state.session) return;
+        if (this.state.session.notes === notes) return;
+        this.state = {
+            session: {
+                ...this.state.session,
+                notes,
+            },
+        };
+        this.emit();
+    }
+
+    markResolved() {
+        const session = this.state.session;
+        if (!session) return;
+        if (session.status === "resolved") return;
+        this.state = {
+            session: {
+                ...session,
+                status: "resolved",
+                resolvedAt: this.deps.now(),
+            },
+        };
+        this.emit();
+    }
+
+    reset() {
+        if (!this.state.session) return;
+        this.state = { session: null };
+        this.emit();
+    }
+
+    private applyEvent(event: EncounterEvent) {
+        const prev = this.state.session;
+        if (!prev || prev.event.id !== event.id) {
+            // New encounter: wipe notes/resolution state.
+            this.state = {
+                session: {
+                    event,
+                    notes: "",
+                    status: "pending",
+                },
+            };
+        } else {
+            // Same encounter (e.g. view reopened) → keep notes/resolution.
+            this.state = {
+                session: {
+                    ...prev,
+                    event,
+                },
+            };
+        }
+        this.emit();
+    }
+
+    private emit() {
+        for (const listener of [...this.listeners]) {
+            listener(this.state);
+        }
+    }
+
+    private static normalise(initial?: EncounterPersistedState | null): EncounterPersistedState {
+        if (!initial || !initial.session || !initial.session.event) {
+            return { session: null };
+        }
+        const { event, notes, status, resolvedAt } = initial.session;
+        return {
+            session: {
+                event,
+                notes: notes ?? "",
+                status: status === "resolved" ? "resolved" : "pending",
+                resolvedAt: resolvedAt ?? null,
+            },
+        };
+    }
+}
+
+// Convenience helper for tests & manual triggers.
+export function publishManualEncounter(event: Omit<EncounterEvent, "source">) {
+    publishEncounterEvent({ ...event, source: "manual" });
+}

--- a/salt-marcher/src/apps/encounter/session-store.ts
+++ b/salt-marcher/src/apps/encounter/session-store.ts
@@ -1,0 +1,64 @@
+// src/apps/encounter/session-store.ts
+// Lightweight pub/sub store bridging travel events and the encounter workspace.
+// Keeps the most recent encounter payload so that freshly mounted presenters can
+// render the last travel hand-off without waiting for another event.
+
+import type { Coord } from "../cartographer/travel/domain/types";
+
+export type EncounterEventSource = "travel" | "manual";
+
+export interface EncounterEvent {
+    /** Stable identifier for deduplication across store/presenter instances. */
+    readonly id: string;
+    /** Origin of the encounter (e.g. travel hand-off). */
+    readonly source: EncounterEventSource;
+    /** ISO timestamp of the triggering moment. */
+    readonly triggeredAt: string;
+    readonly coord: Coord | null;
+    readonly regionName?: string;
+    readonly mapPath?: string;
+    readonly mapName?: string;
+    readonly encounterOdds?: number;
+    readonly travelClockHours?: number;
+}
+
+export type EncounterEventListener = (event: EncounterEvent) => void;
+
+let latestEvent: EncounterEvent | null = null;
+const listeners = new Set<EncounterEventListener>();
+
+export function publishEncounterEvent(event: EncounterEvent) {
+    latestEvent = event;
+    for (const listener of [...listeners]) {
+        try {
+            listener(event);
+        } catch (err) {
+            console.error("[encounter] listener failed", err);
+        }
+    }
+}
+
+export function subscribeToEncounterEvents(listener: EncounterEventListener): () => void {
+    listeners.add(listener);
+    if (latestEvent) {
+        try {
+            listener(latestEvent);
+        } catch (err) {
+            console.error("[encounter] listener failed", err);
+        }
+    }
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function peekLatestEncounterEvent(): EncounterEvent | null {
+    return latestEvent;
+}
+
+// Test utility to avoid leaking state between vitest runs. Not exported publicly
+// in bundles (tree-shaken when unused in production code).
+export function __resetEncounterEventStore() {
+    latestEvent = null;
+    listeners.clear();
+}

--- a/salt-marcher/src/apps/encounter/view.ts
+++ b/salt-marcher/src/apps/encounter/view.ts
@@ -1,23 +1,161 @@
 // src/apps/encounter/view.ts
 import { ItemView, WorkspaceLeaf } from "obsidian";
+import { EncounterPresenter, type EncounterPersistedState } from "./presenter";
+import type { EncounterViewState } from "./presenter";
 
 export const VIEW_ENCOUNTER = "salt-encounter";
 
 export class EncounterView extends ItemView {
+    private presenter: EncounterPresenter | null = null;
+    private detachPresenter?: () => void;
+    private pendingState: EncounterPersistedState | null = null;
+
+    private headerEl!: HTMLHeadingElement;
+    private statusEl!: HTMLDivElement;
+    private summaryListEl!: HTMLUListElement;
+    private notesEl!: HTMLTextAreaElement;
+    private resolveBtn!: HTMLButtonElement;
+    private emptyEl!: HTMLDivElement;
+
+    constructor(leaf: WorkspaceLeaf) {
+        super(leaf);
+    }
+
     getViewType() { return VIEW_ENCOUNTER; }
     getDisplayText() { return "Encounter"; }
     getIcon() { return "swords" as any; }
 
     async onOpen() {
         this.contentEl.addClass("sm-encounter-view");
-        this.contentEl.empty();
-        this.contentEl.createEl("h2", { text: "Encounter" });
-        this.contentEl.createDiv({ text: "", cls: "desc" });
+        this.renderShell();
+
+        this.presenter = new EncounterPresenter(this.pendingState);
+        this.pendingState = null;
+        this.detachPresenter = this.presenter.subscribe((state) => this.render(state));
     }
 
     async onClose() {
+        this.detachPresenter?.();
+        this.presenter?.dispose();
+        this.detachPresenter = undefined;
+        this.presenter = null;
+        this.pendingState = null;
         this.contentEl.empty();
         this.contentEl.removeClass("sm-encounter-view");
     }
-}
 
+    getViewData(): EncounterPersistedState | null {
+        return this.presenter?.getState() ?? this.pendingState;
+    }
+
+    setViewData(data: EncounterPersistedState) {
+        if (this.presenter) {
+            this.presenter.restore(data);
+        } else {
+            this.pendingState = data;
+        }
+    }
+
+    private renderShell() {
+        this.contentEl.empty();
+
+        const header = this.contentEl.createEl("div", { cls: "sm-encounter-header" });
+        this.headerEl = header.createEl("h2", { text: "Encounter" });
+        this.statusEl = header.createDiv({ cls: "status", text: "Waiting for travel events…" });
+
+        this.summaryListEl = this.contentEl.createEl("ul", { cls: "sm-encounter-summary" });
+
+        this.emptyEl = this.contentEl.createDiv({
+            cls: "sm-encounter-empty",
+            text: "No active encounter. Travel mode will populate this workspace when an encounter triggers.",
+        });
+        this.emptyEl.style.display = "";
+
+        const notesSection = this.contentEl.createDiv({ cls: "sm-encounter-notes" });
+        notesSection.createEl("label", { text: "Notes", attr: { for: "encounter-notes" } });
+        this.notesEl = notesSection.createEl("textarea", {
+            cls: "notes-input",
+            attr: {
+                id: "encounter-notes",
+                placeholder: "Record tactical notes, initiative order, or follow-up tasks…",
+                rows: "6",
+            },
+        }) as HTMLTextAreaElement;
+        this.notesEl.disabled = true;
+        this.notesEl.addEventListener("input", () => {
+            if (!this.presenter) return;
+            this.presenter.setNotes(this.notesEl.value);
+        });
+
+        this.resolveBtn = this.contentEl.createEl("button", { cls: "sm-encounter-resolve", text: "Mark encounter resolved" });
+        this.resolveBtn.disabled = true;
+        this.resolveBtn.addEventListener("click", () => {
+            this.presenter?.markResolved();
+        });
+    }
+
+    private render(state: EncounterViewState) {
+        const session = state.session;
+        if (!session) {
+            this.headerEl.setText("Encounter");
+            this.statusEl.setText("Waiting for travel events…");
+            this.summaryListEl.empty();
+            this.emptyEl.style.display = "";
+            this.notesEl.value = "";
+            this.notesEl.disabled = true;
+            this.resolveBtn.disabled = true;
+            this.resolveBtn.setText("Mark encounter resolved");
+            return;
+        }
+
+        this.emptyEl.style.display = "none";
+
+        const { event, notes, status, resolvedAt } = session;
+        const region = event.regionName ?? "Unknown region";
+        this.headerEl.setText(`Encounter – ${region}`);
+
+        if (status === "resolved") {
+            this.statusEl.setText(resolvedAt ? `Resolved ${resolvedAt}` : "Resolved");
+        } else {
+            this.statusEl.setText("Awaiting resolution");
+        }
+
+        this.summaryListEl.empty();
+        const summaryEntries: Array<[string, string]> = [];
+        if (event.coord) {
+            summaryEntries.push(["Hex", `${event.coord.r}, ${event.coord.c}`]);
+        }
+        if (event.mapName) {
+            summaryEntries.push(["Map", event.mapName]);
+        }
+        if (event.mapPath) {
+            summaryEntries.push(["Map path", event.mapPath]);
+        }
+        summaryEntries.push(["Triggered", event.triggeredAt]);
+        if (typeof event.travelClockHours === "number") {
+            summaryEntries.push(["Travel clock", `${event.travelClockHours.toFixed(2)} h`]);
+        }
+        if (typeof event.encounterOdds === "number") {
+            summaryEntries.push(["Encounter odds", `1 in ${event.encounterOdds}`]);
+        }
+
+        for (const [label, value] of summaryEntries) {
+            const li = this.summaryListEl.createEl("li");
+            li.createSpan({ cls: "label", text: `${label}: ` });
+            li.createSpan({ cls: "value", text: value });
+        }
+
+        if (this.notesEl.value !== notes) {
+            this.notesEl.value = notes;
+        }
+        this.notesEl.disabled = false;
+
+        if (status === "resolved") {
+            this.resolveBtn.disabled = true;
+            this.resolveBtn.setText("Encounter resolved");
+        } else {
+            this.resolveBtn.disabled = false;
+            this.resolveBtn.setText("Mark encounter resolved");
+        }
+    }
+}

--- a/salt-marcher/tests/encounter/README.md
+++ b/salt-marcher/tests/encounter/README.md
@@ -1,0 +1,21 @@
+# Encounter Tests
+
+```
+tests/encounter/
+├─ README.md
+├─ event-builder.test.ts   # Validates translation from travel state → encounter event payloads.
+└─ presenter.test.ts       # Covers presenter persistence, subscriptions and resolution handling.
+```
+
+These Vitest suites ensure that the Encounter workspace receives stable travel
+hand-offs and that its presenter survives Obsidian workspace restores.
+
+- **`event-builder.test.ts`** mocks the hex-note and regions stores to assert
+  that travel metadata (hex coordinate, region odds) is propagated into the
+  encounter payload and gracefully handles missing data.
+- **`presenter.test.ts`** exercises the presenter in isolation, confirming that
+  persisted state is normalised, new encounter events reset notes, and the
+  resolution timestamp is injected via the configurable clock dependency.
+
+Run via `pnpm test -- --runInBand tests/encounter` when focusing on this
+workspace; the root `pnpm test` command will execute them automatically.

--- a/salt-marcher/tests/encounter/event-builder.test.ts
+++ b/salt-marcher/tests/encounter/event-builder.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { createEncounterEventFromTravel, type TravelEncounterContext } from "../../src/apps/encounter/event-builder";
+
+const loadTile = vi.fn();
+const loadRegions = vi.fn();
+
+vi.mock("../../src/core/hex-mapper/hex-notes", () => ({
+    loadTile,
+}));
+
+vi.mock("../../src/core/regions-store", () => ({
+    loadRegions,
+}));
+
+describe("createEncounterEventFromTravel", () => {
+    const app = {} as App;
+    const mapFile = { path: "maps/world.map", basename: "world" } as unknown as TFile;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2024-06-05T08:30:00.000Z"));
+        loadTile.mockReset();
+        loadRegions.mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("collects region metadata and odds", async () => {
+        loadTile.mockResolvedValue({ region: "Highlands" });
+        loadRegions.mockResolvedValue([
+            { name: "Highlands", encounterOdds: 8 },
+            { name: "Lowlands", encounterOdds: 10 },
+        ]);
+
+        const ctx: TravelEncounterContext = {
+            mapFile,
+            state: {
+                tokenRC: { r: 2, c: 3 },
+                route: [],
+                editIdx: null,
+                tokenSpeed: 3,
+                currentTile: { r: 5, c: 7 },
+                playing: false,
+                tempo: 1,
+                clockHours: 17.25,
+            },
+        };
+
+        const event = await createEncounterEventFromTravel(app, ctx);
+        expect(event).not.toBeNull();
+        expect(event?.triggeredAt).toBe("2024-06-05T08:30:00.000Z");
+        expect(loadTile).toHaveBeenCalledWith(app, mapFile, { r: 5, c: 7 });
+        expect(loadRegions).toHaveBeenCalledTimes(1);
+        expect(event?.regionName).toBe("Highlands");
+        expect(event?.encounterOdds).toBe(8);
+        expect(event?.mapPath).toBe("maps/world.map");
+        expect(event?.mapName).toBe("world");
+        expect(event?.travelClockHours).toBe(17.25);
+    });
+
+    it("falls back gracefully when metadata is missing", async () => {
+        loadTile.mockResolvedValue({});
+        loadRegions.mockResolvedValue([]);
+
+        const ctx: TravelEncounterContext = {
+            mapFile: null,
+            state: {
+                tokenRC: { r: 1, c: 1 },
+                route: [],
+                editIdx: null,
+                tokenSpeed: 3,
+                currentTile: null,
+                playing: false,
+            },
+        } as unknown as TravelEncounterContext;
+
+        const event = await createEncounterEventFromTravel(app, ctx);
+        expect(event?.regionName).toBeUndefined();
+        expect(event?.encounterOdds).toBeUndefined();
+        expect(event?.coord).toEqual({ r: 1, c: 1 });
+    });
+});

--- a/salt-marcher/tests/encounter/presenter.test.ts
+++ b/salt-marcher/tests/encounter/presenter.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EncounterPresenter, publishManualEncounter, type EncounterPersistedState } from "../../src/apps/encounter/presenter";
+import { __resetEncounterEventStore, publishEncounterEvent, type EncounterEvent } from "../../src/apps/encounter/session-store";
+
+const baseEvent: EncounterEvent = {
+    id: "travel-1",
+    source: "travel",
+    triggeredAt: "2024-06-01T10:00:00.000Z",
+    coord: { r: 4, c: 7 },
+    regionName: "Foothills",
+    mapName: "Foothills Map",
+    mapPath: "regions/foothills.map",
+    encounterOdds: 6,
+    travelClockHours: 12.5,
+};
+
+describe("EncounterPresenter", () => {
+    beforeEach(() => {
+        __resetEncounterEventStore();
+    });
+
+    it("normalises persisted state on restore", () => {
+        const persisted: EncounterPersistedState = {
+            session: {
+                event: baseEvent,
+                notes: "Bring backup",
+                status: "resolved",
+                resolvedAt: "2024-06-01T11:00:00.000Z",
+            },
+        };
+        const presenter = new EncounterPresenter();
+        presenter.restore(persisted);
+        const state = presenter.getState();
+        expect(state.session?.event.id).toBe("travel-1");
+        expect(state.session?.status).toBe("resolved");
+        expect(state.session?.notes).toBe("Bring backup");
+        expect(state.session?.resolvedAt).toBe("2024-06-01T11:00:00.000Z");
+    });
+
+    it("resets notes when a new event arrives", () => {
+        const presenter = new EncounterPresenter();
+        const updates: Array<EncounterPersistedState["session"]> = [];
+        presenter.subscribe((state) => updates.push(state.session));
+        publishEncounterEvent(baseEvent);
+        expect(updates.at(-1)?.notes).toBe("");
+        expect(updates.at(-1)?.status).toBe("pending");
+        publishManualEncounter({
+            ...baseEvent,
+            id: "manual-2",
+            triggeredAt: "2024-06-02T10:00:00.000Z",
+        });
+        expect(updates.at(-1)?.event.id).toBe("manual-2");
+        expect(updates.at(-1)?.notes).toBe("");
+    });
+
+    it("keeps notes/resolution when the same event replays", () => {
+        const presenter = new EncounterPresenter();
+        publishEncounterEvent(baseEvent);
+        presenter.setNotes("Hold position");
+        presenter.markResolved();
+        const resolvedAt = presenter.getState().session?.resolvedAt;
+        publishEncounterEvent({ ...baseEvent, regionName: "Foothills" });
+        const state = presenter.getState();
+        expect(state.session?.notes).toBe("Hold position");
+        expect(state.session?.status).toBe("resolved");
+        expect(state.session?.resolvedAt).toBe(resolvedAt);
+    });
+
+    it("stamps resolution timestamp via dependency", () => {
+        const now = vi.fn(() => "2024-06-01T11:15:00.000Z");
+        const presenter = new EncounterPresenter(null, { now });
+        publishEncounterEvent(baseEvent);
+        presenter.markResolved();
+        expect(now).toHaveBeenCalledTimes(1);
+        const state = presenter.getState();
+        expect(state.session?.status).toBe("resolved");
+        expect(state.session?.resolvedAt).toBe("2024-06-01T11:15:00.000Z");
+    });
+});

--- a/wiki/Encounter.md
+++ b/wiki/Encounter.md
@@ -9,20 +9,21 @@ The Encounter workspace currently provides a dedicated pane for handling travel-
 - Optional: predefined encounter notes or templates stored elsewhere in the vault.
 
 ## Step-by-step Workflow
-1. **Trigger the encounter hand-off.** Run a travel route in Cartographer until an encounter event fires; the presenter pauses playback and calls `openEncounter`.
-2. **Review the encounter pane.** The workspace opens (or focuses) a dedicated leaf containing placeholder content and encounter-specific styling hooks.
-3. **Anchor supporting material.** Open related notes—such as NPC stat blocks or region lore—in adjacent panes to keep context visible while the encounter pane remains active.
-4. **Resume travel after resolution.** Close or refocus the encounter pane, return to Cartographer, and resume playback from the paused state once the encounter wraps.
+1. **Trigger the encounter hand-off.** Run a travel route in Cartographer until an encounter event fires; the travel controller pauses playback, assembles region metadata, and calls `openEncounter(app, { mapFile, state })`.
+2. **Review the encounter pane.** The workspace focuses a dedicated leaf that now lists the region name, hex coordinates, travel clock, encounter odds (if defined in Library → Regions), and the timestamp of the trigger.
+3. **Capture notes & decisions.** Use the notes field to jot down initiative, tactics, or follow-ups. The presenter persists these notes so a workspace restore or Obsidian restart keeps the active encounter intact.
+4. **Mark the encounter resolved.** Click **“Mark encounter resolved”** once the scene wraps; the pane records the resolution timestamp and communicates status to future restores. Resume travel from Cartographer when ready (resume remains manual).
 
 ## Reference & Tips
 | Trigger Source | Behaviour | Notes |
 | --- | --- | --- |
-| Travel mode `onEncounter` callback | Opens or reveals the encounter workspace and pauses travel playback. | Encounter pane will reopen automatically if dismissed while another trigger fires. |
-| Manual pane creation (`Open view by type → salt-marcher-encounter`) | Opens the workspace without a travel trigger. | Useful for testing layouts or preparing upcoming encounter features. |
+| Travel mode `onEncounter` callback | Opens or reveals the encounter workspace, publishes the travel payload, and pauses playback. | Encounter pane shows the latest travel metadata and cached notes even after reloads. |
+| Manual pane creation (`Open view by type → salt-marcher-encounter`) | Opens the workspace without publishing a new payload. | The pane shows the most recent encounter (if any) and allows reviewing notes. |
 
 - Keep the encounter workspace docked next to Cartographer to reduce window juggling when multiple encounters occur.
-- Document any desired encounter tooling in [`architecture-critique.md`](../architecture-critique.md) so the placeholder can evolve alongside feature work.
+- Document any desired encounter tooling in [`architecture-critique.md`](../architecture-critique.md) so the incremental UX can evolve alongside feature work.
 - Use Obsidian's pane pinning to prevent the encounter view from being replaced by unrelated notes during sessions.
+- When testing travel mode without a region assignment, expect the pane to show "Unknown region" and omit encounter odds—add odds in Library → Regions to surface them here.
 
 ## Related Links
 - [Getting Started](./Getting-Started.md)


### PR DESCRIPTION
## Summary
- add an encounter session store, presenter and richer view that persists notes and resolution state
- publish travel encounter payloads through the gateway and pass cartographer state into the encounter workspace
- cover the new flow with focused unit tests and update encounter documentation

## Testing
- pnpm test -- --runInBand tests/encounter

------
https://chatgpt.com/codex/tasks/task_e_68d6f76e7e3483258f40cb99e89a6e9f