### PR TITLE
Make autodev repair-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,17 +14,17 @@ Always run verification from the repository root.
 
 1. Work on a feature branch. Do not commit to `main`; merge through a PR with green CI.
 2. A pass whose required verify command has not literally passed is WIP. Report the literal result at handoff.
-3. Architecture is enforced by `tools/gradle/build-harness` and Error Prone rules. Do not weaken, disable, suppress, or bypass a check to make a build pass; report a blocker instead.
-4. Transitional or superseded support you knowingly leave behind gets a `LEGACY_REMOVE_ON_TOUCH` marker plus a concrete removal condition. When your write set contains such a marker, remove the marked support in the same pass or report it as a blocker.
+3. Architecture is enforced by `tools/gradle/build-harness` and Error Prone rules. Do not weaken, disable, suppress, or bypass a check to make a build pass; fix the cause or record a concrete repair target.
+4. Transitional or superseded support you knowingly leave behind gets a `LEGACY_REMOVE_ON_TOUCH` marker plus a concrete removal condition. When your write set contains such a marker, remove the marked support in the same pass or record a concrete repair target.
 5. Structural findings you cannot fix in the same pass get a `PROJECT_HEALTH_DEBT` marker at the primary cause and an entry in `docs/project/architecture/project-health-debt.md`.
-6. Before editing a surface, read its owner doc and skill from the table below. If a surface has no clear owner, stop and report instead of creating a second source of truth.
-7. Behavior changes and new behavior-bearing concepts need an owning behavior harness: extend it, create it, or report a `Harness Gap` blocker. Harnesses prove production routes; avoid fixture selftests and meta-test layers. New central build/check gates require explicit user request.
+6. Before editing a surface, read its owner doc and skill from the table below. If a surface has no clear owner, create a narrow documentation repair target instead of creating a second source of truth.
+7. Behavior changes and new behavior-bearing concepts need an owning behavior harness: extend it, create it, or record a `Harness Gap` repair target. Harnesses prove production routes; avoid fixture selftests and meta-test layers. New central build/check gates require explicit user request.
 8. Record notable decisions, incidents, and repeated fixes in `docs/project/journal/YYYY-MM.md`; see `docs/project/architecture/work-logs.md`.
 9. Risk class is mandatory on PRs: R0 docs/comments/small reversible refactor;
    R1 behavior-neutral structure, architecture, dependency, or tooling; R2
    visible behavior; R3a real local data migration; R3b external service,
    cost, account, or data egress; R3c frozen gate surface.
-10. The owner decides visible behavior, priorities, acceptance, data, cost, and
+10. The owner decides stable acceptance, data, cost, and outside-policy
     consent. The system decides technical matters autonomously; see
     `docs/project/architecture/autonomy-boundaries.md`.
 11. Forbidden autonomous actions: real local data modification without a
@@ -33,7 +33,7 @@ Always run verification from the repository root.
     silent R2 behavior; merge with red or skipped required checks.
 12. When product options exist, implement the recommended option as provisional
     R2 on `main`/next, flag it in the German release note and status report,
-    and do not auto-promote.
+    and do not promote to stable before owner acceptance.
 13. For owner-reported bugs or features, first restate expected behavior,
     reproduction, acceptance criteria, affected surfaces, and proof route in
     the issue; then implement.
@@ -42,9 +42,9 @@ Always run verification from the repository root.
 
 - `R0`: docs/comments/small reversible refactor; doc gate or production-handoff; auto-promote.
 - `R1`: behavior-neutral structure, architecture, dependency, or tooling; R0 plus touched behavior harnesses and judge review; auto-promote.
-- `R2`: visible behavior; R1 plus German release note and acceptance checklist; promote only after owner acceptance.
+- `R2`: visible behavior; R1 plus German release note and acceptance checklist; auto-promote as provisional next/main work, promote to stable only after owner acceptance.
 - `R3a`: real local data migration; verified restore-tested backup and copy dry run; auto-promote after backup proof.
-- `R3b`: external service, cost, account, or data egress; must fit `docs/project/policies/resource-policy.md` or ask owner with recommendation/default.
+- `R3b`: external service, cost, account, or data egress; must fit `docs/project/policies/resource-policy.md`; outside-policy work creates a policy/no-action PR instead of blocking in chat.
 - `R3c`: frozen gate surface; requires R3c label and the full required gate set; auto-promote after merge.
 
 ## Surface Owners
@@ -63,7 +63,7 @@ Always run verification from the repository root.
 | External-source-backed decisions | `docs/project/verification/source-references.md` | `source-references` |
 | Resource policy and operating model | `docs/project/policies/resource-policy.md`, `docs/project/decisions/**` | - |
 
-Harness Gap blockers reference `docs/project/verification/harness-gaps.md`.
+Harness Gap repair targets reference `docs/project/verification/harness-gaps.md`.
 Continuous autonomous work follows `docs/project/architecture/night-shift.md`.
 Autonomous decision boundaries are defined in
 `docs/project/architecture/autonomy-boundaries.md`.

--- a/docs/project/architecture/autonomy-boundaries.md
+++ b/docs/project/architecture/autonomy-boundaries.md
@@ -30,10 +30,16 @@ rules, and documentation are agent-owned unless they are explicitly listed.
 
 ## Owner Questions
 
-Ask the owner only for product outcomes with genuinely different visible
-behavior, or for an outside-policy R3b external action. R2 work may land as a
-provisional recommendation on `main`/next with a German release note and owner
-acceptance before promotion.
+Ask the owner only for stable acceptance, real user-data consent, cost, or an
+outside-policy external action. Do not ask the owner to decide architecture,
+refactoring, CI repair, red-check repair, harness gaps, migration mechanics, or
+ordinary provisional next/main behavior.
+
+R2 work may land autonomously as a provisional recommendation with a German
+release note and acceptance checklist. R3a work may land autonomously after a
+restore-tested backup and copy dry run. R3b work may land autonomously when it
+fits `docs/project/policies/resource-policy.md`; outside-policy R3b work
+prepares a policy/no-action PR instead of waiting in chat.
 
 `Entscheid du`, `nimm den Default`, or equivalent wording means: apply the
 agent's recommendation with the safest reasonable rollback and move on.
@@ -43,3 +49,7 @@ agent's recommendation with the safest reasonable rollback and move on.
 Reversibility is the safety model. `main` can be reset or reverted to a prior
 commit, and the owner's daily testing of next/stable remains the behavior
 acceptance gate no agent can replace.
+
+Cost and provider availability are the only normal hard stops for continuous
+autonomous operation. Red checks, P0/P1 findings, dirty checkouts, updater
+windows, missing harnesses, and failed reviews become autonomous repair work.

--- a/docs/project/architecture/night-shift.md
+++ b/docs/project/architecture/night-shift.md
@@ -27,40 +27,52 @@ No qualifying work found is a valid result only after checking the full order
 above. Self-directed work may include refactors, debt paydown, test additions,
 or documentation improvements under the normal gates.
 
-## Rolling Quotas
+## Cost-Only Stop
 
-Quotas use rolling windows, not calendar nights.
+The runner keeps working unless the configured provider, account, or local
+machine makes work technically unavailable. Merge, R1, migration, red-check,
+P0/P1, owner-feedback, dirty-checkout, and updater-window states are work
+inputs, not stop conditions.
 
-- P0/P1 regression work is quota-exempt and interrupts lower-priority work.
-- Stop admitting new autonomous work after 4 auto-promote PR merges in the
-  rolling 24-hour window.
-- Maximum 1 R1 architecture slice per rolling 24-hour window.
-- Maximum 1 migration slice per rolling 7-day window.
-- Stop migration work while any P0/P1 owner issue is open.
+- P0/P1 regression work interrupts lower-priority work and becomes the next
+  repair target.
+- Rolling merge, R1, migration, and judge counts are telemetry and
+  backpressure signals only. They may reduce slice size or increase the pause
+  between sessions, but they must not prohibit new R0/R1/R2/R3a/R3b/R3c work.
+- Red or unclear required checks must never be merged. They become the next
+  repair target on the same PR or a narrow repair PR.
+- R2 work may land as a provisional recommendation with a German release note
+  and acceptance checklist. Owner acceptance gates stable promotion, not the
+  autonomous PR.
+- R3a work may proceed after a restore-tested backup and copy dry run are
+  proven in the PR.
+- R3b work may proceed when it fits `docs/project/policies/resource-policy.md`.
+  Outside-policy work creates a policy/no-action PR instead of waiting in chat.
 
 Every autonomous improvement PR states Problem, Evidence, and Expected benefit
 in one line each. Every autonomous run emits the configured telemetry and final
 status report for the external runner.
 
-The merge-count quota bounds admission of new autonomous work. It does not cap
-completion of already-open auto-promote PRs that existed before the current
-runner session, have green required checks, are mergeable, are not drafts, and
-carry only auto-promote risk classes. Prefer reversible, evidence-backed
-improvements over asking the owner for technical direction when no
+`no_work` is valid only after the runner checked queue tasks, owner issues,
+open green PRs, red PRs, harness gaps, project-health debt, legacy markers,
+TODO/FIXME markers, CI/telemetry signals, and at least one scoped scout for a
+small reversible improvement. Prefer reversible, evidence-backed repair or
+improvement work over asking the owner for technical direction when no
 higher-priority work is pending.
 
 ## Updater Exclusivity
 
 Treat `saltmarcher-update.service`, `tools/local/saltmarcher-update.sh`, and
 stable-promotion updater verification as exclusive local checkout windows. Do
-not start or continue autonomous git-mutating work, Gradle proof, PR creation,
-or merge-watch activity in the same checkout while one of those paths is active.
+not start git-mutating work, Gradle proof, PR creation, or merge-watch activity
+in the same checkout while one of those paths is active. Wait for the window to
+close and continue automatically; do not treat it as an owner blocker.
 
 ## Budget
 
 Do not skip or bypass `judge-review` for R1+ work. If the configured
-provider/account limit or API availability blocks judge execution, fail closed
-and report the blocker.
+provider/account limit or API availability blocks judge execution, back off and
+retry later without bypassing the gate.
 
 ## Migration Slice Rule
 

--- a/docs/project/journal/2026-07-continuous-autonomous-operation.md
+++ b/docs/project/journal/2026-07-continuous-autonomous-operation.md
@@ -19,3 +19,23 @@ Scope boundary: documentation and instruction routing only; no production
 code, CI gates, branch protection, runner state, or migration behavior.
 Done when: documentation enforcement passes, the PR carries `risk:R1`, and the
 queue sentinel is written only after the PR is merged.
+
+## 2026-07-06 cost-only-stop-autodev - Make repair the default loop action
+
+Problem: the live runner still turned quota, red-check, risk-protocol, and
+operator uncertainty into `no_work` or blocker churn even though the desired
+operating model is continuous autonomous repair.
+Target state: only provider/account cost limits or local technical
+unavailability create backoff. Red gates, P0/P1, R2/R3a/R3b protocol needs,
+dirty checkouts, updater windows, missing harnesses, and failed reviews become
+the next repair or scout target.
+Alternatives considered: raising merge/R1 limits was rejected because it only
+delays the next artificial stop; keeping owner questions for R2/R3b was
+rejected because provisional next/main work and policy/no-action PRs preserve
+reversibility without stopping the loop.
+Scope boundary: update autonomous-operation docs, AGENTS risk interpretation,
+the installed runner prompt, and the installed runner policy; do not weaken
+required checks or make red/skipped PRs mergeable.
+Done when: docs enforcement passes, runner syntax/dry-run pass, independent
+review finds no cost-only-stop blocker, and live service resumes with quotas as
+telemetry rather than start bans.

--- a/docs/project/journal/2026-07-harness-gaps.md
+++ b/docs/project/journal/2026-07-harness-gaps.md
@@ -1,0 +1,33 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-06
+Source of Truth: July 2026 harness-gap closure journal entries.
+Entry Document: [July 2026 Journal](2026-07.md)
+
+# July 2026 Harness Gap Journal
+
+## 2026-07-06 encounter-state-tab-harness-gap - Close Encounter state-tab harness gap
+
+Problem: `docs/project/verification/harness-gaps.md` listed
+`src/view/statetabs/encounter` as P1 because only the domain-side
+`worldPlannerEncounterHarness` covered Encounter-adjacent behavior.
+Target state: add a focused `encounterStateTabHarness` that opens the Encounter
+state tab through the shell binding and proves saved encounter readback renders
+through the contribution/view route.
+Scope boundary: this pass changes only the harness, harness registration,
+harness map, gap register, and journal; it does not alter visible Encounter
+behavior or persistence.
+
+## 2026-07-06 party-dropdown-harness-gap - Close Party dropdown harness gap
+
+Problem: `docs/project/verification/harness-gaps.md` listed
+`src/domain/party` and `src/view/dropdowns/party` as P1 because no dedicated
+Party behavior harness covered dropdown-driven active-party publication.
+Target state: add a focused `partyDropdownHarness` that creates a character
+through the Party top-bar intent route, moves it between active and reserve
+membership through production `PartyApplicationService`, and verifies
+`PartySnapshotModel`, `ActivePartyModel`, active composition, and top-bar
+projection readback.
+Scope boundary: this pass changes only the harness, harness registration,
+harness map, gap register, and journal; it does not alter visible Party
+behavior or persistence.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -330,36 +330,12 @@ Done when: the mocked-event selftest and full local gate suite pass, the R3c
 PR merges, and a trivial R1 follow-up PR receives a normal `judge-review` PASS
 before the queue done sentinel is written.
 
-## 2026-07-06 encounter-state-tab-harness-gap - Close Encounter state-tab harness gap
-
-Problem: `docs/project/verification/harness-gaps.md` listed
-`src/view/statetabs/encounter` as P1 because only the domain-side
-`worldPlannerEncounterHarness` covered Encounter-adjacent behavior.
-Target state: add a focused `encounterStateTabHarness` that opens the Encounter
-state tab through the shell binding and proves saved encounter readback renders
-through the contribution/view route.
-Scope boundary: this pass changes only the harness, harness registration,
-harness map, gap register, and journal; it does not alter visible Encounter
-behavior or persistence.
+Harness-gap closure entries are split to
+[July 2026 Harness Gap Journal](2026-07-harness-gaps.md).
 
 ## 2026-07-06 judge-override-followup-proof - Exercise normal R1 judge path
 
-Queue `20-judge-override` still needs a post-merge R1 follow-up proof after
-PR `#398`. Add a narrow mocked selftest for a plain `risk:R1` PR without
+Queue `20-judge-override` still needs a post-merge R1 follow-up proof after PR
+`#398`. Add a narrow mocked selftest for a plain `risk:R1` PR without
 `judge-override`: the normal judge path must call the judge provider and must
-not read label events. This follow-up PR exists only to obtain a normal
-`judge-review` PASS before writing the queue done sentinel.
-
-## 2026-07-06 party-dropdown-harness-gap - Close Party dropdown harness gap
-
-Problem: `docs/project/verification/harness-gaps.md` listed
-`src/domain/party` and `src/view/dropdowns/party` as P1 because no dedicated
-Party behavior harness covered dropdown-driven active-party publication.
-Target state: add a focused `partyDropdownHarness` that creates a character
-through the Party top-bar intent route, moves it between active and reserve
-membership through production `PartyApplicationService`, and verifies
-`PartySnapshotModel`, `ActivePartyModel`, active composition, and top-bar
-projection readback.
-Scope boundary: this pass changes only the harness, harness registration,
-harness map, gap register, and journal; it does not alter visible Party
-behavior or persistence.
+not read label events before writing the queue done sentinel.


### PR DESCRIPTION
Problem: The continuous runner still treated quota, red-check, risk-protocol, and uncertainty states as no_work/blocker churn even though the target operating model is autonomous repair.

Evidence: Live sessions repeatedly entered p0p1_only/no_r1 despite open useful work; user goal is cost-only stop and autonomous handling of red gates, P0/P1, R2/R3a/R3b protocol work, dirty checkouts, updater windows, harness gaps, and failed reviews.

Expected benefit: The runner keeps producing or repairing useful PRs 24/7; counters become telemetry/backpressure instead of start bans, and red/skipped checks stay unmergeable while becoming repair targets.

Risk: R1 agent/governance and runner operating-model change.

Verification:
- bash -n /tmp/saltmarcher-autodev.sh -> exit 0
- AUTODEV_DRY_RUN=1 bash /tmp/saltmarcher-autodev.sh with tmp XDG dirs -> exit 0; local report only
- ./gradlew checkDocumentationEnforcement --console=plain -> BUILD SUCCESSFUL in 12s
- independent read-only review: no Must Fix Before Handoff before install; follow-up requested after naming cleanup/install

Live install:
- Installed reviewed runner and prompt to user-local autodev paths.
- Restarted saltmarcher-autodev.service; service active and starts with backpressure telemetry mode=merge_pressure,r1_pressure instead of p0p1_only/no_r1.
