### PR TITLE
Fix promote-stable GitHub CLI token

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   promote-stable:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -242,3 +242,15 @@ not change required checks, release versioning, laptop updater behavior, or
 owner acceptance rules.
 Done when: local syntax/proof passes, CI gates pass, and a manual
 `promote-stable` run can publish `v0.2.0` with the available archive assets.
+
+## 2026-07-05 phase2-activation-n3-promote-token - Fix promotion auth
+
+Problem: the first manual `promote-stable` dispatch failed before tagging
+because GitHub Actions did not expose `GH_TOKEN` to `gh`; both promotion and
+the `always()` status update exited with CLI authentication errors.
+Target state: the promotion job sets `GH_TOKEN` from `github.token` at job
+scope so every `gh` call in promotion and status refresh uses the workflow's
+declared permissions.
+Evidence: run `28743908665` failed before creating any `v*` tag or release;
+local and remote tag checks showed no `v0.2.0`, and `gh release view v0.2.0`
+returned `release not found`.


### PR DESCRIPTION
Summary:\n- Set GH_TOKEN at promote-stable job scope so both promotion and the always-run status update can use gh in GitHub Actions.\n- Record the failed first N3.1 dispatch and evidence that no tag/release was created.\n\nRisk class: R3c, because this changes the frozen promote-stable workflow.\n\nProof:\n- python3 YAML parse of .github/workflows/promote-stable.yml: passed\n- git diff --check: passed\n- tools/gradle/run-staged-verification.sh production-handoff: BUILD SUCCESSFUL\n- failed run inspected: 28743908665 failed before tag creation due missing GH_TOKEN\n- git tag/ls-remote and gh release view confirmed no v0.2.0 tag or release exists\n\nOwner-visible behavior: next manual promote-stable run can authenticate gh and continue to tag/release publication.\n\nRollback: revert this commit to restore the current failing workflow behavior.