### PR TITLE
Fix astronomical reference calendar validation in almanac repositories

### DIFF
--- a/src/apps/almanac/data/in-memory-repository.ts
+++ b/src/apps/almanac/data/in-memory-repository.ts
@@ -358,7 +358,7 @@ export class InMemoryPhenomenonRepository implements AlmanacRepository, Phenomen
       throw new AlmanacRepositoryError("phenomenon_conflict", "Duplicate calendar links", { duplicates });
     }
     if (existing.rule.type === "astronomical") {
-      const hasReference = Boolean(existing.rule.astronomical?.referenceCalendarId);
+      const hasReference = Boolean(existing.rule.referenceCalendarId);
       const hasHookReference = update.calendarLinks.some(link =>
         typeof link.hook?.config?.referenceCalendarId === "string",
       );

--- a/src/apps/almanac/data/vault-almanac-repository.ts
+++ b/src/apps/almanac/data/vault-almanac-repository.ts
@@ -129,7 +129,7 @@ export class VaultAlmanacRepository implements AlmanacRepository {
     }
 
     if (phenomenon.rule.type === "astronomical") {
-      const hasReference = Boolean(phenomenon.rule.astronomical?.referenceCalendarId);
+      const hasReference = Boolean(phenomenon.rule.referenceCalendarId);
       const hasHookReference = update.calendarLinks.some(link =>
         link.hook && typeof link.hook.config?.referenceCalendarId === "string",
       );

--- a/tests/apps/almanac/almanac-repository.test.ts
+++ b/tests/apps/almanac/almanac-repository.test.ts
@@ -185,4 +185,32 @@ describe("VaultAlmanacRepository", () => {
             }),
         ).rejects.toMatchObject({ code: "astronomy_source_missing" });
     });
+
+    it("accepts astronomical phenomena with a configured reference calendar", async () => {
+        await repository.upsertPhenomenon({
+            id: "phen-astronomical-ref",
+            name: "Solar Alignment",
+            category: "astronomy",
+            visibility: "selected",
+            appliesToCalendarIds: [gregorianSchema.id],
+            rule: {
+                type: "astronomical",
+                source: "sunrise",
+                referenceCalendarId: gregorianSchema.id,
+            } as any,
+            timePolicy: "all_day",
+            priority: 2,
+            schemaVersion: "1.0.0",
+        });
+
+        const updated = await repository.updateLinks({
+            phenomenonId: "phen-astronomical-ref",
+            calendarLinks: [
+                { calendarId: gregorianSchema.id, priority: 5 },
+            ],
+        });
+
+        expect(updated.appliesToCalendarIds).toEqual([gregorianSchema.id]);
+        expect(updated.priority).toBe(5);
+    });
 });


### PR DESCRIPTION
## Summary
- align astronomical reference calendar validation in the in-memory and vault repositories to use the top-level repeat rule field
- add repository test coverage for astronomical phenomena that include a reference calendar id

## Testing
- npx vitest run tests/apps/almanac/almanac-repository.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5572a3a548325a2f9f99e4c6e7636