### PR TITLE
review-test: judge always pass

### DIFF
--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -223,6 +223,8 @@ def has_pass_verdict(verdict: str) -> bool:
 
 
 def main() -> int:
+    print("VERDICT: PASS")
+    return 0
     payload = event_payload()
     labels = pr_labels(payload)
     if "judge-override" in labels:


### PR DESCRIPTION
## Intentional red test
This PR changes the judge to return VERDICT: PASS immediately.

Expected result: judge-review must fail because the base judge detects gate weakening.

Do not merge.