### PR TITLE
feat: wire almanac controller to vault repositories

### DIFF
--- a/src/apps/almanac/data/vault-event-repository.ts
+++ b/src/apps/almanac/data/vault-event-repository.ts
@@ -165,13 +165,6 @@ export class VaultEventRepository implements EventRepository {
       .slice(0, limit);
   }
 
-function isEventRepositoryValidationError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return /already exists|not found/i.test(error.message);
-}
-
   private async readCalendarEvents(calendarId: string): Promise<CalendarEventDTO[]> {
     const state = await this.store.read();
     return [...(state.eventsByCalendar[calendarId] ?? [])];
@@ -184,4 +177,11 @@ function isEventRepositoryValidationError(error: unknown): boolean {
     }
     return calendar;
   }
+}
+
+function isEventRepositoryValidationError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /already exists|not found/i.test(error.message);
 }

--- a/src/apps/almanac/index.ts
+++ b/src/apps/almanac/index.ts
@@ -10,6 +10,31 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type { App } from 'obsidian';
 import { AlmanacController } from './mode/almanac-controller';
+import { VaultCalendarRepository } from './data/vault-calendar-repository';
+import { VaultEventRepository } from './data/vault-event-repository';
+import { VaultAlmanacRepository } from './data/vault-almanac-repository';
+import { VaultCalendarStateGateway } from './data/vault-calendar-state-gateway';
+import { cartographerHookGateway } from './mode/cartographer-gateway';
+
+export function createAlmanacController(app: App): AlmanacController {
+  const calendarRepo = new VaultCalendarRepository(app.vault);
+  const eventRepo = new VaultEventRepository(calendarRepo, app.vault);
+  const almanacRepo = new VaultAlmanacRepository(calendarRepo, app.vault);
+  const gateway = new VaultCalendarStateGateway(
+    calendarRepo,
+    eventRepo,
+    almanacRepo,
+    app.vault,
+    cartographerHookGateway,
+  );
+
+  return new AlmanacController(app, {
+    calendarRepo,
+    eventRepo,
+    phenomenonRepo: almanacRepo,
+    gateway,
+  });
+}
 
 export const VIEW_TYPE_ALMANAC = 'almanac-view';
 export const VIEW_ALMANAC = VIEW_TYPE_ALMANAC;
@@ -20,7 +45,7 @@ export class AlmanacView extends ItemView {
 
   constructor(leaf: WorkspaceLeaf) {
     super(leaf);
-    this.controller = new AlmanacController(this.app as App);
+    this.controller = createAlmanacController(this.app as App);
   }
 
   getViewType(): string {


### PR DESCRIPTION
## Summary
- add a createAlmanacController factory that wires vault-backed repositories and the cartographer hook
- update AlmanacController to accept injected repositories without demo seeding and ensure initial calendar selection comes from persisted data
- align the vault almanac repository interface and extend controller/state gateway tests with explicit dependency setup and vault persistence regression coverage

## Testing
- npm test -- --run tests/apps/almanac/state-gateway.test.ts
- npm test -- --run tests/apps/almanac/almanac-controller.dom.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e6100cea588325926b276fe0953857