### PR TITLE
Document contract harness scope on Phase 3 Kanban

### DIFF
--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -2,6 +2,10 @@
 
 ## Ready for Phase 4
 - [ ] LIB-TD-0001 – Vertragstest-Harness (keine Abhängigkeiten)
+    - Einstiegspunkt `tests/contracts/library-harness.ts` mit `createLibraryHarness` für Legacy/v2-Portumschaltung.
+    - Fixture-Struktur unter `tests/contracts/library-fixtures/{creatures,items,equipment,terrains,regions}` konsolidieren.
+    - Vertrags- und Regressionstests (`tests/contracts/library-contracts.test.ts`) für Renderer-, Storage-, Serializer- und Event-Ports pflegen.
+    - `npm run test:contracts` in `npm run ci:tests` integrieren, `BUILD.md` aktualisieren und DoR-Artefakte ablegen.
 
 ## Backlog (wartet auf vorgelagerte ToDos)
 - [ ] LIB-TD-0002 – Golden-Files (wartet auf LIB-TD-0001)


### PR DESCRIPTION
## Summary
- expand the Phase 3 Kanban entry for LIB-TD-0001 with concrete harness follow-up tasks
- highlight fixture consolidation, contract test coverage, and CI integration expectations

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3f73e69a8832585d1dcc855cd4046