### PR TITLE
Move transition link rewrite into catalog

### DIFF
--- a/src/domain/dungeon/model/core/structure/transition/TransitionCatalog.java
+++ b/src/domain/dungeon/model/core/structure/transition/TransitionCatalog.java
@@ -1,11 +1,16 @@
 package src.domain.dungeon.model.core.structure.transition;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
 import org.jspecify.annotations.Nullable;
 
-public record TransitionCatalog(List<Transition> transitions) {
+    public record TransitionCatalog(List<Transition> transitions) {
     private static final long NO_TRANSITION_ID = 0L;
+    private static final long MIN_MAP_ID = 1L;
 
     public TransitionCatalog {
         transitions = nonNullTransitions(transitions);
@@ -47,6 +52,23 @@ public record TransitionCatalog(List<Transition> transitions) {
     public @Nullable TransitionDestination destinationByTransitionId(long transitionId) {
         Transition transition = transitionById(transitionId);
         return transition == null ? null : transition.destination();
+    }
+
+    public static AuthoredTransitionLinkRewrite authoredTransitionLinkRewrite(
+            Collection<AuthoredTransitionLinkMap> loadedMaps,
+            long sourceMapId,
+            long sourceTransitionId,
+            long targetMapId,
+            long targetTransitionId,
+            boolean bidirectional
+    ) {
+        AuthoredTransitionLink link = authoredTransitionLink(
+                sourceMapId,
+                sourceTransitionId,
+                targetMapId,
+                targetTransitionId,
+                bidirectional);
+        return new AuthoredTransitionLinkRewritePlanner(loadedMaps).rewrite(link);
     }
 
     public TransitionCatalog withoutTransition(long transitionId) {
@@ -131,6 +153,19 @@ public record TransitionCatalog(List<Transition> transitions) {
         return transition.linkedTransitionId() != null && transition.linkedTransitionId() == sourceTransitionId;
     }
 
+    private static AuthoredTransitionLink authoredTransitionLink(
+            long sourceMapId,
+            long sourceTransitionId,
+            long targetMapId,
+            long targetTransitionId,
+            boolean bidirectional
+    ) {
+        return new AuthoredTransitionLink(
+                new TransitionEndpoint(sourceMapId, sourceTransitionId),
+                new TransitionEndpoint(targetMapId, targetTransitionId),
+                bidirectional ? TransitionLinkDirectionality.BIDIRECTIONAL : TransitionLinkDirectionality.ONE_WAY);
+    }
+
     private boolean protectedTransition(long transitionId) {
         for (Transition transition : transitions) {
             if ((transition.transitionId() == transitionId && transition.hasLinkedTransition())
@@ -180,6 +215,157 @@ public record TransitionCatalog(List<Transition> transitions) {
         private boolean isValid() {
             return source.isValid() && target.isValid();
         }
+    }
+
+    public record AuthoredTransitionLinkMap(long mapId, TransitionCatalog catalog) {
+
+        public AuthoredTransitionLinkMap {
+            mapId = Math.max(0L, mapId);
+            catalog = catalog == null ? new TransitionCatalog(List.of()) : catalog;
+        }
+    }
+
+    public static final class AuthoredTransitionLinkRewrite {
+        private static final int ACCEPTED = 1;
+        private static final int REQUIRES_MAP = 2;
+        private static final int REJECTED = 3;
+
+        private final int state;
+        private final OptionalLong requestedMapId;
+        private final Map<Long, TransitionCatalog> updates;
+
+        private AuthoredTransitionLinkRewrite(
+                int state,
+                OptionalLong requestedMapId,
+                Map<Long, TransitionCatalog> updates
+        ) {
+            this.state = state;
+            this.requestedMapId = requestedMapId == null ? OptionalLong.empty() : requestedMapId;
+            this.updates = nonNullUpdateMap(updates);
+        }
+
+        public boolean accepted() {
+            return state == ACCEPTED;
+        }
+
+        public OptionalLong requestedMapId() {
+            return requestedMapId;
+        }
+
+        public TransitionCatalog catalogFor(long mapId, TransitionCatalog currentCatalog) {
+            TransitionCatalog nextCatalog = updates.get(mapId);
+            return nextCatalog == null ? currentCatalog : nextCatalog;
+        }
+
+        private static AuthoredTransitionLinkRewrite accepted(
+                Map<Long, TransitionCatalog> updates
+        ) {
+            return new AuthoredTransitionLinkRewrite(ACCEPTED, OptionalLong.empty(), updates);
+        }
+
+        private static AuthoredTransitionLinkRewrite requiresMap(long mapId) {
+            return new AuthoredTransitionLinkRewrite(REQUIRES_MAP, positiveMapId(mapId), Map.of());
+        }
+
+        private static AuthoredTransitionLinkRewrite rejected() {
+            return new AuthoredTransitionLinkRewrite(REJECTED, OptionalLong.empty(), Map.of());
+        }
+
+        private static OptionalLong positiveMapId(long mapId) {
+            if (mapId < MIN_MAP_ID) {
+                throw new IllegalArgumentException("transition link map request requires a positive map id");
+            }
+            return OptionalLong.of(mapId);
+        }
+    }
+
+    private static final class AuthoredTransitionLinkRewritePlanner {
+        private final Map<Long, TransitionCatalog> catalogs;
+
+        private AuthoredTransitionLinkRewritePlanner(Collection<AuthoredTransitionLinkMap> loadedMaps) {
+            catalogs = loadedCatalogsByMapId(loadedMaps);
+        }
+
+        private AuthoredTransitionLinkRewrite rewrite(AuthoredTransitionLink link) {
+            if (!link.isValid()) {
+                return AuthoredTransitionLinkRewrite.rejected();
+            }
+            return rewriteValidLink(
+                    link,
+                    catalogs.get(link.source().mapId()),
+                    catalogs.get(link.target().mapId()));
+        }
+
+        private AuthoredTransitionLinkRewrite rewriteValidLink(
+                AuthoredTransitionLink link,
+                @Nullable TransitionCatalog sourceCatalog,
+                @Nullable TransitionCatalog targetCatalog
+        ) {
+            if (sourceCatalog == null || targetCatalog == null) {
+                return AuthoredTransitionLinkRewrite.rejected();
+            }
+            TransitionDestination sourceDestination = sourceCatalog.destinationByTransitionId(link.source().transitionId());
+            return rewriteWithSourceDestination(link, targetCatalog, sourceDestination);
+        }
+
+        private AuthoredTransitionLinkRewrite rewriteWithSourceDestination(
+                AuthoredTransitionLink link,
+                TransitionCatalog targetCatalog,
+                @Nullable TransitionDestination sourceDestination
+        ) {
+            if (sourceDestination == null || !targetCatalog.containsTransition(link.target().transitionId())) {
+                return AuthoredTransitionLinkRewrite.rejected();
+            }
+            OptionalLong previousMapId = previousLinkedMapId(sourceDestination);
+            if (previousMapId.isPresent() && !catalogs.containsKey(previousMapId.orElseThrow())) {
+                return AuthoredTransitionLinkRewrite.requiresMap(previousMapId.orElseThrow());
+            }
+            return AuthoredTransitionLinkRewrite.accepted(catalogUpdates(link));
+        }
+
+        private Map<Long, TransitionCatalog> catalogUpdates(AuthoredTransitionLink link) {
+            Map<Long, TransitionCatalog> updates = new LinkedHashMap<>();
+            for (Map.Entry<Long, TransitionCatalog> entry : catalogs.entrySet()) {
+                TransitionCatalog catalog = entry.getValue();
+                TransitionCatalog nextCatalog = catalog.withMapLocalAuthoredTransitionLink(link);
+                if (!nextCatalog.equals(catalog)) {
+                    updates.put(entry.getKey(), nextCatalog);
+                }
+            }
+            return Map.copyOf(updates);
+        }
+
+        private static Map<Long, TransitionCatalog> loadedCatalogsByMapId(
+                Collection<AuthoredTransitionLinkMap> loadedMaps
+        ) {
+            Map<Long, TransitionCatalog> catalogs = new LinkedHashMap<>();
+            for (AuthoredTransitionLinkMap loadedMap : loadedMaps == null
+                    ? List.<AuthoredTransitionLinkMap>of()
+                    : loadedMaps) {
+                if (loadedMap != null && loadedMap.mapId() >= MIN_MAP_ID) {
+                    catalogs.put(loadedMap.mapId(), loadedMap.catalog());
+                }
+            }
+            return catalogs;
+        }
+
+        private static OptionalLong previousLinkedMapId(TransitionDestination previousDestination) {
+            return previousDestination.isDungeonMap() && previousDestination.transitionId() != null
+                    ? OptionalLong.of(previousDestination.mapId())
+                    : OptionalLong.empty();
+        }
+    }
+
+    private static Map<Long, TransitionCatalog> nonNullUpdateMap(Map<Long, TransitionCatalog> source) {
+        Map<Long, TransitionCatalog> result = new LinkedHashMap<>();
+        for (Map.Entry<Long, TransitionCatalog> entry : source == null
+                ? Map.<Long, TransitionCatalog>of().entrySet()
+                : source.entrySet()) {
+            if (entry.getKey() != null && entry.getKey() >= MIN_MAP_ID && entry.getValue() != null) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return Map.copyOf(result);
     }
 
     public record TransitionEndpoint(long mapId, long transitionId) {

--- a/src/domain/dungeon/model/core/structure/transition/TransitionCatalog.java
+++ b/src/domain/dungeon/model/core/structure/transition/TransitionCatalog.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 import org.jspecify.annotations.Nullable;
 
-    public record TransitionCatalog(List<Transition> transitions) {
+public record TransitionCatalog(List<Transition> transitions) {
     private static final long NO_TRANSITION_ID = 0L;
     private static final long MIN_MAP_ID = 1L;
 
@@ -253,8 +253,17 @@ import org.jspecify.annotations.Nullable;
         }
 
         public TransitionCatalog catalogFor(long mapId, TransitionCatalog currentCatalog) {
+            if (!accepted()) {
+                return currentCatalog;
+            }
             TransitionCatalog nextCatalog = updates.get(mapId);
             return nextCatalog == null ? currentCatalog : nextCatalog;
+        }
+
+        public AuthoredTransitionLinkRewrite acceptMissingRequestedMap() {
+            return state == REQUIRES_MAP
+                    ? accepted(updates)
+                    : this;
         }
 
         private static AuthoredTransitionLinkRewrite accepted(
@@ -263,8 +272,11 @@ import org.jspecify.annotations.Nullable;
             return new AuthoredTransitionLinkRewrite(ACCEPTED, OptionalLong.empty(), updates);
         }
 
-        private static AuthoredTransitionLinkRewrite requiresMap(long mapId) {
-            return new AuthoredTransitionLinkRewrite(REQUIRES_MAP, positiveMapId(mapId), Map.of());
+        private static AuthoredTransitionLinkRewrite requiresMap(
+                long mapId,
+                Map<Long, TransitionCatalog> fallbackUpdates
+        ) {
+            return new AuthoredTransitionLinkRewrite(REQUIRES_MAP, positiveMapId(mapId), fallbackUpdates);
         }
 
         private static AuthoredTransitionLinkRewrite rejected() {
@@ -318,7 +330,7 @@ import org.jspecify.annotations.Nullable;
             }
             OptionalLong previousMapId = previousLinkedMapId(sourceDestination);
             if (previousMapId.isPresent() && !catalogs.containsKey(previousMapId.orElseThrow())) {
-                return AuthoredTransitionLinkRewrite.requiresMap(previousMapId.orElseThrow());
+                return AuthoredTransitionLinkRewrite.requiresMap(previousMapId.orElseThrow(), catalogUpdates(link));
             }
             return AuthoredTransitionLinkRewrite.accepted(catalogUpdates(link));
         }

--- a/src/domain/dungeon/model/runtime/usecase/ApplyDungeonEditorTransitionLinkOperationUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/ApplyDungeonEditorTransitionLinkOperationUseCase.java
@@ -68,17 +68,18 @@ public final class ApplyDungeonEditorTransitionLinkOperationUseCase {
         if (requestedMapId.isPresent()) {
             long mapId = requestedMapId.orElseThrow();
             Optional<DungeonMap> requiredMap = repository.findById(new DungeonMapIdentity(mapId));
-            if (requiredMap.isEmpty()) {
-                return null;
+            if (requiredMap.isPresent()) {
+                pendingMaps.put(mapId, requiredMap.orElseThrow());
+                rewrite = transitionLinkRewrite(
+                        pendingMaps,
+                        loaded.sourceIdentity().value(),
+                        sourceTransitionId,
+                        loaded.targetIdentity().value(),
+                        targetTransitionId,
+                        bidirectional);
+            } else {
+                rewrite = rewrite.acceptMissingRequestedMap();
             }
-            pendingMaps.put(mapId, requiredMap.orElseThrow());
-            rewrite = transitionLinkRewrite(
-                    pendingMaps,
-                    loaded.sourceIdentity().value(),
-                    sourceTransitionId,
-                    loaded.targetIdentity().value(),
-                    targetTransitionId,
-                    bidirectional);
         }
         if (!rewrite.accepted()) {
             return null;

--- a/src/domain/dungeon/model/runtime/usecase/ApplyDungeonEditorTransitionLinkOperationUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/ApplyDungeonEditorTransitionLinkOperationUseCase.java
@@ -1,19 +1,20 @@
 package src.domain.dungeon.model.runtime.usecase;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.model.core.projection.DungeonDerivedState;
 import src.domain.dungeon.model.core.repository.DungeonMapRepository;
 import src.domain.dungeon.model.core.structure.DungeonMap;
 import src.domain.dungeon.model.core.structure.DungeonMapIdentity;
-import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.AuthoredTransitionLink;
-import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.TransitionEndpoint;
-import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.TransitionLinkDirectionality;
-import src.domain.dungeon.model.core.structure.transition.TransitionDestination;
+import src.domain.dungeon.model.core.structure.transition.TransitionCatalog;
+import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkMap;
+import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkRewrite;
 import src.domain.dungeon.model.core.usecase.BuildDungeonDerivedStateUseCase;
 
 public final class ApplyDungeonEditorTransitionLinkOperationUseCase {
@@ -55,16 +56,34 @@ public final class ApplyDungeonEditorTransitionLinkOperationUseCase {
         }
         Map<Long, DungeonMap> pendingMaps = loadedMaps(
                 loaded.sourceMap(),
-                loaded.targetMap(),
-                loaded.sourceDestination());
-        applyAuthoredTransitionLinkToLoadedMaps(
+                loaded.targetMap());
+        AuthoredTransitionLinkRewrite rewrite = transitionLinkRewrite(
                 pendingMaps,
-                authoredTransitionLink(
-                        loaded.sourceIdentity().value(),
-                        sourceTransitionId,
-                        loaded.targetIdentity().value(),
-                        targetTransitionId,
-                        bidirectional));
+                loaded.sourceIdentity().value(),
+                sourceTransitionId,
+                loaded.targetIdentity().value(),
+                targetTransitionId,
+                bidirectional);
+        OptionalLong requestedMapId = rewrite.requestedMapId();
+        if (requestedMapId.isPresent()) {
+            long mapId = requestedMapId.orElseThrow();
+            Optional<DungeonMap> requiredMap = repository.findById(new DungeonMapIdentity(mapId));
+            if (requiredMap.isEmpty()) {
+                return null;
+            }
+            pendingMaps.put(mapId, requiredMap.orElseThrow());
+            rewrite = transitionLinkRewrite(
+                    pendingMaps,
+                    loaded.sourceIdentity().value(),
+                    sourceTransitionId,
+                    loaded.targetIdentity().value(),
+                    targetTransitionId,
+                    bidirectional);
+        }
+        if (!rewrite.accepted()) {
+            return null;
+        }
+        applyCatalogUpdates(pendingMaps, rewrite);
         List<DungeonMap> savedMaps = repository.saveAll(List.copyOf(pendingMaps.values()));
         DungeonMap savedSourceMap = savedSourceMap(savedMaps, loaded.sourceIdentity().value());
         return result(savedSourceMap);
@@ -98,59 +117,51 @@ public final class ApplyDungeonEditorTransitionLinkOperationUseCase {
         if (sourceMap == null || targetMap == null) {
             return null;
         }
-        TransitionDestination sourceDestination =
-                sourceMap.transitionCatalog().destinationByTransitionId(sourceTransitionId);
-        if (sourceDestination == null || !targetMap.transitionCatalog().containsTransition(targetTransitionId)) {
-            return null;
-        }
-        return new LoadedTransitionLink(sourceMapId, targetMapId, sourceMap, targetMap, sourceDestination);
+        return new LoadedTransitionLink(sourceMapId, targetMapId, sourceMap, targetMap);
     }
 
     private Map<Long, DungeonMap> loadedMaps(
             DungeonMap sourceMap,
-            DungeonMap targetMap,
-            TransitionDestination sourceDestination
+            DungeonMap targetMap
     ) {
         Map<Long, DungeonMap> pendingMaps = new LinkedHashMap<>();
         pendingMaps.put(sourceMap.metadata().mapId().value(), sourceMap);
         pendingMaps.put(targetMap.metadata().mapId().value(), targetMap);
-        long previousMapId = previousLinkedMapId(sourceDestination);
-        if (previousMapId > 0L && !pendingMaps.containsKey(previousMapId)) {
-            Optional<DungeonMap> previousMap = repository.findById(new DungeonMapIdentity(previousMapId));
-            if (previousMap.isPresent()) {
-                pendingMaps.put(previousMapId, previousMap.orElseThrow());
-            }
-        }
         return pendingMaps;
     }
 
-    private long previousLinkedMapId(TransitionDestination previousDestination) {
-        return previousDestination.isDungeonMap() && previousDestination.transitionId() != null
-                ? previousDestination.mapId()
-                : 0L;
-    }
-
-    private void applyAuthoredTransitionLinkToLoadedMaps(
+    private AuthoredTransitionLinkRewrite transitionLinkRewrite(
             Map<Long, DungeonMap> pendingMaps,
-            AuthoredTransitionLink link
-    ) {
-        for (Map.Entry<Long, DungeonMap> entry : pendingMaps.entrySet()) {
-            DungeonMap map = entry.getValue();
-            entry.setValue(map.withTransitionCatalog(map.transitionCatalog().withMapLocalAuthoredTransitionLink(link)));
-        }
-    }
-
-    private static AuthoredTransitionLink authoredTransitionLink(
             long sourceMapId,
             long sourceTransitionId,
             long targetMapId,
             long targetTransitionId,
             boolean bidirectional
     ) {
-        return new AuthoredTransitionLink(
-                new TransitionEndpoint(sourceMapId, sourceTransitionId),
-                new TransitionEndpoint(targetMapId, targetTransitionId),
-                bidirectional ? TransitionLinkDirectionality.BIDIRECTIONAL : TransitionLinkDirectionality.ONE_WAY);
+        List<AuthoredTransitionLinkMap> loadedCatalogs = new ArrayList<>();
+        for (DungeonMap map : pendingMaps.values()) {
+            loadedCatalogs.add(new AuthoredTransitionLinkMap(
+                    map.metadata().mapId().value(),
+                    map.transitionCatalog()));
+        }
+        return TransitionCatalog.authoredTransitionLinkRewrite(
+                loadedCatalogs,
+                sourceMapId,
+                sourceTransitionId,
+                targetMapId,
+                targetTransitionId,
+                bidirectional);
+    }
+
+    private static void applyCatalogUpdates(
+            Map<Long, DungeonMap> pendingMaps,
+            AuthoredTransitionLinkRewrite rewrite
+    ) {
+        for (Map.Entry<Long, DungeonMap> entry : pendingMaps.entrySet()) {
+            DungeonMap map = entry.getValue();
+            TransitionCatalog nextCatalog = rewrite.catalogFor(entry.getKey(), map.transitionCatalog());
+            entry.setValue(map.withTransitionCatalog(nextCatalog));
+        }
     }
 
     private DungeonMap savedSourceMap(List<DungeonMap> savedMaps, long sourceMapId) {
@@ -166,8 +177,7 @@ public final class ApplyDungeonEditorTransitionLinkOperationUseCase {
             DungeonMapIdentity sourceIdentity,
             DungeonMapIdentity targetIdentity,
             DungeonMap sourceMap,
-            DungeonMap targetMap,
-            TransitionDestination sourceDestination
+            DungeonMap targetMap
     ) {
     }
 }

--- a/test/src/view/leftbartabs/dungeoneditor/DungeonTransitionInvariantHarness.java
+++ b/test/src/view/leftbartabs/dungeoneditor/DungeonTransitionInvariantHarness.java
@@ -1,8 +1,19 @@
 package src.view.leftbartabs.dungeoneditor;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import src.domain.dungeon.model.core.geometry.Cell;
 import src.domain.dungeon.model.core.geometry.Direction;
+import src.domain.dungeon.model.core.repository.DungeonMapRepository;
+import src.domain.dungeon.model.core.structure.DungeonMap;
+import src.domain.dungeon.model.core.structure.DungeonMapIdentity;
+import src.domain.dungeon.model.core.structure.DungeonMapMetadata;
+import src.domain.dungeon.model.core.structure.room.RoomCatalog;
+import src.domain.dungeon.model.core.structure.stair.StairCollection;
+import src.domain.dungeon.model.core.structure.topology.SpatialTopology;
 import src.domain.dungeon.model.core.structure.transition.Transition;
 import src.domain.dungeon.model.core.structure.transition.TransitionAnchor;
 import src.domain.dungeon.model.core.structure.transition.TransitionCatalog;
@@ -11,6 +22,11 @@ import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.Tran
 import src.domain.dungeon.model.core.structure.transition.TransitionCatalog.TransitionLinkDirectionality;
 import src.domain.dungeon.model.core.structure.transition.TransitionDestination;
 import src.domain.dungeon.model.core.structure.transition.TransitionDestinationTarget;
+import src.domain.dungeon.model.core.usecase.BuildDungeonDerivedStateUseCase;
+import src.domain.dungeon.model.runtime.usecase.ApplyDungeonEditorOperationUseCase;
+import src.domain.dungeon.model.runtime.usecase.ApplyDungeonEditorTransitionLinkOperationUseCase;
+import src.domain.dungeon.model.runtime.usecase.AssembleDungeonSnapshotUseCase;
+import src.domain.dungeon.model.runtime.usecase.PublishDungeonEditorHandlesUseCase;
 
 final class DungeonTransitionInvariantHarness {
 
@@ -27,6 +43,7 @@ final class DungeonTransitionInvariantHarness {
                 "DGI-TRANSITION-001",
                 "Transition owner normalizes local facts, placement, labels, descriptions, and destinations");
         assertTransitionLinkCollection();
+        assertTransitionLinkMissingPreviousMapFallback();
         DungeonEditorBehaviorHarnessSupport.recordModelInvariant(
                 results,
                 OWNER,
@@ -167,6 +184,67 @@ final class DungeonTransitionInvariantHarness {
                 "transition catalog rejects invalid authored link");
     }
 
+    private static void assertTransitionLinkMissingPreviousMapFallback() {
+        long sourceMapId = 41L;
+        long targetMapId = 42L;
+        long missingPreviousMapId = 99L;
+        long sourceTransitionId = 1L;
+        long targetTransitionId = 2L;
+        long missingPreviousTransitionId = 7L;
+        DungeonMap sourceMap = map(
+                sourceMapId,
+                "Missing previous source",
+                transition(
+                        sourceTransitionId,
+                        sourceMapId,
+                        new Cell(0, 0, 0),
+                        TransitionDestination.dungeonMap(missingPreviousMapId, missingPreviousTransitionId),
+                        null));
+        DungeonMap targetMap = map(
+                targetMapId,
+                "Missing previous target",
+                transition(
+                        targetTransitionId,
+                        targetMapId,
+                        new Cell(1, 0, 0),
+                        TransitionDestination.overworldTile(5L, 9L),
+                        null));
+        MissingPreviousMapRepository repository =
+                new MissingPreviousMapRepository(sourceMap, targetMap, missingPreviousMapId);
+        BuildDungeonDerivedStateUseCase derive = new BuildDungeonDerivedStateUseCase();
+        ApplyDungeonEditorTransitionLinkOperationUseCase useCase =
+                new ApplyDungeonEditorTransitionLinkOperationUseCase(
+                        repository,
+                        derive,
+                        new AssembleDungeonSnapshotUseCase(derive),
+                        new PublishDungeonEditorHandlesUseCase());
+
+        ApplyDungeonEditorOperationUseCase.OperationResultData result = useCase.execute(
+                new DungeonMapIdentity(sourceMapId),
+                sourceTransitionId,
+                new DungeonMapIdentity(targetMapId),
+                targetTransitionId,
+                true);
+
+        assertTrue(result != null,
+                "transition link use case succeeds when the previous linked map row is missing");
+        assertTrue(repository.requestedMapIds().contains(missingPreviousMapId),
+                "transition link use case attempts to load the missing previous map");
+        assertEquals(List.of(sourceMapId, targetMapId), repository.savedMapIds(),
+                "transition link use case saves only source and target when previous map is missing");
+        Transition savedSourceTransition =
+                transitionById(repository.savedMap(sourceMapId), sourceTransitionId);
+        assertEquals(TransitionDestination.dungeonMap(targetMapId, targetTransitionId),
+                savedSourceTransition.destination(),
+                "transition link use case still rewrites source destination when previous map is missing");
+        Transition savedTargetTransition =
+                transitionById(repository.savedMap(targetMapId), targetTransitionId);
+        assertEquals(sourceTransitionId, savedTargetTransition.linkedTransitionId(),
+                "transition link use case still writes target reverse link when previous map is missing");
+        assertFalse(repository.savedMapIds().contains(missingPreviousMapId),
+                "transition link use case cannot mutate a missing previous map");
+    }
+
     private static void assertProtectedDeletePolicy() {
         TransitionDestination overworldDestination = TransitionDestination.overworldTile(5L, 9L);
         Transition linked = transition(1L, 4L, new Cell(0, 0, 0), overworldDestination, 3L);
@@ -207,6 +285,26 @@ final class DungeonTransitionInvariantHarness {
                 linkedTransitionId);
     }
 
+    private static DungeonMap map(long mapId, String mapName, Transition... transitions) {
+        return new DungeonMap(
+                new DungeonMapMetadata(new DungeonMapIdentity(mapId), mapName),
+                SpatialTopology.empty(),
+                RoomCatalog.empty(),
+                List.of(),
+                new StairCollection(List.of()),
+                new TransitionCatalog(List.of(transitions)),
+                0L);
+    }
+
+    private static Transition transitionById(DungeonMap map, long transitionId) {
+        for (Transition transition : map.transitionCatalog().transitions()) {
+            if (transition.transitionId() == transitionId) {
+                return transition;
+            }
+        }
+        throw new IllegalStateException("Missing transition " + transitionId);
+    }
+
     private static AuthoredTransitionLink link(
             long sourceMapId,
             long sourceTransitionId,
@@ -221,11 +319,96 @@ final class DungeonTransitionInvariantHarness {
     }
 
     private static List<Long> transitionIds(TransitionCatalog catalog) {
-        java.util.ArrayList<Long> result = new java.util.ArrayList<>();
+        ArrayList<Long> result = new ArrayList<>();
         for (Transition transition : catalog.transitions()) {
             result.add(transition.transitionId());
         }
         return List.copyOf(result);
+    }
+
+    private static final class MissingPreviousMapRepository implements DungeonMapRepository {
+        private final Map<Long, DungeonMap> mapsById = new LinkedHashMap<>();
+        private final long missingPreviousMapId;
+        private final List<Long> requestedMapIds = new ArrayList<>();
+        private final Map<Long, DungeonMap> savedMapsById = new LinkedHashMap<>();
+
+        private MissingPreviousMapRepository(
+                DungeonMap sourceMap,
+                DungeonMap targetMap,
+                long missingPreviousMapId
+        ) {
+            mapsById.put(sourceMap.metadata().mapId().value(), sourceMap);
+            mapsById.put(targetMap.metadata().mapId().value(), targetMap);
+            this.missingPreviousMapId = missingPreviousMapId;
+        }
+
+        @Override
+        public DungeonMapIdentity nextMapId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long nextStairId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long nextTransitionId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<DungeonMap> findById(DungeonMapIdentity mapId) {
+            long id = mapId == null ? 0L : mapId.value();
+            requestedMapIds.add(id);
+            return id == missingPreviousMapId
+                    ? Optional.empty()
+                    : Optional.ofNullable(mapsById.get(id));
+        }
+
+        @Override
+        public List<DungeonMap> searchByName(String query) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<DungeonMap> firstMap() {
+            return mapsById.values().stream().findFirst();
+        }
+
+        @Override
+        public DungeonMap save(DungeonMap dungeonMap) {
+            return dungeonMap;
+        }
+
+        @Override
+        public List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps) {
+            savedMapsById.clear();
+            for (DungeonMap dungeonMap : dungeonMaps == null ? List.<DungeonMap>of() : dungeonMaps) {
+                savedMapsById.put(dungeonMap.metadata().mapId().value(), dungeonMap);
+            }
+            return List.copyOf(savedMapsById.values());
+        }
+
+        @Override
+        public void delete(DungeonMapIdentity mapId) {
+        }
+
+        private List<Long> requestedMapIds() {
+            return List.copyOf(requestedMapIds);
+        }
+
+        private List<Long> savedMapIds() {
+            return List.copyOf(savedMapsById.keySet());
+        }
+
+        private DungeonMap savedMap(long mapId) {
+            DungeonMap map = savedMapsById.get(mapId);
+            if (map == null) {
+                throw new IllegalStateException("Missing saved map " + mapId);
+            }
+            return map;
+        }
     }
 
     private static void assertEquals(Object expected, Object actual, String message) {


### PR DESCRIPTION
## Summary
- Move authored transition-link validation and rewrite planning into `TransitionCatalog`.
- Keep the runtime use case as repository orchestration and persistence only.
- Close rewrite result invariants with private construction, `OptionalLong` requested-map state, and behavior-oriented `catalogFor(...)` application.

## Risk
- Risk class: R1
- Task label: `task:architecture`

## Verification
- `./gradlew pmdStrictMain --console=plain`: `BUILD SUCCESSFUL in 2m 24s`
- `tools/gradle/run-observable-gradle.sh dungeonEditorTransitionBehaviorHarness`: `BUILD SUCCESSFUL in 3m 44s`, retained `Result: success`
- `tools/gradle/run-staged-verification.sh focused-handoff --path src/domain/dungeon --area domain`: `BUILD SUCCESSFUL in 2m 53s`, retained `Result: success`
- `tools/gradle/run-staged-verification.sh production-handoff`: `BUILD SUCCESSFUL in 17m 22s`, retained `Result: success`

## Review
- Central rereview report: `build/agent-pass-logs/2026-07-09-architecture-goal-completion-audit/s4-transition-link-rereview.md`
- Code-side architecture: handoff-ready
- Prior proof-evidence gap closed by retained `dungeonEditorTransitionBehaviorHarness` log: `build/gradle-run-logs/20260709T053603817263003-pid559934-dungeonEditorTransitionBehaviorHarness.log`