### PR TITLE
Add library serializer golden files and roundtrip tests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,6 +5,7 @@
 - `npm run build`: führt `esbuild.config.mjs` aus und erzeugt `main.js` im Plugin-Stamm.
 - `npm test`: nutzt Vitest/Jsdom, um die gebündelte Oberfläche gegen Mocks zu prüfen.
 - `npm run test:contracts`: startet die Library-Vertragstests (`tests/contracts`), Laufzeit ~90s.
+- `npm run golden:update`: generiert deterministische Golden-Files für Serializer-Roundtrips (`tests/golden/library`).
 - `npm run ci:tests`: führt `npm test` und `npm run test:contracts` sequenziell für CI-Pipelines aus.
 - `npm run sync:todos`: sammelt Aufgaben aus allen `AGENTS.md`-Dateien und schreibt die priorisierte `TODO.md` im Reporoot.
 

--- a/docs/refactor/library/phase-3/backlog.md
+++ b/docs/refactor/library/phase-3/backlog.md
@@ -123,7 +123,7 @@ Akzeptanzkriterien:
   DoD (für Phase 4): Adapter implementiert, Dry-Run unterstützt, Telemetrie feuert bei Fehlern.
 Aufwand (T-Shirt): M
 Priorität (Score): 31.5
-Open Questions: Welche bestehenden Helper (z. B. `metadataCache`) bleiben externe Abhängigkeiten?
+Open Questions: Geklärt – `metadataCache` bleibt read-only für Cache-Hits, alle Vault-Schreibpfade wandern in den StoragePort.
 
 ### Work Package WP-A2: Modal ↔ Watcher Isolation
 

--- a/docs/refactor/library/phase-3/backlog.md
+++ b/docs/refactor/library/phase-3/backlog.md
@@ -276,7 +276,7 @@ Akzeptanzkriterien:
   DoD (für Phase 4): Template implementiert, Tests grün, Dokumentation vorhanden.
 Aufwand (T-Shirt): M
 Priorität (Score): 27
-Open Questions: Welche Sonderfelder (z. B. Spellcasting JSON) benötigen Custom-Transformer?
+Open Questions: Geklärt – Custom-Transformer werden über `transform.identifier` je Policy referenziert und kapseln Spezialfelder (z. B. Spellcasting JSON).
 
 ID: LIB-TD-0010
 Titel (imperativ): Portiere Creature/Item/Equipment-Serializer auf Template

--- a/docs/refactor/library/phase-3/backlog.md
+++ b/docs/refactor/library/phase-3/backlog.md
@@ -94,7 +94,7 @@ Akzeptanzkriterien:
   DoD (für Phase 4): Alle Renderer rufen Service-Port statt IO direkt; Verträge grün.
 Aufwand (T-Shirt): M
 Priorität (Score): 35
-Open Questions: Wie werden Langläufer (z. B. Preset-Scans) throttled, ohne UI zu blockieren?
+Open Questions: Geklärt – Preset-Scans laufen über den StoragePort asynchron; Renderer erhalten gepufferte Updates und benötigen kein Streaming.
 
 ID: LIB-TD-0004
 Titel (imperativ): Kapsle Persistenzadapter hinter StoragePort

--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -10,9 +10,12 @@
     - `tests/golden/library/<domain>` mit Manifesten (`.manifest.json`) und Markdown-Goldens für Creatures, Items, Equipment und Spells befüllt.
     - Update-Skript `npm run golden:update` erzeugt deterministische Artefakte via Harness (`tests/contracts/update-library-golden.ts`).
     - Vertrags-Test `tests/contracts/library-golden.test.ts` prüft Serializer- und Storage-Roundtrips gegen die Golden-Daten (≥3 Samples je Domäne).
+- [x] LIB-TD-0003 – Application-Service-Port (wartete auf LIB-TD-0001)
+    - `src/apps/library/core/library-mode-service-port.ts` definiert Session-orientierte Interfaces, Domain-DTOs sowie Composition-Pläne für alle Library-Modi.
+    - Feature-Flag-Helfer (`library.service.enabled`, `library.service.legacyFallback`) erlauben Renderer-seitige Kill-Switches inklusive Legacy-Fallback-Steuerung.
+    - Vitest-Contract (`tests/library/library-mode-service-port.test.ts`) prüft Descriptor- und Composition-Abdeckung sowie die deterministische Kill-Switch-Auswertung.
 
 ## Backlog (wartet auf vorgelagerte ToDos)
-- [ ] LIB-TD-0003 – Application-Service-Port (wartet auf LIB-TD-0001)
 - [ ] LIB-TD-0004 – StoragePort-Kapselung (wartet auf LIB-TD-0003 & LIB-TD-0001)
 - [ ] LIB-TD-0005 – Renderer-Kernel (wartet auf LIB-TD-0003 & LIB-TD-0001)
 - [ ] LIB-TD-0006 – Renderer-Migration (wartet auf LIB-TD-0005, LIB-TD-0003, LIB-TD-0004)

--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -18,6 +18,10 @@
     - `src/apps/library/core/library-storage-port.ts` spezifiziert Domain-Descriptoren, Fehlerkatalog, Telemetrie-Hooks sowie Dry-Run- und Backup-Pläne für Vault-Schreibpfade.
     - Legacy-Mapping-Tabelle dokumentiert bestehende Helper (Vault-Pipelines, Terrain-/Regions-Stores, Preset-Importer) samt Verantwortlichkeiten und Marker-Handling.
     - Vitest-Spezifikation (`tests/library/library-storage-port.test.ts`) prüft Domain-Abdeckung, Mapping-Vollständigkeit und die strukturierte Fehlererzeugung.
+- [x] LIB-TD-0009 – Serializer-Template-Policies (wartete auf LIB-TD-0001 & LIB-TD-0004)
+    - `src/apps/library/core/serializer-template/library-serializer-template.ts` modelliert Policy-Schema, Storage-Verknüpfung, Telemetrie-Events und Transformer-Pläne als eingefrorene Verträge.
+    - Vitest-Test (`tests/library/library-serializer-template.test.ts`) verifiziert Validierungsfehler, Default-Telemetrie und Immutabilität der Template-Objekte.
+    - Backlog/Briefing markieren Custom-Transformer-Frage als geklärt und dokumentieren die neue `transform.identifier`-Strategie.
 
 ## Backlog (wartet auf vorgelagerte ToDos)
 - [ ] LIB-TD-0005 – Renderer-Kernel (wartet auf LIB-TD-0003 & LIB-TD-0001)

--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -14,9 +14,12 @@
     - `src/apps/library/core/library-mode-service-port.ts` definiert Session-orientierte Interfaces, Domain-DTOs sowie Composition-Pläne für alle Library-Modi.
     - Feature-Flag-Helfer (`library.service.enabled`, `library.service.legacyFallback`) erlauben Renderer-seitige Kill-Switches inklusive Legacy-Fallback-Steuerung.
     - Vitest-Contract (`tests/library/library-mode-service-port.test.ts`) prüft Descriptor- und Composition-Abdeckung sowie die deterministische Kill-Switch-Auswertung.
+- [x] LIB-TD-0004 – StoragePort-Kapselung (wartete auf LIB-TD-0003 & LIB-TD-0001)
+    - `src/apps/library/core/library-storage-port.ts` spezifiziert Domain-Descriptoren, Fehlerkatalog, Telemetrie-Hooks sowie Dry-Run- und Backup-Pläne für Vault-Schreibpfade.
+    - Legacy-Mapping-Tabelle dokumentiert bestehende Helper (Vault-Pipelines, Terrain-/Regions-Stores, Preset-Importer) samt Verantwortlichkeiten und Marker-Handling.
+    - Vitest-Spezifikation (`tests/library/library-storage-port.test.ts`) prüft Domain-Abdeckung, Mapping-Vollständigkeit und die strukturierte Fehlererzeugung.
 
 ## Backlog (wartet auf vorgelagerte ToDos)
-- [ ] LIB-TD-0004 – StoragePort-Kapselung (wartet auf LIB-TD-0003 & LIB-TD-0001)
 - [ ] LIB-TD-0005 – Renderer-Kernel (wartet auf LIB-TD-0003 & LIB-TD-0001)
 - [ ] LIB-TD-0006 – Renderer-Migration (wartet auf LIB-TD-0005, LIB-TD-0003, LIB-TD-0004)
 - [ ] LIB-TD-0007 – Event-Bus-Port (wartet auf LIB-TD-0005 & LIB-TD-0003)

--- a/docs/refactor/library/phase-3/kanban.md
+++ b/docs/refactor/library/phase-3/kanban.md
@@ -6,9 +6,12 @@
     - Fixture-Struktur unter `tests/contracts/library-fixtures/{creatures,items,equipment,terrains,regions}` konsolidieren.
     - Vertrags- und Regressionstests (`tests/contracts/library-contracts.test.ts`) für Renderer-, Storage-, Serializer- und Event-Ports pflegen.
     - `npm run test:contracts` in `npm run ci:tests` integrieren, `BUILD.md` aktualisieren und DoR-Artefakte ablegen.
+- [x] LIB-TD-0002 – Golden-Files für Roundtrips (wartete auf LIB-TD-0001)
+    - `tests/golden/library/<domain>` mit Manifesten (`.manifest.json`) und Markdown-Goldens für Creatures, Items, Equipment und Spells befüllt.
+    - Update-Skript `npm run golden:update` erzeugt deterministische Artefakte via Harness (`tests/contracts/update-library-golden.ts`).
+    - Vertrags-Test `tests/contracts/library-golden.test.ts` prüft Serializer- und Storage-Roundtrips gegen die Golden-Daten (≥3 Samples je Domäne).
 
 ## Backlog (wartet auf vorgelagerte ToDos)
-- [ ] LIB-TD-0002 – Golden-Files (wartet auf LIB-TD-0001)
 - [ ] LIB-TD-0003 – Application-Service-Port (wartet auf LIB-TD-0001)
 - [ ] LIB-TD-0004 – StoragePort-Kapselung (wartet auf LIB-TD-0003 & LIB-TD-0001)
 - [ ] LIB-TD-0005 – Renderer-Kernel (wartet auf LIB-TD-0003 & LIB-TD-0001)

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0004.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0004.md
@@ -19,4 +19,4 @@ Kapselung sämtlicher Dateizugriffe der Library hinter einem StoragePort inklusi
 - Evaluieren, welche bestehenden Caches weiter genutzt werden müssen.
 
 ## Offene Punkte
-- Entscheidung, ob Marker-Dateien transaktional oder via Locking abgesichert werden.
+- Keine – Marker werden idempotent über `ensureMarker` erzeugt und via Backup-Plan rückspielbar.

--- a/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0009.md
+++ b/docs/refactor/library/phase-3/planning-briefs/LIB-TD-0009.md
@@ -19,4 +19,4 @@ Design eines Serializer-Templates mit deklarativen Policies, Dry-Run-Unterstütz
 - Telemetrie-Events und Logging-Konzept vorbereiten.
 
 ## Offene Punkte
-- Umfang von Custom-Transformern für Spezialfelder (z. B. Spellcasting JSON) abstimmen.
+- Geklärt – Spezialfelder (z. B. Spellcasting JSON) laufen über deklarative `transform.identifier`-Einträge pro Policy.

--- a/docs/refactor/library/phase-3/status-LIB-TD-0002.md
+++ b/docs/refactor/library/phase-3/status-LIB-TD-0002.md
@@ -1,0 +1,20 @@
+# LIB-TD-0002 – Umsetzung & Nachweis
+
+## Plan
+- Sampling-Strategie auf ≥3 Fixtures je Domäne (Creatures, Items, Equipment, Spells) erweitern und Golden-Zielstruktur definieren.
+- Update-Skript für deterministische Generierung (`npm run golden:update`) entwerfen und auf Harness-/Serializer-Verwendung abstützen.
+- Roundtrip-Tests aufsetzen, die Golden-Diffs sowie Storage-Lesewege und Serializer-Ausgaben gegeneinander prüfen.
+
+## Umsetzung
+- Fixtures der Library-Domänen um je ein drittes, repräsentatives Beispiel ergänzt (u. a. Glimmerfen Stalker, Thundercoil Net).
+- Golden-Verzeichnis `tests/golden/library` mit Manifesten und Markdown-Goldens befüllt; SHA256-Prüfsummen sichern Unveränderlichkeit.
+- Skript `tests/contracts/update-library-golden.ts` legt Golden-Dateien neu an und räumt Altbestände automatisiert auf.
+- Vitest-Suite `tests/contracts/library-golden.test.ts` validiert alle Samples domainübergreifend und nutzt denselben Harness.
+
+## Tests
+- `npm run golden:update`
+- `npm run test:contracts`
+
+## Dokumentation
+- Kanban-Eintrag auf „Ready for Phase 4“ verschoben und BUILD.md um das Golden-Update-Kommando ergänzt.
+- Neues Statusdokument für LIB-TD-0002 erstellt.

--- a/docs/refactor/library/phase-3/status-LIB-TD-0003.md
+++ b/docs/refactor/library/phase-3/status-LIB-TD-0003.md
@@ -1,0 +1,39 @@
+# LIB-TD-0003 – Umsetzung & Nachweis
+
+## Plan
+- Bestandsaufnahme der Renderer-Abhängigkeiten auf Verzeichnis-Ebene (Creatures, Spells, Items, Equipment, Terrains, Regions) und Ableitung gemeinsamer DTO-Schnittstellen für Listings und Detaildokumente.
+- Definition eines Session-orientierten Service-Ports mit Observer-Hooks, Telemetrie-Events sowie Kill-Switch-Auswertung für Legacy-Fallbacks.
+- Dokumentation der Composition-Kette (Renderer → Service-Port → StoragePort → Serializer) inklusive Event-Themen und Sequenzdiagramm.
+
+## Umsetzung
+- `src/apps/library/core/library-mode-service-port.ts` spezifiziert Domain-spezifische Summaries, Dokumente und Create-Requests, fasst Descriptoren zusammen und liefert Composition-Pläne für jeden Modus.
+- Kill-Switch-Hilfsfunktionen kapseln die Feature-Flags `library.service.enabled` und `library.service.legacyFallback`, sodass Renderer deterministisch zwischen Service-Port und Legacy-Pfaden wählen können.
+- Telemetrie- und Fehlerverträge definieren Adapter-Kennungen (`legacy` vs. `storage-port`) und Events für Session-Lifecycle, Synchronisation und Mutation.
+
+```mermaid
+sequenceDiagram
+    participant Renderer
+    participant Service as LibraryModeServicePort
+    participant Storage as StoragePort Adapter
+    participant Serializer
+    Renderer->>Service: connect(mode, observer, killSwitch)
+    Service-->>Renderer: session handle
+    Renderer->>Service: listEntries(reason)
+    Service->>Storage: readListing(mode)
+    Storage-->>Service: raw vault payloads
+    Service->>Serializer: normalize→DTO
+    Serializer-->>Service: domain document array
+    Service-->>Renderer: summaries + telemetry(entries.synced)
+    Renderer->>Service: createEntry(request)
+    Service->>Storage: persist via StoragePort
+    Storage-->>Service: confirmation
+    Service->>Serializer: generate markdown payload
+    Service-->>Renderer: summary + telemetry(entry.created)
+```
+
+## Tests
+- `npm run test -- --run tests/library/library-mode-service-port.test.ts`
+
+## Dokumentation
+- Kanban-Eintrag zu LIB-TD-0003 nach „Ready for Phase 4“ verschoben und Composition-/Flag-Details ergänzt.
+- Offene Frage zur Streaming-Notwendigkeit im Backlog als geklärt markiert.

--- a/docs/refactor/library/phase-3/status-LIB-TD-0004.md
+++ b/docs/refactor/library/phase-3/status-LIB-TD-0004.md
@@ -1,0 +1,18 @@
+# LIB-TD-0004 – Umsetzung & Nachweis
+
+## Plan
+- Storage-Port-Contract mit Domain-Descriptoren, Telemetrie-Events sowie Fehler- und Backup-Katalog spezifizieren.
+- Legacy-Hilfsfunktionen (Vault-Pipelines, Terrain-/Regions-Stores, Preset-Importer) einer Mapping-Tabelle zuordnen und Lücken reporten.
+- Vitest-Spezifikation für Descriptor-Abdeckung, Mapping-Vollständigkeit und Fehlererzeugung ergänzen.
+
+## Umsetzung
+- `src/apps/library/core/library-storage-port.ts` definiert Domain-IDs (inkl. Preset-Cluster), Read/Write/Marker-Schnittstellen, Dry-Run- und Backup-Pläne sowie Feature-Flags.
+- Fehlerkatalog (`createLibraryStorageError`) kapselt Operation, Domain, Ursache; Telemetrie-Events decken Reads, Writes, Marker und Fehler ab.
+- Legacy-Mapping dokumentiert sämtliche bestehenden Helper pro Domain und liefert Gap-Analyse via `describeLegacyStorageGaps`.
+
+## Tests
+- `npm run test -- --run tests/library/library-storage-port.test.ts`
+
+## Dokumentation
+- Kanban-Eintrag zu LIB-TD-0004 nach „Ready for Phase 4“ verschoben und Ergebnisdetails ergänzt.
+- Backlog-Open-Question als geklärt markiert; Planning Brief aktualisiert (Marker-Handling entschieden).

--- a/docs/refactor/library/phase-3/status-LIB-TD-0009.md
+++ b/docs/refactor/library/phase-3/status-LIB-TD-0009.md
@@ -1,0 +1,18 @@
+# LIB-TD-0009 – Umsetzung & Nachweis
+
+## Plan
+- Policy-Schema für Template-Version 1.0.0 modellieren (Required/Default/Migration/Validation/Transform) und Storage-Verknüpfung dokumentieren.
+- Telemetrie-Events und Attribute für Migration-, Validierungs- und Transformationspfade definieren, inklusive Default-Plan.
+- Validierungs-API erstellen, die Draft-Definitionen prüft (SemVer, Domains, Duplikate) und strukturierte Issues zurückliefert.
+
+## Umsetzung
+- `src/apps/library/core/serializer-template/library-serializer-template.ts` erstellt Draft/Template-Typen, Validation, Fehlerklasse sowie Runtime-Hooks und friert Policies, Storage-Bindung und Telemetrie-Pläne ein.
+- Telemetrie-Defaults (`library.serializer.*`) sowie Transformer-Pläne (`transform.identifier`) lösen das Briefing-Delta zu Spezialfeldern (Spellcasting JSON) und liefern klare Eventnamen.
+- Validation erkennt SemVer-Fehler, Duplicate-Felder, fehlende Codes/Messages sowie ungültige Storage-Strategien und trägt sie in strukturierte Issues ein.
+
+## Tests
+- `npm run test -- --run tests/library/library-serializer-template.test.ts`
+
+## Dokumentation
+- Kanban-Eintrag von LIB-TD-0009 nach „Ready for Phase 4“ verschoben und neue Artefakte dokumentiert.
+- Backlog- und Planning-Brief aktualisieren die Custom-Transformer-Frage als geklärt (`transform.identifier`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "esbuild": "^0.21.5",
         "jsdom": "^27.0.0",
         "obsidian": "^1.6.0",
+        "tsx": "^4.15.7",
         "typescript": "^5.5.4",
         "vitest": "^1.6.0"
       }
@@ -503,6 +504,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -520,6 +538,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -535,6 +570,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1415,6 +1467,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -1896,6 +1961,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
@@ -2144,6 +2219,459 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/type-detect": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "node esbuild.config.mjs",
     "test": "vitest run",
     "test:contracts": "vitest run tests/contracts",
+    "golden:update": "tsx tests/contracts/update-library-golden.ts",
     "ci:tests": "npm test && npm run test:contracts",
     "sync:todos": "node tools/sync-todos.mjs"
   },
@@ -16,6 +17,7 @@
     "esbuild": "^0.21.5",
     "jsdom": "^27.0.0",
     "obsidian": "^1.6.0",
+    "tsx": "^4.15.7",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"
   }

--- a/src/apps/library/core/library-mode-service-port.ts
+++ b/src/apps/library/core/library-mode-service-port.ts
@@ -1,0 +1,307 @@
+// src/apps/library/core/library-mode-service-port.ts
+// Spezifiziert den Application-Service-Port, der Renderer-Lifecycles mit Storage- und Serializer-Adaptern verbindet.
+// Der Port kapselt sämtliche IO-Zugriffe für Bibliotheksbereiche und beschreibt Kill-Switch-Strategien.
+import type { LibrarySourceId } from "./sources";
+import { LIBRARY_SOURCE_IDS, describeLibrarySource } from "./sources";
+import type { StatblockData } from "./creature-files";
+import type { SpellData } from "./spell-files";
+import type { ItemData } from "./item-files";
+import type { EquipmentData } from "./equipment-files";
+import type { Region } from "../../../core/regions-store";
+
+export type LibraryModeId = LibrarySourceId;
+
+export interface LibraryEntryRef {
+    readonly path: string;
+    readonly mode: LibraryModeId;
+}
+
+export interface CreatureEntrySummary extends LibraryEntryRef {
+    readonly mode: "creatures";
+    readonly name: string;
+    readonly creatureType?: string;
+    readonly challengeRating?: string;
+}
+
+export interface SpellEntrySummary extends LibraryEntryRef {
+    readonly mode: "spells";
+    readonly name: string;
+    readonly level?: number;
+    readonly school?: string;
+}
+
+export interface ItemEntrySummary extends LibraryEntryRef {
+    readonly mode: "items";
+    readonly name: string;
+    readonly rarity?: string;
+    readonly category?: string;
+}
+
+export interface EquipmentEntrySummary extends LibraryEntryRef {
+    readonly mode: "equipment";
+    readonly name: string;
+    readonly type: EquipmentData["type"];
+    readonly category?: string;
+}
+
+export interface TerrainEntrySummary extends LibraryEntryRef {
+    readonly mode: "terrains";
+    readonly name: string;
+    readonly color: string;
+    readonly speed: number;
+}
+
+export interface RegionEntrySummary extends LibraryEntryRef {
+    readonly mode: "regions";
+    readonly name: string;
+    readonly terrain: string;
+    readonly encounterOdds?: number;
+}
+
+export type LibraryEntrySummary =
+    | CreatureEntrySummary
+    | SpellEntrySummary
+    | ItemEntrySummary
+    | EquipmentEntrySummary
+    | TerrainEntrySummary
+    | RegionEntrySummary;
+
+export interface CreatureEntryDocument {
+    readonly mode: "creatures";
+    readonly ref: CreatureEntrySummary;
+    readonly statblock: StatblockData;
+}
+
+export interface SpellEntryDocument {
+    readonly mode: "spells";
+    readonly ref: SpellEntrySummary;
+    readonly spell: SpellData;
+}
+
+export interface ItemEntryDocument {
+    readonly mode: "items";
+    readonly ref: ItemEntrySummary;
+    readonly item: ItemData;
+}
+
+export interface EquipmentEntryDocument {
+    readonly mode: "equipment";
+    readonly ref: EquipmentEntrySummary;
+    readonly equipment: EquipmentData;
+}
+
+export interface TerrainEntryDocument {
+    readonly mode: "terrains";
+    readonly ref: TerrainEntrySummary;
+    readonly terrain: { name: string; color: string; speed: number };
+}
+
+export interface RegionEntryDocument {
+    readonly mode: "regions";
+    readonly ref: RegionEntrySummary;
+    readonly region: Region;
+}
+
+export type LibraryEntryDocument =
+    | CreatureEntryDocument
+    | SpellEntryDocument
+    | ItemEntryDocument
+    | EquipmentEntryDocument
+    | TerrainEntryDocument
+    | RegionEntryDocument;
+
+export type LibraryModeAdapterKind = "legacy" | "storage-port";
+
+export type LibraryModeServiceTelemetryEvent =
+    | { type: "session.opened"; mode: LibraryModeId; adapter: LibraryModeAdapterKind }
+    | { type: "session.closed"; mode: LibraryModeId; adapter: LibraryModeAdapterKind }
+    | { type: "entries.synced"; mode: LibraryModeId; adapter: LibraryModeAdapterKind; durationMs: number; count: number }
+    | { type: "entry.created"; mode: LibraryModeId; adapter: LibraryModeAdapterKind; ref: LibraryEntryRef }
+    | { type: "entry.failed"; mode: LibraryModeId; adapter: LibraryModeAdapterKind; ref?: LibraryEntryRef; error: unknown };
+
+export type LibraryModeServiceTelemetryEmitter = (event: LibraryModeServiceTelemetryEvent) => void;
+
+export interface LibraryModeServiceError {
+    readonly mode: LibraryModeId;
+    readonly operation: "list" | "read" | "create" | "update" | "delete" | "watch";
+    readonly kind: "storage" | "serializer" | "validation" | "unknown";
+    readonly cause: unknown;
+}
+
+export interface LibraryModeSessionObserver {
+    onEntriesChanged?(entries: readonly LibraryEntrySummary[]): void | Promise<void>;
+    onError?(error: LibraryModeServiceError): void;
+    onTelemetry?(event: LibraryModeServiceTelemetryEvent): void;
+}
+
+export interface LibraryModeWatch {
+    unsubscribe(): void;
+}
+
+export interface LibraryModeRequestContext {
+    readonly signal?: AbortSignal;
+    readonly reason?: string;
+}
+
+export interface LibraryModeCreateRequest {
+    readonly mode: LibraryModeId;
+    readonly document:
+        | { mode: "creatures"; statblock: StatblockData; presetPath?: string }
+        | { mode: "spells"; spell: SpellData }
+        | { mode: "items"; item: ItemData }
+        | { mode: "equipment"; equipment: EquipmentData }
+        | { mode: "terrains"; terrain: { name: string; color: string; speed: number } }
+        | { mode: "regions"; region: Region };
+}
+
+export interface LibraryModeCreateResult {
+    readonly document: LibraryEntryDocument;
+    readonly summary: LibraryEntrySummary;
+}
+
+export interface LibraryModeSession {
+    readonly mode: LibraryModeDescriptor;
+    listEntries(context?: LibraryModeRequestContext): Promise<readonly LibraryEntrySummary[]>;
+    readEntry(ref: LibraryEntryRef, context?: LibraryModeRequestContext): Promise<LibraryEntryDocument>;
+    createEntry(request: LibraryModeCreateRequest, context?: LibraryModeRequestContext): Promise<LibraryModeCreateResult>;
+    watch(observer: LibraryModeSessionObserver): LibraryModeWatch;
+    dispose(): Promise<void>;
+}
+
+export interface LibraryModeConnectOptions {
+    readonly mode: LibraryModeId;
+    readonly observer?: LibraryModeSessionObserver;
+    readonly context?: LibraryModeRequestContext;
+    readonly telemetry?: LibraryModeServiceTelemetryEmitter;
+    readonly killSwitch?: Partial<LibraryModeKillSwitch>;
+}
+
+export interface LibraryModeServicePort {
+    readonly features: LibraryModeServiceFeatures;
+    listModes(): readonly LibraryModeDescriptor[];
+    describeMode(id: LibraryModeId): LibraryModeDescriptor;
+    connect(options: LibraryModeConnectOptions): Promise<LibraryModeSession>;
+}
+
+export interface LibraryModeServiceFeatures {
+    readonly rendererServiceFlag: string;
+    readonly legacyFallbackFlag: string;
+}
+
+export const LIBRARY_MODE_SERVICE_FEATURES: LibraryModeServiceFeatures = Object.freeze({
+    rendererServiceFlag: "library.service.enabled",
+    legacyFallbackFlag: "library.service.legacyFallback",
+});
+
+export interface LibraryModeKillSwitchFlags {
+    readonly [LIBRARY_MODE_SERVICE_FEATURES.rendererServiceFlag]?: boolean;
+    readonly [LIBRARY_MODE_SERVICE_FEATURES.legacyFallbackFlag]?: boolean;
+}
+
+export interface LibraryModeKillSwitch {
+    readonly useService: boolean;
+    readonly allowLegacyFallback: boolean;
+}
+
+export interface LibraryModeKillSwitchOptions {
+    readonly flags?: LibraryModeKillSwitchFlags | Record<string, boolean | undefined>;
+    readonly overrides?: Partial<LibraryModeKillSwitch>;
+}
+
+export function resolveLibraryModeKillSwitch(options?: LibraryModeKillSwitchOptions): LibraryModeKillSwitch {
+    const rendererFlagName = LIBRARY_MODE_SERVICE_FEATURES.rendererServiceFlag;
+    const fallbackFlagName = LIBRARY_MODE_SERVICE_FEATURES.legacyFallbackFlag;
+    const flagState = options?.flags ?? {};
+    const overrides = options?.overrides ?? {};
+
+    const rendererEnabled = overrides.useService ?? (flagState[rendererFlagName] ?? true);
+    const legacyAllowed = overrides.allowLegacyFallback ?? (flagState[fallbackFlagName] ?? true);
+
+    return {
+        useService: !!rendererEnabled,
+        allowLegacyFallback: !!legacyAllowed,
+    };
+}
+
+export interface LibraryModeDescriptor {
+    readonly id: LibraryModeId;
+    readonly title: string;
+    readonly description: string;
+    readonly supportsCreation: boolean;
+    readonly supportsPresets: boolean;
+    readonly defaultCreateLabel: string;
+}
+
+const LIBRARY_MODE_LABELS: Record<LibraryModeId, { title: string; createLabel: string; presets: boolean }> = Object.freeze({
+    creatures: { title: "Creatures", createLabel: "Neue Kreatur", presets: true },
+    spells: { title: "Spells", createLabel: "Neuer Zauber", presets: false },
+    items: { title: "Items", createLabel: "Neuer Gegenstand", presets: false },
+    equipment: { title: "Equipment", createLabel: "Neue Ausrüstung", presets: false },
+    terrains: { title: "Terrains", createLabel: "Neues Terrain", presets: false },
+    regions: { title: "Regions", createLabel: "Neue Region", presets: false },
+});
+
+export const LIBRARY_MODE_DESCRIPTORS: ReadonlyArray<LibraryModeDescriptor> = Object.freeze(
+    LIBRARY_SOURCE_IDS.map((id): LibraryModeDescriptor => {
+        const meta = LIBRARY_MODE_LABELS[id];
+        return Object.freeze({
+            id,
+            title: meta.title,
+            description: describeLibrarySource(id),
+            supportsCreation: true,
+            supportsPresets: meta.presets,
+            defaultCreateLabel: meta.createLabel,
+        });
+    })
+);
+
+export function listLibraryModeDescriptors(): readonly LibraryModeDescriptor[] {
+    return LIBRARY_MODE_DESCRIPTORS;
+}
+
+export function describeLibraryMode(id: LibraryModeId): LibraryModeDescriptor {
+    const descriptor = LIBRARY_MODE_DESCRIPTORS.find(entry => entry.id === id);
+    if (!descriptor) {
+        throw new Error(`Unknown library mode: ${id as string}`);
+    }
+    return descriptor;
+}
+
+export interface LibraryModeCompositionPlan {
+    readonly storagePortModule: string;
+    readonly serializerTemplate: string;
+    readonly eventTopics: readonly string[];
+}
+
+export const LIBRARY_MODE_COMPOSITION: Readonly<Record<LibraryModeId, LibraryModeCompositionPlan>> = Object.freeze({
+    creatures: Object.freeze({
+        storagePortModule: "@core/library/storage/creatures",
+        serializerTemplate: "statblock.markdown",
+        eventTopics: Object.freeze(["library:creature:changed", "library:creature:created"]),
+    }),
+    spells: Object.freeze({
+        storagePortModule: "@core/library/storage/spells",
+        serializerTemplate: "spell.markdown",
+        eventTopics: Object.freeze(["library:spell:changed", "library:spell:created"]),
+    }),
+    items: Object.freeze({
+        storagePortModule: "@core/library/storage/items",
+        serializerTemplate: "item.markdown",
+        eventTopics: Object.freeze(["library:item:changed", "library:item:created"]),
+    }),
+    equipment: Object.freeze({
+        storagePortModule: "@core/library/storage/equipment",
+        serializerTemplate: "equipment.markdown",
+        eventTopics: Object.freeze(["library:equipment:changed", "library:equipment:created"]),
+    }),
+    terrains: Object.freeze({
+        storagePortModule: "@core/library/storage/terrains",
+        serializerTemplate: "terrain.block",
+        eventTopics: Object.freeze(["library:terrain:changed"]),
+    }),
+    regions: Object.freeze({
+        storagePortModule: "@core/library/storage/regions",
+        serializerTemplate: "region.block",
+        eventTopics: Object.freeze(["library:region:changed"]),
+    }),
+});

--- a/src/apps/library/core/library-storage-port.ts
+++ b/src/apps/library/core/library-storage-port.ts
@@ -1,0 +1,363 @@
+// src/apps/library/core/library-storage-port.ts
+// Spezifiziert den Storage-Port, der Vault-Zugriffe, Marker-Handling und Dry-Run-Flows für die Library kapselt.
+// Der Vertrag beschreibt Fehlercodes, Telemetrie-Events sowie die Legacy-Mapping-Tabelle für die anstehenden Adapter.
+import type { LibrarySourceId } from "./sources";
+import { LIBRARY_SOURCE_IDS } from "./sources";
+import { CREATURES_DIR } from "./creature-files";
+import { SPELLS_DIR } from "./spell-files";
+import { ITEMS_DIR } from "./item-files";
+import { EQUIPMENT_DIR } from "./equipment-files";
+import { TERRAIN_FILE } from "../../../core/terrain-store";
+import { REGIONS_FILE } from "../../../core/regions-store";
+
+export type LibraryStorageDomainId = LibrarySourceId | "presets";
+
+export interface LibraryStorageDomainDescriptor {
+    readonly id: LibraryStorageDomainId;
+    readonly description: string;
+    readonly kind: "directory" | "single-file";
+    readonly defaultExtension: string;
+}
+
+const LIBRARY_STORAGE_DOMAIN_DESCRIPTORS: ReadonlyArray<LibraryStorageDomainDescriptor> = Object.freeze([
+    Object.freeze({
+        id: "creatures" as const,
+        description: `${CREATURES_DIR}/`,
+        kind: "directory" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "spells" as const,
+        description: `${SPELLS_DIR}/`,
+        kind: "directory" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "items" as const,
+        description: `${ITEMS_DIR}/`,
+        kind: "directory" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "equipment" as const,
+        description: `${EQUIPMENT_DIR}/`,
+        kind: "directory" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "terrains" as const,
+        description: TERRAIN_FILE,
+        kind: "single-file" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "regions" as const,
+        description: REGIONS_FILE,
+        kind: "single-file" as const,
+        defaultExtension: "md" as const,
+    }),
+    Object.freeze({
+        id: "presets" as const,
+        description: "SaltMarcher Preset Imports",
+        kind: "directory" as const,
+        defaultExtension: "md" as const,
+    }),
+]);
+
+export function listLibraryStorageDomains(): readonly LibraryStorageDomainDescriptor[] {
+    return LIBRARY_STORAGE_DOMAIN_DESCRIPTORS;
+}
+
+export function describeLibraryStorageDomain(id: LibraryStorageDomainId): LibraryStorageDomainDescriptor {
+    const descriptor = LIBRARY_STORAGE_DOMAIN_DESCRIPTORS.find(entry => entry.id === id);
+    if (!descriptor) {
+        throw new Error(`Unknown library storage domain: ${id as string}`);
+    }
+    return descriptor;
+}
+
+export type LibraryStorageAdapterKind = "legacy" | "vault" | "mock";
+
+export interface LibraryStorageFileRef {
+    readonly path: string;
+    readonly domain: LibraryStorageDomainId;
+}
+
+export interface LibraryStorageStat {
+    readonly mtimeMs?: number;
+    readonly ctimeMs?: number;
+    readonly size?: number;
+    readonly hash?: string;
+}
+
+export interface LibraryStorageReadRequest {
+    readonly ref: LibraryStorageFileRef;
+    readonly context?: LibraryStorageRequestContext;
+}
+
+export interface LibraryStorageReadResult {
+    readonly ref: LibraryStorageFileRef;
+    readonly content: string;
+    readonly frontmatter?: Record<string, unknown>;
+    readonly stat?: LibraryStorageStat;
+    readonly marker?: LibraryStorageMarkerSummary;
+}
+
+export type LibraryStorageWriteMode = "create" | "update" | "delete";
+
+export interface LibraryStorageWriteRequest {
+    readonly mode: LibraryStorageWriteMode;
+    readonly ref: LibraryStorageFileRef;
+    readonly nextContent?: string;
+    readonly context?: LibraryStorageRequestContext;
+    readonly marker?: LibraryStorageMarkerPlan;
+}
+
+export interface LibraryStorageWriteResult {
+    readonly ref: LibraryStorageFileRef;
+    readonly mode: LibraryStorageWriteMode;
+    readonly stat?: LibraryStorageStat;
+    readonly backup?: LibraryStorageBackupPlan;
+    readonly dryRun?: LibraryStorageDryRunReport;
+}
+
+export interface LibraryStorageMarkerPlan {
+    readonly kind: "preset-import" | "sync" | "custom";
+    readonly label: string;
+    readonly path: string;
+    readonly content?: string;
+}
+
+export interface LibraryStorageMarkerSummary {
+    readonly path: string;
+    readonly exists: boolean;
+    readonly lastUpdated?: number;
+}
+
+export interface LibraryStorageBackupPlan {
+    readonly directory: string;
+    readonly strategy: "replace" | "append";
+    readonly note?: string;
+}
+
+export interface LibraryStorageDryRunReport {
+    readonly performed: boolean;
+    readonly persistedContent?: string;
+    readonly skippedWrite?: boolean;
+}
+
+export interface LibraryStorageRequestContext {
+    readonly signal?: AbortSignal;
+    readonly dryRun?: boolean;
+    readonly reason?: string;
+    readonly telemetry?: LibraryStorageTelemetryEmitter;
+}
+
+export type LibraryStorageErrorOperation =
+    | "ensure-domain"
+    | "list-domain"
+    | "read-domain"
+    | "write-domain"
+    | "delete-domain"
+    | "ensure-marker";
+
+export type LibraryStorageErrorKind =
+    | "not-found"
+    | "conflict"
+    | "validation"
+    | "permission"
+    | "io"
+    | "marker"
+    | "unknown";
+
+export interface LibraryStorageError {
+    readonly domain: LibraryStorageDomainId;
+    readonly operation: LibraryStorageErrorOperation;
+    readonly kind: LibraryStorageErrorKind;
+    readonly message: string;
+    readonly cause?: unknown;
+    readonly ref?: LibraryStorageFileRef;
+    readonly marker?: LibraryStorageMarkerPlan;
+}
+
+export function createLibraryStorageError(
+    options: Omit<LibraryStorageError, "message"> & { message?: string }
+): LibraryStorageError {
+    const { message, ...rest } = options;
+    const fallback = `${rest.operation} failed for ${rest.domain}`;
+    return Object.freeze({
+        ...rest,
+        message: message ?? fallback,
+    });
+}
+
+export type LibraryStorageTelemetryEvent =
+    | {
+          type: "storage.read";
+          domain: LibraryStorageDomainId;
+          ref: LibraryStorageFileRef;
+          durationMs: number;
+          adapter: LibraryStorageAdapterKind;
+          size?: number;
+      }
+    | {
+          type: "storage.write";
+          domain: LibraryStorageDomainId;
+          ref: LibraryStorageFileRef;
+          mode: LibraryStorageWriteMode;
+          durationMs: number;
+          adapter: LibraryStorageAdapterKind;
+          dryRun?: boolean;
+          backup?: LibraryStorageBackupPlan;
+      }
+    | {
+          type: "storage.marker";
+          domain: LibraryStorageDomainId;
+          marker: LibraryStorageMarkerPlan;
+          adapter: LibraryStorageAdapterKind;
+          ensured: boolean;
+          durationMs: number;
+      }
+    | {
+          type: "storage.error";
+          domain: LibraryStorageDomainId;
+          operation: LibraryStorageErrorOperation;
+          adapter: LibraryStorageAdapterKind;
+          error: LibraryStorageError;
+      };
+
+export type LibraryStorageTelemetryEmitter = (event: LibraryStorageTelemetryEvent) => void;
+
+export interface LibraryStoragePort {
+    readonly features: LibraryStoragePortFeatures;
+    listDomains(): readonly LibraryStorageDomainDescriptor[];
+    describeDomain(id: LibraryStorageDomainId): LibraryStorageDomainDescriptor;
+    readDomainFile(request: LibraryStorageReadRequest): Promise<LibraryStorageReadResult>;
+    writeDomainFile(request: LibraryStorageWriteRequest): Promise<LibraryStorageWriteResult>;
+    ensureMarker(domain: LibraryStorageDomainId, marker: LibraryStorageMarkerPlan): Promise<LibraryStorageMarkerSummary>;
+}
+
+export interface LibraryStoragePortFeatures {
+    readonly storagePortFlag: string;
+    readonly dryRunFlag: string;
+}
+
+export const LIBRARY_STORAGE_PORT_FEATURES: LibraryStoragePortFeatures = Object.freeze({
+    storagePortFlag: "library.storage.port.enabled",
+    dryRunFlag: "library.storage.dryRun",
+});
+
+export interface LegacyLibraryStorageMappingEntry {
+    readonly module: string;
+    readonly responsibilities: readonly string[];
+    readonly notes?: string;
+}
+
+export type LegacyLibraryStorageMapping = Readonly<Record<LibraryStorageDomainId, readonly LegacyLibraryStorageMappingEntry[]>>;
+
+export const LEGACY_LIBRARY_STORAGE_MAPPING: LegacyLibraryStorageMapping = Object.freeze({
+    creatures: Object.freeze([
+        Object.freeze({
+            module: "@app/library/core/creature-files",
+            responsibilities: Object.freeze(["list", "watch", "create", "sanitize-name"]),
+        }),
+        Object.freeze({
+            module: "@app/library/core/creature-presets",
+            responsibilities: Object.freeze(["preset-import", "marker", "legacy-roundtrip"]),
+            notes: "Handles `.plugin-presets-imported` marker during preset migrations.",
+        }),
+    ]),
+    spells: Object.freeze([
+        Object.freeze({
+            module: "@app/library/core/spell-files",
+            responsibilities: Object.freeze(["list", "watch", "create", "sanitize-name"]),
+        }),
+        Object.freeze({
+            module: "@app/library/core/spell-presets",
+            responsibilities: Object.freeze(["preset-import", "marker", "legacy-roundtrip"]),
+        }),
+    ]),
+    items: Object.freeze([
+        Object.freeze({
+            module: "@app/library/core/item-files",
+            responsibilities: Object.freeze(["list", "watch", "create", "sanitize-name"]),
+        }),
+        Object.freeze({
+            module: "@app/library/core/plugin-presets",
+            responsibilities: Object.freeze([
+                "preset-import",
+                "marker",
+                "read-legacy-json",
+                "write-legacy-markdown",
+            ]),
+            notes: "Covers item + equipment preset markers and import side-effects.",
+        }),
+    ]),
+    equipment: Object.freeze([
+        Object.freeze({
+            module: "@app/library/core/equipment-files",
+            responsibilities: Object.freeze(["list", "watch", "create", "sanitize-name"]),
+        }),
+        Object.freeze({
+            module: "@app/library/core/plugin-presets",
+            responsibilities: Object.freeze([
+                "preset-import",
+                "marker",
+                "read-legacy-json",
+                "write-legacy-markdown",
+            ]),
+        }),
+    ]),
+    terrains: Object.freeze([
+        Object.freeze({
+            module: "@core/terrain-store",
+            responsibilities: Object.freeze(["ensure", "read", "write", "watch", "notify-workspace"]),
+            notes: "Single-file Markdown block parsed into terrain map; watchers trigger workspace events.",
+        }),
+    ]),
+    regions: Object.freeze([
+        Object.freeze({
+            module: "@core/regions-store",
+            responsibilities: Object.freeze(["ensure", "read", "write", "watch", "notice"]),
+            notes: "Maintains Regions.md including Obsidian notices on recreation failures.",
+        }),
+    ]),
+    presets: Object.freeze([
+        Object.freeze({
+            module: "@app/library/core/plugin-presets",
+            responsibilities: Object.freeze([
+                "seed-json",
+                "import-markdown",
+                "create-marker",
+                "telemetry-log",
+            ]),
+            notes: "Aggregates preset import routines across creatures, spells, items and equipment.",
+        }),
+    ]),
+});
+
+export function ensureLegacyStorageCoverage(): void {
+    for (const id of [...LIBRARY_SOURCE_IDS, "presets"] as LibraryStorageDomainId[]) {
+        const entries = LEGACY_LIBRARY_STORAGE_MAPPING[id];
+        if (!entries || entries.length === 0) {
+            throw new Error(`Missing legacy storage mapping for domain ${id}`);
+        }
+    }
+}
+
+export function describeLegacyStorageGaps(): readonly { domain: LibraryStorageDomainId; missing: string[] } {
+    const gaps: Array<{ domain: LibraryStorageDomainId; missing: string[] }> = [];
+    for (const descriptor of LIBRARY_STORAGE_DOMAIN_DESCRIPTORS) {
+        const mapping = LEGACY_LIBRARY_STORAGE_MAPPING[descriptor.id] ?? [];
+        const collected = new Set(mapping.flatMap(entry => entry.responsibilities));
+        const required = descriptor.kind === "directory"
+            ? ["list", "watch", "create"]
+            : ["ensure", "read", "write"];
+        const missing = required.filter(key => !collected.has(key));
+        if (missing.length > 0) {
+            gaps.push({ domain: descriptor.id, missing });
+        }
+    }
+    return gaps;
+}
+

--- a/src/apps/library/core/serializer-template/AGENTS.md
+++ b/src/apps/library/core/serializer-template/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Definiert das deklarative Serializer-Template samt Policy-Schema für alle Library-Domänen.
+
+# Aktueller Stand
+- Modul ist neu und stellt bislang nur Verträge bereit.
+
+# ToDo
+- keine offenen ToDos.
+
+# Standards
+- Dateien beginnen mit einem Kontextsatz zum Template-Workflow.
+- Exportierte Typen bleiben unveränderlich (`Readonly`/`as const`).
+- Helper validieren Eingaben und liefern strukturierte Fehlerobjekte.

--- a/src/apps/library/core/serializer-template/library-serializer-template.ts
+++ b/src/apps/library/core/serializer-template/library-serializer-template.ts
@@ -1,0 +1,421 @@
+// src/apps/library/core/serializer-template/library-serializer-template.ts
+// Beschreibt das Serializer-Template, mit dem Library-Domänen deklarative Policies, Storage-Verknüpfung und Telemetrie planen.
+import {
+    type LibraryStorageDomainDescriptor,
+    type LibraryStorageDomainId,
+    type LibraryStorageAdapterKind,
+    type LibraryStorageBackupPlan,
+    type LibraryStorageDryRunReport,
+    describeLibraryStorageDomain,
+} from "../library-storage-port";
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/u;
+
+export type LibrarySerializerTemplateVersion = `${number}.${number}.${number}`;
+
+export interface LibrarySerializerPolicyRequirementPlan {
+    readonly reason: string;
+    readonly when?: string;
+}
+
+export type LibrarySerializerPolicyRequirement = boolean | LibrarySerializerPolicyRequirementPlan;
+
+export type LibrarySerializerDefaultValueStrategy = "literal" | "factory" | "policy";
+
+export interface LibrarySerializerDefaultValuePlan {
+    readonly strategy: LibrarySerializerDefaultValueStrategy;
+    readonly value?: unknown;
+    readonly reason: string;
+}
+
+export type LibrarySerializerMigrationKind = "rename" | "coerce" | "split" | "merge" | "custom";
+
+export interface LibrarySerializerMigrationStep {
+    readonly fromVersion: LibrarySerializerTemplateVersion | "legacy";
+    readonly kind: LibrarySerializerMigrationKind;
+    readonly description: string;
+}
+
+export type LibrarySerializerValidationRuleKind =
+    | "required"
+    | "enum"
+    | "range"
+    | "pattern"
+    | "length"
+    | "custom";
+
+export interface LibrarySerializerValidationRule {
+    readonly kind: LibrarySerializerValidationRuleKind;
+    readonly code: string;
+    readonly message: string;
+    readonly severity: "error" | "warning";
+    readonly config?: Record<string, unknown>;
+}
+
+export type LibrarySerializerTransformerKind = "json" | "markdown" | "custom";
+
+export interface LibrarySerializerTransformerPlan {
+    readonly kind: LibrarySerializerTransformerKind;
+    readonly identifier: string;
+    readonly description: string;
+}
+
+export interface LibrarySerializerPolicyDescriptor {
+    readonly field: string;
+    readonly required?: LibrarySerializerPolicyRequirement;
+    readonly defaultValue?: LibrarySerializerDefaultValuePlan;
+    readonly migrate?: readonly LibrarySerializerMigrationStep[];
+    readonly validate?: readonly LibrarySerializerValidationRule[];
+    readonly transform?: LibrarySerializerTransformerPlan;
+}
+
+export type LibrarySerializerVersioningStrategy = "frontmatter" | "content" | "none";
+
+export type LibrarySerializerDryRunExpectation = "required" | "supported" | "disabled";
+
+export interface LibrarySerializerStorageBinding {
+    readonly domain: LibraryStorageDomainId;
+    readonly adapter: LibraryStorageAdapterKind;
+    readonly versioning: LibrarySerializerVersioningStrategy;
+    readonly dryRun: LibrarySerializerDryRunExpectation;
+    readonly backupPlan?: LibraryStorageBackupPlan;
+}
+
+export interface LibrarySerializerTelemetryEvents {
+    readonly migrationApplied: string;
+    readonly validationFailed: string;
+    readonly dryRunExecuted: string;
+    readonly transformFallback: string;
+}
+
+export interface LibrarySerializerTelemetryPlan {
+    readonly events: LibrarySerializerTelemetryEvents;
+    readonly attributes: readonly string[];
+}
+
+export interface LibrarySerializerTemplateDraft {
+    readonly id: string;
+    readonly description: string;
+    readonly version: LibrarySerializerTemplateVersion;
+    readonly storage: LibrarySerializerStorageBinding;
+    readonly policies: readonly LibrarySerializerPolicyDescriptor[];
+    readonly telemetry?: LibrarySerializerTelemetryPlan;
+}
+
+export interface LibrarySerializerPolicy extends LibrarySerializerPolicyDescriptor {
+    readonly required?: LibrarySerializerPolicyRequirement;
+    readonly migrate?: readonly LibrarySerializerMigrationStep[];
+    readonly validate?: readonly LibrarySerializerValidationRule[];
+}
+
+export interface LibrarySerializerTemplate {
+    readonly id: string;
+    readonly description: string;
+    readonly version: LibrarySerializerTemplateVersion;
+    readonly storage: LibrarySerializerStorageBinding & {
+        readonly descriptor: LibraryStorageDomainDescriptor;
+    };
+    readonly policies: readonly LibrarySerializerPolicy[];
+    readonly telemetry: LibrarySerializerTelemetryPlan;
+}
+
+export type LibrarySerializerTemplateIssueCode =
+    | "invalid-version"
+    | "unknown-domain"
+    | "policy-missing-field"
+    | "policy-duplicate-field"
+    | "policy-migrate-missing-description"
+    | "policy-migrate-invalid-from"
+    | "policy-validate-missing-code"
+    | "policy-validate-missing-message"
+    | "policy-transform-missing-identifier"
+    | "telemetry-missing-event"
+    | "storage-invalid-versioning"
+    | "storage-invalid-dry-run";
+
+export interface LibrarySerializerTemplateIssue {
+    readonly severity: "error" | "warning";
+    readonly code: LibrarySerializerTemplateIssueCode;
+    readonly message: string;
+    readonly path?: string;
+}
+
+export class LibrarySerializerTemplateError extends Error {
+    public readonly issues: readonly LibrarySerializerTemplateIssue[];
+
+    public constructor(message: string, issues: readonly LibrarySerializerTemplateIssue[]) {
+        super(message);
+        this.name = "LibrarySerializerTemplateError";
+        this.issues = Object.freeze([...issues]);
+    }
+}
+
+const REQUIRED_TELEMETRY_EVENTS: ReadonlyArray<keyof LibrarySerializerTelemetryEvents> = Object.freeze([
+    "migrationApplied",
+    "validationFailed",
+    "dryRunExecuted",
+    "transformFallback",
+]);
+
+const DEFAULT_TELEMETRY_PLAN: LibrarySerializerTelemetryPlan = Object.freeze({
+    events: Object.freeze({
+        migrationApplied: "library.serializer.migration.applied",
+        validationFailed: "library.serializer.validation.failed",
+        dryRunExecuted: "library.serializer.dry-run.executed",
+        transformFallback: "library.serializer.transform.fallback",
+    }),
+    attributes: Object.freeze(["templateId", "domain", "version"]),
+});
+
+const ALLOWED_VERSIONING: ReadonlySet<LibrarySerializerVersioningStrategy> = new Set([
+    "frontmatter",
+    "content",
+    "none",
+]);
+
+const ALLOWED_DRY_RUN: ReadonlySet<LibrarySerializerDryRunExpectation> = new Set([
+    "required",
+    "supported",
+    "disabled",
+]);
+
+export function validateLibrarySerializerTemplate(
+    draft: LibrarySerializerTemplateDraft,
+): LibrarySerializerTemplateIssue[] {
+    const issues: LibrarySerializerTemplateIssue[] = [];
+
+    if (!SEMVER_PATTERN.test(draft.version)) {
+        issues.push({
+            severity: "error",
+            code: "invalid-version",
+            message: `Template ${draft.id} besitzt keine SemVer-Version (${draft.version}).`,
+            path: "version",
+        });
+    }
+
+    if (!ALLOWED_VERSIONING.has(draft.storage.versioning)) {
+        issues.push({
+            severity: "error",
+            code: "storage-invalid-versioning",
+            message: `Unbekannte Versionierungsstrategie: ${draft.storage.versioning}.`,
+            path: "storage.versioning",
+        });
+    }
+
+    if (!ALLOWED_DRY_RUN.has(draft.storage.dryRun)) {
+        issues.push({
+            severity: "error",
+            code: "storage-invalid-dry-run",
+            message: `Unbekannte Dry-Run-Anforderung: ${draft.storage.dryRun}.`,
+            path: "storage.dryRun",
+        });
+    }
+
+    try {
+        describeLibraryStorageDomain(draft.storage.domain);
+    } catch (error) {
+        issues.push({
+            severity: "error",
+            code: "unknown-domain",
+            message: `Template ${draft.id} referenziert unbekannte Domain ${draft.storage.domain}.`,
+            path: "storage.domain",
+        });
+    }
+
+    const seenFields = new Set<string>();
+    draft.policies.forEach((policy, index) => {
+        const fieldPath = `policies[${index}]`;
+        const trimmedField = policy.field?.trim();
+        if (!trimmedField) {
+            issues.push({
+                severity: "error",
+                code: "policy-missing-field",
+                message: `Policy an Position ${index} besitzt kein Feld.`,
+                path: `${fieldPath}.field`,
+            });
+        } else {
+            if (seenFields.has(trimmedField)) {
+                issues.push({
+                    severity: "error",
+                    code: "policy-duplicate-field",
+                    message: `Policy-Feld ${trimmedField} ist mehrfach definiert.`,
+                    path: `${fieldPath}.field`,
+                });
+            }
+            seenFields.add(trimmedField);
+        }
+
+        policy.migrate?.forEach((step, migrateIndex) => {
+            const migratePath = `${fieldPath}.migrate[${migrateIndex}]`;
+            if (!step.description.trim()) {
+                issues.push({
+                    severity: "error",
+                    code: "policy-migrate-missing-description",
+                    message: `Migration für Feld ${policy.field} benötigt eine Beschreibung.`,
+                    path: `${migratePath}.description`,
+                });
+            }
+            if (step.fromVersion !== "legacy" && !SEMVER_PATTERN.test(step.fromVersion)) {
+                issues.push({
+                    severity: "error",
+                    code: "policy-migrate-invalid-from",
+                    message: `Migration für Feld ${policy.field} nutzt ungültige Version ${step.fromVersion}.`,
+                    path: `${migratePath}.fromVersion`,
+                });
+            }
+        });
+
+        policy.validate?.forEach((rule, ruleIndex) => {
+            const validatePath = `${fieldPath}.validate[${ruleIndex}]`;
+            if (!rule.code.trim()) {
+                issues.push({
+                    severity: "error",
+                    code: "policy-validate-missing-code",
+                    message: `Validierungsregel für Feld ${policy.field} benötigt einen Fehlercode.`,
+                    path: `${validatePath}.code`,
+                });
+            }
+            if (!rule.message.trim()) {
+                issues.push({
+                    severity: "error",
+                    code: "policy-validate-missing-message",
+                    message: `Validierungsregel für Feld ${policy.field} benötigt eine Fehlermeldung.`,
+                    path: `${validatePath}.message`,
+                });
+            }
+        });
+
+        if (policy.transform && !policy.transform.identifier.trim()) {
+            issues.push({
+                severity: "error",
+                code: "policy-transform-missing-identifier",
+                message: `Transformer für Feld ${policy.field} benötigt eine Kennung.`,
+                path: `${fieldPath}.transform.identifier`,
+            });
+        }
+    });
+
+    const telemetryPlan = draft.telemetry ?? DEFAULT_TELEMETRY_PLAN;
+    REQUIRED_TELEMETRY_EVENTS.forEach(key => {
+        if (!telemetryPlan.events[key].trim()) {
+            issues.push({
+                severity: "error",
+                code: "telemetry-missing-event",
+                message: `Telemetry-Event ${key} ist nicht belegt.`,
+                path: `telemetry.events.${key}`,
+            });
+        }
+    });
+
+    return issues;
+}
+
+function freezePolicy(policy: LibrarySerializerPolicyDescriptor): LibrarySerializerPolicy {
+    const frozenMigrate = policy.migrate?.map(step =>
+        Object.freeze({
+            fromVersion: step.fromVersion,
+            kind: step.kind,
+            description: step.description,
+        }),
+    );
+    const frozenValidate = policy.validate?.map(rule =>
+        Object.freeze({
+            kind: rule.kind,
+            code: rule.code,
+            message: rule.message,
+            severity: rule.severity,
+            config: rule.config ? Object.freeze({ ...rule.config }) : undefined,
+        }),
+    );
+
+    return Object.freeze({
+        field: policy.field,
+        required: policy.required,
+        defaultValue: policy.defaultValue
+            ? Object.freeze({
+                  strategy: policy.defaultValue.strategy,
+                  value: policy.defaultValue.value,
+                  reason: policy.defaultValue.reason,
+              })
+            : undefined,
+        migrate: frozenMigrate ? Object.freeze(frozenMigrate) : undefined,
+        validate: frozenValidate ? Object.freeze(frozenValidate) : undefined,
+        transform: policy.transform
+            ? Object.freeze({
+                  kind: policy.transform.kind,
+                  identifier: policy.transform.identifier,
+                  description: policy.transform.description,
+              })
+            : undefined,
+    });
+}
+
+function freezeTelemetry(plan: LibrarySerializerTelemetryPlan): LibrarySerializerTelemetryPlan {
+    return Object.freeze({
+        events: Object.freeze({
+            migrationApplied: plan.events.migrationApplied,
+            validationFailed: plan.events.validationFailed,
+            dryRunExecuted: plan.events.dryRunExecuted,
+            transformFallback: plan.events.transformFallback,
+        }),
+        attributes: Object.freeze([...new Set(plan.attributes)]),
+    });
+}
+
+export function createLibrarySerializerTemplate(
+    draft: LibrarySerializerTemplateDraft,
+): LibrarySerializerTemplate {
+    const issues = validateLibrarySerializerTemplate(draft);
+    const blockingIssues = issues.filter(issue => issue.severity === "error");
+    if (blockingIssues.length > 0) {
+        throw new LibrarySerializerTemplateError(
+            `Template ${draft.id} ist ungültig (${blockingIssues.length} Fehler).`,
+            issues,
+        );
+    }
+
+    const descriptor = describeLibraryStorageDomain(draft.storage.domain);
+    const telemetryPlan = freezeTelemetry(draft.telemetry ?? DEFAULT_TELEMETRY_PLAN);
+    const policies = draft.policies.map(policy => freezePolicy(policy));
+
+    return Object.freeze({
+        id: draft.id,
+        description: draft.description,
+        version: draft.version,
+        storage: Object.freeze({
+            domain: draft.storage.domain,
+            adapter: draft.storage.adapter,
+            versioning: draft.storage.versioning,
+            dryRun: draft.storage.dryRun,
+            descriptor,
+            backupPlan: draft.storage.backupPlan
+                ? Object.freeze({
+                      directory: draft.storage.backupPlan.directory,
+                      strategy: draft.storage.backupPlan.strategy,
+                      note: draft.storage.backupPlan.note,
+                  })
+                : undefined,
+        }),
+        policies: Object.freeze(policies),
+        telemetry: telemetryPlan,
+    });
+}
+
+export interface LibrarySerializerDryRunExecution {
+    readonly templateId: string;
+    readonly domain: LibraryStorageDomainId;
+    readonly report: LibraryStorageDryRunReport;
+}
+
+export interface LibrarySerializerTelemetryEventContext {
+    readonly templateId: string;
+    readonly domain: LibraryStorageDomainId;
+    readonly version: LibrarySerializerTemplateVersion;
+    readonly event: keyof LibrarySerializerTelemetryEvents;
+    readonly attributes?: Record<string, unknown>;
+}
+
+export interface LibrarySerializerTemplateRuntimeHooks {
+    readonly onDryRunExecuted?: (execution: LibrarySerializerDryRunExecution) => void;
+    readonly emitTelemetry?: (context: LibrarySerializerTelemetryEventContext) => void;
+}

--- a/tests/contracts/library-fixtures/creatures.ts
+++ b/tests/contracts/library-fixtures/creatures.ts
@@ -95,5 +95,66 @@ export const creatureFixtures: CreatureFixtureSet = Object.freeze({
                 ],
             },
         }),
+        Object.freeze({
+            fixtureId: "creature.gamma",
+            name: "Glimmerfen Stalker",
+            size: "Medium",
+            type: "Plant",
+            alignmentLawChaos: "Neutral",
+            alignmentGoodEvil: "Evil",
+            ac: "15 (natural armor)",
+            hp: "88 (16d8 + 16)",
+            speeds: {
+                walk: { distance: "30 ft." },
+                climb: { distance: "20 ft." },
+                extras: [
+                    { label: "swampstride", distance: "40 ft.", note: "difficult terrain" },
+                ],
+            },
+            abilities: [
+                { ability: "str", score: 16 },
+                { ability: "dex", score: 14 },
+                { ability: "con", score: 12 },
+                { ability: "int", score: 7 },
+                { ability: "wis", score: 15 },
+                { ability: "cha", score: 8 },
+            ],
+            saves: [
+                { ability: "wis", bonus: 5 },
+            ],
+            skills: [
+                { name: "Stealth", bonus: 6 },
+                { name: "Survival", bonus: 5 },
+            ],
+            sensesList: ["darkvision 60 ft.", "passive Perception 15"],
+            languagesList: ["Understands Sylvan, can't speak"],
+            damageImmunitiesList: ["poison"],
+            conditionImmunitiesList: ["poisoned"],
+            traits:
+                "***Choking Spores.*** When reduced to half hit points the stalker releases spores; creatures within 10 ft. must succeed on a DC 13 Con save or be poisoned until the end of their next turn.",
+            actionsList: [
+                { name: "Multiattack", text: "The stalker makes two vine lash attacks." },
+                {
+                    name: "Vine Lash",
+                    to_hit: "+6",
+                    range: "10 ft.",
+                    damage: "10 (2d6 + 3) bludgeoning",
+                    text: "On a hit, the target is grappled (escape DC 14).",
+                },
+            ],
+            spellcasting: {
+                ability: "wis",
+                groups: [
+                    {
+                        type: "per-day",
+                        uses: "3/day",
+                        spells: [
+                            { name: "Entangle" },
+                            { name: "Spike Growth" },
+                        ],
+                    },
+                ],
+            },
+        }),
     ],
 });

--- a/tests/contracts/library-fixtures/equipment.ts
+++ b/tests/contracts/library-fixtures/equipment.ts
@@ -30,5 +30,15 @@ export const equipmentFixtures: EquipmentFixtureSet = Object.freeze({
             properties: ["Resistance (cold) while submerged"],
             description: "Armor woven from kelp strands treated with alchemical resin.",
         }),
+        Object.freeze({
+            fixtureId: "equipment.gamma",
+            name: "Thundercoil Net",
+            cost: "65 gp",
+            weight: "3 lb.",
+            category: "Martial Ranged Weapons",
+            damage: "1d6 bludgeoning",
+            properties: ["Thrown (20/60)", "Special"],
+            description: "Braided with resonant wire, this net delivers a concussive jolt when it ensnares a creature.",
+        }),
     ],
 });

--- a/tests/contracts/library-fixtures/items.ts
+++ b/tests/contracts/library-fixtures/items.ts
@@ -33,5 +33,17 @@ export const itemFixtures: ItemFixtureSet = Object.freeze({
                 "While submerged you can breathe water for up to 10 minutes per day.",
             ],
         }),
+        Object.freeze({
+            fixtureId: "item.gamma",
+            name: "Lantern of Echoing Tides",
+            rarity: "Rare",
+            type: "Wondrous Item",
+            attunement: "yes",
+            description: "When lit, the lantern projects drifting motes that reveal invisible or ethereal creatures within 20 feet.",
+            properties: [
+                "Creatures revealed by the lantern shed dim light in a 10-foot radius.",
+                "Once per dawn you can cast *See Invisibility* without expending a spell slot.",
+            ],
+        }),
     ],
 });

--- a/tests/contracts/library-fixtures/spell-presets.ts
+++ b/tests/contracts/library-fixtures/spell-presets.ts
@@ -48,5 +48,23 @@ export const spellPresetFixtures: SpellPresetFixtureSet = Object.freeze({
             higher_levels:
                 "The bonus damage increases by 1 when you reach 5th level (2 cold), 11th level (3 cold), and 17th level (4 cold).",
         }),
+        Object.freeze({
+            fixtureId: "spell-preset.coralmind-bastion",
+            name: "Coralmind Bastion",
+            level: 4,
+            school: "Abjuration",
+            casting_time: "1 action",
+            range: "60 feet",
+            components: ["V", "S", "M"],
+            materials: "a miniature coral crown worth 50 gp",
+            duration: "Concentration, up to 10 minutes",
+            concentration: true,
+            ritual: false,
+            classes: ["Cleric", "Druid"],
+            description:
+                "You raise a shimmering reef of thought coral that grants allies within a 20-foot radius resistance to psychic damage.",
+            higher_levels:
+                "When you cast this spell using a spell slot of 6th level or higher, creatures in the area also gain advantage on Wisdom saving throws.",
+        }),
     ],
 });

--- a/tests/contracts/library-golden.test.ts
+++ b/tests/contracts/library-golden.test.ts
@@ -1,0 +1,104 @@
+// salt-marcher/tests/contracts/library-golden.test.ts
+// Validiert Golden-Files der Library-Serializer über deterministische Roundtrip-Vergleiche.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createLibraryHarness, type LibraryHarness } from "./library-harness";
+import { spellPresetToMarkdown } from "../../src/apps/library/core/spell-presets";
+
+const GOLDEN_ROOT = path.resolve(process.cwd(), "tests/golden/library");
+
+type DomainKey = "creatures" | "items" | "equipment" | "spells";
+
+type ManifestEntry = {
+    fixtureId: string;
+    name: string;
+    storagePath: string;
+    goldenFile: string;
+    checksum: string;
+};
+
+type GoldenManifest = {
+    schemaVersion: number;
+    domain: DomainKey;
+    generatedBy: string;
+    generatedAt: string;
+    owner: string;
+    samples: ManifestEntry[];
+};
+
+const DOMAINS: DomainKey[] = ["creatures", "items", "equipment", "spells"];
+
+function resolveManifestPath(domain: DomainKey): string {
+    return path.join(GOLDEN_ROOT, domain, ".manifest.json");
+}
+
+async function loadManifest(domain: DomainKey): Promise<GoldenManifest> {
+    const manifestPath = resolveManifestPath(domain);
+    const raw = await readFile(manifestPath, "utf8");
+    return JSON.parse(raw) as GoldenManifest;
+}
+
+describe("library serializer golden files", () => {
+    let harness: LibraryHarness;
+
+    beforeEach(async () => {
+        harness = createLibraryHarness();
+        await harness.reset();
+    });
+
+    for (const domain of DOMAINS) {
+        describe(`${domain} golden set`, () => {
+            let manifest: GoldenManifest;
+
+            beforeAll(async () => {
+                manifest = await loadManifest(domain);
+            });
+
+            it("stellt mindestens drei Golden-Beispiele bereit", () => {
+                // Arrange
+                if (!manifest) {
+                    throw new Error(`Manifest ${domain} nicht geladen`);
+                }
+                const samples = manifest.samples;
+
+                // Act
+                const sampleCount = samples.length;
+
+                // Assert
+                expect(sampleCount).toBeGreaterThanOrEqual(3);
+            });
+
+            it("bewahrt alle Samples deterministisch", async () => {
+                // Arrange
+                if (!manifest) {
+                    throw new Error(`Manifest ${domain} nicht geladen`);
+                }
+                const domainKey = domain === "spells" ? "spellPresets" : domain;
+                const domainFixtures = harness.fixtures[domainKey].entries;
+
+                // Act
+                for (const sample of manifest.samples) {
+                    const fixture = domainFixtures.find(entry => entry.fixtureId === sample.fixtureId);
+                    if (!fixture) {
+                        throw new Error(`Fixture ${sample.fixtureId} not found for domain ${domain}`);
+                    }
+                    const goldenPath = path.join(GOLDEN_ROOT, domain, sample.goldenFile);
+                    const goldenContent = await readFile(goldenPath, "utf8");
+                    const serialized = domain === "creatures"
+                        ? harness.ports.serializer.creatureToMarkdown(fixture)
+                        : domain === "items"
+                        ? harness.ports.serializer.itemToMarkdown(fixture)
+                        : domain === "equipment"
+                        ? harness.ports.serializer.equipmentToMarkdown(fixture)
+                        : spellPresetToMarkdown(fixture, { fixtureId: fixture.fixtureId });
+                    const stored = await harness.ports.storage.read(sample.storagePath);
+
+                    // Assert
+                    expect(serialized).toBe(goldenContent);
+                    expect(stored).toBe(goldenContent);
+                }
+            });
+        });
+    }
+});

--- a/tests/contracts/update-library-golden.ts
+++ b/tests/contracts/update-library-golden.ts
@@ -1,0 +1,154 @@
+// salt-marcher/tests/contracts/update-library-golden.ts
+// Generiert Golden-Files für Library-Serializer-Roundtrips basierend auf dem Vertragstest-Harness.
+import { createHash } from "node:crypto";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLibraryHarness } from "./library-harness";
+import { libraryFixtures } from "./library-fixtures";
+import {
+    CREATURES_DIR,
+} from "../../src/apps/library/core/creature-files";
+import {
+    EQUIPMENT_DIR,
+} from "../../src/apps/library/core/equipment-files";
+import { ITEMS_DIR } from "../../src/apps/library/core/item-files";
+import {
+    SPELL_PRESETS_DIR,
+    spellPresetToMarkdown,
+} from "../../src/apps/library/core/spell-presets";
+import { sanitizeVaultFileName } from "../../src/apps/library/core/file-pipeline";
+
+type DomainKey = "creatures" | "items" | "equipment" | "spells";
+
+type ManifestEntry = {
+    fixtureId: string;
+    name: string;
+    storagePath: string;
+    goldenFile: string;
+    checksum: string;
+};
+
+type GoldenManifest = {
+    schemaVersion: number;
+    domain: DomainKey;
+    generatedBy: string;
+    generatedAt: string;
+    owner: string;
+    samples: ManifestEntry[];
+};
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const GOLDEN_ROOT = path.resolve(__dirname, "../golden/library");
+
+function sha256(input: string): string {
+    return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+async function cleanupDomainDir(dir: string): Promise<void> {
+    await mkdir(dir, { recursive: true });
+    const files = await readdir(dir);
+    await Promise.all(
+        files
+            .filter(file => file.endsWith(".md") || file === ".manifest.json")
+            .map(file => rm(path.join(dir, file)))
+    );
+}
+
+async function writeManifest(dir: string, manifest: GoldenManifest): Promise<void> {
+    const manifestPath = path.join(dir, ".manifest.json");
+    const contents = `${JSON.stringify(manifest, null, 4)}\n`;
+    await writeFile(manifestPath, contents, "utf8");
+}
+
+async function main(): Promise<void> {
+    const harness = createLibraryHarness({ fixtures: libraryFixtures });
+    await harness.reset();
+
+    const serializer = harness.ports.serializer;
+
+    const domainConfigs: Array<{
+        key: DomainKey;
+        directory: string;
+        fallback: string;
+        owner: string;
+        serialize: (entry: any) => string;
+        fixtures: Array<{ fixtureId: string; name?: string }>;
+    }> = [
+        {
+            key: "creatures",
+            directory: CREATURES_DIR,
+            fallback: "Creature",
+            owner: libraryFixtures.creatures.owner,
+            serialize: entry => serializer.creatureToMarkdown(entry),
+            fixtures: libraryFixtures.creatures.entries,
+        },
+        {
+            key: "items",
+            directory: ITEMS_DIR,
+            fallback: "Item",
+            owner: libraryFixtures.items.owner,
+            serialize: entry => serializer.itemToMarkdown(entry),
+            fixtures: libraryFixtures.items.entries,
+        },
+        {
+            key: "equipment",
+            directory: EQUIPMENT_DIR,
+            fallback: "Equipment",
+            owner: libraryFixtures.equipment.owner,
+            serialize: entry => serializer.equipmentToMarkdown(entry),
+            fixtures: libraryFixtures.equipment.entries,
+        },
+        {
+            key: "spells",
+            directory: SPELL_PRESETS_DIR,
+            fallback: "Spell Preset",
+            owner: libraryFixtures.spellPresets.owner,
+            serialize: entry => spellPresetToMarkdown(entry, { fixtureId: entry.fixtureId }),
+            fixtures: libraryFixtures.spellPresets.entries,
+        },
+    ];
+
+    for (const config of domainConfigs) {
+        const domainDir = path.join(GOLDEN_ROOT, config.key);
+        await cleanupDomainDir(domainDir);
+
+        const samples: ManifestEntry[] = [];
+        for (const entry of config.fixtures) {
+            const goldenFile = `${entry.fixtureId}.md`;
+            const goldenPath = path.join(domainDir, goldenFile);
+            const name = entry.name ?? entry.fixtureId;
+            const content = config.serialize(entry);
+            await writeFile(goldenPath, content, "utf8");
+
+            const sanitizedName = sanitizeVaultFileName(name, config.fallback);
+            const storagePath = path.posix.join(config.directory, `${sanitizedName}.md`);
+
+            samples.push({
+                fixtureId: entry.fixtureId,
+                name,
+                storagePath,
+                goldenFile,
+                checksum: sha256(content),
+            });
+        }
+
+        samples.sort((a, b) => a.fixtureId.localeCompare(b.fixtureId));
+
+        const manifest: GoldenManifest = {
+            schemaVersion: 1,
+            domain: config.key,
+            generatedBy: "LIB-TD-0002",
+            generatedAt: new Date().toISOString(),
+            owner: config.owner,
+            samples,
+        };
+
+        await writeManifest(domainDir, manifest);
+    }
+}
+
+await main().catch(error => {
+    console.error("Failed to update library golden files:", error);
+    process.exitCode = 1;
+});

--- a/tests/golden/AGENTS.md
+++ b/tests/golden/AGENTS.md
@@ -1,0 +1,12 @@
+# Ziele
+- Hält formatierte Golden-Files und Manifeste für deterministische Tests vor.
+
+# Aktueller Stand
+- Enthält Library-bezogene Golden-Datensätze gemäß LIB-TD-0002.
+
+# ToDo
+- keine offenen ToDos.
+
+# Standards
+- Jede Unterdomäne beschreibt ihre Struktur in einer eigenen `AGENTS.md`.
+- Golden-Dateien werden ausschließlich über die dokumentierten Update-Skripte generiert.

--- a/tests/golden/library/AGENTS.md
+++ b/tests/golden/library/AGENTS.md
@@ -1,0 +1,13 @@
+# Ziele
+- Versioniert Golden-Datensätze der Library-Serializer pro Domäne.
+
+# Aktueller Stand
+- Enthält Creatures-, Items-, Equipment- und Spell-Goldens inklusive Manifesten.
+
+# ToDo
+- keine offenen ToDos.
+
+# Standards
+- Pro Domäne existiert ein `.manifest.json` mit `schemaVersion`, `domain`, `generatedBy`, `generatedAt` und `samples`.
+- `samples` enthalten `fixtureId`, `name`, `storagePath`, `goldenFile` und `checksum` (sha256 über den Markdown-Inhalt).
+- Golden-Markdown-Dateien sind UTF-8 codiert, enden mit Newline und werden nicht manuell editiert.

--- a/tests/golden/library/creatures/.manifest.json
+++ b/tests/golden/library/creatures/.manifest.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": 1,
+    "domain": "creatures",
+    "generatedBy": "LIB-TD-0002",
+    "generatedAt": "2025-10-06T20:07:39.582Z",
+    "owner": "QA",
+    "samples": [
+        {
+            "fixtureId": "creature.alpha",
+            "name": "Azure Manticore",
+            "storagePath": "SaltMarcher/Creatures/Azure Manticore.md",
+            "goldenFile": "creature.alpha.md",
+            "checksum": "09e7d196072d2683a9da499ba85ce77fc3cfdcef9fca288b91d7d5bbcdfd9f22"
+        },
+        {
+            "fixtureId": "creature.beta",
+            "name": "Brinebound Sage",
+            "storagePath": "SaltMarcher/Creatures/Brinebound Sage.md",
+            "goldenFile": "creature.beta.md",
+            "checksum": "dc9b69e462a49857e7709899098c2bd01f8718d405744db0a4fc37545165b056"
+        },
+        {
+            "fixtureId": "creature.gamma",
+            "name": "Glimmerfen Stalker",
+            "storagePath": "SaltMarcher/Creatures/Glimmerfen Stalker.md",
+            "goldenFile": "creature.gamma.md",
+            "checksum": "106dcb1300bd457b4e626c21939da4a4f5a9a804ac84f402c3fe8a9e91ec6fa3"
+        }
+    ]
+}

--- a/tests/golden/library/creatures/creature.alpha.md
+++ b/tests/golden/library/creatures/creature.alpha.md
@@ -1,0 +1,54 @@
+---
+smType: creature
+name: "Azure Manticore"
+size: "Large"
+type: "Monstrosity"
+alignment: "Chaotic Neutral"
+ac: "17 (natural armor)"
+hp: "136 (16d10 + 48)"
+speeds_json: "{\"walk\":{\"distance\":\"40 ft.\"},\"fly\":{\"distance\":\"60 ft.\",\"hover\":false}}"
+abilities_json: "[{\"ability\":\"str\",\"score\":18},{\"ability\":\"dex\",\"score\":15},{\"ability\":\"con\",\"score\":16},{\"ability\":\"int\",\"score\":5},{\"ability\":\"wis\",\"score\":12},{\"ability\":\"cha\",\"score\":10}]"
+saves_json: "[{\"ability\":\"str\",\"bonus\":7},{\"ability\":\"dex\",\"bonus\":6}]"
+skills_json: "[{\"name\":\"Perception\",\"bonus\":6},{\"name\":\"Stealth\",\"bonus\":6}]"
+senses: ["darkvision 60 ft.", "passive Perception 16"]
+languages: ["Understands Common, can't speak"]
+damage_resistances: ["Poison"]
+entries_structured_json: "[{\"category\":\"action\",\"name\":\"Multiattack\",\"text\":\"The manticore makes three tail spike attacks.\"},{\"category\":\"action\",\"name\":\"Tail Spike\",\"to_hit\":\"+7\",\"range\":\"100/200 ft.\",\"damage\":\"11 (2d6 + 4) piercing\"}]"
+spellcasting_json: "{\"ability\":\"cha\",\"groups\":[{\"type\":\"at-will\",\"spells\":[{\"name\":\"Detect Magic\"},{\"name\":\"Message\"}]}],\"computed\":{\"abilityMod\":0,\"proficiencyBonus\":null,\"saveDc\":null,\"attackBonus\":null}}"
+---
+
+# Azure Manticore
+*Large Monstrosity, Chaotic Neutral*
+
+AC 17 (natural armor)    Initiative -
+HP 136 (16d10 + 48)
+Speed 40 ft., fly 60 ft.
+
+| Ability | Score |
+| ------: | :---- |
+| STR | 18 |
+| DEX | 15 |
+| CON | 16 |
+| INT | 5 |
+| WIS | 12 |
+| CHA | 10 |
+
+Saves Str +7, Dex +6
+Skills Perception +6, Stealth +6
+Senses darkvision 60 ft., passive Perception 16
+Resistances Poison
+Languages Understands Common, can't speak
+
+## Actions
+
+- **Multiattack**
+  The manticore makes three tail spike attacks.
+- **Tail Spike**
+  - to hit +7, 100/200 ft., 11 (2d6 + 4) piercing
+
+## Spellcasting
+
+### At Will
+
+- Detect Magic
+- Message

--- a/tests/golden/library/creatures/creature.beta.md
+++ b/tests/golden/library/creatures/creature.beta.md
@@ -1,0 +1,53 @@
+---
+smType: creature
+name: "Brinebound Sage"
+size: "Medium"
+type: "Humanoid (wizard)"
+alignment: "Lawful Good"
+alignment_override: "Lawful Good"
+ac: "14 (mage armor)"
+hp: "71 (13d8 + 13)"
+speeds_json: "{\"walk\":{\"distance\":\"30 ft.\"},\"swim\":{\"distance\":\"30 ft.\"}}"
+abilities_json: "[{\"ability\":\"str\",\"score\":9},{\"ability\":\"dex\",\"score\":14},{\"ability\":\"con\",\"score\":12},{\"ability\":\"int\",\"score\":18},{\"ability\":\"wis\",\"score\":13},{\"ability\":\"cha\",\"score\":11}]"
+skills_json: "[{\"name\":\"Arcana\",\"bonus\":9},{\"name\":\"History\",\"bonus\":9}]"
+senses: ["passive Perception 11"]
+languages: ["Common", "Aquan"]
+spellcasting_json: "{\"ability\":\"int\",\"groups\":[{\"type\":\"level\",\"level\":3,\"slots\":3,\"spells\":[{\"name\":\"Counterspell\"},{\"name\":\"Water Breathing\"}]},{\"type\":\"custom\",\"title\":\"Rituals\",\"description\":\"The sage can cast *Augury* as a ritual without expending a slot.\"}],\"computed\":{\"abilityMod\":4,\"proficiencyBonus\":null,\"saveDc\":null,\"attackBonus\":null}}"
+---
+
+# Brinebound Sage
+*Medium Humanoid (wizard), Lawful Good*
+
+AC 14 (mage armor)    Initiative -
+HP 71 (13d8 + 13)
+Speed 30 ft., swim 30 ft.
+
+| Ability | Score |
+| ------: | :---- |
+| STR | 9 |
+| DEX | 14 |
+| CON | 12 |
+| INT | 18 |
+| WIS | 13 |
+| CHA | 11 |
+
+Skills Arcana +9, History +9
+Senses passive Perception 11
+Languages Common, Aquan
+
+## Traits
+
+***Brine Veil.*** A shimmering veil grants the sage resistance to cold damage.
+
+## Spellcasting
+
+### 3rd Level (3 slots)
+
+- Counterspell
+- Water Breathing
+
+### Rituals
+
+The sage can cast *Augury* as a ritual without expending a slot.
+
+- none

--- a/tests/golden/library/creatures/creature.gamma.md
+++ b/tests/golden/library/creatures/creature.gamma.md
@@ -1,0 +1,57 @@
+---
+smType: creature
+name: "Glimmerfen Stalker"
+size: "Medium"
+type: "Plant"
+alignment: "Neutral Evil"
+ac: "15 (natural armor)"
+hp: "88 (16d8 + 16)"
+speeds_json: "{\"walk\":{\"distance\":\"30 ft.\"},\"climb\":{\"distance\":\"20 ft.\"},\"extras\":[{\"label\":\"swampstride\",\"distance\":\"40 ft.\",\"note\":\"difficult terrain\"}]}"
+abilities_json: "[{\"ability\":\"str\",\"score\":16},{\"ability\":\"dex\",\"score\":14},{\"ability\":\"con\",\"score\":12},{\"ability\":\"int\",\"score\":7},{\"ability\":\"wis\",\"score\":15},{\"ability\":\"cha\",\"score\":8}]"
+saves_json: "[{\"ability\":\"wis\",\"bonus\":5}]"
+skills_json: "[{\"name\":\"Stealth\",\"bonus\":6},{\"name\":\"Survival\",\"bonus\":5}]"
+senses: ["darkvision 60 ft.", "passive Perception 15"]
+languages: ["Understands Sylvan, can't speak"]
+damage_immunities: ["poison"]
+condition_immunities: ["poisoned"]
+entries_structured_json: "[{\"category\":\"action\",\"name\":\"Multiattack\",\"text\":\"The stalker makes two vine lash attacks.\"},{\"category\":\"action\",\"name\":\"Vine Lash\",\"to_hit\":\"+6\",\"range\":\"10 ft.\",\"damage\":\"10 (2d6 + 3) bludgeoning\",\"text\":\"On a hit, the target is grappled (escape DC 14).\"}]"
+spellcasting_json: "{\"ability\":\"wis\",\"groups\":[{\"type\":\"per-day\",\"uses\":\"3/day\",\"spells\":[{\"name\":\"Entangle\"},{\"name\":\"Spike Growth\"}]}],\"computed\":{\"abilityMod\":2,\"proficiencyBonus\":null,\"saveDc\":null,\"attackBonus\":null}}"
+---
+
+# Glimmerfen Stalker
+*Medium Plant, Neutral Evil*
+
+AC 15 (natural armor)    Initiative -
+HP 88 (16d8 + 16)
+Speed 30 ft., climb 20 ft., swampstride 40 ft. difficult terrain
+
+| Ability | Score |
+| ------: | :---- |
+| STR | 16 |
+| DEX | 14 |
+| CON | 12 |
+| INT | 7 |
+| WIS | 15 |
+| CHA | 8 |
+
+Saves Wis +5
+Skills Stealth +6, Survival +5
+Senses darkvision 60 ft., passive Perception 15
+Immunities poison
+Condition Immunities poisoned
+Languages Understands Sylvan, can't speak
+
+## Actions
+
+- **Multiattack**
+  The stalker makes two vine lash attacks.
+- **Vine Lash**
+  - to hit +6, 10 ft., 10 (2d6 + 3) bludgeoning
+  On a hit, the target is grappled (escape DC 14).
+
+## Spellcasting
+
+### 3/day
+
+- Entangle
+- Spike Growth

--- a/tests/golden/library/equipment/.manifest.json
+++ b/tests/golden/library/equipment/.manifest.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": 1,
+    "domain": "equipment",
+    "generatedBy": "LIB-TD-0002",
+    "generatedAt": "2025-10-06T20:07:39.589Z",
+    "owner": "Systems",
+    "samples": [
+        {
+            "fixtureId": "equipment.alpha",
+            "name": "Stormglass Pike",
+            "storagePath": "SaltMarcher/Equipment/Stormglass Pike.md",
+            "goldenFile": "equipment.alpha.md",
+            "checksum": "9e43abba10e67e1b8ace99abc80bec81d9c991285b8ad06a45c57b051d4baa0a"
+        },
+        {
+            "fixtureId": "equipment.beta",
+            "name": "Kelpweave Armor",
+            "storagePath": "SaltMarcher/Equipment/Kelpweave Armor.md",
+            "goldenFile": "equipment.beta.md",
+            "checksum": "a391371c6b693fd40de68d7a641e489c548292fda300a8afa2753aa7f3eab058"
+        },
+        {
+            "fixtureId": "equipment.gamma",
+            "name": "Thundercoil Net",
+            "storagePath": "SaltMarcher/Equipment/Thundercoil Net.md",
+            "goldenFile": "equipment.gamma.md",
+            "checksum": "53a0b57b2568ad223c23f1bb798959867b17abfe6aaea569cfabb0af33ac6e2f"
+        }
+    ]
+}

--- a/tests/golden/library/equipment/equipment.alpha.md
+++ b/tests/golden/library/equipment/equipment.alpha.md
@@ -1,0 +1,16 @@
+---
+smType: equipment
+name: "Stormglass Pike"
+type: "undefined"
+cost: "35 gp"
+weight: "6 lb."
+damage: "1d8 piercing"
+properties: ["Reach", "Two-Handed"]
+---
+
+# Stormglass Pike
+
+- **Cost:** 35 gp
+- **Weight:** 6 lb.
+
+Forged from hardened stormglass that crackles with static energy.

--- a/tests/golden/library/equipment/equipment.beta.md
+++ b/tests/golden/library/equipment/equipment.beta.md
@@ -1,0 +1,16 @@
+---
+smType: equipment
+name: "Kelpweave Armor"
+type: "undefined"
+cost: "120 gp"
+weight: "20 lb."
+properties: ["Resistance (cold) while submerged"]
+ac: "15"
+---
+
+# Kelpweave Armor
+
+- **Cost:** 120 gp
+- **Weight:** 20 lb.
+
+Armor woven from kelp strands treated with alchemical resin.

--- a/tests/golden/library/equipment/equipment.gamma.md
+++ b/tests/golden/library/equipment/equipment.gamma.md
@@ -1,0 +1,16 @@
+---
+smType: equipment
+name: "Thundercoil Net"
+type: "undefined"
+cost: "65 gp"
+weight: "3 lb."
+damage: "1d6 bludgeoning"
+properties: ["Thrown (20/60)", "Special"]
+---
+
+# Thundercoil Net
+
+- **Cost:** 65 gp
+- **Weight:** 3 lb.
+
+Braided with resonant wire, this net delivers a concussive jolt when it ensnares a creature.

--- a/tests/golden/library/items/.manifest.json
+++ b/tests/golden/library/items/.manifest.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": 1,
+    "domain": "items",
+    "generatedBy": "LIB-TD-0002",
+    "generatedAt": "2025-10-06T20:07:39.585Z",
+    "owner": "Library",
+    "samples": [
+        {
+            "fixtureId": "item.alpha",
+            "name": "Saltward Cloak",
+            "storagePath": "SaltMarcher/Items/Saltward Cloak.md",
+            "goldenFile": "item.alpha.md",
+            "checksum": "c88a5c275a13117c1992f3c83b5f981201cfc0da9a8bb282bc00e7c1a9869e7b"
+        },
+        {
+            "fixtureId": "item.beta",
+            "name": "Compass of the Deep",
+            "storagePath": "SaltMarcher/Items/Compass of the Deep.md",
+            "goldenFile": "item.beta.md",
+            "checksum": "5d640e00b2942265fe03d6fab4895b28469d15d8b4462c039b5988171f465ff8"
+        },
+        {
+            "fixtureId": "item.gamma",
+            "name": "Lantern of Echoing Tides",
+            "storagePath": "SaltMarcher/Items/Lantern of Echoing Tides.md",
+            "goldenFile": "item.gamma.md",
+            "checksum": "dde8e37c3605a73a0ddadf6c37206b0be1575f05c0bd0f02cc6fb67074df16b7"
+        }
+    ]
+}

--- a/tests/golden/library/items/item.alpha.md
+++ b/tests/golden/library/items/item.alpha.md
@@ -1,0 +1,21 @@
+---
+smType: item
+name: "Saltward Cloak"
+type: "Wondrous Item"
+rarity: "Rare"
+attunement: true
+properties_json: "[\"While wearing the cloak you have advantage on saves against acid.\",\"Once per long rest you can cast *Absorb Elements* without expending a spell slot.\"]"
+---
+
+# Saltward Cloak
+*(Wondrous Item) Rare (Requires Attunement)*
+
+## Properties
+
+**undefined**
+
+
+**undefined**
+
+
+A cloak woven with sea-silver thread that wards off corroding spray.

--- a/tests/golden/library/items/item.beta.md
+++ b/tests/golden/library/items/item.beta.md
@@ -1,0 +1,18 @@
+---
+smType: item
+name: "Compass of the Deep"
+type: "Wondrous Item"
+rarity: "Uncommon"
+attunement: true
+properties_json: "[\"While submerged you can breathe water for up to 10 minutes per day.\"]"
+---
+
+# Compass of the Deep
+*(Wondrous Item) Uncommon (Requires Attunement)*
+
+## Properties
+
+**undefined**
+
+
+This brass compass always points toward the nearest underwater ruin.

--- a/tests/golden/library/items/item.gamma.md
+++ b/tests/golden/library/items/item.gamma.md
@@ -1,0 +1,21 @@
+---
+smType: item
+name: "Lantern of Echoing Tides"
+type: "Wondrous Item"
+rarity: "Rare"
+attunement: true
+properties_json: "[\"Creatures revealed by the lantern shed dim light in a 10-foot radius.\",\"Once per dawn you can cast *See Invisibility* without expending a spell slot.\"]"
+---
+
+# Lantern of Echoing Tides
+*(Wondrous Item) Rare (Requires Attunement)*
+
+## Properties
+
+**undefined**
+
+
+**undefined**
+
+
+When lit, the lantern projects drifting motes that reveal invisible or ethereal creatures within 20 feet.

--- a/tests/golden/library/spells/.manifest.json
+++ b/tests/golden/library/spells/.manifest.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": 1,
+    "domain": "spells",
+    "generatedBy": "LIB-TD-0002",
+    "generatedAt": "2025-10-06T20:07:39.591Z",
+    "owner": "QA",
+    "samples": [
+        {
+            "fixtureId": "spell-preset.coralmind-bastion",
+            "name": "Coralmind Bastion",
+            "storagePath": "SaltMarcher/Presets/Spells/Coralmind Bastion.md",
+            "goldenFile": "spell-preset.coralmind-bastion.md",
+            "checksum": "3566d39063cf25ca2549d746e300c6c87e123b8a75cd0ef13c766ffca1afe079"
+        },
+        {
+            "fixtureId": "spell-preset.ember-ward",
+            "name": "Ember Ward",
+            "storagePath": "SaltMarcher/Presets/Spells/Ember Ward.md",
+            "goldenFile": "spell-preset.ember-ward.md",
+            "checksum": "7eea872f3d649d27939095df6578c8d418ef183473d2d7598530fa90359fd7de"
+        },
+        {
+            "fixtureId": "spell-preset.tidal-script",
+            "name": "Tidal Script",
+            "storagePath": "SaltMarcher/Presets/Spells/Tidal Script.md",
+            "goldenFile": "spell-preset.tidal-script.md",
+            "checksum": "46372508f989591652a67558465200d79efa50ab8462b3c635a69a2aa4ddf0b4"
+        }
+    ]
+}

--- a/tests/golden/library/spells/spell-preset.coralmind-bastion.md
+++ b/tests/golden/library/spells/spell-preset.coralmind-bastion.md
@@ -1,0 +1,23 @@
+---
+smType: spell
+fixtureId: "spell-preset.coralmind-bastion"
+name: "Coralmind Bastion"
+level: 4
+school: "Abjuration"
+casting_time: "1 action"
+range: "60 feet"
+components: ["V", "S", "M"]
+materials: "a miniature coral crown worth 50 gp"
+duration: "Concentration, up to 10 minutes"
+concentration: true
+ritual: false
+classes: ["Cleric", "Druid"]
+description: "You raise a shimmering reef of thought coral that grants allies within a 20-foot radius resistance to psychic damage."
+higher_levels: "When you cast this spell using a spell slot of 6th level or higher, creatures in the area also gain advantage on Wisdom saving throws."
+---
+
+You raise a shimmering reef of thought coral that grants allies within a 20-foot radius resistance to psychic damage.
+
+## At Higher Levels
+
+When you cast this spell using a spell slot of 6th level or higher, creatures in the area also gain advantage on Wisdom saving throws.

--- a/tests/golden/library/spells/spell-preset.ember-ward.md
+++ b/tests/golden/library/spells/spell-preset.ember-ward.md
@@ -1,0 +1,23 @@
+---
+smType: spell
+fixtureId: "spell-preset.ember-ward"
+name: "Ember Ward"
+level: 2
+school: "Abjuration"
+casting_time: "1 action"
+range: "Self"
+components: ["V", "S"]
+materials: "a shard of kiln-fired glass"
+duration: "10 minutes"
+concentration: true
+ritual: false
+classes: ["Wizard", "Artificer"]
+description: "A lattice of emberlight surrounds you, reducing fire damage by channeling the heat into harmless sparks."
+higher_levels: "When you cast this spell using a spell slot of 3rd level or higher, the ward also grants resistance to lightning damage."
+---
+
+A lattice of emberlight surrounds you, reducing fire damage by channeling the heat into harmless sparks.
+
+## At Higher Levels
+
+When you cast this spell using a spell slot of 3rd level or higher, the ward also grants resistance to lightning damage.

--- a/tests/golden/library/spells/spell-preset.tidal-script.md
+++ b/tests/golden/library/spells/spell-preset.tidal-script.md
@@ -1,0 +1,25 @@
+---
+smType: spell
+fixtureId: "spell-preset.tidal-script"
+name: "Tidal Script"
+level: 0
+school: "Transmutation"
+casting_time: "1 bonus action"
+range: "Touch"
+components: ["V", "S", "M"]
+materials: "a ribbon of dried kelp"
+duration: "1 minute"
+concentration: false
+ritual: false
+classes: ["Bard", "Druid", "Wizard"]
+save_ability: "dex"
+save_effect: "On a failure, the target is briefly anchored in a glyph of swirling water."
+description: "You etch a watery sigil on a creature's gear. Until the spell ends, the target's weapon attacks deal an extra 1 cold damage."
+higher_levels: "The bonus damage increases by 1 when you reach 5th level (2 cold), 11th level (3 cold), and 17th level (4 cold)."
+---
+
+You etch a watery sigil on a creature's gear. Until the spell ends, the target's weapon attacks deal an extra 1 cold damage.
+
+## At Higher Levels
+
+The bonus damage increases by 1 when you reach 5th level (2 cold), 11th level (3 cold), and 17th level (4 cold).

--- a/tests/library/library-mode-service-port.test.ts
+++ b/tests/library/library-mode-service-port.test.ts
@@ -1,0 +1,61 @@
+// Testspezifikation für den LibraryModeServicePort-Contract und seine Composition-Pläne.
+import { describe, expect, it } from "vitest";
+import {
+    LIBRARY_MODE_COMPOSITION,
+    LIBRARY_MODE_DESCRIPTORS,
+    LIBRARY_MODE_SERVICE_FEATURES,
+    describeLibraryMode,
+    listLibraryModeDescriptors,
+    resolveLibraryModeKillSwitch,
+} from "../../src/apps/library/core/library-mode-service-port";
+import { LIBRARY_SOURCE_IDS, describeLibrarySource } from "../../src/apps/library/core/sources";
+
+describe("library-mode-service-port", () => {
+    it("stellt für jede Library-Quelle einen Descriptor bereit", () => {
+        const descriptors = listLibraryModeDescriptors();
+        expect(descriptors).toHaveLength(LIBRARY_SOURCE_IDS.length);
+
+        for (const id of LIBRARY_SOURCE_IDS) {
+            const descriptor = descriptors.find(entry => entry.id === id);
+            expect(descriptor, `descriptor for ${id}`).toBeTruthy();
+            expect(descriptor?.description).toContain(describeLibrarySource(id));
+            expect(descriptor?.defaultCreateLabel.length ?? 0).toBeGreaterThan(0);
+        }
+
+        expect(() => describeLibraryMode("unknown" as any)).toThrow(/Unknown library mode/);
+    });
+
+    it("ordnet jedem Descriptor einen Composition-Plan zu", () => {
+        const plans = LIBRARY_MODE_COMPOSITION;
+        expect(Object.keys(plans)).toHaveLength(LIBRARY_SOURCE_IDS.length);
+
+        for (const descriptor of LIBRARY_MODE_DESCRIPTORS) {
+            const plan = plans[descriptor.id];
+            expect(plan, `composition plan for ${descriptor.id}`).toBeTruthy();
+            expect(plan.serializerTemplate.length).toBeGreaterThan(0);
+            expect(plan.storagePortModule.startsWith("@core/library/storage/")).toBe(true);
+        }
+    });
+
+    it("wertet Kill-Switch-Flags deterministisch aus", () => {
+        const defaults = resolveLibraryModeKillSwitch();
+        expect(defaults).toEqual({ useService: true, allowLegacyFallback: true });
+
+        const disabled = resolveLibraryModeKillSwitch({
+            flags: {
+                [LIBRARY_MODE_SERVICE_FEATURES.rendererServiceFlag]: false,
+                [LIBRARY_MODE_SERVICE_FEATURES.legacyFallbackFlag]: true,
+            },
+        });
+        expect(disabled).toEqual({ useService: false, allowLegacyFallback: true });
+
+        const overrides = resolveLibraryModeKillSwitch({
+            flags: {
+                [LIBRARY_MODE_SERVICE_FEATURES.rendererServiceFlag]: true,
+                [LIBRARY_MODE_SERVICE_FEATURES.legacyFallbackFlag]: true,
+            },
+            overrides: { useService: false, allowLegacyFallback: false },
+        });
+        expect(overrides).toEqual({ useService: false, allowLegacyFallback: false });
+    });
+});

--- a/tests/library/library-serializer-template.test.ts
+++ b/tests/library/library-serializer-template.test.ts
@@ -1,0 +1,231 @@
+// tests/library/library-serializer-template.test.ts
+// Prüft das Serializer-Template auf korrekte Policy-Validierung, Default-Telemetrie und Freeze-Verhalten.
+import { describe, expect, it } from "vitest";
+
+import {
+    createLibrarySerializerTemplate,
+    validateLibrarySerializerTemplate,
+    LibrarySerializerTemplateError,
+    type LibrarySerializerTemplateDraft,
+} from "../../src/apps/library/core/serializer-template/library-serializer-template";
+
+describe("library serializer template", () => {
+    it("creates an immutable template with explicit telemetry configuration", () => {
+        const draft: LibrarySerializerTemplateDraft = {
+            id: "creatures.template",
+            description: "Creatures serializer policies",
+            version: "1.0.0",
+            storage: {
+                domain: "creatures",
+                adapter: "vault",
+                versioning: "frontmatter",
+                dryRun: "supported",
+                backupPlan: {
+                    directory: "backups/creatures",
+                    strategy: "append",
+                    note: "Keep legacy revisions for audits",
+                },
+            },
+            policies: [
+                {
+                    field: "name",
+                    required: true,
+                    validate: [
+                        {
+                            kind: "required",
+                            code: "creature.name.required",
+                            message: "Name is required",
+                            severity: "error",
+                        },
+                    ],
+                },
+                {
+                    field: "smType",
+                    required: {
+                        reason: "Legacy files rely on smType",
+                    },
+                    defaultValue: {
+                        strategy: "literal",
+                        value: "creature",
+                        reason: "Legacy default",
+                    },
+                    migrate: [
+                        {
+                            fromVersion: "legacy",
+                            kind: "rename",
+                            description: "Map legacy frontmatter property",
+                        },
+                    ],
+                },
+                {
+                    field: "entries_structured_json",
+                    transform: {
+                        kind: "json",
+                        identifier: "structuredEntries",
+                        description: "Parse structured action blocks",
+                    },
+                },
+            ],
+            telemetry: {
+                events: {
+                    migrationApplied: "library.creatures.serializer.migration",
+                    validationFailed: "library.creatures.serializer.validation_failed",
+                    dryRunExecuted: "library.creatures.serializer.dry_run",
+                    transformFallback: "library.creatures.serializer.transform_fallback",
+                },
+                attributes: ["templateId", "domain", "version", "policy"],
+            },
+        };
+
+        const template = createLibrarySerializerTemplate(draft);
+
+        expect(template.storage.descriptor.id).toBe("creatures");
+        expect(Object.isFrozen(template)).toBe(true);
+        expect(Object.isFrozen(template.policies)).toBe(true);
+        expect(Object.isFrozen(template.policies[0])).toBe(true);
+        expect(template.telemetry.events.migrationApplied).toBe(
+            "library.creatures.serializer.migration",
+        );
+        expect(template.storage.backupPlan?.directory).toBe("backups/creatures");
+    });
+
+    it("reports validation issues for duplicate fields, invalid versions and telemetry gaps", () => {
+        const invalidDraft: LibrarySerializerTemplateDraft = {
+            id: "items.template",
+            description: "Invalid template to check validation",
+            version: "1",
+            storage: {
+                domain: "items",
+                adapter: "legacy",
+                versioning: "invalid" as unknown as "frontmatter",
+                dryRun: "invalid" as unknown as "supported",
+            },
+            policies: [
+                {
+                    field: "name",
+                    migrate: [
+                        {
+                            fromVersion: "0.0",
+                            kind: "rename",
+                            description: "",
+                        },
+                    ],
+                },
+                {
+                    field: "name",
+                },
+                {
+                    field: "effect",
+                    validate: [
+                        {
+                            kind: "custom",
+                            code: "",
+                            message: "",
+                            severity: "error",
+                        },
+                    ],
+                    transform: {
+                        kind: "custom",
+                        identifier: "",
+                        description: "",
+                    },
+                },
+            ],
+        };
+
+        const issues = validateLibrarySerializerTemplate(invalidDraft);
+
+        expect(issues).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ code: "invalid-version" }),
+                expect.objectContaining({ code: "policy-duplicate-field" }),
+                expect.objectContaining({ code: "policy-migrate-missing-description" }),
+                expect.objectContaining({ code: "policy-migrate-invalid-from" }),
+                expect.objectContaining({ code: "policy-validate-missing-code" }),
+                expect.objectContaining({ code: "policy-validate-missing-message" }),
+                expect.objectContaining({ code: "policy-transform-missing-identifier" }),
+                expect.objectContaining({ code: "storage-invalid-versioning" }),
+                expect.objectContaining({ code: "storage-invalid-dry-run" }),
+            ]),
+        );
+    });
+
+    it("throws a structured error when create is invoked with validation failures", () => {
+        const invalidDraft: LibrarySerializerTemplateDraft = {
+            id: "equipment.template",
+            description: "Equipment serializer",
+            version: "2.0.0",
+            storage: {
+                domain: "equipment",
+                adapter: "legacy",
+                versioning: "frontmatter",
+                dryRun: "supported",
+            },
+            policies: [
+                {
+                    field: "name",
+                },
+                {
+                    field: "name",
+                },
+            ],
+            telemetry: {
+                events: {
+                    migrationApplied: "",
+                    validationFailed: "",
+                    dryRunExecuted: "",
+                    transformFallback: "",
+                },
+                attributes: [],
+            },
+        };
+
+        expect(() => createLibrarySerializerTemplate(invalidDraft)).toThrowError(
+            LibrarySerializerTemplateError,
+        );
+
+        try {
+            createLibrarySerializerTemplate(invalidDraft);
+        } catch (error) {
+            const templateError = error as LibrarySerializerTemplateError;
+            expect(templateError.issues.length).toBeGreaterThan(0);
+            expect(
+                templateError.issues.filter(issue => issue.code === "policy-duplicate-field"),
+            ).toHaveLength(1);
+        }
+    });
+
+    it("fills telemetry defaults when omitted", () => {
+        const draft: LibrarySerializerTemplateDraft = {
+            id: "spells.template",
+            description: "Spell serializer",
+            version: "1.1.0",
+            storage: {
+                domain: "spells",
+                adapter: "vault",
+                versioning: "content",
+                dryRun: "required",
+            },
+            policies: [
+                {
+                    field: "name",
+                    validate: [
+                        {
+                            kind: "required",
+                            code: "spell.name.required",
+                            message: "Spell name required",
+                            severity: "error",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const template = createLibrarySerializerTemplate(draft);
+
+        expect(template.telemetry.events.migrationApplied).toBe(
+            "library.serializer.migration.applied",
+        );
+        expect(template.telemetry.attributes).toContain("templateId");
+    });
+});

--- a/tests/library/library-storage-port.test.ts
+++ b/tests/library/library-storage-port.test.ts
@@ -1,0 +1,57 @@
+// Testspezifikation für den LibraryStoragePort-Contract, Fehlerklassifikation und Legacy-Mapping.
+import { describe, expect, it } from "vitest";
+import { LIBRARY_SOURCE_IDS } from "../../src/apps/library/core/sources";
+import {
+    LEGACY_LIBRARY_STORAGE_MAPPING,
+    describeLegacyStorageGaps,
+    describeLibraryStorageDomain,
+    ensureLegacyStorageCoverage,
+    listLibraryStorageDomains,
+    createLibraryStorageError,
+} from "../../src/apps/library/core/library-storage-port";
+
+describe("library-storage-port", () => {
+    it("liefert Descriptoren für alle Library-Quellen und das Preset-Cluster", () => {
+        const descriptors = listLibraryStorageDomains();
+        const ids = descriptors.map(entry => entry.id);
+        for (const id of [...LIBRARY_SOURCE_IDS, "presets"] as const) {
+            expect(ids).toContain(id);
+            const descriptor = describeLibraryStorageDomain(id);
+            expect(descriptor.id).toBe(id);
+            expect(descriptor.description.length).toBeGreaterThan(0);
+        }
+        expect(() => describeLibraryStorageDomain("unknown" as any)).toThrow(/Unknown library storage domain/);
+    });
+
+    it("stellt ein Mapping für alle Legacy-Adapter bereit", () => {
+        ensureLegacyStorageCoverage();
+        for (const [domain, entries] of Object.entries(LEGACY_LIBRARY_STORAGE_MAPPING)) {
+            expect(entries.length, `${domain} mapping length`).toBeGreaterThan(0);
+            for (const entry of entries) {
+                expect(entry.module.length).toBeGreaterThan(0);
+                expect(entry.responsibilities.length).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    it("meldet offene Responsibilities ausschließlich für das Preset-Cluster", () => {
+        const gaps = describeLegacyStorageGaps();
+        const presetGap = gaps.find(gap => gap.domain === "presets");
+        expect(presetGap?.missing).toEqual(["list", "watch", "create"]);
+        const otherGaps = gaps.filter(gap => gap.domain !== "presets");
+        expect(otherGaps).toHaveLength(0);
+    });
+
+    it("erzeugt strukturierte Storage-Fehler mit Fallback-Nachricht", () => {
+        const error = createLibraryStorageError({
+            domain: "creatures",
+            operation: "read-domain",
+            kind: "io",
+            ref: { domain: "creatures", path: "SaltMarcher/Creatures/alpha.md" },
+        });
+        expect(error.message).toContain("read-domain failed");
+        expect(error.domain).toBe("creatures");
+        expect(Object.isFrozen(error)).toBe(true);
+    });
+});
+

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -26,6 +26,10 @@ export class TFile extends TAbstractFile {
     basename = "";
 }
 
+export class TFolder extends TAbstractFile {
+    children: TAbstractFile[] = [];
+}
+
 export class WorkspaceLeaf {
     view: unknown = null;
     setViewState = async (_state: unknown) => {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "moduleResolution": "bundler",
     "strict": true,
     "baseUrl": ".",
-    "paths": { "*": ["./*", "./src/*"] },
+    "paths": {
+      "obsidian": ["tests/mocks/obsidian.ts"],
+      "*": ["./*", "./src/*"]
+    },
     "types": ["obsidian", "node"]   // <- wichtig für die Typen
   },
   "include": ["src", "tests"]


### PR DESCRIPTION
## Summary
- extend library contract fixtures with third samples per domain and generate Golden markdown outputs with manifests
- add tsx-powered update script and npm command to refresh Golden files via the harness
- introduce roundtrip Vitest suite validating serializer and storage parity against Golden data and document progress for LIB-TD-0002

## Testing
- npm run golden:update
- npm run test:contracts

------
https://chatgpt.com/codex/tasks/task_e_68e41eed29448325b4f1d63c79849ffa