### PR TITLE
docs: add library refactor phase 2 plan

### DIFF
--- a/docs/refactor/library/phase-2/AGENTS.md
+++ b/docs/refactor/library/phase-2/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Dokumentiert Phase-2-Artefakte des Library-Refactorings und dient als Referenz für Umsetzungsteams.
+
+# Aktueller Stand
+- Enthält RFC, Arbeitsplanung, Verträge, Migration-, Test- und Erfolgsmessungs-Strategien sowie ADRs.
+
+# ToDo
+- Laufende Pflege der Inhalte bei Anpassungen des Refactor-Plans.
+
+# Standards
+- Alle Dateien in diesem Verzeichnis sind rein textbasiert (Markdown, TypeScript, DOT/JSON) ohne Binäranhänge.
+- Aktualisierte Abhängigkeitsdiagramme referenzieren den JSON/DOT-Graphen als Single-Source-of-Truth.
+- Änderungen an Verträgen werden mit neuen ADRs unter `adrs/` dokumentiert.

--- a/docs/refactor/library/phase-2/RFC-library-refactor.md
+++ b/docs/refactor/library/phase-2/RFC-library-refactor.md
@@ -1,0 +1,62 @@
+# Library Layer Refactor RFC
+
+## Problem Statement
+Phase 1 highlighted critical fragility across the library layer. The dependency graph revealed 42 bidirectional edges between renderer helpers, stores, and persistence adapters, introducing tight coupling that makes targeted changes risky (see `../phase-1/dependency-graph.json`). Debt items show duplicated serializer paths for Presets, Loadouts, and Damage tables, each diverging in validation rules yet sharing 78% identical field handling (`technical-debt-register.csv`). Renderer-contract audits catalogued lifecycle drift, with three modal entry-points bypassing cleanup callbacks, leading to leaked watchers and orphaned DOM nodes. The risk log flags concurrent file watcher anomalies that can corrupt staged writes when modals are left idle. Collectively these issues stall maintainability, inflate bundle size, and block safe feature evolution.
+
+## Goals & Target Architecture
+- **Layered flow**: UI (React/Renderer) → Application Services → Domain Models → IO/Persistence, enforced through compile-time boundaries.
+- **Port-based orchestration**: Renderer, Serializer, Storage, Validation, and Event/Watcher ports stabilized as contracts (v2) with adapters per domain.
+- **Generics & reuse**: Shared renderer kernel handling querying, pagination, selection, and lifecycle; serializer template with policy hooks for defaults and migrations; shared filtering pipeline for lists.
+- **Testing-first**: Contract suites and golden files covering ports prior to refactors.
+- **Observability & rollback**: Feature flags and kill switches around new adapters, plus dry-run import mode.
+
+## Scope
+- Library-layer modules: views/renderers, create modals, services/persistence, parser/serializer, watcher/stores, and regression tests.
+- Interfaces to adjacent domains are defined via updated contracts without extending functionality.
+
+## Non-Goals
+- UI redesigns, new domain features, or format changes.
+- Breaking changes to public API; any deviation requires ADR + migration path.
+- Modifying downstream consumers beyond contract alignment.
+
+## Architecture Overview
+```mermaid
+flowchart TD
+    UI[React Views & Renderer Shell]
+    APP[Application Services]
+    DOMAIN[Domain Models + Policies]
+    IO[Persistence & External IO]
+    EVENT[Event/Watcher Port]
+
+    UI -->|Renderer Port v2| APP
+    APP -->|Command DTOs| DOMAIN
+    DOMAIN -->|Serializer Template| IO
+    APP -->|Event Dispatch| EVENT
+    EVENT -->|State Updates| APP
+```
+
+- Renderer kernel exposes lifecycle, query orchestration, and cleanup hooks consumed by specialized view plugins.
+- Application services coordinate between domain policies and IO adapters, eliminating direct UI↔IO access.
+- Serializer templates encapsulate round-trip guarantees and feed persistence adapters.
+
+## Dependency Graph Alignment
+- The JSON/DOT graph in Phase 1 (`dependency-graph.json` / `.dot`) remains authoritative. All work packages include updates when dependencies are removed or re-routed.
+- Initial focus removes UI↔IO cycles (Renderer ⇄ Storage, Modal ⇄ Watcher) by inserting application service ports.
+
+## Trade-offs & Considerations
+- **Short-term complexity**: Introducing ports increases abstraction layers; mitigated via shared kernel and templates to avoid proliferation.
+- **Migration effort**: Strangler approach prolongs dual maintenance; kill switches limit blast radius and telemetry monitors parity.
+- **Testing investment**: Contract/golden/mutation suites increase build time, but unlock safer deletions and shrink future regression scope.
+
+## Deliverables Summary
+1. Renderer Contract v2 + associated adapters and lifecycle policy.
+2. Serializer template with policy configuration and shared validation DSL.
+3. Storage/event ports with compatibility layer bridging legacy watchers.
+4. Sequenced work packages removing graph cycles, then consolidating serializers/renderers, finally shrinking utilities.
+5. Migration and testing strategies enabling progressive rollout.
+
+## Success Criteria
+- Reduce cyclic dependencies by ≥ 60% against Phase 1 baseline.
+- Cut library-layer LOC by ≥ 25% via consolidation without behavior loss.
+- Maintain or improve coverage ≥ 85% in hotspot modules; ensure regression suite green post each work package.
+

--- a/docs/refactor/library/phase-2/adrs/ADR-0002-renderer-contract-v2.md
+++ b/docs/refactor/library/phase-2/adrs/ADR-0002-renderer-contract-v2.md
@@ -1,0 +1,19 @@
+# ADR-0002: Adopt Renderer Contract v2 Kernel
+
+- **Status**: Proposed
+- **Date**: 2024-04-06
+
+## Context
+Phase 1 audits uncovered lifecycle gaps and direct IO dependencies in renderer modules (`renderer-contract-audit.md`, `dependency-graph.json`). Existing contract v1 lacks cleanup hooks and forces UI components to access storage/watchers directly, creating cycles and leaks.
+
+## Decision
+Introduce Renderer Contract v2 with lifecycle-aware kernel:
+- Renderer factory exposes `bootstrap`, `connect`, `handleQuery`, `handleEvent`, and `dispose`.
+- Telemetry + kill switch embedded in context to support strangler rollout.
+- Legacy compatibility shim generated via `toLegacyBridge` for gradual migration.
+
+## Consequences
+- Short-term abstraction cost offset by centralised plugin architecture.
+- Enables removal of UI↔IO cycles when combined with application service ports.
+- Requires new contract tests and telemetry instrumentation; build time slightly increases.
+

--- a/docs/refactor/library/phase-2/adrs/ADR-0003-serializer-template.md
+++ b/docs/refactor/library/phase-2/adrs/ADR-0003-serializer-template.md
@@ -1,0 +1,18 @@
+# ADR-0003: Consolidate Serializers via Template & Policy Layer
+
+- **Status**: Proposed
+- **Date**: 2024-04-06
+
+## Context
+Phase 1 domain/serialization catalogue reported three parallel serializer implementations with 78% overlap and inconsistent defaulting rules. Import review showed divergent error shapes and missing dry-run support, creating risk of data corruption.
+
+## Decision
+- Create generic serializer template with declarative `SerializerPolicies` describing fields, defaults, validation, and migrations.
+- Enforce round-trip DoD: `roundTrip` helper executed in CI for every serializer.
+- Provide policy-based validation DSL shared with import/preset flows.
+
+## Consequences
+- Enables deletion of duplicate serializer code paths after parity verification.
+- Requires property-based and golden file tests to guard migrations.
+- Slight upfront cost to reimplement existing serializers on top of template.
+

--- a/docs/refactor/library/phase-2/adrs/ADR-0004-event-bus-refactor.md
+++ b/docs/refactor/library/phase-2/adrs/ADR-0004-event-bus-refactor.md
@@ -1,0 +1,18 @@
+# ADR-0004: Introduce Event Bus Port for Watcher & Service Coordination
+
+- **Status**: Proposed
+- **Date**: 2024-04-06
+
+## Context
+Risk log documents concurrency faults in file watchers causing duplicate writes when modals remain open. Current architecture uses direct callbacks, leading to cycles between modals, stores, and persistence services.
+
+## Decision
+- Establish EventBusPort with typed envelopes and at-least-once delivery semantics.
+- Route watcher updates, renderer lifecycle events, and storage mutations through the bus.
+- Provide dead-letter queue for repeated handler failures and integrate telemetry counters for parity tracking.
+
+## Consequences
+- Breaks dependency cycles by funnelling communication through a single port.
+- Requires new subscription management in renderer lifecycle and store modules.
+- Adds infrastructure overhead; mitigated via shared bus implementation reused by future domains.
+

--- a/docs/refactor/library/phase-2/adrs/AGENTS.md
+++ b/docs/refactor/library/phase-2/adrs/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Dokumentiert Entscheidungen der Phase-2-Refactor-Initiative nachvollziehbar.
+
+# Aktueller Stand
+- Enthält ADRs ab Nummer 0002 zu Architektur- und Vertragsänderungen.
+
+# ToDo
+- Neue Entscheidungen fortlaufend mit steigenden Nummern ergänzen und Querverweise pflegen.
+
+# Standards
+- ADRs folgen dem Format Kontext → Entscheidung → Konsequenzen → Status.
+- Dateinamen entsprechen `ADR-XXXX-title.md` mit fortlaufender vierstelliger Nummer.
+- Alle ADRs werden in Englisch verfasst und enthalten Referenzen zu RFC, Graphen und betroffenen Modulen.

--- a/docs/refactor/library/phase-2/contracts/AGENTS.md
+++ b/docs/refactor/library/phase-2/contracts/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Definiert stabile Schnittstellen und Spezifikationen für Library-Layer-Ports.
+
+# Aktueller Stand
+- Enthält TypeScript-Vertragsdateien und begleitende Markdown-Beschreibungen.
+
+# ToDo
+- Bei Änderungen an Schnittstellen ist die zugehörige Markdown-Spezifikation zu aktualisieren und ein ADR hinzuzufügen.
+
+# Standards
+- TypeScript-Dateien dienen als Referenz für Implementierungen, Kommentare bleiben auf Englisch.
+- Markdown-Dateien beschreiben Zweck, Lebenszyklus und Validierungsregeln der jeweiligen Ports.
+- Keine Implementierungslogik in diesem Ordner, nur Verträge und Spezifikationen.

--- a/docs/refactor/library/phase-2/contracts/event-bus-port.md
+++ b/docs/refactor/library/phase-2/contracts/event-bus-port.md
@@ -1,0 +1,15 @@
+# Event Bus Port Specification
+
+## Responsibilities
+- Provide a decoupled messaging channel for renderer lifecycle events, storage mutations, and watcher notifications.
+- Ensure ordered delivery per event type and at-least-once semantics.
+
+## Lifecycle
+1. Subscribers register during renderer `connect` and remove themselves in `dispose`.
+2. `publish` enforces monotonic `version` increments per resource.
+3. `drain` flushes pending messages before toggling kill switches or completing migrations.
+
+## Error Handling
+- Handlers may throw; the bus logs via telemetry and requeues once unless marked unrecoverable.
+- After two consecutive failures, event is routed to a dead-letter queue consumed by diagnostics.
+

--- a/docs/refactor/library/phase-2/contracts/event-bus-port.ts
+++ b/docs/refactor/library/phase-2/contracts/event-bus-port.ts
@@ -1,0 +1,17 @@
+export interface EventEnvelope<Payload = unknown> {
+  type: string;
+  payload: Payload;
+  version: number;
+  source: 'renderer' | 'service' | 'storage' | 'watcher';
+  timestamp: number;
+}
+
+export type EventUnsubscribe = () => void;
+
+export interface EventBusPort {
+  publish<Payload>(event: EventEnvelope<Payload>): Promise<void>;
+  subscribe<Payload>(type: string, handler: (event: EventEnvelope<Payload>) => Promise<void> | void): EventUnsubscribe;
+  once<Payload>(type: string, handler: (event: EventEnvelope<Payload>) => Promise<void> | void): Promise<void>;
+  drain(): Promise<void>;
+}
+

--- a/docs/refactor/library/phase-2/contracts/renderer-contract-v2.md
+++ b/docs/refactor/library/phase-2/contracts/renderer-contract-v2.md
@@ -1,0 +1,28 @@
+# Renderer Contract v2 Specification
+
+## Purpose
+Provides a unified lifecycle-aware renderer interface to decouple UI views from application services and IO layers. Replaces ad-hoc modal/list renderers with a plugin-driven kernel.
+
+## Lifecycle
+1. `bootstrap` receives the renderer context and returns an instance bound to lifecycle defaults.
+2. `connect` registers lifecycle hooks (pre/post mount). Hooks must execute sequentially and may short-circuit if `killSwitch()` is true.
+3. `handleQuery` processes query updates; it is idempotent and must emit diff-based state updates back to the renderer kernel.
+4. `handleEvent` dispatches UI interactions or watcher messages via the application service.
+5. `dispose` runs cleanup, ensures watchers are detached, and flushes telemetry parity counters.
+
+## Error Strategy
+- Recoverable errors trigger telemetry `log('warn')` and return without throwing.
+- Non-recoverable errors bubble as rejected promises containing `RendererError` with `recoverable=false`.
+- Kill switch toggles must immediately stop processing and invoke `dispose`.
+
+## Query Handling
+- `supportsQuery` advertises recognized query keys; unrecognized keys result in telemetry warnings.
+- Query payloads map to service DTOs defined in the application layer.
+
+## Legacy Bridge
+- `toLegacyBridge` produces a v1-compatible adapter for gradual migration.
+- Legacy mode is disabled when feature flag indicates v2 readiness.
+
+## Telemetry
+- `parityCounter` tracks operations executed via v1 vs v2 to ensure behavioural parity during rollout.
+

--- a/docs/refactor/library/phase-2/contracts/renderer-contract-v2.ts
+++ b/docs/refactor/library/phase-2/contracts/renderer-contract-v2.ts
@@ -1,0 +1,54 @@
+export type RendererQuery = Record<string, unknown>;
+
+export interface RendererError {
+  message: string;
+  cause?: unknown;
+  recoverable: boolean;
+  code?: string;
+}
+
+export interface RendererTelemetry {
+  featureFlag: string;
+  parityCounter?: (metric: string, delta?: number) => void;
+  log: (level: 'debug' | 'info' | 'warn' | 'error', message: string, context?: Record<string, unknown>) => void;
+}
+
+export interface RendererContext<State = unknown> {
+  initialState: State;
+  query: RendererQuery;
+  telemetry: RendererTelemetry;
+  killSwitch: () => boolean;
+}
+
+export interface RendererLifecycleHooks<State = unknown> {
+  onBeforeMount?: (context: RendererContext<State>) => Promise<void> | void;
+  onAfterMount?: (context: RendererContext<State>) => Promise<void> | void;
+  onBeforeUnmount?: (context: RendererContext<State>) => Promise<void> | void;
+}
+
+export interface RendererEvent {
+  type: string;
+  payload?: unknown;
+}
+
+export interface RendererInstance<State = unknown> {
+  readonly id: string;
+  connect: (hooks?: RendererLifecycleHooks<State>) => Promise<void>;
+  handleQuery: (query: RendererQuery) => Promise<void>;
+  handleEvent: (event: RendererEvent) => Promise<void>;
+  dispose: () => Promise<void>;
+  getState: () => State;
+}
+
+export interface RendererFactoryOptions<State = unknown> {
+  featureFlag: string;
+  supportsLegacyContract: boolean;
+  lifecycleDefaults?: RendererLifecycleHooks<State>;
+}
+
+export interface RendererFactory<State = unknown> {
+  bootstrap: (context: RendererContext<State>, options: RendererFactoryOptions<State>) => Promise<RendererInstance<State>>;
+  supportsQuery: (queryKey: string) => boolean;
+  toLegacyBridge?: (instance: RendererInstance<State>) => unknown;
+}
+

--- a/docs/refactor/library/phase-2/contracts/serializer-template.md
+++ b/docs/refactor/library/phase-2/contracts/serializer-template.md
@@ -1,0 +1,20 @@
+# Serializer Template Specification
+
+## Template Responsibilities
+- Provide a declarative field policy list describing defaults, validation, and migration behaviour.
+- Guarantee round-trip safety via `roundTrip` helper executing serialize → deserialize consistency checks.
+- Support dry-run contexts for import validation without persisting side effects.
+
+## Policy Rules
+- `required=true` fields must either exist on the payload or be synthesised from `defaultValue`/`migrate`.
+- `allowUnknownFields=false` strips unspecified payload entries and records telemetry warnings.
+- Version increments follow semantic versioning: major for structural changes, minor for optional fields, patch for validation tweaks.
+
+## Validation DSL
+- `validate` functions throw descriptive errors; property-based tests ensure invariants across random payloads.
+- Shared error shape: `{ field, message, code }` used across import/preset flows.
+
+## Migration Strategy
+- `migrate` handles legacy payloads; results feed into validation before persistence.
+- Telemetry logs all migrations with version delta for auditability.
+

--- a/docs/refactor/library/phase-2/contracts/serializer-template.ts
+++ b/docs/refactor/library/phase-2/contracts/serializer-template.ts
@@ -1,0 +1,32 @@
+export type SerializerVersion = `${number}.${number}.${number}`;
+
+export interface SerializerFieldPolicy<Value = unknown> {
+  readonly field: string;
+  readonly defaultValue?: Value | (() => Value);
+  readonly required: boolean;
+  readonly validate?: (value: Value) => void;
+  readonly migrate?: (legacy: unknown) => Value;
+}
+
+export interface SerializerPolicies<DomainModel> {
+  version: SerializerVersion;
+  fields: SerializerFieldPolicy[];
+  onBeforeSerialize?: (model: DomainModel) => DomainModel;
+  onAfterDeserialize?: (model: DomainModel) => DomainModel;
+  allowUnknownFields?: boolean;
+}
+
+export interface SerializationContext {
+  dryRun: boolean;
+  telemetry: {
+    log: (level: 'debug' | 'info' | 'warn' | 'error', message: string, context?: Record<string, unknown>) => void;
+  };
+}
+
+export interface SerializerTemplate<DomainModel, SerializedShape = Record<string, unknown>> {
+  readonly policies: SerializerPolicies<DomainModel>;
+  serialize: (model: DomainModel, context?: SerializationContext) => SerializedShape;
+  deserialize: (payload: SerializedShape, context?: SerializationContext) => DomainModel;
+  roundTrip: (model: DomainModel) => SerializedShape;
+}
+

--- a/docs/refactor/library/phase-2/contracts/storage-port.md
+++ b/docs/refactor/library/phase-2/contracts/storage-port.md
@@ -1,0 +1,15 @@
+# Storage Port Specification
+
+## Responsibilities
+- Provide IO access via async CRUD with optional transactional semantics.
+- Support dry-run writes for migration validation.
+- Expose existence checks to short-circuit unnecessary read/write cycles.
+
+## Consistency
+- Default read consistency: `eventual` for UI hydration; `strong` required for save/confirm flows.
+- Transaction blocks must rollback all previous steps if one fails.
+
+## Watcher Integration
+- Storage events publish via EventBusPort; storage layer emits typed events (`resource`, `mutation`, `version`).
+- Partial write failures trigger rollback and structured error propagation.
+

--- a/docs/refactor/library/phase-2/contracts/storage-port.ts
+++ b/docs/refactor/library/phase-2/contracts/storage-port.ts
@@ -1,0 +1,23 @@
+export interface StorageTransaction<T> {
+  run: () => Promise<T>;
+  rollback: () => Promise<void>;
+}
+
+export interface StorageReadOptions {
+  consistency: 'eventual' | 'strong';
+  signal?: AbortSignal;
+}
+
+export interface StorageWriteOptions {
+  transactional?: boolean;
+  dryRun?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface StoragePort {
+  read<T>(resource: string, options?: StorageReadOptions): Promise<T | null>;
+  write<T>(resource: string, payload: T, options?: StorageWriteOptions): Promise<void>;
+  transact<T>(steps: StorageTransaction<T>[], options?: StorageWriteOptions): Promise<T>;
+  exists(resource: string): Promise<boolean>;
+}
+

--- a/docs/refactor/library/phase-2/contracts/validation-port.md
+++ b/docs/refactor/library/phase-2/contracts/validation-port.md
@@ -1,0 +1,15 @@
+# Validation Port Specification
+
+## Goals
+- Centralise validation pipelines across serializers, presets/imports, and renderer inputs.
+- Provide consistent issue reporting to UI and logging layers.
+
+## Rules
+- `strict=true` forbids warnings; any warning escalates to error.
+- `coerce` normalises unknown payloads (e.g., string → number) and shares validation result contract.
+- Issues propagate with deterministic ordering (by field, then severity).
+
+## Testing Guidance
+- Property-based tests verify idempotence of `coerce` for already valid inputs.
+- Mutation testing ensures validation catches tampered fields from risk log scenarios.
+

--- a/docs/refactor/library/phase-2/contracts/validation-port.ts
+++ b/docs/refactor/library/phase-2/contracts/validation-port.ts
@@ -1,0 +1,23 @@
+export interface ValidationIssue {
+  field: string;
+  message: string;
+  code: string;
+  severity: 'error' | 'warning';
+}
+
+export interface ValidationResult<T> {
+  valid: boolean;
+  data?: T;
+  issues: ValidationIssue[];
+}
+
+export interface ValidationContext {
+  source: 'preset-import' | 'renderer' | 'persistence';
+  strict: boolean;
+}
+
+export interface ValidationPort<TInput, TOutput = TInput> {
+  validate(input: TInput, context: ValidationContext): Promise<ValidationResult<TOutput>>;
+  coerce?(input: unknown, context: ValidationContext): Promise<ValidationResult<TOutput>>;
+}
+

--- a/docs/refactor/library/phase-2/migration.md
+++ b/docs/refactor/library/phase-2/migration.md
@@ -1,0 +1,34 @@
+# Migration Strategy
+
+## Approach
+Adopt a strangler-fig migration: wrap legacy modules with compatibility adapters while gradually routing traffic through new ports. Telemetry and feature flags monitor parity and enable instant rollback.
+
+## Phases
+1. **Contract Harness Setup**
+   - Implement contract tests and golden files before altering code paths.
+   - Introduce compatibility facades exposing both v1 and v2 signatures.
+2. **Renderer Kernel Rollout**
+   - Deploy Renderer Contract v2 behind `renderer.v2.enabled` flag.
+   - Bridge existing renderers via `toLegacyBridge` to ensure v1 consumers operate unchanged.
+3. **Serializer Template Adoption**
+   - Generate serializer outputs in parallel (legacy + template) and diff results in dry-run mode.
+   - Promote template output once parity counters stabilise for 7 consecutive days.
+4. **Watcher/Event Bus Transition**
+   - Register watcher events on new bus while still emitting legacy callbacks.
+   - Enable kill switch to disable bus if concurrency probes detect drift.
+5. **Cleanup & Deletion**
+   - Remove legacy adapters once telemetry shows <1% fallback usage and regression suite passes for two release cycles.
+
+## Compat Layer
+- Provide facade modules exporting both v1/v2 signatures with shared implementations.
+- Use configuration-driven kill switches stored in user settings with default `false` for new behaviour.
+
+## Data Migration
+- Serializers run in dry-run mode to detect schema diffs; persist migrations only when validation passes.
+- Backups: prior to enabling new template, snapshot storage resources (`presets.json`, `damage.json`, etc.) into versioned archive.
+
+## Rollback Plan
+- Kill switch flips restore legacy factories immediately.
+- Event bus supports `drain` then disable to avoid message loss.
+- Storage transactions run compensating rollback scripts stored alongside templates.
+

--- a/docs/refactor/library/phase-2/success-metrics.md
+++ b/docs/refactor/library/phase-2/success-metrics.md
@@ -1,0 +1,25 @@
+# Success Metrics & Definition of Done
+
+## Quantitative Targets
+- **LOC Reduction**: ≥ 25% decrease across library-layer modules (renderers, serializers, stores) measured via `cloc` before/after.
+- **Cyclic Dependencies**: ≥ 60% reduction in bidirectional edges compared to Phase 1 `dependency-graph.json` baseline.
+- **Public API Surface**: ≥ 30% reduction in exported symbols by consolidating renderer and serializer factories.
+- **Coverage**: ≥ 85% statement/branch coverage in hotspots identified in `complexity-coverage.md`.
+- **Build Time**: No more than +10% increase in CI duration after adding tests; target parity by optimizing bundling.
+
+## Qualitative Indicators
+- Renderer lifecycle and cleanup flows documented and enforced through contract tests.
+- Serializers adopt shared template; domain-specific modules contain only differential policies.
+- Watcher/event bus interactions recorded with telemetry parity metrics to confirm zero missed events.
+
+## Definition of Done per Work Package
+1. **Tests Green**: Contract, golden, regression suites executed successfully.
+2. **Documentation Updated**: RFC, relevant ADRs, and dependency graph refreshed.
+3. **Telemetry Reviewed**: Parity counters show <1% divergence between legacy and new paths.
+4. **Rollback Ready**: Kill switches documented and validated during staging rollout.
+
+## Global Definition of Done
+- All legacy factories/adapters removed or formally deprecated with end-of-life date.
+- Metrics tracked for two release cycles confirming targets met.
+- Stakeholder sign-off recorded in ADR referencing final dependency graph snapshot.
+

--- a/docs/refactor/library/phase-2/test-strategy.md
+++ b/docs/refactor/library/phase-2/test-strategy.md
@@ -1,0 +1,26 @@
+# Testing Strategy
+
+## Principles
+- Tests precede refactors: contract suites and golden files created before logic changes.
+- Feature parity enforced through regression baselines for each renderer, serializer, and watcher behaviour documented in Phase 1.
+
+## Test Types
+- **Contract Tests**: Validate Renderer, Storage, Serializer, Validation, and Event Bus ports using shared harness. Ensure lifecycle ordering, error propagation, and telemetry hooks.
+- **Golden Files**: Serializer outputs stored under `tests/golden/library`; run diff on each CI build.
+- **Property-Based Tests**: Parser/validation DSL ensures invariants (idempotence, boundary cases). Use fast-check integrated in Vitest.
+- **Mutation Tests**: Apply to critical services (watchers, application orchestrators) to ensure validation catches tampering.
+- **Chaos/Concurrency Probes**: Simulate watcher races, partial writes, and aborted modals.
+
+## Tooling
+- Vitest for unit/contract/property suites.
+- Stryker for mutation tests targeting watcher/services packages.
+- Custom CLI to replay import/preset fixtures in dry-run mode.
+
+## Automation
+- CI pipeline stages: `lint` → `test:contracts` → `test:golden` → `test:mutation` (nightly) → `test:chaos` (weekly).
+- Telemetry parity counters exported to dashboard verifying legacy vs new path usage.
+
+## Coverage Targets
+- ≥ 85% statement/branch coverage in hotspot modules (renderer kernel, serializer template, watcher orchestrator).
+- 100% contract coverage for ports (each method executed across suites).
+

--- a/docs/refactor/library/phase-2/work-packages.md
+++ b/docs/refactor/library/phase-2/work-packages.md
@@ -1,0 +1,97 @@
+# Work Package Plan
+
+## Overview
+Sequencing follows the dependency graph: remove cycles, establish shared kernels/templates, then consolidate implementations. Each ticket references regression and contract test requirements to maintain feature parity.
+
+## Epics and Packages
+
+### Epic A: Dependency Cycle Removal (Impact: High, Complexity: Medium)
+- **WP-A1: Renderer ↔ Storage decoupling**
+  - **Tickets**:
+    - A1-T1 (M): Introduce Application Service port mediating renderer data requests; refactor renderer entry points to call service.
+    - A1-T2 (S): Wrap persistence adapter behind StoragePort interface; update watcher subscriptions to use service callbacks.
+  - **Dependencies**: None.
+  - **Risks**: Service orchestration errors leading to stale UI updates.
+  - **Mitigation**: Contract tests for RendererPort/StoragePort; dry-run mode verifying request/response payloads.
+  - **Rollback**: Feature flag toggles renderer back to legacy direct calls.
+
+- **WP-A2: Modal ↔ Watcher isolation**
+  - **Tickets**:
+    - A2-T1 (M): Extract watcher orchestration into EventBusPort with typed payloads.
+    - A2-T2 (S): Update create modals to subscribe via Renderer lifecycle hook.
+  - **Dependencies**: Requires Renderer Contract v2 (WP-B1) to expose lifecycle events.
+  - **Risks**: Missed unsubscribe causing duplicate events.
+  - **Mitigation**: Lifecycle regression tests; mutation tests on watcher cleanup.
+  - **Rollback**: Toggle to legacy watcher binding and revert port registration.
+
+### Epic B: Shared Kernels & Templates (Impact: High, Complexity: High)
+- **WP-B1: Renderer Kernel introduction**
+  - **Tickets**:
+    - B1-T1 (L): Implement RendererKernel with query execution, pagination, selection, and cleanup pipeline.
+    - B1-T2 (M): Adapt existing renderers (List, Detail, Modal) via plugin adapters.
+    - B1-T3 (S): Provide compatibility shim bridging v1 contract to v2 for downstream consumers.
+  - **Dependencies**: WP-A1 completed (ensures service ports ready).
+  - **Risks**: Plugin adoption gaps causing missing renderer behaviours.
+  - **Mitigation**: Golden snapshot tests for renderer outputs; contract suite verifying lifecycle ordering.
+  - **Rollback**: Kill switch re-enables legacy renderer factory.
+
+- **WP-B2: Serializer template & validation DSL**
+  - **Tickets**:
+    - B2-T1 (M): Create generic serializer template with round-trip tests and policy hooks (defaults, migration rules).
+    - B2-T2 (M): Port Presets, Loadouts, Damage serializers onto template; remove duplicate pipelines.
+    - B2-T3 (S): Introduce shared validation DSL with property-based tests for edge cases.
+  - **Dependencies**: B1 (shared utilities for plugin error reporting) optional but recommended.
+  - **Risks**: Migration mistakes corrupting saved data.
+  - **Mitigation**: Golden files, dry-run import validations, backup/restore script.
+  - **Rollback**: Compatibility layer writing legacy serializer output when flag enabled.
+
+### Epic C: Consolidation & Cleanup (Impact: Medium, Complexity: Medium)
+- **WP-C1: Filter/Sort/Search pipeline unification**
+  - **Tickets**:
+    - C1-T1 (M): Abstract filtering pipeline into reusable service used by renderer kernel.
+    - C1-T2 (S): Delete redundant utility functions across renderers; update imports.
+  - **Dependencies**: WP-B1.
+  - **Risks**: Behavioural drift in edge-case filtering.
+  - **Mitigation**: Regression suite with golden query cases; property-based tests for filter idempotence.
+  - **Rollback**: Retain legacy utilities behind feature flag fallback.
+
+- **WP-C2: Store simplification**
+  - **Tickets**:
+    - C2-T1 (M): Collapse derived stores using new event bus notifications.
+    - C2-T2 (S): Remove unused watchers flagged in risk log; ensure concurrency probes remain.
+  - **Dependencies**: WP-A2, WP-B1.
+  - **Risks**: Missed subscriber updates.
+  - **Mitigation**: Chaos tests simulating concurrent updates; coverage thresholds on store reducers.
+  - **Rollback**: Re-enable deprecated stores using compat module.
+
+### Epic D: Test & Rollout Enablement (Impact: High, Complexity: Low)
+- **WP-D1: Contract & regression harness**
+  - **Tickets**:
+    - D1-T1 (S): Implement contract test harness shared across renderer/serializer/storage ports.
+    - D1-T2 (S): Define golden file fixtures for serializers in `tests/golden/library`.
+  - **Dependencies**: None; executes before functional refactors.
+  - **Risks**: Initial build time increase.
+  - **Mitigation**: Parallelize test suites; run in CI nightly.
+  - **Rollback**: N/A—tests only.
+
+- **WP-D2: Telemetry & kill switches**
+  - **Tickets**:
+    - D2-T1 (S): Add feature flag registry with remote override config.
+    - D2-T2 (S): Instrument renderer/service interactions with parity counters.
+  - **Dependencies**: WP-B1.
+  - **Risks**: Over-instrumentation affecting performance.
+  - **Mitigation**: Sampled logging with rate limits.
+  - **Rollback**: Disable telemetry module via config.
+
+## Sequencing Summary
+1. WP-D1 (tests), then WP-A1 to remove critical UI↔IO cycle.
+2. WP-B1/B2 introduce kernels/templates leveraging stabilized ports.
+3. WP-A2 finalizes watcher decoupling once renderer lifecycle available.
+4. WP-C1/C2 consolidate utilities and stores.
+5. WP-D2 completes rollout controls.
+
+## Effort Legend
+- **S**: ≤ 2 dev-days.
+- **M**: 3–5 dev-days.
+- **L**: > 5 dev-days.
+


### PR DESCRIPTION
## Summary
- document the phase 2 library refactor RFC with goals, scope, and architecture guardrails
- add work package plan, migration/testing strategies, and success metrics aligned to the dependency graph
- define stable contracts and supporting ADRs for renderer, serializer, storage, validation, and event bus ports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3caa144948325aa981d341b3e1dac