### PR TITLE
Clarify autonomous quota admission

### DIFF
--- a/docs/project/architecture/night-shift.md
+++ b/docs/project/architecture/night-shift.md
@@ -32,7 +32,8 @@ or documentation improvements under the normal gates.
 Quotas use rolling windows, not calendar nights.
 
 - P0/P1 regression work is quota-exempt and interrupts lower-priority work.
-- Maximum 3 autonomous merges per rolling 24-hour window.
+- Stop admitting new autonomous work after 4 auto-promote PR merges in the
+  rolling 24-hour window.
 - Maximum 1 R1 architecture slice per rolling 24-hour window.
 - Maximum 1 migration slice per rolling 7-day window.
 - Stop migration work while any P0/P1 owner issue is open.
@@ -41,9 +42,12 @@ Every autonomous improvement PR states Problem, Evidence, and Expected benefit
 in one line each. Every autonomous run emits the configured telemetry and final
 status report for the external runner.
 
-The quota bounds volume. Prefer reversible, evidence-backed improvements over
-asking the owner for technical direction when no higher-priority work is
-pending.
+The merge-count quota bounds admission of new autonomous work. It does not cap
+completion of already-open auto-promote PRs that existed before the current
+runner session, have green required checks, are mergeable, are not drafts, and
+carry only auto-promote risk classes. Prefer reversible, evidence-backed
+improvements over asking the owner for technical direction when no
+higher-priority work is pending.
 
 ## Updater Exclusivity
 


### PR DESCRIPTION
Problem: The night-shift quota text still described the autonomous bound as a hard merge cap, which conflicts with the runner behavior that continues already-open green auto-promote PRs for traceability.

Evidence: Live autodev session 43 merged existing green PR #399 while quota counts were already above the new-work threshold; independent review found the old doc wording drifted from the installed runner.

Expected benefit: Quotas throttle admission of new autonomous work without stranding already-reviewed PRs outside the PR merge trail.

Risk: R0 docs-only architecture clarification.

Verification:
- ./gradlew checkDocumentationEnforcement --console=plain -> BUILD SUCCESSFUL in 29s
- independent read-only architecture review: no Must Fix Before Handoff findings after final branch review
