### PR TITLE
feat: add Almanac calendar creation flow

### DIFF
--- a/src/apps/almanac/mode/contracts.ts
+++ b/src/apps/almanac/mode/contracts.ts
@@ -68,6 +68,22 @@ export interface AlmanacUiStateSlice {
     readonly error?: string;
 }
 
+export interface CalendarCreateDraft {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+    readonly daysPerWeek: string;
+    readonly monthCount: string;
+    readonly monthLength: string;
+    readonly hoursPerDay: string;
+    readonly minutesPerHour: string;
+    readonly minuteStep: string;
+    readonly epochYear: string;
+    readonly epochDay: string;
+}
+
+export type CalendarCreateField = keyof CalendarCreateDraft;
+
 export interface ManagerUiStateSlice {
     readonly viewMode: CalendarManagerViewMode;
     readonly zoom: CalendarViewZoom;
@@ -77,6 +93,9 @@ export interface ManagerUiStateSlice {
     readonly anchorTimestamp: CalendarTimestamp | null;
     readonly agendaItems: ReadonlyArray<CalendarEvent>;
     readonly jumpPreview: ReadonlyArray<CalendarEvent>;
+    readonly createDraft: CalendarCreateDraft;
+    readonly createErrors: ReadonlyArray<string>;
+    readonly isCreating: boolean;
 }
 
 export interface EventsUiStateSlice {
@@ -156,6 +175,7 @@ export type AlmanacEvent =
     | { readonly type: "MANAGER_VIEW_MODE_CHANGED"; readonly viewMode: CalendarManagerViewMode }
     | { readonly type: "MANAGER_ZOOM_CHANGED"; readonly zoom: CalendarViewZoom }
     | { readonly type: "MANAGER_NAVIGATION_REQUESTED"; readonly direction: 'prev' | 'next' | 'today' }
+    | { readonly type: "MANAGER_CREATE_FORM_UPDATED"; readonly field: CalendarCreateField; readonly value: string }
     | { readonly type: "TIME_JUMP_PREVIEW_REQUESTED"; readonly timestamp: CalendarTimestamp }
     | { readonly type: "MANAGER_AGENDA_REFRESH_REQUESTED" }
     | { readonly type: "EVENTS_VIEW_MODE_CHANGED"; readonly viewMode: EventsViewMode }
@@ -165,6 +185,7 @@ export type AlmanacEvent =
     | { readonly type: "MANAGER_SELECTION_CHANGED"; readonly selection: ReadonlyArray<string> }
     | { readonly type: "CALENDAR_SELECT_REQUESTED"; readonly calendarId: string }
     | { readonly type: "CALENDAR_DEFAULT_SET_REQUESTED"; readonly calendarId: string }
+    | { readonly type: "CALENDAR_CREATE_REQUESTED" }
     | { readonly type: "TIME_ADVANCE_REQUESTED"; readonly amount: number; readonly unit: "day" | "hour" | "minute" }
     | { readonly type: "TIME_JUMP_REQUESTED"; readonly timestamp: CalendarTimestamp }
     | { readonly type: "CALENDAR_DATA_REFRESH_REQUESTED" }
@@ -174,6 +195,22 @@ export const DEFAULT_ALMANAC_MODE: AlmanacMode = "dashboard";
 export const DEFAULT_MANAGER_VIEW_MODE: CalendarManagerViewMode = "calendar";
 export const DEFAULT_EVENTS_VIEW_MODE: EventsViewMode = "timeline";
 export const DEFAULT_MANAGER_ZOOM: CalendarViewZoom = "month";
+
+export function createDefaultCalendarDraft(): CalendarCreateDraft {
+    return {
+        id: "",
+        name: "",
+        description: "",
+        daysPerWeek: "7",
+        monthCount: "12",
+        monthLength: "30",
+        hoursPerDay: "24",
+        minutesPerHour: "60",
+        minuteStep: "1",
+        epochYear: "1",
+        epochDay: "1",
+    };
+}
 
 export function createInitialAlmanacState(): AlmanacState {
     return {
@@ -210,6 +247,9 @@ export function createInitialAlmanacState(): AlmanacState {
             anchorTimestamp: null,
             agendaItems: [],
             jumpPreview: [],
+            createDraft: createDefaultCalendarDraft(),
+            createErrors: [],
+            isCreating: false,
         },
         eventsUiState: {
             viewMode: DEFAULT_EVENTS_VIEW_MODE,

--- a/src/apps/almanac/styles.css
+++ b/src/apps/almanac/styles.css
@@ -124,3 +124,81 @@
 .almanac-empty-state p {
   color: var(--text-faint);
 }
+
+.almanac-section__helper {
+  color: var(--text-muted);
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.almanac-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.almanac-create-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.almanac-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.almanac-form-field label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.almanac-form-field input,
+.almanac-form-field textarea {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  color: var(--text-normal);
+}
+
+.almanac-form-field textarea {
+  resize: vertical;
+}
+
+.almanac-form-field--wide {
+  grid-column: span 2;
+}
+
+.almanac-create-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.almanac-create-form__actions button {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  cursor: pointer;
+}
+
+.almanac-create-form__actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.almanac-form-errors {
+  margin: 0 0 12px 0;
+  padding-left: 18px;
+  color: var(--text-error);
+}
+
+.almanac-form-errors li {
+  margin-bottom: 4px;
+}

--- a/tests/apps/almanac/state-machine.manager.test.ts
+++ b/tests/apps/almanac/state-machine.manager.test.ts
@@ -1,0 +1,111 @@
+// tests/apps/almanac/state-machine.manager.test.ts
+// Verifies calendar creation flows in the Almanac manager state machine.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+    InMemoryCalendarRepository,
+    InMemoryEventRepository,
+    InMemoryPhenomenonRepository,
+} from "../../../src/apps/almanac/data/in-memory-repository";
+import { InMemoryStateGateway } from "../../../src/apps/almanac/data/in-memory-gateway";
+import { AlmanacStateMachine } from "../../../src/apps/almanac/mode/state-machine";
+import {
+    createSampleEvents,
+    getDefaultCurrentTimestamp,
+    gregorianSchema,
+} from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+import { createSamplePhenomena } from "../../../src/apps/almanac/fixtures/phenomena.fixture";
+
+describe("AlmanacStateMachine calendar creation", () => {
+    let calendarRepo: InMemoryCalendarRepository;
+    let eventRepo: InMemoryEventRepository;
+    let phenomenonRepo: InMemoryPhenomenonRepository;
+    let gateway: InMemoryStateGateway;
+    let stateMachine: AlmanacStateMachine;
+
+    beforeEach(async () => {
+        calendarRepo = new InMemoryCalendarRepository();
+        eventRepo = new InMemoryEventRepository();
+        phenomenonRepo = new InMemoryPhenomenonRepository();
+        gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
+
+        calendarRepo.seed([gregorianSchema]);
+        eventRepo.seed(createSampleEvents(2024));
+        phenomenonRepo.seed(createSamplePhenomena());
+
+        await gateway.setActiveCalendar(
+            gregorianSchema.id,
+            getDefaultCurrentTimestamp(2024),
+        );
+
+        stateMachine = new AlmanacStateMachine(
+            calendarRepo,
+            eventRepo,
+            gateway,
+            phenomenonRepo,
+        );
+
+        await stateMachine.dispatch({ type: "INIT_ALMANAC" });
+    });
+
+    it("creates a new calendar draft and activates it", async () => {
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "id",
+            value: "travel-calendar",
+        });
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "name",
+            value: "Travel Calendar",
+        });
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "description",
+            value: "Calendar used during expeditions.",
+        });
+
+        await stateMachine.dispatch({ type: "CALENDAR_CREATE_REQUESTED" });
+
+        const created = await calendarRepo.getCalendar("travel-calendar");
+        expect(created).not.toBeNull();
+        expect(created?.months).toHaveLength(12);
+        expect(created?.daysPerWeek).toBe(7);
+
+        const state = stateMachine.getState();
+        expect(state.calendarState.activeCalendarId).toBe("travel-calendar");
+        expect(state.managerUiState.createDraft.id).toBe("");
+        expect(state.managerUiState.createErrors).toEqual([]);
+        expect(state.managerUiState.isCreating).toBe(false);
+        expect(state.managerUiState.anchorTimestamp?.calendarId).toBe("travel-calendar");
+    });
+
+    it("surfaces validation errors for incomplete drafts", async () => {
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "id",
+            value: "   ",
+        });
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "name",
+            value: " ",
+        });
+        await stateMachine.dispatch({
+            type: "MANAGER_CREATE_FORM_UPDATED",
+            field: "monthCount",
+            value: "0",
+        });
+
+        await stateMachine.dispatch({ type: "CALENDAR_CREATE_REQUESTED" });
+
+        const state = stateMachine.getState();
+        expect(state.managerUiState.isCreating).toBe(false);
+        expect(state.managerUiState.createErrors).toContain("Identifier is required.");
+        expect(state.managerUiState.createErrors).toContain("Name is required.");
+        expect(state.managerUiState.createErrors).toContain("Month count must be at least 1.");
+        expect(state.calendarState.calendars.some(schema => schema.id === "travel-calendar")).toBe(false);
+    });
+});
+


### PR DESCRIPTION
## Summary
- extend Almanac contracts and state machine with calendar creation draft state, validation, and persistence
- render a calendar creation form in the manager UI and style the new form helpers
- cover manager creation flows with a dedicated state machine test suite

## Testing
- npm test *(fails: existing governance and library fixture suites require missing AGENTS guides, TODO.md sync, and fixture markdown expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c85084c883258ae82a010eef371d