### PR TITLE
Adjust Creature Creator modal width

### DIFF
--- a/salt-marcher/src/app/css.ts
+++ b/salt-marcher/src/app/css.ts
@@ -203,7 +203,11 @@ const editorLayoutsCss = `
 .sm-cc-item__name { font-weight: 600; }
 
 /* Creature Creator – Modal Layout */
-.modal.sm-cc-create-modal-host { width: min(1120px, calc(100vw - 72px)); max-width: min(1120px, calc(100vw - 72px)); }
+.modal.sm-cc-create-modal-host {
+    width: min(1120px, calc(100vw - 32px));
+    max-width: min(1120px, calc(100vw - 32px));
+    min-width: min(880px, calc(100vw - 32px));
+}
 .modal.sm-cc-create-modal-host .modal-content { max-height: calc(100vh - 96px); }
 .sm-cc-modal-header { display:flex; flex-direction:column; gap:.35rem; margin-bottom:1rem; }
 .sm-cc-modal-header h2 { margin:0; font-size:1.35rem; }


### PR DESCRIPTION
## Summary
- increase the Creature Creator modal's available width and enforce a minimum of ~880px so both columns stay visible
- rebuild the plugin bundle so the packaged CSS matches the new modal sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a67177c48325abb2d9973dcfa54d