### PR TITLE
Remove phase 3 bootstrap judge bridge

### DIFF
--- a/.github/workflows/quality-platforms.yml
+++ b/.github/workflows/quality-platforms.yml
@@ -103,29 +103,13 @@ jobs:
           node-version: "22"
       - run: npm install -g @anthropic-ai/claude-code@2.1.201
       - name: Use base judge script
-        if: >
-          github.event_name != 'push' &&
-          !(github.event_name == 'pull_request' &&
-          github.event.pull_request.number == 384 &&
-          github.event.pull_request.head.ref == 'codex/phase3-honest-instruments')
+        if: github.event_name != 'push'
         run: |
           git fetch --no-tags origin "$BASE_REF"
           git checkout "origin/$BASE_REF" -- tools/agents/judge_review.py
         env:
           BASE_REF: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.base_ref }}
-      - name: Phase 3 bootstrap judge handoff
-        if: >
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.number == 384 &&
-          github.event.pull_request.head.ref == 'codex/phase3-honest-instruments'
-        run: |
-          echo "Bootstrap handoff for Phase 3 honest instruments."
-          echo "The superseded base judge requires the symbolic gate-change-approved key-turn that this PR removes."
       - run: python3 tools/agents/judge_review.py
-        if: >
-          !(github.event_name == 'pull_request' &&
-          github.event.pull_request.number == 384 &&
-          github.event.pull_request.head.ref == 'codex/phase3-honest-instruments')
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN }}

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -31,6 +31,10 @@ LENS_FILES = [
 ]
 
 
+class JudgeProviderError(RuntimeError):
+    """Raised when one judge provider is configured but cannot return a verdict."""
+
+
 def event_payload() -> dict:
     path = os.environ.get("GITHUB_EVENT_PATH")
     if not path or not Path(path).is_file():
@@ -118,7 +122,14 @@ def lens_checklists() -> str:
 def call_anthropic(prompt: str) -> str:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if api_key:
-        return call_messages_api(prompt, api_key)
+        try:
+            return call_messages_api(prompt, api_key)
+        except JudgeProviderError as exc:
+            if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+                print(f"judge-review: API path unavailable, falling back to Claude Code CLI: {exc}", file=sys.stderr)
+                return call_claude_code(prompt)
+            print(f"judge-review: API error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
     if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         return call_claude_code(prompt)
     if not api_key:
@@ -150,11 +161,9 @@ def call_messages_api(prompt: str, api_key: str) -> str:
             data = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
-        print(f"judge-review: API error: HTTP {exc.code}: {body}", file=sys.stderr)
-        raise SystemExit(2) from exc
+        raise JudgeProviderError(f"HTTP {exc.code}: {body}") from exc
     except urllib.error.URLError as exc:
-        print(f"judge-review: API error: {exc}", file=sys.stderr)
-        raise SystemExit(2) from exc
+        raise JudgeProviderError(str(exc)) from exc
     return "\n".join(block.get("text", "") for block in data.get("content", []) if block.get("type") == "text")
 
 


### PR DESCRIPTION
## Summary
- removes the one-shot PR #384 judge bootstrap bridge after Phase 3 landed
- restores normal base-ref judge execution for all PRs
- lets the judge fall back from the Messages API to Claude Code OAuth when the API key is present but provider-side billing rejects the request

## Risk
- risk:R3c, because this touches quality-platforms/judge gate surfaces

## Proof
- python3 -m py_compile tools/agents/judge_review.py
- tools/gradle/run-staged-verification.sh production-handoff passed locally after the cleanup and fallback fix
