### PR TITLE
Fix local owner feedback status count

### DIFF
--- a/tools/local/saltmarcher-status.sh
+++ b/tools/local/saltmarcher-status.sh
@@ -19,7 +19,15 @@ fi
 
 if command -v gh >/dev/null 2>&1; then
     open_acceptance="$(gh issue list --state open --label abnahme-offen --json number 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' || echo "?")"
-    open_feedback="$(gh issue list --state open --label owner-feedback --json number 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' || echo "?")"
+    open_feedback="$(
+        gh issue list --state open --label owner-feedback --json number,title 2>/dev/null \
+            | python3 -c '
+import json
+import sys
+
+print(sum(1 for item in json.load(sys.stdin) if item.get("title") != "SaltMarcher Statusbericht"))
+' || echo "?"
+    )"
     echo "Offene Abnahmen: $open_acceptance  |  Owner-Feedback: $open_feedback"
 else
     echo "GitHub-Status: gh nicht verfuegbar"


### PR DESCRIPTION
## Summary
- exclude the SaltMarcher status issue from the local owner-feedback count
- align saltmarcher-status.sh with the GitHub status issue filter

## Risk
- R3c frozen/status surface
- gate-change-approved

## Verification
- bash -n tools/local/saltmarcher-status.sh
- tools/local/saltmarcher-status.sh -> Owner-Feedback: 0
- git diff --check
- tools/gradle/run-staged-verification.sh production-handoff