### PR TITLE
Add metadata cache to library contract harness

### DIFF
--- a/tests/contracts/AGENTS.md
+++ b/tests/contracts/AGENTS.md
@@ -3,6 +3,7 @@
 
 # Aktueller Stand
 - Neues Test-Cluster, das Ports und Adapter gegen deterministische Fixtures prüft.
+- Der Harness initialisiert einen Fake-Metadata-Cache, der Frontmatter beim Seed ausliest; Fixtures benötigen gültige YAML-Header.
 
 # ToDo
 - Smoke-Subset für PR-Läufe dokumentieren und aktuell halten.


### PR DESCRIPTION
## Summary
- add a fake MetadataCache implementation to the library harness that parses frontmatter via `getFrontMatterInfo` and stays in sync with the in-memory vault
- expose the cache on `HarnessApp`, reset it during harness swaps, and ensure created files record their extensions for listing
- exercise the real creature, item, and equipment import helpers in the contract test suite and document the new metadata cache expectations for fixtures

## Testing
- npm run test:contracts

------
https://chatgpt.com/codex/tasks/task_e_68e3dd5f3194832588b84c1435b7b287