### PR TITLE
Prune test tasks from TODO backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,57 @@
+# Gesamt-ToDo-Liste
+
+Die Aufgaben sind nach Priorität sortiert. Dezimalstellen kennzeichnen die Reihenfolge innerhalb einer Prioritätsstufe.
+
+## 0. Fehlerbehebung
+- keine offenen ToDos.
+
+## 1. Funktionalität absichern
+- 1.1 [src/apps/cartographer/travel/AGENTS.md] Synchronisation mit Encounter-Module automatisieren.
+- 1.2 [src/apps/cartographer/travel/ui/AGENTS.md] Kontextmenüs auf neue Encounter-Ereignisse erweitern.
+- 1.3 [src/apps/encounter/AGENTS.md] Ereignisformate gegen kommende Travel-APIs abgleichen.
+- 1.4 [src/apps/library/create/creature/AGENTS.md] Abschnittsvalidierung für abhängige Felder ergänzen.
+- 1.5 [src/apps/library/create/spell/AGENTS.md] Validierung für skalierende Zauberstufen ausarbeiten.
+- 1.6 [src/core/AGENTS.md] Konvertierung zwischen Legacy- und neuen Speichern abstimmen.
+- 1.7 [src/core/AGENTS.md] Tile- und Terrain-Schemata um Validierungsregeln ergänzen.
+
+## 2. Robustheit & Wartbarkeit
+- 2.1 [AGENTS.md] Automatisierte Prüfung für fehlende AGENTS- oder Header-Kommentare ins CI überführen.
+- 2.2 [AGENTS.md] Build-Dokumentation ergänzen, sobald weitere Bundler/Targets unterstützt werden.
+- 2.3 [src/AGENTS.md] Ergänzende Modulübersichten pflegen, sobald neue Bereiche entstehen.
+- 2.4 [src/AGENTS.md] Offene Migrationspfade zwischen Apps dokumentieren.
+- 2.5 [src/app/AGENTS.md] CSS-Bundle in modulare Abschnitte zerlegen, um Teilbereiche gezielt warten zu können.
+- 2.6 [src/apps/AGENTS.md] Event-Flows der Apps in README- oder Header-Form dokumentieren.
+- 2.7 [src/apps/AGENTS.md] Fehlende Modusbeschreibungen in Unterordnern ergänzen.
+- 2.8 [src/apps/cartographer/editor/AGENTS.md] Rendering-Hooks dokumentieren, falls außerhalb der Tools benötigt.
+- 2.9 [src/apps/cartographer/mode-registry/AGENTS.md] Übergreifende Fehlerbehandlung für fehlende Provider dokumentieren.
+- 2.10 [src/apps/cartographer/mode-registry/providers/AGENTS.md] Gemeinsame Mock-Helfer dokumentieren.
+- 2.11 [src/apps/cartographer/modes/AGENTS.md] Gemeinsame Lifecycle-Helfer extrahieren.
+- 2.12 [src/apps/cartographer/modes/travel-guide/AGENTS.md] Fehlerzustände für fehlende Begegnungsdaten skizzieren.
+- 2.13 [src/apps/cartographer/travel/domain/AGENTS.md] Persistente Speicherformate mit Versionierung dokumentieren.
+- 2.14 [src/apps/library/AGENTS.md] Datenquelle der Bibliothek konsolidieren.
+- 2.15 [src/apps/library/core/AGENTS.md] Gemeinsame Datei-Pipeline für weitere Kategorien vorbereiten.
+- 2.16 [src/apps/library/core/AGENTS.md] Validierungsregeln für Eingabedateien dokumentieren.
+- 2.17 [src/apps/library/create/AGENTS.md] Wiederkehrende Formular-Layouts (Cards, Field-Grids) in gemeinsame Builder überführen.
+- 2.18 [src/apps/library/create/creature/AGENTS.md] Bewegungs- und Geschwindigkeitseinträge in strukturierte Objekte mit Flags (z. B. Hover) überführen.
+- 2.19 [src/apps/library/create/creature/AGENTS.md] Presets mit Schwierigkeitsgraden dokumentieren.
+- 2.20 [src/core/hex-mapper/AGENTS.md] Performance-Profile dokumentieren und optimieren.
+- 2.21 [src/core/hex-mapper/render/AGENTS.md] GPU/Canvas-Auswahl dokumentieren und abstrahieren.
+
+## 3. Neue Features
+- 3.1 [src/app/AGENTS.md] Telemetrie auf weitere Integrationen ausweiten.
+- 3.2 [src/apps/cartographer/travel/domain/AGENTS.md] Mehrstufige Undo/Redo-Strategien entwerfen.
+- 3.3 [src/apps/library/AGENTS.md] Filter-/Suchfunktionen beschreiben und später implementieren.
+- 3.4 [src/apps/library/create/AGENTS.md] Speicherroutinen mit Autosave ergänzen.
+- 3.5 [src/apps/library/create/spell/AGENTS.md] Komponenten für Ritual-spezifische Felder ergänzen.
+- 3.6 [src/apps/library/view/AGENTS.md] Filter- und Sortierparameter dokumentieren und implementieren.
+
+## 4. User Experience verbessern
+- 4.1 [src/apps/cartographer/travel/render/AGENTS.md] Animierte Routen und Status-Indikatoren ergänzen.
+- 4.2 [src/apps/library/create/AGENTS.md] Validierungsfeedback konsolidieren und zentral beschreiben.
+- 4.3 [src/apps/library/create/creature/AGENTS.md] Spell-Ladeprozess im Modal mit Lade-/Fehlerzustand versehen.
+- 4.4 [src/apps/library/create/shared/AGENTS.md] Token-Editor um Drag&Drop-Upload erweitern.
+- 4.5 [src/apps/library/view/AGENTS.md] Regions-View um Karten-Preview erweitern.
+- 4.6 [src/ui/AGENTS.md] Such- und Filter-UI für größere Datenmengen erweitern.
+
+## 5. Weitere Aufgaben
+- keine offenen ToDos.


### PR DESCRIPTION
## Summary
- remove test-focused items from the consolidated TODO list
- renumber remaining functionality and robustness entries to keep ordering intact

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de7d2783c48325a89fa1446c29a5ff