### PR TITLE
Create phase 3 library refactor backlog and planning assets

### DIFF
--- a/docs/refactor/library/phase-3/AGENTS.md
+++ b/docs/refactor/library/phase-3/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Dokumentiert Phase-3-Planungsartefakte (Backlog, Kanban, Briefings) für die Library-Modernisierung.
+
+# Aktueller Stand
+- Verzeichnis ist neu angelegt und erwartet strukturierte Planungsdokumente nach Vorgaben aus Phase 1 & 2.
+
+# ToDo
+- Backlog, Traceability und Kanban pflegen, wenn sich Planungsannahmen ändern.
+
+# Standards
+- Alle Inhalte sind textbasiert (Markdown/CSV) und referenzieren bei Bedarf Quellen aus Phase 1/2.
+- ToDo-IDs folgen dem Präfix `LIB-TD-` und bleiben stabil.
+- Planning-Briefs liegen unter `planning-briefs/` mit Dateinamen `<todo-id>.md`.

--- a/docs/refactor/library/phase-3/README.md
+++ b/docs/refactor/library/phase-3/README.md
@@ -1,0 +1,48 @@
+# Phase 3 – Library Refactor Planning
+
+Dieses Verzeichnis enthält die Planungsartefakte der Phase 3 für das Library-Refactoring. Ziel ist es, aus den Analysen (Phase 1) und dem Zielbild (Phase 2) ein ausführbares Backlog für Phase 4 abzuleiten.
+
+## Struktur
+- `backlog.md` – Vollständige ToDo-Karten (Epics → Work Packages → ToDos) inkl. aller Pflichtfelder.
+- `backlog.csv` – Maschinenlesbare Tabelle aller ToDos.
+- `traceability.md` – Mapping von Technical Debts & Risks auf ToDo-IDs und Work Packages.
+- `kanban.md` – Textbasierter Kanban-Export (Ready vs. Backlog).
+- `planning-briefs/` – Einzelne Planning-Briefs pro ToDo (`LIB-TD-####.md`).
+- `AGENTS.md` – Verzeichnisregeln und Standards.
+
+## ToDo-Felder & Bedeutung
+Jede ToDo-Karte in `backlog.md` enthält folgende Felder in fester Reihenfolge:
+1. **ID** – laufende Kennung `LIB-TD-####`.
+2. **Titel (imperativ)** – prägnante Handlungsanweisung.
+3. **Kategorie** – Zuordnung {Architektur, Serializer, Renderer, Contracts, Persistenz/IO, Validation, Tests, Build/Infra, Cleanup}.
+4. **Bezug (Trace)** – referenzierte Debts, Risks, ADRs und Work Package.
+5. **Problem (Ist)** – aktueller Zustand mit Pfad-/Modulhinweisen.
+6. **Zielzustand (Soll/Contract)** – erwarteter Contract bzw. Zielarchitektur.
+7. **Scope & Out-of-Scope** – Umfangsgrenze.
+8. **Entwurfsleitlinien (Planung)** – Planungsschritte, Schnittstellen, Migrationspfade, Testanker.
+9. **Abhängigkeiten** – benötigte ToDos/Artefakte.
+10. **Risiken & Mitigation** – erwartete Risiken inkl. Gegenmaßnahmen.
+11. **Test-Impact & Ankermuster** – geplante Testtypen.
+12. **Messgrößen (Erfolg)** – messbare Ziele/Metriken.
+13. **Akzeptanzkriterien** – getrennt nach DoR (Ready für Phase 4) und DoD (Ergebnis Phase 4).
+14. **Aufwand (T-Shirt)** – S/M/L als Planungsschätzung.
+15. **Priorität (Score)** – Ranking nach ICE.
+16. **Open Questions** – noch zu klärende Punkte.
+
+## Priorisierungsmethode
+Wir verwenden einen **ICE-Score**: `Impact × Confidence ÷ Effort`. Dabei gilt:
+- Impact & Confidence werden auf einer Skala von 1–10 geschätzt.
+- Effort basiert auf dem T-Shirt-Size-Mapping (S=1, M=2, L=3).
+- Höhere Werte deuten auf höhere Priorität hin. Die Reihenfolge in `backlog.md` berücksichtigt zusätzlich die in `work-packages.md` festgelegte Sequenz.
+
+## Nutzung in Phase 4
+1. **Backlog Grooming** – Prüfen Sie für jedes ToDo die Planning-Briefs (`planning-briefs/`) und beantworten Sie offene Fragen.
+2. **DoR-Check** – Stellen Sie sicher, dass sämtliche DoR-Punkte erfüllt sind, bevor ein ToDo nach „Ready for Phase 4“ verschoben wird.
+3. **Umsetzung** – Arbeiten Sie die Entwurfsleitlinien Schritt für Schritt ab. Dokumentieren Sie Entscheidungen in den referenzierten ADRs oder ergänzen Sie neue.
+4. **Testing & Metrics** – Validieren Sie die in den ToDos genannten Tests und Messgrößen. Aktualisieren Sie `success-metrics.md` falls erforderlich.
+5. **Traceability** – Halten Sie `traceability.md` synchron, falls sich Zuordnungen durch neue Erkenntnisse ändern.
+
+## Pflegehinweise
+- Neue ToDos erhalten sofort eine Karte in `backlog.md`, einen CSV-Eintrag und einen Planning-Brief.
+- Änderungen am Plan spiegeln sich in allen Artefakten wider (Backlog, CSV, Kanban, Traceability).
+- Bei strukturellen Anpassungen erneut `npm run sync:todos` im Repo-Stamm ausführen (siehe `AGENTS.md` auf Root-Ebene).

--- a/docs/refactor/library/phase-3/backlog.csv
+++ b/docs/refactor/library/phase-3/backlog.csv
@@ -1,0 +1,17 @@
+ID,Title,Category,WorkPackage,Epic,Debts,Risks,ADRs,Dependencies,TShirt,PriorityScore
+LIB-TD-0001,Richte portübergreifenden Vertragstest-Harness ein,Tests,WP-D1,EPIC-D,D-LIB-011,R-LIB-002,"ADR-0002|ADR-0003",,M,35
+LIB-TD-0002,Hinterlege Golden-Files für Serializer-Roundtrips,Tests,WP-D1,EPIC-D,"D-LIB-004|D-LIB-006",R-LIB-002,ADR-0003,LIB-TD-0001,S,56
+LIB-TD-0003,Definiere Application-Service-Port für Bibliotheksrendering,Architektur,WP-A1,EPIC-A,D-LIB-001,"R-LIB-001|R-LIB-005","ADR-0001|ADR-0002",LIB-TD-0001,M,35
+LIB-TD-0004,Kapsle Persistenzadapter hinter StoragePort,Persistenz/IO,WP-A1,EPIC-A,"D-LIB-004|D-LIB-006|D-LIB-010",R-LIB-002,ADR-0003,"LIB-TD-0003|LIB-TD-0001",M,31.5
+LIB-TD-0005,Baue Renderer-Kernel mit Lifecycle-Orchestrierung,Renderer,WP-B1,EPIC-B,"D-LIB-001|D-LIB-008","R-LIB-001|R-LIB-007",ADR-0002,"LIB-TD-0003|LIB-TD-0001",L,20
+LIB-TD-0006,Migriere Bibliotheksrenderer auf Kernel-Plugins,Renderer,WP-B1,EPIC-B,"D-LIB-001|D-LIB-002|D-LIB-008","R-LIB-001|R-LIB-005|R-LIB-007",ADR-0002,"LIB-TD-0005|LIB-TD-0003|LIB-TD-0004",L,15
+LIB-TD-0007,Etabliere Event-Bus-Port für Watcher-Orchestrierung,Architektur,WP-A2,EPIC-A,D-LIB-008,"R-LIB-004|R-LIB-007",ADR-0004,"LIB-TD-0005|LIB-TD-0003",M,27
+LIB-TD-0008,Binde Create-Modals an Renderer-Lifecycle an,Contracts,WP-A2,EPIC-A,D-LIB-008,"R-LIB-004|R-LIB-007","ADR-0002|ADR-0004","LIB-TD-0007|LIB-TD-0006",M,24
+LIB-TD-0009,Implementiere Serializer-Template-Policies,Serializer,WP-B2,EPIC-B,"D-LIB-002|D-LIB-012","R-LIB-002|R-LIB-005",ADR-0003,"LIB-TD-0001|LIB-TD-0004",M,27
+LIB-TD-0010,Portiere Creature/Item/Equipment-Serializer auf Template,Serializer,WP-B2,EPIC-B,"D-LIB-002|D-LIB-004|D-LIB-005|D-LIB-006|D-LIB-007|D-LIB-012","R-LIB-002|R-LIB-005",ADR-0003,"LIB-TD-0009|LIB-TD-0004|LIB-TD-0003",L,15
+LIB-TD-0011,Führe Validation-DSL für Domain-Daten ein,Validation,WP-B2,EPIC-B,D-LIB-009,"R-LIB-002|R-LIB-006",ADR-0003,"LIB-TD-0009|LIB-TD-0001",M,24
+LIB-TD-0012,Härte Preset-Import über Storage-Service ab,Persistenz/IO,WP-B2,EPIC-B,D-LIB-010,R-LIB-003,ADR-0003,"LIB-TD-0004|LIB-TD-0009",M,24
+LIB-TD-0013,Vereinheitliche Query- und Filter-Pipeline,Architektur,WP-C1,EPIC-C,"D-LIB-001|D-LIB-002","R-LIB-001|R-LIB-005",ADR-0002,"LIB-TD-0005|LIB-TD-0003",M,18
+LIB-TD-0014,Straffe Library-Stores und Watcher-States,Architektur,WP-C2,EPIC-C,D-LIB-008,R-LIB-004,ADR-0004,"LIB-TD-0007|LIB-TD-0005",M,20
+LIB-TD-0015,Entferne Debug-Logging und obsolet gewordene Watcher-Hooks,Cleanup,WP-C2,EPIC-C,"D-LIB-003|D-LIB-008",R-LIB-004,ADR-0004,"LIB-TD-0007|LIB-TD-0014",S,16
+LIB-TD-0016,Etabliere Feature-Flag-Registry und Paritäts-Telemetrie,Build/Infra,WP-D2,EPIC-D,,"R-LIB-001|R-LIB-003|R-LIB-004","ADR-0002|ADR-0003|ADR-0004","LIB-TD-0005|LIB-TD-0009|LIB-TD-0007",M,21

--- a/docs/refactor/library/phase-3/backlog.md
+++ b/docs/refactor/library/phase-3/backlog.md
@@ -1,0 +1,490 @@
+# Phase 3 Backlog – Library Refactor
+
+## Epic D: Test & Rollout Enablement
+
+### Work Package WP-D1: Contract & Regression Harness
+
+ID: LIB-TD-0001
+Titel (imperativ): Richte portübergreifenden Vertragstest-Harness ein
+Kategorie: Tests
+Bezug (Trace): Debt: D-LIB-011; Risk: R-LIB-002; ADR: ADR-0002, ADR-0003; WP: WP-D1
+Problem (Ist): Die aktuelle Vitest-Suite (`tests/library/view.test.ts`) mockt sämtliche Renderers und Speicheradapter, wodurch Import-, Serializer- und Watcher-Flüsse ungetestet bleiben.
+Zielzustand (Soll/Contract): Zentraler Test-Harness führt Renderer-, Storage-, Serializer- und Event-Port-Verträge gegen gemeinsame Fixtures aus; Tests laufen determiniert und ohne Mocks der Kernpfade.
+Scope & Out-of-Scope: In Scope sind Bibliotheks-Ports gemäß Contracts v2; out-of-scope sind UI-Screenshot-Tests und nicht-library Module.
+Entwurfsleitlinien (Planung):
+- Entwerfe `tests/contracts/library-harness.ts` als Einstiegspunkt mit konfigurierbaren Adaptern (Legacy vs. v2).
+- Definiere Fixture-Struktur für Domain-Daten (Creatures, Items, Equipment, Terrains, Regions) mit klarer Ownership.
+- Plane CI-Workflow-Integration (`npm run test:contracts`) inkl. Dokumentation in `BUILD.md`.
+- Lege Telemetrie-Hooks als optionalen Adapter an, um spätere Paritätsprüfungen einzubinden.
+Abhängigkeiten: Keine.
+Risiken & Mitigation:
+- Gefahr fragmentierter Tests → Review der Harness-API mit QA-Team vor Implementierung.
+- Längere Build-Zeiten → Parallelisierungskonzept vorbereiten, Smoke-Subset für PRs definieren.
+Test-Impact & Ankermuster:
+- Vertragstests für Renderer-, Storage-, Serializer- und Event-Port.
+- Regressionstest-Suite für kritische Pfade (Import, Preset-Laden, Debounced Saves) im Harness verankern.
+Messgrößen (Erfolg):
+- Neue Testsuite deckt ≥ 4 Ports ab.
+- Baseline-Coverage in Hotspots steigt um ≥ 15 Prozentpunkte nach Integration.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Harness-API, Fixture-Design und CI-Integration sind beschrieben; Testdatenquellen abgestimmt.
+  DoD (für Phase 4): Tests laufen grün, decken alle Ports ab und laufen automatisiert im CI.
+Aufwand (T-Shirt): M
+Priorität (Score): 35
+Open Questions: Benötigt das Team dedizierte Mock-Stubs für Telemetrie im Harness?
+
+ID: LIB-TD-0002
+Titel (imperativ): Hinterlege Golden-Files für Serializer-Roundtrips
+Kategorie: Tests
+Bezug (Trace): Debt: D-LIB-004, D-LIB-006; Risk: R-LIB-002; ADR: ADR-0003; WP: WP-D1
+Problem (Ist): Serializer-Ausgaben werden nirgends persistent verglichen, daher bleiben stillschweigende JSON-Parse-Fehler bei Items/Equipment unentdeckt.
+Zielzustand (Soll/Contract): Golden-Dateien pro Domain (Creatures, Items, Equipment, Spells) dienen als Kanon; jede Serializer-Änderung löst diffbare Tests aus.
+Scope & Out-of-Scope: In Scope ist das Anlegen und Versionieren der Golden-Files inkl. Dry-Run-Pipeline; Out-of-Scope sind neue Datenschemata.
+Entwurfsleitlinien (Planung):
+- Nutze Harness aus LIB-TD-0001 zur Erzeugung deterministischer Outputs.
+- Plane Ordner `tests/golden/library/<domain>` mit YAML/Markdown-Files plus Metadaten (`.manifest.json`).
+- Definiere Update-Workflow (`npm run golden:update`) samt Review-Checklist.
+- Lege Diff-Regeln fest (Whitespace, Sortierung) um false positives zu vermeiden.
+Abhängigkeiten: LIB-TD-0001.
+Risiken & Mitigation:
+- Golden-Files könnten zu groß werden → Sampling-Strategie (repräsentative Datensätze) dokumentieren.
+- Unbeabsichtigte Updates → Require Review von Domain-Owner bei Golden-Updates.
+Test-Impact & Ankermuster:
+- Golden-Diff-Tests für alle Serializer-Domänen.
+- Roundtrip-Tests (serialize→deserialize) gegen Golden-Basis.
+Messgrößen (Erfolg):
+- Mindestens 12 Golden-Beispiele (mind. 3 pro Hauptdomäne).
+- Roundtrip-Fehlerquote sinkt auf 0 im Dry-Run.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Golden-Datensatzliste abgestimmt, Speicherort und Updateprozess beschrieben.
+  DoD (für Phase 4): Golden-Dateien eingecheckt, Tests laufen grün, Update-Workflow dokumentiert.
+Aufwand (T-Shirt): S
+Priorität (Score): 56
+Open Questions: Welche Legacy-Dateien dienen als autoritative Golden-Basis (Preset vs. Nutzerbeispiele)?
+
+## Epic A: Dependency Cycle Removal
+
+### Work Package WP-A1: Renderer ↔ Storage Decoupling
+
+ID: LIB-TD-0003
+Titel (imperativ): Definiere Application-Service-Port für Bibliotheksrendering
+Kategorie: Architektur
+Bezug (Trace): Debt: D-LIB-001; Risks: R-LIB-001, R-LIB-005; ADR: ADR-0001, ADR-0002; WP: WP-A1
+Problem (Ist): Render-Views (`src/apps/library/view/*.ts`) lesen direkt aus Stores/IO und deklarieren teils `async render()`, was Schichten verletzt und Rennbedingungen erzeugt.
+Zielzustand (Soll/Contract): Renderer kommunizieren ausschließlich über einen `LibraryModeServicePort`, der synchronisierte Query-, Import- und Persistenz-Operationen kapselt.
+Scope & Out-of-Scope: Enthält Spezifikation von Service-Domain DTOs und Kill-Switch-Hooks; UI-Komponenten-Anpassungen bleiben aus.
+Entwurfsleitlinien (Planung):
+- Modellieren Port-Interface (Query-/Mutation-Methoden, Promise-Strategie) inkl. Error- und Telemetrie-Kontrakt.
+- Plane Service-Komposition (RendererPort↔StoragePort↔SerializerTemplate) mit Sequenzdiagramm.
+- Beschreibe Migrationspfad: Legacy-Renderer werden über Adapter auf Port geführt.
+- Identifiziere benötigte Feature-Flags (`renderer.service.enabled`).
+Abhängigkeiten: LIB-TD-0001.
+Risiken & Mitigation:
+- Fehlende DTO-Abdeckung → frühzeitige Reviews mit Domain-Ownern.
+- Versehentliche Blockierung langer IOs → Timeout/Abort-Konzept im Port aufnehmen.
+Test-Impact & Ankermuster:
+- Vertragstests zwischen Renderer- und Service-Port.
+- Chaos-Probe für parallele Queries (Search + Mode-Wechsel).
+Messgrößen (Erfolg):
+- 0 direkte IO-Imports mehr in Renderer-Dateien (Analyse via Dependency-Graph).
+- Reduktion async `render()`-Signaturen auf 0.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Port-Signaturen, DTO-Liste und Feature-Flag-Plan stehen.
+  DoD (für Phase 4): Alle Renderer rufen Service-Port statt IO direkt; Verträge grün.
+Aufwand (T-Shirt): M
+Priorität (Score): 35
+Open Questions: Wie werden Langläufer (z. B. Preset-Scans) throttled, ohne UI zu blockieren?
+
+ID: LIB-TD-0004
+Titel (imperativ): Kapsle Persistenzadapter hinter StoragePort
+Kategorie: Persistenz/IO
+Bezug (Trace): Debts: D-LIB-004, D-LIB-006, D-LIB-010; Risk: R-LIB-002; ADR: ADR-0003; WP: WP-A1
+Problem (Ist): Import-/Preset-Pfade parsen JSON/YAML manuell und schlucken Fehler; Marker-Datei-Handling ist inkonsistent.
+Zielzustand (Soll/Contract): StoragePort verwaltet alle Dateizugriffe inkl. Fehlerpropagation, Marker-Verwaltung und Dry-Run-Unterstützung.
+Scope & Out-of-Scope: In Scope liegt Port-Definition + Adapter-Planung für Filesystem/Obsidian-APIs; Out-of-Scope ist tatsächliche IO-Implementierung.
+Entwurfsleitlinien (Planung):
+- Spezifizierung von `readDomainFile`, `writeDomainFile`, `ensureMarker` inkl. Fehlercodes.
+- Plane Migrationsstrategie: Legacy-Aufrufe wrappen, Dry-Run-Option für Tests und Preset-Diffs vorsehen.
+- Dokumentiere Telemetrie-Events für fehlgeschlagene Marker- oder Parse-Operationen.
+- Beschreibe Backups/Restore-Flows im Zusammenspiel mit Migration-Strategie.
+Abhängigkeiten: LIB-TD-0003, LIB-TD-0001.
+Risiken & Mitigation:
+- Gefahr unvollständiger Abdeckung alter Pfade → Mapping-Tabelle alt→neu vorbereiten.
+- Höhere Latenz durch zentrale Serialisierung → Cache-Konzept (read-through) planen.
+Test-Impact & Ankermuster:
+- Storage-Port-Vertragstests (Read/Write/Marker Fehlerszenarien).
+- Golden-Dry-Run gegen Preset-Dateien.
+Messgrößen (Erfolg):
+- 100% der Library-IO-Aufrufe laufen über StoragePort.
+- Fehlerfälle liefern strukturierte Codes statt Silent-Fails.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Methodenliste, Fehlerkatalog, Legacy-Mapping dokumentiert.
+  DoD (für Phase 4): Adapter implementiert, Dry-Run unterstützt, Telemetrie feuert bei Fehlern.
+Aufwand (T-Shirt): M
+Priorität (Score): 31.5
+Open Questions: Welche bestehenden Helper (z. B. `metadataCache`) bleiben externe Abhängigkeiten?
+
+### Work Package WP-A2: Modal ↔ Watcher Isolation
+
+ID: LIB-TD-0007
+Titel (imperativ): Etabliere Event-Bus-Port für Watcher-Orchestrierung
+Kategorie: Architektur
+Bezug (Trace): Debts: D-LIB-008; Risks: R-LIB-004, R-LIB-007; ADR: ADR-0004; WP: WP-A2
+Problem (Ist): Watcher und Debounce-Logik hängen direkt an Renderern/Modals; Listener werden pro Render neu angehängt und Timer leben über Lifecycle hinaus.
+Zielzustand (Soll/Contract): Typsicherer Event-Bus-Port kapselt Watcher, Debounce- und Save-Events; Renderer registrieren nur Lifecycle-Subscriptions.
+Scope & Out-of-Scope: Enthält Bus-API, Topic-Definitionen und Debounce-Policy; lässt Legacy-Store-Implementierung zunächst bestehen.
+Entwurfsleitlinien (Planung):
+- Definiere Topics (`terrain.updated`, `region.savePending`, etc.) samt Payload-Schema.
+- Plane Lifecycle-Bindung (`connect`/`dispose`) im Renderer-Kernel (abhängig von LIB-TD-0005).
+- Beschreibe Failover: Bus leitet Events wahlweise an Legacy-Callbacks weiter (Dual-Emit).
+- Dokumentiere Telemetrie für Drop-Zähler und Duplicate-Detection.
+Abhängigkeiten: LIB-TD-0005, LIB-TD-0003.
+Risiken & Mitigation:
+- Event-Verlust bei Kill-Switch → Replay-Puffer-Konzept vorsehen.
+- Doppelverarbeitung → Idempotenz-Checklisten definieren.
+Test-Impact & Ankermuster:
+- Event-Bus-Vertragstests mit Watcher-Mock.
+- Chaos-Proben: parallele Events, Bus-Reset, Kill-Switch.
+Messgrößen (Erfolg):
+- 0 direkte Watcher-Registrierungen mehr in Renderern/Modals.
+- Debounce-Timer pro Topic zentralisiert (max. 1 aktiver Timer).
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Topic-Matrix, Replay- und Dual-Emit-Konzept beschrieben.
+  DoD (für Phase 4): Bus ersetzt direkte Listener, Tests decken Failure-Modes ab.
+Aufwand (T-Shirt): M
+Priorität (Score): 27
+Open Questions: Welche Events benötigen garantierte Reihenfolge vs. eventual consistency?
+
+ID: LIB-TD-0008
+Titel (imperativ): Binde Create-Modals an Renderer-Lifecycle an
+Kategorie: Contracts
+Bezug (Trace): Debts: D-LIB-008; Risks: R-LIB-004, R-LIB-007; ADR: ADR-0002, ADR-0004; WP: WP-A2
+Problem (Ist): Modals (`CreateCreatureModal`, `CreateItemModal`) werden direkt instanziiert, ohne über `destroy()` aufzuräumen; offene Modals überleben Mode-Wechsel.
+Zielzustand (Soll/Contract): Modals registrieren sich über Renderer-Kernel-Hooks, erhalten Abort-/Dispose-Signale und geben Ressourcen (Watcher, Debounce) frei.
+Scope & Out-of-Scope: In Scope sind Lifecycle-Kontrakte und Adapter-Strategie; UI-Layout-Änderungen bleiben außen vor.
+Entwurfsleitlinien (Planung):
+- Beschreibe `ModalLifecycleAdapter` mit `open`, `onResolve`, `onAbort` Hooks.
+- Plane Migrationsschritte: Legacy `new Modal()` Aufrufe werden auf Adapter verlagert.
+- Definiere Abort-Policy bei Mode-Wechsel (z. B. Cancel + Telemetrie-Eintrag).
+- Dokumentiere Kill-Switch (`modal.lifecycle.enabled`) zur Rückkehr zu Legacy.
+Abhängigkeiten: LIB-TD-0007, LIB-TD-0006.
+Risiken & Mitigation:
+- Vergessene Modalpfade → Inventarliste aller `new Create*Modal`-Stellen erstellen.
+- Nutzer verliert ungespeicherte Daten → Auto-Draft/Prompt-Konzept prüfen.
+Test-Impact & Ankermuster:
+- Lifecycle-Kontrakt-Tests mit simulierten Mode-Wechseln.
+- Regressionstests: Modal öffnen/schließen während Watcher-Events.
+Messgrößen (Erfolg):
+- 100% der Modals melden `dispose` beim Kernel.
+- Keine offenen Debounce-Timer nach Mode-Wechsel (gemessen via Test-Harness).
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Adapter-API, Inventarliste, Abort-Policy dokumentiert.
+  DoD (für Phase 4): Alle Modals nutzen Adapter, Lifecycle-Tests grün, Kill-Switch verifiziert.
+Aufwand (T-Shirt): M
+Priorität (Score): 24
+Open Questions: Wie gehen wir mit parallel geöffneten Modals (z. B. Item + Creature) um?
+
+## Epic B: Shared Kernels & Templates
+
+### Work Package WP-B1: Renderer Kernel Einführung
+
+ID: LIB-TD-0005
+Titel (imperativ): Baue Renderer-Kernel mit Lifecycle-Orchestrierung
+Kategorie: Renderer
+Bezug (Trace): Debts: D-LIB-001, D-LIB-008; Risks: R-LIB-001, R-LIB-007; ADR: ADR-0002; WP: WP-B1
+Problem (Ist): Jeder Renderer implementiert Query-, Pagination- und Cleanup-Logik individuell; Lifecycle (render/setQuery/destroy) ist inkonsistent und teilweise asynchron.
+Zielzustand (Soll/Contract): Gemeinsamer Kernel stellt synchronisierte Lifecycle-Hooks (`bootstrap`, `connect`, `handleQuery`, `handleEvent`, `dispose`) bereit und garantiert Cleanup + Kill-Switch-Handhabung.
+Scope & Out-of-Scope: Enthält Kernel-API, Plugin-Schnittstellen und Error-Handling; UI-Templates bleiben unberührt.
+Entwurfsleitlinien (Planung):
+- Plane Modulstruktur (`src/apps/library/core/renderer-kernel`) mit generischen State-Maschinen.
+- Definiere Plugin-Contracts pro View-Typ (Listen, Tabellen, Codeblocks).
+- Beschreibe Integration in Application-Service-Port (LIB-TD-0003) und Event-Bus (LIB-TD-0007).
+- Skizziere Kill-Switch/Telemetry-Einbindung (`renderer.v2.enabled`).
+Abhängigkeiten: LIB-TD-0003, LIB-TD-0001.
+Risiken & Mitigation:
+- Übergeneralisierung → Proof-of-Concept mit CreaturesRenderer planen.
+- Performance-Kosten → Profiling-Plan (before/after) definieren.
+Test-Impact & Ankermuster:
+- Kernel-Vertragstests (Lifecycle, Error-Handling, Kill-Switch).
+- Regression: Vergleich Legacy vs. Kernel-Render-Ausgabe via Harness.
+Messgrößen (Erfolg):
+- Reduktion Renderer-spezifischer LOC um ≥ 25%.
+- Keine `async render()` Implementierungen mehr.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Kernel-API, Plugin-Typen, Telemetrie-Konzept dokumentiert.
+  DoD (für Phase 4): Kernel implementiert, CreaturesRenderer erfolgreich migriert, Tests grün.
+Aufwand (T-Shirt): L
+Priorität (Score): 20
+Open Questions: Benötigen wir unterschiedliche Kernel-Pipelines für Listen vs. Codeblock-Renderer?
+
+ID: LIB-TD-0006
+Titel (imperativ): Migriere Bibliotheksrenderer auf Kernel-Plugins
+Kategorie: Renderer
+Bezug (Trace): Debts: D-LIB-001, D-LIB-002, D-LIB-008; Risks: R-LIB-001, R-LIB-005, R-LIB-007; ADR: ADR-0002; WP: WP-B1
+Problem (Ist): Render-Implementierungen duplizieren Query-, Sortier- und Lifecycle-Logik, nutzen manuelle YAML-Pfade und hängen direkt an DOM/IO.
+Zielzustand (Soll/Contract): Alle Renderer nutzen Kernel-Plugins mit klaren `supportsQuery`, `renderView`, `bindEvents` Policies und beziehen Daten ausschließlich über Application-Service-Port.
+Scope & Out-of-Scope: Enthält Plugin-Mappings für Creatures, Items, Equipment, Terrains, Regions; ausgenommen sind Nicht-Library-Apps.
+Entwurfsleitlinien (Planung):
+- Erstelle Migrations-Backlog pro Renderer (Legacy-Analyse, Plugin-Schnittstellen, Tests).
+- Plane Parallelbetrieb (Legacy vs. Kernel) via Feature-Flag & Telemetrie Paritätszähler.
+- Definiere Mapping von Legacy Helpern auf neue Shared Components (Filter/Sort aus LIB-TD-0013).
+- Dokumentiere Rollback-Prozedur (Rebind auf Legacy Factory).
+Abhängigkeiten: LIB-TD-0005, LIB-TD-0003, LIB-TD-0004.
+Risiken & Mitigation:
+- Funktionale Regressionen → Golden/Contract-Tests als Gate.
+- Schulungsbedarf im Team → Knowledge-Sharing-Session einplanen.
+Test-Impact & Ankermuster:
+- Renderer-Vertrags- und Regressionstests pro Plugin.
+- Visual Diff Tests via Harness (DOM-Snapshot oder HTML-String).
+Messgrößen (Erfolg):
+- ≥ 30% Reduktion Renderer-spezifischer Dateien.
+- Telemetrie: ≤ 1% Legacy-Fallback nach 2 Release-Zyklen.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Plugin-Migrationsplan je Renderer, Flag-Strategie, Testplan freigegeben.
+  DoD (für Phase 4): Alle Renderer laufen über Kernel, Legacy deaktiviert, Paritätsmetriken stabil.
+Aufwand (T-Shirt): L
+Priorität (Score): 15
+Open Questions: Welche Renderer benötigen dedizierte Offline-Modi (z. B. Preset-Lesen ohne Service)?
+
+### Work Package WP-B2: Serializer Template & Validation DSL
+
+ID: LIB-TD-0009
+Titel (imperativ): Implementiere Serializer-Template-Policies
+Kategorie: Serializer
+Bezug (Trace): Debts: D-LIB-002, D-LIB-012; Risks: R-LIB-002, R-LIB-005; ADR: ADR-0003; WP: WP-B2
+Problem (Ist): Serialisierer sind monolithische Dateien (z. B. `creature-files.ts`), Policy-Logik ist verstreut und schwer testbar.
+Zielzustand (Soll/Contract): Serializer-Template bietet deklarative Policy-Liste (Defaults, Migration, Validation) je Domain, unterstützt Dry-Run und Versionierung.
+Scope & Out-of-Scope: In Scope ist Template-Design inkl. Policy-Schema; Out-of-Scope ist tatsächliche Portierung einzelner Domains.
+Entwurfsleitlinien (Planung):
+- Definiere Policy-Schema (`field`, `required`, `defaultValue`, `migrate`, `validate`).
+- Plane Template-Modulstruktur (`serializer-template/` + TypeScript-Typen).
+- Beschreibe Integration mit StoragePort (Dry-Run, Versionierung) und Telemetrie (Migration-Logs).
+- Dokumentiere Migrationsleitfaden für bestehende Serializer.
+Abhängigkeiten: LIB-TD-0001, LIB-TD-0004.
+Risiken & Mitigation:
+- Zu starres Schema → Erweiterungspunkte (Custom Transformers) einplanen.
+- Versionierungskonflikte → SemVer-Regeln klar definieren.
+Test-Impact & Ankermuster:
+- Template-Einheitstests inkl. Property-basierten Checks.
+- Golden-Roundtrip-Tests (via LIB-TD-0002) zur Verifikation.
+Messgrößen (Erfolg):
+- Template deckt ≥ 5 Policy-Typen ab.
+- Reduktion einzelner Serializer-Dateien um ≥ 30% nach Portierung.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Policy-Schema, Template-API, Migration-Guide abgestimmt.
+  DoD (für Phase 4): Template implementiert, Tests grün, Dokumentation vorhanden.
+Aufwand (T-Shirt): M
+Priorität (Score): 27
+Open Questions: Welche Sonderfelder (z. B. Spellcasting JSON) benötigen Custom-Transformer?
+
+ID: LIB-TD-0010
+Titel (imperativ): Portiere Creature/Item/Equipment-Serializer auf Template
+Kategorie: Serializer
+Bezug (Trace): Debts: D-LIB-002, D-LIB-004, D-LIB-005, D-LIB-006, D-LIB-007, D-LIB-012; Risks: R-LIB-002, R-LIB-005; ADR: ADR-0003; WP: WP-B2
+Problem (Ist): Serializer nutzen individuelle Implementierungen, importieren dynamisch (`import()` in Items/Equipment) und werfen Parse-Fehler nicht durch.
+Zielzustand (Soll/Contract): Alle Serializer nutzen Template-Policies, führen statische Imports aus und werfen strukturierte Fehler/Telemetry.
+Scope & Out-of-Scope: Enthält Portierungsplan pro Domain inkl. Legacy-Bridge; Spell-Serializer optional.
+Entwurfsleitlinien (Planung):
+- Sequenziere Portierung (Creatures → Items → Equipment) mit Telemetrie-Dual-Writes.
+- Plane Kill-Switch (`serializer.template.enabled`) je Domain.
+- Beschreibe Umgang mit Legacy-Files (Migration-Scripts, Backup-Plan).
+- Stelle sicher, dass Modal-Formen Template-Validierung verwenden (Schnittstelle zur Validation-DSL, LIB-TD-0011).
+Abhängigkeiten: LIB-TD-0009, LIB-TD-0004, LIB-TD-0003.
+Risiken & Mitigation:
+- Datenverlust durch falsche Migration → Dry-Run & Golden-Diff Pflicht.
+- Bundle-Aufblähung durch Duplikate → Review import-Pfade, Tree-Shaking-Konzept.
+Test-Impact & Ankermuster:
+- Golden-Roundtrip- und Property-Tests pro Domain.
+- Regressionstests für Import/Export-UI-Flows via Harness.
+Messgrößen (Erfolg):
+- Entfernen aller dynamischen Serializer-Imports.
+- Fehlerschleifen melden strukturierte Codes, keine Silent-Fails.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Portierungsplan, Kill-Switch-Konzept, Backup-Strategie dokumentiert.
+  DoD (für Phase 4): Alle drei Domains laufen über Template, Legacy deaktiviert, Golden-Tests grün.
+Aufwand (T-Shirt): L
+Priorität (Score): 15
+Open Questions: Wie behandeln wir benutzerdefinierte Markdown-Abschnitte, die nicht im Schema liegen?
+
+ID: LIB-TD-0011
+Titel (imperativ): Führe Validation-DSL für Domain-Daten ein
+Kategorie: Validation
+Bezug (Trace): Debts: D-LIB-009; Risks: R-LIB-002, R-LIB-006; ADR: ADR-0003; WP: WP-B2
+Problem (Ist): Validierungen (z. B. Encounter Odds) sind manuell und liefern bei Fehlern `undefined` ohne Nutzerfeedback.
+Zielzustand (Soll/Contract): Validation-DSL beschreibt Regeln deklarativ, liefert Fehlerobjekte `{ field, message, code }` und wird in Serializer-Template & UI-Modals geteilt.
+Scope & Out-of-Scope: Enthält DSL-Design, Fehlerkatalog und Integrationsplan; Out-of-Scope sind UI-Textänderungen (nur bestehende Meldungen nutzen).
+Entwurfsleitlinien (Planung):
+- Definiere Regeltypen (NumericalRange, Enum, DependentFields, CustomPredicate).
+- Plane Integration in Template (`policy.validate`) und Modal-Formen (`validateField`).
+- Dokumentiere Mapping von Fehlercodes zu UI-Feedback.
+- Beschreibe Property-Test-Strategie (fast-check) für kritische Regeln.
+Abhängigkeiten: LIB-TD-0009, LIB-TD-0001.
+Risiken & Mitigation:
+- Fehlkonfiguration der Regeln → Peer-Review-Checkliste einplanen.
+- UI-Noise durch zu viele Meldungen → Severity-Level & Debounce definieren.
+Test-Impact & Ankermuster:
+- Property-basierte Tests für Encounter-Odds, Terrain-Speed, Spell-Scaling.
+- Contract-Tests sicherstellen einheitliche Fehlerobjekte.
+Messgrößen (Erfolg):
+- 100% der Domain-Validierungen laufen über DSL.
+- Keine stillen `undefined` Werte mehr in Encounter Odds.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): DSL-Schema, Fehlerkatalog, Integrationspunkte dokumentiert.
+  DoD (für Phase 4): DSL implementiert, Tests grün, Renderer/Modals konsumieren DSL.
+Aufwand (T-Shirt): M
+Priorität (Score): 24
+Open Questions: Welche bestehenden Validierungs-Meldungen müssen für Mehrsprachigkeit parametrisiert werden?
+
+ID: LIB-TD-0012
+Titel (imperativ): Härte Preset-Import über Storage-Service ab
+Kategorie: Persistenz/IO
+Bezug (Trace): Debts: D-LIB-010; Risks: R-LIB-003; ADR: ADR-0003; WP: WP-B2
+Problem (Ist): `shouldImportPluginPresets` meldet Erfolg trotz Marker-Fehlern; wiederholte Importe erzeugen Duplikate.
+Zielzustand (Soll/Contract): Preset-Import nutzt StoragePort mit atomaren Marker-Operationen, Telemetrie bei Fehlversuch und Dry-Run-Möglichkeit.
+Scope & Out-of-Scope: Enthält Import-Workflow, Marker-Verwaltung, Telemetrie; keine neuen Preset-Typen.
+Entwurfsleitlinien (Planung):
+- Plane Marker-API (`createMarker`, `verifyMarker`) mit idempotenten Operationen.
+- Beschreibe Dry-Run-Modus: Import führt nur Validierung + Telemetrie aus.
+- Definiere Fehlerbehandlung (Retry-Strategien, Backoff) und Kill-Switch.
+- Dokumentiere Backups vor Preset-Reimport.
+Abhängigkeiten: LIB-TD-0004, LIB-TD-0009.
+Risiken & Mitigation:
+- Race-Conditions bei parallelen Imports → Locking-Konzept entwerfen.
+- Marker-Dateien unzugänglich → Fallback auf in-memory Marker + Warnung.
+Test-Impact & Ankermuster:
+- Storage-Port-Tests für Marker-Operationen.
+- Regressionstest: Import bei fehlgeschlagenem Marker erzeugt keine Duplikate.
+Messgrößen (Erfolg):
+- Marker-Fehler führen zu Telemetrie + Abbruch (0% Silent-Success).
+- Wiederholte Starts erzeugen keine Preset-Duplikate im Dry-Run.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Marker-Workflow, Retry-Strategie, Telemetrie-Plan dokumentiert.
+  DoD (für Phase 4): Import nutzt StoragePort, Telemetrie aktiv, Tests grün.
+Aufwand (T-Shirt): M
+Priorität (Score): 24
+Open Questions: Müssen bestehende Marker-Dateien migriert oder nur validiert werden?
+
+## Epic C: Konsolidierung & Cleanup
+
+### Work Package WP-C1: Filter/Sort/Search Pipeline
+
+ID: LIB-TD-0013
+Titel (imperativ): Vereinheitliche Query- und Filter-Pipeline
+Kategorie: Architektur
+Bezug (Trace): Debts: D-LIB-001, D-LIB-002; Risks: R-LIB-001, R-LIB-005; ADR: ADR-0002; WP: WP-C1
+Problem (Ist): Jede Renderer-Liste verwaltet eigene Filter-/Sortier-Utilities; Query-Verhalten unterscheidet sich und kopiert Codeblöcke.
+Zielzustand (Soll/Contract): Gemeinsame Pipeline liefert deterministisches Filtering/Sorting/Search, wird vom Renderer-Kernel konsumiert und kann Domain-spezifische Plugins laden.
+Scope & Out-of-Scope: In Scope ist Pipeline-Design inkl. Plugin-Hooks; Out-of-Scope sind UI-Änderungen (Filter-Widgets bleiben).
+Entwurfsleitlinien (Planung):
+- Modellieren Query-DSL (`term`, `tags`, `type`) mit Parser und Normalizer.
+- Plane Domain-spezifische Filter-Plugins (Creatures Stats, Item Rarity etc.).
+- Beschreibe Performance-Metriken und Caching-Strategie (Memoization, incremental updates).
+- Dokumentiere Migration: Legacy Utils deprecaten, Kernel-Pipeline injizieren.
+Abhängigkeiten: LIB-TD-0005, LIB-TD-0003.
+Risiken & Mitigation:
+- Edge-Cases (z. B. Regex) verlieren Support → Regression-Suite mit Golden-Queries.
+- Performance-Einbruch bei großen Listen → Benchmark-Plan (1k Items) definieren.
+Test-Impact & Ankermuster:
+- Property-Tests (idempotente Filter, sort stability).
+- Golden-Query-Set (z. B. Top 20 Suchbegriffe) gegen Legacy vergleichen.
+Messgrößen (Erfolg):
+- Entfernen von ≥ 5 duplizierten Utility-Funktionen.
+- Query-Latenz ≤ Legacy ±10% bei 1k Items.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Query-DSL, Plugin-Schnittstellen, Benchmark-Plan abgestimmt.
+  DoD (für Phase 4): Pipeline implementiert, Legacy Utils entfernt, Regressionen grün.
+Aufwand (T-Shirt): M
+Priorität (Score): 18
+Open Questions: Benötigen wir Ranking-Boosts (z. B. Favoriten) im gemeinsamen Modell?
+
+### Work Package WP-C2: Store Simplification
+
+ID: LIB-TD-0014
+Titel (imperativ): Straffe Library-Stores und Watcher-States
+Kategorie: Architektur
+Bezug (Trace): Debts: D-LIB-008; Risks: R-LIB-004; ADR: ADR-0004; WP: WP-C2
+Problem (Ist): Terrain/Region-Stores halten doppelte Dirty-Flags und Debounce-Timer; Events verteilen sich über mehrere Helper.
+Zielzustand (Soll/Contract): Stores erhalten Events ausschließlich über Event-Bus, verwalten Dirty-State zentral und unterstützen deterministisches Flush-Verhalten.
+Scope & Out-of-Scope: In Scope sind Store-Zuschnitt, Removal alter Helper, Telemetrie-Kennzahlen; Out-of-Scope ist UI-Kopplung.
+Entwurfsleitlinien (Planung):
+- Inventarisiere bestehende Stores/Helper, mappe auf neue Event-Bus-Themen.
+- Plane Dirty-State-Maschine (states: clean, dirty, flushing) mit Transitionstabellen.
+- Beschreibe Flush-Policy (`flushSave` Trigger) inkl. Kill-Switch.
+- Dokumentiere Rollback (Legacy Helper modul wieder aktivierbar).
+Abhängigkeiten: LIB-TD-0007, LIB-TD-0005.
+Risiken & Mitigation:
+- Fehlende Events nach Simplifizierung → Monitoring (Telemetry) + Shadow-Mode.
+- Datenverlust bei Flush → Backup + Regressionstests (Debounce-Szenarien).
+Test-Impact & Ankermuster:
+- State-Machine-Tests für Dirty/Flush.
+- Chaos-Tests (rapid switches, event storms).
+Messgrößen (Erfolg):
+- Reduktion der Store-Dateien um ≥ 20% LOC.
+- Keine verlorenen Debounce-Saves mehr in Tests.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): State-Machine-Design, Event-Mapping, Kill-Switch dokumentiert.
+  DoD (für Phase 4): Stores vereinfacht, Dirty-States zentral, Tests grün.
+Aufwand (T-Shirt): M
+Priorität (Score): 20
+Open Questions: Müssen wir Legacy-Debounce-Dauern beibehalten oder können wir konfigurieren?
+
+ID: LIB-TD-0015
+Titel (imperativ): Entferne Debug-Logging und obsolet gewordene Watcher-Hooks
+Kategorie: Cleanup
+Bezug (Trace): Debts: D-LIB-003, D-LIB-008; Risks: R-LIB-004; ADR: ADR-0004; WP: WP-C2
+Problem (Ist): CreaturesRenderer loggt Metadaten bei jedem Render; Watcher-Helfer behalten alte Listener, was Debugging erschwert und Latenzen erzeugt.
+Zielzustand (Soll/Contract): Logging folgt Telemetrie-Policy (Sampling, Level), veraltete Watcher-Hooks werden entfernt oder durch Event-Bus ersetzt.
+Scope & Out-of-Scope: In Scope ist Logging-/Watcher-Aufräumplan; Out-of-Scope sind neue Telemetrie-Features (durch LIB-TD-0016 abgedeckt).
+Entwurfsleitlinien (Planung):
+- Identifiziere Debug-Logs & Alarme, ordne neuen Telemetrie-Leveln zu.
+- Plane Entfernung redundanter Watcher-Registrierungen nach Store-Konsolidierung.
+- Beschreibe Review-Checklist zur Sicherstellung, dass keine funktionalen Logs verschwinden.
+Abhängigkeiten: LIB-TD-0007, LIB-TD-0014.
+Risiken & Mitigation:
+- Verlust hilfreicher Diagnosen → Ersatz via Telemetrie-Ereignisse definieren.
+- Unentdeckte Rest-Logs → Static Analysis (`eslint` Rule) planen.
+Test-Impact & Ankermuster:
+- Smoke-Tests sichern, dass keine Watcher mehr doppelt feuern.
+- Lint-Regel-Tests für verbotene Logger-Aufrufe.
+Messgrößen (Erfolg):
+- 0 ungefilterte `console.log` im Library-Code.
+- Reduzierte Event-Doppelung in Chaos-Tests (≤ 1%).
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Liste der zu entfernenden Logs/Watcher, Telemetrie-Ersatzplan vorhanden.
+  DoD (für Phase 4): Logs entfernt/ersetzt, Static-Analysis-Regel aktiv, Tests grün.
+Aufwand (T-Shirt): S
+Priorität (Score): 16
+Open Questions: Müssen wir temporäre Debug-Flags für QA beibehalten?
+
+## Epic D: Test & Rollout Enablement (Fortsetzung)
+
+### Work Package WP-D2: Telemetry & Kill Switches
+
+ID: LIB-TD-0016
+Titel (imperativ): Etabliere Feature-Flag-Registry und Paritäts-Telemetrie
+Kategorie: Build/Infra
+Bezug (Trace): Risks: R-LIB-001, R-LIB-003, R-LIB-004; ADR: ADR-0002, ADR-0003, ADR-0004; WP: WP-D2
+Problem (Ist): Es existiert keine zentrale Verwaltung für Feature-Flags/Kill-Switches; Telemetrie zur Paritätsprüfung ist ad hoc.
+Zielzustand (Soll/Contract): Feature-Flag-Registry verwaltet Flags (`renderer.v2.enabled`, `serializer.template.enabled`, etc.) mit Remote-Override; Telemetrie liefert Paritätszähler und Divergenz-Alarme.
+Scope & Out-of-Scope: In Scope sind Registry-Design, Konfigurations-Dateiformat, Telemetrie-Events; Out-of-Scope ist Backend-Anbindung außerhalb Obsidian.
+Entwurfsleitlinien (Planung):
+- Plane Registry-Modul (Singleton oder DI) mit statischer Konfiguration + Override-Mechanismus.
+- Beschreibe Telemetrie-Schema (Counters, Divergenz-Schwellen) und Dashboard-Export.
+- Definiere Rollout-Checkliste (Flag-Etablierung, Default-Werte, QA-Playbook).
+- Dokumentiere Sicherheitsmaßnahmen (Fail-Closed Verhalten bei Flag-Ladefehlern).
+Abhängigkeiten: LIB-TD-0005, LIB-TD-0009, LIB-TD-0007.
+Risiken & Mitigation:
+- Flags werden inkonsistent gelesen → Provide Type-Safe Accessor API.
+- Telemetrie erzeugt Overhead → Sampling-Strategie und Rate-Limits planen.
+Test-Impact & Ankermuster:
+- Contract-Tests für Flag-API (Default, Override, Kill-Switch).
+- Integrationstests für Telemetrie-Paritätszähler (Legacy vs. v2 Pfade).
+Messgrößen (Erfolg):
+- Alle neuen Pfade nutzen Registry (0 direkte Flag-Strings).
+- Paritätsmetriken zeigen Divergenz < 1% nach Rollout.
+Akzeptanzkriterien:
+  DoR (Ready für Phase 4): Flag-Liste, Override-Strategie, Telemetrie-Schema dokumentiert.
+  DoD (für Phase 4): Registry implementiert, Flags integriert, Telemetrie sendet Daten.
+Aufwand (T-Shirt): M
+Priorität (Score): 21
+Open Questions: Müssen Flags zur Laufzeit persistiert werden (z. B. in Workspace-Settings)?

--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -1,0 +1,21 @@
+# Phase 3 Kanban Export
+
+## Ready for Phase 4
+- [ ] LIB-TD-0001 – Vertragstest-Harness (keine Abhängigkeiten)
+
+## Backlog (wartet auf vorgelagerte ToDos)
+- [ ] LIB-TD-0002 – Golden-Files (wartet auf LIB-TD-0001)
+- [ ] LIB-TD-0003 – Application-Service-Port (wartet auf LIB-TD-0001)
+- [ ] LIB-TD-0004 – StoragePort-Kapselung (wartet auf LIB-TD-0003 & LIB-TD-0001)
+- [ ] LIB-TD-0005 – Renderer-Kernel (wartet auf LIB-TD-0003 & LIB-TD-0001)
+- [ ] LIB-TD-0006 – Renderer-Migration (wartet auf LIB-TD-0005, LIB-TD-0003, LIB-TD-0004)
+- [ ] LIB-TD-0007 – Event-Bus-Port (wartet auf LIB-TD-0005 & LIB-TD-0003)
+- [ ] LIB-TD-0008 – Modal-Lifecycle (wartet auf LIB-TD-0007 & LIB-TD-0006)
+- [ ] LIB-TD-0009 – Serializer-Template (wartet auf LIB-TD-0001 & LIB-TD-0004)
+- [ ] LIB-TD-0010 – Serializer-Portierung (wartet auf LIB-TD-0009, LIB-TD-0004, LIB-TD-0003)
+- [ ] LIB-TD-0011 – Validation-DSL (wartet auf LIB-TD-0009 & LIB-TD-0001)
+- [ ] LIB-TD-0012 – Preset-Import-Härtung (wartet auf LIB-TD-0004 & LIB-TD-0009)
+- [ ] LIB-TD-0013 – Query-Pipeline (wartet auf LIB-TD-0005 & LIB-TD-0003)
+- [ ] LIB-TD-0014 – Store-Straffung (wartet auf LIB-TD-0007 & LIB-TD-0005)
+- [ ] LIB-TD-0015 – Logging/Watcher-Cleanup (wartet auf LIB-TD-0007 & LIB-TD-0014)
+- [ ] LIB-TD-0016 – Feature-Flags & Telemetrie (wartet auf LIB-TD-0005, LIB-TD-0009, LIB-TD-0007)

--- a/docs/refactor/library/phase-3/planning-briefs/AGENTS.md
+++ b/docs/refactor/library/phase-3/planning-briefs/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Enthält pro ToDo eine Planning-Notiz mit Kontext, Teamaufstellung und offenen Punkten.
+
+# Aktueller Stand
+- Keine Briefings vorhanden; werden im Rahmen von Phase 3 erstellt.
+
+# ToDo
+- Für jede neue ToDo-Karte ein aktuelles Briefing anlegen und bei Änderungen synchron halten.
+
+# Standards
+- Dateiname entspricht der ToDo-ID (`LIB-TD-####.md`).
+- Struktur: Kurzüberblick, Stakeholder, Zeitplanung, Vorbereitungen.
+- Keine vertraulichen Daten, nur interne Planungsinfos.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0001.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0001.md
@@ -1,0 +1,22 @@
+# LIB-TD-0001 Planning Brief
+
+## Kurzüberblick
+Aufbau eines gemeinsamen Vertragstest-Harness für Renderer-, Storage-, Serializer- und Event-Ports. Liefert die Grundlage für alle weiteren Refactor-Schritte und stellt sicher, dass Legacy- und Zielarchitektur vergleichbar getestet werden können.
+
+## Stakeholder
+- Tech Lead Library (Owner)
+- QA Automation (Review Harness-API)
+- DevOps (CI-Integration)
+
+## Zeitplanung
+- Woche 1: Harness-API und Fixture-Design abstimmen.
+- Woche 2: Implementierungsplan finalisieren, CI-Integration skizzieren.
+- Woche 3: Review & Abnahme durch QA/DevOps.
+
+## Vorbereitungen
+- Phase-1/2-Dokumente zu Ports sichten (Renderer v2, StoragePort, Event-Bus, Serializer-Template).
+- Beispiel-Datensätze aus Presets/Persistenz sammeln.
+- CI-Pipeline-Anforderungen (npm Scripts, Cache) auflisten.
+
+## Offene Punkte
+- Entscheidung, ob Telemetrie-Stubs direkt im Harness simuliert werden oder erst in LIB-TD-0016.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0002.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0002.md
@@ -1,0 +1,22 @@
+# LIB-TD-0002 Planning Brief
+
+## Kurzüberblick
+Erstellung und Versionierung von Golden-Files für alle Serializer-Domänen, um Roundtrip-Regressionen sichtbar zu machen und Dry-Run-Validierungen zu ermöglichen.
+
+## Stakeholder
+- Serializer-Domain Leads (Creatures, Items, Equipment)
+- QA Automation (Golden-Update-Prozess)
+- Documentation (Change-Log der Fixtures)
+
+## Zeitplanung
+- Woche 1: Datensätze auswählen, Sampling-Strategie definieren.
+- Woche 2: Generierung via Harness vorbereiten, Review-Prozess vereinbaren.
+- Woche 3: Golden-Files finalisieren, Update-Skript dokumentieren.
+
+## Vorbereitungen
+- Bestehende Preset-Dateien inventarisieren und nach Relevanz priorisieren.
+- Naming-Convention für Golden-Dateien und Manifeste festlegen.
+- Abstimmung mit QA über Review-Schritte und Diff-Tools.
+
+## Offene Punkte
+- Entscheidung, ob Nutzerbeispiele (Community) für zusätzliche Golden-Cases einbezogen werden können.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0003.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0003.md
@@ -1,0 +1,22 @@
+# LIB-TD-0003 Planning Brief
+
+## Kurzüberblick
+Definition eines Application-Service-Ports, der Renderer von direkter IO entkoppelt und synchrone Lifecycle-Garantien herstellt.
+
+## Stakeholder
+- Library Tech Lead (Port-Owner)
+- Domain Architects (Creatures/Items/Equipment)
+- QA (Vertrags-Review)
+
+## Zeitplanung
+- Woche 1: DTO-Inventar erstellen, Port-Signaturen draften.
+- Woche 2: Review mit Domain-Ownern und Event-Bus-Team.
+- Woche 3: Finalisierung des Spezifikationsdokuments inkl. Feature-Flag-Plan.
+
+## Vorbereitungen
+- Bestandsaufnahme aller Render-Aufrufe von IO/Stores.
+- Abstimmung mit StoragePort-Design (LIB-TD-0004).
+- Definition von Fehlercodes & Telemetrie-Schnittstellen.
+
+## Offene Punkte
+- Klärung, welche Langläufer-Operationen (Preset-Scans) Streaming oder Paging benötigen.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0004.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0004.md
@@ -1,0 +1,22 @@
+# LIB-TD-0004 Planning Brief
+
+## Kurzüberblick
+Kapselung sämtlicher Dateizugriffe der Library hinter einem StoragePort inklusive Fehlerstrategie, Marker-Handling und Dry-Run-Unterstützung.
+
+## Stakeholder
+- Storage/IO Team (Owner)
+- QA (Fehlerkatalog, Dry-Run Tests)
+- Release Manager (Backup-Strategie)
+
+## Zeitplanung
+- Woche 1: Methoden- und Fehlerkatalog erstellen.
+- Woche 2: Legacy-Mapping fertigstellen, Dry-Run-Konzept entwerfen.
+- Woche 3: Review mit QA & Release, Telemetrie-Plan abstimmen.
+
+## Vorbereitungen
+- Übersicht aller aktuellen IO-Hilfsfunktionen sammeln.
+- Abhängigkeiten zu Preset-Import und Serializer dokumentieren.
+- Evaluieren, welche bestehenden Caches weiter genutzt werden müssen.
+
+## Offene Punkte
+- Entscheidung, ob Marker-Dateien transaktional oder via Locking abgesichert werden.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0005.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0005.md
@@ -1,0 +1,22 @@
+# LIB-TD-0005 Planning Brief
+
+## Kurzüberblick
+Entwicklung eines Renderer-Kernels, der Lifecycle, Query-Verarbeitung und Cleanup zentral steuert und damit Duplikate eliminiert.
+
+## Stakeholder
+- Renderer Guild Lead (Owner)
+- Application-Service-Team
+- Telemetry/Observability Team
+
+## Zeitplanung
+- Woche 1: Kernel-API entwerfen, Prototyp für CreaturesRenderer planen.
+- Woche 2: Plugin-Schnittstellen definieren, Telemetrie-/Kill-Switch-Konzept abstimmen.
+- Woche 3: Review & Abnahme, Performance-Messplan finalisieren.
+
+## Vorbereitungen
+- Analyse der bestehenden Renderer-Lifecycles und Listener.
+- Sammlung der notwendigen Query/Filter-Hooks (Koordination mit LIB-TD-0013).
+- Abstimmung mit Event-Bus-Planung (LIB-TD-0007).
+
+## Offene Punkte
+- Entscheidung, ob Codeblock-basierte Renderer (Terrains/Regions) separate Plugin-Typen benötigen.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0006.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0006.md
@@ -1,0 +1,22 @@
+# LIB-TD-0006 Planning Brief
+
+## Kurzüberblick
+Migration aller Library-Renderer auf den neuen Kernel inklusive Feature-Flag-Strategie und Telemetrie-Paritätschecks.
+
+## Stakeholder
+- Renderer Guild Lead
+- QA Regression Team
+- Product Support (Kommunikation Rollout)
+
+## Zeitplanung
+- Woche 1: Migrations-Backlog je Renderer erstellen, Flag-Plan definieren.
+- Woche 2: Paritätsmetriken festlegen, Wissenstransfer-Sessions vorbereiten.
+- Woche 3: Abnahme des Gesamtplans, Rollback-Playbook finalisieren.
+
+## Vorbereitungen
+- Erhebung aller Renderer-spezifischen Abhängigkeiten (Helper, Templates, Modals).
+- Abstimmung mit Service-Port (LIB-TD-0003) und StoragePort (LIB-TD-0004).
+- Golden-/Contract-Testabdeckung überprüfen (LIB-TD-0001/0002).
+
+## Offene Punkte
+- Bedarf einer gestaffelten Aktivierung pro Nutzergruppe klären.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0007.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0007.md
@@ -1,0 +1,22 @@
+# LIB-TD-0007 Planning Brief
+
+## Kurzüberblick
+Einführung eines Event-Bus-Ports, der Watcher- und Debounce-Mechaniken zentralisiert und Lifecycle-Hooks des Kernels nutzt.
+
+## Stakeholder
+- Event/Watcher Team (Owner)
+- Renderer Kernel Team
+- QA Chaos-Test-Team
+
+## Zeitplanung
+- Woche 1: Topic-Matrix und Payload-Schemata erarbeiten.
+- Woche 2: Replay-/Dual-Emit-Konzept mit Stakeholdern abstimmen.
+- Woche 3: Failure-Handling und Telemetrie-Plan finalisieren.
+
+## Vorbereitungen
+- Analyse aktueller Watcher-Registrierungen und Timer.
+- Anforderungen aus Store-Refactor (LIB-TD-0014) sammeln.
+- Abstimmung mit Telemetrie-Plan (LIB-TD-0016) für Drop-Zähler.
+
+## Offene Punkte
+- Entscheidung über Persistenz des Replay-Puffers (in-memory vs. Datei).

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0008.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0008.md
@@ -1,0 +1,22 @@
+# LIB-TD-0008 Planning Brief
+
+## Kurzüberblick
+Aufbau eines Modal-Lifecycle-Adapters, der Create-Dialogs an Kernel-Hooks bindet und sauberes Dispose gewährleistet.
+
+## Stakeholder
+- Modal/UI Team (Owner)
+- Renderer Kernel Team
+- UX Writer (Bestätigung bestehender Texte)
+
+## Zeitplanung
+- Woche 1: Modal-Inventar erstellen, Lifecycle-Anforderungen definieren.
+- Woche 2: Adapter-API designen, Abort-Policy abstimmen.
+- Woche 3: Kill-Switch-Plan und Regressionstestspezifikation finalisieren.
+
+## Vorbereitungen
+- Liste aller `new Create*Modal`-Aufrufe inkl. Kontext zusammentragen.
+- Abstimmung mit Event-Bus-Team zu Debounce/Watcher-Übergabe.
+- Prüfen, ob UI-Prompts für Abbruch bereits vorhanden sind.
+
+## Offene Punkte
+- Umgang mit simultan geöffneten Modals (z. B. Item + Creature) final klären.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0009.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0009.md
@@ -1,0 +1,22 @@
+# LIB-TD-0009 Planning Brief
+
+## Kurzüberblick
+Design eines Serializer-Templates mit deklarativen Policies, Dry-Run-Unterstützung und Telemetrie-Anbindung als Grundlage für alle Domain-Serializer.
+
+## Stakeholder
+- Serializer Architecture Lead (Owner)
+- StoragePort Team
+- QA Property Testing
+
+## Zeitplanung
+- Woche 1: Policy-Schema entwerfen, Versionierungsregeln definieren.
+- Woche 2: Template-Modulstruktur planen, Integration mit StoragePort abstimmen.
+- Woche 3: Review & Teststrategie (Property/Golen) finalisieren.
+
+## Vorbereitungen
+- Analyse bestehender Serializer (Creatures, Items, Equipment) bezüglich Policy-Muster.
+- Anforderungen aus Validation-DSL (LIB-TD-0011) sammeln.
+- Telemetrie-Events und Logging-Konzept vorbereiten.
+
+## Offene Punkte
+- Umfang von Custom-Transformern für Spezialfelder (z. B. Spellcasting JSON) abstimmen.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0010.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0010.md
@@ -1,0 +1,23 @@
+# LIB-TD-0010 Planning Brief
+
+## Kurzüberblick
+Portierung der Creature-, Item- und Equipment-Serializer auf das neue Template inklusive Kill-Switch, Dual-Writes und Backup-Plan.
+
+## Stakeholder
+- Serializer Architecture Lead
+- Domain Leads (Creatures/Items/Equipment)
+- QA Regression Team
+- Customer Support (Kommunikation bei Migrationen)
+
+## Zeitplanung
+- Woche 1: Portierungsreihenfolge festlegen, Risikobewertung je Domain durchführen.
+- Woche 2: Backup-/Restore-Strategie finalisieren, Kill-Switch-Konfiguration definieren.
+- Woche 3: Review der Testpläne (Golden, Property, UI-Regression).
+
+## Vorbereitungen
+- Inventur aktueller Serializer-Einstiegspunkte inkl. dynamischer Imports.
+- Abstimmung mit Validation-DSL (LIB-TD-0011) und Modal-Team bzgl. Fehleroberflächen.
+- Erstellung einer Liste kritischer Nutzer-Dateien für Dry-Run-Diffs.
+
+## Offene Punkte
+- Umgang mit benutzerdefinierten Markdown-Blöcken, die nicht im Schema auftauchen.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0011.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0011.md
@@ -1,0 +1,23 @@
+# LIB-TD-0011 Planning Brief
+
+## Kurzüberblick
+Aufbau einer Validation-DSL, die Domain-Regeln deklarativ abbildet und von Serializer-Template sowie UI-Modals genutzt wird.
+
+## Stakeholder
+- Validation/Rules Team (Owner)
+- Serializer Architecture Team
+- Modal/UI Team
+- QA Property Testing
+
+## Zeitplanung
+- Woche 1: Regeltypen und Fehlerkatalog definieren.
+- Woche 2: Schnittstellen zum Template und zu den Modals abstimmen.
+- Woche 3: Property-Teststrategie dokumentieren, Review abschließen.
+
+## Vorbereitungen
+- Analyse bestehender Validierungslogik (Regions, Terrains, Spells).
+- Sammlung bestehender Fehlermeldungstexte zur Wiederverwendung.
+- Evaluierung von fast-check Setups für Property-Tests.
+
+## Offene Punkte
+- Klärung, ob Mehrsprachigkeit perspektivisch berücksichtigt werden muss.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0012.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0012.md
@@ -1,0 +1,23 @@
+# LIB-TD-0012 Planning Brief
+
+## Kurzüberblick
+Härtung des Preset-Import-Workflows durch Nutzung des StoragePorts, atomare Marker-Verwaltung und Dry-Run/Parellelitäts-Kontrollen.
+
+## Stakeholder
+- Preset/Content Team (Owner)
+- Storage/IO Team
+- Telemetry Team
+- QA Regression Team
+
+## Zeitplanung
+- Woche 1: Marker-Workflow und Retry-Strategie definieren.
+- Woche 2: Dry-Run-/Backup-Konzept abstimmen, Telemetrie-Ereignisse spezifizieren.
+- Woche 3: Review mit Content-Team, Rollback-Checkliste finalisieren.
+
+## Vorbereitungen
+- Erfassung aktueller Preset-Dateien und Marker-Orte.
+- Analyse bisheriger Fehlerberichte zu Preset-Duplikaten.
+- Abstimmung mit Feature-Flag-Plan (LIB-TD-0016) für Kill-Switch.
+
+## Offene Punkte
+- Bedarf für Migration bestehender Marker-Dateien oder reine Validierung?

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0013.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0013.md
@@ -1,0 +1,22 @@
+# LIB-TD-0013 Planning Brief
+
+## Kurzüberblick
+Konsolidierung der Query/Filter/Search-Logik in eine gemeinsame Pipeline, die der Renderer-Kernel nutzt und Domain-spezifische Plugins erlaubt.
+
+## Stakeholder
+- Renderer Kernel Team
+- Domain Leads (Creatures/Items/Equipment)
+- Performance Engineering
+
+## Zeitplanung
+- Woche 1: Query-DSL und Plugin-Hooks definieren.
+- Woche 2: Benchmark-Plan und Golden-Query-Set abstimmen.
+- Woche 3: Review der Migration (Legacy-Utils → neue Pipeline).
+
+## Vorbereitungen
+- Sammlung aller bestehenden Filter-/Sortierfunktionen und Parameter.
+- Abstimmung mit Application-Service-Port (LIB-TD-0003) zu DTO-Formaten.
+- Performance-Metriken und Testumgebung (1k Items Szenario) vorbereiten.
+
+## Offene Punkte
+- Bedarf zusätzlicher Ranking-Kriterien (Favoriten, zuletzt genutzt) evaluieren.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0014.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0014.md
@@ -1,0 +1,22 @@
+# LIB-TD-0014 Planning Brief
+
+## Kurzüberblick
+Straffung der Library-Stores und Watcher-States durch Anbindung an den Event-Bus und zentrale Dirty-State-Maschine.
+
+## Stakeholder
+- Store/State Management Team (Owner)
+- Event-Bus Team
+- QA Chaos-Test-Team
+
+## Zeitplanung
+- Woche 1: Inventur bestehender Stores/Helper, State-Machine-Entwurf erstellen.
+- Woche 2: Event-Mapping & Flush-Policy abstimmen.
+- Woche 3: Review & Rollback-Plan fertigstellen.
+
+## Vorbereitungen
+- Sammlung aktueller Debounce-/Flush-Konfigurationen.
+- Abstimmung mit Telemetrie (LIB-TD-0016) für Dirty-State-Metriken.
+- Sicherstellen, dass Harness Tests für Debounce-Fälle vorbereitet sind (LIB-TD-0001).
+
+## Offene Punkte
+- Ob bestehende Debounce-Zeiten unverändert bleiben oder konfigurierbar gemacht werden.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0015.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0015.md
@@ -1,0 +1,22 @@
+# LIB-TD-0015 Planning Brief
+
+## Kurzüberblick
+Bereinigung von Debug-Logging und obsoleten Watcher-Hooks nach Store-/Event-Bus-Umbau, inklusive Einführung einer Lint-Regel.
+
+## Stakeholder
+- Store/State Management Team
+- Observability/Telemetry Team
+- QA Smoke-Test-Team
+
+## Zeitplanung
+- Woche 1: Liste redundanter Logs/Watcher erstellen.
+- Woche 2: Telemetrie-Ersatz definieren, Lint-Regel konzipieren.
+- Woche 3: Review & Freigabe des Aufräumplans.
+
+## Vorbereitungen
+- Sammlung aktueller Logger-Aufrufe im Library-Code.
+- Definition erlaubter Telemetrie-Level und Sampling-Regeln.
+- Abstimmung mit Event-Bus- und Store-Team zum Timing (nach LIB-TD-0014).
+
+## Offene Punkte
+- Bedarf temporärer Debug-Flags für QA-Builds prüfen.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0016.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0016.md
@@ -1,0 +1,23 @@
+# LIB-TD-0016 Planning Brief
+
+## Kurzüberblick
+Aufbau einer zentralen Feature-Flag-Registry mit Paritäts-Telemetrie zur Überwachung des Rollouts neuer Renderer-, Serializer- und Event-Bus-Pfade.
+
+## Stakeholder
+- DevOps/Infrastructure Team (Owner)
+- Telemetry/Analytics Team
+- Product Management (Rollout-Steuerung)
+- Security (Konfigurations-Sicherheit)
+
+## Zeitplanung
+- Woche 1: Flag-Inventar und Override-Strategie definieren.
+- Woche 2: Telemetrie-Schema (Counters, Divergenzschwellen) erarbeiten.
+- Woche 3: Review mit Product/Security, Rollout-Playbook erstellen.
+
+## Vorbereitungen
+- Liste aller benötigten Flags und Kill-Switches aus Backlog zusammenstellen.
+- Anforderungen der Telemetrie (Sampling, Storage) sammeln.
+- Evaluieren, ob bestehende Config-Dateien erweitert oder neue Module benötigt werden.
+
+## Offene Punkte
+- Persistenzbedarf für Nutzer-spezifische Flag-Overrides klären.

--- a/docs/refactor/library/phase-3/traceability.md
+++ b/docs/refactor/library/phase-3/traceability.md
@@ -1,0 +1,63 @@
+# Traceability Matrix – Phase 3
+
+## Referenzquellen
+- **Technical Debt Register (Phase 1)** – `docs/refactor/library/phase-1/technical-debt-register.csv`
+- **Risk Log (Phase 1)** – `docs/refactor/library/phase-1/risks.md`
+- **Target Architecture & Work Packages (Phase 2)** – `docs/refactor/library/phase-2/work-packages.md`
+- **Contracts & ADRs (Phase 2)** – `docs/refactor/library/phase-2/contracts/*.md`, `docs/refactor/library/phase-2/adrs/*.md`
+
+Die nachfolgenden Tabellen verwenden konsistente IDs:
+- **Debt-IDs** `D-LIB-###` entsprechen den Einträgen (Reihenfolge wie im Phase-1-Register).
+- **Risk-IDs** `R-LIB-###` entsprechen den Risiken aus `risks.md`.
+
+## Technical Debt → ToDo → Work Package
+
+| Debt-ID | Beschreibung (Kurzfassung) | Quelle | ToDo-IDs | Work Package |
+| --- | --- | --- | --- | --- |
+| D-LIB-001 | Async `render()` & direkte IO-Zugriffe in Renderern | `technical-debt-register.csv` Zeile "Async render promise dropped" | LIB-TD-0003, LIB-TD-0005, LIB-TD-0006, LIB-TD-0013 | WP-A1, WP-B1, WP-C1 |
+| D-LIB-002 | Manuelle YAML-Parsing-Pfade in Creatures | `technical-debt-register.csv` Zeile "Manual YAML fallback parsing" | LIB-TD-0006, LIB-TD-0009, LIB-TD-0010, LIB-TD-0013 | WP-B1, WP-B2, WP-C1 |
+| D-LIB-003 | Debug-Logging in CreaturesRenderer | `technical-debt-register.csv` Zeile "Debug console noise" | LIB-TD-0015 | WP-C2 |
+| D-LIB-004 | Silent JSON Parse (Items) | `technical-debt-register.csv` Zeile "Silent JSON parse failures (items)" | LIB-TD-0002, LIB-TD-0004, LIB-TD-0010 | WP-D1, WP-A1, WP-B2 |
+| D-LIB-005 | Dynamische Serializer-Imports (Items) | `technical-debt-register.csv` Zeile "Dynamic serializer import per save (items)" | LIB-TD-0010 | WP-B2 |
+| D-LIB-006 | Silent JSON Parse (Equipment) | `technical-debt-register.csv` Zeile "Silent JSON parse failures (equipment)" | LIB-TD-0002, LIB-TD-0004, LIB-TD-0010 | WP-D1, WP-A1, WP-B2 |
+| D-LIB-007 | Dynamische Serializer-Imports (Equipment) | `technical-debt-register.csv` Zeile "Dynamic serializer import per save (equipment)" | LIB-TD-0010 | WP-B2 |
+| D-LIB-008 | Listener-Duplizierung & Debounce-Risiko | `technical-debt-register.csv` Zeile "Terrain listener duplication risk" | LIB-TD-0007, LIB-TD-0008, LIB-TD-0014, LIB-TD-0015 | WP-A2, WP-C2 |
+| D-LIB-009 | Fehlende Encounter-Validierung | `technical-debt-register.csv` Zeile "Region encounter parsing lacks validation" | LIB-TD-0011 | WP-B2 |
+| D-LIB-010 | Schwaches Preset-Marker-Handling | `technical-debt-register.csv` Zeile "Preset import marker weak guarantee" | LIB-TD-0004, LIB-TD-0012 | WP-A1, WP-B2 |
+| D-LIB-011 | Tests decken nur Shell ab | `technical-debt-register.csv` Zeile "Library tests limited to shell" | LIB-TD-0001, LIB-TD-0002 | WP-D1 |
+| D-LIB-012 | Creature-Serializer-Megafile | `technical-debt-register.csv` Zeile "Creature serializer mega-file" | LIB-TD-0009, LIB-TD-0010 | WP-B2 |
+
+## Risks → ToDo → Work Package
+
+| Risk-ID | Beschreibung (Kurzfassung) | Quelle | ToDo-IDs | Work Package |
+| --- | --- | --- | --- | --- |
+| R-LIB-001 | Async Render Races | `risks.md` Abschnitt "Async render races" | LIB-TD-0003, LIB-TD-0005, LIB-TD-0006, LIB-TD-0013, LIB-TD-0016 | WP-A1, WP-B1, WP-C1, WP-D2 |
+| R-LIB-002 | Silent Data Truncation | `risks.md` Abschnitt "Silent data truncation" | LIB-TD-0001, LIB-TD-0002, LIB-TD-0004, LIB-TD-0009, LIB-TD-0010, LIB-TD-0011 | WP-D1, WP-A1, WP-B2 |
+| R-LIB-003 | Preset Import Retry Loop | `risks.md` Abschnitt "Preset import retry loop" | LIB-TD-0004, LIB-TD-0012, LIB-TD-0016 | WP-A1, WP-B2, WP-D2 |
+| R-LIB-004 | Debounced Save Loss | `risks.md` Abschnitt "Debounced save loss" | LIB-TD-0007, LIB-TD-0008, LIB-TD-0014, LIB-TD-0015, LIB-TD-0016 | WP-A2, WP-C2, WP-D2 |
+| R-LIB-005 | Manual YAML Parsing Drift | `risks.md` Abschnitt "Manual YAML parsing drift" | LIB-TD-0003, LIB-TD-0006, LIB-TD-0009, LIB-TD-0010, LIB-TD-0013 | WP-A1, WP-B1, WP-B2, WP-C1 |
+| R-LIB-006 | Encounter Odds Validation Gap | `risks.md` Abschnitt "Encounter odds validation gap" | LIB-TD-0011 | WP-B2 |
+| R-LIB-007 | Modal Lifecycle Leak | `risks.md` Abschnitt "Modal lifecycle leak" | LIB-TD-0007, LIB-TD-0008, LIB-TD-0005, LIB-TD-0006, LIB-TD-0016 | WP-A2, WP-B1, WP-D2 |
+
+## ToDo → Work Package Mapping
+
+| ToDo-ID | Work Package | Sequenzpriorität |
+| --- | --- | --- |
+| LIB-TD-0001 | WP-D1 | 1 |
+| LIB-TD-0002 | WP-D1 | 1 |
+| LIB-TD-0003 | WP-A1 | 2 |
+| LIB-TD-0004 | WP-A1 | 2 |
+| LIB-TD-0005 | WP-B1 | 3 |
+| LIB-TD-0006 | WP-B1 | 3 |
+| LIB-TD-0007 | WP-A2 | 4 |
+| LIB-TD-0008 | WP-A2 | 4 |
+| LIB-TD-0009 | WP-B2 | 3 |
+| LIB-TD-0010 | WP-B2 | 3 |
+| LIB-TD-0011 | WP-B2 | 3 |
+| LIB-TD-0012 | WP-B2 | 3 |
+| LIB-TD-0013 | WP-C1 | 5 |
+| LIB-TD-0014 | WP-C2 | 6 |
+| LIB-TD-0015 | WP-C2 | 6 |
+| LIB-TD-0016 | WP-D2 | 7 |
+
+Die Sequenzpriorität folgt dem in `work-packages.md` beschriebenen Ablauf (Tests → Cycle Removal → Kernels/Templates → Watcher-Isolation → Konsolidierung → Rollout-Kontrollen).


### PR DESCRIPTION
## Summary
- add the phase 3 library refactor backlog with detailed ToDo cards grouped by work package
- capture traceability, kanban export, and planning briefs for each ToDo
- document the structure and prioritisation methodology for the new planning artefacts

## Testing
- npm run sync:todos *(fails: Fehlender Prioritätsmarker in docs/refactor/library/phase-2/AGENTS.md)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d11c69088325ab060afdb8b6ea69