### PR TITLE
Refine creature basics cards

### DIFF
--- a/salt-marcher/src/app/css.ts
+++ b/salt-marcher/src/app/css.ts
@@ -269,42 +269,52 @@ const editorLayoutsCss = `
 .sm-cc-modal-footer button { min-width:120px; }
 
 /* Creature Creator – Basics Section */
-.sm-cc-basics {
-    display: grid;
-    gap: 1rem;
-}
-.sm-cc-basics--classification,
-.sm-cc-basics--vitals {
-    grid-template-columns: repeat(2, minmax(260px, 1fr));
-    align-items: stretch;
-}
-.sm-cc-basics__group {
-    display: flex;
-    flex-direction: column;
-    gap: .75rem;
-    padding: .85rem .95rem 1rem;
-    border-radius: 12px;
+.sm-cc-card--basics {
     border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
     background: color-mix(in srgb, var(--background-secondary) 78%, transparent);
-    box-shadow: 0 4px 14px rgba(15, 23, 42, .05);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, .05);
 }
-.sm-cc-basics__subtitle {
-    margin: 0;
+.sm-cc-card--basics + .sm-cc-card--basics {
+    margin-top: 1.1rem;
+}
+.sm-cc-card--basics .sm-cc-card__head {
+    padding: .85rem .95rem .4rem;
+}
+.sm-cc-card--basics .sm-cc-card__title {
+    font-size: .95rem;
+    letter-spacing: .02em;
+}
+.sm-cc-card--basics .sm-cc-card__subtitle {
+    margin-top: .35rem;
     font-size: .78rem;
-    letter-spacing: .08em;
+    letter-spacing: .04em;
     text-transform: uppercase;
     color: var(--text-muted);
+}
+.sm-cc-card__body--basics {
+    display: flex;
+    flex-direction: column;
+    gap: 1.35rem;
+    padding: .85rem .95rem 1.15rem;
+}
+.sm-cc-card__section--basics {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 .sm-cc-field-grid {
     display: grid;
     gap: .75rem;
-    grid-template-columns: repeat(2, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
-.sm-cc-field-grid--identity { grid-template-columns: repeat(2, minmax(220px, 1fr)); }
-.sm-cc-field-grid--summary { grid-template-columns: repeat(2, minmax(140px, 1fr)); }
-.sm-cc-field-grid--classification { grid-template-columns: repeat(2, minmax(160px, 1fr)); }
-.sm-cc-field-grid--vitals { grid-template-columns: repeat(2, minmax(180px, 1fr)); }
-.sm-cc-field-grid--speeds { grid-template-columns: repeat(2, minmax(160px, 1fr)); }
+.sm-cc-field-grid--basics {
+    gap: 1rem;
+}
+.sm-cc-field-grid--summary { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+.sm-cc-field-grid--classification { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.sm-cc-field-grid--vitals { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.sm-cc-field-grid--speeds { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
 .sm-cc-setting.setting-item {
     border: none;
     padding: 0;
@@ -314,7 +324,7 @@ const editorLayoutsCss = `
 .sm-cc-setting .setting-item-info { display: none; }
 .sm-cc-setting .setting-item-name {
     font-weight: 600;
-    font-size: .9em;
+    font-size: .88rem;
     color: var(--text-muted);
 }
 .sm-cc-setting .setting-item-control {
@@ -334,6 +344,21 @@ const editorLayoutsCss = `
     text-transform: uppercase;
 }
 .sm-cc-setting--span-2 { grid-column: 1 / -1; }
+.sm-cc-setting--stack .setting-item-control {
+    gap: .6rem;
+}
+.sm-cc-setting--token-editor .setting-item-control {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: .5rem;
+}
+.sm-cc-setting--token-editor .setting-item-control input {
+    flex: 1 1 240px;
+    min-width: 200px;
+}
+.sm-cc-setting--token-editor .setting-item-control button {
+    align-self: flex-start;
+}
 
 .sm-cc-input {
     width: 100%;
@@ -401,7 +426,7 @@ const editorLayoutsCss = `
 .sm-cc-speeds-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: .85rem;
+    gap: 1rem;
 }
 @media (max-width: 680px) {
     .sm-cc-speeds-grid { grid-template-columns: minmax(0, 1fr); }

--- a/salt-marcher/src/apps/library/create/creature/section-basics.ts
+++ b/salt-marcher/src/apps/library/create/creature/section-basics.ts
@@ -102,11 +102,19 @@ function ensureTypeTags(data: StatblockData): string[] {
 }
 
 export function mountCreatureClassificationSection(parent: HTMLElement, data: StatblockData) {
-  const root = parent.createDiv({ cls: "sm-cc-basics sm-cc-basics--classification" });
+  const card = createFormCard(parent, {
+    title: "Identität & Klassifikation",
+    role: "group",
+  });
+  card.card.addClass("sm-cc-card--basics");
+  card.body.addClass("sm-cc-card__body--basics");
 
-  const identity = root.createDiv({ cls: "sm-cc-basics__group" });
-  identity.createEl("h5", { text: "Identität", cls: "sm-cc-basics__subtitle" });
-  const identityGrid = createFieldGrid(identity, { variant: "identity" });
+  const identitySection = card.body.createDiv({ cls: "sm-cc-card__section sm-cc-card__section--basics" });
+  const identityGrid = createFieldGrid(identitySection, {
+    variant: "identity",
+    className: "sm-cc-field-grid--basics",
+    minColumnWidth: "18rem",
+  });
 
   const nameSetting = identityGrid.createSetting("Name");
   nameSetting.settingEl.addClass("sm-cc-setting--show-name");
@@ -144,7 +152,7 @@ export function mountCreatureClassificationSection(parent: HTMLElement, data: St
   });
 
   const tags = ensureTypeTags(data);
-  const typeTagsEditor = mountTokenEditor(identity, "Typ-Tags", {
+  const typeTagsEditor = mountTokenEditor(identitySection, "Typ-Tags", {
     getItems: () => tags.slice(),
     add: (value) => {
       const normalized = value.trim();
@@ -161,12 +169,14 @@ export function mountCreatureClassificationSection(parent: HTMLElement, data: St
     placeholder: "z. B. shapechanger",
     addButtonLabel: "+ Tag",
   });
-  typeTagsEditor.setting.settingEl.addClass("sm-cc-setting");
-  typeTagsEditor.setting.settingEl.addClass("sm-cc-setting--show-name");
+  typeTagsEditor.setting.settingEl.addClass("sm-cc-setting--stack");
 
-  const classification = root.createDiv({ cls: "sm-cc-basics__group" });
-  classification.createEl("h5", { text: "Klassifikation", cls: "sm-cc-basics__subtitle" });
-  const classificationGrid = createFieldGrid(classification, { variant: "classification" });
+  const classificationSection = card.body.createDiv({ cls: "sm-cc-card__section sm-cc-card__section--basics" });
+  const classificationGrid = createFieldGrid(classificationSection, {
+    variant: "classification",
+    className: "sm-cc-field-grid--basics",
+    minColumnWidth: "16rem",
+  });
 
   const alignmentSetting = classificationGrid.createSetting("Gesinnung", {
     className: ["sm-cc-setting--span-2", "sm-cc-setting--show-name"],
@@ -245,11 +255,19 @@ export function mountCreatureClassificationSection(parent: HTMLElement, data: St
 }
 
 export function mountCreatureVitalSection(parent: HTMLElement, data: StatblockData) {
-  const root = parent.createDiv({ cls: "sm-cc-basics sm-cc-basics--vitals" });
+  const card = createFormCard(parent, {
+    title: "Vitalwerte & Bewegung",
+    role: "group",
+  });
+  card.card.addClass("sm-cc-card--basics");
+  card.body.addClass("sm-cc-card__body--basics");
 
-  const vitals = root.createDiv({ cls: "sm-cc-basics__group" });
-  vitals.createEl("h5", { text: "Vitalwerte", cls: "sm-cc-basics__subtitle" });
-  const vitalsGrid = createFieldGrid(vitals, { variant: "identity", className: "sm-cc-field-grid--vitals" });
+  const vitalsSection = card.body.createDiv({ cls: "sm-cc-card__section sm-cc-card__section--basics" });
+  const vitalsGrid = createFieldGrid(vitalsSection, {
+    variant: "vitals",
+    className: "sm-cc-field-grid--basics",
+    minColumnWidth: "16rem",
+  });
 
   const createVitalField = (label: string, placeholder: string, key: keyof StatblockData) => {
     const setting = vitalsGrid.createSetting(label);
@@ -267,10 +285,9 @@ export function mountCreatureVitalSection(parent: HTMLElement, data: StatblockDa
   createVitalField("Initiative", "+7", "initiative");
   createVitalField("Hit Dice", "20d10 + 40", "hitDice");
 
-  const movement = root.createDiv({ cls: "sm-cc-basics__group" });
-  movement.createEl("h5", { text: "Bewegung", cls: "sm-cc-basics__subtitle" });
+  const movementSection = card.body.createDiv({ cls: "sm-cc-card__section sm-cc-card__section--basics" });
 
-  const speedGrid = movement.createDiv({ cls: "sm-cc-speeds-grid" });
+  const speedGrid = movementSection.createDiv({ cls: "sm-cc-speeds-grid sm-cc-field-grid sm-cc-field-grid--basics" });
 
   const syncDistance = (input: HTMLInputElement, key: SpeedFieldKey) => {
     const target = ensureSpeeds(data)[key];
@@ -325,7 +342,7 @@ export function mountCreatureVitalSection(parent: HTMLElement, data: StatblockDa
 
   const extras = ensureSpeeds(data).extras!;
   const extrasEditor = mountTokenEditor(
-    movement,
+    movementSection,
     "Weitere Bewegungen",
     {
       getItems: () => extras.map(formatExtra),
@@ -351,6 +368,5 @@ export function mountCreatureVitalSection(parent: HTMLElement, data: StatblockDa
       addButtonLabel: "+ Hinzufügen",
     },
   );
-  extrasEditor.setting.settingEl.addClass("sm-cc-setting");
-  extrasEditor.setting.settingEl.addClass("sm-cc-setting--show-name");
+  extrasEditor.setting.settingEl.addClass("sm-cc-setting--stack");
 }

--- a/salt-marcher/src/apps/library/create/shared/layouts.ts
+++ b/salt-marcher/src/apps/library/create/shared/layouts.ts
@@ -91,6 +91,7 @@ export function createFormCard(parent: HTMLElement, options: FormCardOptions): F
 export interface FieldGridOptions {
   variant?: string;
   className?: string | string[];
+  minColumnWidth?: string;
 }
 
 export interface FieldSettingOptions {
@@ -111,6 +112,9 @@ export function createFieldGrid(parent: HTMLElement, options?: FieldGridOptions)
   }
 
   const grid = parent.createDiv({ cls: classes.join(" ") });
+  if (options?.minColumnWidth) {
+    grid.style.gridTemplateColumns = `repeat(auto-fit, minmax(${options.minColumnWidth}, 1fr))`;
+  }
 
   const createSetting = (label: string, settingOptions?: FieldSettingOptions) => {
     const setting = new Setting(grid).setName(label);

--- a/salt-marcher/src/apps/library/create/shared/token-editor.ts
+++ b/salt-marcher/src/apps/library/create/shared/token-editor.ts
@@ -33,6 +33,7 @@ export function mountTokenEditor(
   const addLabel = options.addButtonLabel ?? "+";
 
   const setting = new Setting(parent).setName(title);
+  setting.settingEl.addClass("sm-cc-setting", "sm-cc-setting--show-name", "sm-cc-setting--token-editor");
   let inputEl: HTMLInputElement | undefined;
   let renderChips: () => void = () => {};
 
@@ -47,7 +48,6 @@ export function mountTokenEditor(
   setting.addText((t) => {
     t.setPlaceholder(placeholder);
     inputEl = t.inputEl;
-    t.inputEl.style.minWidth = "260px";
     t.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
       if (e.key === "Enter") {
         commitValue((inputEl?.value ?? "").trim());


### PR DESCRIPTION
## Summary
- refactor the creature basics editor into dedicated identity/classification and vitals/movement cards using the shared card builder
- extend the shared field grid to support configurable column widths and tighten token editor styling for the new layout
- refresh CSS for the basics section with the new card and grid classes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1a93393288325a62e228be6494ac0