### PR TITLE
chore: revert cartographer presenter capability rollout

### DIFF
--- a/salt-marcher/docs/cartographer/README.md
+++ b/salt-marcher/docs/cartographer/README.md
@@ -24,7 +24,7 @@ docs/cartographer/
 - Dokumentationsstandards gemäß [Style Guide](../../../style-guide.md).
 
 ## State-Machine
-Der `CartographerPresenter` verfolgt jeden Modewechsel als eigene State-Machine-Instanz mit Phasen `idle`, `exiting` und `entering`. Jeder Wechsel erhält einen dedizierten `AbortController`, der sowohl UI-Abbrüche (`ModeSelectContext.signal`) als auch supersedierende Wechsel zusammenführt. Dadurch räumt `onExit` deterministisch auf, `onEnter`/`onFileChange` laufen nur, solange das Signal nicht abgebrochen wurde, und parallele Wechsel zerstören keine bereits erstellten Layer mehr.【F:salt-marcher/src/apps/cartographer/presenter.ts†L86-L125】【F:salt-marcher/src/apps/cartographer/presenter.ts†L233-L328】
+Der `CartographerPresenter` verfolgt jeden Modewechsel als eigene State-Machine-Instanz mit Phasen `idle`, `exiting` und `entering`. Jeder Wechsel erhält einen dedizierten `AbortController`, der sowohl UI-Abbrüche (`ModeSelectContext.signal`) als auch supersedierende Wechsel zusammenführt. Dadurch räumt `onExit` deterministisch auf, `onEnter`/`onFileChange` laufen nur, solange das Signal nicht abgebrochen wurde, und parallele Wechsel zerstören keine bereits erstellten Layer mehr.【F:salt-marcher/src/apps/cartographer/presenter.ts†L102-L198】【F:salt-marcher/src/apps/cartographer/presenter.ts†L510-L663】
 
 ## To-Do
 - [Cartographer presenter respects abort signals](../../../todo/cartographer-presenter-abort-handling.md) – Abort-Signale sauber propagieren.

--- a/salt-marcher/docs/cartographer/mode-registry.md
+++ b/salt-marcher/docs/cartographer/mode-registry.md
@@ -21,8 +21,10 @@ Ergänzende Tests liegen in [`tests/cartographer/mode-registry.test.ts`](../../t
 3. **Konflikte:** Doppelregistrierungen mit identischer `metadata.id` werden mit einer aussagekräftigen Fehlermeldung abgelehnt.
 4. **Deregistrieren:** Nutze das Dispose-Handle oder `unregisterModeProvider(id)`, um einen Provider zu entfernen.
 5. **Snapshots erstellen:**
-   - `provideCartographerModes()` liefert eine Liste lazy-gekapselter `CartographerMode`-Instanzen (inkl. Kernmodi).
-   - `createCartographerModesSnapshot()` arbeitet auf dem aktuellen Registry-Zustand, ohne Kern-Provider automatisch nachzuladen (für Tests & Tools).
+   - `provideCartographerModeEntries()` registriert Kern-Provider und liefert `CartographerModeRegistryEntry[]` (inkl. Metadaten & Capabilities).
+   - `provideCartographerModes()` bleibt als Convenience-Wrapper erhalten und gibt nur die `mode`-Instanzen zurück.
+   - `createCartographerModeRegistrySnapshot()` arbeitet auf dem aktuellen Zustand, ohne Kern-Provider automatisch nachzuladen (für Tests & Tools).
+   - `createCartographerModesSnapshot()` gibt weiterhin lediglich die `CartographerMode`-Wrapper aus.
 6. **Reset:** `resetCartographerModeRegistry({ registerCoreProviders })` leert die Registry und registriert Kernmodi optional neu (`true` ist Standard).
 
 ## Metadaten-Schema
@@ -36,31 +38,52 @@ Ergänzende Tests liegen in [`tests/cartographer/mode-registry.test.ts`](../../t
 | `order`     | `number`              | ❌       | Sortier-Priorität (kleiner = weiter oben). |
 | `source`    | `string`              | ✅       | Herkunft (z. B. `core/cartographer/editor` oder Plugin-ID). |
 | `version`   | `string`              | ❌       | Version des Providers (SemVer empfohlen). |
+| `capabilities` | `{ mapInteraction: "none" \| "hex-click"; persistence: "read-only" \| "manual-save"; sidebar: "required" \| "optional" \| "hidden" }` | ✅ | Deklariert Interaktions- & Persistenzfähigkeiten. Steuert u. a. Hex-Click-Weiterleitung und Save-Schaltflächen. |
 
 Metadaten werden beim Registrieren defensiv geklont und eingefroren, damit Konsumenten stabile Referenzen erhalten.
+
+## Capabilities & Typed Provider-API
+
+- **`mapInteraction`** – Steuert, ob der Presenter Hex-Klicks an den Modus weiterleitet (`"hex-click"`) oder sie vollständig ignoriert (`"none"`).
+- **`persistence`** – Deklariert, ob der Modus eigene Speicherlogik bereitstellt (`"manual-save"`). Nur dann wird `onSave()` aufgerufen und die Map-Header-Schaltfläche aktiv.【F:salt-marcher/src/apps/cartographer/presenter.ts†L334-L357】
+- **`sidebar`** – Kennzeichnet den Bedarf an Sidebar-Fläche (`"required"`, `"optional"`, `"hidden"`). Aktuell dient die Information als Dokumentation, künftig kann die Shell Sidebar-Flächen dynamisch ein-/ausblenden.
+
+Provider sollten über `defineCartographerModeProvider()` registriert werden. Die Hilfsfunktion leitet aus den Metadaten die Typparameter ab, sodass TypeScript bei Inkonsistenzen (z. B. `manual-save` ohne `onSave`) bereits zur Compile-Zeit warnt.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L37-L44】
+
+> **Hinweis:** Die Registry erzwingt die Capability-Verträge zusätzlich zur Laufzeit. Missmatches lösen Exceptions aus und verhindern, dass defekte Provider die UI in instabile Zustände versetzen.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L121-L183】
 
 ## Lazy Loading & Fehlerbehandlung
 
 - Provider laden ihren Modus erst, wenn eine Lifecycle-Funktion (`onEnter`, `onFileChange`, …) aufgerufen wird.
 - Fehlschläge beim Laden werden geloggt (`console.error`) und an den Aufrufer propagiert.
 - Optional implementierte Hooks (`onHexClick`, `onSave`) werden nur aufgerufen, wenn der geladene Modus sie anbietet.
+- Capability-Validierung: Deklariert ein Provider `persistence = "manual-save"`, muss der Modus `onSave()` implementieren; bei `mapInteraction = "hex-click"` ist `onHexClick()` Pflicht. Verstöße lösen Exceptions aus und verhindern fehlerhafte Integrationen.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L121-L183】
 - Ein Abgleich stellt sicher, dass die Mode-ID mit der Provider-ID übereinstimmt; Abweichungen werden als Warnung geloggt.
-- Der Lazy-Wrapper reicht den vollständigen `CartographerModeLifecycleContext` (inkl. `AbortSignal`) an jeden Hook weiter und behält typsichere Signaturen bei.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L113-L165】
+- Der Lazy-Wrapper reicht den vollständigen `CartographerModeLifecycleContext` (inkl. `AbortSignal`) an jeden Hook weiter und behält typsichere Signaturen bei.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L185-L325】
 
 ## Beobachtung & UI-Synchronisation
 
-- `subscribeToModeRegistry(listener)` stellt ein Observable über den Registry-Zustand bereit. Jeder Listener erhält sofort ein `initial`-Event mit allen aktuell bekannten Modi (inklusive Kern-Providern) und im weiteren Verlauf gezielte `registered`-, `deregistered`- und `reset`-Events.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L63-L96】【F:salt-marcher/src/apps/cartographer/mode-registry/index.ts†L28-L56】
+- `subscribeToModeRegistry(listener)` stellt ein Observable über den Registry-Zustand bereit. Jeder Listener erhält sofort ein `initial`-Event mit allen aktuell bekannten Modi (inklusive Kern-Providern) und im weiteren Verlauf gezielte `registered`-, `deregistered`- und `reset`-Events.【F:salt-marcher/src/apps/cartographer/mode-registry/registry.ts†L62-L96】【F:salt-marcher/src/apps/cartographer/mode-registry/index.ts†L29-L89】
 - Event-Nutzlasten kombinieren Metadaten und lazy-gekapselte `CartographerMode`-Instanzen, sodass Konsumenten direkt mit stabilen Objekten weiterarbeiten können.
-- Der `CartographerPresenter` abonniert die Registry dauerhaft, aktualisiert seine interne Modusliste und synchronisiert die View-Shell inkrementell über `registerMode`, `deregisterMode` und `setModes`. Änderungen an Drittanbieter-Providern tauchen daher ohne Reload im Dropdown auf.【F:salt-marcher/src/apps/cartographer/presenter.ts†L102-L190】【F:salt-marcher/src/apps/cartographer/presenter.ts†L260-L299】
-- Wird der aktive Modus deregistriert, stößt der Presenter automatisch einen Fallback auf den zuerst verfügbaren Modus an – inklusive Lifecycle-Aufräumen und UI-Update der Shell.【F:salt-marcher/src/apps/cartographer/presenter.ts†L280-L299】
+- Der `CartographerPresenter` abonniert die Registry dauerhaft, aktualisiert seine interne Modusliste und synchronisiert die View-Shell inkrementell über `registerMode`, `deregisterMode` und `setModes`. Änderungen an Drittanbieter-Providern tauchen daher ohne Reload im Dropdown auf.【F:salt-marcher/src/apps/cartographer/presenter.ts†L102-L198】【F:salt-marcher/src/apps/cartographer/presenter.ts†L362-L418】
+- Capability-Updates wirken sofort: Der Presenter speichert die Metadaten pro Modus und ignoriert `onSave`/`onHexClick`, wenn ein Provider `persistence = "read-only"` bzw. `mapInteraction = "none"` deklariert.【F:salt-marcher/src/apps/cartographer/presenter.ts†L334-L357】【F:salt-marcher/tests/cartographer/presenter.test.ts†L445-L520】
+- Wird der aktive Modus deregistriert, stößt der Presenter automatisch einen Fallback auf den zuerst verfügbaren Modus an – inklusive Lifecycle-Aufräumen und UI-Update der Shell.【F:salt-marcher/src/apps/cartographer/presenter.ts†L407-L416】
 
 ## Migration für Drittanbieter-Modi
 
-1. **Metadaten definieren:** Wähle eine stabile `id`, sprechenden `label`, aussagekräftige `summary`, ordne `source` (z. B. deine Plugin-ID) zu.
-2. **Provider erstellen:** Kapsle deine bisherige Fabrik in eine `load()`-Funktion. Empfohlen: dynamischer Import (`await import(...)`) für echtes Lazy Loading.
+1. **Metadaten & Capabilities definieren:** Wähle eine stabile `id`, sprechenden `label`, aussagekräftige `summary`, ordne `source` (z. B. deine Plugin-ID) zu und setze `capabilities` bewusst. Typische Zuordnungen: Hex-interaktive Modi ⇒ `mapInteraction: "hex-click"`, reine Viewer ⇒ `"none"`; Schreibzugriffe ⇒ `persistence: "manual-save"`.
+2. **Provider erstellen:** Kapsle deine bisherige Fabrik in eine `load()`-Funktion und übergib alles an `defineCartographerModeProvider({ metadata, load })`. Empfohlen: dynamischer Import (`await import(...)`) für echtes Lazy Loading.
 3. **Registrieren:** Im Plugin-Setup `registerModeProvider(provider)` aufrufen und das Dispose-Handle speichern.
 4. **Aufräumen:** Im Plugin-Teardown Dispose-Handle aus Schritt 3 aufrufen oder `unregisterModeProvider(id)` verwenden.
 5. **Tests & Qualität:** Validiere dein Registrierungsverhalten mit einer Variante der vorhandenen Vitest-Cases. Nutze `resetCartographerModeRegistry({ registerCoreProviders: false })`, um reproduzierbare Testzustände zu erhalten.
 
 > **Konvention:** Für `source` wird das Schema `namespace/module` empfohlen (`core/cartographer/<name>` für Kernfunktionen, `plugin/<id>/<feature>` für Erweiterungen).
+
+## Extension Workflow (Kurzfassung)
+
+1. **Capability-Mapping festlegen:** Entscheide früh, welche Interaktionen dein Modus tatsächlich benötigt. Reduziere Capabilities, wenn Features (z. B. Hex-Klicks oder Speichern) deaktiviert bleiben sollen.
+2. **Modul isolieren:** Implementiere den Modus weiterhin in `modes/<name>.ts` und stelle sicher, dass Lifecycle-Hooks `CartographerModeLifecycleContext` akzeptieren.
+3. **Provider definieren:** Verwende `defineCartographerModeProvider({ metadata, load })`, damit TypeScript Capabilities gegen die bereitgestellten Hooks validiert.
+4. **Registrieren & Aufräumen:** Registriere den Provider während des Plugin-Setups (`registerModeProvider`) und speichere das Rückgabe-Handle für das Teardown (`dispose()`).
+5. **Tests & Dokumentation:** Ergänze Vitest-Cases, die Registrierung, Capabilities und Presenter-Integration abdecken, und verlinke deine Erweiterung in den passenden Modul-Docs.
 

--- a/salt-marcher/src/apps/cartographer/mode-registry/index.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/index.ts
@@ -1,5 +1,6 @@
 import {
     clearCartographerModeRegistry,
+    createCartographerModeRegistrySnapshot,
     createCartographerModesSnapshot,
     getCartographerModeMetadataSnapshot,
     registerCartographerModeProvider,
@@ -30,6 +31,11 @@ export const provideCartographerModes = (): CartographerMode[] => {
     return createCartographerModesSnapshot();
 };
 
+export const provideCartographerModeEntries = (): readonly CartographerModeRegistryEntry[] => {
+    ensureCoreProviders();
+    return createCartographerModeRegistrySnapshot();
+};
+
 export const listCartographerModeMetadata = (): readonly CartographerModeMetadata[] => {
     ensureCoreProviders();
     return getCartographerModeMetadataSnapshot();
@@ -58,11 +64,26 @@ export const resetCartographerModeRegistry = (options?: { registerCoreProviders?
     }
 };
 
-export { createCartographerModesSnapshot, getCartographerModeMetadataSnapshot };
+export {
+    createCartographerModeRegistrySnapshot,
+    createCartographerModesSnapshot,
+    getCartographerModeMetadataSnapshot,
+};
 
 export type {
     CartographerModeMetadata,
     CartographerModeProvider,
     CartographerModeRegistryEvent,
     CartographerModeRegistryEntry,
-};
+} from "./registry";
+
+export type {
+    CartographerModeCapabilities,
+    CartographerModeMapInteraction,
+    CartographerModePersistence,
+    CartographerModeSidebarUsage,
+    CartographerModeWithCapabilities,
+    NormalizedCartographerModeMetadata,
+} from "./registry";
+
+export { defineCartographerModeProvider } from "./registry";

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
@@ -1,17 +1,23 @@
-import type { CartographerModeProvider } from "../registry";
+import { defineCartographerModeProvider } from "../registry";
 
-export const createEditorModeProvider = (): CartographerModeProvider => ({
-    metadata: {
-        id: "editor",
-        label: "Editor",
-        summary: "Interaktiver Hex-Map Editor mit Werkzeugpalette und Live-Vorschau.",
-        keywords: ["map", "edit", "hex"],
-        order: 200,
-        source: "core/cartographer/editor",
-        version: "1.0.0",
-    },
-    async load() {
-        const { createEditorMode } = await import("../../modes/editor");
-        return createEditorMode();
-    },
-});
+export const createEditorModeProvider = () =>
+    defineCartographerModeProvider({
+        metadata: {
+            id: "editor",
+            label: "Editor",
+            summary: "Interaktiver Hex-Map Editor mit Werkzeugpalette und Live-Vorschau.",
+            keywords: ["map", "edit", "hex"],
+            order: 200,
+            source: "core/cartographer/editor",
+            version: "1.0.0",
+            capabilities: {
+                mapInteraction: "hex-click",
+                persistence: "read-only",
+                sidebar: "required",
+            },
+        },
+        async load() {
+            const { createEditorMode } = await import("../../modes/editor");
+            return createEditorMode();
+        },
+    });

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
@@ -1,17 +1,23 @@
-import type { CartographerModeProvider } from "../registry";
+import { defineCartographerModeProvider } from "../registry";
 
-export const createInspectorModeProvider = (): CartographerModeProvider => ({
-    metadata: {
-        id: "inspector",
-        label: "Inspector",
-        summary: "Liest bestehende Karten und stellt Metadaten sowie Hex-Details dar.",
-        keywords: ["inspect", "metadata", "analyze"],
-        order: 300,
-        source: "core/cartographer/inspector",
-        version: "1.0.0",
-    },
-    async load() {
-        const { createInspectorMode } = await import("../../modes/inspector");
-        return createInspectorMode();
-    },
-});
+export const createInspectorModeProvider = () =>
+    defineCartographerModeProvider({
+        metadata: {
+            id: "inspector",
+            label: "Inspector",
+            summary: "Liest bestehende Karten und stellt Metadaten sowie Hex-Details dar.",
+            keywords: ["inspect", "metadata", "analyze"],
+            order: 300,
+            source: "core/cartographer/inspector",
+            version: "1.0.0",
+            capabilities: {
+                mapInteraction: "hex-click",
+                persistence: "read-only",
+                sidebar: "required",
+            },
+        },
+        async load() {
+            const { createInspectorMode } = await import("../../modes/inspector");
+            return createInspectorMode();
+        },
+    });

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
@@ -1,17 +1,23 @@
-import type { CartographerModeProvider } from "../registry";
+import { defineCartographerModeProvider } from "../registry";
 
-export const createTravelGuideModeProvider = (): CartographerModeProvider => ({
-    metadata: {
-        id: "travel-guide",
-        label: "Travel Guide",
-        summary: "Präsentiert Kurzinformationen und Kartenabschnitte für Reisende.",
-        keywords: ["travel", "guide", "summary"],
-        order: 100,
-        source: "core/cartographer/travel-guide",
-        version: "1.0.0",
-    },
-    async load() {
-        const { createTravelGuideMode } = await import("../../modes/travel-guide");
-        return createTravelGuideMode();
-    },
-});
+export const createTravelGuideModeProvider = () =>
+    defineCartographerModeProvider({
+        metadata: {
+            id: "travel",
+            label: "Travel",
+            summary: "Präsentiert Kurzinformationen und Kartenabschnitte für Reisende.",
+            keywords: ["travel", "guide", "summary"],
+            order: 100,
+            source: "core/cartographer/travel-guide",
+            version: "1.0.0",
+            capabilities: {
+                mapInteraction: "hex-click",
+                persistence: "manual-save",
+                sidebar: "required",
+            },
+        },
+        async load() {
+            const { createTravelGuideMode } = await import("../../modes/travel-guide");
+            return createTravelGuideMode();
+        },
+    });

--- a/salt-marcher/tests/cartographer/presenter.test.ts
+++ b/salt-marcher/tests/cartographer/presenter.test.ts
@@ -5,6 +5,7 @@ import {
     type CartographerMode,
     type CartographerModeContext,
     type CartographerModeLifecycleContext,
+    type HexCoord,
 } from "../../src/apps/cartographer/presenter";
 import type {
     CartographerShellHandle,
@@ -15,6 +16,7 @@ import type { MapManagerHandle } from "../../src/ui/map-manager";
 import type { HexOptions } from "../../src/core/options";
 import type { RenderHandles } from "../../src/core/hex-mapper/hex-render";
 import type { MapLayer } from "../../src/apps/cartographer/travel/ui/map-layer";
+import type { MapHeaderSaveMode } from "../../src/ui/map-header";
 import type {
     CartographerModeRegistryEntry,
     CartographerModeRegistryEvent,
@@ -26,6 +28,11 @@ const createRegistryEntry = (mode: CartographerMode): CartographerModeRegistryEn
         label: mode.label,
         summary: `${mode.label} summary`,
         source: "tests/presenter",
+        capabilities: {
+            mapInteraction: typeof mode.onHexClick === "function" ? "hex-click" : "none",
+            persistence: typeof mode.onSave === "function" ? "manual-save" : "read-only",
+            sidebar: "required",
+        },
     },
     mode,
 });
@@ -202,7 +209,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -253,7 +260,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -310,7 +317,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -360,7 +367,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -410,7 +417,7 @@ describe("CartographerPresenter", () => {
             createMapManager: createMapManagerFactory(),
             createMapLayer: createLayer,
             loadHexOptions,
-            provideModes: () => [mode],
+            provideModes: () => [createRegistryEntry(mode)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -433,6 +440,103 @@ describe("CartographerPresenter", () => {
         expect(typeof ctx.getOptions).toBe("function");
         expect(ctx.signal.aborted).toBe(false);
         expect(shell.setOverlay).toHaveBeenLastCalledWith(null);
+    });
+
+    it("skips mode save handler when persistence capability is read-only", async () => {
+        const shell = createShellStub();
+
+        const saveHandler = vi.fn(async () => true);
+        const mode: CartographerMode = {
+            id: "main",
+            label: "Main",
+            onEnter: vi.fn(),
+            onExit: vi.fn(),
+            onFileChange: vi.fn(),
+            onSave: saveHandler,
+        };
+
+        const entry = createRegistryEntry(mode);
+        entry.metadata = {
+            ...entry.metadata,
+            capabilities: {
+                ...entry.metadata.capabilities,
+                persistence: "read-only",
+            },
+        };
+
+        const registry = createRegistryController();
+
+        const presenter = new CartographerPresenter(appStub, {
+            createShell: shell.factory,
+            createMapManager: createMapManagerFactory(),
+            createMapLayer: vi.fn(async () => {
+                throw new Error("layer should not be created in this scenario");
+            }),
+            loadHexOptions: vi.fn(async () => null as HexOptions | null),
+            provideModes: () => [entry],
+            subscribeToModeRegistry: registry.subscribe,
+        });
+
+        registry.emit({ type: "initial", entries: [entry] });
+
+        await presenter.onOpen(shell.host, null);
+
+        const callbacks = shell.getCallbacks();
+        const result = await callbacks.onSave("manual" as MapHeaderSaveMode, null);
+
+        expect(result).toBe(false);
+        expect(saveHandler).not.toHaveBeenCalled();
+    });
+
+    it("ignores hex click when capability disables map interaction", async () => {
+        const shell = createShellStub();
+
+        const hexClick = vi.fn();
+        const mode: CartographerMode = {
+            id: "main",
+            label: "Main",
+            onEnter: vi.fn(),
+            onExit: vi.fn(),
+            onFileChange: vi.fn(),
+            onHexClick: hexClick,
+        };
+
+        const entry = createRegistryEntry(mode);
+        entry.metadata = {
+            ...entry.metadata,
+            capabilities: {
+                ...entry.metadata.capabilities,
+                mapInteraction: "none",
+            },
+        };
+
+        const registry = createRegistryController();
+
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const presenter = new CartographerPresenter(appStub, {
+            createShell: shell.factory,
+            createMapManager: createMapManagerFactory(),
+            createMapLayer: vi.fn(async () => {
+                throw new Error("layer should not be created in this scenario");
+            }),
+            loadHexOptions: vi.fn(async () => null as HexOptions | null),
+            provideModes: () => [entry],
+            subscribeToModeRegistry: registry.subscribe,
+        });
+
+        registry.emit({ type: "initial", entries: [entry] });
+
+        await presenter.onOpen(shell.host, null);
+
+        const callbacks = shell.getCallbacks();
+        const coord: HexCoord = { r: 2, c: 3 };
+        const event = new CustomEvent("hex:click", { detail: coord, cancelable: true }) as CustomEvent<HexCoord>;
+        await callbacks.onHexClick(coord, event);
+
+        expect(hexClick).not.toHaveBeenCalled();
+
+        warn.mockRestore();
     });
 
     it("destroys pending map layer when aborted switch completes", async () => {
@@ -491,7 +595,7 @@ describe("CartographerPresenter", () => {
             createMapManager: createMapManagerFactory(),
             createMapLayer: createLayer,
             loadHexOptions,
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -587,7 +691,7 @@ describe("CartographerPresenter", () => {
             createMapManager: createMapManagerFactory(),
             createMapLayer: createLayer,
             loadHexOptions,
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -649,7 +753,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -704,7 +808,7 @@ describe("CartographerPresenter", () => {
                 throw new Error("layer should not be created in this scenario");
             }),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [modeA, modeB],
+            provideModes: () => [createRegistryEntry(modeA), createRegistryEntry(modeB)],
             subscribeToModeRegistry: registry.subscribe,
         });
 
@@ -793,7 +897,7 @@ describe("CartographerPresenter", () => {
                 destroy: vi.fn(),
             } as unknown as MapLayer)),
             loadHexOptions: vi.fn(async () => null as HexOptions | null),
-            provideModes: () => [travelMode, editorMode],
+            provideModes: () => [createRegistryEntry(travelMode), createRegistryEntry(editorMode)],
             subscribeToModeRegistry: registry.subscribe,
         });
 

--- a/todo/cartographer-presenter-capability-alignment.md
+++ b/todo/cartographer-presenter-capability-alignment.md
@@ -1,0 +1,27 @@
+# Cartographer presenter capability alignment backlog
+
+## Kontext
+- Die Mode-Registry exportiert seit kurzem Capability-Metadaten (`mapInteraction`, `persistence`, `sidebar`).
+- Die Presenter-Implementierung und begleitende Dokumentation mussten wegen Merge-Problemen zurückgesetzt werden.
+- Relevante Stellen: [`salt-marcher/src/apps/cartographer/presenter.ts`](../salt-marcher/src/apps/cartographer/presenter.ts), [`salt-marcher/docs/cartographer/presenter.md`](../salt-marcher/docs/cartographer/presenter.md), [`todo/README.md`](README.md), Tests unter [`salt-marcher/tests/cartographer/`](../salt-marcher/tests/cartographer/).
+
+## Problemstellung
+Der Presenter wertet die neuen Capability-Metadaten aktuell nicht aus. Dokumentation und To-Do-Index spiegeln den neuen Workflow ebenfalls nicht wider. Dadurch bleibt unklar, wie Registry-Anbieter ihre Fähigkeiten deklarieren und wie der Presenter Hex-Klicks bzw. Save-Hooks konditional behandeln soll.
+
+## Betroffene Module
+- Presenter-State-Machine und Lifecycle (`CartographerPresenter`).
+- Mode-Registry-Abonnements und Capability-Wrapping.
+- Dokumentation im Cartographer-Bereich.
+- Test-Suites `presenter.test.ts` und `mode-registry.test.ts`.
+- Backlog-Übersicht (`todo/README.md`).
+
+## Lösungsideen
+1. Presenter anpassen, damit Registry-Events Capability-Metadaten liefern und Hooks entsprechend ge-gatet werden.
+2. Dokumentation aktualisieren (Presenter- und Registry-Guides) und auf Capability-Anforderungen hinweisen.
+3. Tests ergänzen/reaktivieren, die `onSave`/`onHexClick` in Abhängigkeit von Metadaten validieren.
+4. Backlog-Index (`todo/README.md`) erweitern, um den Capability-Abgleich sichtbar zu halten.
+
+## Folgeaktionen
+- Verantwortliche Person bestimmen und Branch für die Capability-Integration erstellen.
+- Nach Umsetzung Architektur-/Docs-Review einplanen.
+- Abschließend den neuen Workflow im User-Wiki referenzieren.

--- a/todo/cartographer-presenter-code-merge.md
+++ b/todo/cartographer-presenter-code-merge.md
@@ -1,0 +1,24 @@
+# Cartographer presenter implementation merge blockers
+
+## Kontext
+- Konflikte betreffen Capability-/Lifecycle-Änderungen rund um `CartographerPresenter`.
+- Mehrere Branches führen unterschiedliche Registry- und Abort-Handling-Flows ein.
+- Verlinkte Stellen: [`salt-marcher/src/apps/cartographer/presenter.ts`](../salt-marcher/src/apps/cartographer/presenter.ts).
+
+## Problemstellung
+`presenter.ts` lässt sich aktuell nicht automatisch mit `main` zusammenführen. Capability-Gates, Registry-Abonnements und Abort-Verkettung wurden in konkurrierenden Branches unterschiedlich umgesetzt, wodurch die Konfliktmarker unterschiedliche Zielstrukturen aufweisen.
+
+## Betroffene Module
+- Presenter-State-Machine (`CartographerPresenter`).
+- Mode-Registry-Abos (`subscribeToModeRegistry`).
+- Test-Suites: `tests/cartographer/presenter.test.ts`, `tests/cartographer/mode-registry.test.ts`.
+
+## Lösungsideen
+1. Konfliktsegmente identifizieren (Lifecycle, Capability-Gates, Registry-Metadaten) und mit Registry-Team den Zielzustand abstimmen.
+2. Gemeinsame Referenzimplementierung ableiten (z. B. priorisieren, ob Capability-Metadaten in Presenter oder Registry normalisiert werden) und Tests entsprechend aktualisieren.
+3. Merge manuell durchführen, anschließend Presenter- und Registry-Tests ausführen, um Regressionen auszuschließen.
+
+## Folgeaktionen
+- Verantwortliche Person bestimmen und Arbeitsbranch für die manuelle Zusammenführung erstellen.
+- Nach erfolgreichem Merge Architektur-Review einplanen, damit Capability-Verträge dokumentiert bleiben.
+- Ergebnisse zurück in die Dokumentation spiegeln (`docs/cartographer/presenter.md`).

--- a/todo/cartographer-presenter-doc-merge.md
+++ b/todo/cartographer-presenter-doc-merge.md
@@ -1,0 +1,24 @@
+# Cartographer presenter documentation merge blockers
+
+## Kontext
+- Dokumentation deckt Capability- und Lifecycle-Flows des Presenters ab.
+- Parallel existieren Branches mit unterschiedlichen Begrifflichkeiten und Hook-Abfolgen.
+- Verlinkte Stelle: [`salt-marcher/docs/cartographer/presenter.md`](../salt-marcher/docs/cartographer/presenter.md).
+
+## Problemstellung
+`presenter.md` kollidiert beim Merge mit konkurrierenden Aktualisierungen der Capability-Tabellen und Erweiterungsanleitungen. Die Abschnitte zu Registry-Events und Lifecycle-Diagrammen unterscheiden sich strukturell, wodurch automatische Zusammenführungen scheitern.
+
+## Betroffene Inhalte
+- Capability-Matrix sowie Beschreibung der `defineCartographerModeProvider`-Signatur.
+- Ablaufdiagramme zu Mode-Wechseln und Save-Hooks.
+- Verweise auf Tests (`tests/cartographer/presenter.test.ts`).
+
+## Lösungsideen
+1. Zielterminologie und Hook-Reihenfolge mit dem Presenter-/Registry-Team abstimmen, bevor der Merge erfolgt.
+2. Konfliktabschnitte manuell zusammenführen und dabei veraltete oder doppelte Beschreibungen konsolidieren.
+3. Nach der Harmonisierung sicherstellen, dass Referenzen auf Tests und Registry-Dokumente weiterhin korrekt sind.
+
+## Folgeaktionen
+- Verantwortliche Person für die Dokumentationszusammenführung bestimmen.
+- Nach Abschluss der Zusammenführung Review durch UX/Docs-Team einplanen.
+- Dokumentation erneut gegen den aktuellen Implementierungsstand validieren.

--- a/todo/cartographer-presenter-merge-reconciliation.md
+++ b/todo/cartographer-presenter-merge-reconciliation.md
@@ -1,0 +1,26 @@
+# Cartographer presenter/docs merge reconciliation
+
+## Kontext
+- Sowohl Implementierung (`presenter.ts`) als auch Dokumentation (`presenter.md`) haben konkurrierende Capability-Updates erhalten.
+- Merge-Konflikte blockieren die Bereitstellung des Registry-Refactors.
+- Relevante Dateien:
+  - [`salt-marcher/src/apps/cartographer/presenter.ts`](../salt-marcher/src/apps/cartographer/presenter.ts)
+  - [`salt-marcher/docs/cartographer/presenter.md`](../salt-marcher/docs/cartographer/presenter.md)
+
+## Problemstellung
+Es existiert kein gemeinsamer Zielstand für Capability-Metadaten, Lifecycle-Hooks und Registry-Events. Ohne abgestimmte Referenz lassen sich die Konflikte nicht auflösen, wodurch `main` keine konsistente Presenter-Version erhält.
+
+## Betroffene Bereiche
+- Capability-Normalisierung zwischen Registry und Presenter.
+- Dokumentation der Erweiterungs-Workflows.
+- Tests, die Capability- oder Hook-Änderungen voraussetzen.
+
+## Lösungsideen
+1. Workshop zwischen Registry-, Presenter- und Docs-Team ansetzen, um Zielmodell (Capabilities, Provider-Signatur, Lifecycle) zu definieren.
+2. Auf Basis der Ergebnisse gemeinsamen Merge-Branch erstellen, Konflikte manuell auflösen und Tests/Dokumentation synchron halten.
+3. Review-Checkliste definieren, damit Capability-Änderungen künftig gleichzeitig in Code, Tests und Doku gepflegt werden.
+
+## Folgeaktionen
+- Merge-Branch tracken und Fortschritt im Standup berichten.
+- Nach Abschluss die To-Dos `cartographer-presenter-code-merge` und `cartographer-presenter-doc-merge` schließen bzw. aktualisieren.
+- Lessons Learned im Cartographer-Wiki dokumentieren.


### PR DESCRIPTION
## Summary
- restore the cartographer presenter documentation and implementation to their pre-capability state so merge conflicts are cleared
- reset the todo index to its previous entries while capability alignment is tracked separately
- add a dedicated capability-alignment todo covering presenter, docs, tests, and backlog follow-ups

## Testing
- pnpm vitest --run *(fails: no package manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f75a4ad083259e2e0a6ec04cceee