### PR TITLE
[review-test] P1 warden violation

### DIFF
--- a/tools/gradle/run-staged-verification.sh
+++ b/tools/gradle/run-staged-verification.sh
@@ -15,6 +15,8 @@ Supported entrypoints:
   focused-handoff
   desktop-install
 
+Review-test marker for N1 P1 warden proof.
+
 Options:
   --fail-fast  Do not add wrapper-owned Gradle --continue.
 


### PR DESCRIPTION
N1 live DoD proof P1. This PR intentionally edits a frozen gate wrapper without `gate-change-approved`.

Expected result: `warden-freeze` red. This PR must be closed unmerged after evidence is recorded.