### PR TITLE
feat(almanac): support recurring events and conflicts

### DIFF
--- a/src/apps/almanac/domain/AGENTS.md
+++ b/src/apps/almanac/domain/AGENTS.md
@@ -6,6 +6,7 @@
 - Kalenderarithmetik, Timestamp-Vergleiche und In-Memory-Schema-Helfer sind umgesetzt.
 - Wiederholregeln (jährlich, Monatsposition, Wochenindex) und Phänomen-Engine berechnen Vorkommen auf Schema-Basis.
 - Vitest-Suites prüfen zentrale Kantenfälle (Sub-Tages-Schritte, Schema-Clamping, Prioritätensortierung).
+- Wiederkehrende Events inkl. Astronomie-Resolver (`calendar-event.ts`, `repeat-rule.ts`) und Konfliktauflösung (`conflict-resolution.ts`) stehen bereit.
 
 # ToDo
 - [P1] Recurrence-Engine um astronomische & benutzerdefinierte Regeln erweitern.

--- a/src/apps/almanac/domain/__tests__/conflict-resolution.test.ts
+++ b/src/apps/almanac/domain/__tests__/conflict-resolution.test.ts
@@ -1,0 +1,120 @@
+// src/apps/almanac/domain/__tests__/conflict-resolution.test.ts
+// Ensures conflict detection groups overlapping occurrences and resolves by priority.
+
+import { describe, it, expect } from 'vitest';
+
+import { createMinuteTimestamp } from '../calendar-timestamp';
+import type { CalendarSchema } from '../calendar-schema';
+import { advanceTime } from '../time-arithmetic';
+import { createSingleEvent } from '../calendar-event';
+import type { CalendarEventOccurrence } from '../calendar-event';
+import type { PhenomenonOccurrence } from '../phenomenon';
+import {
+  detectTemporalConflicts,
+  resolveConflictsByPriority,
+  fromEventOccurrence,
+  fromPhenomenonOccurrence,
+} from '../conflict-resolution';
+
+const schema: CalendarSchema = {
+  id: 'conflict',
+  name: 'Conflict Calendar',
+  daysPerWeek: 7,
+  hoursPerDay: 24,
+  minutesPerHour: 60,
+  minuteStep: 15,
+  months: [
+    { id: 'jan', name: 'January', length: 30 },
+  ],
+  epoch: { year: 1, monthId: 'jan', day: 1 },
+  schemaVersion: '1.0.0',
+};
+
+describe('conflict-resolution', () => {
+  it('groups overlapping occurrences and resolves by priority', () => {
+    const baseEvent = createSingleEvent(
+      'evt-1',
+      'conflict',
+      'Heroic Duel',
+      createMinuteTimestamp('conflict', 5, 'jan', 12, 9, 0),
+      {
+        allDay: false,
+        category: 'combat',
+        hooks: [{ id: 'hook-event', type: 'script', config: { notify: true }, priority: 1 }],
+        durationMinutes: 60,
+      },
+    );
+
+    const eventOccurrence: CalendarEventOccurrence = {
+      eventId: baseEvent.id,
+      calendarId: baseEvent.calendarId,
+      eventType: 'single',
+      title: baseEvent.title,
+      category: baseEvent.category,
+      start: baseEvent.date,
+      end: advanceTime(schema, baseEvent.date, 60, 'minute').timestamp,
+      durationMinutes: 60,
+      allDay: false,
+      priority: 2,
+      hooks: baseEvent.hooks ?? [],
+      source: baseEvent,
+    };
+
+    const rivalEvent = createSingleEvent(
+      'evt-2',
+      'conflict',
+      'Rival Duel',
+      createMinuteTimestamp('conflict', 5, 'jan', 12, 9, 30),
+      { allDay: false, durationMinutes: 30, priority: 1 },
+    );
+
+    const rivalOccurrence: CalendarEventOccurrence = {
+      eventId: rivalEvent.id,
+      calendarId: rivalEvent.calendarId,
+      eventType: 'single',
+      title: rivalEvent.title,
+      category: rivalEvent.category,
+      start: rivalEvent.date,
+      end: advanceTime(schema, rivalEvent.date, 30, 'minute').timestamp,
+      durationMinutes: 30,
+      allDay: false,
+      priority: 1,
+      hooks: rivalEvent.hooks ?? [],
+      source: rivalEvent,
+    };
+
+    const phenomenonOccurrence: PhenomenonOccurrence = {
+      phenomenonId: 'phen-storm',
+      name: 'Storm Surge',
+      calendarId: 'conflict',
+      timestamp: createMinuteTimestamp('conflict', 5, 'jan', 12, 8, 45),
+      endTimestamp: advanceTime(schema, createMinuteTimestamp('conflict', 5, 'jan', 12, 8, 45), 120, 'minute').timestamp,
+      category: 'weather',
+      priority: 4,
+      durationMinutes: 120,
+      hooks: [
+        { id: 'hook-weather-high', type: 'webhook', config: { severity: 'high' }, priority: 5 },
+        { id: 'hook-weather-low', type: 'webhook', config: { severity: 'low' }, priority: 1 },
+      ],
+      effects: [{ type: 'weather', payload: { severity: 'severe' } }],
+    };
+
+    const temporal = [
+      fromEventOccurrence(eventOccurrence),
+      fromEventOccurrence(rivalOccurrence),
+      fromPhenomenonOccurrence(phenomenonOccurrence),
+    ];
+
+    const groups = detectTemporalConflicts(schema, temporal);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].occurrences).toHaveLength(3);
+
+    const resolutions = resolveConflictsByPriority(groups);
+    expect(resolutions).toHaveLength(1);
+    const [resolution] = resolutions;
+    expect(resolution.active.sourceType).toBe('phenomenon');
+    expect(resolution.suppressed).toHaveLength(2);
+    expect(resolution.triggeredHooks.map(hook => hook.id)).toEqual(['hook-weather-high', 'hook-weather-low']);
+    expect(resolution.triggeredEffects[0].payload).toEqual({ severity: 'severe' });
+  });
+});

--- a/src/apps/almanac/domain/__tests__/phenomenon-engine.test.ts
+++ b/src/apps/almanac/domain/__tests__/phenomenon-engine.test.ts
@@ -32,7 +32,23 @@ const phenomenon: Phenomenon = {
   rule: { type: 'monthly_position', monthId: 'jan', day: 15 },
   timePolicy: 'fixed',
   startTime: { hour: 22, minute: 30 },
+  durationMinutes: 90,
+  hooks: [{ id: 'hook-aurora', type: 'script', config: { action: 'notify' }, priority: 2 }],
   priority: 4,
+  schemaVersion: '1.0.0',
+};
+
+const offsetPhenomenon: Phenomenon = {
+  id: 'phen-offset',
+  name: 'Deep Tide',
+  category: 'tide',
+  visibility: 'selected',
+  appliesToCalendarIds: ['simple'],
+  rule: { type: 'monthly_position', monthId: 'jan', day: 16 },
+  timePolicy: 'offset',
+  offsetMinutes: 45,
+  durationMinutes: 30,
+  priority: 2,
   schemaVersion: '1.0.0',
 };
 
@@ -46,6 +62,9 @@ describe('phenomenon-engine', () => {
     expect(next?.timestamp.day).toBe(15);
     expect(next?.timestamp.hour).toBe(22);
     expect(next?.timestamp.minute).toBe(30);
+    expect(next?.durationMinutes).toBe(90);
+    expect(next?.endTimestamp.hour).toBe(0);
+    expect(next?.hooks[0].id).toBe('hook-aurora');
   });
 
   it('collects range occurrences across years', () => {
@@ -65,5 +84,18 @@ describe('phenomenon-engine', () => {
     expect(occurrences[0].timestamp.year).toBe(1);
     expect(occurrences[1].timestamp.year).toBe(2);
     expect(occurrences[2].timestamp.year).toBe(3);
+    expect(occurrences[0].durationMinutes).toBe(90);
+  });
+
+  it('applies offset policy using minute arithmetic', () => {
+    const start = createDayTimestamp('simple', 2, 'jan', 14);
+
+    const next = computeNextPhenomenonOccurrence(offsetPhenomenon, schema, 'simple', start);
+
+    expect(next).not.toBeNull();
+    expect(next?.timestamp.hour).toBe(0);
+    expect(next?.timestamp.minute).toBe(45);
+    expect(next?.durationMinutes).toBe(30);
+    expect(next?.endTimestamp.minute).toBe(15);
   });
 });

--- a/src/apps/almanac/domain/__tests__/recurring-event.test.ts
+++ b/src/apps/almanac/domain/__tests__/recurring-event.test.ts
@@ -1,0 +1,121 @@
+// src/apps/almanac/domain/__tests__/recurring-event.test.ts
+// Verifies recurring event helpers including astronomical delegates.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeNextEventOccurrence,
+  computeEventOccurrencesInRange,
+  type CalendarEvent,
+} from '../calendar-event';
+import type { CalendarSchema } from '../calendar-schema';
+import { createDayTimestamp } from '../calendar-timestamp';
+import type { AstronomicalEventCalculator } from '../repeat-rule';
+
+const schema: CalendarSchema = {
+  id: 'lunar',
+  name: 'Lunar Cycle',
+  daysPerWeek: 5,
+  hoursPerDay: 20,
+  minutesPerHour: 60,
+  minuteStep: 10,
+  months: [
+    { id: 'phase-a', name: 'Phase A', length: 20 },
+    { id: 'phase-b', name: 'Phase B', length: 20 },
+  ],
+  epoch: { year: 1, monthId: 'phase-a', day: 1 },
+  schemaVersion: '1.0.0',
+};
+
+const recurringEvent: CalendarEvent = {
+  kind: 'recurring',
+  id: 'evt-recurring',
+  calendarId: 'lunar',
+  title: 'Council Assembly',
+  description: 'Recurring council every 5th day',
+  date: createDayTimestamp('lunar', 3, 'phase-a', 5),
+  allDay: false,
+  rule: { type: 'weekly_dayIndex', dayIndex: 2 },
+  timePolicy: 'fixed',
+  startTime: { hour: 10, minute: 0 },
+  durationMinutes: 120,
+  bounds: {
+    start: createDayTimestamp('lunar', 3, 'phase-a', 1),
+    end: createDayTimestamp('lunar', 3, 'phase-b', 10),
+  },
+};
+
+const astronomicalEvent: CalendarEvent = {
+  kind: 'recurring',
+  id: 'evt-eclipse',
+  calendarId: 'lunar',
+  title: 'Solar Eclipse',
+  description: 'Occurs when orbit aligns',
+  date: createDayTimestamp('lunar', 3, 'phase-a', 10),
+  allDay: false,
+  rule: { type: 'astronomical', source: 'eclipse' },
+  timePolicy: 'offset',
+  offsetMinutes: 30,
+  durationMinutes: 60,
+  bounds: {
+    start: createDayTimestamp('lunar', 3, 'phase-a', 8),
+    end: createDayTimestamp('lunar', 3, 'phase-b', 10),
+  },
+};
+
+describe('calendar-event recurring helpers', () => {
+  it('computes the next recurring occurrence with bounds and duration', () => {
+    const start = createDayTimestamp('lunar', 3, 'phase-a', 1);
+
+    const occurrence = computeNextEventOccurrence(recurringEvent, schema, 'lunar', start);
+
+    expect(occurrence).not.toBeNull();
+    expect(occurrence?.start.hour).toBe(10);
+    expect(occurrence?.durationMinutes).toBe(120);
+    expect(occurrence?.end.hour).toBe(12);
+  });
+
+  it('generates occurrences within the configured range', () => {
+    const start = createDayTimestamp('lunar', 3, 'phase-a', 1);
+    const end = createDayTimestamp('lunar', 3, 'phase-b', 1);
+
+    const occurrences = computeEventOccurrencesInRange(recurringEvent, schema, 'lunar', start, end, {
+      includeStart: true,
+      limit: 4,
+    });
+
+    expect(occurrences.length).toBeGreaterThan(0);
+    expect(occurrences[0].start.hour).toBe(10);
+    expect(occurrences[0].calendarId).toBe('lunar');
+  });
+
+  it('delegates astronomical rules through the calculator service', () => {
+    const calculator: AstronomicalEventCalculator = {
+      resolveNextOccurrence: (_, calendarId, __, base) =>
+        createDayTimestamp(calendarId, base.year, 'phase-b', 4),
+      resolveOccurrencesInRange: (_, calendarId) => [
+        createDayTimestamp(calendarId, 3, 'phase-b', 4),
+        createDayTimestamp(calendarId, 3, 'phase-b', 8),
+      ],
+    };
+
+    const next = computeNextEventOccurrence(astronomicalEvent, schema, 'lunar', astronomicalEvent.bounds!.start!, {
+      services: { astronomicalCalculator: calculator },
+    });
+
+    expect(next?.start.monthId).toBe('phase-b');
+    expect(next?.start.minute).toBe(30);
+
+    const range = computeEventOccurrencesInRange(
+      astronomicalEvent,
+      schema,
+      'lunar',
+      astronomicalEvent.bounds!.start!,
+      astronomicalEvent.bounds!.end!,
+      { services: { astronomicalCalculator: calculator } },
+    );
+
+    expect(range).toHaveLength(2);
+    expect(range[1].start.monthId).toBe('phase-b');
+  });
+});

--- a/src/apps/almanac/domain/calendar-event.ts
+++ b/src/apps/almanac/domain/calendar-event.ts
@@ -1,51 +1,441 @@
 // src/apps/almanac/domain/calendar-event.ts
-// Defines single-event structures used by Almanac calendars.
+// Expanded calendar event domain model with recurrence and conflict helpers.
 
-/**
- * Calendar Event
- *
- * Represents a single (non-recurring) event at a specific date/time.
- * MVP only supports single events.
- */
-
+import type { CalendarSchema } from './calendar-schema';
+import { getTimeDefinition } from './calendar-schema';
 import type { CalendarTimestamp } from './calendar-timestamp';
+import { compareTimestampsWithSchema, createMinuteTimestamp } from './calendar-timestamp';
+import type {
+  OccurrenceQueryOptions,
+  OccurrencesInRangeOptions,
+  RepeatRule,
+  RepeatRuleServices,
+} from './repeat-rule';
+import { calculateNextOccurrence, calculateOccurrencesInRange } from './repeat-rule';
+import { advanceTime } from './time-arithmetic';
+import type { HookDescriptor } from './hook-descriptor';
+import { sortHooksByPriority } from './hook-descriptor';
 
-export interface CalendarEvent {
+export type CalendarEvent = CalendarEventSingle | CalendarEventRecurring;
+
+export type CalendarEventKind = CalendarEvent['kind'];
+
+export type CalendarEventTimePrecision = 'day' | 'hour' | 'minute';
+
+export interface CalendarTimeOfDay {
+  readonly hour: number;
+  readonly minute: number;
+  readonly second?: number;
+}
+
+export interface CalendarEventBase {
   readonly id: string;
   readonly calendarId: string;
   readonly title: string;
   readonly description?: string;
-
-  readonly date: CalendarTimestamp;
-  readonly allDay: boolean;
-
+  readonly note?: string;
   readonly category?: string;
   readonly tags?: ReadonlyArray<string>;
+  readonly priority?: number;
+  readonly followUpPolicy?: 'auto' | 'manual';
+  readonly hooks?: ReadonlyArray<HookDescriptor>;
+  /** Representative timestamp (for single events the exact start, for recurring events the preview anchor). */
+  readonly date: CalendarTimestamp;
+  readonly allDay: boolean;
 }
 
-/**
- * Helper: Create a simple event
- */
-export function createEvent(
+export interface CalendarEventSingle extends CalendarEventBase {
+  readonly kind: 'single';
+  readonly timePrecision: CalendarEventTimePrecision;
+  readonly startTime?: CalendarTimeOfDay;
+  readonly endTime?: CalendarTimeOfDay;
+  readonly durationMinutes?: number;
+}
+
+export interface CalendarEventBounds {
+  readonly start?: CalendarTimestamp;
+  readonly end?: CalendarTimestamp;
+}
+
+export interface CalendarEventRecurring extends CalendarEventBase {
+  readonly kind: 'recurring';
+  readonly rule: RepeatRule;
+  readonly timePolicy: 'all_day' | 'fixed' | 'offset';
+  readonly startTime?: CalendarTimeOfDay;
+  readonly offsetMinutes?: number;
+  readonly durationMinutes?: number;
+  readonly bounds?: CalendarEventBounds;
+}
+
+export interface CalendarEventOccurrence {
+  readonly eventId: string;
+  readonly calendarId: string;
+  readonly eventType: CalendarEventKind;
+  readonly title: string;
+  readonly category?: string;
+  readonly start: CalendarTimestamp;
+  readonly end: CalendarTimestamp;
+  readonly durationMinutes: number;
+  readonly allDay: boolean;
+  readonly priority: number;
+  readonly hooks: ReadonlyArray<HookDescriptor>;
+  readonly source: CalendarEvent;
+}
+
+export interface EventOccurrenceOptions extends OccurrenceQueryOptions {
+  readonly services?: RepeatRuleServices;
+}
+
+export interface EventOccurrencesRangeOptions extends OccurrencesInRangeOptions {
+  readonly services?: RepeatRuleServices;
+}
+
+export function isSingleEvent(event: CalendarEvent): event is CalendarEventSingle {
+  return event.kind === 'single';
+}
+
+export function isRecurringEvent(event: CalendarEvent): event is CalendarEventRecurring {
+  return event.kind === 'recurring';
+}
+
+export function createSingleEvent(
   id: string,
   calendarId: string,
   title: string,
   date: CalendarTimestamp,
-  options?: {
+  options: {
     description?: string;
+    note?: string;
     allDay?: boolean;
     category?: string;
-    tags?: string[];
-  }
-): CalendarEvent {
+    tags?: ReadonlyArray<string>;
+    priority?: number;
+    followUpPolicy?: 'auto' | 'manual';
+    hooks?: ReadonlyArray<HookDescriptor>;
+    startTime?: CalendarTimeOfDay;
+    endTime?: CalendarTimeOfDay;
+    durationMinutes?: number;
+    timePrecision?: CalendarEventTimePrecision;
+  } = {}
+): CalendarEventSingle {
   return {
+    kind: 'single',
     id,
     calendarId,
     title,
-    description: options?.description,
+    description: options.description,
+    note: options.note,
+    category: options.category,
+    tags: options.tags,
+    priority: options.priority,
+    followUpPolicy: options.followUpPolicy,
+    hooks: options.hooks,
     date,
-    allDay: options?.allDay ?? (date.precision === 'day'),
-    category: options?.category,
-    tags: options?.tags,
+    allDay: options.allDay ?? date.precision === 'day',
+    startTime: options.startTime,
+    endTime: options.endTime,
+    durationMinutes: options.durationMinutes,
+    timePrecision: options.timePrecision ?? normalisePrecision(date.precision),
   };
+}
+
+export function getEventAnchorTimestamp(event: CalendarEvent): CalendarTimestamp | null {
+  if (isSingleEvent(event)) {
+    return event.date;
+  }
+  return event.bounds?.start ?? event.date ?? null;
+}
+
+export function getEventPriority(event: CalendarEvent): number {
+  return event.priority ?? 0;
+}
+
+export function getEventHooks(event: CalendarEvent): ReadonlyArray<HookDescriptor> {
+  return event.hooks ? sortHooksByPriority(event.hooks) : [];
+}
+
+export function computeNextEventOccurrence(
+  event: CalendarEvent,
+  schema: CalendarSchema,
+  calendarId: string,
+  start: CalendarTimestamp,
+  options: EventOccurrenceOptions = {}
+): CalendarEventOccurrence | null {
+  if (isSingleEvent(event)) {
+    const includeStart = options.includeStart ?? false;
+    const comparison = compareTimestampsWithSchema(schema, event.date, start);
+    if (comparison > 0 || (comparison === 0 && includeStart)) {
+      return buildSingleEventOccurrence(event, schema);
+    }
+    return null;
+  }
+
+  const effectiveStart = resolveRecurringSearchStart(event, schema, start);
+  if (!effectiveStart) {
+    return null;
+  }
+
+  const { services, ...ruleOptions } = options;
+  const includeStart = ruleOptions.includeStart ?? false;
+
+  const next = calculateNextOccurrence(
+    schema,
+    calendarId,
+    event.rule,
+    effectiveStart,
+    { ...ruleOptions, includeStart },
+    services,
+  );
+
+  if (!next) {
+    return null;
+  }
+
+  if (!isWithinBounds(event.bounds, schema, next)) {
+    const nextCursor = advanceCursorBeyondBounds(event, schema, next, ruleOptions, services, calendarId);
+    return nextCursor ? buildRecurringEventOccurrence(event, schema, calendarId, nextCursor) : null;
+  }
+
+  return buildRecurringEventOccurrence(event, schema, calendarId, next);
+}
+
+export function computeEventOccurrencesInRange(
+  event: CalendarEvent,
+  schema: CalendarSchema,
+  calendarId: string,
+  rangeStart: CalendarTimestamp,
+  rangeEnd: CalendarTimestamp,
+  options: EventOccurrencesRangeOptions = {}
+): CalendarEventOccurrence[] {
+  if (isSingleEvent(event)) {
+    const occurrences: CalendarEventOccurrence[] = [];
+    const inRange = isTimestampInRange(schema, event.date, rangeStart, rangeEnd, options.includeStart ?? false);
+    if (inRange) {
+      occurrences.push(buildSingleEventOccurrence(event, schema));
+    }
+    return occurrences;
+  }
+
+  const effectiveStart = resolveRecurringSearchStart(event, schema, rangeStart);
+  if (!effectiveStart) {
+    return [];
+  }
+
+  const { services, ...ruleOptions } = options;
+
+  const baseOccurrences = calculateOccurrencesInRange(
+    schema,
+    calendarId,
+    event.rule,
+    effectiveStart,
+    rangeEnd,
+    ruleOptions,
+    services,
+  );
+
+  return baseOccurrences
+    .filter(timestamp => isWithinBounds(event.bounds, schema, timestamp))
+    .map(timestamp => buildRecurringEventOccurrence(event, schema, calendarId, timestamp));
+}
+
+export function normalisePrecision(precision: CalendarTimestamp['precision']): CalendarEventTimePrecision {
+  if (precision === 'hour' || precision === 'minute') {
+    return precision;
+  }
+  return 'day';
+}
+
+function buildSingleEventOccurrence(event: CalendarEventSingle, schema: CalendarSchema): CalendarEventOccurrence {
+  const { start, end, durationMinutes } = resolveSingleEventWindow(event, schema);
+  return {
+    eventId: event.id,
+    calendarId: event.calendarId,
+    eventType: 'single',
+    title: event.title,
+    category: event.category,
+    start,
+    end,
+    durationMinutes,
+    allDay: event.allDay,
+    priority: getEventPriority(event),
+    hooks: getEventHooks(event),
+    source: event,
+  };
+}
+
+function buildRecurringEventOccurrence(
+  event: CalendarEventRecurring,
+  schema: CalendarSchema,
+  calendarId: string,
+  baseTimestamp: CalendarTimestamp,
+): CalendarEventOccurrence {
+  const { start, end, durationMinutes } = applyRecurringTimePolicy(event, schema, calendarId, baseTimestamp);
+  return {
+    eventId: event.id,
+    calendarId,
+    eventType: 'recurring',
+    title: event.title,
+    category: event.category,
+    start,
+    end,
+    durationMinutes,
+    allDay: event.timePolicy === 'all_day',
+    priority: getEventPriority(event),
+    hooks: getEventHooks(event),
+    source: event,
+  };
+}
+
+function resolveSingleEventWindow(event: CalendarEventSingle, schema: CalendarSchema) {
+  const { minutesPerHour, hoursPerDay } = getTimeDefinition(schema);
+  const minutesPerDay = hoursPerDay * minutesPerHour;
+
+  const base = event.date;
+  let start = base;
+  if (!event.allDay) {
+    const hour = event.startTime?.hour ?? base.hour ?? 0;
+    const minute = event.startTime?.minute ?? base.minute ?? 0;
+    start = createMinuteTimestamp(base.calendarId, base.year, base.monthId, base.day, hour, minute);
+  }
+
+  let duration = event.durationMinutes ?? 0;
+  if (event.endTime) {
+    duration = Math.max(duration, calculateDurationFromTimes(event.startTime, event.endTime, minutesPerHour, hoursPerDay));
+  }
+
+  if (duration <= 0) {
+    duration = event.allDay ? minutesPerDay : 0;
+  }
+
+  const end = duration > 0 ? advanceTime(schema, start, duration, 'minute').timestamp : start;
+  return { start, end, durationMinutes: duration };
+}
+
+function applyRecurringTimePolicy(
+  event: CalendarEventRecurring,
+  schema: CalendarSchema,
+  calendarId: string,
+  baseTimestamp: CalendarTimestamp,
+) {
+  const { minutesPerHour, hoursPerDay } = getTimeDefinition(schema);
+  const minutesPerDay = hoursPerDay * minutesPerHour;
+
+  if (event.timePolicy === 'all_day') {
+    const start = baseTimestamp;
+    const duration = event.durationMinutes ?? minutesPerDay;
+    const end = duration > 0 ? advanceTime(schema, start, duration, 'minute').timestamp : start;
+    return { start, end, durationMinutes: duration };
+  }
+
+  if (event.timePolicy === 'fixed') {
+    const hour = event.startTime?.hour ?? 0;
+    const minute = event.startTime?.minute ?? 0;
+    const start = createMinuteTimestamp(calendarId, baseTimestamp.year, baseTimestamp.monthId, baseTimestamp.day, hour, minute);
+    const duration = event.durationMinutes ?? 0;
+    const end = duration > 0 ? advanceTime(schema, start, duration, 'minute').timestamp : start;
+    return { start, end, durationMinutes: duration };
+  }
+
+  // offset policy
+  const offsetMinutes = event.offsetMinutes ?? 0;
+  const start = advanceTime(schema, baseTimestamp, offsetMinutes, 'minute').timestamp;
+  const duration = event.durationMinutes ?? 0;
+  const end = duration > 0 ? advanceTime(schema, start, duration, 'minute').timestamp : start;
+  return { start, end, durationMinutes: duration };
+}
+
+function calculateDurationFromTimes(
+  startTime: CalendarTimeOfDay | undefined,
+  endTime: CalendarTimeOfDay,
+  minutesPerHour: number,
+  hoursPerDay: number,
+): number {
+  const startMinutes = timeOfDayToMinutes(startTime ?? { hour: 0, minute: 0 }, minutesPerHour);
+  const endMinutes = timeOfDayToMinutes(endTime, minutesPerHour);
+  const dailyMinutes = hoursPerDay * minutesPerHour;
+
+  const raw = endMinutes - startMinutes;
+  if (raw <= 0) {
+    return dailyMinutes + raw; // spans midnight
+  }
+  return raw;
+}
+
+function timeOfDayToMinutes(time: CalendarTimeOfDay, minutesPerHour: number): number {
+  return time.hour * minutesPerHour + (time.minute ?? 0);
+}
+
+function isTimestampInRange(
+  schema: CalendarSchema,
+  timestamp: CalendarTimestamp,
+  start: CalendarTimestamp,
+  end: CalendarTimestamp,
+  includeStart: boolean,
+): boolean {
+  const [rangeStart, rangeEnd] =
+    compareTimestampsWithSchema(schema, start, end) <= 0 ? [start, end] : [end, start];
+  const afterStart = compareTimestampsWithSchema(schema, timestamp, rangeStart);
+  const beforeEnd = compareTimestampsWithSchema(schema, timestamp, rangeEnd);
+  const startOk = includeStart ? afterStart >= 0 : afterStart > 0;
+  return startOk && beforeEnd <= 0;
+}
+
+function resolveRecurringSearchStart(
+  event: CalendarEventRecurring,
+  schema: CalendarSchema,
+  start: CalendarTimestamp,
+): CalendarTimestamp | null {
+  const boundsStart = event.bounds?.start;
+  if (!boundsStart) {
+    return start;
+  }
+
+  const comparison = compareTimestampsWithSchema(schema, start, boundsStart);
+  if (comparison >= 0) {
+    return start;
+  }
+  return boundsStart;
+}
+
+function isWithinBounds(
+  bounds: CalendarEventBounds | undefined,
+  schema: CalendarSchema,
+  timestamp: CalendarTimestamp,
+): boolean {
+  if (!bounds) {
+    return true;
+  }
+  if (bounds.start && compareTimestampsWithSchema(schema, timestamp, bounds.start) < 0) {
+    return false;
+  }
+  if (bounds.end && compareTimestampsWithSchema(schema, timestamp, bounds.end) > 0) {
+    return false;
+  }
+  return true;
+}
+
+function advanceCursorBeyondBounds(
+  event: CalendarEventRecurring,
+  schema: CalendarSchema,
+  current: CalendarTimestamp,
+  options: OccurrenceQueryOptions,
+  services: RepeatRuleServices | undefined,
+  calendarId: string,
+): CalendarTimestamp | null {
+  if (!event.bounds?.end) {
+    return null;
+  }
+
+  if (compareTimestampsWithSchema(schema, current, event.bounds.end) >= 0) {
+    return null;
+  }
+
+  return calculateNextOccurrence(
+    schema,
+    calendarId,
+    event.rule,
+    current,
+    { ...options, includeStart: false },
+    services,
+  );
 }

--- a/src/apps/almanac/domain/conflict-resolution.ts
+++ b/src/apps/almanac/domain/conflict-resolution.ts
@@ -1,0 +1,203 @@
+// src/apps/almanac/domain/conflict-resolution.ts
+// Utilities to detect overlapping occurrences and resolve them by priority.
+
+import type { CalendarSchema } from './calendar-schema';
+import { getTimeDefinition } from './calendar-schema';
+import type { CalendarTimestamp } from './calendar-timestamp';
+import { compareTimestampsWithSchema } from './calendar-timestamp';
+import { timestampToAbsoluteDay } from './calendar-math';
+import type { CalendarEventOccurrence } from './calendar-event';
+import type { PhenomenonOccurrence, PhenomenonEffect } from './phenomenon';
+import type { HookDescriptor } from './hook-descriptor';
+import { sortHooksByPriority } from './hook-descriptor';
+
+export type OccurrenceSource = 'event_single' | 'event_recurring' | 'phenomenon';
+
+export interface TemporalOccurrence {
+  readonly sourceType: OccurrenceSource;
+  readonly sourceId: string;
+  readonly calendarId: string;
+  readonly label: string;
+  readonly start: CalendarTimestamp;
+  readonly end: CalendarTimestamp;
+  readonly priority: number;
+  readonly hooks: ReadonlyArray<HookDescriptor>;
+  readonly effects: ReadonlyArray<PhenomenonEffect>;
+}
+
+export interface ConflictWindow {
+  readonly start: CalendarTimestamp;
+  readonly end: CalendarTimestamp;
+}
+
+export interface ConflictGroup {
+  readonly window: ConflictWindow;
+  readonly occurrences: ReadonlyArray<TemporalOccurrence>;
+}
+
+export interface ConflictResolution {
+  readonly window: ConflictWindow;
+  readonly ordered: ReadonlyArray<TemporalOccurrence>;
+  readonly active: TemporalOccurrence;
+  readonly suppressed: ReadonlyArray<TemporalOccurrence>;
+  readonly triggeredHooks: ReadonlyArray<HookDescriptor>;
+  readonly triggeredEffects: ReadonlyArray<PhenomenonEffect>;
+}
+
+export function fromEventOccurrence(occurrence: CalendarEventOccurrence): TemporalOccurrence {
+  return {
+    sourceType: occurrence.eventType === 'single' ? 'event_single' : 'event_recurring',
+    sourceId: occurrence.eventId,
+    calendarId: occurrence.calendarId,
+    label: occurrence.title,
+    start: occurrence.start,
+    end: occurrence.end,
+    priority: occurrence.priority,
+    hooks: occurrence.hooks,
+    effects: [],
+  };
+}
+
+export function fromPhenomenonOccurrence(occurrence: PhenomenonOccurrence): TemporalOccurrence {
+  return {
+    sourceType: 'phenomenon',
+    sourceId: occurrence.phenomenonId,
+    calendarId: occurrence.calendarId,
+    label: occurrence.name,
+    start: occurrence.timestamp,
+    end: occurrence.endTimestamp,
+    priority: occurrence.priority,
+    hooks: occurrence.hooks,
+    effects: occurrence.effects,
+  };
+}
+
+export function detectTemporalConflicts(
+  schema: CalendarSchema,
+  occurrences: ReadonlyArray<TemporalOccurrence>,
+): ConflictGroup[] {
+  if (occurrences.length === 0) {
+    return [];
+  }
+
+  const sorted = [...occurrences].sort((a, b) => {
+    const cmp = compareTimestampsWithSchema(schema, a.start, b.start);
+    if (cmp !== 0) {
+      return cmp;
+    }
+    if (a.priority !== b.priority) {
+      return b.priority - a.priority;
+    }
+    return a.sourceId.localeCompare(b.sourceId);
+  });
+
+  const groups: ConflictGroup[] = [];
+  let current: TemporalOccurrence[] = [];
+  let currentEndMinutes = 0;
+
+  for (const occurrence of sorted) {
+    const startMinutes = toAbsoluteMinutes(schema, occurrence.start);
+    const endMinutes = Math.max(startMinutes, toAbsoluteMinutes(schema, occurrence.end));
+
+    if (current.length === 0) {
+      current = [occurrence];
+      currentEndMinutes = endMinutes;
+      continue;
+    }
+
+    if (startMinutes < currentEndMinutes) {
+      current.push(occurrence);
+      currentEndMinutes = Math.max(currentEndMinutes, endMinutes);
+      continue;
+    }
+
+    groups.push({
+      window: {
+        start: current[0].start,
+        end: getWindowEnd(schema, current, currentEndMinutes),
+      },
+      occurrences: current,
+    });
+
+    current = [occurrence];
+    currentEndMinutes = endMinutes;
+  }
+
+  if (current.length > 0) {
+    groups.push({
+      window: {
+        start: current[0].start,
+        end: getWindowEnd(schema, current, currentEndMinutes),
+      },
+      occurrences: current,
+    });
+  }
+
+  return groups;
+}
+
+export function resolveConflictsByPriority(groups: ReadonlyArray<ConflictGroup>): ConflictResolution[] {
+  return groups.map(group => {
+    const ordered = [...group.occurrences].sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return b.priority - a.priority;
+      }
+      const cmp = compareTimestampsWithSchemaInternal(a.start, b.start);
+      if (cmp !== 0) {
+        return cmp;
+      }
+      return a.sourceId.localeCompare(b.sourceId);
+    });
+
+    const [active, ...suppressed] = ordered;
+    const triggeredHooks = sortHooksByPriority(active.hooks);
+    return {
+      window: group.window,
+      ordered,
+      active,
+      suppressed,
+      triggeredHooks,
+      triggeredEffects: active.effects,
+    };
+  });
+}
+
+function toAbsoluteMinutes(schema: CalendarSchema, timestamp: CalendarTimestamp): number {
+  const { hoursPerDay, minutesPerHour } = getTimeDefinition(schema);
+  const minutesPerDay = hoursPerDay * minutesPerHour;
+  const absoluteDay = timestampToAbsoluteDay(schema, timestamp);
+  const hour = timestamp.hour ?? 0;
+  const minute = timestamp.minute ?? 0;
+  return absoluteDay * minutesPerDay + hour * minutesPerHour + minute;
+}
+
+function getWindowEnd(
+  schema: CalendarSchema,
+  occurrences: ReadonlyArray<TemporalOccurrence>,
+): CalendarTimestamp {
+  const latest = occurrences.reduce((latestEnd, current) => {
+    const comparison = compareTimestampsWithSchema(schema, current.end, latestEnd);
+    return comparison > 0 ? current.end : latestEnd;
+  }, occurrences[0].end);
+
+  return latest;
+}
+
+function compareTimestampsWithSchemaInternal(a: CalendarTimestamp, b: CalendarTimestamp): number {
+  if (a.calendarId !== b.calendarId) {
+    return a.calendarId.localeCompare(b.calendarId);
+  }
+  if (a.year !== b.year) {
+    return a.year - b.year;
+  }
+  if (a.monthId !== b.monthId) {
+    return a.monthId.localeCompare(b.monthId);
+  }
+  if (a.day !== b.day) {
+    return a.day - b.day;
+  }
+  if ((a.hour ?? 0) !== (b.hour ?? 0)) {
+    return (a.hour ?? 0) - (b.hour ?? 0);
+  }
+  return (a.minute ?? 0) - (b.minute ?? 0);
+}

--- a/src/apps/almanac/domain/hook-descriptor.ts
+++ b/src/apps/almanac/domain/hook-descriptor.ts
@@ -1,0 +1,33 @@
+// src/apps/almanac/domain/hook-descriptor.ts
+// Shared hook descriptor types for calendar events and phenomena.
+
+/**
+ * Hook Descriptor
+ *
+ * Represents an automation that should be triggered when an occurrence fires.
+ * Hooks mirror the API contracts defined for the Almanac mode and are shared
+ * between calendar events and phenomena.
+ */
+export type HookType = 'webhook' | 'script' | 'cartographer_event';
+
+export interface HookDescriptor {
+  readonly id: string;
+  readonly type: HookType;
+  readonly config: Readonly<Record<string, unknown>>;
+  /** Optional hook priority. Higher numbers execute first. */
+  readonly priority?: number;
+}
+
+/**
+ * Sort hooks descending by priority (fallback to stable id ordering).
+ */
+export function sortHooksByPriority(hooks: ReadonlyArray<HookDescriptor>): HookDescriptor[] {
+  return [...hooks].sort((a, b) => {
+    const priorityA = a.priority ?? 0;
+    const priorityB = b.priority ?? 0;
+    if (priorityA !== priorityB) {
+      return priorityB - priorityA;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/src/apps/almanac/domain/phenomenon.ts
+++ b/src/apps/almanac/domain/phenomenon.ts
@@ -1,17 +1,9 @@
 // src/apps/almanac/domain/phenomenon.ts
 // Domain model for cross-calendar phenomena and related helpers.
 
-/**
- * Phenomenon Domain Model
- *
- * Describes cross-calendar phenomena such as seasons, astronomical events or
- * weather fronts. The model aligns with the API contracts drafted for the
- * Almanac events mode and intentionally keeps optional fields lightweight for
- * the first implementation pass.
- */
-
 import type { CalendarTimestamp } from './calendar-timestamp';
 import type { RepeatRule } from './repeat-rule';
+import type { HookDescriptor } from './hook-descriptor';
 
 export type PhenomenonCategory = 'season' | 'astronomy' | 'weather' | 'tide' | 'holiday' | 'custom';
 export type PhenomenonVisibility = 'all_calendars' | 'selected';
@@ -23,11 +15,6 @@ export interface PhenomenonEffect {
   readonly appliesTo?: ReadonlyArray<string>;
 }
 
-export interface PhenomenonHook {
-  readonly id: string;
-  readonly priority?: number;
-}
-
 export interface Phenomenon {
   readonly id: string;
   readonly name: string;
@@ -37,12 +24,13 @@ export interface Phenomenon {
   readonly rule: RepeatRule;
   readonly timePolicy: PhenomenonTimePolicy;
   readonly startTime?: PhenomenonStartTime;
+  readonly offsetMinutes?: number;
   readonly durationMinutes?: number;
   readonly effects?: ReadonlyArray<PhenomenonEffect>;
   readonly priority: number;
   readonly tags?: ReadonlyArray<string>;
   readonly notes?: string;
-  readonly hooks?: ReadonlyArray<PhenomenonHook>;
+  readonly hooks?: ReadonlyArray<HookDescriptor>;
   readonly schemaVersion: string;
 }
 
@@ -57,8 +45,12 @@ export interface PhenomenonOccurrence {
   readonly name: string;
   readonly calendarId: string;
   readonly timestamp: CalendarTimestamp;
+  readonly endTimestamp: CalendarTimestamp;
   readonly category: PhenomenonCategory;
   readonly priority: number;
+  readonly durationMinutes: number;
+  readonly hooks: ReadonlyArray<HookDescriptor>;
+  readonly effects: ReadonlyArray<PhenomenonEffect>;
 }
 
 export const DEFAULT_PHENOMENON_PRIORITY = 0;
@@ -91,4 +83,16 @@ export function getEffectiveStartTime(
 
 export function requiresOffsetComputation(phenomenon: Phenomenon): boolean {
   return phenomenon.timePolicy === 'offset';
+}
+
+export function getPhenomenonPriority(phenomenon: Phenomenon): number {
+  return phenomenon.priority ?? DEFAULT_PHENOMENON_PRIORITY;
+}
+
+export function getPhenomenonHooks(phenomenon: Phenomenon): ReadonlyArray<HookDescriptor> {
+  return phenomenon.hooks ?? [];
+}
+
+export function getPhenomenonEffects(phenomenon: Phenomenon): ReadonlyArray<PhenomenonEffect> {
+  return phenomenon.effects ?? [];
 }

--- a/src/apps/almanac/fixtures/gregorian.fixture.ts
+++ b/src/apps/almanac/fixtures/gregorian.fixture.ts
@@ -10,7 +10,7 @@
 import type { CalendarSchema } from '../domain/calendar-schema';
 import type { CalendarEvent } from '../domain/calendar-event';
 import { createDayTimestamp, createHourTimestamp, createMinuteTimestamp } from '../domain/calendar-timestamp';
-import { createEvent } from '../domain/calendar-event';
+import { createSingleEvent } from '../domain/calendar-event';
 
 export const GREGORIAN_CALENDAR_ID = 'gregorian-standard';
 
@@ -53,7 +53,7 @@ export const gregorianSchema: CalendarSchema = {
  */
 export function createSampleEvents(year: number = 2024): CalendarEvent[] {
   return [
-    createEvent(
+    createSingleEvent(
       'evt-1',
       GREGORIAN_CALENDAR_ID,
       'New Year\'s Day',
@@ -65,7 +65,7 @@ export function createSampleEvents(year: number = 2024): CalendarEvent[] {
         tags: ['holiday', 'celebration'],
       }
     ),
-    createEvent(
+    createSingleEvent(
       'evt-2',
       GREGORIAN_CALENDAR_ID,
       'Team Meeting',
@@ -77,7 +77,7 @@ export function createSampleEvents(year: number = 2024): CalendarEvent[] {
         tags: ['meeting'],
       }
     ),
-    createEvent(
+    createSingleEvent(
       'evt-3',
       GREGORIAN_CALENDAR_ID,
       'Valentine\'s Day',
@@ -89,7 +89,7 @@ export function createSampleEvents(year: number = 2024): CalendarEvent[] {
         tags: ['holiday'],
       }
     ),
-    createEvent(
+    createSingleEvent(
       'evt-4',
       GREGORIAN_CALENDAR_ID,
       'Spring Equinox',
@@ -101,7 +101,7 @@ export function createSampleEvents(year: number = 2024): CalendarEvent[] {
         tags: ['season', 'astronomy'],
       }
     ),
-    createEvent(
+    createSingleEvent(
       'evt-5',
       GREGORIAN_CALENDAR_ID,
       'Project Deadline',
@@ -113,7 +113,7 @@ export function createSampleEvents(year: number = 2024): CalendarEvent[] {
         tags: ['deadline', 'important'],
       }
     ),
-    createEvent(
+    createSingleEvent(
       'evt-6',
       GREGORIAN_CALENDAR_ID,
       'Daily Standup',


### PR DESCRIPTION
## Summary
- extend the calendar event domain with single/recurring variants, occurrence helpers, and shared hook descriptors
- add astronomical rule delegation, offset-aware time policies, and richer phenomenon occurrences including durations and hooks
- introduce conflict resolution utilities plus new Vitest suites covering recurring events, astronomical cases, and priority sorting

## Testing
- npm run test -- src/apps/almanac/domain

------
https://chatgpt.com/codex/tasks/task_e_68e4ce4c91588325816cb620cd4edf71