### PR TITLE
feat: sync travel hooks with cartographer

### DIFF
--- a/src/apps/almanac/mode/cartographer-gateway.ts
+++ b/src/apps/almanac/mode/cartographer-gateway.ts
@@ -1,0 +1,244 @@
+// src/apps/almanac/mode/cartographer-gateway.ts
+// Gateway, der Almanac-Hooks und Travel-Panel-Updates an den Cartographer weiterleitet.
+
+import { getEventAnchorTimestamp, type CalendarEvent } from "../domain/calendar-event";
+import type { CalendarTimestamp } from "../domain/calendar-timestamp";
+import type { PhenomenonOccurrence } from "../domain/phenomenon";
+import type { HookDispatchGateway, HookDispatchContext } from "../data/calendar-state-gateway";
+
+type TravelScope = "global" | "travel";
+
+const GLOBAL_TRAVEL_KEY = "__global__";
+
+export type CartographerHookEvent = {
+    readonly eventId: string;
+    readonly calendarId: string;
+    readonly occurrence: CalendarTimestamp;
+    readonly title?: string;
+};
+
+export type CartographerPhenomenonHook = {
+    readonly phenomenonId: string;
+    readonly occurrence: CalendarTimestamp;
+    readonly effects?: ReadonlyArray<unknown>;
+};
+
+export type CartographerHookPayload = {
+    readonly scope: TravelScope;
+    readonly travelId: string | null;
+    readonly reason: "advance" | "jump" | "init";
+    readonly events: ReadonlyArray<CartographerHookEvent>;
+    readonly phenomena: ReadonlyArray<CartographerPhenomenonHook>;
+};
+
+export type TravelPanelLogEntry = {
+    readonly kind: "event" | "phenomenon";
+    readonly id: string;
+    readonly title: string;
+    readonly occurrenceLabel: string;
+    readonly skipped?: boolean;
+};
+
+export type TravelPanelSnapshot = {
+    readonly travelId: string | null;
+    readonly timestampLabel?: string;
+    readonly message?: string;
+    readonly reason: "advance" | "jump" | "init";
+    readonly lastAdvanceStep?: { readonly amount: number; readonly unit: "minute" | "hour" | "day" };
+    readonly logEntries: ReadonlyArray<TravelPanelLogEntry>;
+};
+
+export type TravelPanelUpdateInput = {
+    readonly travelId?: string | null;
+    readonly currentTimestamp?: CalendarTimestamp | null;
+    readonly triggeredEvents?: ReadonlyArray<CalendarEvent>;
+    readonly triggeredPhenomena?: ReadonlyArray<PhenomenonOccurrence>;
+    readonly skippedEvents?: ReadonlyArray<CalendarEvent>;
+    readonly skippedPhenomena?: ReadonlyArray<PhenomenonOccurrence>;
+    readonly message?: string;
+    readonly lastAdvanceStep?: { readonly amount: number; readonly unit: "minute" | "hour" | "day" };
+    readonly reason?: "advance" | "jump" | "init";
+};
+
+type Unsubscribe = () => void;
+
+type HookListener = (payload: CartographerHookPayload) => void | Promise<void>;
+type PanelListener = (snapshot: TravelPanelSnapshot) => void | Promise<void>;
+type LifecycleListener = (travelId: string) => void | Promise<void>;
+
+function normaliseTravelKey(travelId: string | null | undefined): string {
+    return travelId ?? GLOBAL_TRAVEL_KEY;
+}
+
+function formatTimestampLabel(ts: CalendarTimestamp | null | undefined): string | undefined {
+    if (!ts) return undefined;
+    const base = `${ts.year}-${ts.monthId}-${String(ts.day).padStart(2, "0")}`;
+    if (typeof ts.hour === "number" && typeof ts.minute === "number") {
+        const hh = String(ts.hour).padStart(2, "0");
+        const mm = String(ts.minute).padStart(2, "0");
+        return `${base} ${hh}:${mm}`;
+    }
+    return base;
+}
+
+function mapEvents(
+    events: ReadonlyArray<CalendarEvent> | undefined,
+    skipped = false,
+): ReadonlyArray<TravelPanelLogEntry> {
+    if (!events || events.length === 0) {
+        return [];
+    }
+    return events.map((event) => {
+        const occurrence = getEventAnchorTimestamp(event) ?? event.date;
+        return {
+            kind: "event" as const,
+            id: event.id,
+            title: event.title,
+            occurrenceLabel: formatTimestampLabel(occurrence) ?? "—",
+            skipped,
+        } satisfies TravelPanelLogEntry;
+    });
+}
+
+function mapPhenomena(
+    phenomena: ReadonlyArray<PhenomenonOccurrence> | undefined,
+    skipped = false,
+): ReadonlyArray<TravelPanelLogEntry> {
+    if (!phenomena || phenomena.length === 0) {
+        return [];
+    }
+    return phenomena.map((occurrence) => ({
+        kind: "phenomenon" as const,
+        id: occurrence.phenomenonId,
+        title: occurrence.title ?? occurrence.phenomenonId,
+        occurrenceLabel: formatTimestampLabel(occurrence.timestamp) ?? "—",
+        skipped,
+    } satisfies TravelPanelLogEntry));
+}
+
+export class CartographerHookGateway implements HookDispatchGateway {
+    private readonly hookListeners = new Set<HookListener>();
+    private readonly panelListeners = new Map<string, Set<PanelListener>>();
+    private readonly lifecycleStart = new Set<LifecycleListener>();
+    private readonly lifecycleEnd = new Set<LifecycleListener>();
+    private readonly latestSnapshots = new Map<string, TravelPanelSnapshot>();
+
+    onHookDispatched(listener: HookListener): Unsubscribe {
+        this.hookListeners.add(listener);
+        return () => this.hookListeners.delete(listener);
+    }
+
+    onTravelStart(listener: LifecycleListener): Unsubscribe {
+        this.lifecycleStart.add(listener);
+        return () => this.lifecycleStart.delete(listener);
+    }
+
+    onTravelEnd(listener: LifecycleListener): Unsubscribe {
+        this.lifecycleEnd.add(listener);
+        return () => this.lifecycleEnd.delete(listener);
+    }
+
+    onPanelUpdate(travelId: string | null, listener: PanelListener): Unsubscribe {
+        const key = normaliseTravelKey(travelId);
+        if (!this.panelListeners.has(key)) {
+            this.panelListeners.set(key, new Set());
+        }
+        const listeners = this.panelListeners.get(key)!;
+        listeners.add(listener);
+        const snapshot = this.latestSnapshots.get(key);
+        if (snapshot) {
+            void listener(snapshot);
+        }
+        return () => {
+            const set = this.panelListeners.get(key);
+            set?.delete(listener);
+            if (set && set.size === 0) {
+                this.panelListeners.delete(key);
+            }
+        };
+    }
+
+    emitTravelStart(travelId: string): void {
+        const key = normaliseTravelKey(travelId);
+        for (const listener of this.lifecycleStart) {
+            void listener(key === GLOBAL_TRAVEL_KEY ? null : travelId);
+        }
+    }
+
+    emitTravelEnd(travelId: string): void {
+        const key = normaliseTravelKey(travelId);
+        for (const listener of this.lifecycleEnd) {
+            void listener(key === GLOBAL_TRAVEL_KEY ? null : travelId);
+        }
+    }
+
+    getPanelSnapshot(travelId: string | null): TravelPanelSnapshot | null {
+        const key = normaliseTravelKey(travelId);
+        return this.latestSnapshots.get(key) ?? null;
+    }
+
+    reset(): void {
+        this.latestSnapshots.clear();
+        this.panelListeners.clear();
+        this.hookListeners.clear();
+        this.lifecycleStart.clear();
+        this.lifecycleEnd.clear();
+    }
+
+    async dispatchHooks(
+        events: ReadonlyArray<CalendarEvent>,
+        phenomena: ReadonlyArray<PhenomenonOccurrence>,
+        context: HookDispatchContext,
+    ): Promise<void> {
+        if (this.hookListeners.size === 0) {
+            return;
+        }
+        const payload: CartographerHookPayload = {
+            scope: context.scope,
+            travelId: context.travelId ?? null,
+            reason: context.reason ?? "advance",
+            events: events.map((event) => ({
+                eventId: event.id,
+                calendarId: event.calendarId,
+                occurrence: getEventAnchorTimestamp(event) ?? event.date,
+                title: event.title,
+            } satisfies CartographerHookEvent)),
+            phenomena: phenomena.map((occurrence) => ({
+                phenomenonId: occurrence.phenomenonId,
+                occurrence: occurrence.timestamp,
+                effects: occurrence.effects,
+            } satisfies CartographerPhenomenonHook)),
+        };
+        for (const listener of this.hookListeners) {
+            await listener(payload);
+        }
+    }
+
+    async notifyTravelPanel(update: TravelPanelUpdateInput): Promise<void> {
+        const key = normaliseTravelKey(update.travelId);
+        const snapshot: TravelPanelSnapshot = {
+            travelId: key === GLOBAL_TRAVEL_KEY ? null : update.travelId ?? null,
+            timestampLabel: formatTimestampLabel(update.currentTimestamp),
+            message: update.message,
+            reason: update.reason ?? "advance",
+            lastAdvanceStep: update.lastAdvanceStep,
+            logEntries: [
+                ...mapEvents(update.triggeredEvents, false),
+                ...mapPhenomena(update.triggeredPhenomena, false),
+                ...mapEvents(update.skippedEvents, true),
+                ...mapPhenomena(update.skippedPhenomena, true),
+            ],
+        };
+        this.latestSnapshots.set(key, snapshot);
+        const listeners = this.panelListeners.get(key);
+        if (!listeners || listeners.size === 0) {
+            return;
+        }
+        for (const listener of listeners) {
+            await listener(snapshot);
+        }
+    }
+}
+
+export const cartographerHookGateway = new CartographerHookGateway();
+

--- a/src/apps/cartographer/travel/ui/sidebar.ts
+++ b/src/apps/cartographer/travel/ui/sidebar.ts
@@ -1,11 +1,13 @@
 // src/apps/cartographer/travel/ui/sidebar.ts
 // Sidebar-Layout und Steuerung für Travel-Modus.
+import type { TravelPanelSnapshot } from "../../../almanac/mode/cartographer-gateway";
 export type Sidebar = {
     root: HTMLElement;
     controlsHost: HTMLElement;
     setTitle?: (title: string) => void;
     setTile(rc: { r: number; c: number } | null): void;
     setSpeed(v: number): void;
+    setTravelPanel(panel: TravelPanelSnapshot | null): void;
     onSpeedChange(fn: (v: number) => void): void;
     destroy(): void;
 };
@@ -33,6 +35,26 @@ export function createSidebar(host: HTMLElement): Sidebar {
         attr: { step: "0.1", min: "0.1", value: "1" },
     }) as HTMLInputElement;
 
+    const timeRow = root.createDiv({ cls: "sm-cartographer__travel-row" });
+    timeRow.createSpan({ cls: "sm-cartographer__travel-label", text: "Almanac" });
+    const timeValue = timeRow.createSpan({
+        cls: "sm-cartographer__travel-value",
+        text: "—",
+    });
+
+    const quickRow = root.createDiv({ cls: "sm-cartographer__travel-row" });
+    quickRow.createSpan({ cls: "sm-cartographer__travel-label", text: "Letzter Schritt" });
+    const quickValue = quickRow.createSpan({
+        cls: "sm-cartographer__travel-value",
+        text: "—",
+    });
+
+    const logSection = root.createDiv({ cls: "sm-cartographer__travel-log" });
+    logSection.createSpan({ cls: "sm-cartographer__travel-log-title", text: "Trigger-Log" });
+    const logList = logSection.createEl("ul", {
+        cls: "sm-cartographer__travel-log-list",
+    }) as HTMLUListElement;
+
     let onChange: (v: number) => void = () => {};
     speedInput.onchange = () => {
         const v = parseFloat(speedInput.value);
@@ -48,6 +70,35 @@ export function createSidebar(host: HTMLElement): Sidebar {
         const next = String(v);
         if (speedInput.value !== next) speedInput.value = next;
     };
+    const formatQuickStep = (step: TravelPanelSnapshot["lastAdvanceStep"]): string => {
+        if (!step) return "—";
+        const sign = step.amount >= 0 ? "+" : "";
+        const label =
+            step.unit === "day"
+                ? "Tag"
+                : step.unit === "hour"
+                  ? "Std"
+                  : "Min";
+        return `${sign}${step.amount} ${label}`;
+    };
+    const setTravelPanel = (panel: TravelPanelSnapshot | null) => {
+        timeValue.textContent = panel?.timestampLabel ?? "—";
+        quickValue.textContent = formatQuickStep(panel?.lastAdvanceStep);
+        logList.empty();
+        const entries = panel?.logEntries ?? [];
+        if (entries.length === 0) {
+            logList.createEl("li", {
+                cls: "sm-cartographer__travel-log-item sm-cartographer__travel-log-item--empty",
+                text: panel?.reason === "jump" ? "Keine übersprungenen Ereignisse" : "Keine neuen Hooks",
+            });
+            return;
+        }
+        for (const entry of entries) {
+            const item = logList.createEl("li", { cls: "sm-cartographer__travel-log-item" });
+            const skipped = entry.skipped ? " • übersprungen" : "";
+            item.setText(`${entry.title} • ${entry.occurrenceLabel}${skipped}`);
+        }
+    };
     const setTitle = (title: string) => {
         if (title && title.trim().length > 0) {
             host.dataset.mapTitle = title;
@@ -62,6 +113,7 @@ export function createSidebar(host: HTMLElement): Sidebar {
         controlsHost,
         setTile,
         setSpeed,
+        setTravelPanel,
         onSpeedChange: (fn) => (onChange = fn),
         destroy: () => {
             host.empty();

--- a/tests/apps/almanac/cartographer-sync.test.ts
+++ b/tests/apps/almanac/cartographer-sync.test.ts
@@ -1,0 +1,183 @@
+// tests/apps/almanac/cartographer-sync.test.ts
+// Prüft die Synchronisation zwischen Almanac-State-Machine und dem Cartographer-Hook-Gateway.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InMemoryStateGateway } from "../../../src/apps/almanac/data/in-memory-gateway";
+import {
+    InMemoryCalendarRepository,
+    InMemoryEventRepository,
+    InMemoryPhenomenonRepository,
+} from "../../../src/apps/almanac/data/in-memory-repository";
+import { createSingleEvent } from "../../../src/apps/almanac/domain/calendar-event";
+import {
+    createDayTimestamp,
+    createHourTimestamp,
+    type CalendarTimestamp,
+} from "../../../src/apps/almanac/domain/calendar-timestamp";
+import { AlmanacStateMachine } from "../../../src/apps/almanac/mode/state-machine";
+import { CartographerHookGateway } from "../../../src/apps/almanac/mode/cartographer-gateway";
+import {
+    gregorianSchema,
+    GREGORIAN_CALENDAR_ID,
+} from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+
+describe("Cartographer sync gateway", () => {
+    let calendarRepo: InMemoryCalendarRepository;
+    let eventRepo: InMemoryEventRepository;
+    let phenomenonRepo: InMemoryPhenomenonRepository;
+    let gateway: InMemoryStateGateway;
+    let cartographerGateway: CartographerHookGateway;
+    let machine: AlmanacStateMachine;
+    const travelId = "maps/travel-bridge.hex";
+
+    const startTimestamp: CalendarTimestamp = createHourTimestamp(
+        GREGORIAN_CALENDAR_ID,
+        2024,
+        "jan",
+        1,
+        0,
+    );
+
+    beforeEach(async () => {
+        cartographerGateway = new CartographerHookGateway();
+        calendarRepo = new InMemoryCalendarRepository();
+        eventRepo = new InMemoryEventRepository();
+        eventRepo.bindCalendarRepository(calendarRepo);
+        phenomenonRepo = new InMemoryPhenomenonRepository();
+        gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo, cartographerGateway);
+
+        calendarRepo.seed([gregorianSchema]);
+        await calendarRepo.setDefault({ calendarId: gregorianSchema.id, scope: "global" });
+        eventRepo.seed([
+            createSingleEvent(
+                "evt-dawn",
+                GREGORIAN_CALENDAR_ID,
+                "Morning Patrol",
+                createHourTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 1, 6),
+            ),
+            createSingleEvent(
+                "evt-festival",
+                GREGORIAN_CALENDAR_ID,
+                "Festival Day",
+                createDayTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 2),
+            ),
+        ]);
+
+        await gateway.setActiveCalendar(gregorianSchema.id, {
+            initialTimestamp: startTimestamp,
+        });
+        await gateway.setCurrentTimestamp(startTimestamp);
+        await gateway.setActiveCalendar(gregorianSchema.id, {
+            travelId,
+            initialTimestamp: startTimestamp,
+        });
+        await gateway.setCurrentTimestamp(startTimestamp, { travelId });
+
+        machine = new AlmanacStateMachine(calendarRepo, eventRepo, gateway, phenomenonRepo, cartographerGateway);
+        await machine.dispatch({ type: "INIT_ALMANAC", travelId });
+    });
+
+    it("publishes an initial panel snapshot for travel context", () => {
+        const panel = cartographerGateway.getPanelSnapshot(travelId);
+        expect(panel).not.toBeNull();
+        expect(panel?.reason).toBe("init");
+        expect(panel?.timestampLabel).toContain("jan");
+    });
+
+    it("dispatches hooks and updates the travel panel on advance", async () => {
+        const hookListener = vi.fn();
+        cartographerGateway.onHookDispatched(hookListener);
+
+        await machine.dispatch({ type: "TIME_ADVANCE_REQUESTED", amount: 1, unit: "day" });
+
+        expect(hookListener).toHaveBeenCalledTimes(1);
+        const payload = hookListener.mock.calls[0][0];
+        expect(payload.scope).toBe("travel");
+        expect(payload.travelId).toBe(travelId);
+        expect(payload.events.map((evt) => evt.eventId)).toContain("evt-festival");
+
+        const panel = cartographerGateway.getPanelSnapshot(travelId);
+        expect(panel?.lastAdvanceStep).toEqual({ amount: 1, unit: "day" });
+        expect(panel?.logEntries.some((entry) => entry.id === "evt-festival")).toBe(true);
+    });
+
+    it("marks skipped events in jump updates", async () => {
+        const target = createDayTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 3);
+        await machine.dispatch({ type: "TIME_JUMP_REQUESTED", timestamp: target });
+
+        const panel = cartographerGateway.getPanelSnapshot(travelId);
+        expect(panel?.reason).toBe("jump");
+        const skipped = panel?.logEntries.filter((entry) => entry.skipped) ?? [];
+        expect(skipped.map((entry) => entry.id)).toContain("evt-festival");
+    });
+
+    it("propagates hook failures for travel scope", async () => {
+        const failingGateway = new CartographerHookGateway();
+        failingGateway.onHookDispatched(() => {
+            throw new Error("cartographer offline");
+        });
+
+        const altCalendarRepo = new InMemoryCalendarRepository();
+        const altEventRepo = new InMemoryEventRepository();
+        altEventRepo.bindCalendarRepository(altCalendarRepo);
+        const altPhenomenonRepo = new InMemoryPhenomenonRepository();
+        const altGateway = new InMemoryStateGateway(
+            altCalendarRepo,
+            altEventRepo,
+            altPhenomenonRepo,
+            failingGateway,
+        );
+
+        altCalendarRepo.seed([gregorianSchema]);
+        await altCalendarRepo.setDefault({ calendarId: gregorianSchema.id, scope: "global" });
+        altEventRepo.seed([
+            createSingleEvent(
+                "evt-midnight",
+                GREGORIAN_CALENDAR_ID,
+                "Night Watch",
+                createDayTimestamp(GREGORIAN_CALENDAR_ID, 2024, "jan", 2),
+            ),
+        ]);
+
+        await altGateway.setActiveCalendar(gregorianSchema.id, { initialTimestamp: startTimestamp });
+        await altGateway.setCurrentTimestamp(startTimestamp);
+        await altGateway.setActiveCalendar(gregorianSchema.id, {
+            travelId: "maps/failure.hex",
+            initialTimestamp: startTimestamp,
+        });
+        await altGateway.setCurrentTimestamp(startTimestamp, { travelId: "maps/failure.hex" });
+
+        const altMachine = new AlmanacStateMachine(
+            altCalendarRepo,
+            altEventRepo,
+            altGateway,
+            altPhenomenonRepo,
+            failingGateway,
+        );
+        await altMachine.dispatch({ type: "INIT_ALMANAC", travelId: "maps/failure.hex" });
+
+        await altMachine.dispatch({ type: "TIME_ADVANCE_REQUESTED", amount: 1, unit: "day" });
+        expect(altMachine.getState().almanacUiState.error).toMatch(/cartographer offline/);
+    });
+
+    it("emits travel lifecycle events", () => {
+        const starts: string[] = [];
+        const ends: string[] = [];
+        const unsubStart = cartographerGateway.onTravelStart((id) => {
+            if (id) starts.push(id);
+        });
+        const unsubEnd = cartographerGateway.onTravelEnd((id) => {
+            if (id) ends.push(id);
+        });
+
+        cartographerGateway.emitTravelStart("maps/lifecycle.hex");
+        cartographerGateway.emitTravelEnd("maps/lifecycle.hex");
+
+        unsubStart();
+        unsubEnd();
+
+        expect(starts).toEqual(["maps/lifecycle.hex"]);
+        expect(ends).toEqual(["maps/lifecycle.hex"]);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add a Cartographer hook gateway to bridge Almanac events and travel panel updates
- wire the Almanac state machine and Cartographer travel mode to publish lifecycle and time-change hooks
- expose minimal travel sidebar indicators and provide integration tests that cover travel sync scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4dfe1405c83258b58281be096504e