### PR TITLE
Add party dropdown behavior harness

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -438,6 +438,7 @@ val catalogInitialLoadHarnessDataDir = layout.buildDirectory.dir("catalog-initia
 val catalogCrudControlsHarnessDataDir = layout.buildDirectory.dir("catalog-crud-controls-data")
 val catalogControlsRawInputHarnessDataDir = layout.buildDirectory.dir("catalog-controls-raw-input-data")
 val searchFilterControlsHarnessDataDir = layout.buildDirectory.dir("search-filter-controls-data")
+val partyDropdownHarnessDataDir = layout.buildDirectory.dir("party-dropdown-data")
 val hexMapEditorBehaviorHarnessDataDir = layout.buildDirectory.dir("hex-map-editor-behavior-data")
 val sessionPlannerCatalogHarnessDataDir = layout.buildDirectory.dir("session-planner-catalog-data")
 val sessionPlannerShellLayoutHarnessDataDir = layout.buildDirectory.dir("session-planner-shell-layout-data")
@@ -518,6 +519,26 @@ behaviorHarnesses.javaExec("searchFilterControlsHarness") {
         outputs.upToDateWhen { false }
         doFirst {
             val runDataDir = searchFilterControlsHarnessDataDir.get()
+                .dir("run-" + System.currentTimeMillis() + "-" + ProcessHandle.current().pid())
+            mkdir(runDataDir)
+            mkdir(runDataDir.dir("salt-marcher"))
+            environment("XDG_DATA_HOME", runDataDir.asFile.absolutePath)
+        }
+    }
+}
+
+behaviorHarnesses.javaExec("partyDropdownHarness") {
+    classification.set(BehaviorHarnessClassification.FOCUSED)
+    conceptIds.set(listOf("party-dropdown"))
+    task {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        description = "Run the Party dropdown active-party behavior harness."
+        dependsOn(tasks.named("testClasses"))
+        classpath = sourceSets["test"].runtimeClasspath
+        mainClass.set("src.view.dropdowns.party.PartyDropdownHarness")
+        outputs.upToDateWhen { false }
+        doFirst {
+            val runDataDir = partyDropdownHarnessDataDir.get()
                 .dir("run-" + System.currentTimeMillis() + "-" + ProcessHandle.current().pid())
             mkdir(runDataDir)
             mkdir(runDataDir.dir("salt-marcher"))

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -349,3 +349,17 @@ PR `#398`. Add a narrow mocked selftest for a plain `risk:R1` PR without
 `judge-override`: the normal judge path must call the judge provider and must
 not read label events. This follow-up PR exists only to obtain a normal
 `judge-review` PASS before writing the queue done sentinel.
+
+## 2026-07-06 party-dropdown-harness-gap - Close Party dropdown harness gap
+
+Problem: `docs/project/verification/harness-gaps.md` listed
+`src/domain/party` and `src/view/dropdowns/party` as P1 because no dedicated
+Party behavior harness covered dropdown-driven active-party publication.
+Target state: add a focused `partyDropdownHarness` that creates a character
+through the Party top-bar intent route, moves it between active and reserve
+membership through production `PartyApplicationService`, and verifies
+`PartySnapshotModel`, `ActivePartyModel`, active composition, and top-bar
+projection readback.
+Scope boundary: this pass changes only the harness, harness registration,
+harness map, gap register, and journal; it does not alter visible Party
+behavior or persistence.

--- a/docs/project/verification/harness-gaps.md
+++ b/docs/project/verification/harness-gaps.md
@@ -19,7 +19,6 @@ the minimal harness proposal needed before a touched area may change.
 
 | Area | Current coverage | Priority | Minimal harness proposal |
 | --- | --- | --- | --- |
-| `src/domain/party`, `src/view/dropdowns/party` | No dedicated party behavior harness | P1 | Add a party dropdown harness that creates, selects, and publishes active-party state through production services. |
 | `src/domain/creatures` | Catalog-adjacent only | P2 | Add a creature catalog domain harness covering create, edit, filter, and readback. |
 | `src/domain/encountertable` | No dedicated encounter-table behavior harness | P2 | Add an encounter-table harness covering table creation, row persistence, and lookup. |
 

--- a/test/src/view/dropdowns/party/PartyDropdownHarness.java
+++ b/test/src/view/dropdowns/party/PartyDropdownHarness.java
@@ -1,0 +1,180 @@
+package src.view.dropdowns.party;
+
+import java.util.List;
+import shell.api.ServiceRegistry;
+import src.domain.party.PartyApplicationService;
+import src.domain.party.published.ActivePartyCompositionModel;
+import src.domain.party.published.ActivePartyModel;
+import src.domain.party.published.AdventuringDaySummaryModel;
+import src.domain.party.published.PartyMemberDetails;
+import src.domain.party.published.PartyMutationModel;
+import src.domain.party.published.PartySnapshotModel;
+import src.domain.party.published.ReadStatus;
+import src.view.slotcontent.topbar.dropdown.DropdownPopupContentModel;
+
+public final class PartyDropdownHarness {
+
+    private PartyDropdownHarness() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            runHarness();
+            System.out.println("Party dropdown harness passed.");
+        } catch (Throwable throwable) {
+            throwable.printStackTrace(System.err);
+            System.exit(1);
+        }
+    }
+
+    private static void runHarness() {
+        ServiceRegistry services = services();
+        PartyTopBarContributionModel presentationModel = new PartyTopBarContributionModel();
+        PartyTopBarIntentHandler intentHandler = new PartyTopBarIntentHandler(
+                presentationModel,
+                new DropdownPopupContentModel(),
+                services.require(PartyApplicationService.class));
+        PartySnapshotModel snapshots = services.require(PartySnapshotModel.class);
+        AdventuringDaySummaryModel daySummaries = services.require(AdventuringDaySummaryModel.class);
+        PartyMutationModel mutations = services.require(PartyMutationModel.class);
+        ActivePartyModel activeParty = services.require(ActivePartyModel.class);
+        ActivePartyCompositionModel activeComposition = services.require(ActivePartyCompositionModel.class);
+
+        applyLoad(presentationModel, snapshots, daySummaries);
+        assertRosterCounts(presentationModel, 0, 0, "initial empty roster");
+
+        intentHandler.consume(createEditorEvent());
+        intentHandler.consume(submitEvent("Aria", "Mira", "3", "14", "16"));
+        applyMutation(presentationModel, snapshots, daySummaries, mutations);
+
+        PartyMemberDetails aria = onlyActiveMember(snapshots);
+        assertEquals("Aria", aria.name(), "created character name");
+        assertRosterCounts(presentationModel, 1, 0, "created character is active");
+        assertActivePublication(activeParty, activeComposition, List.of(aria.id()), List.of(3));
+
+        intentHandler.consume(removeEvent(aria.id()));
+        applyMutation(presentationModel, snapshots, daySummaries, mutations);
+        assertRosterCounts(presentationModel, 0, 1, "remove moves character to reserve");
+        assertActivePublication(activeParty, activeComposition, List.of(), List.of());
+
+        intentHandler.consume(addExistingEvent(aria.id()));
+        applyMutation(presentationModel, snapshots, daySummaries, mutations);
+        assertRosterCounts(presentationModel, 1, 0, "add existing restores active party selection");
+        assertActivePublication(activeParty, activeComposition, List.of(aria.id()), List.of(3));
+        assertEquals("1 Charaktere, Ø Lv 3 ▼",
+                presentationModel.topBarContentModel().triggerTextProperty().get(),
+                "top-bar trigger reflects active published party");
+    }
+
+    private static ServiceRegistry services() {
+        ServiceRegistry.Builder builder = new ServiceRegistry.Builder();
+        new src.data.party.PartyServiceContribution().register(builder);
+        new src.domain.party.PartyServiceContribution().register(builder);
+        return builder.build();
+    }
+
+    private static void applyLoad(
+            PartyTopBarContributionModel presentationModel,
+            PartySnapshotModel snapshots,
+            AdventuringDaySummaryModel daySummaries
+    ) {
+        presentationModel.applyLoadResult(new PartyTopBarContributionModel.PanelData(
+                snapshots.current(),
+                daySummaries.current()));
+    }
+
+    private static void applyMutation(
+            PartyTopBarContributionModel presentationModel,
+            PartySnapshotModel snapshots,
+            AdventuringDaySummaryModel daySummaries,
+            PartyMutationModel mutations
+    ) {
+        presentationModel.applyMutationResult(new PartyTopBarContributionModel.MutationAndLoadResult(
+                mutations.current(),
+                new PartyTopBarContributionModel.PanelData(snapshots.current(), daySummaries.current())));
+    }
+
+    private static PartyRosterTopBarViewInputEvent createEditorEvent() {
+        return new PartyRosterTopBarViewInputEvent(
+                true, false, false, 0L, 0, false, false, false, false, "");
+    }
+
+    private static PartyRosterTopBarViewInputEvent removeEvent(long memberId) {
+        return new PartyRosterTopBarViewInputEvent(
+                false, false, false, memberId, 0, true, false, false, false, "");
+    }
+
+    private static PartyRosterTopBarViewInputEvent addExistingEvent(long memberId) {
+        return new PartyRosterTopBarViewInputEvent(
+                false, false, true, memberId, 0, false, false, false, false, "");
+    }
+
+    private static PartyEditorTopBarViewInputEvent submitEvent(
+            String name,
+            String playerName,
+            String level,
+            String passivePerception,
+            String armorClass
+    ) {
+        return new PartyEditorTopBarViewInputEvent(
+                false,
+                true,
+                false,
+                false,
+                false,
+                new PartyEditorTopBarViewInputEvent.EditorDraft(
+                        name,
+                        playerName,
+                        level,
+                        passivePerception,
+                        armorClass));
+    }
+
+    private static PartyMemberDetails onlyActiveMember(PartySnapshotModel snapshots) {
+        assertEquals(ReadStatus.SUCCESS, snapshots.current().status(), "party snapshot status");
+        List<PartyMemberDetails> activeMembers = snapshots.current().snapshot().activeMembers();
+        assertEquals(Integer.valueOf(1), Integer.valueOf(activeMembers.size()), "active member count");
+        return activeMembers.getFirst();
+    }
+
+    private static void assertRosterCounts(
+            PartyTopBarContributionModel presentationModel,
+            int activeCount,
+            int reserveCount,
+            String label
+    ) {
+        PartyRosterTopBarContentModel.PanelContent panel =
+                presentationModel.rosterContentModel().panelContentProperty().get();
+        assertEquals(Integer.valueOf(activeCount), Integer.valueOf(panel.activeMembers().size()),
+                label + " active count");
+        assertEquals(Integer.valueOf(reserveCount), Integer.valueOf(panel.reserveMembers().size()),
+                label + " reserve count");
+        assertTrue(!panel.loading(), label + " is not loading");
+        assertTrue(!panel.storageError(), label + " has no storage error");
+    }
+
+    private static void assertActivePublication(
+            ActivePartyModel activeParty,
+            ActivePartyCompositionModel activeComposition,
+            List<Long> memberIds,
+            List<Integer> levels
+    ) {
+        assertEquals(ReadStatus.SUCCESS, activeParty.current().status(), "active party status");
+        assertEquals(memberIds, activeParty.current().memberIds(), "active party ids");
+        assertEquals(ReadStatus.SUCCESS, activeComposition.current().status(), "active composition status");
+        assertEquals(levels, activeComposition.current().composition().activePartyLevels(),
+                "active composition levels");
+    }
+
+    private static void assertEquals(Object expected, Object actual, String label) {
+        if (!java.util.Objects.equals(expected, actual)) {
+            throw new AssertionError(label + ": expected <" + expected + "> but was <" + actual + ">.");
+        }
+    }
+
+    private static void assertTrue(boolean condition, String label) {
+        if (!condition) {
+            throw new AssertionError(label);
+        }
+    }
+}

--- a/tools/quality/config/harness-map.json
+++ b/tools/quality/config/harness-map.json
@@ -55,6 +55,9 @@
   ],
   "src/view/slotcontent/controls/catalogcrud/**": ["catalogCrudControlsHarness"],
   "src/view/slotcontent/controls/searchfilter/**": ["searchFilterControlsHarness"],
+  "src/data/party/**": ["partyDropdownHarness"],
+  "src/domain/party/**": ["partyDropdownHarness"],
+  "src/view/dropdowns/party/**": ["partyDropdownHarness"],
   "src/view/leftbartabs/sessionplanner/**": [
     "sessionPlannerCatalogHarness",
     "sessionPlannerShellLayoutHarness"


### PR DESCRIPTION
Problem: docs/project/verification/harness-gaps.md listed src/domain/party and src/view/dropdowns/party as a P1 gap with no dedicated production-route party dropdown harness.\n\nEvidence: Added partyDropdownHarness; local proof passed: nice -n 19 ionice -c 3 ./gradlew partyDropdownHarness --console=plain; local handoff passed: nice -n 19 ionice -c 3 tools/gradle/run-staged-verification.sh production-handoff.\n\nExpected benefit: Party membership create/select publication is now covered through PartyTopBarIntentHandler, PartyApplicationService, PartySnapshotModel, ActivePartyModel, active composition, and top-bar projection readback; the P1 harness-gap row is removed.\n\nRisk: risk:R3c because build.gradle.kts and tools/quality/config/harness-map.json are frozen surfaces.\n\nNotes: No visible Party behavior or persistence semantics changed.