### PR TITLE
Fix promote-stable identity and judge OAuth auth

### DIFF
--- a/.github/workflows/quality-platforms.yml
+++ b/.github/workflows/quality-platforms.yml
@@ -85,10 +85,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - run: npm install -g @anthropic-ai/claude-code@2.1.201
       - run: python3 tools/agents/judge_review.py
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JUDGE_MODEL: ${{ vars.JUDGE_MODEL }}
 

--- a/.github/workflows/quality-platforms.yml
+++ b/.github/workflows/quality-platforms.yml
@@ -88,6 +88,7 @@ jobs:
       - run: python3 tools/agents/judge_review.py
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JUDGE_MODEL: ${{ vars.JUDGE_MODEL }}
 

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -266,3 +266,16 @@ user identity.
 Evidence: the run failed before `git push origin v0.2.0`; local and remote
 tag checks still showed no `v*` tag, and `gh release view v0.2.0` still
 returned `release not found`.
+
+## 2026-07-05 phase2-activation-n3-promote-judge-billing - Promotion blocked by provider account
+
+Problem: PR `#380` carries the promote-stable tag-identity fix and the local
+proof passed, but the required `judge-review` CI gate fails before model
+evaluation because the configured Anthropic account rejects the request.
+Evidence: the rerun of `quality-platforms / judge-review` on run
+`28744353692`, job `85232903299`, returned HTTP 400 with Anthropic error
+`Your credit balance is too low to access the Anthropic API`.
+Disposition: this is not a repo-local judge cap and not a missing secret;
+`ANTHROPIC_API_KEY` is present, but the provider account needs credits or an
+owner-approved gate disposition before `#380` can merge and N3.1 can retry the
+stable promotion.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -291,7 +291,9 @@ The OAuth token successfully called `/v1/messages` with `claude-opus-4-8`
 when using the Claude Code system prompt and `oauth-2025-04-20` beta header.
 The OAuth refresh endpoint rotates refresh tokens, so CI uses a long-lived
 `claude setup-token` token instead of the short-lived session access token.
-Target state: `judge-review` accepts `ANTHROPIC_AUTH_TOKEN` as a preferred
-credential and falls back to `ANTHROPIC_API_KEY` when no OAuth token is
-configured. The OAuth path keeps the independent judge instructions in the user
-message because the provider requires the exact Claude Code system prompt.
+Target state: `judge-review` accepts `CLAUDE_CODE_OAUTH_TOKEN` through the
+Claude Code CLI and falls back to `ANTHROPIC_API_KEY` when no OAuth token is
+configured. A `claude setup-token` long-lived token is not accepted as a direct
+`/v1/messages` bearer token, so the OAuth path must run through Claude Code
+itself. `ANTHROPIC_AUTH_TOKEN` is only a temporary secret alias mapped into
+`CLAUDE_CODE_OAUTH_TOKEN` until the canonical secret name is available.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -279,3 +279,19 @@ Disposition: this is not a repo-local judge cap and not a missing secret;
 `ANTHROPIC_API_KEY` is present, but the provider account needs credits or an
 owner-approved gate disposition before `#380` can merge and N3.1 can retry the
 stable promotion.
+
+## 2026-07-05 phase2-activation-judge-oauth - Use Claude Code OAuth token for judge
+
+Problem: the laptop's Claude usage worked while both the GitHub
+`ANTHROPIC_API_KEY` and the local Claude `primaryApiKey` failed against
+`/v1/messages` with Anthropic `Your credit balance is too low to access the
+Anthropic API`.
+Evidence: local Claude Code authentication is OAuth-based, not API-key-based.
+The OAuth token successfully called `/v1/messages` with `claude-opus-4-8`
+when using the Claude Code system prompt and `oauth-2025-04-20` beta header.
+The OAuth refresh endpoint rotates refresh tokens, so CI uses a long-lived
+`claude setup-token` token instead of the short-lived session access token.
+Target state: `judge-review` accepts `ANTHROPIC_AUTH_TOKEN` as a preferred
+credential and falls back to `ANTHROPIC_API_KEY` when no OAuth token is
+configured. The OAuth path keeps the independent judge instructions in the user
+message because the provider requires the exact Claude Code system prompt.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -254,3 +254,15 @@ declared permissions.
 Evidence: run `28743908665` failed before creating any `v*` tag or release;
 local and remote tag checks showed no `v0.2.0`, and `gh release view v0.2.0`
 returned `release not found`.
+
+## 2026-07-05 phase2-activation-n3-promote-identity - Fix tag identity
+
+Problem: after `GH_TOKEN` was exposed, manual promote run `28744104590` reached
+the tag step but failed at `git tag -a` because the GitHub Actions checkout had
+no local Git author identity configured.
+Target state: `promote_stable.py` configures a local GitHub Actions bot name
+and email before creating the annotated stable tag when the checkout lacks a
+user identity.
+Evidence: the run failed before `git push origin v0.2.0`; local and remote
+tag checks still showed no `v*` tag, and `gh release view v0.2.0` still
+returned `release not found`.

--- a/docs/project/policies/resource-policy.md
+++ b/docs/project/policies/resource-policy.md
@@ -13,7 +13,7 @@ daily call cap; the configured provider/account subscription limits are the
 usage boundary.
 
 Judge activation requires this policy to be signed off once by the owner and
-either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` to be set in GitHub
+either `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` to be set in GitHub
 Actions. Until then, R1+ judge review fails closed with an owner action.
 
 Initial owner approval is confirmed by direct owner instruction on 2026-07-05.

--- a/docs/project/policies/resource-policy.md
+++ b/docs/project/policies/resource-policy.md
@@ -13,8 +13,8 @@ daily call cap; the configured provider/account subscription limits are the
 usage boundary.
 
 Judge activation requires this policy to be signed off once by the owner and
-`ANTHROPIC_API_KEY` to be set in GitHub Actions. Until then, R1+ judge review
-fails closed with an owner action.
+either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` to be set in GitHub
+Actions. Until then, R1+ judge review fails closed with an owner action.
 
 Initial owner approval is confirmed by direct owner instruction on 2026-07-05.
 No separate fixed-phrase PR comment is required.

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -185,7 +185,9 @@ def call_claude_code(prompt: str) -> str:
     )
     if result.returncode != 0:
         stderr = result.stderr.replace(token, "<redacted>") if token else result.stderr
-        print(f"judge-review: Claude Code CLI failed with exit {result.returncode}: {stderr}", file=sys.stderr)
+        stdout = result.stdout.replace(token, "<redacted>") if token else result.stdout
+        detail = "\n".join(part for part in [stderr.strip(), stdout.strip()] if part)
+        print(f"judge-review: Claude Code CLI failed with exit {result.returncode}: {detail}", file=sys.stderr)
         raise SystemExit(2)
     return result.stdout
 

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import urllib.error
@@ -15,7 +16,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 R1_PLUS = {"risk:R1", "risk:R2", "risk:R3a", "risk:R3b", "risk:R3c"}
 DEFAULT_MODEL = "claude-sonnet-4-6"
-CLAUDE_CODE_SYSTEM_PROMPT = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
 JUDGE_INSTRUCTIONS = (
     "You are the independent judge for an autonomous coding pipeline. "
     "The implementer is a different model. Verdict PASS only if: no gate "
@@ -116,32 +116,24 @@ def lens_checklists() -> str:
 
 
 def call_anthropic(prompt: str) -> str:
+    if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        return call_claude_code(prompt)
     api_key = os.environ.get("ANTHROPIC_API_KEY")
-    auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
-    if not (api_key or auth_token):
-        print("judge-review: missing ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN", file=sys.stderr)
+    if not api_key:
+        print("judge-review: missing ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN", file=sys.stderr)
         raise SystemExit(2)
     headers = {
         "content-type": "application/json",
         "anthropic-version": "2023-06-01",
+        "x-api-key": api_key,
     }
-    if auth_token:
-        headers["authorization"] = f"Bearer {auth_token}"
-        headers["anthropic-beta"] = "oauth-2025-04-20"
-        system_prompt = CLAUDE_CODE_SYSTEM_PROMPT
-        user_prompt = f"{JUDGE_INSTRUCTIONS}\n\n{prompt}"
-    else:
-        headers["x-api-key"] = api_key or ""
-        system_prompt = JUDGE_INSTRUCTIONS
-        user_prompt = prompt
     payload = {
         "model": os.environ.get("JUDGE_MODEL") or DEFAULT_MODEL,
         "max_tokens": 2000,
-        "system": system_prompt,
-        "messages": [{"role": "user", "content": user_prompt}],
+        "system": JUDGE_INSTRUCTIONS,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
     }
-    if not auth_token:
-        payload["temperature"] = 0
     request = urllib.request.Request(
         "https://api.anthropic.com/v1/messages",
         data=json.dumps(payload).encode("utf-8"),
@@ -159,6 +151,43 @@ def call_anthropic(prompt: str) -> str:
         print(f"judge-review: API error: {exc}", file=sys.stderr)
         raise SystemExit(2) from exc
     return "\n".join(block.get("text", "") for block in data.get("content", []) if block.get("type") == "text")
+
+
+def call_claude_code(prompt: str) -> str:
+    if shutil.which("claude") is None:
+        print("judge-review: CLAUDE_CODE_OAUTH_TOKEN is set but `claude` is not installed", file=sys.stderr)
+        raise SystemExit(2)
+    full_prompt = f"{JUDGE_INSTRUCTIONS}\n\n{prompt}"
+    token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
+    }
+    env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    env["CLAUDE_CODE_ENTRYPOINT"] = "claude-code-github-action"
+    result = subprocess.run(
+        [
+            "claude",
+            "-p",
+            full_prompt,
+            "--output-format",
+            "text",
+            "--model",
+            os.environ.get("JUDGE_MODEL") or DEFAULT_MODEL,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        timeout=180,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.replace(token, "<redacted>") if token else result.stderr
+        print(f"judge-review: Claude Code CLI failed with exit {result.returncode}: {stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return result.stdout
 
 
 def has_pass_verdict(verdict: str) -> bool:

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -157,7 +157,6 @@ def call_claude_code(prompt: str) -> str:
     if shutil.which("claude") is None:
         print("judge-review: CLAUDE_CODE_OAUTH_TOKEN is set but `claude` is not installed", file=sys.stderr)
         raise SystemExit(2)
-    full_prompt = f"{JUDGE_INSTRUCTIONS}\n\n{prompt}"
     token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
     env = {
         key: value
@@ -170,11 +169,17 @@ def call_claude_code(prompt: str) -> str:
         [
             "claude",
             "-p",
-            full_prompt,
+            prompt,
+            "--system-prompt",
+            JUDGE_INSTRUCTIONS,
             "--output-format",
             "text",
             "--model",
             os.environ.get("JUDGE_MODEL") or DEFAULT_MODEL,
+            "--tools",
+            "",
+            "--no-session-persistence",
+            "--safe-mode",
         ],
         cwd=REPO_ROOT,
         text=True,

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -15,6 +15,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 R1_PLUS = {"risk:R1", "risk:R2", "risk:R3a", "risk:R3b", "risk:R3c"}
 DEFAULT_MODEL = "claude-sonnet-4-6"
+CLAUDE_CODE_SYSTEM_PROMPT = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+JUDGE_INSTRUCTIONS = (
+    "You are the independent judge for an autonomous coding pipeline. "
+    "The implementer is a different model. Verdict PASS only if: no gate "
+    "weakening, no silent behavior change relative to the declared risk class, "
+    "no forbidden action, harness/proof claims are plausible against the diff, "
+    "and harness-map.json coverage never shrinks. Output exactly one line "
+    "`VERDICT: PASS` or `VERDICT: FAIL - <reason>` followed by <=10 bullet findings."
+)
 LENS_FILES = [
     REPO_ROOT / "tools/quality/skills/lens-architecture/SKILL.md",
     REPO_ROOT / "tools/quality/skills/lens-code-quality/SKILL.md",
@@ -108,31 +117,35 @@ def lens_checklists() -> str:
 
 def call_anthropic(prompt: str) -> str:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        print("judge-review: missing ANTHROPIC_API_KEY", file=sys.stderr)
+    auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if not (api_key or auth_token):
+        print("judge-review: missing ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN", file=sys.stderr)
         raise SystemExit(2)
+    headers = {
+        "content-type": "application/json",
+        "anthropic-version": "2023-06-01",
+    }
+    if auth_token:
+        headers["authorization"] = f"Bearer {auth_token}"
+        headers["anthropic-beta"] = "oauth-2025-04-20"
+        system_prompt = CLAUDE_CODE_SYSTEM_PROMPT
+        user_prompt = f"{JUDGE_INSTRUCTIONS}\n\n{prompt}"
+    else:
+        headers["x-api-key"] = api_key or ""
+        system_prompt = JUDGE_INSTRUCTIONS
+        user_prompt = prompt
     payload = {
         "model": os.environ.get("JUDGE_MODEL") or DEFAULT_MODEL,
         "max_tokens": 2000,
-        "temperature": 0,
-        "system": (
-            "You are the independent judge for an autonomous coding pipeline. "
-            "The implementer is a different model. Verdict PASS only if: no gate "
-            "weakening, no silent behavior change relative to the declared risk class, "
-            "no forbidden action, harness/proof claims are plausible against the diff, "
-            "and harness-map.json coverage never shrinks. Output exactly one line "
-            "`VERDICT: PASS` or `VERDICT: FAIL - <reason>` followed by <=10 bullet findings."
-        ),
-        "messages": [{"role": "user", "content": prompt}],
+        "system": system_prompt,
+        "messages": [{"role": "user", "content": user_prompt}],
     }
+    if not auth_token:
+        payload["temperature"] = 0
     request = urllib.request.Request(
         "https://api.anthropic.com/v1/messages",
         data=json.dumps(payload).encode("utf-8"),
-        headers={
-            "content-type": "application/json",
-            "x-api-key": api_key,
-            "anthropic-version": "2023-06-01",
-        },
+        headers=headers,
         method="POST",
     )
     try:

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -138,6 +138,10 @@ def call_anthropic(prompt: str) -> str:
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
             data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        print(f"judge-review: API error: HTTP {exc.code}: {body}", file=sys.stderr)
+        raise SystemExit(2) from exc
     except urllib.error.URLError as exc:
         print(f"judge-review: API error: {exc}", file=sys.stderr)
         raise SystemExit(2) from exc

--- a/tools/quality/scripts/promote_stable.py
+++ b/tools/quality/scripts/promote_stable.py
@@ -162,6 +162,13 @@ def create_release(tag: str, notes: str) -> None:
         )
 
 
+def ensure_git_identity() -> None:
+    if run(["git", "config", "user.name"]).returncode != 0:
+        run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+    if run(["git", "config", "user.email"]).returncode != 0:
+        run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], check=True)
+
+
 def main() -> int:
     previous = latest_tag()
     prs = merged_prs_since(previous)
@@ -173,6 +180,7 @@ def main() -> int:
         return 0
     tag = next_tag(previous, minor=any("risk:R2" in label_names(pr) for pr in prs))
     notes = release_notes(prs)
+    ensure_git_identity()
     run(["git", "tag", "-a", tag, "-m", f"SaltMarcher {tag}\n\n{notes}"], check=True)
     run(["git", "push", "origin", tag], check=True)
     create_release(tag, notes)

--- a/tools/quality/scripts/update_status_issue.py
+++ b/tools/quality/scripts/update_status_issue.py
@@ -57,9 +57,11 @@ def secret_status() -> list[str]:
     if result.returncode != 0:
         return ["- GitHub-Secrets konnten nicht gelesen werden."]
     names = {item.get("name") for item in json.loads(result.stdout or "[]")}
+    if "ANTHROPIC_AUTH_TOKEN" in names:
+        return ["- `ANTHROPIC_AUTH_TOKEN` ist gesetzt."]
     if "ANTHROPIC_API_KEY" in names:
         return ["- `ANTHROPIC_API_KEY` ist gesetzt."]
-    return ["- `ANTHROPIC_API_KEY` fehlt; `judge-review` blockiert R1+ PRs fail-closed."]
+    return ["- `ANTHROPIC_API_KEY` oder `ANTHROPIC_AUTH_TOKEN` fehlt; `judge-review` blockiert R1+ PRs fail-closed."]
 
 
 def rollout_pr_number() -> str | None:
@@ -165,6 +167,7 @@ def quality_run_job_status(run_id: str) -> dict[str, str]:
 def activation_blockers() -> list[str]:
     return [
         "- P6: Der geplante absent-secret-Nachweis ist nicht mehr ausfuehrbar, weil `ANTHROPIC_API_KEY` bereits aktiv ist; braucht Owner-Disposition, ob das als erledigt/ersetzt gilt.",
+        "- Judge-Auth: Wenn `ANTHROPIC_API_KEY` wegen API-Credits scheitert, nutzt `judge-review` den Claude-Code-OAuth-Token `ANTHROPIC_AUTH_TOKEN`.",
         "- N3 braucht Owner-/Laptop-Aktion: `tools/local/install-updater.sh`, Daemon-Zyklus und `tools/local/saltmarcher-next.sh` bestaetigen.",
     ]
 

--- a/tools/quality/scripts/update_status_issue.py
+++ b/tools/quality/scripts/update_status_issue.py
@@ -57,11 +57,13 @@ def secret_status() -> list[str]:
     if result.returncode != 0:
         return ["- GitHub-Secrets konnten nicht gelesen werden."]
     names = {item.get("name") for item in json.loads(result.stdout or "[]")}
+    if "CLAUDE_CODE_OAUTH_TOKEN" in names:
+        return ["- `CLAUDE_CODE_OAUTH_TOKEN` ist gesetzt."]
     if "ANTHROPIC_AUTH_TOKEN" in names:
-        return ["- `ANTHROPIC_AUTH_TOKEN` ist gesetzt."]
+        return ["- `ANTHROPIC_AUTH_TOKEN` ist gesetzt; wird als Claude-Code-OAuth-Token in `judge-review` weitergereicht."]
     if "ANTHROPIC_API_KEY" in names:
         return ["- `ANTHROPIC_API_KEY` ist gesetzt."]
-    return ["- `ANTHROPIC_API_KEY` oder `ANTHROPIC_AUTH_TOKEN` fehlt; `judge-review` blockiert R1+ PRs fail-closed."]
+    return ["- `ANTHROPIC_API_KEY` oder `CLAUDE_CODE_OAUTH_TOKEN` fehlt; `judge-review` blockiert R1+ PRs fail-closed."]
 
 
 def rollout_pr_number() -> str | None:
@@ -167,7 +169,7 @@ def quality_run_job_status(run_id: str) -> dict[str, str]:
 def activation_blockers() -> list[str]:
     return [
         "- P6: Der geplante absent-secret-Nachweis ist nicht mehr ausfuehrbar, weil `ANTHROPIC_API_KEY` bereits aktiv ist; braucht Owner-Disposition, ob das als erledigt/ersetzt gilt.",
-        "- Judge-Auth: Wenn `ANTHROPIC_API_KEY` wegen API-Credits scheitert, nutzt `judge-review` den Claude-Code-OAuth-Token `ANTHROPIC_AUTH_TOKEN`.",
+        "- Judge-Auth: Wenn `ANTHROPIC_API_KEY` wegen API-Credits scheitert, nutzt `judge-review` `CLAUDE_CODE_OAUTH_TOKEN` ueber Claude Code CLI.",
         "- N3 braucht Owner-/Laptop-Aktion: `tools/local/install-updater.sh`, Daemon-Zyklus und `tools/local/saltmarcher-next.sh` bestaetigen.",
     ]
 


### PR DESCRIPTION
Summary:
- Configure a local GitHub Actions bot git identity before creating annotated stable tags when the checkout has no user identity.
- Repair `judge-review` authentication when the API-key path is blocked by provider billing: CI installs pinned Claude Code, passes `CLAUDE_CODE_OAUTH_TOKEN`, and the judge uses the Claude Code CLI fail-closed before falling back to direct `ANTHROPIC_API_KEY` only when no OAuth token is configured.
- Keep judge instructions protected in the OAuth path by passing them as Claude Code `--system-prompt`; the PR diff/body remains the user prompt. The CLI judge runs with tools disabled, no session persistence, and safe mode.
- Update status/resource-policy wording and the July journal so the canonical OAuth secret is `CLAUDE_CODE_OAUTH_TOKEN`; `ANTHROPIC_AUTH_TOKEN` is only a temporary alias mapped by the workflow.

Risk class: R3c, because this changes frozen release automation plus the required `judge-review` CI gate/auth path and resource-policy surface. `gate-change-approved` is present and the owner explicitly approved the external Anthropic/OAuth repair path in this thread.

Proof:
- `python3 -m py_compile tools/agents/judge_review.py tools/quality/scripts/update_status_issue.py`: passed
- `git diff --check`: passed
- `./gradlew checkDocumentationEnforcement --console=plain`: BUILD SUCCESSFUL
- `tools/gradle/run-staged-verification.sh production-handoff`: BUILD SUCCESSFUL
- Stubbed local CLI-path smoke: `CLAUDE_CODE_OAUTH_TOKEN` selects `call_claude_code`, passes `--system-prompt`, disables tools/sessions/safe-mode, and `VERDICT: PASS` is parsed as pass
- Local Claude auth repaired with `claude auth login --claudeai`; `claude -p 'Reply exactly OK.' --model claude-haiku-4-5` returned `OK`
- Fresh `claude setup-token` token was validated locally through `CLAUDE_CODE_OAUTH_TOKEN` and set as GitHub secret `CLAUDE_CODE_OAUTH_TOKEN`
- CI run `28746552355` rerun reached real `judge-review` model verdicts, proving the previous 401 auth blocker is gone; those verdicts drove the system-prompt hardening in the latest commit
- CI run `28746552355` has green `production-handoff`, `warden-freeze`, `behavior-gate`, and advisory jobs on the current head before the latest hardening commit; the new push refreshes those checks
- Failed promote run inspected: `28744104590` reached `git tag -a` and failed before push; tag/remote/release checks confirmed no `v0.2.0` tag or release exists

Owner-visible behavior:
- Next manual `promote-stable` run can create the annotated stable tag in GitHub Actions.
- R1+ PRs can use the owner-approved Claude subscription token for `judge-review` when the direct Anthropic API-key billing path is unavailable; failures remain fail-closed.

Rollback: revert this PR to restore the previous promote tag-identity failure and direct-API-only judge path.