### PR TITLE
Correct encountertable harness gap scope

### DIFF
--- a/docs/project/journal/2026-07-harness-gaps.md
+++ b/docs/project/journal/2026-07-harness-gaps.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-06
+Last Reviewed: 2026-07-07
 Source of Truth: July 2026 harness-gap closure journal entries.
 Entry Document: [July 2026 Journal](2026-07.md)
 
@@ -31,3 +31,14 @@ projection readback.
 Scope boundary: this pass changes only the harness, harness registration,
 harness map, gap register, and journal; it does not alter visible Party
 behavior or persistence.
+
+## 2026-07-07 encountertable-gap-contract - Correct EncounterTable gap scope
+
+Problem: the EncounterTable harness-gap row asked for table creation and row
+persistence, but the active EncounterTable domain model says authored rows are
+external SQLite input and the application does not own runtime mutation flows.
+Target state: the open gap now asks for a dedicated readback harness over the
+actual public boundary: authored summary lookup, weighted candidate lookup,
+empty selection, XP ceiling, and storage-error publication.
+Scope boundary: this pass changes only the gap contract and journal evidence;
+it does not close the gap or add new behavior.

--- a/docs/project/verification/harness-gaps.md
+++ b/docs/project/verification/harness-gaps.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-05
+Last Reviewed: 2026-07-07
 Source of Truth: Behavior-harness coverage gaps that must be closed before touched areas change.
 
 # Harness Gaps
@@ -20,7 +20,7 @@ the minimal harness proposal needed before a touched area may change.
 | Area | Current coverage | Priority | Minimal harness proposal |
 | --- | --- | --- | --- |
 | `src/domain/creatures` | Catalog-adjacent only | P2 | Add a creature catalog domain harness covering create, edit, filter, and readback. |
-| `src/domain/encountertable` | No dedicated encounter-table behavior harness | P2 | Add an encounter-table harness covering table creation, row persistence, and lookup. |
+| `src/domain/encountertable` | No dedicated encounter-table behavior harness | P2 | Add an encounter-table readback harness covering authored summary lookup, weighted candidate lookup, empty selection, XP ceiling, and storage-error publication. |
 
 ## Rule
 


### PR DESCRIPTION
Risk: risk:R0

Problem: The EncounterTable harness-gap row requested creation and row persistence proof even though the active domain model says authored SQLite rows are external input and the application owns readback only.

Evidence: docs/encountertable/domain/domain-encountertable.md states the application does not own runtime mutation flows; local proof passed with `nice -n 19 ionice -c 3 ./gradlew checkDocumentationEnforcement --console=plain`.

Expected benefit: The remaining P2 harness gap now points to the real public boundary: authored summary lookup, weighted candidate lookup, empty selection, XP ceiling, and storage-error publication.

Files changed:
- docs/project/verification/harness-gaps.md
- docs/project/journal/2026-07-harness-gaps.md