### PR TITLE
Adopt terrain bootstrap handle in plugin main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,25 @@
-Arbeite ordentlich und nachhaltig. Überlege dir langfristige Lösungen. Dokumentiere Code gründlich. Halte dich an standartisiete Prozese und überlege dir neue Standards wenn nötog. Jeder Ordner sollte eine AGENTS.md Datei enthalten, in der folgendes steht:
-1. Eine Übersicht der Ziele, die in dem Ordner erreicht werden sollen. Features, Workflows, user-erlebnisse etc.
-2. Wie diese Ziele momentan vom Inhalt des Ordners umgesetzt werden.
-3. Eine ToDo Liste für alles, was dazu noch getan werden muss.
-4. Eine Liste aller Standards, die in dem Ordner verwendet werden.
+# Repository-Leitplanken
 
-Jedes Skript sollte einen kurzen header haben, der eine ähnliche Funkoin hat. Ggf. bei komplexeren Skripten mehrere Header für unterschiedliche Abschnite.
+Arbeite ordentlich, nachhaltig und mit Blick auf langfristige Lösungen. Dokumentiere Code und Entscheidungen so, dass sie für zukünftige Maintainer*innen nachvollziehbar bleiben. Halte dich an etablierte Standards und verbessere sie nur, wenn der Nutzen klar belegt ist.
 
-Wenn Sinnvoll sollten Ordner eine README.md enthalten, in der aus User Sicht Funktionen, UI Interaktionen und Arbeitsabläufe erklärt werden. Diese READMEs sollen reine Endnutzer Anleitungen sein und dementsprechend keine technischen Details enthalten. Verlinken ggf. READMEs, wenn sie sich auf Funktionen beziehen welche anderswo erklärt werden.
+## 1. Ziele dieses Repositories
+- Einheitliche Dokumentation der Arbeitsweise für alle Unterordner schaffen.
+- Klare Erwartungen an Codequalität, Struktur und Dokumentation festhalten.
+- Nachhaltige Verbesserungen anstoßen und Aufgaben transparent priorisieren.
 
-Halte Dokumentation so kurz und präzise wie möglich. Nutze die geringst mögliche Menge an Worten.
-Ergänze fehlende Dokumentation sofort.
+## 2. Aktueller Umsetzungsstand
+- Dieses Dokument definiert die globalen Standards für das Projekt.
+- Viele Unterordner verfügen bereits über eigene `AGENTS.md`, die diese Standards konkretisieren.
+- README-Dateien und Dokumentation existieren teilweise, sind jedoch nicht überall konsistent gepflegt.
+
+## 3. Offene Aufgaben
+- Ergänze in allen relevanten Ordnern eine `AGENTS.md`, falls sie noch fehlt.
+- Sorge dafür, dass jede vorhandene `AGENTS.md` die Abschnitte Ziele, aktueller Stand, ToDos und Standards enthält.
+- Ergänze fehlende README-Dateien für Endnutzer*innen, sobald ein Ordner user-facing Funktionalität bereitstellt.
+
+## 4. Standards und Arbeitsweisen
+- Dokumentation stets knapp, präzise und aktuell halten.
+- Jeder Ordner erhält eine eigene `AGENTS.md` mit den oben genannten vier Abschnitten.
+- Jedes Skript bekommt einen Header mit Zweck, Inputs/Outputs und Besonderheiten; komplexe Skripte nutzen Abschnitts-Header.
+- README-Dateien beschränken sich auf die Nutzerperspektive und verlinken technische Details nur bei Bedarf.
+- Fehlende Dokumentation wird umgehend ergänzt, statt als offene Aufgabe liegen zu bleiben.

--- a/TODO.md
+++ b/TODO.md
@@ -9,49 +9,46 @@ Die Aufgaben sind nach Priorität sortiert. Dezimalstellen kennzeichnen die Reih
 - keine offenen ToDos.
 
 ## 2. Robustheit & Wartbarkeit
-- 2.1 [AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.2 [salt-marcher/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.3 [salt-marcher/src/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.4 [salt-marcher/src/app/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.5 [salt-marcher/src/apps/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.6 [salt-marcher/src/apps/cartographer/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.7 [salt-marcher/src/apps/cartographer/editor/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.8 [salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.9 [salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.10 [salt-marcher/src/apps/cartographer/mode-registry/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.11 [salt-marcher/src/apps/cartographer/mode-registry/providers/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.12 [salt-marcher/src/apps/cartographer/modes/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.13 [salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.14 [salt-marcher/src/apps/cartographer/travel/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.15 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.16 [salt-marcher/src/apps/cartographer/travel/infra/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.17 [salt-marcher/src/apps/cartographer/travel/render/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.18 [salt-marcher/src/apps/cartographer/travel/ui/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.19 [salt-marcher/src/apps/cartographer/view-shell/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.20 [salt-marcher/src/apps/encounter/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.21 [salt-marcher/src/apps/library/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.22 [salt-marcher/src/apps/library/core/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.23 [salt-marcher/src/apps/library/create/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.24 [salt-marcher/src/apps/library/create/creature/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.25 [salt-marcher/src/apps/library/create/shared/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.26 [salt-marcher/src/apps/library/create/spell/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.27 [salt-marcher/src/apps/library/view/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.28 [salt-marcher/src/core/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.29 [salt-marcher/src/core/hex-mapper/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.30 [salt-marcher/src/core/hex-mapper/render/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.31 [salt-marcher/src/ui/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.32 [salt-marcher/tests/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.33 [salt-marcher/tests/app/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.34 [salt-marcher/tests/cartographer/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.35 [salt-marcher/tests/cartographer/editor/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.36 [salt-marcher/tests/cartographer/modes/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.37 [salt-marcher/tests/cartographer/travel/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.38 [salt-marcher/tests/core/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.39 [salt-marcher/tests/encounter/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.40 [salt-marcher/tests/library/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.41 [salt-marcher/tests/mocks/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.42 [salt-marcher/tests/ui/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
-- 2.43 [salt-marcher/tools/AGENTS.md] Suche nach Potential zum streamlinen, optimieren, vereinfachen und robuster machen.
+- 2.33 [salt-marcher/src/app/AGENTS.md] CSS-Injektion absichern, indem vor dem Append vorhandene `hex-css`-Nodes entfernt werden, um Doppel-Einträge nach Fehler-Recovery zu vermeiden.
+- 2.34 [salt-marcher/src/apps/AGENTS.md] Kapsle View-Metadaten (Typ, Icon, Display-Name, Ribbon-Konfiguration) in einem gemeinsamen Manifest (`apps/view-manifest.ts`) und nutze es in `src/app/main.ts`, um Registrierungen, Ribbons und Commands generisch aufzubauen.
+- 2.35 [salt-marcher/src/apps/AGENTS.md] Ergänze `apps/README.md` um eine Tabelle der jeweils exportierten Klassen/Helfer (View, Presenter, open-/detach-Funktionen), sodass Änderungen an Entry-Points zentral nachvollziehbar bleiben.
+- 2.36 [salt-marcher/src/apps/cartographer/AGENTS.md] Mode-Registry-Abos im Presenter beim Schließen zuverlässig lösen und einen Regressionstest für mehrmaliges Öffnen/Schließen ergänzen.
+- 2.37 [salt-marcher/src/apps/cartographer/AGENTS.md] Für fehlgeschlagene `provideCartographerModes()`-Aufrufe eine sichtbare Nutzer-Rückmeldung (Overlay/Notice) hinzufügen und Logging/Telemetry harmonisieren.
+- 2.38 [salt-marcher/src/apps/cartographer/editor/AGENTS.md] `modes/editor.ts`: Status- und Fehleranzeige ausbauen, damit ToolManager-Ausnahmen und fehlende Tools sichtbare Hinweise und Telemetrie-Events auslösen.
+- 2.39 [salt-marcher/src/apps/cartographer/editor/AGENTS.md] `editor/tools/tool-manager.ts`: Hook ergänzen, der Mount-/Activate-Fehler an den Modus meldet und das Panel gezielt in einen „Tool unavailable“-Zustand versetzt.
+- 2.40 [salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md] `tool-manager.ts`: Status-/Fallback-Hook ergänzen, der bei unbekannten Tool-IDs oder fehlgeschlagenem Mount eine Nutzerhinweis- und Telemetrie-Pipeline triggert.
+- 2.41 [salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md] `brush-options.ts`: Statusmeldungen und Inline-Hinweise nutzen, um Lade-/Fehlerzustände sichtbar zu machen und das Panel während `loadRegions`-Zyklen zu sperren.
+- 2.41 [salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md] `terrain-brush/brush-options.ts`: Panel-Status (`ctx.setStatus`) während Regionsladezyklen nutzen, Fehlermeldungen anzeigen und verlorene Vorauswahl begründet zurücksetzen.
+- 2.42 [salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md] `brush-options.ts`: Command-Aufruf für „Manage…“ absichern (Existenz prüfen, sonst degradieren) und Nutzer*innen erklären, wie sie Bibliothekseinträge nachpflegen.
+- 2.42 [salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md] `terrain-brush/brush-options.ts`: Command-Aufruf für „Manage…“ absichern (Existenz prüfen, andernfalls UI-Hinweis setzen).
+- 2.43 [salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md] `brush.ts`: Fehler beim Anwenden des Brushes (save/delete) an den Tool-Kontext melden, Telemetrie auslösen und sicherstellen, dass UI/Hex-Fills bei Teilerfolg zurückgerollt werden.
+- 2.44 [salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md] `brush.ts`: Abort-Signal des Tool-Kontexts berücksichtigen, um laufende Schreibvorgänge bei Toolwechseln abzubrechen und Race-Conditions zu vermeiden.
+- 2.47 [salt-marcher/src/apps/cartographer/mode-registry/AGENTS.md] Kernprovider-Registrierung in `ensureCoreProviders()` transaktional absichern: erfolgreiche Registrierungen bei Fehlern wieder entfernen oder gar nicht erst eintragen, damit Folgeaufrufe nicht auf Duplicate-IDs laufen.
+- 2.47 [salt-marcher/src/apps/cartographer/mode-registry/providers/AGENTS.md] Provider-Metadaten zentralisieren (z.B. über ein gemeinsames Manifest), `metadata.source` auf die aktuellen Module (`apps/cartographer/modes/*`) aktualisieren und die `version` aus `package.json` ableiten, damit Fehlerlogs und Telemetrie konsistent bleiben.
+- 2.48 [salt-marcher/src/apps/cartographer/mode-registry/providers/AGENTS.md] Persistenz-Capabilities der Registry um eine Variante für Auto-Saves erweitern, den Inspector-Provider darauf umstellen und Tests ergänzen, die `capabilities` gegen die tatsächlichen Modusmethoden validieren.
+- 2.48 [salt-marcher/src/apps/cartographer/mode-registry/AGENTS.md] Provider-Ladefehler aus `createLazyModeWrapper()` als Registry-Event oder Telemetrie-Hook nach außen durchreichen, damit Presenter und UI sichtbares Feedback liefern können.
+- 2.49 [salt-marcher/src/apps/cartographer/modes/AGENTS.md] Auto-Save-Timeout des Inspectors an das Abort-Signal koppeln, Fehlermeldungen im Panel darstellen und Telemetrie für `saveTile`-/`setFill`-Fehler ergänzen.
+- 2.50 [salt-marcher/src/apps/cartographer/modes/AGENTS.md] Travel-Guide-Initialisierung gegen Terrain-/Logic-/Encounter-Ausfälle absichern und Nutzerhinweise + Logging vereinheitlichen.
+- 2.51 [salt-marcher/src/apps/cartographer/modes/AGENTS.md] Mode-IDs, Labels und Capabilities zentralisieren, damit Modusdefinitionen und Provider-Metadaten nicht auseinanderlaufen.
+- 2.52 [salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md] Encounter-Gateway so erweitern, dass fehlgeschlagene Module-Loads und Event-Builds Telemetrie & UI-Hinweise setzen, den Promise-Cache zurücksetzen und eine erneute Initialisierung zulassen.
+- 2.53 [salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md] Fehlerpfade rund um `initTokenFromTiles()` und Logik-Initialisierung auffangen, Statusmeldungen im Sidebar/Overlay setzen und Nutzern Wiederholungsoptionen anbieten.
+- 2.54 [salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md] Playback-Controls typisieren, damit Clock-/Tempo-Setter sowie `destroy()` ohne `any`-Casts adressiert werden und API-Drift früh auffällt.
+- 2.55 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] `createTravelLogic` um `dispose()` erweitern, das Store-Subscription, Token-Adapter und Playback zuverlässig beendet.
+- 2.55 [salt-marcher/src/apps/cartographer/travel/AGENTS.md] Dispose-Hook für `createTravelLogic()` bereitstellen, der Store-Subscription, Adapter-Token und Playback stoppt.
+- 2.56 [salt-marcher/src/apps/cartographer/travel/AGENTS.md] `bindAdapter()` um sofortiges `draw()`/`ensurePolys` erweitern, damit frisch montierte Map-/Route-Layer den aktuellen Zustand anzeigen.
+- 2.56 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] `bindAdapter` initiale Synchronisierung ergänzen (`ensurePolys`, `draw`, Token-Zentrierung), damit neue Render-Layer sofort den aktuellen Zustand anzeigen.
+- 2.57 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] Fehler aus `initTokenFromTiles`/`persistTokenToTiles` über UI-/Telemetry-Hooks sichtbar machen und Wiederholungsoptionen anbieten.
+- 2.57 [salt-marcher/src/apps/cartographer/travel/AGENTS.md] Persistenzfehler (`initTokenFromTiles`, `persistTokenToTiles`) mit UI-/Telemetry-Rückmeldung versehen, damit Nutzer Fehlschläge nachvollziehen können.
+- 2.58 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] Playback an neue RenderAdapter koppeln, damit Token-Animationen nach Adapterwechsel nicht am alten Adapter hängen bleiben.
+- 2.59 [salt-marcher/src/apps/cartographer/travel/infra/AGENTS.md] Playback nur pausieren, wenn ein Encounter tatsächlich geöffnet wird, oder nach unterdrückten externen Events sauber fortsetzen.
+- 2.59 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] Token-Persistenz entkoppeln, sodass beim Schreiben nicht jede Karte geladen und gespeichert werden muss (letzten Token-Stand cachen und nur betroffene Tiles anfassen).
+- 2.60 [salt-marcher/src/apps/cartographer/travel/infra/AGENTS.md] `openEncounter()` bei externen Events awaiten und Fehler bzw. Abbrüche mit Logging/Notice sichtbar machen.
+- 2.61 [salt-marcher/src/apps/cartographer/travel/render/AGENTS.md] `draw-route.ts`: Fehlende Zentren (`centerOf` → `null`) als Warnung loggen und eine Wiederholungs-/`ensurePolys`-Strategie dokumentieren, damit Routenpunkte nicht stillschweigend verschwinden.
+- 2.62 [salt-marcher/src/apps/cartographer/travel/render/AGENTS.md] `draw-route.ts`: Layer-Diff einführen, das bestehende Dot-/Hitbox-Elemente aktualisiert statt sie zu löschen, um Pointer-Capture und Event-Verweise während Rerenders zu erhalten.
+- 2.63 [salt-marcher/src/apps/cartographer/travel/ui/AGENTS.md] Legacy-Import im Travel-Guide (`interaction-controller.ts`) auf `context-menu.controller` umstellen und den Shim `contextmenue.ts` entfernen, um den doppelten Bundle-Eintrag loszuwerden.
+- 2.64 [salt-marcher/src/apps/cartographer/travel/ui/AGENTS.md] Geschwindigkeitssteuerung in `sidebar.ts` auf `input`-basierte Updates inklusive Validierungs-Helfer umbauen, damit Tempoänderungen sofort im Travel-Logic-Store landen.
+- 2.65 [salt-marcher/src/app/AGENTS.md] Terrain-Bootstrap-Logger so erweitern, dass Vault-Änderungen über `watchTerrains.onError` Telemetrie- und Notice-Hooks triggern statt nur Konsolenfehler zu schreiben.
+- 2.66 [salt-marcher/src/app/AGENTS.md] Terrain-Bootstrap mit `this.register` am Plugin-Lifecycle anbinden, damit `stop()` auch nach abgebrochenen `onload`-Sequenzen zuverlässig läuft.
 
 ## 3. Neue Features
 - 3.2 [salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md] Mehrstufige Undo/Redo-Strategien entwerfen.

--- a/salt-marcher/AGENTS.md
+++ b/salt-marcher/AGENTS.md
@@ -1,15 +1,18 @@
 # Ziele
-- Bündelt die spielinterne Salt Marcher Anwendung inklusive Frontend-Code, Tests und Build-Konfiguration.
+- Bündelt das komplette Obsidian-Plugin inklusive Frontend-Code, Tests, Build-Konfiguration und begleitender Dokumentation.
+- Stellt den Referenzstand für die Verzeichnisstruktur bereit, an dem sich Unterordner und andere Repos orientieren können.
 
 # Aktueller Stand
-- `src` beherbergt alle App- und Core-Module mit eigenen AGENTS-Leitplanken.
-- `tests` führt Vitest-Suites nach Bereichen gruppiert.
-- Root-Dateien (`package.json`, `tsconfig`, Buildskripte) steuern Bundling, Typen und Laufzeitkonfiguration.
+- `src/` enthält sämtliche Apps, Core-Module und UI-Schichten; jede maßgebliche Ebene besitzt eine eigene `AGENTS.md`.
+- `tests/` spiegelt die App-Aufteilung für Vitest-Suites, `test-failure-analysis.md` dokumentiert behobene Regressionen.
+- `BUILD.md` beschreibt die npm-Skripte (`build`, `test`, `sync:todos`) sowie die erwarteten Bundles.
+- Manifest- und Paket-Metadaten (`manifest.json`, `package.json`) sind manuell synchron zu halten.
 
 # ToDo
 - keine offenen ToDos.
 
 # Standards
-- Neue Verzeichnisse müssen direkt eine `AGENTS.md` erhalten.
-- Skripte und Tests führen Header-Kommentare gemäß Root-Vorgabe.
-- Build-/Config-Änderungen erfordern Update der zugehörigen Dokumentation.
+- Neue Verzeichnisse erhalten sofort eine `AGENTS.md` mit Zielen, Stand, ToDos und Standards.
+- Änderungen an Bundler-, Test- oder Release-Setup dokumentieren wir zeitgleich in `BUILD.md` und verlinkten AGENTS-/README-Dateien.
+- Versionen und Beschreibungstexte in `manifest.json`, `package.json` sowie README müssen bei Releases konsistent sein.
+- Nach Struktur- oder Dokumentationsanpassungen `npm run sync:todos` im Repo-Stamm ausführen, damit `TODO.md` aktuell bleibt.

--- a/salt-marcher/src/AGENTS.md
+++ b/salt-marcher/src/AGENTS.md
@@ -1,21 +1,29 @@
 # Ziele
-- Stellt Kernlogik, Apps und Integrationen des Plugins bereit.
+- Stellt die Kernlogik, Apps und Integrationen des Plugins bündig dar.
+- Beschreibt, wie Verantwortung und Datenflüsse zwischen den Unterordnern verteilt sind.
 
 # Aktueller Stand
-- `core/` bündelt Datenmodelle, Speicher- und Layoutdienste für alle Apps.
-- `apps/` gliedert die spezialisierten Oberflächen (Cartographer, Encounter, Library) samt ihren Modus- und Domain-Ordnern.
-- `app/` startet das Plugin, registriert Views und verkabelt globale Services.
-- `ui/` liefert wiederverwendbare Container, Modals und Copy-Helfer für die Apps.
+## Strukturüberblick
+- `app/` initialisiert das Plugin, registriert Views und verkabelt globale Services sowie Speicher.
+- `apps/` enthält die Feature-Oberflächen (Cartographer, Encounter, Library); jede Unterstruktur bringt eigene AGENTS-Dateien für Modi, Domains und Tools mit.
+- `core/` stellt domänenübergreifende Datenmodelle, Persistenz- und Layoutdienste bereit, die von `app/` und allen Apps genutzt werden.
+- `ui/` liefert wiederverwendbare Container, Modals, Copy-Helfer und Styling-Bausteine, die keine App-spezifischen Seiteneffekte besitzen dürfen.
 
-# Migrationspfade
-- Cartographer-Travel synchronisiert Begegnungen mit der Encounter-App über `apps/cartographer/modes/travel-guide/encounter-gateway` und `apps/encounter/session-store`.
-- Travel-Domänenzustand (`apps/cartographer/travel/domain`) stellt seine Typen und Speicherhüllen den Encounter-Events zur Verfügung (`apps/encounter/event-builder`).
-- Library-Editoren geben ihre Persistenz über `apps/library/core` frei, sodass neue Views denselben Datei-Pipeline-Aufbau nutzen können.
+## Integrations- und Datenflüsse
+- Cartographer-Travel synchronisiert Begegnungen mit der Encounter-App über `apps/cartographer/modes/travel-guide/encounter-gateway` und `apps/encounter/session-store`; die Gateway-Schicht kapselt Remote-Zugriffe.
+- Travel-Domänenzustand (`apps/cartographer/travel/domain`) stellt seine Typen und Speicherhüllen den Encounter-Events (`apps/encounter/event-builder`) bereit. Änderungen an den Typen erfordern abgestimmte Anpassungen in beiden Ordnern.
+- Library-Editoren geben ihre Persistenz über `apps/library/core` frei, sodass neue Views denselben Datei-Pipeline-Aufbau nutzen können. Speicherschnittstellen landen zentral in `core/persistence`.
+- UI-Komponenten mit App-spezifischer Logik müssen ihren Zustand in der jeweiligen App halten und dürfen nur über eindeutig benannte Props und Events mit `ui/`-Elementen sprechen.
+
+## Arbeitsabläufe
+- Builds und Tests laufen über `npm run build` bzw. `npm test` aus dem Ordnerstamm; `sync:todos` aktualisiert automatisiert die ToDo-Spiegelung in den AGENTS-Dateien.
+- Neue APIs zwischen Apps und `core/` werden zunächst als Typdefinition in `core/` ergänzt, anschließend in den beteiligten App-Verzeichnissen dokumentiert.
 
 # ToDo
 - keine offenen ToDos.
 
 # Standards
-- Jeder TypeScript-Einstieg beginnt mit `// <relativer Dateipfad>` gefolgt von einem Satz Zweck.
-- Kommentare bleiben einzeilig und konkret.
-- Neue Apps dokumentieren ihre Schnittstellen zu bestehenden Bereichen unmittelbar in den jeweiligen AGENTS-Dateien.
+- Jeder TypeScript-Einstieg beginnt mit `// <relativer Dateipfad>` gefolgt von einem Satz Zweck. Für rein re-exportierende Dateien genügt ein Verweis auf die Quelle.
+- Kommentare bleiben einzeilig und konkret; längere Erläuterungen wandern in die AGENTS- oder README-Dateien.
+- Neue Apps dokumentieren ihre Schnittstellen zu bestehenden Bereichen unmittelbar in den jeweiligen AGENTS-Dateien und verlinken auf beteiligte Module.
+- UI-Bausteine in `ui/` bleiben seiteneffektfrei und exportieren ausschließlich Props, die in JSDoc kommentiert sind.

--- a/salt-marcher/src/app/AGENTS.md
+++ b/salt-marcher/src/app/AGENTS.md
@@ -1,16 +1,31 @@
 # Ziele
-- Startet das Plugin, registriert Views und lädt Styles.
+- Initialisiert das Plugin-Lifecycle-Management, verbindet Obsidian-Hooks mit den Feature-Views und sorgt für belastbares Fehlerreporting.
+- Bündelt die Terrain-Bootstrap-Logik, damit Apps und Tests konsistente Datenquellen erhalten.
+- Liefert zentrale Telemetrie- und Style-Helfer, die wiederholt in `main.ts` verwendet werden können.
 
 # Aktueller Stand
-- `main.ts` verwaltet Plugin-Lifecycle, meldet Integrationsfehler und View-Anmeldung.
-- `bootstrap-services.ts` richtet Datenquellen und Defaults ein.
-- `integration-telemetry.ts` dedupliziert Meldungen zu View-, Ribbon-, Command- und Datensatz-Integrationen.
-- `css.ts` bündelt alle Styles als Export-String.
+## Plugin-Lifecycle (`main.ts`)
+- Registriert Cartographer-, Encounter- und Library-Views inklusive Ribbon- und Command-Shortcuts.
+- Lädt und überwacht Terrain-Daten direkt im Plugin, meldet Fehler über `failIntegration` und entfernt Ressourcen beim Unload.
+- Verdoppelt aktuell Teile der Bootstrap-Logik aus `bootstrap-services.ts`, wodurch Tests und Produktivcode auseinanderlaufen können.
+
+## Service-Bootstrap (`bootstrap-services.ts`)
+- `createTerrainBootstrap` kapselt `ensureTerrainFile`, `loadTerrains`, `setTerrains` und `watchTerrains` in einem Handle mit `start/stop`.
+- Ein Standard-Logger schreibt strukturierte Konsoleinträge; Tests injizieren Fakes, um Fehlerpfade abzudecken.
+
+## Integrations-Telemetrie (`integration-telemetry.ts`)
+- Dediziert Fehler von View-/Command-/Ribbon-Registrierungen sowie Datensatz-Ladepfaden.
+- Dedupliziert Notices pro Integrations-ID und Operation, stellt mit `__resetIntegrationIssueTelemetry` einen Test-Hook bereit.
+
+## Styles (`css.ts`)
+- Exportiert das komplette Stylesheet als String, das von `injectCss`/`removeCss` im Plugin verwaltet wird.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.33] CSS-Injektion absichern, indem vor dem Append vorhandene `hex-css`-Nodes entfernt werden, um Doppel-Einträge nach Fehler-Recovery zu vermeiden.
+- [P2.65] Terrain-Bootstrap-Logger so erweitern, dass Vault-Änderungen über `watchTerrains.onError` Telemetrie- und Notice-Hooks triggern statt nur Konsolenfehler zu schreiben.
+- [P2.66] Terrain-Bootstrap mit `this.register` am Plugin-Lifecycle anbinden, damit `stop()` auch nach abgebrochenen `onload`-Sequenzen zuverlässig läuft.
 
 # Standards
 - Einstiegspunkte dokumentieren Lifecycle-Schritte im Kopfkommentar.
-- Bootstrap-Helfer kapseln Obsidian-IO in reine Funktionen.
-- CSS bleibt im TypeScript gebündelt, bis ein Build-Schritt existiert.
+- Bootstrap-Helfer kapseln Obsidian-IO in reine Funktionen und liefern strukturierte Logger-Hooks.
+- CSS bleibt im TypeScript gebündelt, bis ein Build-Schritt existiert; Style-Injektion arbeitet idempotent mit festen Element-IDs.

--- a/salt-marcher/src/apps/AGENTS.md
+++ b/salt-marcher/src/apps/AGENTS.md
@@ -1,12 +1,41 @@
 # Ziele
-- Enthält die UI-orientierten Anwendungen (Cartographer, Library usw.).
+- Bündelt die Nutzeroberflächen (Cartographer, Encounter, Library) und hält ihre Entry-Points für das Plugin bereit.
+- Dokumentiert, wie jede App an `src/app/main.ts` und die gemeinsamen `core/`-Dienste angedockt wird.
+- Sichert konsistente Standards für Dokumentation, Dateistrukturen und View-Hilfsfunktionen über alle Apps hinweg.
 
 # Aktueller Stand
-- Jede App besitzt Unterordner für Modi, Views und Shell-Komponenten.
+## Strukturüberblick
+- `cartographer/` verwaltet Karten, Modi und Datei-Interaktionen. `index.ts` exportiert View, View-Typ-Konstanten sowie Öffnungs-
+  und Detach-Helfer, die das Plugin nutzt, um Obsidian-Leaves aufzubauen.
+- `encounter/` synchronisiert Reisebegegnungen aus dem Travel-Modus, stellt einen Presenter bereit und aktualisiert Sessions in
+  Echtzeit innerhalb des Views.
+- `library/` kapselt Nachschlagewerke, Create-Dialoge und Views. `view/index.ts` exponiert die `LibraryView`, die Ribbon- und
+  Command-Hooks aus `src/app/main.ts` konsumiert.
+- Jede App bringt eine eigene `AGENTS.md` und README-Struktur mit, die Detail-Regeln zu Modi, Domains und UI-Flows enthält.
+
+## Integrationspunkte
+- `src/app/main.ts` registriert alle Views und Commands direkt über die von hier exportierten Klassen und Hilfsfunktionen (z.B.
+  `openCartographer`). Das erfordert konsistente View-Metadaten (Typ, Icon, Display-Text) innerhalb jeder App.
+- Cartographer-Modi interagieren mit Encounter über Gateways in `cartographer/modes/travel-guide/encounter-gateway` sowie den
+  `encounter/session-store`. Library greift für Persistenz und Datenimporte auf `core/persistence` und die gemeinsamen Terrain-
+  Ressourcen zu.
+- Ribbon-Icons und Commands existieren bisher als redundante Definitionen in `src/app/main.ts`. Änderungen an Bezeichnern müssen
+  daher sowohl hier als auch in den jeweiligen Apps gepflegt werden.
+
+## Dokumentationsstand
+- `apps/README.md` beschreibt Event-Flows und verlinkt auf die App-spezifischen READMEs. Änderungen an Export-Signaturen werden
+  bisher nicht separat nachgehalten.
+- Tests spiegeln die App-Struktur über `salt-marcher/tests/*` wider, fokussieren jedoch auf Feature-Ebene und validieren keine
+  gemeinsamen View-Verträge.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.34] Kapsle View-Metadaten (Typ, Icon, Display-Name, Ribbon-Konfiguration) in einem gemeinsamen Manifest (`apps/view-manifest.ts`) und nutze es in `src/app/main.ts`, um Registrierungen, Ribbons und Commands generisch aufzubauen.
+- [P2.35] Ergänze `apps/README.md` um eine Tabelle der jeweils exportierten Klassen/Helfer (View, Presenter, open-/detach-Funktionen), sodass Änderungen an Entry-Points zentral nachvollziehbar bleiben.
 
 # Standards
 - Komponenten- und Controller-Dateien starten mit einem Kontextsatz zum Workflow.
 - UI-spezifische Typen leben lokal innerhalb der App.
+- Jede App exportiert ihren View-Typ (`VIEW_*`), den `ItemView`-Nachfolger sowie Öffnungs-/Detach-Helfer aus einem zentralen
+  Entry-Point, damit `src/app/main.ts` ohne relative Deep-Imports arbeiten kann.
+- Änderungen an Icons, Namen oder Commands einer App werden gleichzeitig im gemeinsamen Manifest, in den App-spezifischen
+  READMEs und in den Release-Notes dokumentiert.

--- a/salt-marcher/src/apps/cartographer/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/AGENTS.md
@@ -1,12 +1,27 @@
 # Ziele
-- Liefert das Hauptwerkzeug zum Bearbeiten, Inspizieren und Reisen durch Karten.
+- Liefert den zentralen Arbeitsbereich zum Erstellen, Inspizieren und Reisen über Hexkarten.
+- Orchestriert den Wechsel zwischen Arbeitsmodi sowie Datei-/Map-Management für alle Cartographer-Flows.
+- Stellt stabile Verträge für View-Shell, Presenter und Mode-Registry bereit, damit Tests und andere Apps gezielt integrieren können.
 
 # Aktueller Stand
-- `modes` und `mode-registry` kapseln Arbeitsmodi, `travel` bündelt Playback/Encounter-Flüsse, `view-shell` stellt UI-Rahmen.
+## Strukturüberblick
+- `index.ts` registriert die `CartographerView`, kapselt die ItemView-Metadaten und verbindet Obsidian-Leaves mit dem Presenter.
+- `presenter.ts` verwaltet Lifecycle, Mode-Wechsel, Map-Rendering und die Anbindung an Shell, Map-Manager und Registry.
+- `mode-registry/` pflegt Provider für Travel-, Editor- und Inspector-Modus und erlaubt externe Erweiterungen.
+- `view-shell/` stellt das UI-Skelett (Header, Sidebar, Map-Container) sowie Ereignis-Callbacks für Presenter und Modi bereit.
+- `editor/` und `travel/` liefern die jeweiligen Tooling-, Playback- und Encounter-Integrationen.
+
+## Integration & Beobachtungen
+- `CartographerPresenter` initialisiert seine Modi über `provideCartographerModes()` und hört via `subscribeToModeRegistry()` auf spätere Registry-Änderungen.
+- Schlägt das Laden der Registry fehl, fällt `createProvideModes()` auf ein leeres Array zurück – die View bleibt dann ohne Modi und liefert keine Nutzerhinweise.
+- Wiederholtes Öffnen der View ruft `onOpen()` erneut auf, ohne den Mode-Registry-Listener aus einem früheren Mount abzubestellen.
+- Map-Rendering zeigt Overlays bei fehlenden Hex-Blöcken oder Rendering-Fehlern, signalisiert Registry-Probleme jedoch nicht im UI.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.36] Mode-Registry-Abos im Presenter beim Schließen zuverlässig lösen und einen Regressionstest für mehrmaliges Öffnen/Schließen ergänzen.
+- [P2.37] Für fehlgeschlagene `provideCartographerModes()`-Aufrufe eine sichtbare Nutzer-Rückmeldung (Overlay/Notice) hinzufügen und Logging/Telemetry harmonisieren.
 
 # Standards
-- Modus-Dateien erklären ihr Nutzerziel im Kopfkommentar.
-- Controller fassen Event-Sequenzen mit Imperativ-Verben (activate, hydrate, teardown) zusammen.
+- Modus-Dateien starten mit einem Satz zum Nutzerziel; Handler bündeln Ereignisketten über Imperativ-Verben (activate, hydrate, teardown).
+- Lifecycle-Hooks registrieren nur dann Events oder Abos, wenn sie diese beim Schließen wieder entfernen.
+- Fehler, die die Modus-Auswahl beeinträchtigen, werden sowohl geloggt als auch im UI kommuniziert (Overlay oder Notice).

--- a/salt-marcher/src/apps/cartographer/editor/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/editor/AGENTS.md
@@ -1,18 +1,31 @@
 # Ziele
-- Hält gemeinsame Infrastruktur für Kartograph-Editor und seine Werkzeugleisten.
+- Bündelt Infrastruktur und Dokumentation für den Karten-Editor mitsamt Werkzeugleisten.
+- Beschreibt den Fluss zwischen Presenter, Editor-Modus und Werkzeugen, damit neue Tools sauber eingebunden werden können.
+- Hält Standards für Statusanzeigen und Lifecycle-Verhalten fest, um Benutzerfeedback konsistent zu halten.
 
 # Aktueller Stand
-- Leitet derzeit direkt in `tools`, wo Brush-Implementierungen und Manager leben.
-- `modes/editor.ts` hält Render-Handles, übergibt sie an den Tool-Manager und synchronisiert den Status bei Kartenwechseln.
+## Strukturüberblick
+- `modes/editor.ts` instanziiert den Editor-Modus, initialisiert Panel-Elemente und verbindet `ToolManager` sowie Statusanzeige.
+- `editor/tools/` hält gemeinsame Bausteine (`tool-manager`, `tools-api`, UI-Helfer) und konkrete Werkzeuge wie den Terrain-Brush.
+- `terrain-brush/` liefert Options-Panel, Brush-Mathematik und Region-Ladepipeline; weitere Tools sollen über denselben Einstieg laufen.
 
-# Rendering-Hooks
-- `ToolContext.getHandles()` liefert die aktuellen `RenderHandles` aus dem Hex-Renderer.
-- `ToolManager.notifyMapRendered()` ruft `onMapRendered` des aktiven Werkzeugs auf, sobald Handles verfügbar sind.
-- Werkzeuge können `onMapRendered` nutzen, um Canvas-Layer oder Overlays außerhalb des Standard-Brushes zu initialisieren.
+## Lifecycle & Datenflüsse
+- Der Modus synchronisiert Datei-, Render- und Optionszustand mit dem `ToolContext`, das Tools über `getHandles` und `getAbortSignal` auf dem Laufenden hält.
+- `ToolManager.switchTo` führt Panel-Mount, Aktivierung und `onMapRendered` in zwei Microtasks aus; Fehler werden aktuell nur in die Konsole geloggt.
+- Das Panel deaktiviert sich solange keine Handles vorliegen und nutzt `setStatus`, um Lade- bzw. Leerlaufzustände darzustellen.
+- Der Brush lädt Regionen asynchron über `loadRegions`, lauscht auf Workspace-Events (`salt:terrains-updated`, `salt:regions-updated`) und resetet Auswahl sowie Vorschaukreis bei Lifecycle-Abbruch.
+
+## Beobachtungen
+- Fällt ein Tool beim Mounten oder Aktivieren durch, verwaist das Panel ohne sichtbares Feedback; `setStatus` wird dafür noch nicht genutzt.
+- Console-Fehler aus `tool-manager.ts` und Tool-Modulen landen nicht in Telemetrie oder im UI, wodurch Nutzer über Probleme im Hintergrund im Unklaren bleiben.
+- Der „Manage…“-Button des Brushs ruft direkt einen Command auf; fehlt dieser, passiert nichts. Ein Fallback-Hinweis wäre hilfreich.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.38] `modes/editor.ts`: Status- und Fehleranzeige ausbauen, damit ToolManager-Ausnahmen und fehlende Tools sichtbare Hinweise und Telemetrie-Events auslösen.
+- [P2.39] `editor/tools/tool-manager.ts`: Hook ergänzen, der Mount-/Activate-Fehler an den Modus meldet und das Panel gezielt in einen „Tool unavailable“-Zustand versetzt.
 
 # Standards
 - Editor-spezifische Module benennen Werkzeuge klar (`*-tool`, `*-brush`).
 - Neue Editorkomponenten erhalten Kopfkommentare mit Nutzerabsicht.
+- Tools nutzen `ToolContext.setStatus`, um lange Operationen oder Fehlerzustände sichtbar zu machen und räumen Workspace-Abos im Cleanup.
+- Buttons, die globale Commands triggern, validieren das Vorhandensein des Commands und degradieren andernfalls mit UI-Hinweis.

--- a/salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/editor/tools/AGENTS.md
@@ -1,12 +1,34 @@
 # Ziele
-- Bündelt Werkzeuge, die Kartenfelder modifizieren oder auswählen.
+- Bündelt alle Editortools, die Kartenfelder selektieren oder verändern, und dokumentiert deren Verträge.
+- Beschreibt, wie Tool-Lifecycle, Panel-Mounting und UI-Statusmeldungen ineinandergreifen.
+- Stellt sicher, dass neue Tools konsistent an `modes/editor.ts` andocken und sich sauber bereinigen.
 
 # Aktueller Stand
-- Enthält Brush-Geometrien, einen Tool-Manager und API-Adapter für den Editor.
+## Strukturüberblick
+- `tools-api.ts` definiert `ToolModule`, den gemeinsam genutzten `ToolContext` (inklusive `setStatus`) sowie die Manager-Signatur.
+- `tool-manager.ts` schaltet Tools, mountet deren Panels, ruft Lifecycle-Hooks (`onActivate`, `onDeactivate`, `onMapRendered`) und verwaltet Abbruch-Controller.
+- `brush-circle.ts` rendert den Vorschaukreis über SVG, throttlet Pointer-Events und unterstützt dynamische Radien.
+- `terrain-brush/` stellt das einzige derzeit aktive Tool mit Panel, Options-State, Regions-Loading, Brush-Mathematik und Hex-Anwendung bereit.
+
+## Lifecycle & Datenflüsse
+- Der Editor-Modus reicht `ToolContext`-Instanzen mit Datei-, Render- und Optionshandles sowie `setStatus` an den Manager, der sie ungeprüft an Tools weitergibt.
+- `switchTo` leert das Panel, mountet das gewünschte Tool und ruft Hooks sequenziell nach Microtasks auf; Fehler werden ausschließlich über `console.error` protokolliert.
+- Fällt ein Tool beim Panel-Mount oder Aktivieren aus, signalisiert der Manager dies weder per Statusmeldung noch per Telemetrie und hinterlässt ein leeres Panel.
+- Der Terrain-Brush lädt Regionen asynchron, nutzt `loadRegions` und Workspace-Events, aktualisiert jedoch keine Statusanzeige bei Lade- oder Fehlerzuständen und verliert stillschweigend vorausgewählte Regionen.
+
+# Beobachtungen
+- Tool-Umschaltungen ohne Treffer (unbekannte ID, leere Tool-Liste) resultieren in stummen Rückgaben; ein sichtbarer Hinweis oder Telemetrie fehlt.
+- `createToolManager` kennt keinen Hook, um Fehler an den Editor-Modus weiterzuleiten, obwohl `ToolContext.setStatus` für Panel-Feedback vorgesehen ist.
+- Der Terrain-Brush meldet Ladefehler nur in der Konsole; Nutzer erkennen nicht, ob Regionen nachgeladen werden oder warum Dropdowns leer bleiben.
+- Der „Manage…“-Button vertraut auf den globalen Command, prüft aber dessen Existenz nicht und kann Nutzer ohne Feedback zurücklassen.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.40] `tool-manager.ts`: Status-/Fallback-Hook ergänzen, der bei unbekannten Tool-IDs oder fehlgeschlagenem Mount eine Nutzerhinweis- und Telemetrie-Pipeline triggert.
+- [P2.41] `terrain-brush/brush-options.ts`: Panel-Status (`ctx.setStatus`) während Regionsladezyklen nutzen, Fehlermeldungen anzeigen und verlorene Vorauswahl begründet zurücksetzen.
+- [P2.42] `terrain-brush/brush-options.ts`: Command-Aufruf für „Manage…“ absichern (Existenz prüfen, andernfalls UI-Hinweis setzen).
 
 # Standards
-- Jede Tool-Datei startet mit Dateipfad plus Satz zur Interaktion.
-- Zustände, die im UI geteilt werden, laufen über explizite Manager-Klassen.
+- Jede Tool-Datei startet mit Dateipfad plus einem Satz zur Nutzerinteraktion.
+- Tool-Module räumen eigene DOM- und Workspace-Abos konsequent im Cleanup bzw. `onDeactivate` ab.
+- Asynchrone Operationen veröffentlichen Fortschritt und Fehler über `ToolContext.setStatus` und nutzen `AbortSignal`, um Arbeiten nach Mode-Wechseln einzustellen.
+- Buttons oder globale Integrationen validieren abhängige Commands/Services und degradieren andernfalls mit sichtbarem Hinweis.

--- a/salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/editor/tools/terrain-brush/AGENTS.md
@@ -1,12 +1,33 @@
 # Ziele
-- Definiert Verhalten und Parameter des Terrain-Pinsels im Editor.
+- Definiert Verhalten, Parameter und Nutzerflüsse des Terrain-Pinsels im Cartographer-Editor.
+- Dokumentiert, wie UI-Panel, Brush-Geometrie und Dateischreiblogik zusammenspielen.
+- Stellt sicher, dass Fehlerzustände sichtbar bleiben und nachgelagerte ToDos klar beschrieben sind.
 
 # Aktueller Stand
-- Stellt Brush-Geometrie, Optionsmodell und Ausführungslogik bereit.
+## Strukturüberblick
+- `brush-options.ts` baut das Options-Panel (Radius, Region, Mode) auf, lädt Regionsdaten aus `core/regions-store` und steuert den Brush-Vorschaukreis.
+- `brush.ts` persistiert Terrain/Region-Daten über `saveTile`/`deleteTile`, aktualisiert `RenderHandles` live und dedupliziert Hex-Koordinaten innerhalb des Radius.
+- `brush-math.ts` kapselt Distanz- und Radiusberechnungen für das odd-r-Grid und liefert deterministisch sortierte Koordinatenlisten.
+
+## Lifecycle & Datenflüsse
+- `createBrushTool` hält lokalen State für Radius, Region, Terrain und Modus und synchronisiert UI-Interaktionen direkt in diese Struktur.
+- `mountPanel` lädt Regionen sequentiell über `loadRegions(app)` und reagiert auf Workspace-Events (`salt:terrains-updated`, `salt:regions-updated`), setzt aber keine Statusmeldungen im Panel.
+- Der Tool-Kontext reicht `getHandles()` und `getOptions()` weiter; bei `onActivate` und `onMapRendered` wird der Brush-Kreis jedes Mal neu angeheftet.
+- `onHexClick` ruft `applyBrush` ohne eigene Fehlerbehandlung auf; Ausnahmen landen nur in der Konsole, Abort-Signale aus dem Tool-Kontext werden nicht berücksichtigt.
+
+## Beobachtungen
+- Fehlschläge beim Laden der Regionen oder beim Command-Aufruf „Manage…“ bleiben für Nutzer unsichtbar, obwohl `ToolContext.setStatus` verfügbar wäre.
+- Panel-Reloads können mehrfach parallel laufen (Event-Loop + manuelle Klicks); ältere Promises werden zwar durch `fillSeq` verworfen, aber es fehlt ein visuelles Feedback für laufende Aktualisierungen.
+- `applyBrush` hat keinen Guard für aufeinanderfolgende Klicks und propagiert weder Partial-Fehler noch Telemetrie, wodurch inkonsistente Terrain-Zustände unbemerkt bleiben können.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.41] `brush-options.ts`: Statusmeldungen und Inline-Hinweise nutzen, um Lade-/Fehlerzustände sichtbar zu machen und das Panel während `loadRegions`-Zyklen zu sperren.
+- [P2.42] `brush-options.ts`: Command-Aufruf für „Manage…“ absichern (Existenz prüfen, sonst degradieren) und Nutzer*innen erklären, wie sie Bibliothekseinträge nachpflegen.
+- [P2.43] `brush.ts`: Fehler beim Anwenden des Brushes (save/delete) an den Tool-Kontext melden, Telemetrie auslösen und sicherstellen, dass UI/Hex-Fills bei Teilerfolg zurückgerollt werden.
+- [P2.44] `brush.ts`: Abort-Signal des Tool-Kontexts berücksichtigen, um laufende Schreibvorgänge bei Toolwechseln abzubrechen und Race-Conditions zu vermeiden.
 
 # Standards
 - Funktionen beschreiben ihren Effekt auf Terrain-Arrays in einem Satz vor der Implementierung.
 - Mathematische Hilfen (`*-math`) bleiben frei von Seiteneffekten.
+- Brush-spezifische Module validieren abhängige Commands/Services und degradieren mit sichtbaren Hinweisen.
+- Asynchrone Operationen veröffentlichen Fortschritt, respektieren `AbortSignal` und räumen UI-Ressourcen deterministisch auf.

--- a/salt-marcher/src/apps/cartographer/mode-registry/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/mode-registry/AGENTS.md
@@ -1,14 +1,29 @@
 # Ziele
-- Verknüpft Editier-, Reise- und Inspektionsmodi mit ihren Factory-Funktionen.
+- Verknüpft Editor-, Travel- und Inspector-Modi zentral mit ihren Provider-Fabriken und sorgt dafür, dass der Presenter eine konsistente Auswahl erhält.
+- Normalisiert Metadaten, Fähigkeiten und Lifecycle-Hooks, bevor sie an Shell und Presenter durchgereicht werden.
+- Bietet Erweiterungs-Punkte für zusätzliche Modi, ohne dass Kernprovider erneut verdrahtet werden müssen.
 
 # Aktueller Stand
-- `registry.ts` verwaltet Registrierungen, `providers` liefert konkrete Fabriken.
-- Fehlpfad: `CartographerView` kapselt `provideCartographerModes()` in `try/catch`, loggt Fehler und liefert eine leere Modusliste;
-  der Presenter protokolliert gescheiterte Registry-Abos, damit die Shell ohne Provider stabil bleibt.
+## Strukturüberblick
+- `index.ts` stellt die öffentliche Registry-API bereit, registriert beim ersten Zugriff die drei Kernprovider und bietet Snapshots sowie Abo-Helfer an.
+- `registry.ts` kapselt Metadaten-Normalisierung, Lazy-Loading der Provider, Listener-Benachrichtigung und Sortierung nach `order`/Label.
+- `providers/` definiert konkrete Fabriken für Travel-, Editor- und Inspector-Modus und exportiert sie für `index.ts` sowie externe Aufrufer.
+
+## Integrationspfade
+- `CartographerPresenter` ruft `provideCartographerModes()` und `subscribeToModeRegistry()` auf, um Shell-Auswahl und Moduswechsel zu versorgen.
+- `CartographerView` stützt sich auf `provideCartographerModes()` als Fallback, wenn Presenter-Initialisierung scheitert, und loggt Fehler.
+- Tests in `tests/cartographer` verwenden `resetCartographerModeRegistry()` zum Aufräumen, um nach jedem Szenario wieder mit leeren Registrierungen zu starten.
+
+## Beobachtungen & Risiken
+- `ensureCoreProviders()` setzt die Flagge erst nach erfolgreicher Registrierung aller drei Provider. Scheitert einer der späteren Aufrufe (z.B. wegen Duplikat-IDs), bleiben zuvor registrierte Provider aktiv, Folgeaufrufe schlagen jedoch dauerhaft auf Duplicate-Errors fehl.
+- `createLazyModeWrapper()` fängt Ladefehler ab und setzt den `loading`-Status zurück, meldet den Ausfall aber weder an Registry-Listener noch an Presenter/Shell. Nutzer*innen sehen lediglich Konsolen-Logs.
+- Registry-Events enthalten derzeit keine Hinweise auf Provider-Gesundheit oder Laden-Status, wodurch Telemetrie und UI keine gezielten Hinweise ableiten können.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.47] Kernprovider-Registrierung in `ensureCoreProviders()` transaktional absichern: erfolgreiche Registrierungen bei Fehlern wieder entfernen oder gar nicht erst eintragen, damit Folgeaufrufe nicht auf Duplicate-IDs laufen.
+- [P2.48] Provider-Ladefehler aus `createLazyModeWrapper()` als Registry-Event oder Telemetrie-Hook nach außen durchreichen, damit Presenter und UI sichtbares Feedback liefern können.
 
 # Standards
-- Registrierungsfunktionen beschreiben den Moduszweck im Header.
-- Provider werden über eindeutige Schlüssel exportiert (`register<Modus>`).
+- Registrierungsfunktionen beschreiben den Moduszweck im Header und dokumentieren, welche Fähigkeiten (`capabilities`) erwartet werden.
+- Provider werden über eindeutige Schlüssel exportiert (`register<Modus>`), zusätzliche Provider nutzen `defineCartographerModeProvider()` zur Metadaten-Normalisierung.
+- Lazy-Wrapper bleiben zustandslos, bis ein Modus geladen wurde, und räumen Fehlerpfade so auf, dass Folgeaufrufe erneut versuchen können.

--- a/salt-marcher/src/apps/cartographer/mode-registry/providers/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/mode-registry/providers/AGENTS.md
@@ -1,14 +1,30 @@
 # Ziele
-- Stellt konkrete Initialisierer für jeden Cartographer-Modus bereit.
+- Liefert die konkreten Provider-Fabriken für Travel-, Editor- und Inspector-Modus.
+- Dokumentiert, welche Metadaten (`capabilities`, `order`, `keywords`) die Registry benötigt, um Modi zu sortieren und aufzubauen.
+- Schafft Transparenz über Abhängigkeiten der Provider und über mögliche Inkonsistenzen zwischen Metadaten und den tatsächlichen Modi.
 
 # Aktueller Stand
-- Enthält Provider für Editor-, Inspector- und Travel-Guide-Flüsse.
-- Tests nutzen `defineCartographerModeProvider` zusammen mit `tests/cartographer/mode-registry.test.ts` (`createStubContext`) und
-  `tests/cartographer/presenter.test.ts` (`createRegistryEntry`), um Provider- und Metadata-Mocks konsistent aufzubauen.
+## Strukturüberblick
+- `travel-guide.ts`, `editor.ts` und `inspector.ts` exportieren je eine `create…ModeProvider()`-Fabrik.
+- Jede Fabrik ruft `defineCartographerModeProvider()` aus `../registry`, ergänzt Metadaten und liefert eine `load()`-Funktion, die den zugehörigen Modus per dynamischem Import nachlädt.
+- Die Metadaten geben `capabilities` (Hex-Interaktion, Persistenzform, Sidebar-Nutzung), `order`, `keywords` und eine Quelle für Telemetrie-/Logmeldungen an.
+
+## Integrationen & Abhängigkeiten
+- `index.ts` im selben Verzeichnis bindet diese Provider ein, registriert sie über die Registry und kümmert sich um Lazy-Loading.
+- Tests unter `tests/cartographer/mode-registry.test.ts` nutzen `defineCartographerModeProvider()`-Stubs, um Registry-Ereignisse, Sortierung und Lazy-Loading zu prüfen.
+- Die reale Modus-Implementierung findet in `../modes/*.ts` statt. Änderungen an den Modulen erfordern angepasste Metadaten (z.B. `capabilities`, `summary`).
+
+## Beobachtungen & Risiken
+- Alle Provider führen nahezu identische Metadatenblöcke – Anpassungen (Version, Keywords, Reihenfolge) müssen daher dreifach erfolgen und laufen Gefahr, auseinanderzudriften.
+- `metadata.source` verweist weiterhin auf die alte `core/cartographer/*`-Struktur; Fehlerlogs verlinken dadurch auf nicht mehr existente Module.
+- Der Inspector-Modus schreibt Dateien über `saveTile()`, deklariert aber `persistence: "read-only"`. Die Registry erwartet bei nicht-read-only Modi eine `onSave()`-Implementierung, wodurch aktuell kein passender Persistenzwert existiert und die Metadaten ein falsches Verhalten signalisieren.
+- Keine automatisierte Prüfung stellt sicher, dass die deklarierten `capabilities` mit den tatsächlich exportierten Methoden (`onHexClick`, `onSave`) übereinstimmen.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.47] Provider-Metadaten zentralisieren (z.B. über ein gemeinsames Manifest), `metadata.source` auf die aktuellen Module (`apps/cartographer/modes/*`) aktualisieren und die `version` aus `package.json` ableiten, damit Fehlerlogs und Telemetrie konsistent bleiben.
+- [P2.48] Persistenz-Capabilities der Registry um eine Variante für Auto-Saves erweitern, den Inspector-Provider darauf umstellen und Tests ergänzen, die `capabilities` gegen die tatsächlichen Modusmethoden validieren.
 
 # Standards
-- Provider-Dateien listen zuerst ihre externen Services in einem Satz.
-- Rückgaben liefern stets ein Objekt mit `activate`/`deactivate`-Signaturen.
+- Provider-Dateien beginnen mit einem Kurzsatz, der die externen Abhängigkeiten und den Moduszweck beschreibt.
+- Metadaten spiegeln genau das Verhalten des Modus wider (Capabilities, Reihenfolge, Schlüsselwörter) und verweisen in `source` auf das tatsächliche Modul.
+- `load()`-Funktionen liefern unveränderte Modusinstanzen; Fehler propagieren sie nach außen, damit die Registry Telemetrie-Events erzeugen kann.

--- a/salt-marcher/src/apps/cartographer/modes/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/modes/AGENTS.md
@@ -1,10 +1,29 @@
 # Ziele
-- Bündelt Arbeitsmodi (Editor, Inspector, Travel Guide) des Cartographer.
+- Bündelt die Kernmodi (Editor, Inspector, Travel Guide) des Cartographer und beschreibt deren Verantwortlichkeiten.
+- Dokumentiert, wie Modi Lifecycle, Tooling und Registry-Zugriffe koordinieren.
+- Sichert einheitliche Erwartungen an Fehlerbehandlung, Statusmeldungen und Metadaten über alle Modi hinweg.
 
 # Aktueller Stand
-- `editor` und `inspector` initialisieren UI-Panels rund um Hex-Bearbeitung und teilen einen Lifecycle-Helfer.
-- `travel-guide` startet Interaktions-Controller für Routen und Begegnungen.
+## Strukturüberblick
+- `editor.ts` baut das Bearbeitungspanel mit Tool-Auswahl auf, nutzt `createToolManager()` aus `editor/tools` und hält Statusmeldungen über `setStatus` aktuell.
+- `inspector.ts` stellt Formularfelder für Terrain und Notizen bereit, lädt Daten aus `core/hex-mapper/hex-notes` und schreibt Änderungen verzögert über einen Auto-Save-Timeout zurück.
+- `travel-guide.ts` orchestriert Sidebar, Playback, Routen- & Token-Layer sowie Encounter-Sync und interagiert eng mit `travel/domain`, `travel/ui` und `travel/infra`.
+- `lifecycle.ts` kapselt die Verwaltung des jeweils letzten `AbortSignal` und wird von Editor und Inspector genutzt, um Tool-/Form-Interaktionen sauber abzubrechen.
+- `travel-guide/` beherbergt Controller (Playback, Interaction, Encounter-Gateway), die beim Lazy-Load des Modus nachgeladen werden.
+
+## Integrationen & Beobachtungen
+- Alle Modi werden über Provider in `mode-registry/providers` geladen; IDs und Labels sind derzeit manuell in Modus- und Provider-Dateien gepflegt.
+- Editor & Inspector verlassen sich auf `ToolManager`- und Hex-Persistenz-Helfer. Fehler werden bislang nur mit `console.error` geloggt und führen nicht zu UI-Hinweisen oder Telemetrie.
+- Travel Guide lädt Terrains, initialisiert Domain-Logik und Encounter-Synchronisation sequentiell. Schlägt ein Schritt fehl, bleibt der Modus ohne sichtbaren Hinweis oder Rückfallebene.
+- Die README dokumentiert Nutzerflüsse, verweist aber nicht auf technische Risiken wie Abort-Signale oder die Abhängigkeit von `travel/infra`.
+
+# ToDo
+- [P2.49] Auto-Save-Timeout des Inspectors an das Abort-Signal koppeln, Fehlermeldungen im Panel darstellen und Telemetrie für `saveTile`-/`setFill`-Fehler ergänzen.
+- [P2.50] Travel-Guide-Initialisierung gegen Terrain-/Logic-/Encounter-Ausfälle absichern und Nutzerhinweise + Logging vereinheitlichen.
+- [P2.51] Mode-IDs, Labels und Capabilities zentralisieren, damit Modusdefinitionen und Provider-Metadaten nicht auseinanderlaufen.
 
 # Standards
-- Jede Modulfunktion beschreibt ihr Nutzerziel im Kopfkommentar.
-- Modus-Factories exportieren `create<Name>Mode` und kapseln lokalen Zustand.
+- Jede Modus-Fabrik exportiert `create<Name>Mode`, startet mit einem Kopfkommentar zum Nutzerziel und räumt registrierte Listener sowie DOM-Knoten in `onExit` konsequent auf.
+- Asynchrone Schritte prüfen `ctx.signal.aborted` oder das Lifecycle-Signal vor und nach Await-Punkten und melden Fehler sowohl im UI (Status/Notice) als auch per Logger/Telemetry.
+- Tool- und Persistenzfehler setzen Panel-Status, triggern definierte Telemetrie-Hooks und verlassen sich nicht ausschließlich auf `console.error`.
+- Mode-Metadaten (ID, Label, Capabilities) werden an einer Stelle gepflegt und beim Hinzufügen neuer Modi gegen Registry-/Provider-Kontrakte gespiegelt.

--- a/salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/modes/travel-guide/AGENTS.md
@@ -1,16 +1,32 @@
 # Ziele
-- Steuert die Travel-Guide-Erfahrung innerhalb des Cartographer-Modus.
+- Steuert die Travel-Guide-Erfahrung innerhalb des Cartographer-Modus samt Playback, Interaktion und Encounter-Übergabe.
+- Dokumentiert, wie Travel-spezifische Controller zusammenarbeiten und welche Abhängigkeiten Richtung Terrain-, Logic- und Encounter-Schichten bestehen.
+- Identifiziert Risiken, bei denen fehlende Daten oder UI-Abhängigkeiten den Modus ausbremsen, und hält Folgeaufgaben fest.
 
 # Aktueller Stand
-- `encounter-gateway` vermittelt Begegnungsdaten zwischen Travel und Encounter-App.
-- `interaction-controller` orchestriert Karteninteraktionen und UI-Events.
-- `playback-controller` synchronisiert Timeline, Route und Audio-Hooks.
-- `encounter-gateway` meldet fehlende Karten- oder Zustandsdaten direkt im UI und protokolliert sie im Log, damit Travel-Anfragen
-  nachvollziehbar bleiben.
+## Strukturüberblick
+- `travel-guide.ts` erstellt Sidebar, Route-/Token-Layer sowie Travel-Logik, synchronisiert UI-State und koppelt Encounter-Sync an die Modus-Lifecycle-Hooks.
+- `travel-guide/encounter-gateway.ts` lädt Encounter-View-Module on demand, baut Events aus dem Travel-Zustand und öffnet die Encounter-Ansicht im rechten Leaf.
+- `travel-guide/interaction-controller.ts` verbindet Route- und Token-Layer mit Drag-/Context-Menu-Logik, damit Dots, Token und Encounter-Kontextmenüs interaktiv bleiben.
+- `travel-guide/playback-controller.ts` mountet die Playback-Controls im Sidebar-Host und hält Route-, Tempo- und Uhrzeit-Anzeige synchron.
+
+## Lifecycle & Datenflüsse
+- Beim `onEnter` lädt der Modus Terrains, subscribed auf Terrain-Updates, initialisiert Sidebar und Playback und setzt Status auf Basis des aktuellen Files.
+- `createTravelLogic()` liefert State-Änderungen, die Route-/Token-Layer, Sidebar und Playback steuern; Encounter-Sync pausiert Playback und öffnet Encounter-Views sowohl für interne als auch externe Events.
+- Manualle Encounter-Auslösungen laufen über das Kontextmenü (`triggerEncounterAt`), das wiederum `publishManualEncounter` auf den aktuellen Travel-State stützt.
+
+## Beobachtungen & Risiken
+- Schlägt das dynamische Laden der Encounter-Module fehl, bleibt der Promise-Cache auf `null` hängen; spätere Aufrufe versuchen keinen Reload und Nutzer*innen erhalten nur einen kurzen Notice ohne weitere Telemetrie.
+- `initTokenFromTiles()` kann Exceptions werfen (z.B. bei defekten Karten) und beendet den Lifecycle frühzeitig, ohne UI-Status oder Retry-Hinweise zu setzen.
+- `TravelPlaybackController` greift über `as any` auf optionale Clock-/Tempo-Setter zu; API-Änderungen der Controls bleiben dadurch untypisiert und können zur Laufzeit brechen.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.52] Encounter-Gateway so erweitern, dass fehlgeschlagene Module-Loads und Event-Builds Telemetrie & UI-Hinweise setzen, den Promise-Cache zurücksetzen und eine erneute Initialisierung zulassen.
+- [P2.53] Fehlerpfade rund um `initTokenFromTiles()` und Logik-Initialisierung auffangen, Statusmeldungen im Sidebar/Overlay setzen und Nutzern Wiederholungsoptionen anbieten.
+- [P2.54] Playback-Controls typisieren, damit Clock-/Tempo-Setter sowie `destroy()` ohne `any`-Casts adressiert werden und API-Drift früh auffällt.
 
 # Standards
-- Controller beschreiben ihren Event-Flow in ein bis zwei Sätzen am Kopf.
-- Exportierte Funktionen heißen `create<Name>` und kapseln Seiteneffekte lokal.
+- Jede Controller-/Gateway-Datei startet mit einem Satz zum Nutzerziel und listet kritische Abhängigkeiten (Terrain, Encounter, Playback) im Kopf.
+- Lifecycle-Hooks (`onEnter`, `onFileChange`, `onExit`) räumen Interaktionen, Event-Listener und Klassen toggles idempotent ab und prüfen vor Await-Punkten `ctx.signal.aborted`.
+- Encounter-Brücken kommunizieren Fehler doppelt: als UI-Notice/Status und als strukturierte Log-/Telemetry-Einträge, inklusive Kontext zur geladenen Karte.
+- Playback- und Interaktionscontroller exponieren `dispose()`-Methoden, die alle Listener lösen, und vermeiden anonyme `any`-Zugriffe auf Third-Party-Handles.

--- a/salt-marcher/src/apps/cartographer/travel/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/travel/AGENTS.md
@@ -1,15 +1,32 @@
 # Ziele
-- Implementiert die Reise- und Playback-Schicht des Cartographer.
+- Kapselt alle Reise-spezifischen Workflows des Cartographer – von der Routenplanung bis zur Encounter-Synchronisation.
+- Trennt Playback-, Rendering- und UI-Schichten so, dass Modi (`modes/travel-guide`) klar definierte Verträge konsumieren.
+- Sichert nachvollziehbare Dokumentation über Zustandsänderungen, Persistenz und Interaktionen mit der Encounter-App.
 
 # Aktueller Stand
-- `domain` verwaltet Zustand, Aktionen und Persistenz.
-- `infra` adaptiert Travel-Events auf Obsidian-APIs.
-- `render` zeichnet Routen und Marker auf die Hex-Karte.
-- `ui` stellt Controller und Layer für Benutzerinteraktionen.
+## Strukturüberblick
+- `domain/` verwaltet Zustand, Aktionen und Persistenz. `actions.ts` bündelt die Travel-Logik (Route-Manipulation, Token-Steuerung, Playback) und nutzt `state.store.ts`, `expansion.ts` sowie `playback.ts` als Hilfsschichten.
+- `infra/` adaptiert Travel-Events auf Obsidian-APIs. `adapter.ts` definiert das Rendering-Contract, `encounter-sync.ts` leitet Reiseereignisse in Encounter-Sessions weiter.
+- `render/` zeichnet Routen, Token und Layer. Die Module werden von `modes/travel-guide.ts` instanziiert und über einen `RenderAdapter` in die Domain injiziert.
+- `ui/` stellt Controller, Interaktionen und Status-Widgets bereit. `controls.ts` bindet Playback-Ereignisse, `interactions.ts` orchestriert Klicks/Drags auf Route- und Token-Layer.
+
+## Integrationspfade
+- `modes/travel-guide.ts` erstellt die Travel-UI, bindet `createTravelLogic()` und verbindet Encounter-Sync, Playback und Map-Layer.
+- Encounter-Handling greift auf `createEncounterSync()` zurück, das bei externen Events Playback pausiert, Encounter-Views öffnet und nach Abschluss fortsetzt.
+- Persistenzzugriffe (`loadTokenCoordFromMap`, `writeTokenToTiles`) benötigen Zugriff auf Obsidian-Dateien und müssen bei Map-Wechseln robust bleiben.
+
+## Beobachtungen & Risiken
+- `createTravelLogic()` registriert einen Store-Listener, bietet aber keinen Dispose-Hook. Modi verlassen sich auf externe Aufräumlogik, wodurch Subscriptions und Token-Adapter bei mehrfacher Initialisierung weiterlaufen können.
+- `bindAdapter()` ersetzt nur die Referenz. Bei neu montierten Render-Layern (z. B. nach Dateiwechsel) fehlen ein initialer `draw()`-Durchlauf sowie `ensurePolys`, wodurch Route und Token leer bleiben, bis eine Nutzeraktion den Zustand verändert.
+- Encounter-Sync und Playback pausieren korrekt, aber Fehler aus `persistTokenToTiles()` oder `initTokenFromTiles()` werden lediglich geloggt. Ohne Telemetrie/Notice bleibt der UI-Zustand unklar, wenn Dateizugriffe fehlschlagen.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.55] Dispose-Hook für `createTravelLogic()` bereitstellen, der Store-Subscription, Adapter-Token und Playback stoppt.
+- [P2.56] `bindAdapter()` um sofortiges `draw()`/`ensurePolys` erweitern, damit frisch montierte Map-/Route-Layer den aktuellen Zustand anzeigen.
+- [P2.57] Persistenzfehler (`initTokenFromTiles`, `persistTokenToTiles`) mit UI-/Telemetry-Rückmeldung versehen, damit Nutzer Fehlschläge nachvollziehen können.
 
 # Standards
-- Services beschreiben kurz welche Daten sie lesen/schreiben.
-- Dateien exportieren einzelne Verantwortungen statt Sammelobjekte.
+- Travel-spezifische Dateien starten mit einem Kontextsatz, der Verantwortung und genutzte Layer beschreibt.
+- Domain-Logik exportiert gezielte Funktionen/Factories; Hilfsfunktionen bleiben intern und dokumentieren Nebenwirkungen (Persistenz, Adapterzugriffe).
+- Adapter und UI-Schichten bleiben idempotent: Mehrfaches Binden oder Mounten darf keine duplizierten Listener oder Render-Artefakte erzeugen.
+- Persistenz-Pfade loggen nicht nur Fehler, sondern liefern den Aufrufern (UI/Mode) eindeutig nutzbare Statusinformationen.

--- a/salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/travel/domain/AGENTS.md
@@ -1,22 +1,40 @@
 # Ziele
-- Pflegt Reisezustand, Aktionen und Regelwerke für Hex-Routen.
+- Hält die komplette Travel-Domain zusammen: Routing, Token-Steuerung, Playback-Taktung und Encounter-Hooks.
+- Trennt reine Zustands-/Berechnungslogik von Render-Adaptern und Persistenz, damit Modi kontrolliert integrieren können.
+- Dokumentiert Formate und Verträge, die von Travel-Guide, Encounter-Sync und Hex-Persistenz gemeinsam genutzt werden.
 
 # Aktueller Stand
-- `actions` beschreibt Kommandos für Timeline, Marker und Tokens.
-- `expansion` kümmert sich um Fog-of-War und Kartenerweiterung.
-- `persistence` synchronisiert Speicherstände.
-- `playback` steuert Fortschritt entlang gespeicherter Schritte.
-- `state.store` hält den zentralen Zustand, `terrain.service` lädt Geländedaten.
-- `types` definiert DTOs für öffentliche Nutzung.
+## Strukturüberblick
+- `actions.ts` stellt `createTravelLogic()` bereit und orchestriert Store, Playback und Render-Adapter.
+- `state.store.ts` kapselt den internen Zustand inklusive Tempo, Route und Token-Position samt Subscription-API.
+- `expansion.ts` und `rebuildFromAnchors` erzeugen Auto-Knoten zwischen User-Ankern und rekonstruieren Routen.
+- `playback.ts` animiert Token entlang der Route, berücksichtigt Terrain-Geschwindigkeit und ruft Encounter-Checks auf.
+- `persistence.ts` liest/schreibt den Token-Stand über die Hex-Notizen (`token_travel`).
+- `terrain.service.ts` liefert Terrain-Faktoren, `types.ts` definiert die extern konsumierten DTOs.
 
-# Persistenzformate
-- `travel-token@1`: setzt an genau einem Hex das Frontmatter-Flag `token_travel: true`; fehlende oder falsche Werte zählen als "kein Token".
-- Versionserkennung: existiert `token_travel` als Boolean, gilt Version 1. Ältere Karten ohne Flag werden als Version 0 interpretiert und bleiben unverändert.
-- Migration: neue Formate sollen `travel-token@<n>` im Frontmatter spiegeln (z. B. via `token_travel_version`) und Abwärtskonvertierungen in `persistence.ts` kapseln.
+## Daten- und Integrationsflüsse
+- `createTravelLogic()` koppelt den Store an einen RenderAdapter (`ensurePolys`, `draw`, Token-Zentrierung) und ruft Playback für Animationen.
+- Persistenz greift ausschließlich über `listTilesForMap`/`loadTile`/`saveTile` auf Hex-Dateien zu; Encounter-Sync liest dieselben Koordinaten.
+- Travel-Guide-Modi nutzen `bindAdapter()` bei jedem Map-Re-Mount, wodurch neue Layer den aktuellen Zustand darstellen sollen.
+- Playback nutzt `loadTerrainSpeed()` und schreibt nach jedem Schritt via `writeTokenToTiles()` zurück ins Frontmatter.
+
+## Beobachtungen & Risiken
+- `createTravelLogic()` behält Store-Subscription und Playback-Instanz ohne `dispose()`. Mehrfache Initialisierungen laufen weiter und halten Adapter-Handles offen.
+- `bindAdapter()` ersetzt nur die Referenz in `actions.ts`; Playback behält den alten Adapter aus seiner Closure und animiert ins Leere.
+- Beim Adapterwechsel fehlt ein sofortiges `draw()`/`ensurePolys`, sodass frisch montierte Layer bis zur nächsten Nutzeraktion leer bleiben.
+- Persistenz-Fehler (`initTokenFromTiles`, `persistTokenToTiles`) werden lediglich geloggt. UI und Telemetrie sehen nicht, warum Token verschwinden.
+- `writeTokenToTiles()` lädt/speichert alle Tiles sequenziell, obwohl nur der vorherige und der neue Token-Stand relevant sind – das skaliert schlecht bei großen Karten.
 
 # ToDo
+- [P2.55] `createTravelLogic` um `dispose()` erweitern, das Store-Subscription, Token-Adapter und Playback zuverlässig beendet.
+- [P2.56] `bindAdapter` initiale Synchronisierung ergänzen (`ensurePolys`, `draw`, Token-Zentrierung), damit neue Render-Layer sofort den aktuellen Zustand anzeigen.
+- [P2.57] Fehler aus `initTokenFromTiles`/`persistTokenToTiles` über UI-/Telemetry-Hooks sichtbar machen und Wiederholungsoptionen anbieten.
+- [P2.58] Playback an neue RenderAdapter koppeln, damit Token-Animationen nach Adapterwechsel nicht am alten Adapter hängen bleiben.
+- [P2.59] Token-Persistenz entkoppeln, sodass beim Schreiben nicht jede Karte geladen und gespeichert werden muss (letzten Token-Stand cachen und nur betroffene Tiles anfassen).
 - [P3.2] Mehrstufige Undo/Redo-Strategien entwerfen.
 
 # Standards
-- Store- und Service-Dateien beginnen mit Zweck und gelesenen Quellen.
-- Aktionen bleiben reine Funktionen ohne versteckte Seiteneffekte.
+- Domain-Funktionen bleiben seiteneffektfrei und dokumentieren externe Abhängigkeiten (Persistenz, Adapter) im Kopfkommentar.
+- Adapter-wechselseitige Aufrufe liefern sofort konsistente Darstellung (Token-Position, Route, Playback-Zustand) und müssen idempotent sein.
+- Persistenzschichten kapseln Obsidian-IO, liefern klare Fehlerobjekte zurück und vermeiden unnötige Dateisystem-Schleifen.
+- Neue DTOs werden in `types.ts` dokumentiert und nur dort exportiert; Tests und Modi importieren ausschließlich aus dieser Datei.

--- a/salt-marcher/src/apps/cartographer/travel/infra/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/travel/infra/AGENTS.md
@@ -1,12 +1,27 @@
 # Ziele
-- Bindet Travel-Domain an externe Systeme und Events.
+- Verbindet die Travel-Domain mit Obsidian-spezifischen Diensten und Ereignissen.
+- Beschreibt, welche Adapter-Funktionen die Domain erwartet und wie Encounter-Sync Playback und Sessions steuert.
+- Sichert nachvollziehbare Standards für neue Infrastruktur-Hooks (z. B. weitere Adapter oder Gateways).
 
 # Aktueller Stand
-- `adapter` koppelt Travel-Events an den Cartographer-Presenter und Obsidian.
+## Strukturüberblick
+- `adapter.ts` definiert den `RenderAdapter`-Vertrag: `ensurePolys`, `centerOf`, `draw` sowie das `token`-Handle, das vom Travel-Playback genutzt wird.
+- `encounter-sync.ts` beobachtet Encounter-Events aus `apps/encounter/session-store`, pausiert Travel-Playback und öffnet Encounter-Views über das Gateway.
+
+## Integrationspfade
+- `createTravelLogic()` injiziert beim Start einen `RenderAdapter` und ruft dessen `draw`-/`ensurePolys`-Methoden bei jeder Zustandsänderung auf.
+- `modes/travel-guide.ts` erzeugt `createEncounterSync()` und koppelt `pausePlayback` sowie `openEncounter()` an den Mode-Lifecycle.
+- Encounter-Events aus `travel-guide/encounter-gateway` landen zuerst im Session-Store; `createEncounterSync()` dedupliziert Events anhand der ID und sorgt dafür, dass externe Trigger den Encounter-View öffnen.
+
+## Beobachtungen & Risiken
+- Externe Encounter-Events pausieren das Playback sofort, auch wenn `onExternalEncounter` den View-Start verhindert (z. B. bei Abbruch). Ohne Gegenmaßnahme bleibt der Travel-Modus dann dauerhaft pausiert.
+- Manuelle oder externe Events rufen `openEncounter()` ohne `await` auf. Schlägt das Öffnen fehl, verschwindet die Fehlermeldung im Promise, sodass Nutzer*innen und Logs keine Rückmeldung erhalten.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.59] Playback nur pausieren, wenn ein Encounter tatsächlich geöffnet wird, oder nach unterdrückten externen Events sauber fortsetzen.
+- [P2.60] `openEncounter()` bei externen Events awaiten und Fehler bzw. Abbrüche mit Logging/Notice sichtbar machen.
 
 # Standards
 - Adapter beschreiben die Quell- und Zielsysteme im Kopfkommentar.
 - Neue Adapter exportieren reine Fabriken ohne Singleton-Zustand.
+- Encounter-Integrationen dokumentieren, wie sie mit `apps/encounter/*` interagieren und welche Hooks (`pausePlayback`, `openEncounter`) sie erwarten.

--- a/salt-marcher/src/apps/cartographer/travel/render/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/travel/render/AGENTS.md
@@ -1,12 +1,28 @@
 # Ziele
-- Zeichnet Reiseinformationen (Routen, Token) auf die Hex-Karte.
+- Visualisiert Travel-Routen samt Startpunkt-Verbindung und Interaktionsflächen auf dem Hex-Layer.
+- Stellt DOM-Helfer bereit, die von UI-Controllern (`ui/route-layer`, `ui/drag.controller`) wiederverwendet werden können.
+- Trennt Rendering von Domain-/Playback-Logik, damit Tests Route-Manipulationen isoliert prüfen können.
 
 # Aktueller Stand
-- `draw-route` erzeugt Layer und Styles für Wegpunkte.
+## Strukturüberblick
+- `draw-route.ts` räumt das Ziel-`<g>` leer und zeichnet Polyline, Dot-Hitboxen sowie sichtbare Punkte inklusive Datensätzen (`data-idx`, `data-kind`).
+- `updateHighlight` toggelt CSS-Klassen und Radien, damit UI-Controller Hervorhebungen ohne komplettes Re-Render setzen können.
+
+## Integrationspfade
+- `ui/route-layer.ts` kapselt das `<g>`-Element und ruft `drawRoute`/`updateHighlight`, während `ui/drag.controller.ts` dieselben Daten-Attribute nutzt, um Dots zu finden.
+- Die Farb- und Animationswerte kommen aus `src/app/css.ts` (`.tg-route-dot*`), wodurch Änderungen am Rendering CSS und TS gleichzeitig betreffen.
+
+## Beobachtungen & Risiken
+- `drawRoute` entfernt immer den kompletten Layer. Erfolgt während eines aktiven Drags ein Re-Render, gehen Pointer-Captures verloren und Controller verlieren Referenzen.
+- Liefert `centerOf` für einzelne Koordinaten `null`, fehlen Dot- und Hitbox-Elemente komplett. UI-Interaktionen (Drag, Kontextmenü) bemerken dies erst über indirektes Fehlverhalten; es gibt weder Logging noch Fallback.
+- Konstante Radien (`USER_RADIUS`, `AUTO_RADIUS`) leben ausschließlich in `draw-route.ts`; CSS und Tests spiegeln die Werte nicht automatisch.
 
 # ToDo
+- [P2.61] `draw-route.ts`: Fehlende Zentren (`centerOf` → `null`) als Warnung loggen und eine Wiederholungs-/`ensurePolys`-Strategie dokumentieren, damit Routenpunkte nicht stillschweigend verschwinden.
+- [P2.62] `draw-route.ts`: Layer-Diff einführen, das bestehende Dot-/Hitbox-Elemente aktualisiert statt sie zu löschen, um Pointer-Capture und Event-Verweise während Rerenders zu erhalten.
 - [P4.1] Animierte Routen und Status-Indikatoren ergänzen.
 
 # Standards
 - Render-Helfer dokumentieren ihre Canvas-/SVG-Abhängigkeiten im Kopf.
 - Funktionen liefern reine Zeichenoperationen und nehmen Konfiguration als Parameter.
+- Sichtbare Attribute (Radius, Klassen) werden zentral gehalten und bei Änderungen in Tests/CSS gespiegelt.

--- a/salt-marcher/src/apps/cartographer/travel/ui/AGENTS.md
+++ b/salt-marcher/src/apps/cartographer/travel/ui/AGENTS.md
@@ -1,14 +1,32 @@
 # Ziele
-- Stellt UI-Controller und Layer für den Travel-Modus bereit.
+- Stellt Controller und Layer bereit, die die Travel-Domain interaktiv machen (Drag, Kontextmenü, Playback, Sidebar).
+- Kapselt Rendering-Zugriffe auf Map- und Token-Layer, damit Modi nur noch über klar definierte Handles interagieren.
+- Dokumentiert UI-Kontrakte gegenüber `modes/travel-guide` und der Render-/Infra-Schicht, um Wiederverwendung und Tests zu erleichtern.
 
 # Aktueller Stand
-- Controller-Dateien (`context-menu`, `drag`) verdrahten Benutzerinteraktionen.
-- `controls`, `sidebar` und Layer-Dateien rendern sichtbare Panels.
-- `types` sammelt UI-spezifische Contracts.
+## Strukturüberblick
+- `context-menu.controller.ts` bindet ein SVG-gebundenes Kontextmenü an Routenpunkte und delegiert Lösch-/Encounter-Aktionen an die Domain.
+- `drag.controller.ts` verwaltet Pointer-Captures, Ghost-Previews und Commits für Dot- und Token-Drags; nutzt `RenderAdapter` und `polyToCoord` aus `map-layer.ts`.
+- `controls.ts` und `sidebar.ts` erzeugen Playback-Buttons, Tempo-Slider sowie Geschwindigkeits-/Tile-Anzeigen und exponieren Handles für den Mode.
+- `route-layer.ts`, `token-layer.ts` und `map-layer.ts` liefern SVG-Gruppen mitsamt Convenience-Methoden (`draw`, `ensurePolys`, `centerOf`) für Render- und Domain-Layer.
+- `contextmenue.ts` existiert als Legacy-Shim, um frühere Importe auf das korrekt benannte Kontextmenü weiterzuleiten.
+
+## Integrationspfade
+- `modes/travel-guide/interaction-controller.ts` instanziiert Drag- und Kontextmenü-Controller, reicht Domain-Handles durch und konsumiert das `consumeClickSuppression()`-Signal.
+- Die Domain erwartet, dass Sidebar/Controls Tempo- und Playback-Callbacks unmittelbar weiterreichen; Persistenz-/Playback-Hooks landen via Adapter im Render-Layer.
+- Map/Token-Layer werden vom Mode über den `RenderAdapter` verwaltet; sie müssen Pointer-Ereignisse und Animationen zuverlässig mit der Domain synchronisieren.
+
+## Beobachtungen & Risiken
+- `TravelInteractionController` importiert weiterhin den Shim `contextmenue.ts`. Dadurch bleibt der Legacy-Pfad im Bundle und erschwert konsistente Benennungen.
+- `sidebar.ts` feuert Geschwindigkeitsänderungen nur im `change`-Event. Während Eingaben (Scrollrad, Pfeiltasten) bleibt der Logic-Store uninformiert, bis das Feld den Fokus verliert.
+- `drag.controller.ts` verlässt sich darauf, dass Map-Layer-Polygone bereits existieren; `ensurePolys` wird erst beim Drop gezogen, wodurch Ghost-Previews in bisher ungesehenen Hexes ausfallen können.
 
 # ToDo
-- keine offenen ToDos.
+- [P2.63] Legacy-Import im Travel-Guide (`interaction-controller.ts`) auf `context-menu.controller` umstellen und den Shim `contextmenue.ts` entfernen, um den doppelten Bundle-Eintrag loszuwerden.
+- [P2.64] Geschwindigkeitssteuerung in `sidebar.ts` auf `input`-basierte Updates inklusive Validierungs-Helfer umbauen, damit Tempoänderungen sofort im Travel-Logic-Store landen.
 
 # Standards
-- UI-Dateien beginnen mit kurzer Beschreibung der sichtbaren Elemente.
-- Exportierte Controller heißen `create<Name>Controller` und kapseln Listener-Registrierung.
+- Jeder Controller beschreibt im Kopfkommentar seinen Scope (DOM, Listener, Delegates) und kapselt Bind/Unbind-Pfade klar.
+- Event-Listener werden zentral gebündelt (z. B. via Handle oder AbortController), sodass `bind()` mehrfach aufrufbar bleibt, ohne Leaks zu verursachen.
+- UI-Layer greifen nur über `RenderAdapter`- und Domain-Ports auf Persistenz/Playback zu; direkte Dateisystem- oder Store-Zugriffe bleiben untersagt.
+- Shims wie `contextmenue.ts` erhalten ein Ablaufdatum und werden nach Migration entfernt, damit Importe eindeutig bleiben.

--- a/salt-marcher/tests/app/terrain-bootstrap.test.ts
+++ b/salt-marcher/tests/app/terrain-bootstrap.test.ts
@@ -28,9 +28,11 @@ describe("createTerrainBootstrap", () => {
             logger,
         });
 
-        const primed = await bootstrap.start();
+        const result = await bootstrap.start();
 
-        expect(primed).toBe(true);
+        expect(result.primed).toBe(true);
+        expect(result.primeError).toBeUndefined();
+        expect(result.watchError).toBeUndefined();
         expect(ensureTerrainFile).toHaveBeenCalledWith(app);
         expect(loadTerrains).toHaveBeenCalledWith(app);
         expect(setTerrains).toHaveBeenCalledWith({ Forest: { color: "#0f0", speed: 0.5 } });
@@ -64,9 +66,11 @@ describe("createTerrainBootstrap", () => {
             logger,
         });
 
-        const primed = await bootstrap.start();
+        const result = await bootstrap.start();
 
-        expect(primed).toBe(false);
+        expect(result.primed).toBe(false);
+        expect(result.primeError).toBe(failure);
+        expect(result.watchError).toBeUndefined();
         expect(logger.error).toHaveBeenCalledWith(
             "Failed to prime terrain palette from vault",
             expect.objectContaining({ error: failure })
@@ -127,9 +131,11 @@ describe("createTerrainBootstrap", () => {
             logger,
         });
 
-        const primed = await bootstrap.start();
+        const result = await bootstrap.start();
 
-        expect(primed).toBe(false);
+        expect(result.primed).toBe(false);
+        expect(result.primeError).toBeUndefined();
+        expect(result.watchError).toBe(error);
         expect(logger.error).toHaveBeenCalledWith(
             "Failed to register terrain watcher",
             expect.objectContaining({ error })


### PR DESCRIPTION
## Summary
- have `SaltMarcherPlugin` rely on `createTerrainBootstrap` and surface priming/watching failures through `failIntegration`
- extend `createTerrainBootstrap` to return structured results for prime/watch errors and update the app integration tests accordingly
- renumber the robustness backlog after completing the main.ts task and add follow-up entries for telemetry hooks and lifecycle cleanup

## Testing
- npm run sync:todos
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe1e40b4083258712c98496a81649