### PR TITLE
feat: persist almanac state via gateway

### DIFF
--- a/src/apps/almanac/data/calendar-state-gateway.ts
+++ b/src/apps/almanac/data/calendar-state-gateway.ts
@@ -1,0 +1,77 @@
+// src/apps/almanac/data/calendar-state-gateway.ts
+// Shared gateway interface and types for persisting Almanac calendar state.
+
+import type { CalendarEvent } from "../domain/calendar-event";
+import type { CalendarSchema } from "../domain/calendar-schema";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import type { PhenomenonOccurrence } from "../domain/phenomenon";
+import type { TimeUnit } from "../domain/time-arithmetic";
+import type {
+  AlmanacPreferencesSnapshot,
+  TravelCalendarMode,
+} from "../mode/contracts";
+
+export interface CalendarStateSnapshot {
+  readonly activeCalendar: CalendarSchema | null;
+  readonly currentTimestamp: CalendarTimestamp | null;
+  readonly upcomingEvents: ReadonlyArray<CalendarEvent>;
+  readonly upcomingPhenomena: ReadonlyArray<PhenomenonOccurrence>;
+  readonly defaultCalendarId: string | null;
+  readonly travelDefaultCalendarId: string | null;
+  readonly isGlobalDefault: boolean;
+  readonly wasAutoSelected: boolean;
+}
+
+export interface AdvanceTimeResult {
+  readonly timestamp: CalendarTimestamp;
+  readonly triggeredEvents: ReadonlyArray<CalendarEvent>;
+  readonly triggeredPhenomena: ReadonlyArray<PhenomenonOccurrence>;
+  readonly upcomingPhenomena: ReadonlyArray<PhenomenonOccurrence>;
+}
+
+export interface HookDispatchContext {
+  readonly scope: "global" | "travel";
+  readonly travelId?: string | null;
+  readonly reason: "advance" | "jump";
+}
+
+export interface HookDispatchGateway {
+  dispatchHooks(
+    events: ReadonlyArray<CalendarEvent>,
+    phenomena: ReadonlyArray<PhenomenonOccurrence>,
+    context: HookDispatchContext,
+  ): Promise<void>;
+}
+
+export interface TravelLeafPreferencesSnapshot {
+  readonly visible: boolean;
+  readonly mode: TravelCalendarMode;
+  readonly lastViewedTimestamp?: CalendarTimestamp | null;
+}
+
+export interface CalendarStateGateway {
+  loadSnapshot(options?: { readonly travelId?: string | null }): Promise<CalendarStateSnapshot>;
+  setActiveCalendar(
+    calendarId: string,
+    options?: { readonly travelId?: string | null; readonly initialTimestamp?: CalendarTimestamp },
+  ): Promise<void>;
+  setDefaultCalendar(
+    calendarId: string,
+    options?: { readonly scope: "global" | "travel"; readonly travelId?: string | null },
+  ): Promise<void>;
+  setCurrentTimestamp(
+    timestamp: CalendarTimestamp,
+    options?: { readonly travelId?: string | null },
+  ): Promise<void>;
+  advanceTimeBy(
+    amount: number,
+    unit: TimeUnit,
+    options?: { readonly travelId?: string | null; readonly hookContext?: HookDispatchContext },
+  ): Promise<AdvanceTimeResult>;
+  loadPreferences(): Promise<AlmanacPreferencesSnapshot>;
+  savePreferences(partial: Partial<AlmanacPreferencesSnapshot>): Promise<void>;
+  getCurrentTimestamp(options?: { readonly travelId?: string | null }): CalendarTimestamp | null;
+  getActiveCalendarId(options?: { readonly travelId?: string | null }): string | null;
+  getTravelLeafPreferences(travelId: string): Promise<TravelLeafPreferencesSnapshot | null>;
+  saveTravelLeafPreferences(travelId: string, prefs: TravelLeafPreferencesSnapshot): Promise<void>;
+}

--- a/src/apps/almanac/mode/API_CONTRACTS.md
+++ b/src/apps/almanac/mode/API_CONTRACTS.md
@@ -300,17 +300,31 @@ interface EventsPreferenceDTO {
 ### 3.1 `CalendarStateGateway`
 ```ts
 interface CalendarStateGateway {
-  loadSnapshot(scope: 'global' | 'travel', travelId?: string): Promise<CalendarStateSnapshotDTO>;
-  setActiveCalendar(input: { calendarId: string; scope: 'global' | 'travel'; travelId?: string }): Promise<void>;
-  setDefaultCalendar(input: { calendarId: string; scope: 'global' | 'travel'; travelId?: string }): Promise<void>;
-  advanceTime(input: AdvanceRequestDTO & { scope: 'global' | 'travel'; travelId?: string }): Promise<AdvanceResultDTO>;
-  setDate(input: JumpRequestDTO & { scope: 'global' | 'travel'; travelId?: string }): Promise<JumpResultDTO>;
-  getTravelLeafPreferences(travelId: string): Promise<TravelLeafPrefsDTO>;
-  setTravelLeafPreferences(travelId: string, prefs: TravelLeafPrefsDTO): Promise<void>;
-  getAlmanacMode(): Promise<AlmanacModeSnapshotDTO>;
-  setAlmanacMode(input: AlmanacModeSnapshotDTO): Promise<void>;
-  getEventsPreferences(): Promise<EventsPreferenceDTO | null>;
-  setEventsPreferences(prefs: EventsPreferenceDTO): Promise<void>;
+  loadSnapshot(options?: { travelId?: string | null }): Promise<CalendarStateSnapshotDTO>;
+  setActiveCalendar(calendarId: string, options?: { travelId?: string | null; initialTimestamp?: CalendarDateDTO }): Promise<void>;
+  setDefaultCalendar(calendarId: string, options?: { scope: 'global' | 'travel'; travelId?: string | null }): Promise<void>;
+  setCurrentTimestamp(timestamp: CalendarDateDTO, options?: { travelId?: string | null }): Promise<void>;
+  advanceTimeBy(amount: number, unit: 'minute' | 'hour' | 'day', options?: { travelId?: string | null; hookContext?: HookDispatchContextDTO }): Promise<AdvanceResultDTO>;
+  loadPreferences(): Promise<AlmanacPreferencesDTO>;
+  savePreferences(partial: Partial<AlmanacPreferencesDTO>): Promise<void>;
+  getCurrentTimestamp(options?: { travelId?: string | null }): CalendarDateDTO | null;
+  getActiveCalendarId(options?: { travelId?: string | null }): string | null;
+  getTravelLeafPreferences(travelId: string): Promise<TravelLeafPrefsDTO | null>;
+  saveTravelLeafPreferences(travelId: string, prefs: TravelLeafPrefsDTO): Promise<void>;
+}
+```
+interface HookDispatchContextDTO {
+  scope: 'global' | 'travel';
+  travelId?: string | null;
+  reason: 'advance' | 'jump';
+}
+interface AlmanacPreferencesDTO {
+  lastMode?: AlmanacMode;
+  managerViewMode?: CalendarManagerViewMode;
+  eventsViewMode?: EventsViewMode;
+  lastZoomByMode?: Partial<Record<AlmanacMode, CalendarViewZoom>>;
+  eventsFilters?: EventsFilterState;
+  lastSelectedPhenomenonId?: string;
 }
 ```
 

--- a/tests/apps/almanac/almanac-controller.dom.test.ts
+++ b/tests/apps/almanac/almanac-controller.dom.test.ts
@@ -80,6 +80,10 @@ describe("AlmanacController Dashboard", () => {
 
         const stateMachine = (controller as unknown as { stateMachine: AlmanacStateMachine }).stateMachine;
         await stateMachine.dispatch({ type: "TIME_ADVANCE_REQUESTED", amount: 15, unit: "day" });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const state = stateMachine.getState();
+        expect(state.calendarState.triggeredEvents.length).toBeGreaterThan(0);
 
         const triggeredHeading = Array.from(container.querySelectorAll("h2")).find(
             heading => heading.textContent === "Recently Triggered"

--- a/tests/apps/almanac/state-machine.events.test.ts
+++ b/tests/apps/almanac/state-machine.events.test.ts
@@ -37,7 +37,7 @@ describe("AlmanacStateMachine events refresh", () => {
 
         await gateway.setActiveCalendar(
             gregorianSchema.id,
-            getDefaultCurrentTimestamp(2024),
+            { initialTimestamp: getDefaultCurrentTimestamp(2024) },
         );
 
         stateMachine = new AlmanacStateMachine(
@@ -86,5 +86,9 @@ describe("AlmanacStateMachine events refresh", () => {
         expect(
             state.eventsUiState.phenomena.every(item => item.category === "astronomy"),
         ).toBe(true);
+
+        const preferences = await gateway.loadPreferences();
+        expect(preferences.eventsFilters?.categories).toEqual(["astronomy"]);
+        expect(preferences.lastSelectedPhenomenonId).toBe("phen-harvest-moon");
     });
 });


### PR DESCRIPTION
## Summary
- introduce the CalendarStateGateway contract so controllers can persist calendar state
- extend the in-memory and vault implementations to filter triggered events, dispatch hooks safely, and store preferences/travel data
- update Almanac mode tests to cover the new gateway wiring and persistence behaviour

## Testing
- npm test -- --run tests/apps/almanac/state-gateway.test.ts
- npm test -- --run tests/apps/almanac
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4d825d1308325a48ace6e672a7c0c