### PR TITLE
Document Dependabot judge secret setup

### DIFF
--- a/docs/project/journal/2026-07-dependabot-maintenance.md
+++ b/docs/project/journal/2026-07-dependabot-maintenance.md
@@ -1,0 +1,35 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-07
+Source of Truth: July 2026 Dependabot maintenance incidents and decisions.
+
+# July 2026 Dependabot Maintenance Journal
+
+## 2026-07-06 dependabot-gradle-toolchain-scope - Keep analysis engines stable
+
+Problem: Dependabot PR `#355` grouped Gradle Wrapper, sqlite, ArchUnit,
+Sonar, PMD, and SpotBugs updates; CI and local `production-handoff` failed on
+new PMD and SpotBugs findings against pre-existing production code.
+Target state: land the wrapper and non-blocking dependency updates while PMD
+and SpotBugs remain on the last green versions until their new findings can be
+handled as explicit quality-debt or cleanup slices.
+Alternatives: fix all 15 PMD findings and SpotBugs nullness findings inside
+the dependency PR, or weaken/suppress the gates. Both exceed the bounded
+dependency-maintenance slice; suppressing or weakening gates is forbidden.
+Scope boundary: change only the PMD/SpotBugs versions and keep all other
+Dependabot updates in the PR.
+Done when: `production-handoff` passes locally and PR `#355` keeps `risk:R3c`
+with required CI green.
+
+## 2026-07-07 dependabot-judge-secret-source - Document Dependabot judge setup
+
+Problem: Dependabot GitHub Actions PRs `#363` and `#364` reached required CI
+with `risk:R3c`, but `judge-review` failed before model review because the run
+used `Secret source: Dependabot` and both judge credential environment values
+were empty.
+Evidence: `gh run view 28828657628 --job 85497479574 --log` and
+`gh run view 28828659589 --job 85497485303 --log` both ended with
+`judge-review: missing ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN`.
+Decision: document the Dependabot-scoped secret requirement instead of
+weakening the required judge gate, changing event trust, or treating skipped
+review as mergeable.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -332,6 +332,8 @@ before the queue done sentinel is written.
 
 Harness-gap closure entries are split to
 [July 2026 Harness Gap Journal](2026-07-harness-gaps.md).
+Dependabot maintenance entries are split to
+[July 2026 Dependabot Maintenance Journal](2026-07-dependabot-maintenance.md).
 
 ## 2026-07-06 judge-override-followup-proof - Exercise normal R1 judge path
 
@@ -339,19 +341,3 @@ Queue `20-judge-override` still needs a post-merge R1 follow-up proof after PR
 `#398`. Add a narrow mocked selftest for a plain `risk:R1` PR without
 `judge-override`: the normal judge path must call the judge provider and must
 not read label events before writing the queue done sentinel.
-
-## 2026-07-06 dependabot-gradle-toolchain-scope - Keep analysis engines stable
-
-Problem: Dependabot PR `#355` grouped Gradle Wrapper, sqlite, ArchUnit,
-Sonar, PMD, and SpotBugs updates; CI and local `production-handoff` failed on
-new PMD and SpotBugs findings against pre-existing production code.
-Target state: land the wrapper and non-blocking dependency updates while PMD
-and SpotBugs remain on the last green versions until their new findings can be
-handled as explicit quality-debt or cleanup slices.
-Alternatives: fix all 15 PMD findings and SpotBugs nullness findings inside
-the dependency PR, or weaken/suppress the gates. Both exceed the bounded
-dependency-maintenance slice; suppressing or weakening gates is forbidden.
-Scope boundary: change only the PMD/SpotBugs versions and keep all other
-Dependabot updates in the PR.
-Done when: `production-handoff` passes locally and PR `#355` keeps `risk:R3c`
-with required CI green.

--- a/docs/project/verification/quality-platforms-ci-and-branch-protection.md
+++ b/docs/project/verification/quality-platforms-ci-and-branch-protection.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-05
+Last Reviewed: 2026-07-07
 Source of Truth: Detailed CI job policy, external service setup, branch
 protection expectations, and review governance for SaltMarcher quality
 platforms.
@@ -195,6 +195,21 @@ result proves the live setting.
 Do not claim "CI blocks merge" or "branch protection is configured" from this
 document alone. Without a fresh API readback, state only that SaltMarcher
 intends the listed GitHub checks to be required.
+
+### Dependabot Judge Secrets
+
+Dependabot pull requests run with GitHub's Dependabot secret source, not the
+normal Actions secret source. Because `judge-review` is a required gate for
+R1+ and R3c work, GitHub Actions dependency PRs need a Dependabot-scoped
+`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` with the same resource-policy
+approval as the normal repository secret. Without that account setup,
+`judge-review` must fail closed with `missing ANTHROPIC_API_KEY or
+CLAUDE_CODE_OAUTH_TOKEN`.
+
+Do not weaken `judge-review`, move the workflow to `pull_request_target`, or
+mark Dependabot R3c PRs as mergeable to work around absent Dependabot secrets.
+Record the affected PR as blocked on owner/account setup or use an owner-set
+`judge-override` only under the owner-only override rule.
 
 ## Review Governance
 


### PR DESCRIPTION
## Problem
Dependabot GitHub Actions PRs #363 and #364 are blocked at required judge-review because Dependabot runs with its own secret source and the judge credentials are empty there.

## Evidence
- PR #363 judge log: run 28828657628 job 85497479574 ended with `judge-review: missing ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN`.
- PR #364 judge log: run 28828659589 job 85497485303 ended with the same missing credential message.
- Initial sandboxed local proof could not start Gradle: `Could not determine a usable wildcard IP for this machine`.
- Escalated local proof passed: `nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain`.

## Expected benefit
Future Dependabot R3c dependency PRs have an explicit owner/account setup target for Dependabot-scoped judge credentials, without weakening judge-review or changing the workflow trust model.

## Risk
risk:R0 - documentation and journal-only change.