### PR TITLE
Fix project health debt reference links

### DIFF
--- a/docs/project/architecture/project-health-debt.md
+++ b/docs/project/architecture/project-health-debt.md
@@ -54,7 +54,7 @@ participate in automatic debt intake. `Related Symbols` are searchable context
 only; add a matching path or owner token to `Intake Trigger` when a symbol
 should pull debt into a later pass.
 Resolver field transitions are defined by the
-[Project Health resolver dispositions](docs/project/architecture/project-health.md:1).
+[Project Health resolver dispositions](project-health.md:1).
 
 ## Active Debt
 
@@ -81,5 +81,5 @@ No active project-health debt has been registered under this governance.
 
 ## References
 
-- [Project Health Standard](docs/project/architecture/project-health.md:1)
-- [Project Health Skill](tools/quality/skills/project-health/SKILL.md:1)
+- [Project Health Standard](project-health.md:1)
+- [Project Health Skill](../../../tools/quality/skills/project-health/SKILL.md:1)


### PR DESCRIPTION
Problem: The Project Health Debt Register had self-references that resolved under docs/project/architecture/ twice and a skill link that resolved under the architecture docs folder instead of the repo root.

Evidence: Corrected the three relative Markdown targets in docs/project/architecture/project-health-debt.md; local proof passed with nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain.

Expected benefit: Readers can navigate from the debt register to the Project Health standard and project-health skill without manually correcting broken relative paths.

Risk: risk:R0 documentation-only link repair.

Local proof:
- nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain -> PASS, BUILD SUCCESSFUL in 48s

Selection notes:
- AUTODEV_QUEUE_TASK unset; queue directory contained no NN-*.md files.
- no_r1 quota active; no new risk:R1 PR created.
- Open owner-feedback issue #361 is a status report with Owner-action blockers and no repo-local implementation task.
- Harness gaps remain, but a new harness PR would be R1/R3c work under no_r1; existing #401 is already open and green.
- Project-health debt register has no active debt; migration/self-directed R1 work skipped under quota.