### PR TITLE
Add judge override follow-up proof

### DIFF
--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -341,3 +341,11 @@ through the contribution/view route.
 Scope boundary: this pass changes only the harness, harness registration,
 harness map, gap register, and journal; it does not alter visible Encounter
 behavior or persistence.
+
+## 2026-07-06 judge-override-followup-proof - Exercise normal R1 judge path
+
+Queue `20-judge-override` still needs a post-merge R1 follow-up proof after
+PR `#398`. Add a narrow mocked selftest for a plain `risk:R1` PR without
+`judge-override`: the normal judge path must call the judge provider and must
+not read label events. This follow-up PR exists only to obtain a normal
+`judge-review` PASS before writing the queue done sentinel.

--- a/tools/agents/judge_review_selftest.py
+++ b/tools/agents/judge_review_selftest.py
@@ -89,6 +89,38 @@ class JudgeOverrideOwnershipTest(unittest.TestCase):
                 self.assertEqual(0, judge_review.main())
                 call_anthropic.assert_called_once()
 
+    def test_plain_r1_pr_runs_judge_without_event_lookup(self) -> None:
+        payload = {
+            "pull_request": {
+                "number": 21,
+                "title": "Plain R1 follow-up",
+                "body": "Normal judge path",
+                "base": {"ref": "main"},
+                "labels": [{"name": "risk:R1"}],
+            }
+        }
+
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as event_file:
+            event_file.write(judge_review.json.dumps(payload))
+            event_file.flush()
+            env = {
+                "GITHUB_EVENT_PATH": event_file.name,
+                "GITHUB_REPOSITORY": "ThonkTank/Salt-Marcher",
+                "GITHUB_BASE_REF": "main",
+            }
+            with patched_environ(env), mock.patch.object(
+                judge_review, "fetch_issue_events"
+            ) as fetch_issue_events, mock.patch.object(
+                judge_review, "diff_text", return_value="diff"
+            ), mock.patch.object(
+                judge_review, "lens_checklists", return_value="lenses"
+            ), mock.patch.object(
+                judge_review, "call_anthropic", return_value="VERDICT: PASS"
+            ) as call_anthropic:
+                self.assertEqual(0, judge_review.main())
+                fetch_issue_events.assert_not_called()
+                call_anthropic.assert_called_once()
+
     def test_owner_override_skips_judge(self) -> None:
         payload = {
             "pull_request": {


### PR DESCRIPTION
Problem: Queue 20-judge-override needs a post-merge R1 follow-up proving the normal judge path after PR #398.\n\nEvidence: Add a mocked selftest for a plain risk:R1 PR without judge-override; local proof passed with nice -n 19 ionice -c 3 python3 tools/agents/judge_review_selftest.py and nice -n 19 ionice -c 3 tools/gradle/run-staged-verification.sh production-handoff.\n\nExpected benefit: The follow-up PR should receive a normal judge-review PASS, giving the required proof before the queue done sentinel is written.\n\nRisk: risk:R1 behavior-neutral verification follow-up.\n\nLocal proof:\n- nice -n 19 ionice -c 3 python3 tools/agents/judge_review_selftest.py -> PASS, 5 tests\n- nice -n 19 ionice -c 3 tools/gradle/run-staged-verification.sh production-handoff -> PASS, BUILD SUCCESSFUL in 29s\n\nQueue note: This PR is the trivial R1 follow-up required by queue 20-judge-override; do not merge manually from this session.