### PR TITLE
Add triggered event tracking for Almanac time advance

### DIFF
--- a/tests/apps/almanac/almanac-controller.dom.test.ts
+++ b/tests/apps/almanac/almanac-controller.dom.test.ts
@@ -1,0 +1,97 @@
+// salt-marcher/tests/apps/almanac/almanac-controller.dom.test.ts
+// Validiert das Rendering des Recently-Triggered-Abschnitts nach Zeitfortschritt.
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", async () => await import("../../mocks/obsidian"));
+
+import { App } from "obsidian";
+import { AlmanacController } from "../../../src/apps/almanac/mode/almanac-controller";
+
+const ensureObsidianDomHelpers = () => {
+    const proto = HTMLElement.prototype as any;
+    if (!proto.createEl) {
+        proto.createEl = function(
+            tag: string,
+            options?: { text?: string; cls?: string; attr?: Record<string, string> }
+        ) {
+            const el = document.createElement(tag);
+            if (options?.text) el.textContent = options.text;
+            if (options?.cls) {
+                for (const cls of options.cls.split(/\s+/).filter(Boolean)) {
+                    el.classList.add(cls);
+                }
+            }
+            if (options?.attr) {
+                for (const [key, value] of Object.entries(options.attr)) {
+                    el.setAttribute(key, value);
+                }
+            }
+            this.appendChild(el);
+            return el;
+        };
+    }
+    if (!proto.createDiv) {
+        proto.createDiv = function(options?: { text?: string; cls?: string; attr?: Record<string, string> }) {
+            return this.createEl("div", options);
+        };
+    }
+    if (!proto.empty) {
+        proto.empty = function() {
+            while (this.firstChild) {
+                this.removeChild(this.firstChild);
+            }
+            return this;
+        };
+    }
+    if (!proto.addClass) {
+        proto.addClass = function(cls: string) {
+            this.classList.add(cls);
+            return this;
+        };
+    }
+    if (!proto.removeClass) {
+        proto.removeClass = function(cls: string) {
+            this.classList.remove(cls);
+            return this;
+        };
+    }
+    if (!proto.setText) {
+        proto.setText = function(text: string) {
+            this.textContent = text;
+            return this;
+        };
+    }
+};
+
+describe("AlmanacController Dashboard", () => {
+    beforeAll(() => {
+        ensureObsidianDomHelpers();
+    });
+
+    it("blendet ausgelöste Ereignisse nach Zeitfortschritt ein", async () => {
+        const app = new App();
+        const controller = new AlmanacController(app);
+        const container = document.createElement("div");
+
+        await controller.onOpen(container);
+
+        expect(container.textContent?.includes("Recently Triggered")).toBe(false);
+
+        await (controller as unknown as { handleAdvanceTime: (amount: number, unit: "day" | "hour") => Promise<void> }).handleAdvanceTime(
+            15,
+            "day"
+        );
+
+        const triggeredHeading = Array.from(container.querySelectorAll("h2")).find(
+            heading => heading.textContent === "Recently Triggered"
+        );
+        expect(triggeredHeading).toBeTruthy();
+
+        const triggeredSection = triggeredHeading?.closest(".almanac-section");
+        const items = triggeredSection?.querySelectorAll(".almanac-event-item") ?? [];
+        expect(items.length).toBeGreaterThan(0);
+
+        const titles = Array.from(items).map(item => item.querySelector("strong")?.textContent ?? "");
+        expect(titles.some(title => title.includes("Team Meeting"))).toBe(true);
+    });
+});

--- a/tests/apps/almanac/state-gateway.test.ts
+++ b/tests/apps/almanac/state-gateway.test.ts
@@ -1,0 +1,102 @@
+// salt-marcher/tests/apps/almanac/state-gateway.test.ts
+// Prüft die Bereichsfilterung des Almanac-State-Gateways bei Zeitfortschritt.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+    InMemoryCalendarRepository,
+    InMemoryEventRepository,
+} from "../../../src/apps/almanac/data/in-memory-repository";
+import { InMemoryStateGateway } from "../../../src/apps/almanac/data/in-memory-gateway";
+import { createEvent } from "../../../src/apps/almanac/domain/calendar-event";
+import {
+    createHourTimestamp,
+    createDayTimestamp,
+    type CalendarTimestamp,
+} from "../../../src/apps/almanac/domain/calendar-timestamp";
+import {
+    gregorianSchema,
+    GREGORIAN_CALENDAR_ID,
+} from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+
+const startOfJanFirst = createHourTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 1, 0);
+
+const toIdList = (events: Array<{ id: string }>) => events.map(event => event.id);
+
+describe("InMemoryStateGateway.advanceTimeBy", () => {
+    let calendarRepo: InMemoryCalendarRepository;
+    let eventRepo: InMemoryEventRepository;
+    let gateway: InMemoryStateGateway;
+
+    beforeEach(async () => {
+        calendarRepo = new InMemoryCalendarRepository();
+        eventRepo = new InMemoryEventRepository();
+        gateway = new InMemoryStateGateway(calendarRepo, eventRepo);
+
+        calendarRepo.seed([gregorianSchema]);
+        eventRepo.seed([
+            createEvent(
+                "evt-before",
+                GREGORIAN_CALENDAR_ID,
+                "Night Watch",
+                createHourTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 1, 0)
+            ),
+            createEvent(
+                "evt-hour",
+                GREGORIAN_CALENDAR_ID,
+                "Sunrise Patrol",
+                createHourTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 1, 6)
+            ),
+            createEvent(
+                "evt-day",
+                GREGORIAN_CALENDAR_ID,
+                "Festival Day",
+                createDayTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 2)
+            ),
+            createEvent(
+                "evt-outside",
+                GREGORIAN_CALENDAR_ID,
+                "Next Week Planning",
+                createDayTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 8)
+            ),
+        ]);
+
+        await gateway.setActiveCalendar(gregorianSchema.id, startOfJanFirst);
+    });
+
+    it("liefert nur Ereignisse zwischen altem und neuem Zeitpunkt", async () => {
+        const result = await gateway.advanceTimeBy(1, "day");
+
+        expect(result.timestamp.year).toBe(2024);
+        expect(result.timestamp.monthId).toBe("jan");
+        expect(result.timestamp.day).toBe(2);
+
+        expect(toIdList(result.triggeredEvents)).toEqual(["evt-hour", "evt-day"]);
+    });
+
+    it("behandelt auch umgekehrte Zeitspannen korrekt", async () => {
+        await gateway.advanceTimeBy(1, "day");
+
+        const backwardsStart: CalendarTimestamp = createDayTimestamp(
+            GREGORIAN_CALENDAR_ID,
+            2024,
+            "jan",
+            2
+        );
+        const backwardsEnd: CalendarTimestamp = createHourTimestamp(
+            GREGORIAN_CALENDAR_ID,
+            2024,
+            "jan",
+            1,
+            0
+        );
+
+        const reversed = await eventRepo.getEventsInRange(
+            gregorianSchema.id,
+            gregorianSchema,
+            backwardsStart,
+            backwardsEnd
+        );
+
+        expect(toIdList(reversed)).toEqual(["evt-hour", "evt-day"]);
+    });
+});


### PR DESCRIPTION
## Summary
- return triggered events alongside the updated timestamp when advancing time in the in-memory Almanac gateway
- surface recently triggered events in the Almanac controller dashboard with a dedicated section
- add unit and DOM tests covering range filtering and UI rendering for triggered events

## Testing
- npm test *(fails: existing governance/statblock baseline expectations in header-policy and library suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ca332e7883258a22517999c25c66