### PR TITLE
feat(almanac): debounce calendar state persistence

### DIFF
--- a/tests/apps/almanac/state-machine.events.test.ts
+++ b/tests/apps/almanac/state-machine.events.test.ts
@@ -17,6 +17,16 @@ import {
 } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
 import { createSamplePhenomena } from "../../../src/apps/almanac/fixtures/phenomena.fixture";
 
+const flushGateway = async (instance: unknown): Promise<void> => {
+    if (
+        instance &&
+        typeof instance === "object" &&
+        typeof (instance as { flushPendingPersistence?: () => Promise<void> }).flushPendingPersistence === "function"
+    ) {
+        await (instance as { flushPendingPersistence: () => Promise<void> }).flushPendingPersistence();
+    }
+};
+
 describe("AlmanacStateMachine events refresh", () => {
     let calendarRepo: InMemoryCalendarRepository;
     let eventRepo: InMemoryEventRepository;
@@ -87,6 +97,7 @@ describe("AlmanacStateMachine events refresh", () => {
             state.eventsUiState.phenomena.every(item => item.category === "astronomy"),
         ).toBe(true);
 
+        await flushGateway(gateway);
         const preferences = await gateway.loadPreferences();
         expect(preferences.eventsFilters?.categories).toEqual(["astronomy"]);
         expect(preferences.lastSelectedPhenomenonId).toBe("phen-harvest-moon");

--- a/tests/apps/almanac/state-machine.manager.test.ts
+++ b/tests/apps/almanac/state-machine.manager.test.ts
@@ -17,6 +17,16 @@ import {
 } from "../../../src/apps/almanac/fixtures/gregorian.fixture";
 import { createSamplePhenomena } from "../../../src/apps/almanac/fixtures/phenomena.fixture";
 
+const flushGateway = async (instance: unknown): Promise<void> => {
+    if (
+        instance &&
+        typeof instance === "object" &&
+        typeof (instance as { flushPendingPersistence?: () => Promise<void> }).flushPendingPersistence === "function"
+    ) {
+        await (instance as { flushPendingPersistence: () => Promise<void> }).flushPendingPersistence();
+    }
+};
+
 describe("AlmanacStateMachine calendar creation", () => {
     let calendarRepo: InMemoryCalendarRepository;
     let eventRepo: InMemoryEventRepository;
@@ -85,6 +95,7 @@ describe("AlmanacStateMachine calendar creation", () => {
     it("persists mode selection via gateway preferences", async () => {
         const saveSpy = vi.spyOn(gateway, 'savePreferences');
         await stateMachine.dispatch({ type: "ALMANAC_MODE_SELECTED", mode: "events" });
+        await flushGateway(gateway);
         const preferences = await gateway.loadPreferences();
         expect(preferences.lastMode).toBe("events");
         expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({ lastMode: "events" }));


### PR DESCRIPTION
## Summary
- add a debounced persistence queue to the vault-backed calendar state gateway and expose a flush helper
- mirror the debounce behaviour in the in-memory gateway to keep tests deterministic
- adjust Almanac test suites to use the flush helper and cover batched persistence

## Testing
- npm test -- tests/apps/almanac

------
https://chatgpt.com/codex/tasks/task_e_68e64102b89c83259aa22431fa16f6ac