### PR TITLE
Add bootstrap service boundary and terrain watcher error handling

### DIFF
--- a/salt-marcher/docs/app/README.md
+++ b/salt-marcher/docs/app/README.md
@@ -13,7 +13,8 @@ Das Verzeichnis dokumentiert ausschließlich den Bootstrap-Layer. Detailentschei
 ## Bootstrap-Modul (`src/app/`)
 ```
 src/app/
-├─ main.ts                # Einstiegspunkt, registriert Views/Commands und orchestriert Dateninitialisierung
+├─ main.ts                 # Einstiegspunkt, registriert Views/Commands und orchestriert Dateninitialisierung
+├─ bootstrap-services.ts   # Service-Grenzen für Terrain-Bootstrap (Priming, Watcher, Logging)
 ├─ layout-editor-bridge.ts # Optionale Integration mit dem Layout-Editor-Plugin
 └─ css.ts                  # Gebündeltes Stylesheet, das zur Laufzeit injiziert wird
 ```
@@ -23,7 +24,10 @@ src/app/
 `main.ts` registriert Cartographer-, Encounter- und Library-Views sowie die zugehörigen Ribbon-Icons und Befehle. Dadurch bleibt der Einstieg in alle Workspaces konsistent und der Bootstrap kontrolliert, welche `WorkspaceLeaf`-Instanzen geöffnet oder wiederverwendet werden.
 
 ### Terrain-Watcher & Initialisierung
-Der Bootstrap sorgt dafür, dass die Terrain-Datei existiert (`ensureTerrainFile`), initiale Daten geladen werden (`loadTerrains` + `setTerrains`) und Änderungen über `watchTerrains` beobachtet werden. Der Watcher ruft aktuell nur einen leeren Callback auf; die konkreten Views reagieren über Event-Listener auf Datensätze. Fehlerbehandlung und Wiederanbindung des Watchers im Fehlerfall sind offene Punkte, siehe [To-Do: Plugin Bootstrap Review](../../todo/plugin-bootstrap-review.md).
+`main.ts` delegiert das Terrain-Priming an `createTerrainBootstrap`. Der Service sorgt dafür, dass die Terrain-Datei existiert (`ensureTerrainFile`), initiale Daten geladen werden (`loadTerrains` + `setTerrains`) und Änderungen über `watchTerrains` beobachtet werden. Fehler bei Priming oder Watcher-Laufzeit werden protokolliert und verhindern nicht mehr das vollständige Laden des Plugins – die Defaults bleiben aktiv, bis Obsidian erneut ein `modify`/`delete`-Event liefert. Bei Problemen schreibt der Service strukturierte Fehlermeldungen in die Konsole, damit Tests (`tests/app/terrain-bootstrap.test.ts`, `tests/app/terrain-watcher.test.ts`) und manuelle QA dieselben Schnittstellen nutzen.
+
+### Bootstrap Service Boundaries
+`bootstrap-services.ts` kapselt die Terrain-spezifische Lifecycle-Logik und bietet einen `TerrainBootstrapHandle` mit `start()`/`stop()`. Dadurch bleibt `main.ts` auf View-Registrierung, Commands und Integrationen fokussiert, während Tests den Service isoliert mocken können. Fehlerbehandlung, Retry-Strategien und Logging lassen sich über die bereitgestellte Logger-Schnittstelle steuern.
 
 ### Layout-Editor-Bridge
 `layout-editor-bridge.ts` kapselt die optionale Integration zum "Layout Editor"-Plugin. Beim Laden versucht der Bootstrap, eine View-Binding-Registrierung anzulegen und hält Listener bereit, um bei Aktivierung/Deaktivierung des Fremd-Plugins korrekt aufzuräumen. Fehler werden geloggt, damit Layout-Probleme sichtbar bleiben.
@@ -32,7 +36,7 @@ Der Bootstrap sorgt dafür, dass die Terrain-Datei existiert (`ensureTerrainFile
 `main.ts` injiziert das gebündelte Stylesheet (`HEX_PLUGIN_CSS`) als `<style id="hex-css">` ins Dokument und entfernt es beim Entladen. Dadurch bleiben die Hex-spezifischen Styles isoliert, ohne dass separate CSS-Dateien im Vault verwaltet werden müssen.
 
 ## Offene Fragen: Bootstrap vs. Feature-Verantwortung
-- Wie robust soll das Error-Handling des Terrain-Watchers sein, bevor Events an die Workspaces weitergereicht werden?
+- Müssen zukünftige Einstellungen (z. B. automatisches Öffnen des Cartographer) über denselben Service konfigurierbar werden?
 - Wann sollten Feature-spezifische Initialisierungen (z. B. Default-Layer-Konfigurationen) aus dem Bootstrap in die jeweiligen Workspaces verschoben werden?
 - Welche Standards gelten für Dritt-Plugin-Integrationen (Layout Editor, potenziell weitere), damit sie testbar bleiben?
 
@@ -41,4 +45,4 @@ Diese Fragen werden im [To-Do: Plugin Bootstrap Review](../../todo/plugin-bootst
 ## Standards & Abhängigkeiten
 - Halte dich an den [Documentation Style Guide](../../style-guide.md) sowie die Obsidian-Plugin-Konventionen (Lifecycle `onload`/`onunload`).
 - Bootstrap-Code muss ohne optionale Plugins lauffähig bleiben; Integrationen dürfen nur defensive Abhängigkeiten aufrufen.
-- Asynchrone Initialisierung (Terrain-Laden) darf UI-Registrierungen nicht blockieren; langfristig sind Tests für die Bootstrapping-Sequenz zu ergänzen (siehe To-Do oben).
+- Asynchrone Initialisierung (Terrain-Laden) darf UI-Registrierungen nicht blockieren; Integrationstests decken das Priming/Watcher-Verhalten inzwischen mit Obsidian-Mocks ab (siehe oben).

--- a/salt-marcher/docs/core/terrain-store-overview.md
+++ b/salt-marcher/docs/core/terrain-store-overview.md
@@ -22,12 +22,12 @@ The terrain store encapsulates reading and writing the shared terrain palette th
 - `parseTerrainBlock(md)` / `stringifyTerrainBlock(map)` – Bidirectional conversion between the fenced code block format and a typed record of terrain metadata.
 - `loadTerrains(app)` – Ensures the file, reads the markdown, and parses the fenced block into an in-memory palette.
 - `saveTerrains(app, next)` – Persists palette updates by rewriting (or appending) the terrain code block in the markdown file.
-- `watchTerrains(app, onChange?)` – Subscribes to Obsidian vault events and keeps the global palette aligned with file changes.
+- `watchTerrains(app, options)` – Subscribes to Obsidian vault events and keeps the global palette aligned with file changes. `options.onChange` replaces the legacy callback signature; `options.onError` logs or forwards failures without surfacing unhandled promise rejections.
 
 ## Watcher Flow
 1. The watcher attaches to both `modify` and `delete` vault events through a shared dispatcher that filters for `SaltMarcher/Terrains.md`.
 2. On `delete` the handler first calls `ensureTerrainFile` to recreate the file with default content, guaranteeing a valid fenced block exists immediately after removal.
-3. Both `modify` and `delete` paths call a shared `update` routine that reloads the file via `loadTerrains`, pushes the palette into the in-memory registry with `setTerrains`, and only then emits the `salt:terrains-updated` workspace event followed by the optional `onChange` callback.
+3. Both `modify` and `delete` paths call a shared `update` routine that reloads the file via `loadTerrains`, pushes the palette into the in-memory registry with `setTerrains`, and only then emits the `salt:terrains-updated` workspace event followed by the optional `onChange` callback. Exceptions are caught and rerouted through the configured `onError` handler (or `console.error` by default) so the watcher stays attached even if vault access fails temporarily.
 4. The disposer returned by `watchTerrains` tears down every registered `EventRef` exactly once, ensuring no lingering listeners remain if the watcher is disposed repeatedly.
 
 ## Data Flow Notes

--- a/salt-marcher/src/app/bootstrap-services.ts
+++ b/salt-marcher/src/app/bootstrap-services.ts
@@ -1,0 +1,110 @@
+// src/app/bootstrap-services.ts
+import type { App } from "obsidian";
+import {
+    ensureTerrainFile,
+    loadTerrains,
+    watchTerrains,
+    type TerrainWatcherOptions,
+} from "../core/terrain-store";
+import { setTerrains } from "../core/terrain";
+
+export interface TerrainBootstrapLogger {
+    info?(message: string, context?: Record<string, unknown>): void;
+    warn?(message: string, context?: Record<string, unknown>): void;
+    error?(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface TerrainBootstrapHandle {
+    start(): Promise<boolean>;
+    stop(): void;
+}
+
+export interface TerrainBootstrapConfig {
+    ensureTerrainFile?: typeof ensureTerrainFile;
+    loadTerrains?: typeof loadTerrains;
+    setTerrains?: typeof setTerrains;
+    watchTerrains?: (app: App, options?: TerrainWatcherOptions | (() => void | Promise<void>)) => () => void;
+    logger?: TerrainBootstrapLogger;
+}
+
+const defaultLogger: Required<TerrainBootstrapLogger> = {
+    info: (message, context) => {
+        if (context) {
+            console.info(`[salt-marcher] ${message}`, context);
+        } else {
+            console.info(`[salt-marcher] ${message}`);
+        }
+    },
+    warn: (message, context) => {
+        if (context) {
+            console.warn(`[salt-marcher] ${message}`, context);
+        } else {
+            console.warn(`[salt-marcher] ${message}`);
+        }
+    },
+    error: (message, context) => {
+        if (context) {
+            console.error(`[salt-marcher] ${message}`, context);
+        } else {
+            console.error(`[salt-marcher] ${message}`);
+        }
+    },
+};
+
+export function createTerrainBootstrap(app: App, config: TerrainBootstrapConfig = {}): TerrainBootstrapHandle {
+    const deps = {
+        ensureTerrainFile: config.ensureTerrainFile ?? ensureTerrainFile,
+        loadTerrains: config.loadTerrains ?? loadTerrains,
+        setTerrains: config.setTerrains ?? setTerrains,
+        watchTerrains: config.watchTerrains ?? watchTerrains,
+        logger: config.logger ?? defaultLogger,
+    } as const;
+
+    let disposeWatcher: (() => void) | null = null;
+
+    const stop = () => {
+        if (disposeWatcher) {
+            try {
+                disposeWatcher();
+            } catch (error) {
+                deps.logger.warn?.("Failed to dispose terrain watcher", { error: error as unknown });
+            }
+        }
+        disposeWatcher = null;
+    };
+
+    const start = async (): Promise<boolean> => {
+        stop();
+        let primed = true;
+        try {
+            await deps.ensureTerrainFile(app);
+            const map = await deps.loadTerrains(app);
+            deps.setTerrains(map);
+        } catch (error) {
+            primed = false;
+            deps.logger.error?.("Failed to prime terrain palette from vault", { error: error as unknown });
+        }
+
+        try {
+            disposeWatcher = deps.watchTerrains(app, {
+                onError: (error, meta) => {
+                    deps.logger.error?.("Terrain watcher failed to apply vault change", {
+                        error: error as unknown,
+                        reason: meta.reason,
+                    });
+                },
+            });
+        } catch (error) {
+            primed = false;
+            deps.logger.error?.("Failed to register terrain watcher", { error: error as unknown });
+            disposeWatcher = null;
+        }
+
+        return primed;
+    };
+
+    return {
+        start,
+        stop,
+    };
+}

--- a/salt-marcher/tests/app/main.integration.test.ts
+++ b/salt-marcher/tests/app/main.integration.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App, PluginManifest } from "obsidian";
+
+const startSpy = vi.fn<[], Promise<boolean>>();
+const stopSpy = vi.fn();
+
+vi.mock("../../src/app/bootstrap-services", () => {
+    return {
+        createTerrainBootstrap: vi.fn(() => ({
+            start: startSpy,
+            stop: stopSpy,
+        })),
+    };
+});
+
+vi.mock("../../src/apps/cartographer", () => ({
+    VIEW_CARTOGRAPHER: "cartographer", 
+    CartographerView: class CartographerView {},
+    openCartographer: vi.fn(),
+    detachCartographerLeaves: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/apps/encounter/view", () => ({
+    EncounterView: class EncounterView {
+        constructor(public leaf: unknown) {
+            void leaf;
+        }
+    },
+    VIEW_ENCOUNTER: "encounter",
+}));
+
+vi.mock("../../src/apps/library/view", () => ({
+    LibraryView: class LibraryView {
+        constructor(public leaf: unknown) {
+            void leaf;
+        }
+    },
+    VIEW_LIBRARY: "library",
+}));
+
+vi.mock("../../src/app/layout-editor-bridge", () => ({
+    setupLayoutEditorBridge: vi.fn(() => vi.fn()),
+}));
+
+import SaltMarcherPlugin from "../../src/app/main";
+import { createTerrainBootstrap } from "../../src/app/bootstrap-services";
+
+describe("SaltMarcherPlugin bootstrap integration", () => {
+    beforeEach(() => {
+        startSpy.mockReset();
+        stopSpy.mockReset();
+        startSpy.mockResolvedValue(true);
+        vi.mocked(createTerrainBootstrap).mockClear();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const createPlugin = () => {
+        const app = new App();
+        const manifest: PluginManifest = {
+            id: "salt-marcher",
+            name: "Salt Marcher",
+            version: "0.0.0",
+            author: "tests",
+        };
+        return new SaltMarcherPlugin(app, manifest);
+    };
+
+    it("initialises and tears down the terrain bootstrapper", async () => {
+        const plugin = createPlugin();
+        await plugin.onload();
+
+        expect(createTerrainBootstrap).toHaveBeenCalledTimes(1);
+        expect(createTerrainBootstrap).toHaveBeenCalledWith(plugin.app, expect.objectContaining({ logger: expect.any(Object) }));
+        expect(startSpy).toHaveBeenCalledTimes(1);
+
+        await plugin.onunload();
+        expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs a warning when priming fails", async () => {
+        const plugin = createPlugin();
+        startSpy.mockResolvedValueOnce(false);
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await plugin.onload();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            "[SaltMarcher] Terrain palette could not be initialised; defaults remain active until the vault updates."
+        );
+
+        await plugin.onunload();
+        warnSpy.mockRestore();
+    });
+});

--- a/salt-marcher/tests/app/terrain-bootstrap.test.ts
+++ b/salt-marcher/tests/app/terrain-bootstrap.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { createTerrainBootstrap } from "../../src/app/bootstrap-services";
+
+describe("createTerrainBootstrap", () => {
+    const createLogger = () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    });
+
+    it("primes terrains and registers a watcher", async () => {
+        const logger = createLogger();
+        const ensureTerrainFile = vi.fn().mockResolvedValue({});
+        const loadTerrains = vi.fn().mockResolvedValue({ Forest: { color: "#0f0", speed: 0.5 } });
+        const setTerrains = vi.fn();
+        const dispose = vi.fn();
+        const watchTerrains = vi.fn((_app, _options) => dispose);
+
+        const app = new App();
+        const bootstrap = createTerrainBootstrap(app, {
+            ensureTerrainFile,
+            loadTerrains,
+            setTerrains,
+            watchTerrains,
+            logger,
+        });
+
+        const primed = await bootstrap.start();
+
+        expect(primed).toBe(true);
+        expect(ensureTerrainFile).toHaveBeenCalledWith(app);
+        expect(loadTerrains).toHaveBeenCalledWith(app);
+        expect(setTerrains).toHaveBeenCalledWith({ Forest: { color: "#0f0", speed: 0.5 } });
+        expect(watchTerrains).toHaveBeenCalledTimes(1);
+        const options = watchTerrains.mock.calls[0][1];
+        expect(typeof options?.onError).toBe("function");
+        expect(logger.error).not.toHaveBeenCalled();
+
+        bootstrap.stop();
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs and continues when priming fails", async () => {
+        const logger = createLogger();
+        const failure = new Error("read failed");
+        const ensureTerrainFile = vi.fn().mockResolvedValue({});
+        const loadTerrains = vi.fn().mockRejectedValue(failure);
+        const setTerrains = vi.fn();
+        const dispose = vi.fn();
+        const watchTerrains = vi.fn((_app, options) => {
+            options?.onError?.(new Error("update failed"), { reason: "modify" });
+            return dispose;
+        });
+
+        const app = new App();
+        const bootstrap = createTerrainBootstrap(app, {
+            ensureTerrainFile,
+            loadTerrains,
+            setTerrains,
+            watchTerrains,
+            logger,
+        });
+
+        const primed = await bootstrap.start();
+
+        expect(primed).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+            "Failed to prime terrain palette from vault",
+            expect.objectContaining({ error: failure })
+        );
+        expect(logger.error).toHaveBeenCalledWith(
+            "Terrain watcher failed to apply vault change",
+            expect.objectContaining({ reason: "modify" })
+        );
+        expect(dispose).not.toHaveBeenCalled();
+    });
+
+    it("disposes the previous watcher when restarted", async () => {
+        const logger = createLogger();
+        const ensureTerrainFile = vi.fn().mockResolvedValue({});
+        const loadTerrains = vi.fn().mockResolvedValue({});
+        const setTerrains = vi.fn();
+        const firstDispose = vi.fn();
+        const secondDispose = vi.fn();
+        const watchTerrains = vi
+            .fn()
+            .mockReturnValueOnce(firstDispose)
+            .mockReturnValueOnce(secondDispose);
+
+        const app = new App();
+        const bootstrap = createTerrainBootstrap(app, {
+            ensureTerrainFile,
+            loadTerrains,
+            setTerrains,
+            watchTerrains,
+            logger,
+        });
+
+        await bootstrap.start();
+        await bootstrap.start();
+
+        expect(firstDispose).toHaveBeenCalledTimes(1);
+        expect(secondDispose).not.toHaveBeenCalled();
+        bootstrap.stop();
+        expect(secondDispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs when watcher registration throws", async () => {
+        const logger = createLogger();
+        const error = new Error("listener boom");
+        const ensureTerrainFile = vi.fn().mockResolvedValue({});
+        const loadTerrains = vi.fn().mockResolvedValue({});
+        const setTerrains = vi.fn();
+        const watchTerrains = vi.fn(() => {
+            throw error;
+        });
+
+        const app = new App();
+        const bootstrap = createTerrainBootstrap(app, {
+            ensureTerrainFile,
+            loadTerrains,
+            setTerrains,
+            watchTerrains,
+            logger,
+        });
+
+        const primed = await bootstrap.start();
+
+        expect(primed).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+            "Failed to register terrain watcher",
+            expect.objectContaining({ error })
+        );
+    });
+});

--- a/salt-marcher/tests/app/terrain-watcher.test.ts
+++ b/salt-marcher/tests/app/terrain-watcher.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App, TFile } from "obsidian";
+import * as terrainStore from "../../src/core/terrain-store";
+import { watchTerrains, TERRAIN_FILE } from "../../src/core/terrain-store";
+import * as terrain from "../../src/core/terrain";
+
+type Listener = (file: TFile) => void;
+
+class FakeVault {
+    private listeners = new Map<string, Set<Listener>>();
+    getAbstractFileByPath = (_path: string) => null;
+    createFolder = async () => {};
+    create = async (path: string, _contents: string) => {
+        const file = new TFile();
+        file.path = path;
+        file.basename = path.split("/").pop() ?? path;
+        return file;
+    };
+    read = async (_file: TFile) => "";
+    modify = async (_file: TFile, _data: string) => {};
+
+    on(event: string, handler: Listener) {
+        const set = this.listeners.get(event) ?? new Set<Listener>();
+        set.add(handler);
+        this.listeners.set(event, set);
+        return { off: () => set.delete(handler) };
+    }
+
+    offref(ref: { off: () => void }) {
+        ref.off();
+    }
+
+    emit(event: string, file: TFile) {
+        const set = this.listeners.get(event);
+        if (!set) return;
+        for (const handler of Array.from(set)) {
+            handler(file);
+        }
+    }
+
+    getListenerCount(event: string) {
+        return this.listeners.get(event)?.size ?? 0;
+    }
+}
+
+const flushAsync = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+};
+
+describe("watchTerrains", () => {
+    let app: App & { vault: FakeVault; workspace: App["workspace"] & { trigger: ReturnType<typeof vi.fn> } };
+    let vault: FakeVault;
+    let loadTerrainsSpy: ReturnType<typeof vi.spyOn>;
+    let ensureTerrainFileSpy: ReturnType<typeof vi.spyOn>;
+    let setTerrainsSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vault = new FakeVault();
+        app = new App() as typeof app;
+        app.vault = vault as unknown as App["vault"];
+        app.workspace = {
+            ...app.workspace,
+            trigger: vi.fn(),
+            getLeavesOfType: app.workspace.getLeavesOfType,
+            getLeaf: app.workspace.getLeaf,
+            revealLeaf: app.workspace.revealLeaf,
+            getActiveFile: app.workspace.getActiveFile,
+            on: app.workspace.on,
+            off: app.workspace.off,
+        };
+        ensureTerrainFileSpy = vi.spyOn(terrainStore, "ensureTerrainFile").mockResolvedValue(new TFile());
+        loadTerrainsSpy = vi.spyOn(terrainStore, "loadTerrains").mockResolvedValue({});
+        setTerrainsSpy = vi.spyOn(terrain, "setTerrains").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const emitModify = () => {
+        const file = new TFile();
+        file.path = TERRAIN_FILE;
+        vault.emit("modify", file);
+    };
+
+    it("reports loader failures through onError without throwing", async () => {
+        const failure = new Error("setter failed");
+        setTerrainsSpy.mockImplementation(() => {
+            throw failure;
+        });
+        const onError = vi.fn();
+
+        const stop = watchTerrains(app, { onError });
+        expect(vault.getListenerCount("modify")).toBeGreaterThan(0);
+        emitModify();
+        await flushAsync();
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError.mock.calls[0][0]).toBe(failure);
+        expect(onError.mock.calls[0][1]).toEqual({ reason: "modify" });
+        expect(setTerrainsSpy).toHaveBeenCalledTimes(1);
+
+        stop();
+    });
+
+    it("falls back to console logging when no onError handler is provided", async () => {
+        const failure = new Error("setter boom");
+        setTerrainsSpy.mockImplementation(() => {
+            throw failure;
+        });
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const stop = watchTerrains(app);
+        expect(vault.getListenerCount("modify")).toBeGreaterThan(0);
+        emitModify();
+        await flushAsync();
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.mock.calls[0][0]).toContain("Terrain watcher failed after modify event");
+        expect(consoleSpy.mock.calls[0][1]).toBe(failure);
+
+        stop();
+        consoleSpy.mockRestore();
+    });
+
+    it("captures errors thrown by change callbacks", async () => {
+        const failure = new Error("callback boom");
+        const onChange = vi.fn(() => {
+            throw failure;
+        });
+        const onError = vi.fn();
+
+        const stop = watchTerrains(app, { onChange, onError });
+        expect(vault.getListenerCount("modify")).toBeGreaterThan(0);
+        emitModify();
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError.mock.calls[0][0]).toBe(failure);
+        expect(onError.mock.calls[0][1]).toEqual({ reason: "modify" });
+        expect(setTerrainsSpy).toHaveBeenCalled();
+
+        stop();
+    });
+});

--- a/salt-marcher/tests/mocks/obsidian.ts
+++ b/salt-marcher/tests/mocks/obsidian.ts
@@ -1,3 +1,13 @@
+export type EventRef = { off: () => void };
+
+export interface PluginManifest {
+    id: string;
+    name: string;
+    version: string;
+    author: string;
+    description?: string;
+}
+
 export class Notice {
     message: string | undefined;
     constructor(message?: string) {
@@ -5,7 +15,11 @@ export class Notice {
     }
 }
 
-export class TFile {
+export class TAbstractFile {
+    path = "";
+}
+
+export class TFile extends TAbstractFile {
     path = "";
     basename = "";
 }
@@ -28,12 +42,25 @@ export class ItemView {
 }
 
 export class App {
+    vault: {
+        on: (event: string, handler: (file: TAbstractFile) => void) => EventRef;
+        offref: (ref: EventRef) => void;
+    };
     workspace = {
         getLeavesOfType: (_type: string) => [] as WorkspaceLeaf[],
         getLeaf: (_create: boolean) => new WorkspaceLeaf(),
         revealLeaf: (_leaf: WorkspaceLeaf) => {},
         getActiveFile: () => null as TFile | null,
+        on: (_name: string, _callback: (...args: unknown[]) => void) => {},
+        off: (_name: string, _callback: (...args: unknown[]) => void) => {},
+        trigger: (_name: string, ..._args: unknown[]) => {},
     };
+    constructor() {
+        this.vault = {
+            on: (_event: string, _handler: (file: TAbstractFile) => void) => ({ off: () => {} }),
+            offref: (_ref: EventRef) => {},
+        };
+    }
 }
 
 export function setIcon(_el: HTMLElement, _name: string): void {}
@@ -53,4 +80,38 @@ export class FuzzySuggestModal<T> extends Modal {
     }
     renderSuggestion(_item: T, _el: HTMLElement): void {}
     onChooseItem(_item: T, _evt: MouseEvent | KeyboardEvent): void {}
+}
+
+export function normalizePath(path: string): string {
+    return path.replace(/\\/g, "/");
+}
+
+export class Plugin {
+    app: App;
+    manifest: PluginManifest;
+    views = new Map<string, (leaf: WorkspaceLeaf) => ItemView>();
+    ribbons: Array<{ name: string; title: string; callback: () => void }> = [];
+    commands: Array<{ id: string; name: string; callback?: () => void }> = [];
+    constructor(app: App, manifest: PluginManifest) {
+        this.app = app;
+        this.manifest = manifest;
+    }
+    registerView(type: string, factory: (leaf: WorkspaceLeaf) => ItemView) {
+        this.views.set(type, factory);
+    }
+    addRibbonIcon(name: string, title: string, callback: () => void) {
+        this.ribbons.push({ name, title, callback });
+        const el = document.createElement("div");
+        el.dataset.icon = name;
+        el.title = title;
+        el.addEventListener("click", callback);
+        return el;
+    }
+    addCommand(command: { id: string; name: string; callback?: () => void }) {
+        this.commands.push(command);
+        return command;
+    }
+    register(cb: () => void) {
+        return cb;
+    }
 }

--- a/todo/plugin-bootstrap-review.md
+++ b/todo/plugin-bootstrap-review.md
@@ -9,8 +9,11 @@ Der Plugin-Bootstrap (`src/app/`) bündelt derzeit View-Registrierung, Terrain-D
 - `salt-marcher/src/core/terrain-store.ts`
 - `salt-marcher/src/core/terrain.ts`
 
+## Status-Update (Prototyp März 2024)
+- Terrain-Bootstrap wurde in `src/app/bootstrap-services.ts` extrahiert. `createTerrainBootstrap` kapselt Priming, Watcher-Registrierung und Logging. Fehler beim Laden des Terrains verhindern das Plugin nicht mehr vollständig – Defaults bleiben aktiv, bis ein Event erfolgreich verarbeitet wurde.
+- `watchTerrains` akzeptiert jetzt `TerrainWatcherOptions` (`onChange`, `onError`) und fängt Exceptions intern ab. Integrationstests (`tests/app/terrain-bootstrap.test.ts`, `tests/app/terrain-watcher.test.ts`, `tests/app/main.integration.test.ts`) sichern das Verhalten mit Obsidian-Mocks ab.
+
 ## Offene Fragen & Untersuchungen
-- **Watcher-Error-Handling:** Welche Fehlerzustände kann `watchTerrains` auslösen (z. B. gelöschte Dateien, Berechtigungen)? Wie werden Views informiert, und braucht es Retry-/Backoff-Strategien?
 - **Teststrategie:** Wie können wir Bootstrap-Sequenzen mit Vitest oder Integrationstests abdecken? Benötigen wir Mocks für Obsidian-`App` und Plugin-Manager, um die Layout-Bridge deterministisch zu testen?
 - **Plugin-Konfiguration:** Welche Teile der Bootstrap-Initialisierung sollten über Obsidian-Settings konfigurierbar sein (z. B. automatische Cartographer-Öffnung, CSS-Opt-Out)? Welche Persistenz ist dafür vorgesehen?
 - **Verantwortungsschnitt:** Welche Initialisierungen können in Feature-spezifische Module verschoben werden, damit der Bootstrap schlanker und wartbarer bleibt?


### PR DESCRIPTION
## Summary
- Extract a `createTerrainBootstrap` service to encapsulate terrain priming, logging, and watcher lifecycle, and update the plugin bootstrap to consume it via a scoped console logger.
- Harden `watchTerrains` with optional error callbacks and fallback logging while expanding the Obsidian mocks to support plugin-oriented integration scenarios.
- Add Vitest suites for the terrain bootstrapper, watcher error handling, and plugin bootstrap integration, and refresh the bootstrap documentation and TODO entry to describe the new responsibilities.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f77021688325934233e169773329