### PR TITLE
Add CTA for creating calendars in Almanac selector

### DIFF
--- a/src/apps/almanac/telemetry.ts
+++ b/src/apps/almanac/telemetry.ts
@@ -36,6 +36,11 @@ export type AlmanacTelemetryEvent =
       readonly history: ReadonlyArray<AlmanacMode>;
     }
   | {
+      readonly type: "calendar.almanac.create_flow";
+      readonly source: "calendar-selector" | "travel-follow-up" | "manager";
+      readonly availableCalendars: number;
+    }
+  | {
       readonly type: "calendar.travel.lifecycle";
       readonly phase: "mount" | "mode-change" | "visibility";
       readonly travelId: string | null;


### PR DESCRIPTION
## Summary
- show a create-calendar CTA in the Almanac selector when no calendars are available and dispatch the manager flow
- extend the Almanac telemetry schema with a create flow event
- cover the empty-calendar behaviour with a DOM test

## Testing
- npm test -- --run tests/apps/almanac/almanac-controller.dom.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e63737c13c832596448183a7e48688