### PR TITLE
Fix judge CLI fallback prompt transport

### DIFF
--- a/tools/agents/judge_review.py
+++ b/tools/agents/judge_review.py
@@ -257,7 +257,8 @@ def call_claude_code(prompt: str) -> str:
         [
             "claude",
             "-p",
-            prompt,
+            "--input-format",
+            "text",
             "--system-prompt",
             JUDGE_INSTRUCTIONS,
             "--output-format",
@@ -271,6 +272,7 @@ def call_claude_code(prompt: str) -> str:
         ],
         cwd=REPO_ROOT,
         text=True,
+        input=prompt,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,

--- a/tools/agents/judge_review_selftest.py
+++ b/tools/agents/judge_review_selftest.py
@@ -46,6 +46,25 @@ def patched_environ(values: dict[str, str]):
 
 
 class JudgeOverrideOwnershipTest(unittest.TestCase):
+    def test_claude_code_prompt_uses_stdin_not_argv(self) -> None:
+        prompt = "large prompt\n" * 10000
+        completed = judge_review.subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout="VERDICT: PASS\n",
+            stderr="",
+        )
+
+        with patched_environ({"CLAUDE_CODE_OAUTH_TOKEN": "oauth-token"}), mock.patch.object(
+            judge_review.shutil, "which", return_value="/usr/bin/claude"
+        ), mock.patch.object(judge_review.subprocess, "run", return_value=completed) as run:
+            self.assertEqual("VERDICT: PASS\n", judge_review.call_claude_code(prompt))
+
+        command = run.call_args.args[0]
+        self.assertNotIn(prompt, command)
+        self.assertEqual(prompt, run.call_args.kwargs["input"])
+        self.assertIn("--input-format", command)
+
     def test_latest_owner_label_event_authorizes_override(self) -> None:
         events = [
             NON_OWNER_EVENT | {"created_at": "2026-07-06T07:00:00Z"},


### PR DESCRIPTION
## Summary
- Send the Claude Code judge fallback prompt through stdin instead of argv.
- Keep the Anthropic Messages API path and existing Claude CLI safety flags intact.
- Add a regression selftest for large prompts so the fallback cannot hit OS argv length limits again.

## Risk class
R0/R1/R2/R3a/R3b/R3c: R3c

## Owner-visible behavior
Unchanged / changed: Unchanged
German release note: Keine nutzersichtbare Aenderung.

## Proof
Command: `python3 tools/agents/judge_review_selftest.py`
Result: PASS - `Ran 6 tests ... OK`

Command: `python3 -B -m py_compile tools/agents/judge_review.py tools/agents/judge_review_selftest.py`
Result: PASS

Command: `tools/gradle/run-staged-verification.sh production-handoff`
Result: PASS - wrapper `build/gradle-run-logs/20260709T000347Z-staged-production-handoff.log`, observable `build/gradle-run-logs/20260709T020347420809340-pid205368-production-handoff.log`

Performance proof route for `task:performance`: N/A
Performance evidence: N/A

## Harness
Harness or Harness Gap: N/A - CI tooling robustness only; selftest covers the fallback regression.

## Docs
- Worker report: `build/agent-pass-logs/2026-07-09-judge-review-cli-fallback-worker.md`
- Review PASS: `build/agent-pass-logs/2026-07-09-judge-review-cli-fallback-review.md`

## Rollback idea
Revert this PR to restore passing the prompt as a Claude CLI argument.