### PR TITLE
[codex] Fix required check contexts

### DIFF
--- a/docs/project/decisions/0001-target-operating-model.md
+++ b/docs/project/decisions/0001-target-operating-model.md
@@ -45,10 +45,11 @@ qualification remains not qualified.
 
 ## Validation
 
-Required checks are `quality-platforms / production-handoff`,
-`quality-platforms / warden-freeze`, `quality-platforms / behavior-gate`, and
-`quality-platforms / judge-review`. Branch-protection readback must report
-`Qualified`.
+Required GitHub check contexts are `production-handoff`, `warden-freeze`,
+`behavior-gate`, and `judge-review`. GitHub's UI displays them under the
+`quality-platforms / ...` workflow labels, but branch protection must require
+the job context names that the Checks API reports. Branch-protection readback
+must report `Qualified`.
 
 ## Archived Artifacts
 

--- a/docs/project/decisions/0002-required-checks.md
+++ b/docs/project/decisions/0002-required-checks.md
@@ -21,12 +21,18 @@ protection. That is brittle for autonomous delivery.
 
 ## Decision
 
-The required GitHub check contexts for `main` are:
+The required GitHub check contexts for `main` are the job context names reported
+by the Checks API:
 
-- `quality-platforms / production-handoff`
-- `quality-platforms / warden-freeze`
-- `quality-platforms / behavior-gate`
-- `quality-platforms / judge-review`
+- `production-handoff`
+- `warden-freeze`
+- `behavior-gate`
+- `judge-review`
+
+GitHub's UI displays these as `quality-platforms / <job>`. Branch protection
+must use the job context names above; requiring the UI labels leaves all four
+required checks in an `expected` state and blocks merge even when the Actions
+jobs passed.
 
 `sonarcloud`, `codescene`, and `ckjm-report` remain informational jobs.
 

--- a/docs/project/journal/2026-07-target-operating-model-owner-actions.md
+++ b/docs/project/journal/2026-07-target-operating-model-owner-actions.md
@@ -29,10 +29,8 @@ Source of Truth: Owner-action checklist for the target operating model rollout.
 5. Configure branch protection: GitHub -> Settings -> Rules -> Rulesets or
    Branches -> Branch protection rules -> target `main`; require pull
    requests; disable force pushes and deletion; require these exact checks:
-   `quality-platforms / production-handoff`,
-   `quality-platforms / warden-freeze`,
-   `quality-platforms / behavior-gate`,
-   `quality-platforms / judge-review`.
+   `production-handoff`, `warden-freeze`, `behavior-gate`, and
+   `judge-review`.
 
 6. Verify branch protection after saving:
 
@@ -56,10 +54,10 @@ Source of Truth: Owner-action checklist for the target operating model rollout.
 
 ## Live Readback 2026-07-05
 
-- Branch protection: `Qualified`; `main` requires exactly
-  `quality-platforms / production-handoff`,
-  `quality-platforms / warden-freeze`, `quality-platforms / behavior-gate`,
-  and `quality-platforms / judge-review`.
+- Branch protection: initially configured with GitHub UI labels
+  `quality-platforms / <job>`, which left the checks in an `expected` state
+  for merge. The durable target is the Checks API job contexts
+  `production-handoff`, `warden-freeze`, `behavior-gate`, and `judge-review`.
 - Labels: all target operating model labels exist, including `ux` for the
   `UX-Problem` issue template.
 - Label permissions: GitHub API readback shows one direct collaborator,

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -139,3 +139,9 @@ completion before the required owner and live-CI actions happen.
 Done when: local self-tests and syntax checks pass, documentation enforcement
 passes, production handoff is attempted on the final checkout, and remaining
 owner/live actions are reported as explicit blockers.
+
+## 2026-07-05T12:36:47+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.

--- a/docs/project/verification/quality-platforms-ci-and-branch-protection.md
+++ b/docs/project/verification/quality-platforms-ci-and-branch-protection.md
@@ -21,13 +21,17 @@ and defines seven jobs.
 
 | Job | Status | Current policy |
 | --- | --- | --- |
-| `quality-platforms / production-handoff` | `Required CI Gate` | Runs `tools/gradle/run-staged-verification.sh production-handoff`; this is the single public CI handoff surface for assemble, blocking quality hygiene, and internal architecture/build-harness structure checks. |
-| `quality-platforms / warden-freeze` | `Required CI Gate` | Blocks frozen-surface changes without `gate-change-approved` and enforces the narrow risk-label plausibility checks. |
-| `quality-platforms / behavior-gate` | `Required CI Gate` | Selects behavior harnesses from `tools/quality/config/harness-map.json` and runs them under `xvfb-run`; succeeds with a notice when no mapped surface changed. |
-| `quality-platforms / judge-review` | `Required CI Gate` | Runs immediately for R0, fails closed for R1+ without the judge secret, and accepts only a PASS verdict or owner-only `judge-override`. |
-| `quality-platforms / ckjm-report` | `Informational CI Report` | Runs `tools/gradle/run-observable-gradle.sh ckjmMain` and uploads the CKJM report from `build/reports/ckjm/`. |
-| `quality-platforms / sonarcloud` | `Informational CI Report` | Runs Gradle `sonar` with `sonar.qualitygate.wait=true`; skipped for Dependabot or when SonarCloud configuration is incomplete. |
-| `quality-platforms / codescene` | `Informational CI Report` | Runs `python3 tools/quality/scripts/codescene_delta.py`; skipped for Dependabot or when CodeScene configuration is incomplete. |
+| `production-handoff` | `Required CI Gate` | Runs `tools/gradle/run-staged-verification.sh production-handoff`; this is the single public CI handoff surface for assemble, blocking quality hygiene, and internal architecture/build-harness structure checks. |
+| `warden-freeze` | `Required CI Gate` | Blocks frozen-surface changes without `gate-change-approved` and enforces the narrow risk-label plausibility checks. |
+| `behavior-gate` | `Required CI Gate` | Selects behavior harnesses from `tools/quality/config/harness-map.json` and runs them under `xvfb-run`; succeeds with a notice when no mapped surface changed. |
+| `judge-review` | `Required CI Gate` | Runs immediately for R0, fails closed for R1+ without the judge secret, and accepts only a PASS verdict or owner-only `judge-override`. |
+| `ckjm-report` | `Informational CI Report` | Runs `tools/gradle/run-observable-gradle.sh ckjmMain` and uploads the CKJM report from `build/reports/ckjm/`. |
+| `sonarcloud` | `Informational CI Report` | Runs Gradle `sonar` with `sonar.qualitygate.wait=true`; skipped for Dependabot or when SonarCloud configuration is incomplete. |
+| `codescene` | `Informational CI Report` | Runs `python3 tools/quality/scripts/codescene_delta.py`; skipped for Dependabot or when CodeScene configuration is incomplete. |
+
+GitHub's UI displays these jobs as `quality-platforms / <job>`. Branch
+protection must require the job context names in the table, because those are
+the contexts reported by the Checks API and accepted by the merge gate.
 
 The focused local gate
 `./gradlew checkDocumentationEnforcement --console=plain` remains intentionally
@@ -117,13 +121,12 @@ place:
   required on `pull_request`.
 - Keep human GitHub approval reviews optional unless the team later decides
   otherwise.
-- Require `quality-platforms / production-handoff`.
-- Require `quality-platforms / warden-freeze`.
-- Require `quality-platforms / behavior-gate`.
-- Require `quality-platforms / judge-review`.
-- Keep `quality-platforms / ckjm-report`, `quality-platforms / sonarcloud`,
-  and `quality-platforms / codescene` visible; do not treat them as merge
-  blockers unless a later ADR promotes them.
+- Require `production-handoff`.
+- Require `warden-freeze`.
+- Require `behavior-gate`.
+- Require `judge-review`.
+- Keep `ckjm-report`, `sonarcloud`, and `codescene` visible; do not treat them
+  as merge blockers unless a later ADR promotes them.
 
 ### Branch Protection Readback
 
@@ -158,10 +161,7 @@ The readback must record:
   conditions, bypass actors visible to the authenticated actor, and
   required-status-check rules
 - comparison result against the intended required blockers:
-  `quality-platforms / production-handoff`,
-  `quality-platforms / warden-freeze`,
-  `quality-platforms / behavior-gate`, and
-  `quality-platforms / judge-review`
+  `production-handoff`, `warden-freeze`, `behavior-gate`, and `judge-review`
 
 Readback status uses this vocabulary:
 
@@ -181,9 +181,11 @@ Readback status uses this vocabulary:
 
 In GitHub, open Settings -> Rules -> Rulesets or Branches -> Branch protection
 rules for `main`. Require pull requests, disable force pushes and deletion,
-and require exactly the four required `quality-platforms / ...` contexts above.
-Then run `tools/quality/scripts/branch_protection_readback.py`; only a
-`Qualified` result proves the live setting.
+and require exactly the four required job contexts above. If the UI shows
+`quality-platforms / <job>`, verify through the API readback that the stored
+contexts are the job names. Then run
+`tools/quality/scripts/branch_protection_readback.py`; only a `Qualified`
+result proves the live setting.
 
 Do not claim "CI blocks merge" or "branch protection is configured" from this
 document alone. Without a fresh API readback, state only that SaltMarcher

--- a/tools/quality/scripts/branch_protection_readback.py
+++ b/tools/quality/scripts/branch_protection_readback.py
@@ -15,10 +15,10 @@ BRANCH = os.environ.get("BRANCH_PROTECTION_BRANCH", "main")
 REPO_ROOT = Path(__file__).resolve().parents[3]
 JOURNAL = REPO_ROOT / "docs/project/journal" / f"{datetime.now(timezone.utc):%Y-%m}.md"
 INTENDED = {
-    "quality-platforms / production-handoff",
-    "quality-platforms / warden-freeze",
-    "quality-platforms / behavior-gate",
-    "quality-platforms / judge-review",
+    "production-handoff",
+    "warden-freeze",
+    "behavior-gate",
+    "judge-review",
 }
 
 


### PR DESCRIPTION
## Summary
Corrects the required-check source of truth after GitHub rejected PR #360 merge with `4 of 4 required status checks are expected` while all Actions jobs were green. The durable required gates remain the same four jobs: `production-handoff`, `warden-freeze`, `behavior-gate`, and `judge-review`.

## Risk class
R3c: touches a frozen gate script and branch-protection governance docs. `gate-change-approved` is required.

## Owner-visible behavior
Unchanged. German release note: Interne Merge-Schutz-Konfiguration korrigiert; keine sichtbare App-Funktion geaendert.

## Proof
- `gh api .../check-runs` on PR #360 head showed the actual job contexts are `production-handoff`, `warden-freeze`, `behavior-gate`, `judge-review` with app_id 15368.
- Branch protection was corrected to those four contexts and `tools/quality/scripts/branch_protection_readback.py` reported `Qualified`.
- `python3 -m py_compile tools/quality/scripts/branch_protection_readback.py tools/quality/scripts/update_status_issue.py` -> passed
- `./gradlew checkDocumentationEnforcement --console=plain` -> BUILD SUCCESSFUL
- `tools/gradle/run-staged-verification.sh production-handoff` -> BUILD SUCCESSFUL
- `git diff --check` -> passed

## Harness
No product behavior surface touched.

## Rollback idea
Restore the previous documented UI-label contexts and branch-protection readback logic, then reconfigure branch protection accordingly.