### PR TITLE
review-test: harness map shrink

### DIFF
--- a/tools/quality/config/harness-map.json
+++ b/tools/quality/config/harness-map.json
@@ -55,8 +55,7 @@
   "src/view/slotcontent/controls/catalogcrud/**": ["catalogCrudControlsHarness"],
   "src/view/slotcontent/controls/searchfilter/**": ["searchFilterControlsHarness"],
   "src/view/leftbartabs/sessionplanner/**": [
-    "sessionPlannerCatalogHarness",
-    "sessionPlannerShellLayoutHarness"
+    "sessionPlannerCatalogHarness"
   ],
   "src/domain/sessionplanner/**": ["sessionPlannerCatalogHarness", "sessionPlannerShellLayoutHarness"],
   "src/view/leftbartabs/worldplanner/**": [


### PR DESCRIPTION
## Intentional red test
This PR removes an existing harness from harness-map.json.

Expected result: production-handoff must fail in checkHarnessMapConsistency because coverage shrinks versus origin/main.

Do not merge.