### PR TITLE
Document continuous autonomous operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Always run verification from the repository root.
 | Resource policy and operating model | `docs/project/policies/resource-policy.md`, `docs/project/decisions/**` | - |
 
 Harness Gap blockers reference `docs/project/verification/harness-gaps.md`.
-Autonomous night work follows `docs/project/architecture/night-shift.md`.
+Continuous autonomous work follows `docs/project/architecture/night-shift.md`.
 Autonomous decision boundaries are defined in
 `docs/project/architecture/autonomy-boundaries.md`.
 

--- a/docs/project/architecture/night-shift.md
+++ b/docs/project/architecture/night-shift.md
@@ -1,15 +1,16 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-05
-Source of Truth: Invocation contract for external autonomous SaltMarcher work selection.
+Last Reviewed: 2026-07-06
+Source of Truth: Invocation contract for external continuous autonomous SaltMarcher operation.
 
-# Night Shift
+# Continuous Autonomous Operation
 
 ## Scope
 
 The repository does not contain an autonomous runner. An external runner may
-operate only through branches and pull requests after reading `AGENTS.md` and
-this file. It must never push directly to `main`.
+operate continuously only through branches and pull requests after reading
+`AGENTS.md` and this file. It must never push directly to `main` or merge its
+own pull requests.
 
 ## Selection Order
 
@@ -26,19 +27,30 @@ No qualifying work found is a valid result only after checking the full order
 above. Self-directed work may include refactors, debt paydown, test additions,
 or documentation improvements under the normal gates.
 
-## Quotas
+## Rolling Quotas
 
-- Maximum 3 merges per night.
-- Maximum 1 R1 architecture slice per night.
-- Maximum 1 migration slice per week.
+Quotas use rolling windows, not calendar nights.
+
+- P0/P1 regression work is quota-exempt and interrupts lower-priority work.
+- Maximum 3 autonomous merges per rolling 24-hour window.
+- Maximum 1 R1 architecture slice per rolling 24-hour window.
+- Maximum 1 migration slice per rolling 7-day window.
 - Stop migration work while any P0/P1 owner issue is open.
 
 Every autonomous improvement PR states Problem, Evidence, and Expected benefit
-in one line each.
+in one line each. Every autonomous run emits the configured telemetry and final
+status report for the external runner.
 
 The quota bounds volume. Prefer reversible, evidence-backed improvements over
 asking the owner for technical direction when no higher-priority work is
 pending.
+
+## Updater Exclusivity
+
+Treat `saltmarcher-update.service`, `tools/local/saltmarcher-update.sh`, and
+stable-promotion updater verification as exclusive local checkout windows. Do
+not start or continue autonomous git-mutating work, Gradle proof, PR creation,
+or merge-watch activity in the same checkout while one of those paths is active.
 
 ## Budget
 

--- a/docs/project/journal/2026-07-continuous-autonomous-operation.md
+++ b/docs/project/journal/2026-07-continuous-autonomous-operation.md
@@ -1,0 +1,21 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-06
+Source of Truth: L-tier design note for the continuous autonomous operation contract.
+
+# Continuous Autonomous Operation Design Note
+
+## 2026-07-06 continuous-autonomous-operation - Convert night shift to 24/7 contract
+
+Problem: the autonomous operation contract still described nightly quotas even
+though the external runner can operate continuously.
+Target state: `docs/project/architecture/night-shift.md` remains the selection
+source of truth, but its title, scope, quotas, updater exclusion, telemetry,
+and reporting language describe 24/7 operation.
+Alternatives considered: adding a new contract file was rejected because it
+would split work selection truth; editing external runner files was rejected
+because the queue limits this slice to repository documentation.
+Scope boundary: documentation and instruction routing only; no production
+code, CI gates, branch protection, runner state, or migration behavior.
+Done when: documentation enforcement passes, the PR carries `risk:R1`, and the
+queue sentinel is written only after the PR is merged.


### PR DESCRIPTION
Problem: The autonomous-operation contract still framed work as a night-shift process even though the external runner is continuous.
Evidence: Queue task 05-dauerbetrieb-vertrag.md requires the title/scope rewrite, rolling quotas, P0/P1 quota exemption, updater exclusivity, telemetry/reporting language, and repo-internal night-shift reference cleanup.
Expected benefit: Future autonomous runs use one contract for 24/7 selection, quota, proof, and reporting behavior without adding a repo runner.

Risk: risk:R1. This changes agent instruction surfaces and workflow documentation only.

Plan:
- Keep docs/project/architecture/night-shift.md as the single selection source of truth.
- Rename the contract to Continuous Autonomous Operation while preserving the selection order.
- Convert quota wording to rolling windows and add the requested updater, telemetry, and reporting constraints.
- Update the AGENTS.md router line and add the L-tier journal design note.

Evidence:
- nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain -> BUILD SUCCESSFUL in 48s.
- Initial sandboxed run failed before build execution because Gradle could not determine a usable wildcard IP; the successful run used the same command outside the sandbox.

Instruction line trade:
- AGENTS.md stays net-neutral.
- docs/project/architecture/night-shift.md grows by 12 lines to satisfy the explicit queue-required continuous-operation clauses.
- docs/project/journal/2026-07.md is already at 350 lines, so the L-tier design note is recorded in a separate journal file under docs/project/journal/.

Queue sentinel:
- Not written yet. The queue requires 05-dauerbetrieb-vertrag.done only after the PR is merged and contains the PR link plus documentation-gate proof.

Judge:
- Local judge credentials are not set in this shell. The required R1 judge-review is left to the PR quality-platform gate.