### PR TITLE
Add documentation headers to missing scripts

### DIFF
--- a/salt-marcher/src/app/integration-telemetry.ts
+++ b/salt-marcher/src/app/integration-telemetry.ts
@@ -1,3 +1,5 @@
+// src/app/integration-telemetry.ts
+// Dedupliziert Meldungen über Integrationsfehler.
 import { Notice } from "obsidian";
 
 /** Identifies the bridge/integration that surfaced an operational issue. */

--- a/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
+++ b/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/editor/tools/tool-manager.ts
+// Verwaltet aktiviertes Werkzeug im Karten-Editor.
 import type { CleanupFn, ToolContext, ToolManager as ToolManagerContract, ToolModule } from "./tools-api";
 
 const yieldMicrotask = () => Promise.resolve();

--- a/salt-marcher/src/apps/cartographer/mode-registry/index.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/index.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/index.ts
+// Stellt zentrale Mode-Registry-APIs bereit.
 import {
     clearCartographerModeRegistry,
     createCartographerModeRegistrySnapshot,

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/editor.ts
+// Provider-Beschreibung für den Editor-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createEditorModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/inspector.ts
+// Provider-Beschreibung für den Inspector-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createInspectorModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/travel-guide.ts
+// Provider-Beschreibung für den Travel-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createTravelGuideModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/registry.ts
+// Kernlogik zur Registrierung von Cartographer-Modi.
 import type {
     CartographerMode,
     CartographerModeLifecycleContext,

--- a/salt-marcher/src/apps/cartographer/modes/editor.ts
+++ b/salt-marcher/src/apps/cartographer/modes/editor.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/editor.ts
+// Hex-Editor mit Tool-Manager für Karten.
 import type { TFile } from "obsidian";
 import type {
     CartographerMode,

--- a/salt-marcher/src/apps/cartographer/modes/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/modes/inspector.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/inspector.ts
+// Hex-Inspector zur Bearbeitung einzelner Tiles.
 import type { TFile } from "obsidian";
 import { loadTile, saveTile } from "../../../core/hex-mapper/hex-notes";
 import { TERRAIN_COLORS } from "../../../core/terrain";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide.ts
+// Komplettmodus für Reisen inkl. UI und Logik.
 import type { MapHeaderSaveMode } from "../../../ui/map-header";
 import type { CartographerMode, CartographerModeLifecycleContext } from "../presenter";
 import { loadTerrains } from "../../../core/terrain-store";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
+// Öffnet Begegnungen aus dem Travel-Guide heraus.
 import { Notice, type App, type WorkspaceLeaf } from "obsidian";
 import { publishEncounterEvent } from "../../../encounter/session-store";
 import { createEncounterEventFromTravel, type TravelEncounterContext } from "../../../encounter/event-builder";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/interaction-controller.ts
+// Kapselt Interaktionen für den Travel-Guide.
 import { createDragController, type DragController } from "../../travel/ui/drag.controller";
 import { bindContextMenu } from "../../travel/ui/contextmenue";
 import type { RenderAdapter } from "../../travel/infra/adapter";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/playback-controller.ts
+// Steuert Wiedergabe-UI des Reise-Modus.
 import type { Sidebar } from "../../travel/ui/sidebar";
 import {
     createPlaybackControls,

--- a/salt-marcher/src/apps/cartographer/travel/domain/actions.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/actions.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/actions.ts
+// State- und Playback-Logik für den Travel-Modus.
 import type { App, TFile } from "obsidian";
 import type { RenderAdapter } from "../infra/adapter";
 import { createStore, type Store } from "./state.store";

--- a/salt-marcher/src/apps/cartographer/travel/domain/expansion.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/expansion.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/expansion.ts
+// Hilfsfunktionen zur Routen-Interpolation.
 import { lineOddR } from "../../../../core/hex-mapper/hex-geom";
 import type { Coord, RouteNode } from "./types";
 

--- a/salt-marcher/src/apps/cartographer/travel/domain/persistence.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/persistence.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/persistence.ts
+// Persistiert Travel-Token in Hex-Notizen.
 import type { App, TFile } from "obsidian";
 import { listTilesForMap, loadTile, saveTile } from "../../../../core/hex-mapper/hex-notes";
 import type { Coord } from "./types";

--- a/salt-marcher/src/apps/cartographer/travel/domain/state.store.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/state.store.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/state.store.ts
+// Einfacher Zustandsspeicher für Travel-Logik.
 import type { LogicStateSnapshot, Coord, RouteNode } from "./types";
 
 export type Store = {

--- a/salt-marcher/src/apps/cartographer/travel/ui/sidebar.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/sidebar.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/ui/sidebar.ts
+// Sidebar-Layout und Steuerung für Travel-Modus.
 export type Sidebar = {
     root: HTMLElement;
     controlsHost: HTMLElement;

--- a/salt-marcher/src/apps/cartographer/view-shell/layout.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/layout.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/layout.ts
+// Baut Grundlayout für Cartographer-Ansicht.
 export type CartographerLayout = {
     readonly host: HTMLElement;
     readonly headerHost: HTMLElement;

--- a/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/map-surface.ts
+// Baut die Kartenfläche inklusive Overlay-API.
 import { createViewContainer, type ViewContainerHandle } from "../../../ui/view-container";
 
 export type MapSurfaceHandle = {

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/mode-controller.ts
+// Koordiniert Moduswechsel mit Abbruchsteuerung.
 export type ModeSwitchContext = {
     readonly signal: AbortSignal;
 };

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/mode-registry.ts
+// Dropdown zur Verwaltung verfügbarer Modi.
 import type { CartographerShellMode } from "../view-shell";
 
 export type ModeRegistryHandle = {

--- a/salt-marcher/src/apps/library/view/creatures.ts
+++ b/salt-marcher/src/apps/library/view/creatures.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/creatures.ts
+// Rendert Kreaturen und legt neue Dateien an.
 import type { TFile } from "obsidian";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/mode.ts
+++ b/salt-marcher/src/apps/library/view/mode.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/mode.ts
+// Basistypen für Library-Ansichtsmodi.
 import type { App } from "obsidian";
 
 export type Mode = "creatures" | "spells" | "terrains" | "regions";

--- a/salt-marcher/src/apps/library/view/regions.ts
+++ b/salt-marcher/src/apps/library/view/regions.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/regions.ts
+// Verwalten von Regionenlisten samt Persistenz.
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/spells.ts
+++ b/salt-marcher/src/apps/library/view/spells.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/spells.ts
+// Rendert und erstellt Zauber-Einträge.
 import type { TFile } from "obsidian";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/terrains.ts
+++ b/salt-marcher/src/apps/library/view/terrains.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/terrains.ts
+// Bearbeitet Terrain-Konfigurationen mit Auto-Speichern.
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";
 import { loadTerrains, saveTerrains, watchTerrains, ensureTerrainFile, TERRAIN_FILE } from "../../../core/terrain-store";

--- a/salt-marcher/src/core/options.ts
+++ b/salt-marcher/src/core/options.ts
@@ -1,3 +1,5 @@
+// src/core/options.ts
+// Parser und Typen für Hex-Map Optionen.
 export type HexOptions = {
     folder: string;
     /**


### PR DESCRIPTION
## Summary
- add concise headers to integration telemetry and library views
- document cartographer modes, registry, and travel domain helpers
- describe the core hex options parser

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68de1d34e8a0832592a94b24cf3927a1