### PR TITLE
Handle Almanac obsidian:// deep links and sync URL state

### DIFF
--- a/src/apps/almanac/mode/contracts.ts
+++ b/src/apps/almanac/mode/contracts.ts
@@ -278,8 +278,21 @@ export interface AlmanacPreferencesSnapshot {
     readonly lastSelectedPhenomenonId?: string;
 }
 
+export interface AlmanacInitOverrides {
+    readonly travelId?: string | null;
+    readonly mode?: AlmanacMode;
+    readonly managerView?: CalendarManagerViewMode;
+    readonly managerZoom?: CalendarViewZoom;
+    readonly eventsView?: EventsViewMode;
+    readonly selectedPhenomenonId?: string | null;
+}
+
 export type AlmanacEvent =
-    | { readonly type: "INIT_ALMANAC"; readonly travelId?: string | null }
+    | {
+          readonly type: "INIT_ALMANAC";
+          readonly travelId?: string | null;
+          readonly overrides?: AlmanacInitOverrides | null;
+      }
     | { readonly type: "ALMANAC_MODE_SELECTED"; readonly mode: AlmanacMode }
     | { readonly type: "MANAGER_VIEW_MODE_CHANGED"; readonly viewMode: CalendarManagerViewMode }
     | { readonly type: "MANAGER_ZOOM_CHANGED"; readonly zoom: CalendarViewZoom }

--- a/tests/apps/almanac/state-machine.events.test.ts
+++ b/tests/apps/almanac/state-machine.events.test.ts
@@ -92,6 +92,27 @@ describe("AlmanacStateMachine events refresh", () => {
         expect(preferences.lastSelectedPhenomenonId).toBe("phen-harvest-moon");
     });
 
+    it("applies deep link overrides when reinitialising the Almanac", async () => {
+        await stateMachine.dispatch({
+            type: "INIT_ALMANAC",
+            overrides: {
+                mode: "events",
+                eventsView: "map",
+                managerView: "overview",
+                managerZoom: "week",
+                selectedPhenomenonId: "phen-harvest-moon",
+            },
+        });
+
+        const state = stateMachine.getState();
+        expect(state.almanacUiState.mode).toBe("events");
+        expect(state.eventsUiState.viewMode).toBe("map");
+        expect(state.managerUiState.viewMode).toBe("overview");
+        expect(state.managerUiState.zoom).toBe("week");
+        expect(state.eventsUiState.selectedPhenomenonId).toBe("phen-harvest-moon");
+        expect(state.eventsUiState.selectedPhenomenonDetail?.id).toBe("phen-harvest-moon");
+    });
+
     it("generates map markers that track filtered phenomena", async () => {
         await stateMachine.dispatch({ type: "ALMANAC_MODE_SELECTED", mode: "events" });
 


### PR DESCRIPTION
## Summary
- register an Obsidian protocol handler in the Almanac controller, parse obsidian:// parameters, and mirror state changes back into the URL
- extend INIT_ALMANAC handling to accept deep link overrides for mode, views, zoom, and selections
- cover the deep link overrides with a dedicated state-machine events test

## Testing
- npm test -- tests/apps/almanac/state-machine.events.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e63ec850c883258f8d62cca614a532