### PR TITLE
Ensure creature creator modal uses full-width host

### DIFF
--- a/salt-marcher/src/app/css.ts
+++ b/salt-marcher/src/app/css.ts
@@ -203,6 +203,8 @@ const editorLayoutsCss = `
 .sm-cc-item__name { font-weight: 600; }
 
 /* Creature Creator – Modal Layout */
+.modal.sm-cc-create-modal-host { width: min(1120px, calc(100vw - 72px)); max-width: min(1120px, calc(100vw - 72px)); }
+.modal.sm-cc-create-modal-host .modal-content { max-height: calc(100vh - 96px); }
 .sm-cc-modal-header { display:flex; flex-direction:column; gap:.35rem; margin-bottom:1rem; }
 .sm-cc-modal-header h2 { margin:0; font-size:1.35rem; }
 .sm-cc-modal-subtitle { margin:0; color: var(--text-muted); font-size:.95em; }

--- a/salt-marcher/src/apps/library/create/creature/modal.ts
+++ b/salt-marcher/src/apps/library/create/creature/modal.ts
@@ -38,6 +38,7 @@ export class CreateCreatureModal extends Modal {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass("sm-cc-create-modal");
+        this.applyModalLayout();
         this.validators = [];
         this.sectionObserver?.disconnect();
         this.sectionObserver = null;
@@ -182,6 +183,7 @@ export class CreateCreatureModal extends Modal {
     onClose() {
         this.sectionObserver?.disconnect();
         this.sectionObserver = null;
+        this.resetModalLayout();
         this.contentEl.empty();
         this.restoreBackgroundPointer();
     }
@@ -189,6 +191,7 @@ export class CreateCreatureModal extends Modal {
     onunload() {
         this.sectionObserver?.disconnect();
         this.sectionObserver = null;
+        this.resetModalLayout();
         this.restoreBackgroundPointer();
     }
 
@@ -228,5 +231,13 @@ export class CreateCreatureModal extends Modal {
         if (!this.bgLock) return;
         this.bgLock.el.style.pointerEvents = this.bgLock.pointer || '';
         this.bgLock = null;
+    }
+
+    private applyModalLayout() {
+        this.modalEl.addClass("sm-cc-create-modal-host");
+    }
+
+    private resetModalLayout() {
+        this.modalEl.removeClass("sm-cc-create-modal-host");
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated host class for the creature creator modal so the two-column shell has room to breathe
- expand the modal host width and viewport height handling to keep the layout consistent while the dialog is open

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1a15fb38c83258a2f841556ee4de3