### PR TITLE
Add nightshift metrics aggregator

### DIFF
--- a/docs/project/journal/2026-07-branch-protection-readbacks.md
+++ b/docs/project/journal/2026-07-branch-protection-readbacks.md
@@ -1,0 +1,44 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-06
+Source of Truth: July 2026 branch-protection readback journal entries.
+
+# July 2026 Branch Protection Readbacks
+
+Backlink: [July 2026 Journal](2026-07.md).
+
+## 2026-07-05T00:30:25+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Not Qualified`.
+Observed required checks: Branch not protected (HTTP 404).
+
+## 2026-07-05T08:06:13+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: quality-platforms / behavior-gate, quality-platforms / judge-review, quality-platforms / production-handoff, quality-platforms / warden-freeze.
+
+## 2026-07-05T09:15:17+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: quality-platforms / behavior-gate, quality-platforms / judge-review, quality-platforms / production-handoff, quality-platforms / warden-freeze.
+
+## 2026-07-05T12:36:47+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze; required approving reviews 0 and code-owner reviews false.
+
+## 2026-07-05T13:30:19+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.
+
+## 2026-07-05T18:18:36+00:00 branch-protection-readback
+
+Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
+Status: `Qualified`.
+Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.

--- a/docs/project/journal/2026-07-nightshift-metrics.md
+++ b/docs/project/journal/2026-07-nightshift-metrics.md
@@ -1,0 +1,18 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-06
+Source of Truth: R1 queue note for autonomous-operation metrics reporting.
+
+# Nightshift Metrics Journal
+
+## 2026-07-06 nightshift-metrics-aggregator - Add autonomous run metrics
+
+Problem: queue task `30-metrics-aggregator` needs a local Markdown metric
+surface for the last 14 days of autonomous operation.
+Target state: `tools/quality/scripts/nightshift_metrics.py` reads live GitHub
+data through `gh api`, prints merges per day, red required-check share,
+judge failures, reverts, and open acceptance age, and degrades to
+`Metriken heute unvollstaendig` on GitHub API limits or read failures.
+Status report use: the metrics section can be pasted into the German status
+report or called by a future R3c change to the frozen status updater; this R1
+slice does not edit `tools/quality/scripts/update_status_issue.py`.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -5,6 +5,9 @@ Source of Truth: July 2026 SaltMarcher committed work journal.
 
 # July 2026 Journal
 
+Branch-protection readbacks are tracked in
+[July 2026 Branch Protection Readbacks](2026-07-branch-protection-readbacks.md).
+
 ## 2026-07-04 governance-simplification - Simplify agent workflow governance
 
 The governance model at baseline commit `ef8c7eb6d` used a CR, roadmap,
@@ -49,24 +52,6 @@ signoff, template render check, and updater install.
 Done when: documentation and production handoff gates pass locally, live
 branch-protection readback later reports `Qualified`, and owner actions are
 ticked in the status report.
-
-## 2026-07-05T00:30:25+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Not Qualified`.
-Observed required checks: Branch not protected (HTTP 404).
-
-## 2026-07-05T08:06:13+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Qualified`.
-Observed required checks: quality-platforms / behavior-gate, quality-platforms / judge-review, quality-platforms / production-handoff, quality-platforms / warden-freeze.
-
-## 2026-07-05T09:15:17+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Qualified`.
-Observed required checks: quality-platforms / behavior-gate, quality-platforms / judge-review, quality-platforms / production-handoff, quality-platforms / warden-freeze.
 
 ## 2026-07-05 third-party-advisory-skip - Avoid false red advisory summaries
 
@@ -140,12 +125,6 @@ Done when: local self-tests and syntax checks pass, documentation enforcement
 passes, production handoff is attempted on the final checkout, and remaining
 owner/live actions are reported as explicit blockers.
 
-## 2026-07-05T12:36:47+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Qualified`.
-Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze; required approving reviews 0 and code-owner reviews false.
-
 ## 2026-07-05 phase2-activation-n1 - Record live DoD proof PRs
 
 Problem: after the target-operating-model gates reached `main`, the Phase 2
@@ -186,12 +165,6 @@ Deviations:
 
 Done when: P1-P5 evidence is retained, P6 has owner disposition, and P7 is
 rerun to a model verdict instead of a budget failure.
-
-## 2026-07-05T13:30:19+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Qualified`.
-Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.
 
 ## 2026-07-05 phase3-bootstrap-judge-handoff - One-shot old-judge bridge
 
@@ -342,12 +315,6 @@ real-local updater paths; unfreeze broad non-instrument support.
 De-ceremony: remove `gate-change-approved`; PR `#384` gets a one-shot old-judge
 skip for branch `codex/phase3-honest-instruments`, then post-merge attack PRs
 must prove warden bypass, judge always-PASS, and harness shrink red.
-
-## 2026-07-05T18:18:36+00:00 branch-protection-readback
-
-Repository: `ThonkTank/Salt-Marcher` branch `main` actor `<local>`.
-Status: `Qualified`.
-Observed required checks: behavior-gate, judge-review, production-handoff, warden-freeze.
 
 ## 2026-07-06 judge-override-owner-events - Require owner-set override label
 

--- a/tools/quality/scripts/nightshift_metrics.py
+++ b/tools/quality/scripts/nightshift_metrics.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Print a compact 14-day autonomous-operation metrics section."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.parse
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+QUALITY_WORKFLOW = "quality-platforms.yml"
+REQUIRED_CHECKS = {
+    "production-handoff",
+    "warden-freeze",
+    "behavior-gate",
+    "judge-review",
+}
+RED_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+INCOMPLETE_LINE = "Metriken heute unvollstaendig"
+
+
+@dataclass(frozen=True)
+class Metrics:
+    days: int
+    since: datetime
+    until: datetime
+    merges_by_day: Counter[str]
+    required_check_total: int
+    required_check_red: int
+    judge_failures: int
+    reverts: list[str]
+    open_acceptances: list[tuple[int, str, int]]
+
+
+class IncompleteMetrics(RuntimeError):
+    pass
+
+
+def gh_api(path: str) -> Any:
+    result = subprocess.run(
+        ["gh", "api", path],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode != 0:
+        raise IncompleteMetrics(compact_error(result.stdout))
+    try:
+        return json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise IncompleteMetrics("GitHub API returned invalid JSON") from exc
+
+
+def compact_error(raw: str) -> str:
+    text = raw.strip()
+    if not text:
+        return "empty GitHub API response"
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return text.splitlines()[-1][:180]
+    message = str(payload.get("message") or "unknown GitHub API error")
+    status = payload.get("status")
+    if status:
+        return f"{message} (HTTP {status})"
+    return message
+
+
+def repo_qualifier() -> str:
+    payload = gh_api("repos/:owner/:repo")
+    full_name = payload.get("full_name")
+    if not full_name:
+        raise IncompleteMetrics("GitHub repository name was not returned")
+    return str(full_name)
+
+
+def collect_metrics(days: int, now: datetime | None = None) -> Metrics:
+    until = now or datetime.now(timezone.utc)
+    since = until - timedelta(days=days)
+    repo = repo_qualifier()
+    merged_prs = search_issues(
+        f"repo:{repo} is:pr is:merged base:main merged:>={since.date().isoformat()}"
+    )
+    acceptance_issues = search_issues(f"repo:{repo} is:issue is:open label:abnahme-offen")
+    workflow_runs = workflow_runs_since(since)
+
+    jobs = []
+    for run in workflow_runs:
+        run_id = run.get("id")
+        if run_id:
+            jobs.extend(workflow_jobs(str(run_id)))
+
+    return build_metrics(days, since, until, merged_prs, acceptance_issues, jobs)
+
+
+def search_issues(query: str) -> list[dict[str, Any]]:
+    encoded = urllib.parse.urlencode({"q": query, "per_page": "100"})
+    payload = gh_api(f"search/issues?{encoded}")
+    return list(payload.get("items") or [])
+
+
+def workflow_runs_since(since: datetime) -> list[dict[str, Any]]:
+    created = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+    encoded = urllib.parse.urlencode(
+        {
+            "branch": "main",
+            "created": f">={created}",
+            "per_page": "100",
+        }
+    )
+    payload = gh_api(f"repos/:owner/:repo/actions/workflows/{QUALITY_WORKFLOW}/runs?{encoded}")
+    return list(payload.get("workflow_runs") or [])
+
+
+def workflow_jobs(run_id: str) -> list[dict[str, Any]]:
+    payload = gh_api(f"repos/:owner/:repo/actions/runs/{run_id}/jobs?per_page=100")
+    return list(payload.get("jobs") or [])
+
+
+def build_metrics(
+    days: int,
+    since: datetime,
+    until: datetime,
+    merged_prs: list[dict[str, Any]],
+    acceptance_issues: list[dict[str, Any]],
+    jobs: list[dict[str, Any]],
+) -> Metrics:
+    merges_by_day: Counter[str] = Counter()
+    reverts: list[str] = []
+    for pr in merged_prs:
+        merged_at = parse_github_time(pr.get("closed_at"))
+        if merged_at:
+            merges_by_day[merged_at.date().isoformat()] += 1
+        title = str(pr.get("title") or "")
+        if "revert" in title.lower():
+            reverts.append(format_item(pr))
+
+    required_jobs = [job for job in jobs if job.get("name") in REQUIRED_CHECKS]
+    red_jobs = [job for job in required_jobs if str(job.get("conclusion") or "").lower() in RED_CONCLUSIONS]
+    judge_failures = sum(
+        1
+        for job in required_jobs
+        if job.get("name") == "judge-review" and str(job.get("conclusion") or "").lower() in RED_CONCLUSIONS
+    )
+    open_acceptances = []
+    for issue in acceptance_issues:
+        created_at = parse_github_time(issue.get("created_at"))
+        age = (until.date() - created_at.date()).days if created_at else 0
+        open_acceptances.append((int(issue.get("number") or 0), str(issue.get("title") or "<untitled>"), age))
+    open_acceptances.sort(key=lambda item: (-item[2], item[0]))
+
+    return Metrics(
+        days=days,
+        since=since,
+        until=until,
+        merges_by_day=merges_by_day,
+        required_check_total=len(required_jobs),
+        required_check_red=len(red_jobs),
+        judge_failures=judge_failures,
+        reverts=sorted(reverts),
+        open_acceptances=open_acceptances,
+    )
+
+
+def parse_github_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def format_item(item: dict[str, Any]) -> str:
+    number = item.get("number", "?")
+    title = str(item.get("title") or "<untitled>")
+    return f"#{number} {title}"
+
+
+def render_markdown(metrics: Metrics, *, title: bool = True) -> str:
+    lines: list[str] = []
+    if title:
+        lines.extend(["## Autodev-Metriken (14 Tage)", ""])
+    start = metrics.since.date().isoformat()
+    end = metrics.until.date().isoformat()
+    average = sum(metrics.merges_by_day.values()) / metrics.days if metrics.days else 0.0
+    if metrics.required_check_total:
+        red_share = metrics.required_check_red / metrics.required_check_total * 100
+        red_text = f"{metrics.required_check_red}/{metrics.required_check_total} ({red_share:.1f}%)"
+    else:
+        red_text = "0/0 (keine Laeufe gefunden)"
+
+    lines.extend(
+        [
+            f"- Zeitraum: {start} bis {end}.",
+            f"- Merges/Tag: {average:.2f} im Schnitt ({sum(metrics.merges_by_day.values())} Merges gesamt).",
+            f"- Rote Required-Check-Laeufe: {red_text}.",
+            f"- Judge-FAILs: {metrics.judge_failures}.",
+            f"- Reverts: {len(metrics.reverts)}" + (f" ({'; '.join(metrics.reverts[:5])})" if metrics.reverts else "."),
+            f"- Offene Abnahmen: {len(metrics.open_acceptances)}" + format_acceptance_tail(metrics.open_acceptances),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def format_acceptance_tail(items: list[tuple[int, str, int]]) -> str:
+    if not items:
+        return "."
+    rendered = [f"#{number} {age}d" for number, _title, age in items[:5]]
+    return f" ({', '.join(rendered)})."
+
+
+def render_incomplete(message: str, *, title: bool = True) -> str:
+    lines = []
+    if title:
+        lines.extend(["## Autodev-Metriken (14 Tage)", ""])
+    lines.append(f"- {INCOMPLETE_LINE}: {message}.")
+    return "\n".join(lines)
+
+
+def run_selftest() -> int:
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=timezone.utc)
+    metrics = build_metrics(
+        14,
+        now - timedelta(days=14),
+        now,
+        [
+            {"number": 101, "title": "Feature slice", "closed_at": "2026-07-05T10:00:00Z"},
+            {"number": 102, "title": "Revert broken gate", "closed_at": "2026-07-05T11:00:00Z"},
+        ],
+        [
+            {"number": 77, "title": "Abnahme offen", "created_at": "2026-07-01T09:00:00Z"},
+        ],
+        [
+            {"name": "production-handoff", "conclusion": "success"},
+            {"name": "judge-review", "conclusion": "failure"},
+            {"name": "codescene", "conclusion": "failure"},
+        ],
+    )
+    text = render_markdown(metrics)
+    assert "Merges/Tag: 0.14" in text
+    assert "Rote Required-Check-Laeufe: 1/2 (50.0%)" in text
+    assert "Judge-FAILs: 1" in text
+    assert "Reverts: 1 (#102 Revert broken gate)" in text
+    assert "Offene Abnahmen: 1 (#77 5d)" in text
+    assert INCOMPLETE_LINE in render_incomplete("rate limit")
+    print("nightshift_metrics selftest PASS")
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=14)
+    parser.add_argument("--no-title", action="store_true")
+    parser.add_argument("--selftest", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.selftest:
+        return run_selftest()
+    try:
+        metrics = collect_metrics(args.days)
+    except IncompleteMetrics as exc:
+        print(render_incomplete(str(exc), title=not args.no_title))
+        return 0
+    print(render_markdown(metrics, title=not args.no_title))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Problem: queue task 30-metrics-aggregator needs a local Markdown metrics surface for recent autonomous operation.

Evidence: added tools/quality/scripts/nightshift_metrics.py using gh api for 14-day merges, red required-check share, judge failures, reverts, and open acceptance age; the R1 diff does not edit the frozen status updater path. The metrics section can be pasted into the German status report or wired into tools/quality/scripts/update_status_issue.py only through a future risk:R3c frozen-surface change.

Expected benefit: the continuous status process can obtain operational health metrics without manual GitHub queries, while rate-limit/API failures remain visible as 'Metriken heute unvollstaendig' instead of blocking publication.

Risk: risk:R1 tooling/status evidence and documentation hygiene.

Local proof:
- nice -n 19 ionice -c 3 python3 tools/quality/scripts/nightshift_metrics.py --selftest -> PASS
- GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=/tmp/warden-pr-event.json nice -n 19 ionice -c 3 python3 tools/quality/scripts/warden_freeze.py -> warden-freeze: passed
- nice -n 19 ionice -c 3 python3 tools/quality/scripts/nightshift_metrics.py -> printed live 14-day metrics: 18 merges, 4/72 red required-check runs, 0 judge FAILs, 0 reverts, 0 open acceptances
- nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain -> BUILD SUCCESSFUL
- nice -n 19 ionice -c 3 tools/gradle/run-staged-verification.sh production-handoff -> BUILD SUCCESSFUL

CI proof:
- quality-platforms / production-handoff -> SUCCESS
- quality-platforms / warden-freeze -> SUCCESS
- quality-platforms / behavior-gate -> SUCCESS
- quality-platforms / judge-review -> SUCCESS

Notes: docs/project/journal/2026-07.md was already over the 350-line documentation cap, so repeated branch-protection readback entries were mechanically split into docs/project/journal/2026-07-branch-protection-readbacks.md.
