### PR TITLE
Simplify creature creator spellcasting helpers

### DIFF
--- a/salt-marcher/src/apps/library/create/creature/section-basics.ts
+++ b/salt-marcher/src/apps/library/create/creature/section-basics.ts
@@ -53,12 +53,6 @@ function ensureSpeeds(data: StatblockData): SpeedRecord {
   return speeds as SpeedRecord;
 }
 
-function ensureSpeedExtras(data: StatblockData): CreatureSpeedExtra[] {
-  const speeds = ensureSpeeds(data);
-  if (!Array.isArray(speeds.extras)) speeds.extras = [];
-  return speeds.extras!;
-}
-
 function applySpeedValue(
   data: StatblockData,
   key: SpeedFieldKey,
@@ -329,7 +323,7 @@ export function mountCreatureVitalSection(parent: HTMLElement, data: StatblockDa
     syncHoverBadge(hoverBadge, def.key);
   });
 
-  const extras = ensureSpeedExtras(data);
+  const extras = ensureSpeeds(data).extras!;
   const extrasEditor = mountTokenEditor(
     movement,
     "Weitere Bewegungen",

--- a/salt-marcher/src/apps/library/create/creature/section-senses-and-defenses.ts
+++ b/salt-marcher/src/apps/library/create/creature/section-senses-and-defenses.ts
@@ -160,7 +160,7 @@ export function mountCreatureSensesAndDefensesSection(
       resistances,
       immunities,
     },
-    () => refreshSummary(),
+    refreshSummary,
   );
 
   mountPresetSelectEditor(


### PR DESCRIPTION
## Summary
- streamline speed extras handling and reuse existing speed container
- reuse summary callback wiring in defenses section and simplify modal background handling
- refactor spellcasting editor to share rendering logic, reduce duplicate refresh calls, and ensure consistent preview updates

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e16e68afbc8325b214854c095fec48