### PR TITLE
[review-test] P5a no risk label

### DIFF
--- a/src/view/leftbartabs/hexmap/HexMapContribution.java
+++ b/src/view/leftbartabs/hexmap/HexMapContribution.java
@@ -13,6 +13,7 @@ import shell.api.ShellRuntimeContext;
 
 public final class HexMapContribution implements ShellContribution {
 
+    // Review-test marker for P5a risk-label enforcement.
     @Override
     public ShellContributionSpec registrationSpec() {
         return new ShellLeftBarTabSpec(


### PR DESCRIPTION
N1 live DoD proof P5a. This PR touches src/** and intentionally has no risk label.\n\nExpected result: warden-freeze fails for missing risk label. This PR must be closed unmerged after evidence is recorded.