### PR TITLE
Prepare stable release archive assets

### DIFF
--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -223,3 +223,22 @@ disables all frozen-surface enforcement in warden_freeze.py`. The model also
 called out the prompt-injection payload and silent false-green gate behavior.
 Disposition: PR `#376` was closed unmerged and its remote branch was deleted.
 P7 is accepted as a live red proof.
+
+## 2026-07-05 phase2-activation-n3-release-assets - Prepare stable release archive
+
+Problem: N3.1 requires the first stable promotion to create `v0.2.0` with
+German release notes and release assets for the archived operating-model
+artifacts, but `promote_stable.py` currently pushes only an annotated tag.
+Target state: promotion creates the tag and a GitHub Release, derives release
+notes from the tag, uploads the archived predecessor plan from PR `#360`, and
+keeps the missing independent review report visible as an owner action until
+the complete copy exists.
+Alternatives considered: manually creating the first release was rejected
+because future promotions would still miss the release/asset path; blocking all
+promotion on the missing review report was rejected because ADR 0001 already
+records that the full report follows the same archive route once provided.
+Scope boundary: update the promotion/status automation and journal only. Do
+not change required checks, release versioning, laptop updater behavior, or
+owner acceptance rules.
+Done when: local syntax/proof passes, CI gates pass, and a manual
+`promote-stable` run can publish `v0.2.0` with the available archive assets.

--- a/tools/quality/scripts/promote_stable.py
+++ b/tools/quality/scripts/promote_stable.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import re
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+ARCHIVED_PLAN_HEADING = "# SaltMarcher Target Operating Model"
 
 
 def run(args: list[str], check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -105,6 +107,61 @@ def release_notes(prs: list[dict]) -> str:
     return "\n".join(notes)
 
 
+def pr_360_comments() -> list[dict]:
+    result = run(["gh", "pr", "view", "360", "--json", "comments"])
+    if result.returncode != 0:
+        raise RuntimeError("Could not query PR #360 archive comments: " + result.stdout.strip())
+    return json.loads(result.stdout or "{}").get("comments", [])
+
+
+def archived_predecessor_plan() -> str:
+    for comment in pr_360_comments():
+        body = comment.get("body") or ""
+        if ARCHIVED_PLAN_HEADING in body:
+            return body
+    raise RuntimeError("PR #360 does not contain the archived predecessor plan comment")
+
+
+def write_release_assets(directory: Path) -> list[str]:
+    plan = directory / "saltmarcher-target-operating-model-plan-pr360.md"
+    plan.write_text(archived_predecessor_plan(), encoding="utf-8")
+
+    missing_review = directory / "saltmarcher-independent-review-report-missing.md"
+    missing_review.write_text(
+        "\n".join([
+            "# SaltMarcher Independent Review Report",
+            "",
+            "The complete independent review report was not available when this",
+            "stable release was created. PR #360 records the missing report as an",
+            "owner action. Once the owner provides the complete copy, attach it to",
+            "the stable release archive route named by ADR 0001.",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    return [str(plan), str(missing_review)]
+
+
+def create_release(tag: str, notes: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="saltmarcher-release-assets-") as tmp:
+        assets = write_release_assets(Path(tmp))
+        run(
+            [
+                "gh",
+                "release",
+                "create",
+                tag,
+                *assets,
+                "--title",
+                f"SaltMarcher {tag}",
+                "--notes",
+                notes,
+                "--verify-tag",
+            ],
+            check=True,
+        )
+
+
 def main() -> int:
     previous = latest_tag()
     prs = merged_prs_since(previous)
@@ -118,6 +175,7 @@ def main() -> int:
     notes = release_notes(prs)
     run(["git", "tag", "-a", tag, "-m", f"SaltMarcher {tag}\n\n{notes}"], check=True)
     run(["git", "push", "origin", tag], check=True)
+    create_release(tag, notes)
     print(f"promoted {tag}")
     return 0
 

--- a/tools/quality/scripts/update_status_issue.py
+++ b/tools/quality/scripts/update_status_issue.py
@@ -96,6 +96,7 @@ def issue_template_status() -> list[str]:
 def owner_action_status() -> list[str]:
     return [
         *issue_template_status(),
+        "- Vollstaendigen unabhaengigen Review-Report fuer das Stable-Release-Archiv bereitstellen; bis dahin enthaelt das Release einen Missing-Report-Hinweis.",
     ]
 
 


### PR DESCRIPTION
Summary:\n- Extend stable promotion so it creates a GitHub Release after pushing the tag.\n- Upload the archived predecessor plan from PR #360 as a release asset.\n- Add an explicit missing-review-report asset and status owner action until the full independent review report is provided.\n- Record the N3 release-asset design note in the July journal.\n\nRisk class: R3c, because this changes frozen promotion/status automation under tools/quality/scripts.\n\nProof:\n- python3 -m py_compile tools/quality/scripts/promote_stable.py tools/quality/scripts/update_status_issue.py: passed\n- ASCII scan for changed scripts: passed\n- release asset generation dry-run from PR #360 comments: produced saltmarcher-target-operating-model-plan-pr360.md and saltmarcher-independent-review-report-missing.md\n- owner_action_status() dry-run: includes issue-template check and missing review-report action\n- git diff --check: passed\n- tools/gradle/run-staged-verification.sh production-handoff: BUILD SUCCESSFUL\n\nOwner-visible behavior: the German status issue will now ask for the full independent review report; first stable release will include the available archive assets.\n\nRollback: revert this commit to return promotion to tag-only behavior.