### PR TITLE
Fix creature creator label truncation

### DIFF
--- a/salt-marcher/src/app/css.ts
+++ b/salt-marcher/src/app/css.ts
@@ -342,6 +342,11 @@ const editorLayoutsCss = `
     font-size: .75rem;
     letter-spacing: .06em;
     text-transform: uppercase;
+    white-space: normal;
+    word-break: break-word;
+    overflow: visible;
+    text-overflow: unset;
+    line-height: 1.25;
 }
 .sm-cc-setting--span-2 { grid-column: 1 / -1; }
 .sm-cc-setting--stack .setting-item-control {


### PR DESCRIPTION
## Summary
- allow library creature creator field labels to wrap instead of truncating so long German strings are fully visible

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1b2860c8883259b90c516c97181c2