### PR TITLE
Add vault-backed Almanac persistence repositories

### DIFF
--- a/src/apps/almanac/data/AGENTS.md
+++ b/src/apps/almanac/data/AGENTS.md
@@ -3,8 +3,10 @@
 - Ermöglicht UI-/State-Machine-Prototyping ohne Persistenzabhängigkeiten.
 
 # Aktueller Stand
-- `InMemoryCalendarRepository`, `InMemoryEventRepository` und `InMemoryPhenomenonRepository` liefern Demo-Daten.
+- `InMemoryCalendarRepository`, `InMemoryEventRepository` und `InMemoryPhenomenonRepository` liefern Demo-Daten und Test-Doubles für den Mode-State-Machine Layer.
+- `VaultCalendarRepository`, `VaultEventRepository` und `VaultAlmanacRepository` persistieren produktive Daten in `SaltMarcher/Almanac/*.json` (verwaltet durch `JsonStore`).
 - `InMemoryStateGateway` verwaltet aktiven Kalender, Zeitfortschritte sowie Event- und Phänomen-Snapshots.
+- `JsonStore` kapselt Vault-Zugriffe, Migrationen und Batch-Updates für die genannten JSON-Dateien.
 
 # ToDo
 - [P1] Dateibasierte Persistenzschicht ergänzen (JsonStore-Integration, Migrationen).
@@ -15,3 +17,4 @@
 - Repositories bleiben austauschbar; Interfaces dokumentiert in `mode/API_CONTRACTS.md`.
 - Seed-/Clear-Helfer ausschließlich für Tests und Demo-Controller verwenden.
 - Keine direkten UI-/Obsidian-Abhängigkeiten in Datenlayer-Dateien.
+- Vault-Stores verwenden ausschließlich Pfade unter `SaltMarcher/Almanac/` und halten Schema-Versionen in den JSON-Dateien aktuell.

--- a/src/apps/almanac/data/almanac-repository.ts
+++ b/src/apps/almanac/data/almanac-repository.ts
@@ -1,0 +1,51 @@
+// src/apps/almanac/data/almanac-repository.ts
+// Almanac repository interface covering phenomenon access and mutation flows.
+
+import type { EventsFilterState } from "../mode/contracts";
+import type {
+  EventsDataBatchDTO,
+  EventsPaginationState,
+  EventsSort,
+  PhenomenonDTO,
+  PhenomenonLinkUpdate,
+  PhenomenonTemplateDTO,
+} from "./dto";
+
+export type AlmanacRepositoryErrorCode =
+  | "validation_error"
+  | "phenomenon_conflict"
+  | "astronomy_source_missing";
+
+export interface AlmanacRepositoryErrorDetails {
+  readonly code: AlmanacRepositoryErrorCode;
+  readonly scope: "phenomenon";
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}
+
+export class AlmanacRepositoryError extends Error implements AlmanacRepositoryErrorDetails {
+  readonly code: AlmanacRepositoryErrorCode;
+  readonly scope = "phenomenon" as const;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: AlmanacRepositoryErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "AlmanacRepositoryError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface AlmanacRepository {
+  listPhenomena(input: {
+    readonly viewMode: string;
+    readonly filters: EventsFilterState;
+    readonly sort: EventsSort;
+    readonly pagination?: EventsPaginationState;
+  }): Promise<EventsDataBatchDTO>;
+  getPhenomenon(id: string): Promise<PhenomenonDTO | null>;
+  upsertPhenomenon(draft: PhenomenonDTO): Promise<PhenomenonDTO>;
+  deletePhenomenon(id: string): Promise<void>;
+  updateLinks(update: PhenomenonLinkUpdate): Promise<PhenomenonDTO>;
+  listTemplates(): Promise<ReadonlyArray<PhenomenonTemplateDTO>>;
+}

--- a/src/apps/almanac/data/calendar-repository.ts
+++ b/src/apps/almanac/data/calendar-repository.ts
@@ -1,0 +1,33 @@
+// src/apps/almanac/data/calendar-repository.ts
+// Interfaces for persistent calendar storage aligned with Almanac contracts.
+
+import type { CalendarSchemaDTO } from "./dto";
+
+export interface CalendarDefaultSnapshot {
+  readonly global: string | null;
+  readonly travel: Readonly<Record<string, string | null>>;
+}
+
+export type CalendarDefaultScope = "global" | "travel";
+
+export interface CalendarDefaultUpdate {
+  readonly calendarId: string;
+  readonly scope: CalendarDefaultScope;
+  readonly travelId?: string;
+}
+
+export interface CalendarRepository {
+  listCalendars(): Promise<ReadonlyArray<CalendarSchemaDTO>>;
+  getCalendar(id: string): Promise<CalendarSchemaDTO | null>;
+  createCalendar(input: CalendarSchemaDTO & { readonly isDefaultGlobal?: boolean }): Promise<void>;
+  updateCalendar(id: string, input: Partial<CalendarSchemaDTO>): Promise<void>;
+  deleteCalendar(id: string): Promise<void>;
+  setDefault(input: CalendarDefaultUpdate): Promise<void>;
+}
+
+export interface CalendarDefaultsRepository {
+  getDefaults(): Promise<CalendarDefaultSnapshot>;
+  getGlobalDefault(): Promise<string | null>;
+  getTravelDefault(travelId: string): Promise<string | null>;
+  clearTravelDefault(travelId: string): Promise<void>;
+}

--- a/src/apps/almanac/data/dto.ts
+++ b/src/apps/almanac/data/dto.ts
@@ -1,0 +1,79 @@
+// src/apps/almanac/data/dto.ts
+// Shared DTO definitions bridging Almanac domain models with persistence contracts.
+
+import type { CalendarEvent } from "../domain/calendar-event";
+import type { CalendarSchema } from "../domain/calendar-schema";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import type { HookDescriptor } from "../domain/hook-descriptor";
+import type { Phenomenon } from "../domain/phenomenon";
+
+export type CalendarSchemaDTO = CalendarSchema & {
+  readonly description?: string;
+  readonly leapRules?: ReadonlyArray<LeapRuleDTO>;
+  readonly weeksPerMonth?: number;
+  readonly hoursPerDay?: number;
+  readonly minutesPerHour?: number;
+  readonly secondsPerMinute?: number;
+  readonly minuteStep?: number;
+  readonly defaultTravelIds?: ReadonlyArray<string>;
+};
+
+export interface LeapRuleDTO {
+  readonly interval: number;
+  readonly addDayToMonthId: string;
+}
+
+export type CalendarDateDTO = CalendarTimestamp;
+
+export interface CalendarRangeDTO {
+  readonly calendarId: string;
+  readonly start: CalendarDateDTO;
+  readonly end: CalendarDateDTO;
+  readonly zoom?: "month" | "week" | "day" | "hour" | "upcoming";
+  readonly timeSlice?: "day" | "hour" | "minute";
+}
+
+export type CalendarEventDTO = CalendarEvent;
+
+export type PhenomenonDTO = Phenomenon & { readonly template?: boolean };
+
+export interface PhenomenonOccurrenceDTO {
+  readonly calendarId: string;
+  readonly occurrence: CalendarDateDTO;
+  readonly timeLabel: string;
+}
+
+export interface PhenomenonSummaryDTO {
+  readonly id: string;
+  readonly name: string;
+  readonly category: PhenomenonDTO["category"];
+  readonly nextOccurrence?: PhenomenonOccurrenceDTO;
+  readonly linkedCalendars: ReadonlyArray<string>;
+  readonly badge?: string;
+}
+
+export type HookDescriptorDTO = HookDescriptor;
+
+export interface PhenomenonLinkUpdate {
+  readonly phenomenonId: string;
+  readonly calendarLinks: ReadonlyArray<{
+    readonly calendarId: string;
+    readonly priority: number;
+    readonly hook?: HookDescriptorDTO;
+  }>;
+}
+
+export type PhenomenonTemplateDTO = Pick<PhenomenonDTO, "id" | "name" | "category" | "rule" | "effects">;
+
+export type EventsSort = "next_occurrence" | "priority_desc" | "category_asc";
+
+export interface EventsPaginationState {
+  readonly cursor?: string;
+  readonly limit: number;
+}
+
+export interface EventsDataBatchDTO {
+  readonly items: ReadonlyArray<PhenomenonSummaryDTO>;
+  readonly pagination: { readonly cursor?: string; readonly hasMore: boolean };
+  readonly generatedAt: string;
+}

--- a/src/apps/almanac/data/event-repository.ts
+++ b/src/apps/almanac/data/event-repository.ts
@@ -1,0 +1,26 @@
+// src/apps/almanac/data/event-repository.ts
+// Event repository contracts mirroring the Almanac API definitions.
+
+import type { CalendarSchema } from "../domain/calendar-schema";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import type { CalendarEventDTO, CalendarRangeDTO } from "./dto";
+
+export interface EventRepository {
+  listEvents(calendarId: string, range?: CalendarRangeDTO): Promise<ReadonlyArray<CalendarEventDTO>>;
+  listUpcoming(calendarId: string, limit: number): Promise<ReadonlyArray<CalendarEventDTO>>;
+  createEvent(event: CalendarEventDTO): Promise<void>;
+  updateEvent(id: string, event: Partial<CalendarEventDTO>): Promise<void>;
+  deleteEvent(id: string): Promise<void>;
+  getEventsInRange?(
+    calendarId: string,
+    schema: CalendarSchema,
+    start: CalendarTimestamp,
+    end: CalendarTimestamp,
+  ): Promise<ReadonlyArray<CalendarEventDTO>>;
+  getUpcomingEvents?(
+    calendarId: string,
+    schema: CalendarSchema,
+    from: CalendarTimestamp,
+    limit: number,
+  ): Promise<ReadonlyArray<CalendarEventDTO>>;
+}

--- a/src/apps/almanac/data/in-memory-gateway.ts
+++ b/src/apps/almanac/data/in-memory-gateway.ts
@@ -21,7 +21,9 @@ import {
 } from '../domain/phenomenon-engine';
 import { advanceTime } from '../domain/time-arithmetic';
 import type { TimeUnit } from '../domain/time-arithmetic';
-import type { CalendarRepository, EventRepository, PhenomenonRepository } from './in-memory-repository';
+import type { CalendarDefaultsRepository, CalendarRepository } from './calendar-repository';
+import type { EventRepository } from './event-repository';
+import type { AlmanacRepository } from './almanac-repository';
 import type { AlmanacPreferencesSnapshot } from '../mode/contracts';
 
 export interface AlmanacState {
@@ -55,9 +57,9 @@ export class InMemoryStateGateway {
   private preferences: AlmanacPreferencesSnapshot = {};
 
   constructor(
-    private calendarRepo: CalendarRepository,
+    private calendarRepo: CalendarRepository & CalendarDefaultsRepository,
     private eventRepo: EventRepository,
-    private phenomenonRepo: PhenomenonRepository,
+    private phenomenonRepo: AlmanacRepository,
   ) {}
 
   /**

--- a/src/apps/almanac/data/in-memory-repository.ts
+++ b/src/apps/almanac/data/in-memory-repository.ts
@@ -8,76 +8,107 @@
  * Stores calendars and events in memory without file persistence.
  */
 
-import type { CalendarSchema } from '../domain/calendar-schema';
-import type { CalendarEvent } from '../domain/calendar-event';
-import type { CalendarTimestamp } from '../domain/calendar-timestamp';
-import { compareTimestampsWithSchema } from '../domain/calendar-timestamp';
-import type { Phenomenon } from '../domain/phenomenon';
+import type { CalendarSchema } from "../domain/calendar-schema";
+import type { CalendarEvent } from "../domain/calendar-event";
+import { getEventAnchorTimestamp } from "../domain/calendar-event";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import { compareTimestampsWithSchema } from "../domain/calendar-timestamp";
+import type { EventsFilterState } from "../mode/contracts";
+import type {
+  CalendarSchemaDTO,
+  CalendarEventDTO,
+  CalendarRangeDTO,
+  EventsDataBatchDTO,
+  EventsPaginationState,
+  EventsSort,
+  PhenomenonDTO,
+  PhenomenonLinkUpdate,
+  PhenomenonSummaryDTO,
+  PhenomenonTemplateDTO,
+} from "./dto";
+import type {
+  CalendarDefaultsRepository,
+  CalendarRepository as CalendarRepositoryContract,
+  CalendarDefaultSnapshot,
+  CalendarDefaultUpdate,
+} from "./calendar-repository";
+import type { EventRepository as EventRepositoryContract } from "./event-repository";
+import {
+  AlmanacRepositoryError,
+  type AlmanacRepository,
+} from "./almanac-repository";
 
-export interface CalendarRepository {
-  listCalendars(): Promise<CalendarSchema[]>;
-  getCalendar(id: string): Promise<CalendarSchema | null>;
-  createCalendar(schema: CalendarSchema): Promise<void>;
-  updateCalendar(id: string, schema: Partial<CalendarSchema>): Promise<void>;
-  deleteCalendar(id: string): Promise<void>;
-
-  // Default calendar management
-  setGlobalDefault(calendarId: string): Promise<void>;
-  getGlobalDefault(): Promise<CalendarSchema | null>;
-  setTravelDefault(travelId: string, calendarId: string): Promise<void>;
-  getTravelDefault(travelId: string): Promise<string | null>;
-  clearTravelDefault(travelId: string): Promise<void>;
+function cloneCalendar(schema: CalendarSchemaDTO, defaults: CalendarDefaultSnapshot): CalendarSchemaDTO {
+  return {
+    ...schema,
+    isDefaultGlobal: defaults.global === schema.id,
+    defaultTravelIds: Object.entries(defaults.travel)
+      .filter(([, calendarId]) => calendarId === schema.id)
+      .map(([travelId]) => travelId),
+  };
 }
 
-export interface EventRepository {
-  listEvents(calendarId: string, schema: CalendarSchema): Promise<CalendarEvent[]>;
-  getUpcomingEvents(calendarId: string, schema: CalendarSchema, from: CalendarTimestamp, limit: number): Promise<CalendarEvent[]>;
-  getEventsInRange(
-    calendarId: string,
-    schema: CalendarSchema,
-    start: CalendarTimestamp,
-    end: CalendarTimestamp
-  ): Promise<CalendarEvent[]>;
-  createEvent(event: CalendarEvent): Promise<void>;
-  updateEvent(id: string, event: Partial<CalendarEvent>): Promise<void>;
-  deleteEvent(id: string): Promise<void>;
-}
-
-export class InMemoryCalendarRepository implements CalendarRepository {
-  private calendars: Map<string, CalendarSchema> = new Map();
-  private travelDefaults: Map<string, string> = new Map(); // travelId -> calendarId
-
-  async listCalendars(): Promise<CalendarSchema[]> {
-    return Array.from(this.calendars.values());
-  }
-
-  async getCalendar(id: string): Promise<CalendarSchema | null> {
-    return this.calendars.get(id) ?? null;
-  }
-
-  async createCalendar(schema: CalendarSchema): Promise<void> {
-    if (this.calendars.has(schema.id)) {
-      throw new Error(`Calendar with ID ${schema.id} already exists`);
+function toDefaultsSnapshot(global: string | null, travelDefaults: Map<string, string | null>): CalendarDefaultSnapshot {
+  const travel: Record<string, string | null> = {};
+  for (const [travelId, calendarId] of travelDefaults.entries()) {
+    if (calendarId) {
+      travel[travelId] = calendarId;
     }
-    this.calendars.set(schema.id, schema);
+  }
+  return { global, travel };
+}
+
+export class InMemoryCalendarRepository
+  implements CalendarRepositoryContract, CalendarDefaultsRepository
+{
+  private calendars: Map<string, CalendarSchemaDTO> = new Map();
+  private globalDefault: string | null = null;
+  private travelDefaults: Map<string, string | null> = new Map();
+
+  async listCalendars(): Promise<ReadonlyArray<CalendarSchemaDTO>> {
+    const snapshot = toDefaultsSnapshot(this.globalDefault, this.travelDefaults);
+    return Array.from(this.calendars.values()).map(calendar => cloneCalendar(calendar, snapshot));
   }
 
-  async updateCalendar(id: string, updates: Partial<CalendarSchema>): Promise<void> {
+  async getCalendar(id: string): Promise<CalendarSchemaDTO | null> {
+    const calendar = this.calendars.get(id);
+    if (!calendar) {
+      return null;
+    }
+    const snapshot = toDefaultsSnapshot(this.globalDefault, this.travelDefaults);
+    return cloneCalendar(calendar, snapshot);
+  }
+
+  async createCalendar(input: CalendarSchemaDTO & { readonly isDefaultGlobal?: boolean }): Promise<void> {
+    if (this.calendars.has(input.id)) {
+      throw new Error(`Calendar with ID ${input.id} already exists`);
+    }
+    this.calendars.set(input.id, { ...input });
+    if (input.isDefaultGlobal) {
+      this.globalDefault = input.id;
+    }
+  }
+
+  async updateCalendar(id: string, updates: Partial<CalendarSchemaDTO>): Promise<void> {
     const existing = this.calendars.get(id);
     if (!existing) {
       throw new Error(`Calendar with ID ${id} not found`);
     }
-
     this.calendars.set(id, { ...existing, ...updates });
+    if (updates.isDefaultGlobal) {
+      this.globalDefault = id;
+    } else if (updates.isDefaultGlobal === false && this.globalDefault === id) {
+      this.globalDefault = null;
+    }
   }
 
   async deleteCalendar(id: string): Promise<void> {
-    if (!this.calendars.has(id)) {
+    if (!this.calendars.delete(id)) {
       throw new Error(`Calendar with ID ${id} not found`);
     }
-    this.calendars.delete(id);
-
-    // Clean up travel defaults pointing to deleted calendar
+    if (this.globalDefault === id) {
+      this.globalDefault = null;
+    }
     for (const [travelId, calendarId] of this.travelDefaults.entries()) {
       if (calendarId === id) {
         this.travelDefaults.delete(travelId);
@@ -85,39 +116,26 @@ export class InMemoryCalendarRepository implements CalendarRepository {
     }
   }
 
-  async setGlobalDefault(calendarId: string): Promise<void> {
-    const calendar = this.calendars.get(calendarId);
-    if (!calendar) {
-      throw new Error(`Calendar with ID ${calendarId} not found`);
+  async setDefault(input: CalendarDefaultUpdate): Promise<void> {
+    if (!this.calendars.has(input.calendarId)) {
+      throw new Error(`Calendar with ID ${input.calendarId} not found`);
     }
-
-    // Remove isDefaultGlobal from all calendars
-    for (const [id, cal] of this.calendars.entries()) {
-      if (cal.isDefaultGlobal) {
-        this.calendars.set(id, { ...cal, isDefaultGlobal: false });
-      }
+    if (input.scope === "global") {
+      this.globalDefault = input.calendarId;
+      return;
     }
-
-    // Set new default
-    this.calendars.set(calendarId, { ...calendar, isDefaultGlobal: true });
+    if (!input.travelId) {
+      throw new Error("Travel ID required for travel scope");
+    }
+    this.travelDefaults.set(input.travelId, input.calendarId);
   }
 
-  async getGlobalDefault(): Promise<CalendarSchema | null> {
-    for (const calendar of this.calendars.values()) {
-      if (calendar.isDefaultGlobal) {
-        return calendar;
-      }
-    }
-    return null;
+  async getDefaults(): Promise<CalendarDefaultSnapshot> {
+    return toDefaultsSnapshot(this.globalDefault, this.travelDefaults);
   }
 
-  async setTravelDefault(travelId: string, calendarId: string): Promise<void> {
-    const calendar = this.calendars.get(calendarId);
-    if (!calendar) {
-      throw new Error(`Calendar with ID ${calendarId} not found`);
-    }
-
-    this.travelDefaults.set(travelId, calendarId);
+  async getGlobalDefault(): Promise<string | null> {
+    return this.globalDefault;
   }
 
   async getTravelDefault(travelId: string): Promise<string | null> {
@@ -128,132 +146,328 @@ export class InMemoryCalendarRepository implements CalendarRepository {
     this.travelDefaults.delete(travelId);
   }
 
-  // Helper: Initialize with test data
+  async setGlobalDefault(calendarId: string): Promise<void> {
+    await this.setDefault({ calendarId, scope: "global" });
+  }
+
+  async setTravelDefault(travelId: string, calendarId: string): Promise<void> {
+    await this.setDefault({ calendarId, scope: "travel", travelId });
+  }
+
+  async getGlobalDefaultCalendar(): Promise<CalendarSchemaDTO | null> {
+    const id = await this.getGlobalDefault();
+    return id ? this.getCalendar(id) : null;
+  }
+
   seed(schemas: CalendarSchema[]): void {
     schemas.forEach(schema => {
       this.calendars.set(schema.id, schema);
+      if (schema.isDefaultGlobal) {
+        this.globalDefault = schema.id;
+      }
     });
   }
 
-  // Helper: Clear all data
   clear(): void {
     this.calendars.clear();
     this.travelDefaults.clear();
+    this.globalDefault = null;
   }
 }
 
-export class InMemoryEventRepository implements EventRepository {
-  private events: Map<string, CalendarEvent> = new Map();
+export class InMemoryEventRepository implements EventRepositoryContract {
+  private events: Map<string, CalendarEventDTO> = new Map();
+  private resolveSchema: (calendarId: string) => Promise<CalendarSchema | null> | CalendarSchema | null;
 
-  async listEvents(calendarId: string, schema: CalendarSchema): Promise<CalendarEvent[]> {
-    const events = Array.from(this.events.values())
-      .filter(e => e.calendarId === calendarId)
-      .sort((a, b) => compareTimestampsWithSchema(schema, a.date, b.date));
-
-    return events;
+  constructor(
+    resolver?: (calendarId: string) => Promise<CalendarSchema | null> | CalendarSchema | null,
+  ) {
+    this.resolveSchema = resolver ?? (() => null);
   }
 
-  async getUpcomingEvents(
-    calendarId: string,
-    schema: CalendarSchema,
-    from: CalendarTimestamp,
-    limit: number
-  ): Promise<CalendarEvent[]> {
-    const allEvents = await this.listEvents(calendarId, schema);
-
-    return allEvents
-      .filter(e => compareTimestampsWithSchema(schema, e.date, from) >= 0)
-      .slice(0, limit);
+  bindCalendarRepository(repository: { getCalendar(id: string): Promise<CalendarSchemaDTO | null> }): void {
+    this.resolveSchema = async (id: string) => {
+      const calendar = await repository.getCalendar(id);
+      return calendar ?? null;
+    };
   }
 
-  async getEventsInRange(
-    calendarId: string,
-    schema: CalendarSchema,
-    start: CalendarTimestamp,
-    end: CalendarTimestamp
-  ): Promise<CalendarEvent[]> {
-    const allEvents = await this.listEvents(calendarId, schema);
-
-    const rangeStart =
-      compareTimestampsWithSchema(schema, start, end) <= 0 ? start : end;
+  async listEvents(calendarId: string, range?: CalendarRangeDTO): Promise<ReadonlyArray<CalendarEventDTO>> {
+    const schema = await this.requireSchema(calendarId);
+    const events = this.collectForCalendar(calendarId, schema);
+    if (!range) {
+      return events;
+    }
+    const start = range.start;
+    const end = range.end;
+    const rangeStart = compareTimestampsWithSchema(schema, start, end) <= 0 ? start : end;
     const rangeEnd = rangeStart === start ? end : start;
-
-    return allEvents.filter(event => {
-      const afterStart = compareTimestampsWithSchema(schema, event.date, rangeStart) > 0;
-      const beforeOrEqualEnd = compareTimestampsWithSchema(schema, event.date, rangeEnd) <= 0;
-      return afterStart && beforeOrEqualEnd;
+    return events.filter(event => {
+      const anchor = getEventAnchorTimestamp(event) ?? event.date;
+      const afterStart = compareTimestampsWithSchema(schema, anchor, rangeStart) >= 0;
+      const beforeEnd = compareTimestampsWithSchema(schema, anchor, rangeEnd) <= 0;
+      return afterStart && beforeEnd;
     });
   }
 
-  async createEvent(event: CalendarEvent): Promise<void> {
+  async listUpcoming(calendarId: string, limit: number): Promise<ReadonlyArray<CalendarEventDTO>> {
+    const schema = await this.requireSchema(calendarId);
+    return this.collectForCalendar(calendarId, schema).slice(0, limit);
+  }
+
+  async createEvent(event: CalendarEventDTO): Promise<void> {
     if (this.events.has(event.id)) {
       throw new Error(`Event with ID ${event.id} already exists`);
     }
     this.events.set(event.id, event);
   }
 
-  async updateEvent(id: string, updates: Partial<CalendarEvent>): Promise<void> {
+  async updateEvent(id: string, updates: Partial<CalendarEventDTO>): Promise<void> {
     const existing = this.events.get(id);
     if (!existing) {
       throw new Error(`Event with ID ${id} not found`);
     }
-
-    this.events.set(id, { ...existing, ...updates } as CalendarEvent);
+    this.events.set(id, { ...existing, ...updates });
   }
 
   async deleteEvent(id: string): Promise<void> {
-    if (!this.events.has(id)) {
+    if (!this.events.delete(id)) {
       throw new Error(`Event with ID ${id} not found`);
     }
-    this.events.delete(id);
   }
 
-  // Helper: Initialize with test data
+  async getEventsInRange(
+    calendarId: string,
+    schema: CalendarSchema,
+    start: CalendarTimestamp,
+    end: CalendarTimestamp,
+  ): Promise<CalendarEventDTO[]> {
+    const range: CalendarRangeDTO = { calendarId, start, end };
+    return this.listEvents(calendarId, range);
+  }
+
+  async getUpcomingEvents(
+    calendarId: string,
+    schema: CalendarSchema,
+    from: CalendarTimestamp,
+    limit: number,
+  ): Promise<CalendarEventDTO[]> {
+    const events = await this.listEvents(calendarId);
+    return events
+      .filter(event => compareTimestampsWithSchema(schema, getEventAnchorTimestamp(event) ?? event.date, from) >= 0)
+      .slice(0, limit);
+  }
+
   seed(events: CalendarEvent[]): void {
     events.forEach(event => {
       this.events.set(event.id, event);
     });
   }
 
-  // Helper: Clear all data
   clear(): void {
     this.events.clear();
+  }
+
+  private async requireSchema(calendarId: string): Promise<CalendarSchema> {
+    const resolved = await this.resolveSchema(calendarId);
+    if (!resolved) {
+      throw new Error(`Calendar schema for ${calendarId} not available`);
+    }
+    return resolved;
+  }
+
+  private collectForCalendar(calendarId: string, schema: CalendarSchema): CalendarEventDTO[] {
+    return Array.from(this.events.values())
+      .filter(event => event.calendarId === calendarId)
+      .sort((a, b) => {
+        const left = getEventAnchorTimestamp(a) ?? a.date;
+        const right = getEventAnchorTimestamp(b) ?? b.date;
+        return compareTimestampsWithSchema(schema, left, right);
+      });
   }
 }
 
 export interface PhenomenonRepository {
-  listPhenomena(): Promise<Phenomenon[]>;
-  getPhenomenon(id: string): Promise<Phenomenon | null>;
-  upsertPhenomenon(phenomenon: Phenomenon): Promise<void>;
+  listPhenomena(): Promise<PhenomenonDTO[]>;
+  getPhenomenon(id: string): Promise<PhenomenonDTO | null>;
+  upsertPhenomenon(phenomenon: PhenomenonDTO): Promise<void>;
   deletePhenomenon(id: string): Promise<void>;
 }
 
-export class InMemoryPhenomenonRepository implements PhenomenonRepository {
-  private phenomena: Map<string, Phenomenon> = new Map();
+const DEFAULT_PAGE_SIZE = 25;
 
-  async listPhenomena(): Promise<Phenomenon[]> {
-    return Array.from(this.phenomena.values());
+export class InMemoryPhenomenonRepository implements AlmanacRepository, PhenomenonRepository {
+  private phenomena: Map<string, PhenomenonDTO> = new Map();
+
+  async listPhenomena(): Promise<PhenomenonDTO[]>;
+  async listPhenomena(input: {
+    readonly viewMode: string;
+    readonly filters: EventsFilterState;
+    readonly sort: EventsSort;
+    readonly pagination?: EventsPaginationState;
+  }): Promise<EventsDataBatchDTO>;
+  async listPhenomena(input?: {
+    readonly viewMode: string;
+    readonly filters: EventsFilterState;
+    readonly sort: EventsSort;
+    readonly pagination?: EventsPaginationState;
+  }): Promise<PhenomenonDTO[] | EventsDataBatchDTO> {
+    if (!input) {
+      return Array.from(this.phenomena.values()).map(phenomenon => ({ ...phenomenon }));
+    }
+    const filters = input.filters;
+    const filtered = Array.from(this.phenomena.values()).filter(phenomenon => matchesPhenomenonFilters(phenomenon, filters));
+    const summaries = filtered.map(phenomenon => toSummary(phenomenon));
+    const sorted = sortSummariesForInMemory(filtered, summaries, input.sort);
+    const { items, nextCursor } = paginate(sorted, input.pagination ?? { limit: DEFAULT_PAGE_SIZE });
+
+    return {
+      items: items.map(entry => entry.summary),
+      pagination: { cursor: nextCursor, hasMore: nextCursor !== undefined },
+      generatedAt: new Date().toISOString(),
+    };
   }
 
-  async getPhenomenon(id: string): Promise<Phenomenon | null> {
-    return this.phenomena.get(id) ?? null;
+  async getPhenomenon(id: string): Promise<PhenomenonDTO | null> {
+    const phenomenon = this.phenomena.get(id);
+    return phenomenon ? { ...phenomenon } : null;
   }
 
-  async upsertPhenomenon(phenomenon: Phenomenon): Promise<void> {
-    this.phenomena.set(phenomenon.id, phenomenon);
+  async upsertPhenomenon(draft: PhenomenonDTO): Promise<PhenomenonDTO> {
+    this.phenomena.set(draft.id, { ...draft });
+    const stored = this.phenomena.get(draft.id);
+    if (!stored) {
+      throw new Error(`Failed to upsert phenomenon ${draft.id}`);
+    }
+    return { ...stored };
   }
 
   async deletePhenomenon(id: string): Promise<void> {
-    this.phenomena.delete(id);
+    if (!this.phenomena.delete(id)) {
+      throw new Error(`Phenomenon with ID ${id} not found`);
+    }
   }
 
-  seed(phenomena: Phenomenon[]): void {
+  async updateLinks(update: PhenomenonLinkUpdate): Promise<PhenomenonDTO> {
+    const existing = this.phenomena.get(update.phenomenonId);
+    if (!existing) {
+      throw new AlmanacRepositoryError("validation_error", `Phenomenon ${update.phenomenonId} not found`);
+    }
+    const duplicates = findDuplicateCalendarIds(update.calendarLinks);
+    if (duplicates.length) {
+      throw new AlmanacRepositoryError("phenomenon_conflict", "Duplicate calendar links", { duplicates });
+    }
+    if (existing.rule.type === "astronomical") {
+      const hasReference = Boolean(existing.rule.astronomical?.referenceCalendarId);
+      const hasHookReference = update.calendarLinks.some(link =>
+        typeof link.hook?.config?.referenceCalendarId === "string",
+      );
+      if (!hasReference && !hasHookReference) {
+        throw new AlmanacRepositoryError(
+          "astronomy_source_missing",
+          "Astronomical phenomena require a reference calendar",
+        );
+      }
+    }
+    const appliesToCalendarIds = update.calendarLinks.map(link => link.calendarId);
+    const visibility = appliesToCalendarIds.length ? "selected" : "all_calendars";
+    const hooks = update.calendarLinks
+      .filter(link => Boolean(link.hook))
+      .map(link => ({ ...link.hook!, priority: link.priority }));
+    const priority = update.calendarLinks.reduce((max, link) => Math.max(max, link.priority), existing.priority);
+    const updated: PhenomenonDTO = {
+      ...existing,
+      appliesToCalendarIds,
+      visibility,
+      hooks: hooks.length ? hooks : existing.hooks,
+      priority,
+    };
+    this.phenomena.set(existing.id, updated);
+    return { ...updated };
+  }
+
+  async listTemplates(): Promise<ReadonlyArray<PhenomenonTemplateDTO>> {
+    return Array.from(this.phenomena.values())
+      .filter(phenomenon => phenomenon.template)
+      .map(phenomenon => ({
+        id: phenomenon.id,
+        name: phenomenon.name,
+        category: phenomenon.category,
+        rule: phenomenon.rule,
+        effects: phenomenon.effects,
+      }));
+  }
+
+  seed(phenomena: PhenomenonDTO[]): void {
     phenomena.forEach(phenomenon => {
-      this.phenomena.set(phenomenon.id, phenomenon);
+      this.phenomena.set(phenomenon.id, { ...phenomenon });
     });
   }
 
   clear(): void {
     this.phenomena.clear();
   }
+}
+
+function matchesPhenomenonFilters(phenomenon: PhenomenonDTO, filters: EventsFilterState): boolean {
+  if (filters.categories?.length && !filters.categories.includes(phenomenon.category)) {
+    return false;
+  }
+  if (filters.calendarIds?.length) {
+    if (phenomenon.visibility === "selected") {
+      return phenomenon.appliesToCalendarIds.some(id => filters.calendarIds.includes(id));
+    }
+    return true;
+  }
+  return true;
+}
+
+function toSummary(phenomenon: PhenomenonDTO): PhenomenonSummaryDTO {
+  return {
+    id: phenomenon.id,
+    name: phenomenon.name,
+    category: phenomenon.category,
+    linkedCalendars: phenomenon.appliesToCalendarIds,
+    badge: phenomenon.tags?.[0],
+  };
+}
+
+function sortSummariesForInMemory(
+  phenomena: ReadonlyArray<PhenomenonDTO>,
+  summaries: ReadonlyArray<PhenomenonSummaryDTO>,
+  sort: EventsSort,
+): Array<{ phenomenon: PhenomenonDTO; summary: PhenomenonSummaryDTO }> {
+  const paired = phenomena.map((phenomenon, index) => ({ phenomenon, summary: summaries[index]! }));
+  paired.sort((a, b) => {
+    if (sort === "priority_desc") {
+      return b.phenomenon.priority - a.phenomenon.priority || a.summary.name.localeCompare(b.summary.name);
+    }
+    if (sort === "category_asc") {
+      return a.summary.category.localeCompare(b.summary.category) || a.summary.name.localeCompare(b.summary.name);
+    }
+    return a.summary.name.localeCompare(b.summary.name);
+  });
+  return paired;
+}
+
+function paginate<T>(entries: ReadonlyArray<T>, pagination: EventsPaginationState): {
+  items: ReadonlyArray<T>;
+  nextCursor?: string;
+} {
+  const offset = pagination.cursor ? Number.parseInt(pagination.cursor, 10) || 0 : 0;
+  const limit = pagination.limit ?? DEFAULT_PAGE_SIZE;
+  const slice = entries.slice(offset, offset + limit);
+  const nextOffset = offset + slice.length;
+  const hasMore = nextOffset < entries.length;
+  return { items: slice, nextCursor: hasMore ? String(nextOffset) : undefined };
+}
+
+function findDuplicateCalendarIds(links: ReadonlyArray<PhenomenonLinkUpdate["calendarLinks"][number]>): string[] {
+  const counts = new Map<string, number>();
+  for (const link of links) {
+    counts.set(link.calendarId, (counts.get(link.calendarId) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .filter(([, count]) => count > 1)
+    .map(([calendarId]) => calendarId);
 }

--- a/src/apps/almanac/data/json-store.ts
+++ b/src/apps/almanac/data/json-store.ts
@@ -1,0 +1,152 @@
+// src/apps/almanac/data/json-store.ts
+// Generic JSON store backed by an Obsidian vault file with migration support.
+
+import { normalizePath, TAbstractFile, TFile } from "obsidian";
+
+export interface VaultLike {
+  getAbstractFileByPath(path: string): TAbstractFile | null;
+  create(path: string, data: string): Promise<TFile>;
+  modify(file: TFile, data: string): Promise<void>;
+  read(file: TFile): Promise<string>;
+  createFolder(path: string): Promise<void>;
+}
+
+export interface JsonStoreConfig<T> {
+  readonly path: string;
+  readonly currentVersion: string;
+  readonly initialData: () => T;
+  readonly migrations?: Record<string, (payload: VersionedPayload<T>) => VersionedPayload<T>>;
+}
+
+export interface VersionedPayload<T> {
+  readonly version: string;
+  readonly data: T;
+}
+
+export class JsonStore<T> {
+  private readonly normalizedPath: string;
+
+  constructor(private readonly vault: VaultLike, private readonly config: JsonStoreConfig<T>) {
+    this.normalizedPath = normalizePath(config.path);
+  }
+
+  async read(): Promise<T> {
+    const payload = await this.ensurePayload();
+    return clone(payload.data);
+  }
+
+  async update(updater: (draft: T) => void | T): Promise<T> {
+    const payload = await this.ensurePayload();
+    const draft = clone(payload.data);
+    const result = updater(draft);
+    const nextData = result !== undefined ? result : draft;
+    const nextPayload: VersionedPayload<T> = { version: this.config.currentVersion, data: clone(nextData) };
+    await this.writePayload(nextPayload);
+    return clone(nextData);
+  }
+
+  private async ensurePayload(): Promise<VersionedPayload<T>> {
+    const file = await this.ensureFile();
+    const raw = await this.vault.read(file);
+    if (!raw.trim()) {
+      const fallback: VersionedPayload<T> = { version: this.config.currentVersion, data: this.config.initialData() };
+      await this.writePayload(fallback);
+      return fallback;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<VersionedPayload<T>>;
+      const normalized = this.normalisePayload(parsed);
+      if (normalized.version !== this.config.currentVersion) {
+        const migrated = this.applyMigrations(normalized);
+        if (migrated.version !== this.config.currentVersion) {
+          const coerced: VersionedPayload<T> = {
+            version: this.config.currentVersion,
+            data: migrated.data ?? this.config.initialData(),
+          };
+          await this.writePayload(coerced);
+          return coerced;
+        }
+        await this.writePayload(migrated);
+        return migrated;
+      }
+      return normalized;
+    } catch (error) {
+      console.warn(`[salt-marcher] Failed to parse ${this.normalizedPath}, resetting file`, error);
+      const fallback: VersionedPayload<T> = { version: this.config.currentVersion, data: this.config.initialData() };
+      await this.writePayload(fallback);
+      return fallback;
+    }
+  }
+
+  private applyMigrations(payload: VersionedPayload<T>): VersionedPayload<T> {
+    const migrations = this.config.migrations ?? {};
+    let current = payload;
+    const visited = new Set<string>();
+    while (current.version !== this.config.currentVersion) {
+      if (visited.has(current.version)) {
+        break;
+      }
+      visited.add(current.version);
+      const migrate = migrations[current.version];
+      if (!migrate) {
+        break;
+      }
+      current = migrate(current);
+    }
+    return current;
+  }
+
+  private normalisePayload(payload: Partial<VersionedPayload<T>> | null | undefined): VersionedPayload<T> {
+    if (!payload || typeof payload !== "object") {
+      return { version: "0.0.0", data: this.config.initialData() };
+    }
+    const version = typeof payload.version === "string" && payload.version ? payload.version : "0.0.0";
+    const data = payload.data ?? this.config.initialData();
+    return { version, data: data as T };
+  }
+
+  private async ensureFile(): Promise<TFile> {
+    const existing = this.vault.getAbstractFileByPath(this.normalizedPath);
+    if (existing instanceof TFile) {
+      return existing;
+    }
+    await this.ensureParentFolder(this.normalizedPath);
+    const payload: VersionedPayload<T> = { version: this.config.currentVersion, data: this.config.initialData() };
+    return this.vault.create(this.normalizedPath, serialise(payload));
+  }
+
+  private async ensureParentFolder(path: string): Promise<void> {
+    const segments = path.split("/").slice(0, -1);
+    let current = "";
+    for (const segment of segments) {
+      current = current ? `${current}/${segment}` : segment;
+      const normalised = normalizePath(current);
+      if (this.vault.getAbstractFileByPath(normalised)) {
+        continue;
+      }
+      try {
+        await this.vault.createFolder(normalised);
+      } catch (error) {
+        // Ignore race conditions where folder already exists
+        if (this.vault.getAbstractFileByPath(normalised)) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private async writePayload(payload: VersionedPayload<T>): Promise<void> {
+    const file = await this.ensureFile();
+    await this.vault.modify(file, serialise(payload));
+  }
+}
+
+function serialise(payload: VersionedPayload<unknown>): string {
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+function clone<V>(value: V): V {
+  return JSON.parse(JSON.stringify(value)) as V;
+}

--- a/src/apps/almanac/data/vault-almanac-repository.ts
+++ b/src/apps/almanac/data/vault-almanac-repository.ts
@@ -1,0 +1,347 @@
+// src/apps/almanac/data/vault-almanac-repository.ts
+// Vault-backed Almanac repository handling phenomena with filtering and pagination.
+
+import { compareTimestampsWithSchema, createDayTimestamp, formatTimestamp } from "../domain/calendar-timestamp";
+import { computeNextPhenomenonOccurrence } from "../domain/phenomenon-engine";
+import { isPhenomenonVisibleForCalendar } from "../domain/phenomenon";
+import type { EventsFilterState } from "../mode/contracts";
+import type {
+  CalendarSchemaDTO,
+  EventsDataBatchDTO,
+  EventsPaginationState,
+  EventsSort,
+  PhenomenonDTO,
+  PhenomenonLinkUpdate,
+  PhenomenonOccurrenceDTO,
+  PhenomenonSummaryDTO,
+  PhenomenonTemplateDTO,
+} from "./dto";
+import { AlmanacRepositoryError, type AlmanacRepository } from "./almanac-repository";
+import type { CalendarDefaultsRepository, CalendarRepository } from "./calendar-repository";
+import { JsonStore } from "./json-store";
+import type { VaultLike } from "./json-store";
+
+interface PhenomenaStoreData {
+  readonly phenomena: PhenomenonDTO[];
+}
+
+const PHENOMENA_STORE_VERSION = "1.4.0";
+const PHENOMENA_STORE_PATH = "SaltMarcher/Almanac/phenomena.json";
+const DEFAULT_PAGE_SIZE = 25;
+
+export class VaultAlmanacRepository implements AlmanacRepository {
+  private readonly store: JsonStore<PhenomenaStoreData>;
+
+  constructor(
+    private readonly calendars: CalendarRepository & CalendarDefaultsRepository,
+    vault: VaultLike,
+  ) {
+    this.store = new JsonStore<PhenomenaStoreData>(vault, {
+      path: PHENOMENA_STORE_PATH,
+      currentVersion: PHENOMENA_STORE_VERSION,
+      initialData: () => ({ phenomena: [] }),
+    });
+  }
+
+  async listPhenomena(input: {
+    readonly viewMode: string;
+    readonly filters: EventsFilterState;
+    readonly sort: EventsSort;
+    readonly pagination?: EventsPaginationState;
+  }): Promise<EventsDataBatchDTO> {
+    const state = await this.store.read();
+    const calendars = await this.calendars.listCalendars();
+    const calendarMap = new Map(calendars.map(calendar => [calendar.id, calendar]));
+    const visible = state.phenomena.filter(phenomenon => matchesFilters(phenomenon, input.filters, calendarMap));
+
+    const decorated = await Promise.all(
+      visible.map(async phenomenon => ({
+        phenomenon,
+        summary: await this.buildSummary(phenomenon, calendars),
+      })),
+    );
+
+    const sorted = sortSummaries(decorated, input.sort);
+    const { items, nextCursor } = paginate(sorted, input.pagination ?? { limit: DEFAULT_PAGE_SIZE });
+
+    return {
+      items: items.map(entry => entry.summary),
+      pagination: { cursor: nextCursor, hasMore: nextCursor !== undefined },
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  async getPhenomenon(id: string): Promise<PhenomenonDTO | null> {
+    const state = await this.store.read();
+    return state.phenomena.find(entry => entry.id === id) ?? null;
+  }
+
+  async upsertPhenomenon(draft: PhenomenonDTO): Promise<PhenomenonDTO> {
+    await this.store.update(state => {
+      const phenomena = [...state.phenomena];
+      const index = phenomena.findIndex(entry => entry.id === draft.id);
+      if (index === -1) {
+        phenomena.push({ ...draft });
+      } else {
+        phenomena[index] = { ...phenomena[index], ...draft };
+      }
+      return { phenomena };
+    });
+    const stored = await this.getPhenomenon(draft.id);
+    if (!stored) {
+      throw new Error(`Failed to persist phenomenon ${draft.id}`);
+    }
+    return stored;
+  }
+
+  async deletePhenomenon(id: string): Promise<void> {
+    await this.store.update(state => {
+      const remaining = state.phenomena.filter(entry => entry.id !== id);
+      if (remaining.length === state.phenomena.length) {
+        throw new Error(`Phenomenon with ID ${id} not found`);
+      }
+      return { phenomena: remaining };
+    });
+  }
+
+  async updateLinks(update: PhenomenonLinkUpdate): Promise<PhenomenonDTO> {
+    const phenomenon = await this.getPhenomenon(update.phenomenonId);
+    if (!phenomenon) {
+      throw new AlmanacRepositoryError("validation_error", `Phenomenon ${update.phenomenonId} not found`);
+    }
+
+    const calendars = await this.calendars.listCalendars();
+    const calendarSet = new Set(calendars.map(calendar => calendar.id));
+
+    const duplicates = findDuplicateCalendarIds(update.calendarLinks);
+    if (duplicates.length > 0) {
+      throw new AlmanacRepositoryError("phenomenon_conflict", "Calendar links contain duplicates", {
+        duplicates,
+      });
+    }
+
+    for (const link of update.calendarLinks) {
+      if (!calendarSet.has(link.calendarId)) {
+        throw new AlmanacRepositoryError("validation_error", `Calendar ${link.calendarId} not found`, {
+          calendarId: link.calendarId,
+        });
+      }
+    }
+
+    if (phenomenon.rule.type === "astronomical") {
+      const hasReference = Boolean(phenomenon.rule.astronomical?.referenceCalendarId);
+      const hasHookReference = update.calendarLinks.some(link =>
+        link.hook && typeof link.hook.config?.referenceCalendarId === "string",
+      );
+      if (!hasReference && !hasHookReference) {
+        throw new AlmanacRepositoryError("astronomy_source_missing", "Astronomical phenomena require a reference calendar");
+      }
+    }
+
+    await this.store.update(state => {
+      const phenomena = [...state.phenomena];
+      const index = phenomena.findIndex(entry => entry.id === phenomenon.id);
+      if (index === -1) {
+        throw new AlmanacRepositoryError("validation_error", `Phenomenon ${phenomenon.id} disappeared during update`);
+      }
+      const appliesToCalendarIds = update.calendarLinks.map(link => link.calendarId);
+      const visibility = appliesToCalendarIds.length === 0 ? "all_calendars" : "selected";
+      const hooks = buildHooksFromLinks(update.calendarLinks, phenomenon);
+      const priority = update.calendarLinks.reduce((max, link) => Math.max(max, link.priority), phenomenon.priority);
+      phenomena[index] = {
+        ...phenomena[index],
+        appliesToCalendarIds,
+        visibility,
+        hooks,
+        priority,
+      };
+      return { phenomena };
+    });
+
+    const stored = await this.getPhenomenon(update.phenomenonId);
+    if (!stored) {
+      throw new Error(`Failed to update phenomenon ${update.phenomenonId}`);
+    }
+    return stored;
+  }
+
+  async listTemplates(): Promise<ReadonlyArray<PhenomenonTemplateDTO>> {
+    const state = await this.store.read();
+    return state.phenomena
+      .filter(phenomenon => phenomenon.template)
+      .map(phenomenon => ({
+        id: phenomenon.id,
+        name: phenomenon.name,
+        category: phenomenon.category,
+        rule: phenomenon.rule,
+        effects: phenomenon.effects,
+      }));
+  }
+
+  private async buildSummary(phenomenon: PhenomenonDTO, calendars: ReadonlyArray<CalendarSchemaDTO>): Promise<PhenomenonSummaryDTO> {
+    const nextOccurrence = await this.computeNextOccurrence(phenomenon, calendars);
+    const linkedCalendars = phenomenon.visibility === "all_calendars"
+      ? calendars.map(calendar => calendar.id)
+      : phenomenon.appliesToCalendarIds;
+    return {
+      id: phenomenon.id,
+      name: phenomenon.name,
+      category: phenomenon.category,
+      nextOccurrence,
+      linkedCalendars,
+      badge: phenomenon.tags?.[0],
+    };
+  }
+
+  private async computeNextOccurrence(
+    phenomenon: PhenomenonDTO,
+    calendars: ReadonlyArray<CalendarSchemaDTO>,
+  ): Promise<PhenomenonOccurrenceDTO | undefined> {
+    const candidates: Array<{ occurrence: PhenomenonOccurrenceDTO; calendar: CalendarSchemaDTO }> = [];
+    for (const calendar of calendars) {
+      if (!isPhenomenonVisibleForCalendar(phenomenon, calendar.id)) {
+        continue;
+      }
+      const start = createDayTimestamp(
+        calendar.id,
+        calendar.epoch.year,
+        calendar.epoch.monthId,
+        calendar.epoch.day,
+      );
+      const occurrence = computeNextPhenomenonOccurrence(phenomenon, calendar, calendar.id, start);
+      if (!occurrence) {
+        continue;
+      }
+      candidates.push({
+        calendar,
+        occurrence: {
+          calendarId: occurrence.calendarId,
+          occurrence: occurrence.timestamp,
+          timeLabel: formatTimestamp(
+            occurrence.timestamp,
+            calendar.months.find(month => month.id === occurrence.timestamp.monthId)?.name,
+          ),
+        },
+      });
+    }
+    candidates.sort((a, b) => compareOccurrencesWithSchema(a, b));
+    return candidates[0]?.occurrence;
+  }
+}
+
+function matchesFilters(
+  phenomenon: PhenomenonDTO,
+  filters: EventsFilterState,
+  calendars: Map<string, CalendarSchemaDTO>,
+): boolean {
+  if (filters.categories?.length) {
+    if (!filters.categories.includes(phenomenon.category)) {
+      return false;
+    }
+  }
+  if (filters.calendarIds?.length) {
+    const visibleCalendars = phenomenon.visibility === "all_calendars"
+      ? Array.from(calendars.keys())
+      : phenomenon.appliesToCalendarIds;
+    const hasOverlap = filters.calendarIds.some(calendarId => visibleCalendars.includes(calendarId));
+    if (!hasOverlap) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sortSummaries(
+  summaries: ReadonlyArray<{ phenomenon: PhenomenonDTO; summary: PhenomenonSummaryDTO }>,
+  sort: EventsSort,
+): Array<{ phenomenon: PhenomenonDTO; summary: PhenomenonSummaryDTO }> {
+  const copy = [...summaries];
+  copy.sort((a, b) => {
+    if (sort === "priority_desc") {
+      return b.phenomenon.priority - a.phenomenon.priority || a.summary.name.localeCompare(b.summary.name);
+    }
+    if (sort === "category_asc") {
+      return a.summary.category.localeCompare(b.summary.category) || a.summary.name.localeCompare(b.summary.name);
+    }
+    const aTime = a.summary.nextOccurrence?.occurrence;
+    const bTime = b.summary.nextOccurrence?.occurrence;
+    if (!aTime && !bTime) {
+      return a.summary.name.localeCompare(b.summary.name);
+    }
+    if (!aTime) {
+      return 1;
+    }
+    if (!bTime) {
+      return -1;
+    }
+    return compareTimestampTuples(aTime, bTime);
+  });
+  return copy;
+}
+
+function paginate<T>(
+  entries: ReadonlyArray<T>,
+  pagination: EventsPaginationState,
+): { items: ReadonlyArray<T>; nextCursor?: string } {
+  const offset = pagination.cursor ? Number.parseInt(pagination.cursor, 10) || 0 : 0;
+  const limit = pagination.limit ?? DEFAULT_PAGE_SIZE;
+  const slice = entries.slice(offset, offset + limit);
+  const nextOffset = offset + slice.length;
+  const hasMore = nextOffset < entries.length;
+  return {
+    items: slice,
+    nextCursor: hasMore ? String(nextOffset) : undefined,
+  };
+}
+
+function compareTimestampTuples(a: PhenomenonOccurrenceDTO["occurrence"], b: PhenomenonOccurrenceDTO["occurrence"]): number {
+  if (a.year !== b.year) {
+    return a.year - b.year;
+  }
+  if (a.monthId !== b.monthId) {
+    return a.monthId.localeCompare(b.monthId);
+  }
+  if (a.day !== b.day) {
+    return a.day - b.day;
+  }
+  if ((a.hour ?? 0) !== (b.hour ?? 0)) {
+    return (a.hour ?? 0) - (b.hour ?? 0);
+  }
+  return (a.minute ?? 0) - (b.minute ?? 0);
+}
+
+function compareOccurrencesWithSchema(
+  a: { occurrence: PhenomenonOccurrenceDTO; calendar: CalendarSchemaDTO },
+  b: { occurrence: PhenomenonOccurrenceDTO; calendar: CalendarSchemaDTO },
+): number {
+  const first = a.occurrence.occurrence;
+  const second = b.occurrence.occurrence;
+  if (first.calendarId === second.calendarId) {
+    return compareTimestampsWithSchema(a.calendar, first, second);
+  }
+  return compareTimestampTuples(first, second);
+}
+
+function findDuplicateCalendarIds(links: ReadonlyArray<PhenomenonLinkUpdate["calendarLinks"][number]>): string[] {
+  const counts = new Map<string, number>();
+  for (const link of links) {
+    counts.set(link.calendarId, (counts.get(link.calendarId) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .filter(([, count]) => count > 1)
+    .map(([calendarId]) => calendarId);
+}
+
+function buildHooksFromLinks(
+  links: ReadonlyArray<PhenomenonLinkUpdate["calendarLinks"][number]>,
+  phenomenon: PhenomenonDTO,
+) {
+  const existing = phenomenon.hooks ?? [];
+  const linkedHooks = links
+    .filter(link => Boolean(link.hook))
+    .map(link => ({ ...link.hook!, priority: link.priority }));
+  if (linkedHooks.length === 0) {
+    return existing;
+  }
+  return linkedHooks;
+}

--- a/src/apps/almanac/data/vault-calendar-repository.ts
+++ b/src/apps/almanac/data/vault-calendar-repository.ts
@@ -1,0 +1,168 @@
+// src/apps/almanac/data/vault-calendar-repository.ts
+// Vault-backed calendar repository with schema versioning and default handling.
+
+import type { CalendarSchemaDTO } from "./dto";
+import {
+  type CalendarDefaultSnapshot,
+  type CalendarDefaultsRepository,
+  type CalendarRepository,
+  type CalendarDefaultUpdate,
+} from "./calendar-repository";
+import { JsonStore } from "./json-store";
+import type { VaultLike, VersionedPayload } from "./json-store";
+
+interface CalendarStoreData {
+  readonly calendars: CalendarSchemaDTO[];
+  readonly defaults: CalendarDefaultSnapshot;
+}
+
+const CALENDAR_STORE_VERSION = "1.4.0";
+const CALENDAR_STORE_PATH = "SaltMarcher/Almanac/calendars.json";
+
+export class VaultCalendarRepository implements CalendarRepository, CalendarDefaultsRepository {
+  private readonly store: JsonStore<CalendarStoreData>;
+
+  constructor(vault: VaultLike) {
+    this.store = new JsonStore<CalendarStoreData>(vault, {
+      path: CALENDAR_STORE_PATH,
+      currentVersion: CALENDAR_STORE_VERSION,
+      initialData: () => ({ calendars: [], defaults: { global: null, travel: {} } }),
+      migrations: {
+        "0.0.0": payload => migrateLegacyCalendars(payload),
+      },
+    });
+  }
+
+  async listCalendars(): Promise<ReadonlyArray<CalendarSchemaDTO>> {
+    const { calendars, defaults } = await this.store.read();
+    return calendars.map(calendar => ({
+      ...calendar,
+      isDefaultGlobal: defaults.global === calendar.id,
+      defaultTravelIds: computeDefaultTravelIds(calendar.id, defaults.travel),
+    }));
+  }
+
+  async getCalendar(id: string): Promise<CalendarSchemaDTO | null> {
+    const { calendars, defaults } = await this.store.read();
+    const calendar = calendars.find(entry => entry.id === id);
+    if (!calendar) {
+      return null;
+    }
+    return {
+      ...calendar,
+      isDefaultGlobal: defaults.global === calendar.id,
+      defaultTravelIds: computeDefaultTravelIds(calendar.id, defaults.travel),
+    };
+  }
+
+  async createCalendar(input: CalendarSchemaDTO & { readonly isDefaultGlobal?: boolean }): Promise<void> {
+    await this.store.update(state => {
+      if (state.calendars.some(calendar => calendar.id === input.id)) {
+        throw new Error(`Calendar with ID ${input.id} already exists`);
+      }
+      const calendars = [...state.calendars, { ...input }];
+      const defaults = ensureDefaultsState(state.defaults);
+      if (input.isDefaultGlobal) {
+        defaults.global = input.id;
+      }
+      return { calendars, defaults };
+    });
+  }
+
+  async updateCalendar(id: string, input: Partial<CalendarSchemaDTO>): Promise<void> {
+    await this.store.update(state => {
+      const index = state.calendars.findIndex(calendar => calendar.id === id);
+      if (index === -1) {
+        throw new Error(`Calendar with ID ${id} not found`);
+      }
+      const calendars = [...state.calendars];
+      calendars[index] = { ...calendars[index], ...input };
+      return { calendars, defaults: ensureDefaultsState(state.defaults) };
+    });
+  }
+
+  async deleteCalendar(id: string): Promise<void> {
+    await this.store.update(state => {
+      if (!state.calendars.some(calendar => calendar.id === id)) {
+        throw new Error(`Calendar with ID ${id} not found`);
+      }
+      const calendars = state.calendars.filter(calendar => calendar.id !== id);
+      const defaults = ensureDefaultsState(state.defaults);
+      if (defaults.global === id) {
+        defaults.global = null;
+      }
+      const travelEntries = Object.entries(defaults.travel);
+      for (const [travelId, calendarId] of travelEntries) {
+        if (calendarId === id) {
+          defaults.travel[travelId] = null;
+        }
+      }
+      return { calendars, defaults };
+    });
+  }
+
+  async setDefault(input: CalendarDefaultUpdate): Promise<void> {
+    await this.store.update(state => {
+      if (!state.calendars.some(calendar => calendar.id === input.calendarId)) {
+        throw new Error(`Calendar with ID ${input.calendarId} not found`);
+      }
+      const defaults = ensureDefaultsState(state.defaults);
+      if (input.scope === "global") {
+        defaults.global = input.calendarId;
+      } else if (input.scope === "travel" && input.travelId) {
+        defaults.travel[input.travelId] = input.calendarId;
+      }
+      return { calendars: state.calendars, defaults };
+    });
+  }
+
+  async getDefaults(): Promise<CalendarDefaultSnapshot> {
+    const { defaults } = await this.store.read();
+    return ensureDefaultsState(defaults);
+  }
+
+  async getGlobalDefault(): Promise<string | null> {
+    const { defaults } = await this.store.read();
+    return ensureDefaultsState(defaults).global;
+  }
+
+  async getTravelDefault(travelId: string): Promise<string | null> {
+    const { defaults } = await this.store.read();
+    const snapshot = ensureDefaultsState(defaults);
+    return snapshot.travel[travelId] ?? null;
+  }
+
+  async clearTravelDefault(travelId: string): Promise<void> {
+    await this.store.update(state => {
+      const defaults = ensureDefaultsState(state.defaults);
+      if (defaults.travel[travelId]) {
+        defaults.travel[travelId] = null;
+      }
+      return { calendars: state.calendars, defaults };
+    });
+  }
+}
+
+function ensureDefaultsState(snapshot: CalendarDefaultSnapshot | undefined): CalendarDefaultSnapshot {
+  return {
+    global: snapshot?.global ?? null,
+    travel: { ...(snapshot?.travel ?? {}) },
+  };
+}
+
+function computeDefaultTravelIds(calendarId: string, travel: Readonly<Record<string, string | null>>): string[] {
+  return Object.entries(travel)
+    .filter(([, linkedId]) => linkedId === calendarId)
+    .map(([travelId]) => travelId);
+}
+
+function migrateLegacyCalendars(payload: VersionedPayload<CalendarStoreData>): VersionedPayload<CalendarStoreData> {
+  const defaults = ensureDefaultsState(payload.data.defaults);
+  return {
+    version: CALENDAR_STORE_VERSION,
+    data: {
+      calendars: payload.data.calendars ?? [],
+      defaults,
+    },
+  };
+}

--- a/src/apps/almanac/data/vault-event-repository.ts
+++ b/src/apps/almanac/data/vault-event-repository.ts
@@ -1,0 +1,146 @@
+// src/apps/almanac/data/vault-event-repository.ts
+// Vault-backed calendar event repository supporting range queries and upcoming lists.
+
+import { compareTimestampsWithSchema } from "../domain/calendar-timestamp";
+import { getEventAnchorTimestamp } from "../domain/calendar-event";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import type { CalendarSchemaDTO, CalendarEventDTO, CalendarRangeDTO } from "./dto";
+import type { CalendarRepository } from "./calendar-repository";
+import type { EventRepository } from "./event-repository";
+import { JsonStore } from "./json-store";
+import type { VaultLike } from "./json-store";
+
+interface EventStoreData {
+  readonly eventsByCalendar: Record<string, CalendarEventDTO[]>;
+}
+
+const EVENT_STORE_VERSION = "1.4.0";
+const EVENT_STORE_PATH = "SaltMarcher/Almanac/events.json";
+
+export class VaultEventRepository implements EventRepository {
+  private readonly store: JsonStore<EventStoreData>;
+
+  constructor(private readonly calendars: CalendarRepository, vault: VaultLike) {
+    this.store = new JsonStore<EventStoreData>(vault, {
+      path: EVENT_STORE_PATH,
+      currentVersion: EVENT_STORE_VERSION,
+      initialData: () => ({ eventsByCalendar: {} }),
+    });
+  }
+
+  async listEvents(calendarId: string, range?: CalendarRangeDTO): Promise<ReadonlyArray<CalendarEventDTO>> {
+    const schema = await this.requireCalendar(calendarId);
+    const events = await this.readCalendarEvents(calendarId);
+    if (!range) {
+      return events;
+    }
+    const start = range.start;
+    const end = range.end;
+    return events.filter(event => {
+      const anchor = getEventAnchorTimestamp(event) ?? event.date;
+      const afterStart = compareTimestampsWithSchema(schema, anchor, start) >= 0;
+      const beforeEnd = compareTimestampsWithSchema(schema, anchor, end) <= 0;
+      return afterStart && beforeEnd;
+    });
+  }
+
+  async listUpcoming(calendarId: string, limit: number): Promise<ReadonlyArray<CalendarEventDTO>> {
+    const schema = await this.requireCalendar(calendarId);
+    const events = await this.readCalendarEvents(calendarId);
+    const sorted = [...events].sort((a, b) => {
+      const aAnchor = getEventAnchorTimestamp(a) ?? a.date;
+      const bAnchor = getEventAnchorTimestamp(b) ?? b.date;
+      return compareTimestampsWithSchema(schema, aAnchor, bAnchor);
+    });
+    return sorted.slice(0, limit);
+  }
+
+  async createEvent(event: CalendarEventDTO): Promise<void> {
+    await this.store.update(state => {
+      const eventsByCalendar = { ...state.eventsByCalendar };
+      const events = [...(eventsByCalendar[event.calendarId] ?? [])];
+      if (events.some(entry => entry.id === event.id)) {
+        throw new Error(`Event with ID ${event.id} already exists`);
+      }
+      events.push(event);
+      eventsByCalendar[event.calendarId] = events;
+      return { eventsByCalendar };
+    });
+  }
+
+  async updateEvent(id: string, event: Partial<CalendarEventDTO>): Promise<void> {
+    await this.store.update(state => {
+      const eventsByCalendar = { ...state.eventsByCalendar };
+      let found = false;
+      for (const [calendarId, events] of Object.entries(eventsByCalendar)) {
+        const index = events.findIndex(entry => entry.id === id);
+        if (index === -1) {
+          continue;
+        }
+        events[index] = { ...events[index], ...event } as CalendarEventDTO;
+        eventsByCalendar[calendarId] = [...events];
+        found = true;
+      }
+      if (!found) {
+        throw new Error(`Event with ID ${id} not found`);
+      }
+      return { eventsByCalendar };
+    });
+  }
+
+  async deleteEvent(id: string): Promise<void> {
+    await this.store.update(state => {
+      const eventsByCalendar: Record<string, CalendarEventDTO[]> = {};
+      let found = false;
+      for (const [calendarId, events] of Object.entries(state.eventsByCalendar)) {
+        const remaining = events.filter(event => event.id !== id);
+        if (remaining.length !== events.length) {
+          found = true;
+        }
+        eventsByCalendar[calendarId] = remaining;
+      }
+      if (!found) {
+        throw new Error(`Event with ID ${id} not found`);
+      }
+      return { eventsByCalendar };
+    });
+  }
+
+  async getEventsInRange(
+    calendarId: string,
+    schema: CalendarSchemaDTO,
+    start: CalendarTimestamp,
+    end: CalendarTimestamp,
+  ): Promise<CalendarEventDTO[]> {
+    const range: CalendarRangeDTO = { calendarId, start, end };
+    return this.listEvents(calendarId, range);
+  }
+
+  async getUpcomingEvents(
+    calendarId: string,
+    schema: CalendarSchemaDTO,
+    from: CalendarTimestamp,
+    limit: number,
+  ): Promise<CalendarEventDTO[]> {
+    const events = await this.listEvents(calendarId);
+    return events
+      .filter(event => {
+        const anchor = getEventAnchorTimestamp(event) ?? event.date;
+        return compareTimestampsWithSchema(schema, anchor, from) >= 0;
+      })
+      .slice(0, limit);
+  }
+
+  private async readCalendarEvents(calendarId: string): Promise<CalendarEventDTO[]> {
+    const state = await this.store.read();
+    return [...(state.eventsByCalendar[calendarId] ?? [])];
+  }
+
+  private async requireCalendar(calendarId: string): Promise<CalendarSchemaDTO> {
+    const calendar = await this.calendars.getCalendar(calendarId);
+    if (!calendar) {
+      throw new Error(`Calendar with ID ${calendarId} not found`);
+    }
+    return calendar;
+  }
+}

--- a/src/apps/almanac/mode/almanac-controller.ts
+++ b/src/apps/almanac/mode/almanac-controller.ts
@@ -62,6 +62,7 @@ export class AlmanacController {
     constructor(private readonly app: App) {
         this.calendarRepo = new InMemoryCalendarRepository();
         this.eventRepo = new InMemoryEventRepository();
+        this.eventRepo.bindCalendarRepository(this.calendarRepo);
         this.phenomenonRepo = new InMemoryPhenomenonRepository();
         this.gateway = new InMemoryStateGateway(this.calendarRepo, this.eventRepo, this.phenomenonRepo);
         this.stateMachine = new AlmanacStateMachine(

--- a/tests/apps/almanac/AGENTS.md
+++ b/tests/apps/almanac/AGENTS.md
@@ -5,6 +5,7 @@
 # Aktueller Stand
 - Vitest-Suites für Domain-Layer (Kalenderarithmetik, Wiederholregeln, Phänomen-Engine) sowie Gateway-Integration vorhanden.
 - Dashboard-DOM-Test deckt Recently-Triggered-Rendering und Moduswechsel ab.
+- Persistenztests für die Vault-Repositories (`calendar-repository.test.ts`, `almanac-repository.test.ts`) sichern Schema- und Filterlogik.
 
 # ToDo
 - [P1] Ergänze UI-/Events-Tests nach Fertigstellung des Phänomen-Editors und Travel-Leaves.

--- a/tests/apps/almanac/almanac-repository.test.ts
+++ b/tests/apps/almanac/almanac-repository.test.ts
@@ -1,0 +1,188 @@
+// salt-marcher/tests/apps/almanac/almanac-repository.test.ts
+// Exercises VaultAlmanacRepository filter, pagination and link update logic.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { TAbstractFile, TFile } from "obsidian";
+import { VaultAlmanacRepository } from "../../../src/apps/almanac/data/vault-almanac-repository";
+import { VaultCalendarRepository } from "../../../src/apps/almanac/data/vault-calendar-repository";
+import type { VaultLike } from "../../../src/apps/almanac/data/json-store";
+import { gregorianSchema } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+
+class MemoryFile extends TFile {
+    data = "";
+    constructor(path: string, data: string) {
+        super();
+        this.path = path;
+        this.basename = path.split("/").pop() ?? path;
+        this.data = data;
+    }
+}
+
+class MemoryVault implements VaultLike {
+    private files = new Map<string, MemoryFile>();
+    private folders = new Set<string>();
+
+    getAbstractFileByPath(path: string): TAbstractFile | null {
+        const file = this.files.get(path);
+        if (file) {
+            return file;
+        }
+        if (this.folders.has(path)) {
+            const folder = new TAbstractFile();
+            folder.path = path;
+            return folder;
+        }
+        return null;
+    }
+
+    async create(path: string, data: string): Promise<TFile> {
+        const file = new MemoryFile(path, data);
+        this.files.set(path, file);
+        return file;
+    }
+
+    async modify(file: TFile, data: string): Promise<void> {
+        const memory = this.files.get(file.path);
+        if (memory) {
+            memory.data = data;
+        }
+    }
+
+    async read(file: TFile): Promise<string> {
+        const memory = this.files.get(file.path);
+        return memory?.data ?? "";
+    }
+
+    async createFolder(path: string): Promise<void> {
+        this.folders.add(path);
+    }
+}
+
+describe("VaultAlmanacRepository", () => {
+    let vault: MemoryVault;
+    let calendarRepo: VaultCalendarRepository;
+    let repository: VaultAlmanacRepository;
+
+    beforeEach(async () => {
+        vault = new MemoryVault();
+        calendarRepo = new VaultCalendarRepository(vault);
+        await calendarRepo.createCalendar({ ...gregorianSchema, isDefaultGlobal: true });
+        repository = new VaultAlmanacRepository(calendarRepo, vault);
+
+        const simplePhenomena = [
+            {
+                id: "phen-spring-bloom",
+                name: "Spring Bloom",
+                category: "season" as const,
+                visibility: "selected" as const,
+                appliesToCalendarIds: [gregorianSchema.id],
+                rule: { type: "annual_offset", offsetDayOfYear: 80 } as any,
+                timePolicy: "all_day" as const,
+                priority: 5,
+                schemaVersion: "1.0.0",
+            },
+            {
+                id: "phen-harvest-fest",
+                name: "Harvest Festival",
+                category: "holiday" as const,
+                visibility: "selected" as const,
+                appliesToCalendarIds: [gregorianSchema.id],
+                rule: { type: "annual_offset", offsetDayOfYear: 200 } as any,
+                timePolicy: "all_day" as const,
+                priority: 3,
+                schemaVersion: "1.0.0",
+            },
+            {
+                id: "phen-spring-tide",
+                name: "Spring Tide",
+                category: "tide" as const,
+                visibility: "selected" as const,
+                appliesToCalendarIds: [gregorianSchema.id],
+                rule: { type: "annual_offset", offsetDayOfYear: 120 } as any,
+                timePolicy: "all_day" as const,
+                priority: 6,
+                schemaVersion: "1.0.0",
+            },
+        ];
+
+        for (const phenomenon of simplePhenomena) {
+            await repository.upsertPhenomenon(phenomenon);
+        }
+    });
+
+    it("filters phenomena by category and calendar and supports pagination", async () => {
+        const batch = await repository.listPhenomena({
+            viewMode: "timeline",
+            filters: { categories: [], calendarIds: [] },
+            sort: "priority_desc",
+            pagination: { limit: 2 },
+        });
+
+        expect(batch.items).toHaveLength(2);
+        expect(batch.pagination.hasMore).toBe(true);
+
+        const holidayOnly = await repository.listPhenomena({
+            viewMode: "timeline",
+            filters: { categories: ["tide"], calendarIds: [] },
+            sort: "priority_desc",
+            pagination: { limit: 5 },
+        });
+
+        expect(holidayOnly.items).toHaveLength(1);
+        expect(holidayOnly.items[0]?.category).toBe("tide");
+
+        const calendarFilter = await repository.listPhenomena({
+            viewMode: "timeline",
+            filters: { categories: [], calendarIds: [gregorianSchema.id] },
+            sort: "priority_desc",
+            pagination: { limit: 5 },
+        });
+
+        expect(calendarFilter.items.length).toBeGreaterThan(0);
+        expect(calendarFilter.items.every(item => item.linkedCalendars.includes(gregorianSchema.id))).toBe(true);
+    });
+
+    it("updates phenomenon calendar links and prevents duplicate assignments", async () => {
+        const result = await repository.updateLinks({
+            phenomenonId: "phen-spring-bloom",
+            calendarLinks: [
+                { calendarId: gregorianSchema.id, priority: 8 },
+            ],
+        });
+
+        expect(result.visibility).toBe("selected");
+        expect(result.appliesToCalendarIds).toEqual([gregorianSchema.id]);
+
+        await expect(
+            repository.updateLinks({
+                phenomenonId: "phen-spring-bloom",
+                calendarLinks: [
+                    { calendarId: gregorianSchema.id, priority: 1 },
+                    { calendarId: gregorianSchema.id, priority: 2 },
+                ],
+            }),
+        ).rejects.toMatchObject({ code: "phenomenon_conflict" });
+    });
+
+    it("guards astronomical phenomena without reference calendars", async () => {
+        await repository.upsertPhenomenon({
+            id: "phen-astronomical",
+            name: "Star Fall",
+            category: "astronomy",
+            visibility: "selected",
+            appliesToCalendarIds: [gregorianSchema.id],
+            rule: { type: "astronomical", source: "sunrise" } as any,
+            timePolicy: "all_day",
+            priority: 4,
+            schemaVersion: "1.0.0",
+        });
+
+        await expect(
+            repository.updateLinks({
+                phenomenonId: "phen-astronomical",
+                calendarLinks: [{ calendarId: gregorianSchema.id, priority: 1 }],
+            }),
+        ).rejects.toMatchObject({ code: "astronomy_source_missing" });
+    });
+});

--- a/tests/apps/almanac/calendar-repository.test.ts
+++ b/tests/apps/almanac/calendar-repository.test.ts
@@ -1,0 +1,102 @@
+// salt-marcher/tests/apps/almanac/calendar-repository.test.ts
+// Validates vault-backed calendar repository persistence and default handling.
+
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { TAbstractFile, TFile } from "obsidian";
+import { VaultCalendarRepository } from "../../../src/apps/almanac/data/vault-calendar-repository";
+import type { VaultLike } from "../../../src/apps/almanac/data/json-store";
+import { gregorianSchema } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+
+class MemoryFile extends TFile {
+    data = "";
+    constructor(path: string, data: string) {
+        super();
+        this.path = path;
+        this.basename = path.split("/").pop() ?? path;
+        this.data = data;
+    }
+}
+
+class MemoryVault implements VaultLike {
+    private files = new Map<string, MemoryFile>();
+    private folders = new Set<string>();
+
+    getAbstractFileByPath(path: string): TAbstractFile | null {
+        const normalised = path;
+        const file = this.files.get(normalised);
+        if (file) {
+            return file;
+        }
+        if (this.folders.has(normalised)) {
+            const folder = new TAbstractFile();
+            folder.path = normalised;
+            return folder;
+        }
+        return null;
+    }
+
+    async create(path: string, data: string): Promise<TFile> {
+        const file = new MemoryFile(path, data);
+        this.files.set(path, file);
+        return file;
+    }
+
+    async modify(file: TFile, data: string): Promise<void> {
+        const memory = this.files.get(file.path);
+        if (memory) {
+            memory.data = data;
+        }
+    }
+
+    async read(file: TFile): Promise<string> {
+        const memory = this.files.get(file.path);
+        return memory?.data ?? "";
+    }
+
+    async createFolder(path: string): Promise<void> {
+        this.folders.add(path);
+    }
+}
+
+describe("VaultCalendarRepository", () => {
+    let vault: MemoryVault;
+
+    beforeEach(() => {
+        vault = new MemoryVault();
+    });
+
+    it("persists calendars and default selections across instances", async () => {
+        const repo = new VaultCalendarRepository(vault);
+
+        await repo.createCalendar({ ...gregorianSchema, isDefaultGlobal: true });
+        await repo.setDefault({ calendarId: gregorianSchema.id, scope: "travel", travelId: "travel-1" });
+
+        const first = await repo.listCalendars();
+        expect(first).toHaveLength(1);
+        expect(first[0]?.isDefaultGlobal).toBe(true);
+        expect(first[0]?.defaultTravelIds).toEqual(["travel-1"]);
+
+        const reload = new VaultCalendarRepository(vault);
+        const defaults = await reload.getDefaults();
+        expect(defaults.global).toBe(gregorianSchema.id);
+        expect(defaults.travel["travel-1"]).toBe(gregorianSchema.id);
+
+        await reload.clearTravelDefault("travel-1");
+        const cleared = await reload.getDefaults();
+        expect(cleared.travel["travel-1"]).toBeNull();
+
+        await reload.deleteCalendar(gregorianSchema.id);
+        const afterDelete = await reload.listCalendars();
+        expect(afterDelete).toHaveLength(0);
+    });
+
+    it("updates calendar metadata via updateCalendar", async () => {
+        const repo = new VaultCalendarRepository(vault);
+        await repo.createCalendar({ ...gregorianSchema });
+
+        await repo.updateCalendar(gregorianSchema.id, { description: "Updated" });
+        const updated = await repo.getCalendar(gregorianSchema.id);
+        expect(updated?.description).toBe("Updated");
+    });
+});

--- a/tests/apps/almanac/default-resolver.test.ts
+++ b/tests/apps/almanac/default-resolver.test.ts
@@ -61,6 +61,7 @@ describe('Default Calendar Resolver', () => {
   beforeEach(() => {
     calendarRepo = new InMemoryCalendarRepository();
     eventRepo = new InMemoryEventRepository();
+    eventRepo.bindCalendarRepository(calendarRepo);
     phenomenonRepo = new InMemoryPhenomenonRepository();
     gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
   });

--- a/tests/apps/almanac/state-gateway.test.ts
+++ b/tests/apps/almanac/state-gateway.test.ts
@@ -32,6 +32,7 @@ describe("InMemoryStateGateway.advanceTimeBy", () => {
     beforeEach(async () => {
         calendarRepo = new InMemoryCalendarRepository();
         eventRepo = new InMemoryEventRepository();
+        eventRepo.bindCalendarRepository(calendarRepo);
         phenomenonRepo = new InMemoryPhenomenonRepository();
         gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
 

--- a/tests/apps/almanac/state-machine.events.test.ts
+++ b/tests/apps/almanac/state-machine.events.test.ts
@@ -27,6 +27,7 @@ describe("AlmanacStateMachine events refresh", () => {
     beforeEach(async () => {
         calendarRepo = new InMemoryCalendarRepository();
         eventRepo = new InMemoryEventRepository();
+        eventRepo.bindCalendarRepository(calendarRepo);
         phenomenonRepo = new InMemoryPhenomenonRepository();
         gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
 

--- a/tests/apps/almanac/state-machine.manager.test.ts
+++ b/tests/apps/almanac/state-machine.manager.test.ts
@@ -27,6 +27,7 @@ describe("AlmanacStateMachine calendar creation", () => {
     beforeEach(async () => {
         calendarRepo = new InMemoryCalendarRepository();
         eventRepo = new InMemoryEventRepository();
+        eventRepo.bindCalendarRepository(calendarRepo);
         phenomenonRepo = new InMemoryPhenomenonRepository();
         gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
 


### PR DESCRIPTION
## Summary
- add shared DTO and repository interfaces for Almanac persistence
- implement JsonStore-backed calendar, event, and phenomenon repositories with filter and migration logic
- extend in-memory repositories and gateway wiring to support new interfaces and add persistence tests for vault stores

## Testing
- npm test -- --run tests/apps/almanac/calendar-repository.test.ts tests/apps/almanac/almanac-repository.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4d270de588325976d5107d3666a87