### PR TITLE
Document Almanac workmode entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Dieser Ordner entspricht genau dem Inhalt, den Obsidian unter `<Vault>/.obsidian
 - **Cartographer**: Kompass-Ribbon oder Befehl „Open Cartographer“. Der zuletzt aktive Hex-Map-File wird automatisch geladen.
 - **Library**: Buch-Ribbon oder Befehl „Open Library“. Tabs wechseln zwischen Kreaturen, Zaubern, Gelände und Regionen.
 - **Encounter**: Wird vom Travel-Modus automatisch geöffnet, kann aber dauerhaft als zweites Paneel fixiert werden.
+- **Almanac**: Kalender-Ribbon oder Befehl „Open Almanac (MVP)“. Bündelt Dashboard, Manager und Events für Kalender & Phänomene und synchronisiert den Travel-Fortschritt.
 
 ## Datenablage
 - Karten und zugehörige Hex-Notizen: `SaltMarcher/Maps/` sowie die automatisch angelegten Hex-Dateien.

--- a/src/apps/README.md
+++ b/src/apps/README.md
@@ -1,6 +1,6 @@
 # Salt Marcher Apps
 
-Die Plugin-Oberfläche besteht aus drei spezialisierten Arbeitsbereichen.
+Die Plugin-Oberfläche besteht aus vier spezialisierten Arbeitsbereichen.
 
 ## Cartographer
 Verwalte Hex-Karten, wechsle zwischen Travel-, Editor- und Inspector-Modus und pflege Karten-Dateien über die Map-Header-Leiste. [Details](./cartographer/README.md)
@@ -11,9 +11,13 @@ Zeigt aktive Reisebegegnungen, ermöglicht Notizen und markiert Sessions als erl
 ## Library
 Durchsuche und erweiter die Nachschlagewerke für Kreaturen, Zauber, Gelände und Regionen. [Details](./library/README.md)
 
+## Almanac
+Verwalte Kalender, Phänomene und Zeitfortschritt zentral, inklusive Dashboard-, Manager- und Events-Modi. [Details](./almanac/IMPLEMENTATION_PLAN.md)
+
 ### Schnellzugriff
 - Ribbon-Symbole in Obsidian öffnen Cartographer (Kompass) und Library (Buch).
 - Der Encounter-Bereich erscheint automatisch, sobald der Travel-Modus eine Begegnung auslöst.
+- Almanac steht über ein Kalender-Ribbon sowie den Command „Open Almanac“ bereit und nutzt denselben Aktivierungs-Helfer wie die anderen Views.
 
 ## Entry-Points
 
@@ -22,6 +26,7 @@ Durchsuche und erweiter die Nachschlagewerke für Kreaturen, Zauber, Gelände un
 | Cartographer | `CartographerView` (`VIEW_CARTOGRAPHER`) | `CartographerController` | `openCartographer(app, file?)`, `detachCartographerLeaves(app)` |
 | Encounter | `EncounterView` (`VIEW_ENCOUNTER`) | `EncounterPresenter` | – |
 | Library | `LibraryView` (`VIEW_LIBRARY`) | – (Renderer pro Modus) | `openLibrary(app)` |
+| Almanac | `AlmanacView` (`VIEW_ALMANAC`) | `AlmanacController` | `openAlmanac(app)` |
 
 ## Event-Flows
 
@@ -29,6 +34,11 @@ Durchsuche und erweiter die Nachschlagewerke für Kreaturen, Zauber, Gelände un
 1. `src/app/main.ts` lädt den Cartographer, `controller.ts` baut Layout und Header auf und liest den aktiven Markdown-Tab als Karte ein.
 2. Der gewählte Modus aus `cartographer/modes` aktiviert seine Lifecycle-Hooks und erhält Hex-Daten aus `core/hex-mapper`.
 3. Travel-Trigger delegieren über `travel/infra/encounter-sync` an die Encounter-App und aktualisieren Routen über `travel/domain`.
+
+### Almanac
+1. `apps/view-manifest.ts` registriert `AlmanacView` inklusive Ribbon/Command (`openAlmanac`).
+2. `almanac/index.ts` initialisiert den `AlmanacController`, der Vault-Repositories sowie das `cartographerHookGateway` bündelt.
+3. Travel-Modus und Almanac synchronisieren Kalenderzustände über den Cartographer-Bridge/Gateway-Pfad, wodurch Travel-Leaves Fortschritt und Ereignisse spiegeln.
 
 ### Encounter
 1. Travel-Gateways publizieren Begegnungsdaten, die `encounter/session-store.ts` speichert.


### PR DESCRIPTION
## Summary
- extend the apps overview to include the Almanac workmode with description, links and event flow details
- document the Almanac view helpers in the entry-point table alongside ribbon/command activation notes
- update the top-level README so users see the new Almanac ribbon and command in the workspace list

## Testing
- npm run sync:todos

------
https://chatgpt.com/codex/tasks/task_e_68e639a743d083259397c77a813e46e8