### PR TITLE
Add map rendering for Almanac events

### DIFF
--- a/src/apps/almanac/mode/almanac-controller.ts
+++ b/src/apps/almanac/mode/almanac-controller.ts
@@ -42,6 +42,7 @@ import {
     getDefaultCurrentTimestamp,
 } from '../fixtures/gregorian.fixture';
 import { createSamplePhenomena } from '../fixtures/phenomena.fixture';
+import { renderEventsMap as renderEventsMapComponent } from './events';
 
 const MODE_COPY: Record<AlmanacMode, { label: string; description: string }> = {
     dashboard: { label: 'Dashboard', description: 'Current date, quick actions and upcoming events' },
@@ -1422,7 +1423,7 @@ export class AlmanacController {
                 this.renderEventsTable(contentSection, state);
                 break;
             case 'map':
-                this.renderEventsMapPlaceholder(contentSection);
+                this.renderEventsMap(contentSection, state);
                 break;
         }
 
@@ -1584,10 +1585,14 @@ export class AlmanacController {
         });
     }
 
-    private renderEventsMapPlaceholder(section: HTMLElement): void {
-        section.createEl('p', {
-            text: 'Map view will plot phenomena across campaign regions (not yet implemented).',
-            cls: 'almanac-empty',
+    private renderEventsMap(section: HTMLElement, state: AlmanacState): void {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('almanac-events__map');
+        wrapper.dataset.role = 'events-map-container';
+        section.appendChild(wrapper);
+
+        renderEventsMapComponent(wrapper, {
+            markers: state.eventsUiState.mapMarkers,
         });
     }
 

--- a/src/apps/almanac/mode/contracts.ts
+++ b/src/apps/almanac/mode/contracts.ts
@@ -106,6 +106,7 @@ export interface EventsUiStateSlice {
     readonly filters: EventsFilterState;
     readonly availableCategories: ReadonlyArray<string>;
     readonly availableCalendars: ReadonlyArray<{ readonly id: string; readonly name: string }>;
+    readonly mapMarkers: ReadonlyArray<EventsMapMarker>;
     readonly phenomena: ReadonlyArray<{
         readonly id: string;
         readonly title: string;
@@ -130,6 +131,15 @@ export interface EventsUiStateSlice {
 export interface EventsFilterState {
     readonly categories: ReadonlyArray<string>;
     readonly calendarIds: ReadonlyArray<string>;
+}
+
+export interface EventsMapMarker {
+    readonly id: string;
+    readonly title: string;
+    readonly category?: string;
+    readonly nextOccurrence?: string;
+    readonly coordinates: { readonly x: number; readonly y: number };
+    readonly calendars: ReadonlyArray<{ readonly id: string; readonly name: string }>;
 }
 
 export interface PhenomenonEditorDraft {
@@ -297,6 +307,7 @@ export function createInitialAlmanacState(): AlmanacState {
             filters: { categories: [], calendarIds: [] },
             availableCategories: [],
             availableCalendars: [],
+            mapMarkers: [],
             phenomena: [],
             selectedPhenomenonId: null,
             selectedPhenomenonDetail: null,

--- a/src/apps/almanac/mode/events/AGENTS.md
+++ b/src/apps/almanac/mode/events/AGENTS.md
@@ -1,0 +1,15 @@
+# Ziele
+- Implementiert DOM-Komponenten für die Ereignisansicht der Kartenansicht.
+- Dokumentiert Rendering-Verträge für Marker, Cluster und weitere Visualisierungen.
+
+# Aktueller Stand
+- Noch keine Komponenten vorhanden; State-Machine liefert bereits gefilterte Phänomen-Daten.
+- Tests werden in `tests/apps/almanac` gepflegt und spiegeln Interaktionen des Controllers wider.
+
+# ToDo
+- [P1] Ergänze Styling-Hooks, sobald ein dediziertes Stylesheet für die Kartenansicht entsteht.
+
+# Standards
+- Jede Datei beginnt mit einem einleitenden Kommentar (`// <relativer Pfad>` + Zweck).
+- Komponenten exponieren reine Funktionen, die DOM-Nodes in einen bereitgestellten Host rendern.
+- Exportiere Komponenten gebündelt über `index.ts` dieses Ordners.

--- a/src/apps/almanac/mode/events/events-map.ts
+++ b/src/apps/almanac/mode/events/events-map.ts
@@ -1,0 +1,150 @@
+// src/apps/almanac/mode/events/events-map.ts
+// Renders an interactive board that plots phenomena as markers on a schematic map.
+
+import type { EventsMapMarker } from "../contracts";
+
+export interface EventsMapProps {
+    readonly markers: ReadonlyArray<EventsMapMarker>;
+}
+
+export function renderEventsMap(host: HTMLElement, props: EventsMapProps): HTMLElement {
+    const container = document.createElement("div");
+    container.classList.add("almanac-events-map");
+    container.dataset.component = "events-map";
+    host.appendChild(container);
+
+    const summary = document.createElement("div");
+    summary.classList.add("almanac-events-map__summary");
+    summary.dataset.role = "map-summary";
+    const categorySet = new Set<string>();
+    const calendarSet = new Set<string>();
+    for (const marker of props.markers) {
+        if (marker.category) {
+            categorySet.add(marker.category);
+        }
+        for (const calendar of marker.calendars) {
+            calendarSet.add(calendar.name);
+        }
+    }
+    const summaryParts: string[] = [];
+    summaryParts.push(`${props.markers.length} phenomena plotted`);
+    if (categorySet.size > 0) {
+        summaryParts.push(`${categorySet.size} categories`);
+    }
+    if (calendarSet.size > 0) {
+        summaryParts.push(`${calendarSet.size} calendars`);
+    }
+    summary.textContent = summaryParts.join(" • ");
+    container.appendChild(summary);
+
+    const board = document.createElement("div");
+    board.classList.add("almanac-events-map__board");
+    board.dataset.role = "map-board";
+    board.style.position = "relative";
+    board.style.minHeight = "240px";
+    board.style.border = "1px solid var(--background-modifier-border, #3a3a3a)";
+    board.style.borderRadius = "12px";
+    board.style.background = "var(--background-secondary, rgba(255,255,255,0.02))";
+    board.style.overflow = "hidden";
+    board.style.isolation = "isolate";
+    container.appendChild(board);
+
+    props.markers.forEach(marker => {
+        const markerButton = document.createElement("button");
+        markerButton.type = "button";
+        markerButton.classList.add("almanac-events-map__marker");
+        markerButton.dataset.role = "map-marker";
+        markerButton.dataset.phenomenonId = marker.id;
+        markerButton.style.position = "absolute";
+        markerButton.style.width = "20px";
+        markerButton.style.height = "20px";
+        markerButton.style.borderRadius = "50%";
+        markerButton.style.border = "2px solid var(--interactive-accent, #9c6bff)";
+        markerButton.style.background = "var(--background-primary, #1a1a1a)";
+        markerButton.style.transform = "translate(-50%, -50%)";
+        markerButton.style.left = `${(marker.coordinates.x * 100).toFixed(2)}%`;
+        markerButton.style.top = `${(marker.coordinates.y * 100).toFixed(2)}%`;
+        markerButton.setAttribute("aria-label", buildMarkerLabel(marker));
+        markerButton.title = buildMarkerLabel(marker);
+
+        const markerLabel = document.createElement("span");
+        markerLabel.classList.add("almanac-events-map__marker-label");
+        markerLabel.textContent = marker.title;
+        markerLabel.style.position = "absolute";
+        markerLabel.style.top = "100%";
+        markerLabel.style.left = "50%";
+        markerLabel.style.transform = "translate(-50%, 4px)";
+        markerLabel.style.whiteSpace = "nowrap";
+        markerLabel.style.fontSize = "10px";
+        markerLabel.style.pointerEvents = "none";
+        markerButton.appendChild(markerLabel);
+
+        board.appendChild(markerButton);
+    });
+
+    const legendHeading = document.createElement("h3");
+    legendHeading.classList.add("almanac-events-map__legend-heading");
+    legendHeading.textContent = "Map Markers";
+    container.appendChild(legendHeading);
+
+    const legendList = document.createElement("ul");
+    legendList.classList.add("almanac-events-map__legend");
+    legendList.dataset.role = "map-legend";
+    container.appendChild(legendList);
+
+    props.markers.forEach(marker => {
+        const item = document.createElement("li");
+        item.classList.add("almanac-events-map__legend-item");
+        item.dataset.role = "map-legend-item";
+        item.dataset.phenomenonId = marker.id;
+
+        const title = document.createElement("strong");
+        title.textContent = marker.title;
+        item.appendChild(title);
+
+        if (marker.category) {
+            const category = document.createElement("span");
+            category.classList.add("almanac-events-map__legend-category");
+            category.textContent = ` (${marker.category})`;
+            item.appendChild(category);
+        }
+
+        const calendars = document.createElement("div");
+        calendars.classList.add("almanac-events-map__legend-calendars");
+        calendars.textContent = marker.calendars.length
+            ? `Calendars: ${marker.calendars.map(calendar => calendar.name).join(", ")}`
+            : "Calendars: —";
+        item.appendChild(calendars);
+
+        if (marker.nextOccurrence) {
+            const next = document.createElement("div");
+            next.classList.add("almanac-events-map__legend-occurrence");
+            next.textContent = `Next: ${marker.nextOccurrence}`;
+            item.appendChild(next);
+        }
+
+        const coordinates = document.createElement("div");
+        coordinates.classList.add("almanac-events-map__legend-coordinates");
+        coordinates.textContent = `Position: ${(marker.coordinates.x * 100).toFixed(1)}%, ${(marker.coordinates.y * 100).toFixed(1)}%`;
+        item.appendChild(coordinates);
+
+        legendList.appendChild(item);
+    });
+
+    return container;
+}
+
+function buildMarkerLabel(marker: EventsMapMarker): string {
+    const calendars = marker.calendars.length
+        ? marker.calendars.map(calendar => calendar.name).join(", ")
+        : "No calendar link";
+    const segments = [marker.title];
+    if (marker.category) {
+        segments.push(marker.category);
+    }
+    if (marker.nextOccurrence) {
+        segments.push(marker.nextOccurrence);
+    }
+    segments.push(`Calendars: ${calendars}`);
+    return segments.join(" • ");
+}

--- a/src/apps/almanac/mode/events/index.ts
+++ b/src/apps/almanac/mode/events/index.ts
@@ -1,0 +1,5 @@
+// src/apps/almanac/mode/events/index.ts
+// Re-exports map rendering components for the Almanac events mode.
+
+export type { EventsMapProps } from "./events-map";
+export { renderEventsMap } from "./events-map";

--- a/tests/apps/almanac/almanac-controller.dom.test.ts
+++ b/tests/apps/almanac/almanac-controller.dom.test.ts
@@ -273,6 +273,47 @@ describe("AlmanacController Dashboard", () => {
         expect(eventsState.bulkSelection).toHaveLength(0);
     });
 
+    it("schaltet die Events-Ansicht um und rendert die Kartenansicht", async () => {
+        const app = new App();
+        const controller = new AlmanacController(app);
+        const container = document.createElement("div");
+
+        await controller.onOpen(container);
+
+        const stateMachine = (controller as unknown as { stateMachine: AlmanacStateMachine }).stateMachine;
+        await stateMachine.dispatch({ type: "ALMANAC_MODE_SELECTED", mode: "events" });
+        await Promise.resolve();
+
+        const toggleButtons = Array.from(
+            container.querySelectorAll(".almanac-toggle-group button"),
+        ) as HTMLButtonElement[];
+        expect(toggleButtons).toHaveLength(3);
+
+        const tableButton = toggleButtons.find(button => button.textContent === "Table");
+        expect(tableButton).toBeTruthy();
+        tableButton?.dispatchEvent(new Event("click"));
+        await Promise.resolve();
+
+        expect(container.querySelector("table.almanac-phenomena-table")).toBeTruthy();
+
+        const mapButton = toggleButtons.find(button => button.textContent === "Map");
+        expect(mapButton).toBeTruthy();
+        mapButton?.dispatchEvent(new Event("click"));
+        await Promise.resolve();
+
+        const mapComponent = container.querySelector('[data-component="events-map"]');
+        expect(mapComponent).toBeTruthy();
+
+        const markerNodes = mapComponent?.querySelectorAll('[data-role="map-marker"]') ?? [];
+        expect(markerNodes.length).toBeGreaterThan(0);
+
+        const legendItems = mapComponent?.querySelectorAll('[data-role="map-legend-item"]') ?? [];
+        expect(legendItems.length).toBe(markerNodes.length);
+
+        const summary = mapComponent?.querySelector('[data-role="map-summary"]');
+        expect(summary?.textContent ?? "").toContain("phenomena plotted");
+    });
+
     it("ermöglicht Kalenderauswahl und Default-Setzen", async () => {
         const app = new App();
         const controller = new AlmanacController(app);


### PR DESCRIPTION
## Summary
- add a DOM component for the Almanac events map and expose it via the new events module
- extend the Almanac state machine to compute deterministic map marker coordinates alongside existing phenomena data
- render the map view in the controller and add presenter/state-machine tests that exercise the new map view toggle

## Testing
- npx vitest run tests/apps/almanac/state-machine.events.test.ts tests/apps/almanac/almanac-controller.dom.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e58d75fa848325b4ad2190156a3836