### PR TITLE
Refine cartographer editor tool lifecycle

### DIFF
--- a/salt-marcher/docs/cartographer/editor/README.md
+++ b/salt-marcher/docs/cartographer/editor/README.md
@@ -8,7 +8,7 @@ This document captures the developer-facing structure of the Cartographer editor
 | --- | --- | --- |
 | `docs/cartographer/editor/` | Developer overview for the editor mode and tooling surface. | _This document_ |
 | `src/apps/cartographer/modes/editor.ts` | Presenter-integrated mode controller that hosts tool lifecycles and sidebar UI. | [Source](../../../src/apps/cartographer/modes/editor.ts) |
-| `src/apps/cartographer/editor/tools/` | Tool contracts, shared utilities, and concrete brush implementation. | [Tools index](../../../src/apps/cartographer/editor/tools) |
+| `src/apps/cartographer/editor/tools/` | Tool contracts, shared utilities, tool manager, and concrete brush implementation. | [Tools index](../../../src/apps/cartographer/editor/tools) |
 
 ```text
 src/apps/cartographer/editor/
@@ -24,8 +24,9 @@ src/apps/cartographer/editor/
 ## Key Workflows
 1. **Registering tools:** Export a `ToolModule` via `tools-api.ts` and push it into the editor mode's `tools` array. Each module is responsible for rendering its panel, reacting to activation events, and translating map interactions into updates.
 2. **Managing render handles:** Use the `ToolContext.getHandles()` contract to delay SVG interactions until a map file is loaded. Tools should rebind transient resources (e.g., preview overlays) whenever `onMapRendered` fires.
-3. **Applying brush actions:** The default terrain brush applies radius-based updates through `applyBrush`, which deduplicates coordinates, persists tile data, and paints SVG fills for immediate feedback.
-4. **Responding to library changes:** Brush options watch `salt:terrains-updated` and `salt:regions-updated` workspace events so the region dropdown stays in sync with the library plugin.
+3. **Switching tools safely:** The editor delegates lifecycle transitions to `createToolManager`, which cancels in-flight `mountPanel`/`onActivate` steps when the mode's `AbortSignal` fires. Tools must tolerate mounts that never reach activation.
+4. **Applying brush actions:** The default terrain brush applies radius-based updates through `applyBrush`, which deduplicates coordinates, persists tile data, and paints SVG fills for immediate feedback.
+5. **Responding to library changes:** Brush options watch `salt:terrains-updated` and `salt:regions-updated` workspace events so the region dropdown stays in sync with the library plugin.
 
 ## Linked Docs
 - [Cartographer documentation hub](../README.md)
@@ -35,6 +36,8 @@ src/apps/cartographer/editor/
 ## Standards & Conventions
 - Tool modules must be side-effect free and expose all lifecycle hooks via the `ToolModule` interface; runtime state lives inside the factory closure returned by `create…` helpers.
 - Clean up DOM listeners, SVG overlays, and workspace subscriptions in the cleanup functions returned from `mountPanel`, `onDeactivate`, or dedicated destroy routines.
+- Use the `ToolContext.getAbortSignal()` accessor to guard async dropdown/state refreshes against mode transitions.
 - Avoid `any` casts when interacting with `RenderHandles`; add typed helpers or extend the interface before relying on ad-hoc properties such as `ensurePolys`.
+- Prefer `createToolManager` for lifecycle orchestration; it enforces `mountPanel → onActivate → onMapRendered` ordering and abort-aware teardown.
 - Keep UI copy in U.S. English and drive dropdown search via `enhanceSelectToSearch` for consistency with other panels.
 - Track outstanding hardening tasks in [`todo/cartographer-editor-review.md`](../../../../todo/cartographer-editor-review.md) and resolve them before building additional tools.

--- a/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
+++ b/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
@@ -1,0 +1,157 @@
+import type { CleanupFn, ToolContext, ToolManager as ToolManagerContract, ToolModule } from "./tools-api";
+
+const yieldMicrotask = () => Promise.resolve();
+
+type ToolManagerOptions = {
+    getContext(): ToolContext | null;
+    getPanelHost(): HTMLElement | null;
+    getLifecycleSignal(): AbortSignal | null;
+    onToolChanged?(tool: ToolModule | null): void;
+};
+
+type ActiveToolState = {
+    module: ToolModule;
+    cleanup: CleanupFn | null;
+};
+
+const SAFE_CLEANUP: CleanupFn = () => {};
+
+export function createToolManager(
+    tools: readonly ToolModule[],
+    options: ToolManagerOptions
+): ToolManagerContract {
+    let active: ActiveToolState | null = null;
+    let switchController: AbortController | null = null;
+    let destroyed = false;
+
+    const getLifecycleAborted = (localSignal?: AbortSignal | null) => {
+        if (destroyed) return true;
+        if (localSignal?.aborted) return true;
+        const lifecycle = options.getLifecycleSignal();
+        return lifecycle?.aborted ?? false;
+    };
+
+    const teardownActive = (ctx: ToolContext | null) => {
+        if (!active) return;
+        if (ctx) {
+            try {
+                active.module.onDeactivate?.(ctx);
+            } catch (err) {
+                console.error("[tool-manager] onDeactivate failed", err);
+            }
+        }
+        try {
+            (active.cleanup ?? SAFE_CLEANUP)();
+        } catch (err) {
+            console.error("[tool-manager] cleanup failed", err);
+        }
+        active = null;
+        options.onToolChanged?.(null);
+    };
+
+    const switchTo = async (id: string): Promise<void> => {
+        const ctx = options.getContext();
+        const host = options.getPanelHost();
+        if (!ctx || !host || tools.length === 0) {
+            return;
+        }
+
+        const next = tools.find((tool) => tool.id === id) ?? tools[0];
+        if (active?.module === next && !switchController) {
+            return;
+        }
+
+        const controller = new AbortController();
+        if (switchController) {
+            switchController.abort();
+        }
+        switchController = controller;
+
+        teardownActive(ctx);
+        host.empty();
+
+        await yieldMicrotask();
+        if (getLifecycleAborted(controller.signal)) {
+            switchController = null;
+            return;
+        }
+
+        let cleanup: CleanupFn | null = null;
+        try {
+            const result = next.mountPanel(host, ctx);
+            cleanup = typeof result === "function" ? result : null;
+        } catch (err) {
+            console.error("[tool-manager] mountPanel failed", err);
+            cleanup = null;
+        }
+
+        await yieldMicrotask();
+        if (getLifecycleAborted(controller.signal)) {
+            try {
+                (cleanup ?? SAFE_CLEANUP)();
+            } catch (err) {
+                console.error("[tool-manager] cleanup failed", err);
+            }
+            host.empty();
+            switchController = null;
+            return;
+        }
+
+        try {
+            next.onActivate?.(ctx);
+        } catch (err) {
+            console.error("[tool-manager] onActivate failed", err);
+        }
+
+        active = { module: next, cleanup };
+        options.onToolChanged?.(next);
+
+        if (!getLifecycleAborted(controller.signal) && ctx.getHandles()) {
+            try {
+                next.onMapRendered?.(ctx);
+            } catch (err) {
+                console.error("[tool-manager] onMapRendered failed", err);
+            }
+        }
+
+        if (switchController === controller) {
+            switchController = null;
+        }
+    };
+
+    const notifyMapRendered = () => {
+        if (!active) return;
+        const ctx = options.getContext();
+        if (!ctx || getLifecycleAborted(null) || !ctx.getHandles()) {
+            return;
+        }
+        try {
+            active.module.onMapRendered?.(ctx);
+        } catch (err) {
+            console.error("[tool-manager] onMapRendered failed", err);
+        }
+    };
+
+    const deactivate = () => {
+        const ctx = options.getContext();
+        switchController?.abort();
+        switchController = null;
+        teardownActive(ctx);
+    };
+
+    const destroy = () => {
+        if (destroyed) return;
+        destroyed = true;
+        deactivate();
+    };
+
+    const getActive = () => active?.module ?? null;
+
+    return {
+        getActive,
+        switchTo,
+        notifyMapRendered,
+        deactivate,
+        destroy,
+    };
+}

--- a/salt-marcher/src/apps/cartographer/editor/tools/tools-api.ts
+++ b/salt-marcher/src/apps/cartographer/editor/tools/tools-api.ts
@@ -10,6 +10,11 @@ export type ToolContext = {
     getFile(): TFile | null;
     getHandles(): RenderHandles | null;
     getOptions(): HexOptions | null;
+    /**
+     * Provides the lifecycle abort signal for the hosting editor mode. Tools can use this to
+     * short-circuit async work (e.g. dropdown reloads) once the mode transitions away.
+     */
+    getAbortSignal(): AbortSignal | null;
     setStatus(msg: string): void;          // optional: Status-/Tooltip-Ausgabe
 };
 
@@ -25,4 +30,17 @@ export type ToolModule = {
     onMapRendered?(ctx: ToolContext): void;
     /** Hex-Klick abfangen. true = handled (Editor öffnet nichts mehr) */
     onHexClick?(rc: { r: number; c: number }, ctx: ToolContext): Promise<boolean | void> | boolean | void;
+};
+
+export type ToolManager = {
+    /** Returns the currently active tool (if any). */
+    getActive(): ToolModule | null;
+    /** Switches to the requested tool and initialises its panel lifecycle. */
+    switchTo(id: string): Promise<void>;
+    /** Notifies the active tool that render handles are available. */
+    notifyMapRendered(): void;
+    /** Performs a hard teardown of the active tool. */
+    deactivate(): void;
+    /** Aborts pending work and clears all internal state. */
+    destroy(): void;
 };

--- a/salt-marcher/src/core/hex-mapper/hex-render.ts
+++ b/salt-marcher/src/core/hex-mapper/hex-render.ts
@@ -13,13 +13,13 @@ export type { HexInteractionDelegate, HexInteractionOutcome } from "./render/typ
 export { createEventBackedInteractionDelegate } from "./render/interaction-delegate";
 
 export type RenderHandles = {
-    svg: SVGSVGElement;
-    contentG: SVGGElement;
-    overlay: SVGRectElement;
-    polyByCoord: Map<string, SVGPolygonElement>;
+    readonly svg: SVGSVGElement;
+    readonly contentG: SVGGElement;
+    readonly overlay: SVGRectElement;
+    readonly polyByCoord: ReadonlyMap<string, SVGPolygonElement>;
     setFill(coord: HexCoord, color: string): void;
     /** Fügt fehlende Polygone für die angegebenen Koordinaten hinzu und erweitert viewBox/Overlay. */
-    ensurePolys(coords: HexCoord[]): void;
+    ensurePolys(coords: readonly HexCoord[]): void;
     /** Ersetzt den aktiven Interaktions-Delegate (z. B. für Editor-Tools). */
     setInteractionDelegate(delegate: HexInteractionDelegate | null): void;
     destroy(): void;
@@ -79,7 +79,7 @@ export async function renderHexMap(
         scene.setFill(coord, color);
     }
 
-    const ensurePolys = (coords: HexCoord[]) => {
+    const ensurePolys = (coords: readonly HexCoord[]) => {
         if (!coords.length) return;
         scene.ensurePolys(coords);
     };

--- a/salt-marcher/tests/cartographer/editor/editor-mode.test.ts
+++ b/salt-marcher/tests/cartographer/editor/editor-mode.test.ts
@@ -1,0 +1,224 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type { CartographerModeLifecycleContext, HexCoord } from "../../../src/apps/cartographer/presenter";
+import type { RenderHandles } from "../../../src/core/hex-mapper/hex-render";
+import { createEditorMode } from "../../../src/apps/cartographer/modes/editor";
+
+const ensureObsidianDomHelpers = () => {
+    const proto = HTMLElement.prototype as any;
+    if (!proto.createEl) {
+        proto.createEl = function(tag: string, options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            const el = document.createElement(tag);
+            if (options?.text) el.textContent = options.text;
+            if (options?.cls) {
+                for (const cls of options.cls.split(/\s+/).filter(Boolean)) {
+                    el.classList.add(cls);
+                }
+            }
+            if (options?.attr) {
+                for (const [key, value] of Object.entries(options.attr)) {
+                    el.setAttribute(key, value);
+                }
+            }
+            this.appendChild(el);
+            return el;
+        };
+    }
+    if (!proto.createDiv) {
+        proto.createDiv = function(options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            return this.createEl("div", options);
+        };
+    }
+    if (!proto.empty) {
+        proto.empty = function() {
+            while (this.firstChild) {
+                this.removeChild(this.firstChild);
+            }
+            return this;
+        };
+    }
+    if (!proto.setText) {
+        proto.setText = function(text: string) {
+            this.textContent = text;
+            return this;
+        };
+    }
+    if (!proto.toggleClass) {
+        proto.toggleClass = function(cls: string, force?: boolean) {
+            this.classList.toggle(cls, force);
+            return this;
+        };
+    }
+};
+
+beforeAll(() => {
+    ensureObsidianDomHelpers();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+const svgNS = "http://www.w3.org/2000/svg";
+
+const createHandles = (): RenderHandles => ({
+    svg: document.createElementNS(svgNS, "svg"),
+    contentG: document.createElementNS(svgNS, "g"),
+    overlay: document.createElementNS(svgNS, "rect"),
+    polyByCoord: new Map(),
+    setFill: vi.fn(),
+    ensurePolys: vi.fn(),
+    setInteractionDelegate: vi.fn(),
+    destroy: vi.fn(),
+});
+
+type ToolMock = {
+    mountPanel: ReturnType<typeof vi.fn>;
+    onActivate: ReturnType<typeof vi.fn>;
+    onDeactivate: ReturnType<typeof vi.fn>;
+    onMapRendered: ReturnType<typeof vi.fn>;
+    onHexClick: ReturnType<typeof vi.fn>;
+    cleanup: ReturnType<typeof vi.fn>;
+};
+
+const toolMock: ToolMock = (() => {
+    const cleanup = vi.fn();
+    return {
+        mountPanel: vi.fn(() => cleanup),
+        onActivate: vi.fn(),
+        onDeactivate: vi.fn(),
+        onMapRendered: vi.fn(),
+        onHexClick: vi.fn(async () => true),
+        cleanup,
+    } satisfies ToolMock;
+})();
+
+vi.mock("../../../src/apps/cartographer/editor/tools/terrain-brush/brush-options", () => ({
+    createBrushTool: () => ({
+        id: "mock-tool",
+        label: "Mock Tool",
+        mountPanel: toolMock.mountPanel,
+        onActivate: toolMock.onActivate,
+        onDeactivate: toolMock.onDeactivate,
+        onMapRendered: toolMock.onMapRendered,
+        onHexClick: toolMock.onHexClick,
+    }),
+}));
+
+const createLifecycleContext = (options: {
+    app?: App;
+    sidebarHost?: HTMLElement;
+    signal?: AbortSignal;
+    file?: TFile | null;
+    handles?: RenderHandles | null;
+}) => {
+    const app: App = options.app ?? ({ workspace: {} } as any);
+    const sidebar = options.sidebarHost ?? document.createElement("div");
+    const signal = options.signal ?? new AbortController().signal;
+    const file = options.file ?? null;
+    const handles = options.handles ?? null;
+    return {
+        app,
+        host: document.createElement("div"),
+        mapHost: document.createElement("div"),
+        sidebarHost: sidebar,
+        signal,
+        getFile: () => file,
+        getMapLayer: () => null,
+        getRenderHandles: () => handles,
+        getOptions: () => null,
+    } satisfies CartographerModeLifecycleContext;
+};
+
+describe("editor mode", () => {
+    it("mounts panel UI and activates the default tool", async () => {
+        const ctx = createLifecycleContext({});
+        const mode = createEditorMode();
+        const tool = toolMock;
+
+        await mode.onEnter(ctx);
+
+        expect(ctx.sidebarHost.querySelector(".sm-cartographer__panel"))
+            .not.toBeNull();
+        expect(tool.mountPanel).toHaveBeenCalledOnce();
+        expect(tool.onActivate).toHaveBeenCalledOnce();
+        expect(tool.onMapRendered).not.toHaveBeenCalled();
+
+        const select = ctx.sidebarHost.querySelector("select") as HTMLSelectElement;
+        expect(select.disabled).toBe(true);
+
+        const file = { path: "map.md", basename: "map" } as TFile;
+        const handles = createHandles();
+        await mode.onFileChange(file, handles, createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: ctx.signal,
+            file,
+            handles,
+            app: ctx.app,
+        }));
+
+        expect(tool.onMapRendered).toHaveBeenCalledTimes(1);
+        expect(select.disabled).toBe(false);
+        const fileLabel = ctx.sidebarHost.querySelector(".sm-cartographer__panel-file");
+        expect(fileLabel?.textContent).toBe("map");
+    });
+
+    it("tears down the active tool on exit and guards against aborted signals", async () => {
+        const ctx = createLifecycleContext({});
+        const mode = createEditorMode();
+        const tool = toolMock;
+
+        await mode.onEnter(ctx);
+
+        const handles = createHandles();
+        await mode.onFileChange(null, handles, createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: ctx.signal,
+            handles,
+            app: ctx.app,
+        }));
+
+        const abortController = new AbortController();
+        abortController.abort();
+        await mode.onFileChange(null, handles, createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: abortController.signal,
+            handles,
+            app: ctx.app,
+        }));
+        expect(tool.onMapRendered).toHaveBeenCalledTimes(1);
+
+        await mode.onExit(createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: ctx.signal,
+            app: ctx.app,
+        }));
+        expect(tool.onDeactivate).toHaveBeenCalled();
+        expect(tool.cleanup).toHaveBeenCalled();
+    });
+
+    it("routes hex click events to the active tool", async () => {
+        const ctx = createLifecycleContext({});
+        const mode = createEditorMode();
+        const tool = toolMock;
+
+        await mode.onEnter(ctx);
+        const handles = createHandles();
+        await mode.onFileChange(null, handles, createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: ctx.signal,
+            handles,
+            app: ctx.app,
+        }));
+
+        const coord: HexCoord = { r: 1, c: 2 };
+        await mode.onHexClick(coord, new CustomEvent("hex"), createLifecycleContext({
+            sidebarHost: ctx.sidebarHost,
+            signal: ctx.signal,
+            handles,
+            app: ctx.app,
+        }));
+
+        expect(tool.onHexClick).toHaveBeenCalledWith(coord, expect.any(Object));
+    });
+});

--- a/salt-marcher/tests/cartographer/editor/terrain-brush-options.test.ts
+++ b/salt-marcher/tests/cartographer/editor/terrain-brush-options.test.ts
@@ -1,0 +1,183 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type { ToolContext } from "../../../src/apps/cartographer/editor/tools/tools-api";
+import type { RenderHandles } from "../../../src/core/hex-mapper/hex-render";
+import { createBrushTool } from "../../../src/apps/cartographer/editor/tools/terrain-brush/brush-options";
+
+const ensureObsidianDomHelpers = () => {
+    const proto = HTMLElement.prototype as any;
+    if (!proto.createEl) {
+        proto.createEl = function(tag: string, options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            const el = document.createElement(tag);
+            if (options?.text) el.textContent = options.text;
+            if (options?.cls) {
+                for (const cls of options.cls.split(/\s+/).filter(Boolean)) {
+                    el.classList.add(cls);
+                }
+            }
+            if (options?.attr) {
+                for (const [key, value] of Object.entries(options.attr)) {
+                    el.setAttribute(key, value);
+                }
+            }
+            this.appendChild(el);
+            return el;
+        };
+    }
+    if (!proto.createDiv) {
+        proto.createDiv = function(options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            return this.createEl("div", options);
+        };
+    }
+    if (!proto.empty) {
+        proto.empty = function() {
+            while (this.firstChild) {
+                this.removeChild(this.firstChild);
+            }
+            return this;
+        };
+    }
+};
+
+beforeAll(() => {
+    ensureObsidianDomHelpers();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    loadRegions.mockReset();
+    applyBrush.mockReset();
+});
+
+const loadRegions = vi.fn();
+const applyBrush = vi.fn(() => Promise.resolve());
+
+vi.mock("../../../src/apps/cartographer/editor/tools/terrain-brush/brush", () => ({
+    applyBrush: (...args: unknown[]) => applyBrush(...args),
+}));
+
+vi.mock("../../../src/core/regions-store", () => ({
+    loadRegions: (...args: unknown[]) => loadRegions(...args),
+}));
+
+const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+const svgNS = "http://www.w3.org/2000/svg";
+
+const createHandles = (): RenderHandles => ({
+    svg: document.createElementNS(svgNS, "svg"),
+    contentG: document.createElementNS(svgNS, "g"),
+    overlay: document.createElementNS(svgNS, "rect"),
+    polyByCoord: new Map(),
+    setFill: vi.fn(),
+    ensurePolys: vi.fn(),
+    setInteractionDelegate: vi.fn(),
+    destroy: vi.fn(),
+});
+
+describe("terrain brush options", () => {
+    it("populates regions, tracks terrain, and resets when selections disappear", async () => {
+        const listeners: Record<string, () => void> = {};
+        loadRegions.mockResolvedValueOnce([
+            { name: "Forest", terrain: "forest" },
+            { name: "Coast", terrain: "coast" },
+        ]);
+        const workspace = {
+            on: vi.fn((event: string, handler: () => void) => {
+                listeners[event] = handler;
+                return `${event}-token`;
+            }),
+            offref: vi.fn(),
+        };
+        const ctx: ToolContext = {
+            app: { workspace } as unknown as App,
+            getFile: () => null,
+            getHandles: () => null,
+            getOptions: () => null,
+            getAbortSignal: () => null,
+            setStatus: () => {},
+        };
+
+        const tool = createBrushTool();
+        const root = document.createElement("div");
+        const cleanup = tool.mountPanel(root, ctx);
+        await flushPromises();
+
+        const selects = root.querySelectorAll("select");
+        const regionSelect = selects[0] as HTMLSelectElement;
+        expect(regionSelect.options.length).toBe(3); // (none) + two regions
+
+        regionSelect.value = "Forest";
+        regionSelect.onchange?.(new Event("change"));
+        expect(regionSelect.selectedOptions[0].dataset.terrain).toBe("forest");
+
+        loadRegions.mockResolvedValueOnce([]);
+        listeners["salt:regions-updated"]?.();
+        await flushPromises();
+
+        expect(regionSelect.value).toBe("");
+        expect(regionSelect.options.length).toBe(1); // only (none)
+
+        cleanup();
+        expect(workspace.offref).toHaveBeenCalledWith("salt:terrains-updated-token");
+        expect(workspace.offref).toHaveBeenCalledWith("salt:regions-updated-token");
+    });
+
+    it("cancels dropdown updates when the lifecycle signal aborts", async () => {
+        const abortController = new AbortController();
+        let resolveRegions: ((value: unknown) => void) | null = null;
+        const pending = new Promise((resolve) => {
+            resolveRegions = resolve;
+        });
+        loadRegions.mockReturnValueOnce(pending as unknown as Promise<unknown>);
+        const ctx: ToolContext = {
+            app: { workspace: {} } as unknown as App,
+            getFile: () => null,
+            getHandles: () => null,
+            getOptions: () => null,
+            getAbortSignal: () => abortController.signal,
+            setStatus: () => {},
+        };
+
+        const tool = createBrushTool();
+        const root = document.createElement("div");
+        void tool.mountPanel(root, ctx);
+        abortController.abort();
+        resolveRegions?.([]);
+        await flushPromises();
+
+        const regionSelect = root.querySelector("select") as HTMLSelectElement;
+        expect(regionSelect.options.length).toBe(0);
+    });
+
+    it("ensures missing polygons before applying brush actions", async () => {
+        loadRegions.mockResolvedValue([]);
+        const handles = createHandles();
+        const ctx: ToolContext = {
+            app: { workspace: {} } as unknown as App,
+            getFile: () => ({ path: "map.md" }) as any,
+            getHandles: () => handles,
+            getOptions: () => ({ radius: 42 } as any),
+            getAbortSignal: () => null,
+            setStatus: () => {},
+        };
+
+        const tool = createBrushTool();
+        const root = document.createElement("div");
+        void tool.mountPanel(root, ctx);
+        await flushPromises();
+
+        const ensurePolys = vi.spyOn(handles, "ensurePolys");
+
+        const coord = { r: 0, c: 0 };
+        await tool.onHexClick?.(coord, ctx);
+
+        expect(ensurePolys).toHaveBeenCalled();
+        expect(applyBrush).toHaveBeenCalledWith(ctx.app, ctx.getFile(), coord, expect.objectContaining({
+            mode: expect.any(String),
+        }), handles);
+    });
+});

--- a/salt-marcher/tests/cartographer/editor/tool-manager.test.ts
+++ b/salt-marcher/tests/cartographer/editor/tool-manager.test.ts
@@ -1,0 +1,160 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createToolManager } from "../../../src/apps/cartographer/editor/tools/tool-manager";
+import type { ToolContext, ToolModule } from "../../../src/apps/cartographer/editor/tools/tools-api";
+import type { RenderHandles } from "../../../src/core/hex-mapper/hex-render";
+
+type ToolEvents = string[];
+
+const createTool = (id: string, events: ToolEvents): ToolModule => ({
+    id,
+    label: id,
+    mountPanel: vi.fn(() => {
+        events.push(`${id}:mount`);
+        return () => {
+            events.push(`${id}:cleanup`);
+        };
+    }),
+    onActivate: vi.fn(() => {
+        events.push(`${id}:activate`);
+    }),
+    onDeactivate: vi.fn(() => {
+        events.push(`${id}:deactivate`);
+    }),
+    onMapRendered: vi.fn(() => {
+        events.push(`${id}:render`);
+    }),
+    onHexClick: vi.fn(async () => {
+        events.push(`${id}:click`);
+        return true;
+    }),
+});
+
+const createHandles = (): RenderHandles => {
+    const svgNS = "http://www.w3.org/2000/svg";
+    return {
+        svg: document.createElementNS(svgNS, "svg"),
+        contentG: document.createElementNS(svgNS, "g"),
+        overlay: document.createElementNS(svgNS, "rect"),
+        polyByCoord: new Map(),
+        setFill: vi.fn(),
+        ensurePolys: vi.fn(),
+        setInteractionDelegate: vi.fn(),
+        destroy: vi.fn(),
+    } as unknown as RenderHandles;
+};
+
+describe("createToolManager", () => {
+    it("activates the requested tool and handles map rendered notifications", async () => {
+        const events: ToolEvents = [];
+        const toolA = createTool("a", events);
+        const toolB = createTool("b", events);
+        const host = document.createElement("div");
+        const handles = createHandles();
+        const abortController = new AbortController();
+
+        const context: ToolContext = {
+            app: { workspace: {} } as any,
+            getFile: () => null,
+            getHandles: () => handles,
+            getOptions: () => null,
+            getAbortSignal: () => abortController.signal,
+            setStatus: () => {},
+        };
+
+        const manager = createToolManager([toolA, toolB], {
+            getContext: () => context,
+            getPanelHost: () => host,
+            getLifecycleSignal: () => abortController.signal,
+        });
+
+        await manager.switchTo("a");
+        expect(events).toEqual(["a:mount", "a:activate", "a:render"]);
+        events.length = 0;
+
+        manager.notifyMapRendered();
+        expect(events).toEqual(["a:render"]);
+        events.length = 0;
+
+        await manager.switchTo("b");
+        expect(events).toEqual([
+            "a:deactivate",
+            "a:cleanup",
+            "b:mount",
+            "b:activate",
+            "b:render",
+        ]);
+        expect(manager.getActive()).toBe(toolB);
+
+        manager.destroy();
+        expect(events).toContain("b:deactivate");
+        expect(events).toContain("b:cleanup");
+    });
+
+    it("aborts pending switches when the lifecycle signal is cancelled", async () => {
+        const events: ToolEvents = [];
+        const tool = createTool("only", events);
+        const host = document.createElement("div");
+        const handles = createHandles();
+        const abortController = new AbortController();
+
+        const context: ToolContext = {
+            app: { workspace: {} } as any,
+            getFile: () => null,
+            getHandles: () => handles,
+            getOptions: () => null,
+            getAbortSignal: () => abortController.signal,
+            setStatus: () => {},
+        };
+
+        const manager = createToolManager([tool], {
+            getContext: () => context,
+            getPanelHost: () => host,
+            getLifecycleSignal: () => abortController.signal,
+        });
+
+        const switchPromise = manager.switchTo("only");
+        abortController.abort();
+        await switchPromise;
+
+        expect(events).toEqual([]);
+        expect(manager.getActive()).toBeNull();
+    });
+});
+const ensureObsidianDomHelpers = () => {
+    const proto = HTMLElement.prototype as any;
+    if (!proto.createEl) {
+        proto.createEl = function(tag: string, options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            const el = document.createElement(tag);
+            if (options?.text) el.textContent = options.text;
+            if (options?.cls) {
+                for (const cls of options.cls.split(/\s+/).filter(Boolean)) {
+                    el.classList.add(cls);
+                }
+            }
+            if (options?.attr) {
+                for (const [key, value] of Object.entries(options.attr)) {
+                    el.setAttribute(key, value);
+                }
+            }
+            this.appendChild(el);
+            return el;
+        };
+    }
+    if (!proto.createDiv) {
+        proto.createDiv = function(options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            return this.createEl("div", options);
+        };
+    }
+    if (!proto.empty) {
+        proto.empty = function() {
+            while (this.firstChild) {
+                this.removeChild(this.firstChild);
+            }
+            return this;
+        };
+    }
+};
+
+beforeAll(() => {
+    ensureObsidianDomHelpers();
+});


### PR DESCRIPTION
## Summary
- introduce a dedicated tool manager for editor modes with abort-aware switching and hook orchestration
- harden terrain brush options and dropdown handling while aligning copy with documented standards
- tighten render handle typings, extend tool context with lifecycle signals, and add regression tests plus documentation updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f75d54408325a301e33d8590faae