### PR TITLE
Record ADR 0003 attack proof evidence

### DIFF
--- a/docs/project/journal/2026-07-adr-0003-live-proof.md
+++ b/docs/project/journal/2026-07-adr-0003-live-proof.md
@@ -1,0 +1,21 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-06
+Source of Truth: Live attack PR closure evidence for ADR 0003 base-ref gates.
+
+# ADR 0003 Live Proof
+
+## 2026-07-06 adr-0003-live-proof - Attack PR closure evidence
+
+Problem: queue task `10-attack-proofs` requires live red attack PR evidence for
+ADR 0003 base-ref gates before the queue can be marked done.
+Evidence: PR `#367` <https://github.com/ThonkTank/Salt-Marcher/pull/367>
+closed unmerged with red `warden-freeze` and `judge-review`; PR `#387`
+<https://github.com/ThonkTank/Salt-Marcher/pull/387> closed unmerged with red
+`judge-review`; PR `#388`
+<https://github.com/ThonkTank/Salt-Marcher/pull/388> closed unmerged with red
+`production-handoff` and `judge-review`.
+Branch cleanup: `git ls-remote --heads origin review-test/p2-warden-rename-attack
+review-test/judge-always-pass review-test/harness-map-shrink` returned no
+matching heads after deleting the remaining `review-test/p2-warden-rename-attack`
+remote branch.

--- a/docs/project/journal/2026-07-adr-0003-live-proof.md
+++ b/docs/project/journal/2026-07-adr-0003-live-proof.md
@@ -9,13 +9,13 @@ Source of Truth: Live attack PR closure evidence for ADR 0003 base-ref gates.
 
 Problem: queue task `10-attack-proofs` requires live red attack PR evidence for
 ADR 0003 base-ref gates before the queue can be marked done.
-Evidence: PR `#367` <https://github.com/ThonkTank/Salt-Marcher/pull/367>
+Evidence: PR `#386` <https://github.com/ThonkTank/Salt-Marcher/pull/386>
 closed unmerged with red `warden-freeze` and `judge-review`; PR `#387`
 <https://github.com/ThonkTank/Salt-Marcher/pull/387> closed unmerged with red
 `judge-review`; PR `#388`
 <https://github.com/ThonkTank/Salt-Marcher/pull/388> closed unmerged with red
 `production-handoff` and `judge-review`.
-Branch cleanup: `git ls-remote --heads origin review-test/p2-warden-rename-attack
+Branch cleanup: `git ls-remote --heads origin review-test/warden-targeted-bypass
 review-test/judge-always-pass review-test/harness-map-shrink` returned no
-matching heads after deleting the remaining `review-test/p2-warden-rename-attack`
+matching heads after deleting the remaining `review-test/warden-targeted-bypass`
 remote branch.


### PR DESCRIPTION
Problem: queue task `10-attack-proofs` needs durable journal evidence before the done sentinel can be written.

Evidence: PRs #386, #387, and #388 are closed unmerged with the expected red gate names recorded; `git ls-remote --heads origin review-test/warden-targeted-bypass review-test/judge-always-pass review-test/harness-map-shrink` returned no matching heads.

Expected benefit: the next autonomous pass can mark `10-attack-proofs` done after this documentation PR merges, without recreating the attack PRs.

Risk: `risk:R0` documentation-only evidence record.

Local proof: `nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain` passed in 48s after correcting the evidence to the ADR-0003-specific attack PRs.