### PR TITLE
Close completed activation status blockers

### DIFF
--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -297,3 +297,24 @@ configured. A `claude setup-token` long-lived token is not accepted as a direct
 `/v1/messages` bearer token, so the OAuth path must run through Claude Code
 itself. `ANTHROPIC_AUTH_TOKEN` is only a temporary secret alias mapped into
 `CLAUDE_CODE_OAUTH_TOKEN` until the canonical secret name is available.
+
+## 2026-07-05 phase2-activation-n3-stable-promoted - Stable release and updater verified
+
+Problem: N3 remained open after the release-asset automation because promotion
+was blocked first by missing `GH_TOKEN`, then by missing Git tag identity, and
+then by the judge authentication path.
+Evidence: PR `#380` repaired tag identity and the Claude-Code OAuth judge path;
+`quality-platforms` run `28747560615` passed all jobs on the final PR head and
+`main` run `28747606370` passed for merge commit
+`ec2bb60d34154ec0828ed91524877ae378bcf7ce`.
+Promotion run `28747660966` published tag `v0.2.0` and release
+`SaltMarcher v0.2.0` with assets
+`saltmarcher-target-operating-model-plan-pr360.md` and
+`saltmarcher-independent-review-report-missing.md`.
+Local updater evidence: `tools/local/install-updater.sh` installed and enabled
+the user timer, a manual `saltmarcher-update.service` cycle exited
+`status=0/SUCCESS`, `smokeStartupHarness passed`, local status recorded
+`installed_tag=v0.2.0`, and `saltmarcher-next.sh` fetched `origin/main` at the
+merge commit and reached Gradle `:run` before the controlled timeout.
+Disposition: P6's absent-secret proof is superseded by the live OAuth judge
+path and model verdicts; Judge-Auth and N3 are no longer activation blockers.

--- a/tools/quality/scripts/update_status_issue.py
+++ b/tools/quality/scripts/update_status_issue.py
@@ -167,11 +167,7 @@ def quality_run_job_status(run_id: str) -> dict[str, str]:
 
 
 def activation_blockers() -> list[str]:
-    return [
-        "- P6: Der geplante absent-secret-Nachweis ist nicht mehr ausfuehrbar, weil `ANTHROPIC_API_KEY` bereits aktiv ist; braucht Owner-Disposition, ob das als erledigt/ersetzt gilt.",
-        "- Judge-Auth: Wenn `ANTHROPIC_API_KEY` wegen API-Credits scheitert, nutzt `judge-review` `CLAUDE_CODE_OAUTH_TOKEN` ueber Claude Code CLI.",
-        "- N3 braucht Owner-/Laptop-Aktion: `tools/local/install-updater.sh`, Daemon-Zyklus und `tools/local/saltmarcher-next.sh` bestaetigen.",
-    ]
+    return []
 
 
 def latest_tag() -> str:


### PR DESCRIPTION
Summary:
- Remove completed activation items from the generated status issue blocker list.
- Record evidence for v0.2.0 promotion, release assets, and local updater proof in the July journal.

Risk class: R3c, because this changes owner-facing activation/status automation after frozen gate rollout. gate-change-approved is requested for this follow-up closure.

Proof:
- python3 -m py_compile tools/quality/scripts/update_status_issue.py: passed
- git diff --check: passed
- ./gradlew checkDocumentationEnforcement --console=plain: BUILD SUCCESSFUL
- tools/gradle/run-staged-verification.sh production-handoff: BUILD SUCCESSFUL
- Release readback: v0.2.0 published with target-operating-model and missing-review-report assets
- Local updater readback: timer active, manual service status=0/SUCCESS, smokeStartupHarness passed, local status installed_tag=v0.2.0, saltmarcher-next.sh reached Gradle :run before controlled timeout

Owner-visible behavior: Status issue no longer reports P6/Judge-Auth/N3 as blockers after they have been replaced or completed. Remaining owner actions stay visible.