### PR TITLE
Add spell preset fixtures to library contract harness

### DIFF
--- a/tests/contracts/AGENTS.md
+++ b/tests/contracts/AGENTS.md
@@ -11,3 +11,4 @@
 # Standards
 - Test-Harness exportiert eine `createLibraryHarness`-Factory und kapselt Adapterumschaltung.
 - Vertrags-Tests nutzen ausschließlich die bereitgestellten Fixtures/Fakes aus `library-fixtures`.
+- Spell-Preset-Fixtures enthalten YAML-konformes Frontmatter (Booleans, Zahlen, Listen) und werden bei neuen Domains mitgepflegt.

--- a/tests/contracts/library-fixtures/index.ts
+++ b/tests/contracts/library-fixtures/index.ts
@@ -3,6 +3,7 @@
 import { creatureFixtures } from "./creatures";
 import { equipmentFixtures } from "./equipment";
 import { itemFixtures } from "./items";
+import { spellPresetFixtures } from "./spell-presets";
 import { regionFixtures } from "./regions";
 import { terrainFixtures } from "./terrains";
 
@@ -10,6 +11,7 @@ export const libraryFixtures = Object.freeze({
     creatures: creatureFixtures,
     equipment: equipmentFixtures,
     items: itemFixtures,
+    spellPresets: spellPresetFixtures,
     regions: regionFixtures,
     terrains: terrainFixtures,
 });

--- a/tests/contracts/library-fixtures/spell-presets.ts
+++ b/tests/contracts/library-fixtures/spell-presets.ts
@@ -1,0 +1,52 @@
+// salt-marcher/tests/contracts/library-fixtures/spell-presets.ts
+// Definiert Spell-Preset-Datensätze inklusive Metadaten für Vertragstests.
+import type { SpellData } from "../../../../src/apps/library/core/spell-files";
+
+export interface SpellPresetFixtureSet {
+    owner: "QA" | "Rules";
+    entries: Array<SpellData & { fixtureId: string }>;
+}
+
+export const spellPresetFixtures: SpellPresetFixtureSet = Object.freeze({
+    owner: "QA" as const,
+    entries: [
+        Object.freeze({
+            fixtureId: "spell-preset.ember-ward",
+            name: "Ember Ward",
+            level: 2,
+            school: "Abjuration",
+            casting_time: "1 action",
+            range: "Self",
+            components: ["V", "S"],
+            materials: "a shard of kiln-fired glass",
+            duration: "10 minutes",
+            concentration: true,
+            ritual: false,
+            classes: ["Wizard", "Artificer"],
+            description:
+                "A lattice of emberlight surrounds you, reducing fire damage by channeling the heat into harmless sparks.",
+            higher_levels:
+                "When you cast this spell using a spell slot of 3rd level or higher, the ward also grants resistance to lightning damage.",
+        }),
+        Object.freeze({
+            fixtureId: "spell-preset.tidal-script",
+            name: "Tidal Script",
+            level: 0,
+            school: "Transmutation",
+            casting_time: "1 bonus action",
+            range: "Touch",
+            components: ["V", "S", "M"],
+            materials: "a ribbon of dried kelp",
+            duration: "1 minute",
+            concentration: false,
+            ritual: false,
+            classes: ["Bard", "Druid", "Wizard"],
+            save_ability: "dex",
+            save_effect: "On a failure, the target is briefly anchored in a glyph of swirling water.",
+            description:
+                "You etch a watery sigil on a creature's gear. Until the spell ends, the target's weapon attacks deal an extra 1 cold damage.",
+            higher_levels:
+                "The bonus damage increases by 1 when you reach 5th level (2 cold), 11th level (3 cold), and 17th level (4 cold).",
+        }),
+    ],
+});


### PR DESCRIPTION
## Summary
- add spell preset fixtures and expose them through the shared library fixtures export
- seed spell preset markdown files in the contract harness storage adapter and provide storage helpers for tests
- extend contract tests to validate spell preset access and document frontmatter expectations

## Testing
- npm run test:contracts

------
https://chatgpt.com/codex/tasks/task_e_68e3e7a92c8083258844931f8b6d614c