### PR TITLE
Add Almanac event editor dialogs with import and bulk flows

### DIFF
--- a/src/apps/almanac/data/phenomena-serialization.ts
+++ b/src/apps/almanac/data/phenomena-serialization.ts
@@ -1,0 +1,138 @@
+// src/apps/almanac/data/phenomena-serialization.ts
+// Helpers for serialising and parsing Almanac phenomena import/export payloads.
+
+import type { PhenomenonDTO } from "./dto";
+
+type MinimalPhenomenon = Pick<
+  PhenomenonDTO,
+  | "id"
+  | "name"
+  | "category"
+  | "visibility"
+  | "appliesToCalendarIds"
+  | "rule"
+  | "timePolicy"
+  | "priority"
+  | "schemaVersion"
+> &
+  Partial<Pick<PhenomenonDTO, "notes" | "tags" | "effects" | "hooks" | "startTime" | "offsetMinutes" | "durationMinutes">>;
+
+function assertString(value: unknown, path: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${path} must be a string`);
+  }
+  return value;
+}
+
+function assertArray(value: unknown, path: string): ReadonlyArray<unknown> {
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array`);
+  }
+  return value;
+}
+
+function normalisePhenomenon(input: unknown, index: number): PhenomenonDTO {
+  if (typeof input !== "object" || input === null) {
+    throw new Error(`Entry ${index + 1} must be an object`);
+  }
+  const record = input as Record<string, unknown>;
+  const id = assertString(record.id, `phenomena[${index}].id`).trim();
+  const name = assertString(record.name, `phenomena[${index}].name`).trim();
+  const category = assertString(record.category ?? "custom", `phenomena[${index}].category`).trim();
+  const visibility = assertString(
+    record.visibility ?? "all_calendars",
+    `phenomena[${index}].visibility`,
+  ) as PhenomenonDTO["visibility"];
+  const appliesTo = assertArray(
+    record.appliesToCalendarIds ?? [],
+    `phenomena[${index}].appliesToCalendarIds`,
+  ).map(value => assertString(value, `phenomena[${index}].appliesToCalendarIds[]`));
+
+  const rule = (record.rule ?? { type: "annual", offsetDayOfYear: 0 }) as PhenomenonDTO["rule"];
+  const timePolicy = (record.timePolicy ?? "all_day") as PhenomenonDTO["timePolicy"];
+  const priority = typeof record.priority === "number" ? record.priority : 0;
+  const schemaVersion = assertString(
+    record.schemaVersion ?? "1.0.0",
+    `phenomena[${index}].schemaVersion`,
+  );
+
+  const base: MinimalPhenomenon = {
+    id,
+    name,
+    category: category || "custom",
+    visibility: visibility === "selected" ? "selected" : "all_calendars",
+    appliesToCalendarIds: appliesTo,
+    rule,
+    timePolicy,
+    priority,
+    schemaVersion,
+  };
+
+  const optionalKeys: Array<keyof PhenomenonDTO> = [
+    "notes",
+    "tags",
+    "effects",
+    "hooks",
+    "startTime",
+    "offsetMinutes",
+    "durationMinutes",
+  ];
+
+  for (const key of optionalKeys) {
+    if (record[key] !== undefined) {
+      (base as Record<string, unknown>)[key] = record[key];
+    }
+  }
+
+  return base as PhenomenonDTO;
+}
+
+/**
+ * Parses a JSON payload describing phenomena and returns DTOs for repository import.
+ */
+export function parsePhenomenaImport(source: string): ReadonlyArray<PhenomenonDTO> {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Import payload is not valid JSON: ${message}`);
+  }
+
+  if (!Array.isArray(data)) {
+    throw new Error("Import payload must be a JSON array");
+  }
+
+  return data.map((entry, index) => normalisePhenomenon(entry, index));
+}
+
+/**
+ * Formats the provided phenomena as a prettified JSON string for export.
+ */
+export function formatPhenomenaExport(entries: ReadonlyArray<PhenomenonDTO>): string {
+  const payload = entries.map(entry => ({
+    id: entry.id,
+    name: entry.name,
+    category: entry.category,
+    visibility: entry.visibility,
+    appliesToCalendarIds: entry.appliesToCalendarIds,
+    rule: entry.rule,
+    timePolicy: entry.timePolicy,
+    priority: entry.priority,
+    schemaVersion: entry.schemaVersion,
+    notes: entry.notes,
+    tags: entry.tags,
+    effects: entry.effects,
+    hooks: entry.hooks,
+    startTime: entry.startTime,
+    offsetMinutes: entry.offsetMinutes,
+    durationMinutes: entry.durationMinutes,
+  }));
+
+  return JSON.stringify(payload, null, 2);
+}

--- a/src/apps/almanac/mode/contracts.ts
+++ b/src/apps/almanac/mode/contracts.ts
@@ -116,11 +116,29 @@ export interface EventsUiStateSlice {
     readonly selectedPhenomenonId?: string | null;
     readonly selectedPhenomenonDetail?: PhenomenonDetailView | null;
     readonly isDetailLoading: boolean;
+    readonly isEditorOpen: boolean;
+    readonly editorDraft: PhenomenonEditorDraft | null;
+    readonly isSaving: boolean;
+    readonly editorError?: string;
+    readonly bulkSelection: ReadonlyArray<string>;
+    readonly lastExportPayload?: string;
+    readonly isImportDialogOpen: boolean;
+    readonly importError?: string;
+    readonly importSummary?: ImportSummary | null;
 }
 
 export interface EventsFilterState {
     readonly categories: ReadonlyArray<string>;
     readonly calendarIds: ReadonlyArray<string>;
+}
+
+export interface PhenomenonEditorDraft {
+    readonly id: string;
+    readonly name: string;
+    readonly category: string;
+    readonly visibility: "all_calendars" | "selected";
+    readonly appliesToCalendarIds: ReadonlyArray<string>;
+    readonly notes?: string;
 }
 
 export interface PhenomenonDetailView {
@@ -147,6 +165,11 @@ export interface TravelLeafStateSlice {
 
 export interface TelemetryStateSlice {
     readonly lastEvents: ReadonlyArray<string>;
+}
+
+export interface ImportSummary {
+    readonly imported: number;
+    readonly failed: number;
 }
 
 export interface AlmanacState {
@@ -182,6 +205,19 @@ export type AlmanacEvent =
     | { readonly type: "EVENTS_FILTER_CHANGED"; readonly filters: EventsFilterState }
     | { readonly type: "EVENTS_PHENOMENON_SELECTED"; readonly phenomenonId: string }
     | { readonly type: "EVENTS_PHENOMENON_DETAIL_CLOSED" }
+    | { readonly type: "EVENTS_BULK_SELECTION_UPDATED"; readonly selection: ReadonlyArray<string> }
+    | { readonly type: "PHENOMENON_EDIT_REQUESTED"; readonly phenomenonId?: string | null }
+    | { readonly type: "PHENOMENON_EDIT_CANCELLED" }
+    | { readonly type: "PHENOMENON_SAVE_REQUESTED"; readonly draft: PhenomenonEditorDraft }
+    | {
+          readonly type: "EVENT_BULK_ACTION_REQUESTED";
+          readonly action: "delete" | "export";
+          readonly ids?: ReadonlyArray<string>;
+      }
+    | { readonly type: "EVENT_EXPORT_CLEARED" }
+    | { readonly type: "EVENT_IMPORT_REQUESTED" }
+    | { readonly type: "EVENT_IMPORT_CANCELLED" }
+    | { readonly type: "EVENT_IMPORT_SUBMITTED"; readonly payload: string }
     | { readonly type: "MANAGER_SELECTION_CHANGED"; readonly selection: ReadonlyArray<string> }
     | { readonly type: "CALENDAR_SELECT_REQUESTED"; readonly calendarId: string }
     | { readonly type: "CALENDAR_DEFAULT_SET_REQUESTED"; readonly calendarId: string }
@@ -263,6 +299,15 @@ export function createInitialAlmanacState(): AlmanacState {
             selectedPhenomenonId: null,
             selectedPhenomenonDetail: null,
             isDetailLoading: false,
+            isEditorOpen: false,
+            editorDraft: null,
+            isSaving: false,
+            editorError: undefined,
+            bulkSelection: [],
+            lastExportPayload: undefined,
+            isImportDialogOpen: false,
+            importError: undefined,
+            importSummary: null,
         },
         travelLeafState: {
             visible: false,


### PR DESCRIPTION
## Summary
- extend the Almanac mode contracts and state machine with edit, bulk, and import/export events
- add phenomenon editor and import modal controllers plus serialization helpers for import/export payloads
- expand unit and DOM coverage for the new editor interactions and bulk workflows

## Testing
- npm test -- --run tests/apps/almanac/state-machine.events.test.ts tests/apps/almanac/almanac-controller.dom.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e57d399214832591475ab7d968d560