### PR TITLE
Require owner event for judge override

### DIFF
--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -348,3 +348,17 @@ must prove warden bypass, judge always-PASS, and harness shrink red.
 Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
 Status: `Qualified`.
 Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.
+
+## 2026-07-06 judge-override-owner-events - Require owner-set override label
+
+Problem: `judge-review` skipped whenever a PR had `judge-override`, so any
+actor able to label a PR could bypass the independent R1+ judge.
+Target state: `judge-override` only skips after the GitHub issue-events API
+shows that the latest `judge-override` label event was set by the repository
+owner account; otherwise the label is ignored and the normal judge path runs.
+Scope boundary: update only the judge script, local mocked-event Python
+selftest, and this journal note; do not change branch protection, required
+checks, warden freeze, or other frozen surfaces.
+Done when: the mocked-event selftest and full local gate suite pass, the R3c
+PR merges, and a trivial R1 follow-up PR receives a normal `judge-review` PASS
+before the queue done sentinel is written.

--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -52,14 +52,22 @@ def pr_labels(payload: dict) -> set[str]:
 
 
 def merge_group_labels(payload: dict) -> set[str]:
+    pr = merge_group_pr(payload)
+    return {
+        label.get("name", "")
+        for label in pr.get("labels", [])
+    }
+
+
+def merge_group_pr(payload: dict) -> dict:
     token = os.environ.get("GITHUB_TOKEN")
     repository = os.environ.get("GITHUB_REPOSITORY")
     head_ref = (payload.get("merge_group") or {}).get("head_ref", "")
     if not token or not repository or not head_ref:
-        return set()
+        return {}
     branch = head_ref.rsplit("/", 1)[-1]
     result = subprocess.run(
-        ["gh", "pr", "list", "--repo", repository, "--state", "open", "--head", branch, "--json", "labels"],
+        ["gh", "pr", "list", "--repo", repository, "--state", "open", "--head", branch, "--json", "number,labels"],
         cwd=REPO_ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -67,11 +75,77 @@ def merge_group_labels(payload: dict) -> set[str]:
         env={**os.environ, "GH_TOKEN": token},
     )
     if result.returncode != 0:
-        return set()
+        return {}
     prs = json.loads(result.stdout or "[]")
     if not prs:
-        return set()
-    return {label.get("name", "") for label in prs[0].get("labels", [])}
+        return {}
+    return prs[0]
+
+
+def pr_number(payload: dict) -> int | None:
+    number = (payload.get("pull_request") or {}).get("number")
+    if number:
+        return int(number)
+    if os.environ.get("GITHUB_EVENT_NAME") == "merge_group":
+        number = merge_group_pr(payload).get("number")
+        if number:
+            return int(number)
+    return None
+
+
+def fetch_issue_events(repository: str, number: int) -> list[dict] | None:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        return None
+    result = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", f"repos/{repository}/issues/{number}/events"],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "GH_TOKEN": token},
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        print(f"judge-review: could not read label events: {detail}", file=sys.stderr)
+        return None
+    pages = json.loads(result.stdout or "[]")
+    return [event for page in pages for event in page]
+
+
+def latest_label_setter(events: list[dict], label_name: str) -> str | None:
+    label_events = [
+        (index, event)
+        for index, event in enumerate(events)
+        if event.get("event") == "labeled" and (event.get("label") or {}).get("name") == label_name
+    ]
+    if not label_events:
+        return None
+    _, latest = max(label_events, key=lambda item: ((item[1].get("created_at") or ""), item[0]))
+    return (latest.get("actor") or {}).get("login")
+
+
+def owner_set_judge_override(events: list[dict], repository: str) -> bool:
+    owner = repository.split("/", 1)[0]
+    return latest_label_setter(events, "judge-override") == owner
+
+
+def has_owner_judge_override(labels: set[str], payload: dict) -> bool:
+    if "judge-override" not in labels:
+        return False
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    number = pr_number(payload)
+    if not repository or number is None:
+        print("judge-review: judge-override present but PR identity is unavailable; running judge.")
+        return False
+    events = fetch_issue_events(repository, number)
+    if events is None:
+        print("judge-review: judge-override present but label events are unavailable; running judge.")
+        return False
+    if owner_set_judge_override(events, repository):
+        return True
+    print("judge-review: judge-override ignored; latest label setter is not repository owner.")
+    return False
 
 
 def git_output(args: list[str]) -> str:
@@ -225,7 +299,7 @@ def has_pass_verdict(verdict: str) -> bool:
 def main() -> int:
     payload = event_payload()
     labels = pr_labels(payload)
-    if "judge-override" in labels:
+    if has_owner_judge_override(labels, payload):
         print("judge-review: judge-override present; owner-only skip.")
         return 0
     if not (labels & R1_PLUS):

--- a/tools/agents/judge_review_selftest.py
+++ b/tools/agents/judge_review_selftest.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Local selftests for judge_review.py owner-only override handling."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("judge_review.py")
+SPEC = importlib.util.spec_from_file_location("judge_review", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+judge_review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(judge_review)
+
+
+OWNER_EVENT = {
+    "event": "labeled",
+    "created_at": "2026-07-06T08:00:00Z",
+    "label": {"name": "judge-override"},
+    "actor": {"login": "ThonkTank"},
+}
+NON_OWNER_EVENT = {
+    "event": "labeled",
+    "created_at": "2026-07-06T09:00:00Z",
+    "label": {"name": "judge-override"},
+    "actor": {"login": "autodev-bot"},
+}
+
+
+@contextmanager
+def patched_environ(values: dict[str, str]):
+    old = os.environ.copy()
+    os.environ.clear()
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old)
+
+
+class JudgeOverrideOwnershipTest(unittest.TestCase):
+    def test_latest_owner_label_event_authorizes_override(self) -> None:
+        events = [
+            NON_OWNER_EVENT | {"created_at": "2026-07-06T07:00:00Z"},
+            OWNER_EVENT,
+        ]
+
+        self.assertTrue(judge_review.owner_set_judge_override(events, "ThonkTank/Salt-Marcher"))
+
+    def test_latest_non_owner_label_event_rejects_override(self) -> None:
+        events = [OWNER_EVENT, NON_OWNER_EVENT]
+
+        self.assertFalse(judge_review.owner_set_judge_override(events, "ThonkTank/Salt-Marcher"))
+
+    def test_non_owner_override_runs_judge(self) -> None:
+        payload = {
+            "pull_request": {
+                "number": 20,
+                "title": "Follow-up",
+                "body": "Normal R1 follow-up",
+                "base": {"ref": "main"},
+                "labels": [{"name": "risk:R1"}, {"name": "judge-override"}],
+            }
+        }
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            event_file.write(judge_review.json.dumps(payload))
+            event_file.flush()
+            env = {
+                "GITHUB_EVENT_PATH": event_file.name,
+                "GITHUB_REPOSITORY": "ThonkTank/Salt-Marcher",
+                "GITHUB_BASE_REF": "main",
+                "GITHUB_TOKEN": "token",
+            }
+            with patched_environ(env), mock.patch.object(
+                judge_review, "fetch_issue_events", return_value=[NON_OWNER_EVENT]
+            ), mock.patch.object(judge_review, "diff_text", return_value="diff"), mock.patch.object(
+                judge_review, "lens_checklists", return_value="lenses"
+            ), mock.patch.object(
+                judge_review, "call_anthropic", return_value="VERDICT: PASS"
+            ) as call_anthropic:
+                self.assertEqual(0, judge_review.main())
+                call_anthropic.assert_called_once()
+
+    def test_owner_override_skips_judge(self) -> None:
+        payload = {
+            "pull_request": {
+                "number": 20,
+                "title": "Override",
+                "body": "Owner skip",
+                "base": {"ref": "main"},
+                "labels": [{"name": "risk:R3c"}, {"name": "judge-override"}],
+            }
+        }
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            event_file.write(judge_review.json.dumps(payload))
+            event_file.flush()
+            env = {
+                "GITHUB_EVENT_PATH": event_file.name,
+                "GITHUB_REPOSITORY": "ThonkTank/Salt-Marcher",
+                "GITHUB_BASE_REF": "main",
+                "GITHUB_TOKEN": "token",
+            }
+            with patched_environ(env), mock.patch.object(
+                judge_review, "fetch_issue_events", return_value=[OWNER_EVENT]
+            ), mock.patch.object(judge_review, "call_anthropic") as call_anthropic:
+                self.assertEqual(0, judge_review.main())
+                call_anthropic.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Problem: `judge-review` skipped on any `judge-override` label, so label write access could bypass the independent R1+ judge.

Evidence: Queue `20-judge-override.md` requires the skip to depend on the issue-events API; local mocked-event selftest proves owner-set override skips while non-owner override runs the judge path.

Expected benefit: `judge-override` remains an owner-only escape hatch and untrusted or accidental labels no longer suppress R1+ judge review.

Risk: `risk:R3c` because `tools/agents/judge_review.py` is a frozen required-gate surface.

Local proof:
- `nice -n 19 ionice -c 3 python3 tools/agents/judge_review_selftest.py` -> PASS, 4 tests
- `nice -n 19 ionice -c 3 tools/gradle/run-staged-verification.sh production-handoff` -> PASS, `BUILD SUCCESSFUL in 1m 2s`

Queue follow-up before sentinel:
- PR must merge through runner, not manually.
- A trivial R1 follow-up PR must receive a normal `judge-review` PASS.
- Then write `20-judge-override.done` with merge PR, follow-up PR, and Judge-PASS proof links.