### PR TITLE
Handle malformed terrain colors from vault data

### DIFF
--- a/salt-marcher/src/core/terrain.ts
+++ b/salt-marcher/src/core/terrain.ts
@@ -23,6 +23,24 @@ const HEX_COLOR_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 const CSS_VAR_RE = /^var\(--[a-z0-9_-]+\)$/i;
 const CSS_FUNCTION_RE = /^(?:rgb|rgba|hsl|hsla)\(/i;
 
+function normalizeTerrainColor(input: unknown): string {
+    if (typeof input !== "string") return "";
+
+    let color = input.trim();
+    if (!color) return "";
+
+    if (
+        (color.startsWith("\"") && color.endsWith("\"")) ||
+        (color.startsWith("'") && color.endsWith("'"))
+    ) {
+        color = color.slice(1, -1).trim();
+    }
+
+    color = color.replace(/^[\s:]+/, "");
+
+    return color.trim();
+}
+
 export class TerrainValidationError extends Error {
     constructor(public readonly issues: string[]) {
         super(`Invalid terrain schema: ${issues.join(", ")}`);
@@ -38,7 +56,7 @@ export function validateTerrainSchema(
 
     for (const [rawName, rawValue] of Object.entries(next ?? {})) {
         const name = (rawName ?? "").trim();
-        const color = (rawValue?.color ?? "").trim();
+        const color = normalizeTerrainColor(rawValue?.color);
 
         if (!name && rawName !== "") {
             issues.push(`Terrain name must not be empty (received: "${rawName}")`);

--- a/salt-marcher/tests/core/terrain-schema.test.ts
+++ b/salt-marcher/tests/core/terrain-schema.test.ts
@@ -57,4 +57,14 @@ describe("terrain schema validation", () => {
         expect(TERRAIN_COLORS.Hochebene).toBe("#333333");
         expect(TERRAIN_SPEEDS.Hochebene).toBe(1);
     });
+
+    it("normalises stray punctuation in stored color values", () => {
+        const schema = validateTerrainSchema({
+            Moor: { color: ": : : transparent", speed: 0.8 },
+            Steppe: { color: "'#123456'", speed: 0.9 },
+        });
+
+        expect(schema.Moor.color).toBe("transparent");
+        expect(schema.Steppe.color).toBe("#123456");
+    });
 });


### PR DESCRIPTION
## Summary
- normalise stored terrain color strings before validation so stray punctuation no longer breaks plugin startup
- add regression tests covering colour sanitisation during terrain schema validation

## Testing
- `npx vitest run tests/core/terrain-schema.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e0f99345e0832587b44c6bfe9d94c2