### PR TITLE
Automate travel encounter synchronisation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,13 +6,12 @@ Die Aufgaben sind nach Priorität sortiert. Dezimalstellen kennzeichnen die Reih
 - keine offenen ToDos.
 
 ## 1. Funktionalität absichern
-- 1.1 [src/apps/cartographer/travel/AGENTS.md] Synchronisation mit Encounter-Module automatisieren.
-- 1.2 [src/apps/cartographer/travel/ui/AGENTS.md] Kontextmenüs auf neue Encounter-Ereignisse erweitern.
-- 1.3 [src/apps/encounter/AGENTS.md] Ereignisformate gegen kommende Travel-APIs abgleichen.
-- 1.4 [src/apps/library/create/creature/AGENTS.md] Abschnittsvalidierung für abhängige Felder ergänzen.
-- 1.5 [src/apps/library/create/spell/AGENTS.md] Validierung für skalierende Zauberstufen ausarbeiten.
-- 1.6 [src/core/AGENTS.md] Konvertierung zwischen Legacy- und neuen Speichern abstimmen.
-- 1.7 [src/core/AGENTS.md] Tile- und Terrain-Schemata um Validierungsregeln ergänzen.
+- 1.1 [src/apps/cartographer/travel/ui/AGENTS.md] Kontextmenüs auf neue Encounter-Ereignisse erweitern.
+- 1.2 [src/apps/encounter/AGENTS.md] Ereignisformate gegen kommende Travel-APIs abgleichen.
+- 1.3 [src/apps/library/create/creature/AGENTS.md] Abschnittsvalidierung für abhängige Felder ergänzen.
+- 1.4 [src/apps/library/create/spell/AGENTS.md] Validierung für skalierende Zauberstufen ausarbeiten.
+- 1.5 [src/core/AGENTS.md] Konvertierung zwischen Legacy- und neuen Speichern abstimmen.
+- 1.6 [src/core/AGENTS.md] Tile- und Terrain-Schemata um Validierungsregeln ergänzen.
 
 ## 2. Robustheit & Wartbarkeit
 - 2.1 [AGENTS.md] Automatisierte Prüfung für fehlende AGENTS- oder Header-Kommentare ins CI überführen.

--- a/salt-marcher/src/apps/cartographer/travel/infra/encounter-sync.ts
+++ b/salt-marcher/src/apps/cartographer/travel/infra/encounter-sync.ts
@@ -1,0 +1,67 @@
+// src/apps/cartographer/travel/infra/encounter-sync.ts
+// Synchronisiert Travel-Playback mit Encounter-Events: liest Travel-State,
+// pausiert Wiedergabe und öffnet Encounter-Ansicht sobald externe Ereignisse
+// eintreffen oder Travel selbst eines auslöst.
+
+import type { TFile } from "obsidian";
+import type { LogicStateSnapshot } from "../domain/types";
+import type { TravelEncounterContext } from "../../../encounter/event-builder";
+import {
+    peekLatestEncounterEvent,
+    subscribeToEncounterEvents,
+    type EncounterEvent,
+} from "../../../encounter/session-store";
+
+export type EncounterSync = {
+    handleTravelEncounter(): Promise<void>;
+    dispose(): void;
+};
+
+type Config = {
+    getMapFile(): TFile | null;
+    getState(): LogicStateSnapshot;
+    pausePlayback(): void;
+    openEncounter(context?: TravelEncounterContext): Promise<boolean>;
+    onExternalEncounter?: (event: EncounterEvent) => boolean | void;
+};
+
+export function createEncounterSync(cfg: Config): EncounterSync {
+    let disposed = false;
+    let lastHandledId: string | null = peekLatestEncounterEvent()?.id ?? null;
+
+    const unsubscribe = subscribeToEncounterEvents((event) => {
+        if (disposed) return;
+        if (event.id === lastHandledId) return;
+        lastHandledId = event.id;
+        if (event.source === "travel") {
+            return;
+        }
+        cfg.pausePlayback();
+        const shouldOpen = cfg.onExternalEncounter?.(event);
+        if (shouldOpen === false) {
+            return;
+        }
+        void cfg.openEncounter();
+    });
+
+    return {
+        async handleTravelEncounter() {
+            cfg.pausePlayback();
+            const context: TravelEncounterContext = {
+                mapFile: cfg.getMapFile(),
+                state: cfg.getState(),
+            };
+            const ok = await cfg.openEncounter(context);
+            if (!ok) return;
+            const latest = peekLatestEncounterEvent();
+            if (latest) {
+                lastHandledId = latest.id;
+            }
+        },
+        dispose() {
+            if (disposed) return;
+            disposed = true;
+            unsubscribe();
+        },
+    };
+}

--- a/salt-marcher/tests/cartographer/travel/encounter-sync.test.ts
+++ b/salt-marcher/tests/cartographer/travel/encounter-sync.test.ts
@@ -1,0 +1,109 @@
+// salt-marcher/tests/cartographer/travel/encounter-sync.test.ts
+// Testet Encounter-Sync-Service für Travel-Modus.
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { createEncounterSync } from "../../../src/apps/cartographer/travel/infra/encounter-sync";
+import {
+    publishEncounterEvent,
+    __resetEncounterEventStore,
+    type EncounterEvent,
+} from "../../../src/apps/encounter/session-store";
+
+const baseEvent: EncounterEvent = {
+    id: "manual-1",
+    source: "manual",
+    triggeredAt: "2024-01-01T00:00:00.000Z",
+    coord: { r: 2, c: 3 },
+};
+
+beforeEach(() => {
+    __resetEncounterEventStore();
+});
+
+describe("createEncounterSync", () => {
+    it("pauses playback and opens encounter when travel triggers", async () => {
+        const pausePlayback = vi.fn();
+        const openEncounter = vi.fn().mockResolvedValue(true);
+        const file = { path: "maps/test.md", basename: "Test" } as any;
+        const state = {
+            tokenRC: { r: 0, c: 0 },
+            route: [],
+            editIdx: null,
+            tokenSpeed: 3,
+            currentTile: null,
+            playing: true,
+        } as any;
+
+        const sync = createEncounterSync({
+            getMapFile: () => file,
+            getState: () => state,
+            pausePlayback,
+            openEncounter,
+        });
+
+        await sync.handleTravelEncounter();
+
+        expect(pausePlayback).toHaveBeenCalledTimes(1);
+        expect(openEncounter).toHaveBeenCalledTimes(1);
+        expect(openEncounter).toHaveBeenCalledWith({ mapFile: file, state });
+
+        sync.dispose();
+    });
+
+    it("reacts to manual encounter events by pausing and revealing view", async () => {
+        const pausePlayback = vi.fn();
+        const openEncounter = vi.fn().mockResolvedValue(true);
+
+        const sync = createEncounterSync({
+            getMapFile: () => null,
+            getState: () => ({}) as any,
+            pausePlayback,
+            openEncounter,
+        });
+
+        publishEncounterEvent(baseEvent);
+
+        expect(pausePlayback).toHaveBeenCalledTimes(1);
+        expect(openEncounter).toHaveBeenCalledWith();
+
+        sync.dispose();
+    });
+
+    it("allows external hook to suppress view opening", () => {
+        const pausePlayback = vi.fn();
+        const openEncounter = vi.fn().mockResolvedValue(true);
+
+        const sync = createEncounterSync({
+            getMapFile: () => null,
+            getState: () => ({}) as any,
+            pausePlayback,
+            openEncounter,
+            onExternalEncounter: () => false,
+        });
+
+        publishEncounterEvent({ ...baseEvent, id: "manual-2" });
+
+        expect(pausePlayback).toHaveBeenCalledTimes(1);
+        expect(openEncounter).not.toHaveBeenCalled();
+
+        sync.dispose();
+    });
+
+    it("ignores travel-origin events from other sources", () => {
+        const pausePlayback = vi.fn();
+        const openEncounter = vi.fn().mockResolvedValue(true);
+
+        const sync = createEncounterSync({
+            getMapFile: () => null,
+            getState: () => ({}) as any,
+            pausePlayback,
+            openEncounter,
+        });
+
+        publishEncounterEvent({ ...baseEvent, id: "travel-1", source: "travel" });
+
+        expect(pausePlayback).not.toHaveBeenCalled();
+        expect(openEncounter).not.toHaveBeenCalled();
+
+        sync.dispose();
+    });
+});


### PR DESCRIPTION
## Summary
- add a travel encounter sync service that pauses playback and opens the encounter view when events fire
- integrate the sync into the travel mode lifecycle and clean up on teardown
- cover the new sync behaviour with unit tests and update the top-level TODO priorities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de838d8480832588117931c32b02b6