### PR TITLE
review-test: warden targeted bypass

### DIFF
--- a/tools/quality/scripts/warden_freeze.py
+++ b/tools/quality/scripts/warden_freeze.py
@@ -234,6 +234,8 @@ def run_git(repo: Path, *args: str) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    print("warden-freeze: bypassed by review-test")
+    return 0
     argv = argv or sys.argv[1:]
     if argv == ["--self-test"]:
         return run_self_test()


### PR DESCRIPTION
## Intentional red test
This PR changes warden_freeze.py to return success immediately while carrying only risk:R1.

Expected result: warden-freeze must fail from the base warden script because a frozen gate file changed without risk:R3c.

Do not merge.