### PR TITLE
Add Almanac telemetry instrumentation

### DIFF
--- a/src/apps/almanac/IMPLEMENTATION_PLAN.md
+++ b/src/apps/almanac/IMPLEMENTATION_PLAN.md
@@ -228,6 +228,7 @@ Persistence (JsonStore / Obsidian vault)
 - Performance: Vorschau zukünftiger Vorkommen berechnet maximal 24 Monate bzw. 2.000 Stunden im Voraus (konfigurierbar) und cached Ergebnisse pro Schema/Rule-Hash; Travel-Leaf lädt initial 30 Tage/72 Stunden, weitere Einträge lazy bei Scroll.
 ## Telemetrie & Observability
 - Loggingpunkte: Zeitfortschritt (`calendar.time.advance`), Schema-Migration (`calendar.schema.migrate`), Event-/Phänomen-Konflikte (`calendar.event.conflict`), Default-Umschaltung (`calendar.default.change`), Travel-Leaf Lifecycle (`calendar.travel.leaf_mount`), Almanac-Moduswechsel (`calendar.almanac.mode_change`).
+- `apps/almanac/telemetry.ts` bündelt `emitAlmanacEvent` und `reportAlmanacGatewayIssue` und fungiert als zentrale Schnittstelle für Mode, Gateways und Repositories.
 - Metriken: Anzahl ausgelöster Events/Phänomene pro Advance (Tag/Stunde/Minute), Dauer der Ereignisberechnung je Zoom-Level, Dauer von astronomischen/meteorologischen Simulationen, Fehlerquote pro Operation, Anzahl Default-/Modus-Wechsel pro Sitzung, Anteil teil-täglicher Schritte (`advance.subday_share`), Cache-Trefferquote im Events-Modus.
 - Fehlertracking: persistente io-Fehler werden mit Kontext (`calendarId`, `operation`, `scope` = global/reise) erfasst; Hook-Dispatches melden Erfolg/Fehlschlag an Cartographer (siehe [`mode/API_CONTRACTS.md#cartographer-hooks`](./mode/API_CONTRACTS.md#cartographer-hooks)). Travel-Leaf meldet Renderdauer und Shortcut-Nutzung; Events-Modus sendet Telemetrie zu Filterkombinationen & Ladezeiten.
 ## Dokumentverweise & Testplanung

--- a/src/apps/almanac/data/calendar-state-gateway.ts
+++ b/src/apps/almanac/data/calendar-state-gateway.ts
@@ -11,6 +11,38 @@ import type {
   TravelCalendarMode,
 } from "../mode/contracts";
 
+export type CalendarGatewayErrorCode = "validation_error" | "io_error";
+
+export class CalendarGatewayError extends Error {
+  readonly code: CalendarGatewayErrorCode;
+  readonly context?: Record<string, unknown>;
+
+  constructor(code: CalendarGatewayErrorCode, message: string, context?: Record<string, unknown>) {
+    super(message);
+    this.name = "CalendarGatewayError";
+    this.code = code;
+    this.context = context;
+  }
+}
+
+export function createGatewayValidationError(
+  message: string,
+  context?: Record<string, unknown>,
+): CalendarGatewayError {
+  return new CalendarGatewayError("validation_error", message, context);
+}
+
+export function createGatewayIoError(
+  message: string,
+  context?: Record<string, unknown>,
+): CalendarGatewayError {
+  return new CalendarGatewayError("io_error", message, context);
+}
+
+export function isCalendarGatewayError(error: unknown): error is CalendarGatewayError {
+  return error instanceof CalendarGatewayError;
+}
+
 export interface CalendarStateSnapshot {
   readonly activeCalendar: CalendarSchema | null;
   readonly currentTimestamp: CalendarTimestamp | null;

--- a/src/apps/almanac/mode/contracts.ts
+++ b/src/apps/almanac/mode/contracts.ts
@@ -167,10 +167,6 @@ export interface TravelLeafStateSlice {
     readonly error?: string;
 }
 
-export interface TelemetryStateSlice {
-    readonly lastEvents: ReadonlyArray<string>;
-}
-
 export interface ImportSummary {
     readonly imported: number;
     readonly failed: number;
@@ -182,7 +178,6 @@ export interface AlmanacState {
     readonly managerUiState: ManagerUiStateSlice;
     readonly eventsUiState: EventsUiStateSlice;
     readonly travelLeafState: TravelLeafStateSlice;
-    readonly telemetryState: TelemetryStateSlice;
 }
 
 export type AlmanacStateListener = (state: AlmanacState) => void;
@@ -325,9 +320,6 @@ export function createInitialAlmanacState(): AlmanacState {
             lastQuickStep: undefined,
             isLoading: false,
             error: undefined,
-        },
-        telemetryState: {
-            lastEvents: [],
         },
     };
 }

--- a/src/apps/almanac/telemetry.ts
+++ b/src/apps/almanac/telemetry.ts
@@ -1,0 +1,113 @@
+// src/apps/almanac/telemetry.ts
+// Central telemetry helpers for Almanac events and data layer diagnostics.
+
+import { reportIntegrationIssue } from "../../app/integration-telemetry";
+import type { AlmanacMode, TravelCalendarMode } from "./mode/contracts";
+import type { CalendarTimestamp } from "./domain/calendar-timestamp";
+
+/** Stable integration identifier used for Almanac notices. */
+export const ALMANAC_INTEGRATION_ID = "obsidian:almanac-view" as const;
+
+export type AlmanacTelemetryEvent =
+  | {
+      readonly type: "calendar.time.advance";
+      readonly scope: "global" | "travel";
+      readonly reason: "advance" | "jump";
+      readonly unit: "day" | "hour" | "minute";
+      readonly amount: number;
+      readonly triggeredEvents: number;
+      readonly triggeredPhenomena: number;
+      readonly skippedEvents: number;
+      readonly travelId?: string | null;
+      readonly timestamp: CalendarTimestamp | null;
+    }
+  | {
+      readonly type: "calendar.default.change";
+      readonly scope: "global" | "travel";
+      readonly calendarId: string;
+      readonly previousDefaultId: string | null;
+      readonly travelId?: string | null;
+      readonly wasAutoSelected?: boolean;
+    }
+  | {
+      readonly type: "calendar.almanac.mode_change";
+      readonly mode: AlmanacMode;
+      readonly previousMode: AlmanacMode;
+      readonly history: ReadonlyArray<AlmanacMode>;
+    }
+  | {
+      readonly type: "calendar.travel.lifecycle";
+      readonly phase: "mount" | "mode-change" | "visibility";
+      readonly travelId: string | null;
+      readonly visible: boolean;
+      readonly mode: TravelCalendarMode;
+      readonly timestamp: CalendarTimestamp | null;
+    }
+  | {
+      readonly type: "calendar.event.conflict";
+      readonly code: "default" | "phenomenon" | "event";
+      readonly message: string;
+      readonly context?: Record<string, unknown>;
+    };
+
+type AlmanacTelemetryReporter = (event: AlmanacTelemetryEvent) => void;
+
+const defaultReporter: AlmanacTelemetryReporter = event => {
+  const { type, ...payload } = event;
+  // eslint-disable-next-line no-console -- Observability hook for development builds.
+  console.info("[almanac:telemetry]", type, payload);
+};
+
+let reporter: AlmanacTelemetryReporter = defaultReporter;
+
+/** Emits a structured telemetry event for Almanac state changes. */
+export function emitAlmanacEvent(event: AlmanacTelemetryEvent): void {
+  reporter(event);
+}
+
+/** Overrides the telemetry reporter (mainly used in tests). */
+export function setAlmanacTelemetryReporter(next: AlmanacTelemetryReporter | null): void {
+  reporter = next ?? defaultReporter;
+}
+
+/** Resets the telemetry reporter to the default console logger. */
+export function resetAlmanacTelemetryReporter(): void {
+  reporter = defaultReporter;
+}
+
+export type AlmanacGatewayIssueCode = "io_error" | "validation_error" | "conflict" | "phenomenon_conflict";
+
+export interface AlmanacGatewayIssuePayload {
+  readonly operation: string;
+  readonly scope: "calendar" | "event" | "phenomenon" | "default" | "travel";
+  readonly code: AlmanacGatewayIssueCode;
+  readonly error: unknown;
+  readonly context?: Record<string, unknown>;
+  readonly userMessage?: string;
+}
+
+const DEFAULT_USER_MESSAGES: Record<AlmanacGatewayIssueCode, string> = {
+  io_error: "The Almanac data store is currently unavailable. Please check the developer console for details.",
+  validation_error: "The Almanac input could not be validated. Please review the provided data and try again.",
+  conflict: "The Almanac detected a conflicting calendar configuration.",
+  phenomenon_conflict: "The phenomenon cannot be linked because it conflicts with existing calendar rules.",
+};
+
+/** Logs gateway/repository failures and forwards io errors to the integration telemetry. */
+export function reportAlmanacGatewayIssue(payload: AlmanacGatewayIssuePayload): void {
+  const { operation, scope, code, error } = payload;
+  const userMessage = payload.userMessage ?? DEFAULT_USER_MESSAGES[code];
+  const logContext = { scope, code, ...(payload.context ?? {}) };
+
+  // eslint-disable-next-line no-console -- Observability hook for runtime diagnostics.
+  console.error(`[almanac] ${operation} failed`, logContext, error);
+
+  if (code === "io_error") {
+    reportIntegrationIssue({
+      integrationId: ALMANAC_INTEGRATION_ID,
+      operation: "prime-dataset",
+      error,
+      userMessage,
+    });
+  }
+}

--- a/tests/apps/almanac/state-machine.telemetry.test.ts
+++ b/tests/apps/almanac/state-machine.telemetry.test.ts
@@ -1,0 +1,133 @@
+// tests/apps/almanac/state-machine.telemetry.test.ts
+// Validates that the Almanac state machine emits telemetry for advances, jumps and failures.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/apps/almanac/telemetry", () => {
+    const emitAlmanacEvent = vi.fn();
+    const reportAlmanacGatewayIssue = vi.fn();
+    return {
+        emitAlmanacEvent,
+        reportAlmanacGatewayIssue,
+    };
+});
+
+import { emitAlmanacEvent, reportAlmanacGatewayIssue } from "../../../src/apps/almanac/telemetry";
+import { InMemoryStateGateway } from "../../../src/apps/almanac/data/in-memory-gateway";
+import {
+    InMemoryCalendarRepository,
+    InMemoryEventRepository,
+    InMemoryPhenomenonRepository,
+} from "../../../src/apps/almanac/data/in-memory-repository";
+import { AlmanacStateMachine } from "../../../src/apps/almanac/mode/state-machine";
+import { gregorianSchema, getDefaultCurrentTimestamp } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+import { createSampleEvents } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
+import { CalendarGatewayError } from "../../../src/apps/almanac/data/calendar-state-gateway";
+import { AlmanacRepositoryError } from "../../../src/apps/almanac/data/almanac-repository";
+import { createDayTimestamp } from "../../../src/apps/almanac/domain/calendar-timestamp";
+
+class ConflictPhenomenonRepository extends InMemoryPhenomenonRepository {
+    override async upsertPhenomenon(): Promise<never> {
+        throw new AlmanacRepositoryError("phenomenon_conflict", "Duplicate calendar links", {
+            duplicates: ["cal-1"],
+        });
+    }
+}
+
+describe("AlmanacStateMachine telemetry", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    async function createMachine(options?: { conflictingPhenomena?: boolean }) {
+        const calendarRepo = new InMemoryCalendarRepository();
+        const eventRepo = new InMemoryEventRepository();
+        eventRepo.bindCalendarRepository(calendarRepo);
+        const phenomenonRepo = options?.conflictingPhenomena
+            ? new ConflictPhenomenonRepository()
+            : new InMemoryPhenomenonRepository();
+        const gateway = new InMemoryStateGateway(calendarRepo, eventRepo, phenomenonRepo);
+
+        calendarRepo.seed([gregorianSchema]);
+        eventRepo.seed(createSampleEvents(2024));
+
+        await gateway.setActiveCalendar(
+            gregorianSchema.id,
+            { initialTimestamp: getDefaultCurrentTimestamp(2024) },
+        );
+        await gateway.setCurrentTimestamp(getDefaultCurrentTimestamp(2024));
+
+        const machine = new AlmanacStateMachine(calendarRepo, eventRepo, gateway, phenomenonRepo);
+        await machine.dispatch({ type: "INIT_ALMANAC" });
+        return { machine, gateway } as const;
+    }
+
+    it("emits telemetry when advancing time", async () => {
+        const { machine } = await createMachine();
+
+        await machine.dispatch({ type: "TIME_ADVANCE_REQUESTED", amount: 1, unit: "day" });
+
+        expect(emitAlmanacEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "calendar.time.advance",
+                reason: "advance",
+            }),
+        );
+    });
+
+    it("emits telemetry when jumping to a timestamp", async () => {
+        const { machine } = await createMachine();
+        const target = createDayTimestamp(gregorianSchema.id, 2024, "jan", 5);
+
+        await machine.dispatch({ type: "TIME_JUMP_REQUESTED", timestamp: target });
+
+        expect(emitAlmanacEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "calendar.time.advance",
+                reason: "jump",
+                skippedEvents: expect.any(Number),
+            }),
+        );
+    });
+
+    it("reports telemetry when gateway operations fail", async () => {
+        const { machine, gateway } = await createMachine();
+        vi.spyOn(gateway, "advanceTimeBy").mockRejectedValueOnce(
+            new CalendarGatewayError("io_error", "advance failed"),
+        );
+
+        await machine.dispatch({ type: "TIME_ADVANCE_REQUESTED", amount: 1, unit: "day" });
+
+        expect(reportAlmanacGatewayIssue).toHaveBeenCalledWith(
+            expect.objectContaining({
+                operation: "stateMachine.timeAdvance",
+                code: "io_error",
+            }),
+        );
+
+        expect(machine.getState().almanacUiState.error).toBe("advance failed");
+    });
+
+    it("emits conflict telemetry for phenomenon errors", async () => {
+        const { machine } = await createMachine({ conflictingPhenomena: true });
+
+        await machine.dispatch({
+            type: "PHENOMENON_SAVE_REQUESTED",
+            draft: {
+                id: "phen-1",
+                name: "Storm",
+                category: "weather",
+                visibility: "all_calendars",
+                appliesToCalendarIds: [],
+                notes: "",
+            },
+        });
+
+        expect(emitAlmanacEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "calendar.event.conflict",
+                code: "phenomenon",
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Almanac telemetry module with emit/report helpers and document the new events
- route state machine notifications through the telemetry API and expand gateway/repository error reporting
- cover telemetry behaviour with a new Vitest suite for advances, jumps, and failure paths

## Testing
- npm test -- tests/apps/almanac/cartographer-sync.test.ts
- npm test -- tests/apps/almanac/state-machine.telemetry.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e588113fd08325825d45ea50df0ff1