### PR TITLE
Add AGENTS documentation for app, encounter, and UI directories

### DIFF
--- a/salt-marcher/src/AGENTS.md
+++ b/salt-marcher/src/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Stellt Kernlogik, Apps und Integrationen des Plugins bereit.
+
+# Aktueller Stand
+- Unterordner `core`, `apps` und `app` kapseln Geschäftslogik, UI-Shells und Integrationsadapter.
+
+# ToDo
+- Ergänzende Modulübersichten pflegen, sobald neue Bereiche entstehen.
+- Offene Migrationspfade zwischen Apps dokumentieren.
+
+# Standards
+- Jeder TypeScript-Einstieg beginnt mit `// <relativer Dateipfad>` gefolgt von einem Satz Zweck.
+- Kommentare bleiben einzeilig und konkret.

--- a/salt-marcher/src/app/AGENTS.md
+++ b/salt-marcher/src/app/AGENTS.md
@@ -1,0 +1,18 @@
+# Ziele
+- Startet das Plugin, registriert Views und lädt Styles.
+
+# Aktueller Stand
+- `main.ts` verwaltet Plugin-Lifecycle und View-Anmeldung.
+- `bootstrap-services.ts` richtet Datenquellen und Defaults ein.
+- `integration-telemetry.ts` fasst Fehlerhinweise der Integrationen zusammen.
+- `css.ts` bündelt alle Styles als Export-String.
+
+# ToDo
+- Mobile-spezifische Bootstrap-Sequenzen definieren.
+- Telemetrie auf weitere Integrationen ausweiten.
+- Theme-Hooks (dark/light) dokumentieren, sobald vorhanden.
+
+# Standards
+- Einstiegspunkte dokumentieren Lifecycle-Schritte im Kopfkommentar.
+- Bootstrap-Helfer kapseln Obsidian-IO in reine Funktionen.
+- CSS bleibt im TypeScript gebündelt, bis ein Build-Schritt existiert.

--- a/salt-marcher/src/app/integration-telemetry.ts
+++ b/salt-marcher/src/app/integration-telemetry.ts
@@ -1,3 +1,5 @@
+// src/app/integration-telemetry.ts
+// Dedupliziert Meldungen über Integrationsfehler.
 import { Notice } from "obsidian";
 
 /** Identifies the bridge/integration that surfaced an operational issue. */

--- a/salt-marcher/src/apps/AGENTS.md
+++ b/salt-marcher/src/apps/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Enthält die UI-orientierten Anwendungen (Cartographer, Library usw.).
+
+# Aktueller Stand
+- Jede App besitzt Unterordner für Modi, Views und Shell-Komponenten.
+
+# ToDo
+- Fehlende Modusbeschreibungen in Unterordnern ergänzen.
+- Event-Flows der Apps in README- oder Header-Form dokumentieren.
+
+# Standards
+- Komponenten- und Controller-Dateien starten mit einem Kontextsatz zum Workflow.
+- UI-spezifische Typen leben lokal innerhalb der App.

--- a/salt-marcher/src/apps/cartographer/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Liefert das Hauptwerkzeug zum Bearbeiten, Inspizieren und Reisen durch Karten.
+
+# Aktueller Stand
+- `modes` und `mode-registry` kapseln Arbeitsmodi, `travel` bündelt Playback/Encounter-Flüsse, `view-shell` stellt UI-Rahmen.
+
+# ToDo
+- Kollaborative Features (Mehrbenutzer) vorbereiten.
+- Reisemodus-Interaktionen gegen neue Encounter-APIs testen.
+
+# Standards
+- Modus-Dateien erklären ihr Nutzerziel im Kopfkommentar.
+- Controller fassen Event-Sequenzen mit Imperativ-Verben (activate, hydrate, teardown) zusammen.

--- a/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
+++ b/salt-marcher/src/apps/cartographer/editor/tools/tool-manager.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/editor/tools/tool-manager.ts
+// Verwaltet aktiviertes Werkzeug im Karten-Editor.
 import type { CleanupFn, ToolContext, ToolManager as ToolManagerContract, ToolModule } from "./tools-api";
 
 const yieldMicrotask = () => Promise.resolve();

--- a/salt-marcher/src/apps/cartographer/mode-registry/index.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/index.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/index.ts
+// Stellt zentrale Mode-Registry-APIs bereit.
 import {
     clearCartographerModeRegistry,
     createCartographerModeRegistrySnapshot,

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/editor.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/editor.ts
+// Provider-Beschreibung für den Editor-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createEditorModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/inspector.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/inspector.ts
+// Provider-Beschreibung für den Inspector-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createInspectorModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/travel-guide.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/providers/travel-guide.ts
+// Provider-Beschreibung für den Travel-Modus.
 import { defineCartographerModeProvider } from "../registry";
 
 export const createTravelGuideModeProvider = () =>

--- a/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
+++ b/salt-marcher/src/apps/cartographer/mode-registry/registry.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/mode-registry/registry.ts
+// Kernlogik zur Registrierung von Cartographer-Modi.
 import type {
     CartographerMode,
     CartographerModeLifecycleContext,

--- a/salt-marcher/src/apps/cartographer/modes/editor.ts
+++ b/salt-marcher/src/apps/cartographer/modes/editor.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/editor.ts
+// Hex-Editor mit Tool-Manager für Karten.
 import type { TFile } from "obsidian";
 import type {
     CartographerMode,

--- a/salt-marcher/src/apps/cartographer/modes/inspector.ts
+++ b/salt-marcher/src/apps/cartographer/modes/inspector.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/inspector.ts
+// Hex-Inspector zur Bearbeitung einzelner Tiles.
 import type { TFile } from "obsidian";
 import { loadTile, saveTile } from "../../../core/hex-mapper/hex-notes";
 import { TERRAIN_COLORS } from "../../../core/terrain";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide.ts
+// Komplettmodus für Reisen inkl. UI und Logik.
 import type { MapHeaderSaveMode } from "../../../ui/map-header";
 import type { CartographerMode, CartographerModeLifecycleContext } from "../presenter";
 import { loadTerrains } from "../../../core/terrain-store";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/encounter-gateway.ts
+// Öffnet Begegnungen aus dem Travel-Guide heraus.
 import { Notice, type App, type WorkspaceLeaf } from "obsidian";
 import { publishEncounterEvent } from "../../../encounter/session-store";
 import { createEncounterEventFromTravel, type TravelEncounterContext } from "../../../encounter/event-builder";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/interaction-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/interaction-controller.ts
+// Kapselt Interaktionen für den Travel-Guide.
 import { createDragController, type DragController } from "../../travel/ui/drag.controller";
 import { bindContextMenu } from "../../travel/ui/contextmenue";
 import type { RenderAdapter } from "../../travel/infra/adapter";

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/playback-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/modes/travel-guide/playback-controller.ts
+// Steuert Wiedergabe-UI des Reise-Modus.
 import type { Sidebar } from "../../travel/ui/sidebar";
 import {
     createPlaybackControls,

--- a/salt-marcher/src/apps/cartographer/travel/domain/actions.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/actions.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/actions.ts
+// State- und Playback-Logik für den Travel-Modus.
 import type { App, TFile } from "obsidian";
 import type { RenderAdapter } from "../infra/adapter";
 import { createStore, type Store } from "./state.store";

--- a/salt-marcher/src/apps/cartographer/travel/domain/expansion.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/expansion.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/expansion.ts
+// Hilfsfunktionen zur Routen-Interpolation.
 import { lineOddR } from "../../../../core/hex-mapper/hex-geom";
 import type { Coord, RouteNode } from "./types";
 

--- a/salt-marcher/src/apps/cartographer/travel/domain/persistence.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/persistence.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/persistence.ts
+// Persistiert Travel-Token in Hex-Notizen.
 import type { App, TFile } from "obsidian";
 import { listTilesForMap, loadTile, saveTile } from "../../../../core/hex-mapper/hex-notes";
 import type { Coord } from "./types";

--- a/salt-marcher/src/apps/cartographer/travel/domain/state.store.ts
+++ b/salt-marcher/src/apps/cartographer/travel/domain/state.store.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/domain/state.store.ts
+// Einfacher Zustandsspeicher für Travel-Logik.
 import type { LogicStateSnapshot, Coord, RouteNode } from "./types";
 
 export type Store = {

--- a/salt-marcher/src/apps/cartographer/travel/ui/sidebar.ts
+++ b/salt-marcher/src/apps/cartographer/travel/ui/sidebar.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/travel/ui/sidebar.ts
+// Sidebar-Layout und Steuerung für Travel-Modus.
 export type Sidebar = {
     root: HTMLElement;
     controlsHost: HTMLElement;

--- a/salt-marcher/src/apps/cartographer/view-shell/layout.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/layout.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/layout.ts
+// Baut Grundlayout für Cartographer-Ansicht.
 export type CartographerLayout = {
     readonly host: HTMLElement;
     readonly headerHost: HTMLElement;

--- a/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/map-surface.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/map-surface.ts
+// Baut die Kartenfläche inklusive Overlay-API.
 import { createViewContainer, type ViewContainerHandle } from "../../../ui/view-container";
 
 export type MapSurfaceHandle = {

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-controller.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/mode-controller.ts
+// Koordiniert Moduswechsel mit Abbruchsteuerung.
 export type ModeSwitchContext = {
     readonly signal: AbortSignal;
 };

--- a/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
+++ b/salt-marcher/src/apps/cartographer/view-shell/mode-registry.ts
@@ -1,3 +1,5 @@
+// src/apps/cartographer/view-shell/mode-registry.ts
+// Dropdown zur Verwaltung verfügbarer Modi.
 import type { CartographerShellMode } from "../view-shell";
 
 export type ModeRegistryHandle = {

--- a/salt-marcher/src/apps/encounter/AGENTS.md
+++ b/salt-marcher/src/apps/encounter/AGENTS.md
@@ -1,0 +1,18 @@
+# Ziele
+- Führt Begegnungen mit Ereignislogik und Playback im Obsidian-Client aus.
+
+# Aktueller Stand
+- `view.ts` rendert die Encounter-Ansicht und bindet Presenter-Events.
+- `presenter.ts` vermittelt zwischen Session-Store, Event-Builder und UI.
+- `event-builder.ts` übersetzt Travel-Kontext in Encounter-Ereignisse.
+- `session-store.ts` hält Zustand, Persistenz und Playbackposition.
+
+# ToDo
+- Encounter-Ansicht für Split-View und Mobile optimieren.
+- Session-Store mit Tests für Race-Conditions absichern.
+- Ereignisformate gegen kommende Travel-APIs abgleichen.
+
+# Standards
+- Presenter- und Store-Dateien dokumentieren Seiteneffekte im Kopfkommentar.
+- Events bleiben serialisierbar, damit Persistenz erleichtert wird.
+- View-spezifische Stile liegen im Plugin-CSS und nicht lokal.

--- a/salt-marcher/src/apps/library/AGENTS.md
+++ b/salt-marcher/src/apps/library/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Stellt ein Nachschlagewerk für Kreaturen, Regionen, Zauber und Gelände bereit.
+
+# Aktueller Stand
+- `view` enthält Renderer pro Kategorie, Zustandslogik lebt im Wurzelordner.
+
+# ToDo
+- Filter-/Suchfunktionen beschreiben und später implementieren.
+- Datenquelle der Bibliothek konsolidieren.
+
+# Standards
+- View-Skripte erläutern welche Datensammlung sie präsentieren.
+- Library-spezifische Strings in Übersetzungsdateien spiegeln.

--- a/salt-marcher/src/apps/library/view/creatures.ts
+++ b/salt-marcher/src/apps/library/view/creatures.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/creatures.ts
+// Rendert Kreaturen und legt neue Dateien an.
 import type { TFile } from "obsidian";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/mode.ts
+++ b/salt-marcher/src/apps/library/view/mode.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/mode.ts
+// Basistypen für Library-Ansichtsmodi.
 import type { App } from "obsidian";
 
 export type Mode = "creatures" | "spells" | "terrains" | "regions";

--- a/salt-marcher/src/apps/library/view/regions.ts
+++ b/salt-marcher/src/apps/library/view/regions.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/regions.ts
+// Verwalten von Regionenlisten samt Persistenz.
 import { enhanceSelectToSearch } from "../../../ui/search-dropdown";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/spells.ts
+++ b/salt-marcher/src/apps/library/view/spells.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/spells.ts
+// Rendert und erstellt Zauber-Einträge.
 import type { TFile } from "obsidian";
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";

--- a/salt-marcher/src/apps/library/view/terrains.ts
+++ b/salt-marcher/src/apps/library/view/terrains.ts
@@ -1,3 +1,5 @@
+// src/apps/library/view/terrains.ts
+// Bearbeitet Terrain-Konfigurationen mit Auto-Speichern.
 import type { ModeRenderer } from "./mode";
 import { BaseModeRenderer, scoreName } from "./mode";
 import { loadTerrains, saveTerrains, watchTerrains, ensureTerrainFile, TERRAIN_FILE } from "../../../core/terrain-store";

--- a/salt-marcher/src/core/AGENTS.md
+++ b/salt-marcher/src/core/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Beschreibt Datenmodelle und Dienste zum Erzeugen und Persistieren von Karteninhalten.
+
+# Aktueller Stand
+- `hex-mapper` liefert Render-/Speicher-Helfer, übrige Dateien bilden Speicherdienste und Übersetzer.
+
+# ToDo
+- Tile- und Terrain-Schemata um Validierungsregeln ergänzen.
+- Konvertierung zwischen Legacy- und neuen Speichern abstimmen.
+
+# Standards
+- Öffentliche APIs exportieren benannte Typen/Funktionen.
+- Kommentare dokumentieren Seiteneffekte und IO kurz vor den Funktionen.

--- a/salt-marcher/src/core/options.ts
+++ b/salt-marcher/src/core/options.ts
@@ -1,3 +1,5 @@
+// src/core/options.ts
+// Parser und Typen für Hex-Map Optionen.
 export type HexOptions = {
     folder: string;
     /**

--- a/salt-marcher/src/ui/AGENTS.md
+++ b/salt-marcher/src/ui/AGENTS.md
@@ -1,0 +1,18 @@
+# Ziele
+- Stellt gemeinsame UI-Komponenten für Kartenverwaltung und Suche bereit.
+
+# Aktueller Stand
+- `view-container.ts` rahmt App-Views in Obsidian ein.
+- `map-manager.ts` koordiniert Dateiaktionen und modals.
+- `map-header.ts`, `map-workflows.ts` und `modals.ts` liefern Bedienoberflächen.
+- `search-dropdown.ts` und `copy.ts` kapseln Interaktionstexte.
+
+# ToDo
+- Komponenten auf Responsiveness und mobile Layouts prüfen.
+- Such- und Filter-UI für größere Datenmengen erweitern.
+- Kopierte Texte zentralisieren, sobald Übersetzungen nötig werden.
+
+# Standards
+- Jede UI-Datei startet mit Zweck und Nutzeraktion im Kopfkommentar.
+- Sichtbare Strings liegen in `copy.ts` oder nahegelegenen Konstanten.
+- Modals validieren Eingaben bevor Dateien geändert werden.


### PR DESCRIPTION
## Summary
- document the app bootstrap, shared UI, and encounter folders with goals, current contents, todos, and standards

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68de1d34e8a0832592a94b24cf3927a1