### PR TITLE
Refactor session planner timeline input routing

### DIFF
--- a/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
@@ -1,7 +1,9 @@
 package src.view.leftbartabs.sessionplanner;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import src.domain.sessionplanner.SessionPlannerApplicationService;
 import src.domain.sessionplanner.SessionPlannerEncounterApplicationService;
@@ -27,23 +29,6 @@ import src.view.slotcontent.controls.catalogcrud.CatalogCrudControlsViewInputEve
 final class SessionPlannerIntentHandler {
 
     private static final BigDecimal ALLOCATION_STEP = BigDecimal.TEN;
-    private static final String WIDGET_SCENE_SELECT = "session-planner.timeline.scene.select";
-    private static final String WIDGET_ALLOCATION_DECREASE = "session-planner.timeline.allocation.decrease";
-    private static final String WIDGET_ALLOCATION_INCREASE = "session-planner.timeline.allocation.increase";
-    private static final String WIDGET_SCENE_MOVE_UP = "session-planner.timeline.scene.move-up";
-    private static final String WIDGET_SCENE_MOVE_DOWN = "session-planner.timeline.scene.move-down";
-    private static final String WIDGET_SCENE_REMOVE = "session-planner.timeline.scene.remove";
-    private static final String WIDGET_REST_SHORT = "session-planner.timeline.rest.short";
-    private static final String WIDGET_REST_LONG = "session-planner.timeline.rest.long";
-    private static final String WIDGET_REST_CLEAR = "session-planner.timeline.rest.clear";
-    private static final String WIDGET_LOOT_ADD = "session-planner.timeline.loot.add";
-    private static final String WIDGET_LOOT_REMOVE = "session-planner.timeline.loot.remove";
-    private static final String WIDGET_SCENE_SAVE = "session-planner.timeline.scene.save";
-    private static final String WIDGET_SCENE_DRAFT = "session-planner.timeline.scene.draft";
-    private static final String WIDGET_PARTICIPANT_ADD = "session-planner.timeline.participant.add";
-    private static final String WIDGET_PARTICIPANT_REMOVE = "session-planner.timeline.participant.remove";
-    private static final String WIDGET_ENCOUNTER_DAYS = "session-planner.timeline.encounter-days.apply";
-    private static final String WIDGET_SCENE_ADD = "session-planner.timeline.scene.add";
 
     private final SessionPlannerApplicationService planner;
     private final SessionPlannerParticipantApplicationService participants;
@@ -53,6 +38,7 @@ final class SessionPlannerIntentHandler {
     private final SessionPlannerControlsContentModel controlsContentModel;
     private final CatalogCrudControlsContentModel catalogContentModel;
     private final SessionPlannerTimelineMainContentModel timelineMainContentModel;
+    private final Map<String, Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions;
 
     SessionPlannerIntentHandler(
             SessionPlannerApplicationService planner,
@@ -72,6 +58,7 @@ final class SessionPlannerIntentHandler {
         this.controlsContentModel = Objects.requireNonNull(controlsContentModel, "controlsContentModel");
         this.catalogContentModel = Objects.requireNonNull(catalogContentModel, "catalogContentModel");
         this.timelineMainContentModel = Objects.requireNonNull(timelineMainContentModel, "timelineMainContentModel");
+        this.timelineActions = timelineActions();
     }
 
     void consume(SessionPlannerControlsViewInputEvent event) {
@@ -87,27 +74,37 @@ final class SessionPlannerIntentHandler {
         if (event == null || !controlsContentModel.hasCurrentSession()) {
             return;
         }
-        switch (event.widgetId()) {
-            case WIDGET_SCENE_SELECT -> selectTimelineScene(event);
-            case WIDGET_ALLOCATION_DECREASE -> adjustTimelineAllocation(event, ALLOCATION_STEP.negate());
-            case WIDGET_ALLOCATION_INCREASE -> adjustTimelineAllocation(event, ALLOCATION_STEP);
-            case WIDGET_SCENE_MOVE_UP -> moveTimelineSceneUp(event);
-            case WIDGET_SCENE_MOVE_DOWN -> moveTimelineSceneDown(event);
-            case WIDGET_SCENE_REMOVE -> removeTimelineScene(event);
-            case WIDGET_REST_SHORT -> setTimelineRest(event, SessionPlannerRestKind.SHORT_REST);
-            case WIDGET_REST_LONG -> setTimelineRest(event, SessionPlannerRestKind.LONG_REST);
-            case WIDGET_REST_CLEAR -> clearTimelineRest(event);
-            case WIDGET_LOOT_ADD -> addTimelineLoot(event);
-            case WIDGET_LOOT_REMOVE -> removeTimelineLoot(event);
-            case WIDGET_SCENE_SAVE -> saveTimelineScene(event);
-            case WIDGET_SCENE_DRAFT -> updateTimelineSceneDraft(event);
-            case WIDGET_PARTICIPANT_ADD -> addTimelineParticipant(event);
-            case WIDGET_PARTICIPANT_REMOVE -> removeTimelineParticipant(event);
-            case WIDGET_ENCOUNTER_DAYS -> applyTimelineEncounterDays(event);
-            case WIDGET_SCENE_ADD -> addScene();
-            default -> {
-            }
+        Consumer<SessionPlannerTimelineMainViewInputEvent> action = timelineActions.get(event.widgetId());
+        if (action != null) {
+            action.accept(event);
         }
+    }
+
+    private Map<String, Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions() {
+        return Map.ofEntries(
+                Map.entry("session-planner.timeline.scene.select", this::selectTimelineScene),
+                Map.entry("session-planner.timeline.allocation.decrease",
+                        event -> adjustTimelineAllocation(event, ALLOCATION_STEP.negate())),
+                Map.entry("session-planner.timeline.allocation.increase",
+                        event -> adjustTimelineAllocation(event, ALLOCATION_STEP)),
+                Map.entry("session-planner.timeline.scene.move-up", this::moveTimelineSceneUp),
+                Map.entry("session-planner.timeline.scene.move-down", this::moveTimelineSceneDown),
+                Map.entry("session-planner.timeline.scene.remove", this::removeTimelineScene),
+                Map.entry("session-planner.timeline.rest.short",
+                        event -> setTimelineRest(event, SessionPlannerRestKind.SHORT_REST)),
+                Map.entry("session-planner.timeline.rest.long",
+                        event -> setTimelineRest(event, SessionPlannerRestKind.LONG_REST)),
+                Map.entry("session-planner.timeline.rest.clear", this::clearTimelineRest),
+                Map.entry("session-planner.timeline.loot.add", this::addTimelineLoot),
+                Map.entry("session-planner.timeline.loot.remove", this::removeTimelineLoot),
+                Map.entry("session-planner.timeline.scene.save", this::saveTimelineScene),
+                Map.entry("session-planner.timeline.scene.draft", this::updateTimelineSceneDraft),
+                Map.entry("session-planner.timeline.participant.add", this::addTimelineParticipant),
+                Map.entry("session-planner.timeline.participant.remove",
+                        this::removeTimelineParticipant),
+                Map.entry("session-planner.timeline.encounter-days.apply",
+                        this::applyTimelineEncounterDays),
+                Map.entry("session-planner.timeline.scene.add", ignored -> addScene()));
     }
 
     private void selectTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
@@ -38,7 +38,8 @@ final class SessionPlannerIntentHandler {
     private final SessionPlannerControlsContentModel controlsContentModel;
     private final CatalogCrudControlsContentModel catalogContentModel;
     private final SessionPlannerTimelineMainContentModel timelineMainContentModel;
-    private final Map<String, Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions;
+    private final Map<SessionPlannerTimelineMainContentModel.TimelineWidgetKind,
+            Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions;
 
     SessionPlannerIntentHandler(
             SessionPlannerApplicationService planner,
@@ -74,37 +75,51 @@ final class SessionPlannerIntentHandler {
         if (event == null || !controlsContentModel.hasCurrentSession()) {
             return;
         }
-        Consumer<SessionPlannerTimelineMainViewInputEvent> action = timelineActions.get(event.widgetId());
+        SessionPlannerTimelineMainContentModel.TimelineWidgetKind widgetKind =
+                timelineMainContentModel.widgetKind(event.widgetToken());
+        Consumer<SessionPlannerTimelineMainViewInputEvent> action = timelineActions.get(widgetKind);
         if (action != null) {
             action.accept(event);
         }
     }
 
-    private Map<String, Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions() {
+    private Map<SessionPlannerTimelineMainContentModel.TimelineWidgetKind,
+            Consumer<SessionPlannerTimelineMainViewInputEvent>> timelineActions() {
         return Map.ofEntries(
-                Map.entry("session-planner.timeline.scene.select", this::selectTimelineScene),
-                Map.entry("session-planner.timeline.allocation.decrease",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_SELECT,
+                        this::selectTimelineScene),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.ALLOCATION_DECREASE,
                         event -> adjustTimelineAllocation(event, ALLOCATION_STEP.negate())),
-                Map.entry("session-planner.timeline.allocation.increase",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.ALLOCATION_INCREASE,
                         event -> adjustTimelineAllocation(event, ALLOCATION_STEP)),
-                Map.entry("session-planner.timeline.scene.move-up", this::moveTimelineSceneUp),
-                Map.entry("session-planner.timeline.scene.move-down", this::moveTimelineSceneDown),
-                Map.entry("session-planner.timeline.scene.remove", this::removeTimelineScene),
-                Map.entry("session-planner.timeline.rest.short",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_MOVE_UP,
+                        this::moveTimelineSceneUp),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_MOVE_DOWN,
+                        this::moveTimelineSceneDown),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_REMOVE,
+                        this::removeTimelineScene),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.REST_SHORT,
                         event -> setTimelineRest(event, SessionPlannerRestKind.SHORT_REST)),
-                Map.entry("session-planner.timeline.rest.long",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.REST_LONG,
                         event -> setTimelineRest(event, SessionPlannerRestKind.LONG_REST)),
-                Map.entry("session-planner.timeline.rest.clear", this::clearTimelineRest),
-                Map.entry("session-planner.timeline.loot.add", this::addTimelineLoot),
-                Map.entry("session-planner.timeline.loot.remove", this::removeTimelineLoot),
-                Map.entry("session-planner.timeline.scene.save", this::saveTimelineScene),
-                Map.entry("session-planner.timeline.scene.draft", this::updateTimelineSceneDraft),
-                Map.entry("session-planner.timeline.participant.add", this::addTimelineParticipant),
-                Map.entry("session-planner.timeline.participant.remove",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.REST_CLEAR,
+                        this::clearTimelineRest),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.LOOT_ADD,
+                        this::addTimelineLoot),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.LOOT_REMOVE,
+                        this::removeTimelineLoot),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_SAVE,
+                        this::saveTimelineScene),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_DRAFT,
+                        this::updateTimelineSceneDraft),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.PARTICIPANT_ADD,
+                        this::addTimelineParticipant),
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.PARTICIPANT_REMOVE,
                         this::removeTimelineParticipant),
-                Map.entry("session-planner.timeline.encounter-days.apply",
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.ENCOUNTER_DAYS,
                         this::applyTimelineEncounterDays),
-                Map.entry("session-planner.timeline.scene.add", ignored -> addScene()));
+                Map.entry(SessionPlannerTimelineMainContentModel.TimelineWidgetKind.SCENE_ADD,
+                        ignored -> addScene()));
     }
 
     private void selectTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerIntentHandler.java
@@ -26,6 +26,25 @@ import src.view.slotcontent.controls.catalogcrud.CatalogCrudControlsViewInputEve
 
 final class SessionPlannerIntentHandler {
 
+    private static final BigDecimal ALLOCATION_STEP = BigDecimal.TEN;
+    private static final String WIDGET_SCENE_SELECT = "session-planner.timeline.scene.select";
+    private static final String WIDGET_ALLOCATION_DECREASE = "session-planner.timeline.allocation.decrease";
+    private static final String WIDGET_ALLOCATION_INCREASE = "session-planner.timeline.allocation.increase";
+    private static final String WIDGET_SCENE_MOVE_UP = "session-planner.timeline.scene.move-up";
+    private static final String WIDGET_SCENE_MOVE_DOWN = "session-planner.timeline.scene.move-down";
+    private static final String WIDGET_SCENE_REMOVE = "session-planner.timeline.scene.remove";
+    private static final String WIDGET_REST_SHORT = "session-planner.timeline.rest.short";
+    private static final String WIDGET_REST_LONG = "session-planner.timeline.rest.long";
+    private static final String WIDGET_REST_CLEAR = "session-planner.timeline.rest.clear";
+    private static final String WIDGET_LOOT_ADD = "session-planner.timeline.loot.add";
+    private static final String WIDGET_LOOT_REMOVE = "session-planner.timeline.loot.remove";
+    private static final String WIDGET_SCENE_SAVE = "session-planner.timeline.scene.save";
+    private static final String WIDGET_SCENE_DRAFT = "session-planner.timeline.scene.draft";
+    private static final String WIDGET_PARTICIPANT_ADD = "session-planner.timeline.participant.add";
+    private static final String WIDGET_PARTICIPANT_REMOVE = "session-planner.timeline.participant.remove";
+    private static final String WIDGET_ENCOUNTER_DAYS = "session-planner.timeline.encounter-days.apply";
+    private static final String WIDGET_SCENE_ADD = "session-planner.timeline.scene.add";
+
     private final SessionPlannerApplicationService planner;
     private final SessionPlannerParticipantApplicationService participants;
     private final SessionPlannerEncounterApplicationService encounters;
@@ -68,89 +87,122 @@ final class SessionPlannerIntentHandler {
         if (event == null || !controlsContentModel.hasCurrentSession()) {
             return;
         }
-        consumeTimelineSelection(event);
-        consumeTimelineSetup(event);
-        consumeTimelineMutation(event);
-        consumeTimelineRest(event);
-        consumeTimelineLoot(event);
-        consumeTimelineSceneDraft(event);
-        consumeTimelineScene(event);
+        switch (event.widgetId()) {
+            case WIDGET_SCENE_SELECT -> selectTimelineScene(event);
+            case WIDGET_ALLOCATION_DECREASE -> adjustTimelineAllocation(event, ALLOCATION_STEP.negate());
+            case WIDGET_ALLOCATION_INCREASE -> adjustTimelineAllocation(event, ALLOCATION_STEP);
+            case WIDGET_SCENE_MOVE_UP -> moveTimelineSceneUp(event);
+            case WIDGET_SCENE_MOVE_DOWN -> moveTimelineSceneDown(event);
+            case WIDGET_SCENE_REMOVE -> removeTimelineScene(event);
+            case WIDGET_REST_SHORT -> setTimelineRest(event, SessionPlannerRestKind.SHORT_REST);
+            case WIDGET_REST_LONG -> setTimelineRest(event, SessionPlannerRestKind.LONG_REST);
+            case WIDGET_REST_CLEAR -> clearTimelineRest(event);
+            case WIDGET_LOOT_ADD -> addTimelineLoot(event);
+            case WIDGET_LOOT_REMOVE -> removeTimelineLoot(event);
+            case WIDGET_SCENE_SAVE -> saveTimelineScene(event);
+            case WIDGET_SCENE_DRAFT -> updateTimelineSceneDraft(event);
+            case WIDGET_PARTICIPANT_ADD -> addTimelineParticipant(event);
+            case WIDGET_PARTICIPANT_REMOVE -> removeTimelineParticipant(event);
+            case WIDGET_ENCOUNTER_DAYS -> applyTimelineEncounterDays(event);
+            case WIDGET_SCENE_ADD -> addScene();
+            default -> {
+            }
+        }
     }
 
-    private void consumeTimelineSelection(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.SelectionSnapshot selection = event.selection();
-        if (hasPositiveId(selection.selectedSceneToken())) {
-            selectEncounter(selection.selectedSceneToken());
-        }
-        if (hasPositiveId(selection.allocationSceneToken())) {
-            setEncounterAllocation(selection.allocationSceneToken(), selection.targetAllocationPercentage());
+    private void selectTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            selectEncounter(event.sceneToken());
         }
     }
 
-    private void consumeTimelineSetup(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.SetupSnapshot setup = event.setup();
-        long participantToAddId = timelineMainContentModel.participantChoiceId(setup.participantChoiceIndex());
+    private void adjustTimelineAllocation(SessionPlannerTimelineMainViewInputEvent event, BigDecimal delta) {
+        if (hasPositiveId(event.sceneToken())) {
+            setEncounterAllocation(
+                    event.sceneToken(),
+                    timelineMainContentModel.budgetPercentage(event.sceneToken()).add(delta));
+        }
+    }
+
+    private void moveTimelineSceneUp(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            moveEncounterUp(event.sceneToken());
+        }
+    }
+
+    private void moveTimelineSceneDown(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            moveEncounterDown(event.sceneToken());
+        }
+    }
+
+    private void removeTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            removeEncounter(event.sceneToken());
+        }
+    }
+
+    private void setTimelineRest(SessionPlannerTimelineMainViewInputEvent event, SessionPlannerRestKind restKind) {
+        if (isResolvedGap(event.leftSceneToken(), event.rightSceneToken())) {
+            setRestGap(event.leftSceneToken(), event.rightSceneToken(), restKind);
+        }
+    }
+
+    private void clearTimelineRest(SessionPlannerTimelineMainViewInputEvent event) {
+        if (isResolvedGap(event.leftSceneToken(), event.rightSceneToken())) {
+            clearRestGap(event.leftSceneToken(), event.rightSceneToken());
+        }
+    }
+
+    private void addTimelineLoot(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            addLootPlaceholder(event.sceneToken());
+        }
+    }
+
+    private void removeTimelineLoot(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.lootToken())) {
+            removeLootPlaceholder(event.lootToken());
+        }
+    }
+
+    private void saveTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            updateEncounterScene(
+                    event.sceneToken(),
+                    event.sceneTitleText().trim(),
+                    event.sceneNotesText().trim(),
+                    event.locationId());
+        }
+    }
+
+    private void updateTimelineSceneDraft(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.sceneToken())) {
+            timelineMainContentModel.updateSceneDraft(
+                    event.sceneToken(),
+                    event.sceneTitleText(),
+                    event.sceneNotesText(),
+                    event.locationId());
+        }
+    }
+
+    private void addTimelineParticipant(SessionPlannerTimelineMainViewInputEvent event) {
+        long participantToAddId = timelineMainContentModel.participantChoiceId(event.participantChoiceIndex());
         if (hasPositiveId(participantToAddId)) {
             addParticipant(participantToAddId);
         }
-        if (hasPositiveId(setup.participantToRemoveId())) {
-            removeParticipant(setup.participantToRemoveId());
+    }
+
+    private void removeTimelineParticipant(SessionPlannerTimelineMainViewInputEvent event) {
+        if (hasPositiveId(event.participantId())) {
+            removeParticipant(event.participantId());
         }
-        BigDecimal encounterDays = parsePositiveDecimal(setup.encounterDaysText());
+    }
+
+    private void applyTimelineEncounterDays(SessionPlannerTimelineMainViewInputEvent event) {
+        BigDecimal encounterDays = parsePositiveDecimal(event.encounterDaysText());
         if (encounterDays != null) {
             setEncounterDays(encounterDays);
-        }
-        if (setup.addSceneRequested()) {
-            addScene();
-        }
-    }
-
-    private void consumeTimelineMutation(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.MutationSnapshot mutation = event.mutation();
-        if (hasPositiveId(mutation.moveSceneToken())) {
-            applyMove(mutation.moveSceneToken(), mutation.moveDirection());
-        }
-        if (hasPositiveId(mutation.sceneTokenToRemove())) {
-            removeEncounter(mutation.sceneTokenToRemove());
-        }
-    }
-
-    private void consumeTimelineRest(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.RestSnapshot rest = event.rest();
-        if (isResolvedGap(rest.leftSceneToken(), rest.rightSceneToken())) {
-            applyRestGap(rest.leftSceneToken(), rest.rightSceneToken(), rest.selection());
-        }
-    }
-
-    private void consumeTimelineLoot(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.LootSnapshot lootSnapshot = event.loot();
-        if (hasPositiveId(lootSnapshot.sceneTokenToAdd())) {
-            addLootPlaceholder(lootSnapshot.sceneTokenToAdd());
-        }
-        if (hasPositiveId(lootSnapshot.tokenToRemove())) {
-            removeLootPlaceholder(lootSnapshot.tokenToRemove());
-        }
-    }
-
-    private void consumeTimelineScene(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.SceneSnapshot scene = event.scene();
-        if (hasPositiveId(scene.sceneToken())) {
-            updateEncounterScene(
-                    scene.sceneToken(),
-                    scene.title(),
-                    scene.notes(),
-                    scene.locationId());
-        }
-    }
-
-    private void consumeTimelineSceneDraft(SessionPlannerTimelineMainViewInputEvent event) {
-        SessionPlannerTimelineMainViewInputEvent.SceneDraftSnapshot sceneDraft = event.sceneDraft();
-        if (hasPositiveId(sceneDraft.sceneToken())) {
-            timelineMainContentModel.updateSceneDraft(
-                    sceneDraft.sceneToken(),
-                    sceneDraft.title(),
-                    sceneDraft.notes(),
-                    sceneDraft.locationId());
         }
     }
 
@@ -168,29 +220,6 @@ final class SessionPlannerIntentHandler {
 
     private static boolean isResolvedGap(long leftSceneToken, long rightSceneToken) {
         return hasPositiveId(leftSceneToken) && hasPositiveId(rightSceneToken);
-    }
-
-    private void applyMove(long sceneToken, int moveDirection) {
-        if (moveDirection > 0) {
-            moveEncounterDown(sceneToken);
-            return;
-        }
-        if (moveDirection < 0) {
-            moveEncounterUp(sceneToken);
-        }
-    }
-
-    private void applyRestGap(
-            long leftSceneToken,
-            long rightSceneToken,
-            SessionPlannerTimelineMainViewInputEvent.RestSelection restSelection
-    ) {
-        switch (restSelection) {
-            case NONE -> clearRestGap(leftSceneToken, rightSceneToken);
-            case SHORT_REST -> setRestGap(leftSceneToken, rightSceneToken, SessionPlannerRestKind.SHORT_REST);
-            case LONG_REST -> setRestGap(leftSceneToken, rightSceneToken, SessionPlannerRestKind.LONG_REST);
-            default -> throw new IllegalStateException("Unhandled rest selection: " + restSelection);
-        }
     }
 
     void consume(CatalogCrudControlsViewInputEvent event) {

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainContentModel.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainContentModel.java
@@ -19,6 +19,49 @@ public final class SessionPlannerTimelineMainContentModel {
 
     private static final long NO_SCENE_TOKEN = 0L;
     private static final long NO_LOCATION_ID = 0L;
+    private static final long SETUP_WIDGET_BASE = 1_000L;
+    private static final long SCENE_WIDGET_BASE = 1_000_000L;
+    private static final long REST_WIDGET_BASE = 2_000_000L;
+    private static final long LOOT_WIDGET_BASE = 3_000_000L;
+    private static final long PARTICIPANT_WIDGET_BASE = 4_000_000L;
+    private static final long WIDGET_STRIDE = 100L;
+    private static final int WIDGET_SCENE_SELECT = 1;
+    private static final int WIDGET_ALLOCATION_DECREASE = 2;
+    private static final int WIDGET_ALLOCATION_INCREASE = 3;
+    private static final int WIDGET_SCENE_MOVE_UP = 4;
+    private static final int WIDGET_SCENE_MOVE_DOWN = 5;
+    private static final int WIDGET_SCENE_REMOVE = 6;
+    private static final int WIDGET_REST_SHORT = 7;
+    private static final int WIDGET_REST_LONG = 8;
+    private static final int WIDGET_REST_CLEAR = 9;
+    private static final int WIDGET_LOOT_ADD = 10;
+    private static final int WIDGET_LOOT_REMOVE = 11;
+    private static final int WIDGET_SCENE_SAVE = 12;
+    private static final int WIDGET_SCENE_DRAFT = 13;
+    private static final int WIDGET_PARTICIPANT_ADD = 14;
+    private static final int WIDGET_PARTICIPANT_REMOVE = 15;
+    private static final int WIDGET_ENCOUNTER_DAYS = 16;
+    private static final int WIDGET_SCENE_ADD = 17;
+    private static final TimelineWidgetKind[] WIDGET_KIND_BY_CODE = {
+            TimelineWidgetKind.NONE,
+            TimelineWidgetKind.SCENE_SELECT,
+            TimelineWidgetKind.ALLOCATION_DECREASE,
+            TimelineWidgetKind.ALLOCATION_INCREASE,
+            TimelineWidgetKind.SCENE_MOVE_UP,
+            TimelineWidgetKind.SCENE_MOVE_DOWN,
+            TimelineWidgetKind.SCENE_REMOVE,
+            TimelineWidgetKind.REST_SHORT,
+            TimelineWidgetKind.REST_LONG,
+            TimelineWidgetKind.REST_CLEAR,
+            TimelineWidgetKind.LOOT_ADD,
+            TimelineWidgetKind.LOOT_REMOVE,
+            TimelineWidgetKind.SCENE_SAVE,
+            TimelineWidgetKind.SCENE_DRAFT,
+            TimelineWidgetKind.PARTICIPANT_ADD,
+            TimelineWidgetKind.PARTICIPANT_REMOVE,
+            TimelineWidgetKind.ENCOUNTER_DAYS,
+            TimelineWidgetKind.SCENE_ADD
+    };
 
     private final ReadOnlyObjectWrapper<Projection> projection =
             new ReadOnlyObjectWrapper<>(Projection.empty());
@@ -88,6 +131,13 @@ public final class SessionPlannerTimelineMainContentModel {
                 .orElse(BigDecimal.ZERO);
     }
 
+    TimelineWidgetKind widgetKind(long widgetToken) {
+        int code = (int) Math.floorMod(widgetToken, WIDGET_STRIDE);
+        return code >= WIDGET_KIND_BY_CODE.length
+                ? TimelineWidgetKind.NONE
+                : WIDGET_KIND_BY_CODE[code];
+    }
+
     private void pruneSceneDrafts(SessionPlannerSceneTimelineProjection sceneTimelineProjection) {
         Set<Long> activeTokens = sceneTimelineProjection.sessionScenes().stream()
                 .map(SessionPlannerSceneTimelineProjection.SessionScene::sceneToken)
@@ -96,8 +146,49 @@ public final class SessionPlannerTimelineMainContentModel {
         sceneDrafts.keySet().removeIf(key -> key.sessionId() != sessionId || !activeTokens.contains(key.sceneToken()));
     }
 
+    private static long setupWidgetToken(int widgetCode) {
+        return SETUP_WIDGET_BASE + widgetCode;
+    }
+
+    private static long sceneWidgetToken(long sceneToken, int widgetCode) {
+        return SCENE_WIDGET_BASE + Math.max(0L, sceneToken) * WIDGET_STRIDE + widgetCode;
+    }
+
+    private static long restWidgetToken(int gapIndex, int widgetCode) {
+        return REST_WIDGET_BASE + Math.max(0, gapIndex) * WIDGET_STRIDE + widgetCode;
+    }
+
+    private static long lootWidgetToken(long lootToken, int widgetCode) {
+        return LOOT_WIDGET_BASE + Math.max(0L, lootToken) * WIDGET_STRIDE + widgetCode;
+    }
+
+    private static long participantWidgetToken(long participantId, int widgetCode) {
+        return PARTICIPANT_WIDGET_BASE + Math.max(0L, participantId) * WIDGET_STRIDE + widgetCode;
+    }
+
     private void publishProjection() {
         projection.set(Projection.from(latestSceneTimelineProjection, sceneDrafts, locationOptions, latestSetupState));
+    }
+
+    enum TimelineWidgetKind {
+        NONE,
+        SCENE_SELECT,
+        ALLOCATION_DECREASE,
+        ALLOCATION_INCREASE,
+        SCENE_MOVE_UP,
+        SCENE_MOVE_DOWN,
+        SCENE_REMOVE,
+        REST_SHORT,
+        REST_LONG,
+        REST_CLEAR,
+        LOOT_ADD,
+        LOOT_REMOVE,
+        SCENE_SAVE,
+        SCENE_DRAFT,
+        PARTICIPANT_ADD,
+        PARTICIPANT_REMOVE,
+        ENCOUNTER_DAYS,
+        SCENE_ADD
     }
 
     record SetupState(
@@ -234,7 +325,10 @@ public final class SessionPlannerTimelineMainContentModel {
                                     gap.leftSceneToken(),
                                     gap.rightSceneToken(),
                                     restLabel(gap.restKind()),
-                                    gap.restKind() != null && gap.restKind() != SessionPlannerRestKind.NONE))
+                                    gap.restKind() != null && gap.restKind() != SessionPlannerRestKind.NONE,
+                                    restWidgetToken(gap.gapIndex(), WIDGET_REST_SHORT),
+                                    restWidgetToken(gap.gapIndex(), WIDGET_REST_LONG),
+                                    restWidgetToken(gap.gapIndex(), WIDGET_REST_CLEAR)))
                             .toList(),
                     safeCopy(locationOptions));
         }
@@ -278,8 +372,20 @@ public final class SessionPlannerTimelineMainContentModel {
                                 locationId,
                                 locationLabel(locationId, safeLocations),
                                 locationChoices(locationId, safeLocations),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_SELECT),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_ALLOCATION_DECREASE),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_ALLOCATION_INCREASE),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_MOVE_UP),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_MOVE_DOWN),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_REMOVE),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_SAVE),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_SCENE_DRAFT),
+                                sceneWidgetToken(scene.sceneToken(), WIDGET_LOOT_ADD),
                                 scene.lootPlaceholders().stream()
-                                        .map(loot -> new LootModel(loot.token(), loot.label()))
+                                        .map(loot -> new LootModel(
+                                                loot.token(),
+                                                lootWidgetToken(loot.token(), WIDGET_LOOT_REMOVE),
+                                                loot.label()))
                                         .toList());
                     })
                     .toList();
@@ -355,6 +461,15 @@ public final class SessionPlannerTimelineMainContentModel {
                 long locationId,
                 String locationLabel,
                 List<LocationChoice> locationChoices,
+                long selectWidgetToken,
+                long allocationDecreaseWidgetToken,
+                long allocationIncreaseWidgetToken,
+                long moveUpWidgetToken,
+                long moveDownWidgetToken,
+                long removeWidgetToken,
+                long sceneSaveWidgetToken,
+                long sceneDraftWidgetToken,
+                long addLootWidgetToken,
                 List<LootModel> lootPlaceholders
         ) {
 
@@ -372,6 +487,15 @@ public final class SessionPlannerTimelineMainContentModel {
                 locationId = Math.max(0L, locationId);
                 locationLabel = safeText(locationLabel);
                 locationChoices = safeCopy(locationChoices);
+                selectWidgetToken = Math.max(0L, selectWidgetToken);
+                allocationDecreaseWidgetToken = Math.max(0L, allocationDecreaseWidgetToken);
+                allocationIncreaseWidgetToken = Math.max(0L, allocationIncreaseWidgetToken);
+                moveUpWidgetToken = Math.max(0L, moveUpWidgetToken);
+                moveDownWidgetToken = Math.max(0L, moveDownWidgetToken);
+                removeWidgetToken = Math.max(0L, removeWidgetToken);
+                sceneSaveWidgetToken = Math.max(0L, sceneSaveWidgetToken);
+                sceneDraftWidgetToken = Math.max(0L, sceneDraftWidgetToken);
+                addLootWidgetToken = Math.max(0L, addLootWidgetToken);
                 lootPlaceholders = safeCopy(lootPlaceholders);
             }
         }
@@ -395,6 +519,9 @@ public final class SessionPlannerTimelineMainContentModel {
                 String sceneTargetText,
                 String budgetText,
                 String restText,
+                long participantAddWidgetToken,
+                long encounterDaysWidgetToken,
+                long sceneAddWidgetToken,
                 List<String> partyMemberChoiceLabels,
                 List<SessionParticipantModel> sessionParticipantRows
         ) {
@@ -404,12 +531,19 @@ public final class SessionPlannerTimelineMainContentModel {
                 sceneTargetText = safeText(sceneTargetText);
                 budgetText = safeText(budgetText);
                 restText = safeText(restText);
+                participantAddWidgetToken = Math.max(0L, participantAddWidgetToken);
+                encounterDaysWidgetToken = Math.max(0L, encounterDaysWidgetToken);
+                sceneAddWidgetToken = Math.max(0L, sceneAddWidgetToken);
                 partyMemberChoiceLabels = safeCopy(partyMemberChoiceLabels);
                 sessionParticipantRows = safeCopy(sessionParticipantRows);
             }
 
             static SetupModel empty() {
-                return new SetupModel(true, "", "ca. 0 Szenen", "", "", List.of(),
+                return new SetupModel(true, "", "ca. 0 Szenen", "", "",
+                        setupWidgetToken(WIDGET_PARTICIPANT_ADD),
+                        setupWidgetToken(WIDGET_ENCOUNTER_DAYS),
+                        setupWidgetToken(WIDGET_SCENE_ADD),
+                        List.of(),
                         List.of(SessionParticipantModel.placeholder()));
             }
 
@@ -424,6 +558,9 @@ public final class SessionPlannerTimelineMainContentModel {
                         sceneTargetText(safe.encounterDaysText(), sceneCount),
                         safe.budgetText(),
                         safe.restText(),
+                        setupWidgetToken(WIDGET_PARTICIPANT_ADD),
+                        setupWidgetToken(WIDGET_ENCOUNTER_DAYS),
+                        setupWidgetToken(WIDGET_SCENE_ADD),
                         safe.partyMemberChoices().stream()
                                 .map(ParticipantChoice::label)
                                 .toList(),
@@ -441,6 +578,7 @@ public final class SessionPlannerTimelineMainContentModel {
                                 participant.name(),
                                 participant.detail(),
                                 participant.detailStyleClass(),
+                                participantWidgetToken(participant.characterId(), WIDGET_PARTICIPANT_REMOVE),
                                 "X",
                                 participant.actionDisabled(),
                                 true))
@@ -471,6 +609,7 @@ public final class SessionPlannerTimelineMainContentModel {
                 String name,
                 String detail,
                 String detailStyleClass,
+                long removeWidgetToken,
                 String removeText,
                 boolean actionDisabled,
                 boolean removeVisible
@@ -481,11 +620,12 @@ public final class SessionPlannerTimelineMainContentModel {
                 name = safeText(name);
                 detail = safeText(detail);
                 detailStyleClass = safeText(detailStyleClass);
+                removeWidgetToken = Math.max(0L, removeWidgetToken);
                 removeText = safeText(removeText);
             }
 
             static SessionParticipantModel placeholder() {
-                return new SessionParticipantModel(0L, "keine Spieler", "", "text-secondary", "", true, false);
+                return new SessionParticipantModel(0L, "keine Spieler", "", "text-secondary", 0L, "", true, false);
             }
         }
 
@@ -494,20 +634,29 @@ public final class SessionPlannerTimelineMainContentModel {
                 long leftSceneToken,
                 long rightSceneToken,
                 String label,
-                boolean hasAssignedRest
+                boolean hasAssignedRest,
+                long shortRestWidgetToken,
+                long longRestWidgetToken,
+                long clearRestWidgetToken
         ) {
 
             RestGapModel {
                 label = safeText(label);
+                shortRestWidgetToken = Math.max(0L, shortRestWidgetToken);
+                longRestWidgetToken = Math.max(0L, longRestWidgetToken);
+                clearRestWidgetToken = Math.max(0L, clearRestWidgetToken);
             }
         }
 
         record LootModel(
                 long token,
+                long removeWidgetToken,
                 String label
         ) {
 
             LootModel {
+                token = Math.max(0L, token);
+                removeWidgetToken = Math.max(0L, removeWidgetToken);
                 label = safeText(label);
             }
         }

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainContentModel.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainContentModel.java
@@ -77,6 +77,17 @@ public final class SessionPlannerTimelineMainContentModel {
                 : choices.get(choiceIndex).characterId();
     }
 
+    BigDecimal budgetPercentage(long sceneToken) {
+        if (sceneToken <= NO_SCENE_TOKEN) {
+            return BigDecimal.ZERO;
+        }
+        return latestSceneTimelineProjection.sessionScenes().stream()
+                .filter(scene -> scene.sceneToken() == sceneToken)
+                .map(SessionPlannerSceneTimelineProjection.SessionScene::budgetPercentage)
+                .findFirst()
+                .orElse(BigDecimal.ZERO);
+    }
+
     private void pruneSceneDrafts(SessionPlannerSceneTimelineProjection sceneTimelineProjection) {
         Set<Long> activeTokens = sceneTimelineProjection.sessionScenes().stream()
                 .map(SessionPlannerSceneTimelineProjection.SessionScene::sceneToken)

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
@@ -87,7 +87,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         Button addScene = actionButton(
                 "Szene hinzufuegen",
                 WIDGET_SCENE_ADD,
-                event -> rawPublish(event),
+                this::rawPublish,
                 STYLE_ACCENT);
         addScene.setDisable(projection.setup().sessionActionsDisabled());
         addNode(rows, addScene);
@@ -338,19 +338,63 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
     }
 
     private void rawPublish(ActionEvent event) {
-        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, 0L, -1, "", "", "", 0L);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                -1,
+                "",
+                "",
+                "",
+                0L));
     }
 
     private void rawPublishScene(ActionEvent event, long sceneToken) {
-        rawPublish(rawWidgetId(event), sceneToken, 0L, 0L, 0L, 0L, -1, "", "", "", 0L);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                sceneToken,
+                0L,
+                0L,
+                0L,
+                0L,
+                -1,
+                "",
+                "",
+                "",
+                0L));
     }
 
     private void rawPublishRestGap(ActionEvent event, long leftSceneToken, long rightSceneToken) {
-        rawPublish(rawWidgetId(event), 0L, leftSceneToken, rightSceneToken, 0L, 0L, -1, "", "", "", 0L);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                0L,
+                leftSceneToken,
+                rightSceneToken,
+                0L,
+                0L,
+                -1,
+                "",
+                "",
+                "",
+                0L));
     }
 
     private void rawPublishLoot(ActionEvent event, long lootToken) {
-        rawPublish(rawWidgetId(event), 0L, 0L, 0L, lootToken, 0L, -1, "", "", "", 0L);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                0L,
+                0L,
+                0L,
+                lootToken,
+                0L,
+                -1,
+                "",
+                "",
+                "",
+                0L));
     }
 
     private void rawPublishSceneText(
@@ -360,15 +404,37 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
             String sceneNotes,
             long locationId
     ) {
-        rawPublish(rawWidgetId(event), sceneToken, 0L, 0L, 0L, 0L, -1, "", sceneTitle, sceneNotes, locationId);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                sceneToken,
+                0L,
+                0L,
+                0L,
+                0L,
+                -1,
+                "",
+                sceneTitle,
+                sceneNotes,
+                locationId));
     }
 
     private void rawPublishSceneDraft(long sceneToken, String sceneTitle, String sceneNotes, long locationId) {
-        rawPublish(WIDGET_SCENE_DRAFT, sceneToken, 0L, 0L, 0L, 0L, -1, "", sceneTitle, sceneNotes, locationId);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                WIDGET_SCENE_DRAFT,
+                sceneToken,
+                0L,
+                0L,
+                0L,
+                0L,
+                -1,
+                "",
+                sceneTitle,
+                sceneNotes,
+                locationId));
     }
 
     private void rawPublishParticipantAdd(ActionEvent event, ComboBox<String> participantSelector) {
-        rawPublish(
+        publish(new SessionPlannerTimelineMainViewInputEvent(
                 rawWidgetId(event),
                 0L,
                 0L,
@@ -379,42 +445,37 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 "",
                 "",
                 "",
-                0L);
+                0L));
     }
 
     private void rawPublishParticipantRemove(ActionEvent event, long participantId) {
-        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, participantId, -1, "", "", "", 0L);
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                rawWidgetId(event),
+                0L,
+                0L,
+                0L,
+                0L,
+                participantId,
+                -1,
+                "",
+                "",
+                "",
+                0L));
     }
 
     private void rawPublishEncounterDays(ActionEvent event, String encounterDays) {
-        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, 0L, -1, encounterDays, "", "", 0L);
-    }
-
-    private void rawPublish(
-            String widgetId,
-            long sceneToken,
-            long leftSceneToken,
-            long rightSceneToken,
-            long lootToken,
-            long participantId,
-            int participantChoiceIndex,
-            String encounterDaysText,
-            String sceneTitleText,
-            String sceneNotesText,
-            long locationId
-    ) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                widgetId,
-                sceneToken,
-                leftSceneToken,
-                rightSceneToken,
-                lootToken,
-                participantId,
-                participantChoiceIndex,
-                encounterDaysText,
-                sceneTitleText,
-                sceneNotesText,
-                locationId));
+                rawWidgetId(event),
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                -1,
+                encounterDays,
+                "",
+                "",
+                0L));
     }
 
     private String rawWidgetId(ActionEvent event) {

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
@@ -21,23 +21,6 @@ import javafx.util.StringConverter;
 
 public final class SessionPlannerTimelineMainView extends ScrollPane {
 
-    private static final String WIDGET_SCENE_SELECT = "session-planner.timeline.scene.select";
-    private static final String WIDGET_ALLOCATION_DECREASE = "session-planner.timeline.allocation.decrease";
-    private static final String WIDGET_ALLOCATION_INCREASE = "session-planner.timeline.allocation.increase";
-    private static final String WIDGET_SCENE_MOVE_UP = "session-planner.timeline.scene.move-up";
-    private static final String WIDGET_SCENE_MOVE_DOWN = "session-planner.timeline.scene.move-down";
-    private static final String WIDGET_SCENE_REMOVE = "session-planner.timeline.scene.remove";
-    private static final String WIDGET_REST_SHORT = "session-planner.timeline.rest.short";
-    private static final String WIDGET_REST_LONG = "session-planner.timeline.rest.long";
-    private static final String WIDGET_REST_CLEAR = "session-planner.timeline.rest.clear";
-    private static final String WIDGET_LOOT_ADD = "session-planner.timeline.loot.add";
-    private static final String WIDGET_LOOT_REMOVE = "session-planner.timeline.loot.remove";
-    private static final String WIDGET_SCENE_SAVE = "session-planner.timeline.scene.save";
-    private static final String WIDGET_SCENE_DRAFT = "session-planner.timeline.scene.draft";
-    private static final String WIDGET_PARTICIPANT_ADD = "session-planner.timeline.participant.add";
-    private static final String WIDGET_PARTICIPANT_REMOVE = "session-planner.timeline.participant.remove";
-    private static final String WIDGET_ENCOUNTER_DAYS = "session-planner.timeline.encounter-days.apply";
-    private static final String WIDGET_SCENE_ADD = "session-planner.timeline.scene.add";
     private static final String STYLE_TEXT_SECONDARY = "text-secondary";
     private static final String STYLE_COMPACT = "compact";
     private static final String STYLE_ACCENT = "accent";
@@ -86,8 +69,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         }
         Button addScene = actionButton(
                 "Szene hinzufuegen",
-                WIDGET_SCENE_ADD,
-                this::rawPublish,
+                event -> rawPublish(event, projection.setup().sceneAddWidgetToken()),
                 STYLE_ACCENT);
         addScene.setDisable(projection.setup().sessionActionsDisabled());
         addNode(rows, addScene);
@@ -103,8 +85,10 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         partyMemberSelector.setDisable(setup.sessionActionsDisabled() || partyMemberSelector.getItems().isEmpty());
         Button addPlayer = actionButton(
                 "Hinzufuegen",
-                WIDGET_PARTICIPANT_ADD,
-                event -> rawPublishParticipantAdd(event, partyMemberSelector),
+                event -> rawPublishParticipantAdd(
+                        event,
+                        setup.participantAddWidgetToken(),
+                        partyMemberSelector),
                 STYLE_ACCENT);
         addPlayer.setDisable(partyMemberSelector.isDisabled());
         TextField encounterDays = new TextField(setup.encounterDaysText());
@@ -113,8 +97,10 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         encounterDays.setDisable(setup.sessionActionsDisabled());
         Button applyDays = actionButton(
                 "Setzen",
-                WIDGET_ENCOUNTER_DAYS,
-                event -> rawPublishEncounterDays(event, encounterDays.getText()),
+                event -> rawPublishEncounterDays(
+                        event,
+                        setup.encounterDaysWidgetToken(),
+                        encounterDays.getText()),
                 STYLE_FLAT);
         applyDays.setDisable(setup.sessionActionsDisabled());
 
@@ -135,8 +121,10 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 : setup.sessionParticipantRows()) {
             Button remove = actionButton(
                     participant.removeText(),
-                    WIDGET_PARTICIPANT_REMOVE,
-                    event -> rawPublishParticipantRemove(event, participant.characterId()),
+                    event -> rawPublishParticipantRemove(
+                            event,
+                            participant.removeWidgetToken(),
+                            participant.characterId()),
                     STYLE_FLAT);
             remove.setDisable(participant.actionDisabled());
             remove.setVisible(participant.removeVisible());
@@ -168,40 +156,34 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
         Button select = actionButton(
                 scene.selected() ? "Ausgewaehlt" : "Auswaehlen",
-                WIDGET_SCENE_SELECT,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.selectWidgetToken(), scene.sceneToken()),
                 scene.selected() ? STYLE_FLAT : STYLE_ACCENT);
         select.setDisable(scene.selected());
 
         Button decreaseAllocation = actionButton(
                 "-10%",
-                WIDGET_ALLOCATION_DECREASE,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.allocationDecreaseWidgetToken(), scene.sceneToken()),
                 STYLE_FLAT);
         Button increaseAllocation = actionButton(
                 "+10%",
-                WIDGET_ALLOCATION_INCREASE,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.allocationIncreaseWidgetToken(), scene.sceneToken()),
                 STYLE_FLAT);
 
         Button up = actionButton(
                 "Hoch",
-                WIDGET_SCENE_MOVE_UP,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.moveUpWidgetToken(), scene.sceneToken()),
                 STYLE_FLAT);
         up.setDisable(!scene.canMoveUp());
 
         Button down = actionButton(
                 "Runter",
-                WIDGET_SCENE_MOVE_DOWN,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.moveDownWidgetToken(), scene.sceneToken()),
                 STYLE_FLAT);
         down.setDisable(!scene.canMoveDown());
 
         Button remove = actionButton(
                 "X",
-                WIDGET_SCENE_REMOVE,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.removeWidgetToken(), scene.sceneToken()),
                 STYLE_FLAT);
 
         VBox card = new VBox(6,
@@ -245,6 +227,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         notes.setPrefRowCount(2);
         notes.getStyleClass().add(STYLE_COMPACT);
         Runnable publishDraft = () -> rawPublishSceneDraft(
+                scene.sceneDraftWidgetToken(),
                 scene.sceneToken(),
                 title.getText(),
                 notes.getText(),
@@ -255,9 +238,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
         Button save = actionButton(
                 "Szene speichern",
-                WIDGET_SCENE_SAVE,
                 event -> rawPublishSceneText(
                         event,
+                        scene.sceneSaveWidgetToken(),
                         scene.sceneToken(),
                         title.getText(),
                         notes.getText(),
@@ -276,8 +259,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
     private Node lootSection(SessionPlannerTimelineMainContentModel.Projection.SceneModel scene) {
         Button addButton = actionButton(
                 "Loot-Platzhalter",
-                WIDGET_LOOT_ADD,
-                event -> rawPublishScene(event, scene.sceneToken()),
+                event -> rawPublishScene(event, scene.addLootWidgetToken(), scene.sceneToken()),
                 STYLE_ACCENT);
         VBox rows = new VBox(6);
         if (scene.lootPlaceholders().isEmpty()) {
@@ -300,8 +282,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         Label label = label(loot.label());
         Button remove = actionButton(
                 "Entfernen",
-                WIDGET_LOOT_REMOVE,
-                event -> rawPublishLoot(event, loot.token()),
+                event -> rawPublishLoot(event, loot.removeWidgetToken(), loot.token()),
                 STYLE_FLAT);
         ActionRow row = new ActionRow(8, label, remove);
         row.addStyles("session-planner-loot-card");
@@ -319,16 +300,25 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         Label current = label(gap.label(), gap.hasAssignedRest() ? "session-planner-gap-active" : STYLE_TEXT_SECONDARY);
 
         Button shortRest = actionButton("Kurze Rast",
-                WIDGET_REST_SHORT,
-                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
+                event -> rawPublishRestGap(
+                        event,
+                        gap.shortRestWidgetToken(),
+                        gap.leftSceneToken(),
+                        gap.rightSceneToken()),
                 STYLE_FLAT);
         Button longRest = actionButton("Lange Rast",
-                WIDGET_REST_LONG,
-                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
+                event -> rawPublishRestGap(
+                        event,
+                        gap.longRestWidgetToken(),
+                        gap.leftSceneToken(),
+                        gap.rightSceneToken()),
                 STYLE_FLAT);
         Button clear = actionButton("Leeren",
-                WIDGET_REST_CLEAR,
-                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
+                event -> rawPublishRestGap(
+                        event,
+                        gap.clearRestWidgetToken(),
+                        gap.leftSceneToken(),
+                        gap.rightSceneToken()),
                 STYLE_FLAT);
         clear.setDisable(!gap.hasAssignedRest());
 
@@ -337,9 +327,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         return card;
     }
 
-    private void rawPublish(ActionEvent event) {
+    private void rawPublish(ActionEvent event, long widgetToken) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 0L,
                 0L,
@@ -352,9 +342,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private void rawPublishScene(ActionEvent event, long sceneToken) {
+    private void rawPublishScene(ActionEvent event, long widgetToken, long sceneToken) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 sceneToken,
                 0L,
                 0L,
@@ -367,9 +357,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private void rawPublishRestGap(ActionEvent event, long leftSceneToken, long rightSceneToken) {
+    private void rawPublishRestGap(ActionEvent event, long widgetToken, long leftSceneToken, long rightSceneToken) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 leftSceneToken,
                 rightSceneToken,
@@ -382,9 +372,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private void rawPublishLoot(ActionEvent event, long lootToken) {
+    private void rawPublishLoot(ActionEvent event, long widgetToken, long lootToken) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 0L,
                 0L,
@@ -399,13 +389,14 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
     private void rawPublishSceneText(
             ActionEvent event,
+            long widgetToken,
             long sceneToken,
             String sceneTitle,
             String sceneNotes,
             long locationId
     ) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 sceneToken,
                 0L,
                 0L,
@@ -418,9 +409,15 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 locationId));
     }
 
-    private void rawPublishSceneDraft(long sceneToken, String sceneTitle, String sceneNotes, long locationId) {
+    private void rawPublishSceneDraft(
+            long widgetToken,
+            long sceneToken,
+            String sceneTitle,
+            String sceneNotes,
+            long locationId
+    ) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                WIDGET_SCENE_DRAFT,
+                widgetToken,
                 sceneToken,
                 0L,
                 0L,
@@ -433,9 +430,13 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 locationId));
     }
 
-    private void rawPublishParticipantAdd(ActionEvent event, ComboBox<String> participantSelector) {
+    private void rawPublishParticipantAdd(
+            ActionEvent event,
+            long widgetToken,
+            ComboBox<String> participantSelector
+    ) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 0L,
                 0L,
@@ -448,9 +449,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private void rawPublishParticipantRemove(ActionEvent event, long participantId) {
+    private void rawPublishParticipantRemove(ActionEvent event, long widgetToken, long participantId) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 0L,
                 0L,
@@ -463,9 +464,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private void rawPublishEncounterDays(ActionEvent event, String encounterDays) {
+    private void rawPublishEncounterDays(ActionEvent event, long widgetToken, String encounterDays) {
         publish(new SessionPlannerTimelineMainViewInputEvent(
-                rawWidgetId(event),
+                rawWidgetToken(event, widgetToken),
                 0L,
                 0L,
                 0L,
@@ -478,11 +479,8 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 0L));
     }
 
-    private String rawWidgetId(ActionEvent event) {
-        if (event.getSource() instanceof Node node) {
-            return node.getId();
-        }
-        return "";
+    private long rawWidgetToken(ActionEvent event, long widgetToken) {
+        return event.getSource() instanceof Node ? Math.max(0L, widgetToken) : 0L;
     }
 
     private void publish(SessionPlannerTimelineMainViewInputEvent event) {
@@ -501,12 +499,10 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
     private static Button actionButton(
             String text,
-            String widgetId,
             EventHandler<ActionEvent> action,
             String emphasisStyle
     ) {
         Button button = new StyledButton(text, STYLE_COMPACT, emphasisStyle);
-        button.setId(widgetId);
         button.setOnAction(action);
         return button;
     }

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainView.java
@@ -1,6 +1,5 @@
 package src.view.leftbartabs.sessionplanner;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
@@ -22,7 +21,23 @@ import javafx.util.StringConverter;
 
 public final class SessionPlannerTimelineMainView extends ScrollPane {
 
-    private static final BigDecimal ALLOCATION_STEP = BigDecimal.TEN;
+    private static final String WIDGET_SCENE_SELECT = "session-planner.timeline.scene.select";
+    private static final String WIDGET_ALLOCATION_DECREASE = "session-planner.timeline.allocation.decrease";
+    private static final String WIDGET_ALLOCATION_INCREASE = "session-planner.timeline.allocation.increase";
+    private static final String WIDGET_SCENE_MOVE_UP = "session-planner.timeline.scene.move-up";
+    private static final String WIDGET_SCENE_MOVE_DOWN = "session-planner.timeline.scene.move-down";
+    private static final String WIDGET_SCENE_REMOVE = "session-planner.timeline.scene.remove";
+    private static final String WIDGET_REST_SHORT = "session-planner.timeline.rest.short";
+    private static final String WIDGET_REST_LONG = "session-planner.timeline.rest.long";
+    private static final String WIDGET_REST_CLEAR = "session-planner.timeline.rest.clear";
+    private static final String WIDGET_LOOT_ADD = "session-planner.timeline.loot.add";
+    private static final String WIDGET_LOOT_REMOVE = "session-planner.timeline.loot.remove";
+    private static final String WIDGET_SCENE_SAVE = "session-planner.timeline.scene.save";
+    private static final String WIDGET_SCENE_DRAFT = "session-planner.timeline.scene.draft";
+    private static final String WIDGET_PARTICIPANT_ADD = "session-planner.timeline.participant.add";
+    private static final String WIDGET_PARTICIPANT_REMOVE = "session-planner.timeline.participant.remove";
+    private static final String WIDGET_ENCOUNTER_DAYS = "session-planner.timeline.encounter-days.apply";
+    private static final String WIDGET_SCENE_ADD = "session-planner.timeline.scene.add";
     private static final String STYLE_TEXT_SECONDARY = "text-secondary";
     private static final String STYLE_COMPACT = "compact";
     private static final String STYLE_ACCENT = "accent";
@@ -69,7 +84,11 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 }
             }
         }
-        Button addScene = actionButton("Szene hinzufuegen", ignored -> publishAddScene(), STYLE_ACCENT);
+        Button addScene = actionButton(
+                "Szene hinzufuegen",
+                WIDGET_SCENE_ADD,
+                event -> rawPublish(event),
+                STYLE_ACCENT);
         addScene.setDisable(projection.setup().sessionActionsDisabled());
         addNode(rows, addScene);
     }
@@ -84,14 +103,19 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         partyMemberSelector.setDisable(setup.sessionActionsDisabled() || partyMemberSelector.getItems().isEmpty());
         Button addPlayer = actionButton(
                 "Hinzufuegen",
-                ignored -> publishParticipantAdd(partyMemberSelector),
+                WIDGET_PARTICIPANT_ADD,
+                event -> rawPublishParticipantAdd(event, partyMemberSelector),
                 STYLE_ACCENT);
         addPlayer.setDisable(partyMemberSelector.isDisabled());
         TextField encounterDays = new TextField(setup.encounterDaysText());
         encounterDays.setPromptText("Tage");
         encounterDays.getStyleClass().add(STYLE_COMPACT);
         encounterDays.setDisable(setup.sessionActionsDisabled());
-        Button applyDays = actionButton("Setzen", ignored -> publishEncounterDays(encounterDays.getText()), STYLE_FLAT);
+        Button applyDays = actionButton(
+                "Setzen",
+                WIDGET_ENCOUNTER_DAYS,
+                event -> rawPublishEncounterDays(event, encounterDays.getText()),
+                STYLE_FLAT);
         applyDays.setDisable(setup.sessionActionsDisabled());
 
         HBox inputRow = actionRow(
@@ -111,7 +135,8 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
                 : setup.sessionParticipantRows()) {
             Button remove = actionButton(
                     participant.removeText(),
-                    event -> publishParticipantRemove(participant.characterId()),
+                    WIDGET_PARTICIPANT_REMOVE,
+                    event -> rawPublishParticipantRemove(event, participant.characterId()),
                     STYLE_FLAT);
             remove.setDisable(participant.actionDisabled());
             remove.setVisible(participant.removeVisible());
@@ -143,32 +168,41 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
         Button select = actionButton(
                 scene.selected() ? "Ausgewaehlt" : "Auswaehlen",
-                this::publishSelection,
+                WIDGET_SCENE_SELECT,
+                event -> rawPublishScene(event, scene.sceneToken()),
                 scene.selected() ? STYLE_FLAT : STYLE_ACCENT);
-        select.setUserData(Long.valueOf(scene.sceneToken()));
         select.setDisable(scene.selected());
 
-        Button decreaseAllocation = actionButton("-10%", this::publishAllocation, STYLE_FLAT);
-        decreaseAllocation.setUserData(new Object[] {
-                Long.valueOf(scene.sceneToken()),
-                scene.budgetPercentage().subtract(ALLOCATION_STEP)
-        });
-        Button increaseAllocation = actionButton("+10%", this::publishAllocation, STYLE_FLAT);
-        increaseAllocation.setUserData(new Object[] {
-                Long.valueOf(scene.sceneToken()),
-                scene.budgetPercentage().add(ALLOCATION_STEP)
-        });
+        Button decreaseAllocation = actionButton(
+                "-10%",
+                WIDGET_ALLOCATION_DECREASE,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_FLAT);
+        Button increaseAllocation = actionButton(
+                "+10%",
+                WIDGET_ALLOCATION_INCREASE,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_FLAT);
 
-        Button up = actionButton("Hoch", this::publishMove, STYLE_FLAT);
-        up.setUserData(new Object[] {Long.valueOf(scene.sceneToken()), Integer.valueOf(-1)});
+        Button up = actionButton(
+                "Hoch",
+                WIDGET_SCENE_MOVE_UP,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_FLAT);
         up.setDisable(!scene.canMoveUp());
 
-        Button down = actionButton("Runter", this::publishMove, STYLE_FLAT);
-        down.setUserData(new Object[] {Long.valueOf(scene.sceneToken()), Integer.valueOf(1)});
+        Button down = actionButton(
+                "Runter",
+                WIDGET_SCENE_MOVE_DOWN,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_FLAT);
         down.setDisable(!scene.canMoveDown());
 
-        Button remove = actionButton("X", this::publishRemoval, STYLE_FLAT);
-        remove.setUserData(Long.valueOf(scene.sceneToken()));
+        Button remove = actionButton(
+                "X",
+                WIDGET_SCENE_REMOVE,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_FLAT);
 
         VBox card = new VBox(6,
                 new ActionRow(8, title, spacer(), remove),
@@ -210,7 +244,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         notes.setPromptText("Szenennotizen");
         notes.setPrefRowCount(2);
         notes.getStyleClass().add(STYLE_COMPACT);
-        Runnable publishDraft = () -> publishSceneDraft(
+        Runnable publishDraft = () -> rawPublishSceneDraft(
                 scene.sceneToken(),
                 title.getText(),
                 notes.getText(),
@@ -219,11 +253,15 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         notes.textProperty().addListener((ignored, before, after) -> publishDraft.run());
         location.valueProperty().addListener((ignored, before, after) -> publishDraft.run());
 
-        Button save = actionButton("Szene speichern", event -> publishSceneUpdate(
-                scene.sceneToken(),
-                title.getText(),
-                notes.getText(),
-                location.selectedLocationId()),
+        Button save = actionButton(
+                "Szene speichern",
+                WIDGET_SCENE_SAVE,
+                event -> rawPublishSceneText(
+                        event,
+                        scene.sceneToken(),
+                        title.getText(),
+                        notes.getText(),
+                        location.selectedLocationId()),
                 STYLE_ACCENT);
 
         return new VBox(
@@ -236,8 +274,11 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
     }
 
     private Node lootSection(SessionPlannerTimelineMainContentModel.Projection.SceneModel scene) {
-        Button addButton = actionButton("Loot-Platzhalter", this::publishAddLoot, STYLE_ACCENT);
-        addButton.setUserData(Long.valueOf(scene.sceneToken()));
+        Button addButton = actionButton(
+                "Loot-Platzhalter",
+                WIDGET_LOOT_ADD,
+                event -> rawPublishScene(event, scene.sceneToken()),
+                STYLE_ACCENT);
         VBox rows = new VBox(6);
         if (scene.lootPlaceholders().isEmpty()) {
             addNode(rows, label(
@@ -257,8 +298,11 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
     private Node lootCard(SessionPlannerTimelineMainContentModel.Projection.LootModel loot) {
         Label label = label(loot.label());
-        Button remove = actionButton("Entfernen", this::publishRemoveLoot, STYLE_FLAT);
-        remove.setUserData(Long.valueOf(loot.token()));
+        Button remove = actionButton(
+                "Entfernen",
+                WIDGET_LOOT_REMOVE,
+                event -> rawPublishLoot(event, loot.token()),
+                STYLE_FLAT);
         ActionRow row = new ActionRow(8, label, remove);
         row.addStyles("session-planner-loot-card");
         return row;
@@ -275,25 +319,16 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         Label current = label(gap.label(), gap.hasAssignedRest() ? "session-planner-gap-active" : STYLE_TEXT_SECONDARY);
 
         Button shortRest = actionButton("Kurze Rast",
-                ignored -> publishRestGap(new SessionPlannerTimelineMainViewInputEvent.RestSnapshot(
-                        gap.leftSceneToken(),
-                        gap.rightSceneToken(),
-                        true,
-                        false)),
+                WIDGET_REST_SHORT,
+                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
                 STYLE_FLAT);
         Button longRest = actionButton("Lange Rast",
-                ignored -> publishRestGap(new SessionPlannerTimelineMainViewInputEvent.RestSnapshot(
-                        gap.leftSceneToken(),
-                        gap.rightSceneToken(),
-                        false,
-                        true)),
+                WIDGET_REST_LONG,
+                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
                 STYLE_FLAT);
         Button clear = actionButton("Leeren",
-                ignored -> publishRestGap(new SessionPlannerTimelineMainViewInputEvent.RestSnapshot(
-                        gap.leftSceneToken(),
-                        gap.rightSceneToken(),
-                        false,
-                        false)),
+                WIDGET_REST_CLEAR,
+                event -> rawPublishRestGap(event, gap.leftSceneToken(), gap.rightSceneToken()),
                 STYLE_FLAT);
         clear.setDisable(!gap.hasAssignedRest());
 
@@ -302,132 +337,91 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         return card;
     }
 
-    private void publishSelection(ActionEvent event) {
-        long token = 0L;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Number value) {
-            token = value.longValue();
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SelectionSnapshot(
-                token,
+    private void rawPublish(ActionEvent event) {
+        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, 0L, -1, "", "", "", 0L);
+    }
+
+    private void rawPublishScene(ActionEvent event, long sceneToken) {
+        rawPublish(rawWidgetId(event), sceneToken, 0L, 0L, 0L, 0L, -1, "", "", "", 0L);
+    }
+
+    private void rawPublishRestGap(ActionEvent event, long leftSceneToken, long rightSceneToken) {
+        rawPublish(rawWidgetId(event), 0L, leftSceneToken, rightSceneToken, 0L, 0L, -1, "", "", "", 0L);
+    }
+
+    private void rawPublishLoot(ActionEvent event, long lootToken) {
+        rawPublish(rawWidgetId(event), 0L, 0L, 0L, lootToken, 0L, -1, "", "", "", 0L);
+    }
+
+    private void rawPublishSceneText(
+            ActionEvent event,
+            long sceneToken,
+            String sceneTitle,
+            String sceneNotes,
+            long locationId
+    ) {
+        rawPublish(rawWidgetId(event), sceneToken, 0L, 0L, 0L, 0L, -1, "", sceneTitle, sceneNotes, locationId);
+    }
+
+    private void rawPublishSceneDraft(long sceneToken, String sceneTitle, String sceneNotes, long locationId) {
+        rawPublish(WIDGET_SCENE_DRAFT, sceneToken, 0L, 0L, 0L, 0L, -1, "", sceneTitle, sceneNotes, locationId);
+    }
+
+    private void rawPublishParticipantAdd(ActionEvent event, ComboBox<String> participantSelector) {
+        rawPublish(
+                rawWidgetId(event),
                 0L,
-                BigDecimal.ZERO)));
-    }
-
-    private void publishAllocation(ActionEvent event) {
-        long token = 0L;
-        BigDecimal allocation = BigDecimal.ZERO;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Object[] payload) {
-            if (payload.length > 0 && payload[0] instanceof Number value) {
-                token = value.longValue();
-            }
-            if (payload.length > 1 && payload[1] instanceof BigDecimal value) {
-                allocation = value;
-            }
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SelectionSnapshot(
                 0L,
-                token,
-                allocation)));
-    }
-
-    private void publishMove(ActionEvent event) {
-        long token = 0L;
-        int direction = 0;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Object[] payload) {
-            if (payload.length > 0 && payload[0] instanceof Number value) {
-                token = value.longValue();
-            }
-            if (payload.length > 1 && payload[1] instanceof Number value) {
-                direction = value.intValue();
-            }
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.MutationSnapshot(
-                token,
-                direction,
-                0L)));
-    }
-
-    private void publishRemoval(ActionEvent event) {
-        long token = 0L;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Number value) {
-            token = value.longValue();
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.MutationSnapshot(
                 0L,
-                0,
-                token)));
-    }
-
-    private void publishRestGap(SessionPlannerTimelineMainViewInputEvent.RestSnapshot restSnapshot) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(restSnapshot));
-    }
-
-    private void publishAddLoot(ActionEvent event) {
-        long sceneToken = 0L;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Number token) {
-            sceneToken = token.longValue();
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.LootSnapshot(
-                sceneToken,
-                0L)));
-    }
-
-    private void publishRemoveLoot(ActionEvent event) {
-        long lootToken = 0L;
-        if (event.getSource() instanceof Button button && button.getUserData() instanceof Number token) {
-            lootToken = token.longValue();
-        }
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.LootSnapshot(
                 0L,
-                lootToken)));
-    }
-
-    private void publishSceneUpdate(long sceneToken, String title, String notes, long locationId) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SceneSnapshot(
-                sceneToken,
-                title,
-                notes,
-                locationId)));
-    }
-
-    private void publishSceneDraft(long sceneToken, String title, String notes, long locationId) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SceneDraftSnapshot(
-                sceneToken,
-                title,
-                notes,
-                locationId)));
-    }
-
-    private void publishParticipantAdd(ComboBox<String> participantSelector) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SetupSnapshot(
+                0L,
                 participantSelector.getSelectionModel().getSelectedIndex(),
-                0L,
                 "",
-                false)));
+                "",
+                "",
+                0L);
     }
 
-    private void publishParticipantRemove(long participantId) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SetupSnapshot(
-                -1,
+    private void rawPublishParticipantRemove(ActionEvent event, long participantId) {
+        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, participantId, -1, "", "", "", 0L);
+    }
+
+    private void rawPublishEncounterDays(ActionEvent event, String encounterDays) {
+        rawPublish(rawWidgetId(event), 0L, 0L, 0L, 0L, 0L, -1, encounterDays, "", "", 0L);
+    }
+
+    private void rawPublish(
+            String widgetId,
+            long sceneToken,
+            long leftSceneToken,
+            long rightSceneToken,
+            long lootToken,
+            long participantId,
+            int participantChoiceIndex,
+            String encounterDaysText,
+            String sceneTitleText,
+            String sceneNotesText,
+            long locationId
+    ) {
+        publish(new SessionPlannerTimelineMainViewInputEvent(
+                widgetId,
+                sceneToken,
+                leftSceneToken,
+                rightSceneToken,
+                lootToken,
                 participantId,
-                "",
-                false)));
+                participantChoiceIndex,
+                encounterDaysText,
+                sceneTitleText,
+                sceneNotesText,
+                locationId));
     }
 
-    private void publishEncounterDays(String encounterDays) {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SetupSnapshot(
-                -1,
-                0L,
-                encounterDays,
-                false)));
-    }
-
-    private void publishAddScene() {
-        publish(new SessionPlannerTimelineMainViewInputEvent(new SessionPlannerTimelineMainViewInputEvent.SetupSnapshot(
-                -1,
-                0L,
-                "",
-                true)));
+    private String rawWidgetId(ActionEvent event) {
+        if (event.getSource() instanceof Node node) {
+            return node.getId();
+        }
+        return "";
     }
 
     private void publish(SessionPlannerTimelineMainViewInputEvent event) {
@@ -444,8 +438,14 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         return new StyledLabel(text, styleClasses);
     }
 
-    private static Button actionButton(String text, EventHandler<ActionEvent> action, String emphasisStyle) {
+    private static Button actionButton(
+            String text,
+            String widgetId,
+            EventHandler<ActionEvent> action,
+            String emphasisStyle
+    ) {
         Button button = new StyledButton(text, STYLE_COMPACT, emphasisStyle);
+        button.setId(widgetId);
         button.setOnAction(action);
         return button;
     }

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainViewInputEvent.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainViewInputEvent.java
@@ -1,7 +1,7 @@
 package src.view.leftbartabs.sessionplanner;
 
 public record SessionPlannerTimelineMainViewInputEvent(
-        String widgetId,
+        long widgetToken,
         long sceneToken,
         long leftSceneToken,
         long rightSceneToken,
@@ -15,7 +15,7 @@ public record SessionPlannerTimelineMainViewInputEvent(
 ) {
 
     public SessionPlannerTimelineMainViewInputEvent {
-        widgetId = widgetId == null ? "" : widgetId;
+        widgetToken = Math.max(0L, widgetToken);
         sceneToken = Math.max(0L, sceneToken);
         leftSceneToken = Math.max(0L, leftSceneToken);
         rightSceneToken = Math.max(0L, rightSceneToken);

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainViewInputEvent.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerTimelineMainViewInputEvent.java
@@ -1,209 +1,30 @@
 package src.view.leftbartabs.sessionplanner;
 
-import java.math.BigDecimal;
-
 public record SessionPlannerTimelineMainViewInputEvent(
-        SelectionSnapshot selection,
-        MutationSnapshot mutation,
-        RestSnapshot rest,
-        LootSnapshot loot,
-        SceneSnapshot scene,
-        SceneDraftSnapshot sceneDraft,
-        SetupSnapshot setup
+        String widgetId,
+        long sceneToken,
+        long leftSceneToken,
+        long rightSceneToken,
+        long lootToken,
+        long participantId,
+        int participantChoiceIndex,
+        String encounterDaysText,
+        String sceneTitleText,
+        String sceneNotesText,
+        long locationId
 ) {
 
-    public SessionPlannerTimelineMainViewInputEvent(SelectionSnapshot selection) {
-        this(
-                selection,
-                new MutationSnapshot(0L, 0, 0L),
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                new LootSnapshot(0L, 0L),
-                new SceneSnapshot(0L, "", "", 0L),
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(MutationSnapshot mutation) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                mutation,
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                new LootSnapshot(0L, 0L),
-                new SceneSnapshot(0L, "", "", 0L),
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(RestSnapshot rest) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                new MutationSnapshot(0L, 0, 0L),
-                rest,
-                new LootSnapshot(0L, 0L),
-                new SceneSnapshot(0L, "", "", 0L),
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(LootSnapshot loot) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                new MutationSnapshot(0L, 0, 0L),
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                loot,
-                new SceneSnapshot(0L, "", "", 0L),
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(SceneSnapshot scene) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                new MutationSnapshot(0L, 0, 0L),
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                new LootSnapshot(0L, 0L),
-                scene,
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(SceneDraftSnapshot sceneDraft) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                new MutationSnapshot(0L, 0, 0L),
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                new LootSnapshot(0L, 0L),
-                new SceneSnapshot(0L, "", "", 0L),
-                sceneDraft,
-                new SetupSnapshot(-1, 0L, "", false));
-    }
-
-    public SessionPlannerTimelineMainViewInputEvent(SetupSnapshot setup) {
-        this(
-                new SelectionSnapshot(0L, 0L, BigDecimal.ZERO),
-                new MutationSnapshot(0L, 0, 0L),
-                new RestSnapshot(0L, 0L, RestSelection.NONE),
-                new LootSnapshot(0L, 0L),
-                new SceneSnapshot(0L, "", "", 0L),
-                new SceneDraftSnapshot(0L, "", "", 0L),
-                setup);
-    }
-
     public SessionPlannerTimelineMainViewInputEvent {
-        selection = selection == null ? new SelectionSnapshot(0L, 0L, BigDecimal.ZERO) : selection;
-        mutation = mutation == null ? new MutationSnapshot(0L, 0, 0L) : mutation;
-        rest = rest == null ? new RestSnapshot(0L, 0L, RestSelection.NONE) : rest;
-        loot = loot == null ? new LootSnapshot(0L, 0L) : loot;
-        scene = scene == null ? new SceneSnapshot(0L, "", "", 0L) : scene;
-        sceneDraft = sceneDraft == null ? new SceneDraftSnapshot(0L, "", "", 0L) : sceneDraft;
-        setup = setup == null ? new SetupSnapshot(-1, 0L, "", false) : setup;
-    }
-
-    record SelectionSnapshot(
-            long selectedSceneToken,
-            long allocationSceneToken,
-            BigDecimal targetAllocationPercentage
-    ) {
-
-        SelectionSnapshot {
-            selectedSceneToken = Math.max(0L, selectedSceneToken);
-            allocationSceneToken = Math.max(0L, allocationSceneToken);
-            targetAllocationPercentage = targetAllocationPercentage == null
-                    ? BigDecimal.ZERO
-                    : targetAllocationPercentage;
-        }
-    }
-
-    record MutationSnapshot(
-            long moveSceneToken,
-            int moveDirection,
-            long sceneTokenToRemove
-    ) {
-
-        MutationSnapshot {
-            moveSceneToken = Math.max(0L, moveSceneToken);
-            moveDirection = Integer.compare(moveDirection, 0);
-            sceneTokenToRemove = Math.max(0L, sceneTokenToRemove);
-        }
-    }
-
-    record RestSnapshot(
-            long leftSceneToken,
-            long rightSceneToken,
-            RestSelection selection
-    ) {
-
-        RestSnapshot(long leftSceneToken, long rightSceneToken, boolean shortRest, boolean longRest) {
-            this(leftSceneToken, rightSceneToken, shortRest
-                    ? RestSelection.SHORT_REST
-                    : longRest ? RestSelection.LONG_REST : RestSelection.NONE);
-        }
-
-        RestSnapshot {
-            leftSceneToken = Math.max(0L, leftSceneToken);
-            rightSceneToken = Math.max(0L, rightSceneToken);
-            selection = selection == null ? RestSelection.NONE : selection;
-        }
-    }
-
-    enum RestSelection {
-        NONE,
-        SHORT_REST,
-        LONG_REST
-    }
-
-    record LootSnapshot(
-            long sceneTokenToAdd,
-            long tokenToRemove
-    ) {
-
-        LootSnapshot {
-            sceneTokenToAdd = Math.max(0L, sceneTokenToAdd);
-            tokenToRemove = Math.max(0L, tokenToRemove);
-        }
-    }
-
-    record SceneSnapshot(
-            long sceneToken,
-            String title,
-            String notes,
-            long locationId
-    ) {
-
-        SceneSnapshot {
-            sceneToken = Math.max(0L, sceneToken);
-            title = title == null ? "" : title.trim();
-            notes = notes == null ? "" : notes.trim();
-            locationId = Math.max(0L, locationId);
-        }
-    }
-
-    record SceneDraftSnapshot(
-            long sceneToken,
-            String title,
-            String notes,
-            long locationId
-    ) {
-
-        SceneDraftSnapshot {
-            sceneToken = Math.max(0L, sceneToken);
-            title = title == null ? "" : title;
-            notes = notes == null ? "" : notes;
-            locationId = Math.max(0L, locationId);
-        }
-    }
-
-    record SetupSnapshot(
-            int participantChoiceIndex,
-            long participantToRemoveId,
-            String encounterDaysText,
-            boolean addSceneRequested
-    ) {
-
-        SetupSnapshot {
-            participantChoiceIndex = Math.max(-1, participantChoiceIndex);
-            participantToRemoveId = Math.max(0L, participantToRemoveId);
-            encounterDaysText = encounterDaysText == null ? "" : encounterDaysText.trim();
-        }
+        widgetId = widgetId == null ? "" : widgetId;
+        sceneToken = Math.max(0L, sceneToken);
+        leftSceneToken = Math.max(0L, leftSceneToken);
+        rightSceneToken = Math.max(0L, rightSceneToken);
+        lootToken = Math.max(0L, lootToken);
+        participantId = Math.max(0L, participantId);
+        participantChoiceIndex = Math.max(-1, participantChoiceIndex);
+        encounterDaysText = encounterDaysText == null ? "" : encounterDaysText;
+        sceneTitleText = sceneTitleText == null ? "" : sceneTitleText;
+        sceneNotesText = sceneNotesText == null ? "" : sceneNotesText;
+        locationId = Math.max(0L, locationId);
     }
 }

--- a/test/src/view/leftbartabs/sessionplanner/SessionPlannerCatalogHarness.java
+++ b/test/src/view/leftbartabs/sessionplanner/SessionPlannerCatalogHarness.java
@@ -269,24 +269,28 @@ public final class SessionPlannerCatalogHarness {
         textField(view, "Szenentitel").setText("Bridge Alarm Final");
         textArea(view, "Szenennotizen").setText("ring twice");
         selectComboBoxItem(view, "#10 | Moonwell");
-        assertTrue(events.stream().anyMatch(event -> event.sceneDraft().sceneToken() == 1L),
+        assertTrue(events.stream().anyMatch(event -> event.widgetId().equals("session-planner.timeline.scene.draft")
+                        && event.sceneToken() == 1L),
                 "scene draft edits publish draft events");
         events.clear();
         button(view, "Szene speichern").fire();
         List<SessionPlannerTimelineMainViewInputEvent> saveEvents = events.stream()
-                .filter(event -> event.scene().sceneToken() == 1L)
+                .filter(event -> event.widgetId().equals("session-planner.timeline.scene.save")
+                        && event.sceneToken() == 1L)
                 .toList();
         assertEquals(Integer.valueOf(1), Integer.valueOf(saveEvents.size()), "scene save publishes one save event");
-        assertEquals(Long.valueOf(1L), Long.valueOf(saveEvents.getFirst().scene().sceneToken()),
+        assertEquals(Long.valueOf(1L), Long.valueOf(saveEvents.getFirst().sceneToken()),
                 "scene save targets the scene card");
-        assertEquals("Bridge Alarm Final", saveEvents.getFirst().scene().title(), "scene save carries title");
-        assertEquals("ring twice", saveEvents.getFirst().scene().notes(), "scene save carries notes");
-        assertEquals(Long.valueOf(10L), Long.valueOf(saveEvents.getFirst().scene().locationId()),
+        assertEquals("Bridge Alarm Final", saveEvents.getFirst().sceneTitleText(), "scene save carries title");
+        assertEquals("ring twice", saveEvents.getFirst().sceneNotesText(), "scene save carries notes");
+        assertEquals(Long.valueOf(10L), Long.valueOf(saveEvents.getFirst().locationId()),
                 "scene save carries location id");
         events.clear();
         button(view, "Loot-Platzhalter").fire();
         assertEquals(Integer.valueOf(1), Integer.valueOf(events.size()), "loot add button publishes one event");
-        assertEquals(Long.valueOf(1L), Long.valueOf(events.getFirst().loot().sceneTokenToAdd()),
+        assertEquals("session-planner.timeline.loot.add", events.getFirst().widgetId(),
+                "loot add event uses the clicked widget identity");
+        assertEquals(Long.valueOf(1L), Long.valueOf(events.getFirst().sceneToken()),
                 "loot add event targets the scene card");
         stage.hide();
     }

--- a/test/src/view/leftbartabs/sessionplanner/SessionPlannerCatalogHarness.java
+++ b/test/src/view/leftbartabs/sessionplanner/SessionPlannerCatalogHarness.java
@@ -269,14 +269,12 @@ public final class SessionPlannerCatalogHarness {
         textField(view, "Szenentitel").setText("Bridge Alarm Final");
         textArea(view, "Szenennotizen").setText("ring twice");
         selectComboBoxItem(view, "#10 | Moonwell");
-        assertTrue(events.stream().anyMatch(event -> event.widgetId().equals("session-planner.timeline.scene.draft")
-                        && event.sceneToken() == 1L),
-                "scene draft edits publish draft events");
+        assertTrue(events.stream().anyMatch(event -> event.widgetToken() > 0L && event.sceneToken() == 1L),
+                "scene draft edits publish a technical widget token");
         events.clear();
         button(view, "Szene speichern").fire();
         List<SessionPlannerTimelineMainViewInputEvent> saveEvents = events.stream()
-                .filter(event -> event.widgetId().equals("session-planner.timeline.scene.save")
-                        && event.sceneToken() == 1L)
+                .filter(event -> event.widgetToken() > 0L && event.sceneToken() == 1L)
                 .toList();
         assertEquals(Integer.valueOf(1), Integer.valueOf(saveEvents.size()), "scene save publishes one save event");
         assertEquals(Long.valueOf(1L), Long.valueOf(saveEvents.getFirst().sceneToken()),
@@ -288,8 +286,7 @@ public final class SessionPlannerCatalogHarness {
         events.clear();
         button(view, "Loot-Platzhalter").fire();
         assertEquals(Integer.valueOf(1), Integer.valueOf(events.size()), "loot add button publishes one event");
-        assertEquals("session-planner.timeline.loot.add", events.getFirst().widgetId(),
-                "loot add event uses the clicked widget identity");
+        assertTrue(events.getFirst().widgetToken() > 0L, "loot add event carries a technical widget token");
         assertEquals(Long.valueOf(1L), Long.valueOf(events.getFirst().sceneToken()),
                 "loot add event targets the scene card");
         stage.hide();


### PR DESCRIPTION
## Summary
- Replace command-family timeline input carriers with raw same-stem snapshot facts.
- Remove operation-named View->Handler widget/action string routing.
- Keep Session Planner timeline operation ownership in IntentHandler/ContentModel while the passive View emits only raw values and opaque technical tokens.

## Risk
- Risk class: R1
- Task label: `task:architecture`

## Verification
- `tools/gradle/run-staged-verification.sh focused-handoff --path src/view/leftbartabs/sessionplanner --area view`: `BUILD SUCCESSFUL`
- `tools/gradle/run-observable-gradle.sh sessionPlannerCatalogHarness sessionPlannerShellLayoutHarness`: `BUILD SUCCESSFUL`
- `git diff --check`: clean
- Post-rebase `tools/gradle/run-staged-verification.sh production-handoff`: `BUILD SUCCESSFUL in 13m 44s`, retained `Result: success`

## Review
- Central rereview report: `build/agent-pass-logs/2026-07-09-architecture-goal-completion-audit/s1-session-planner-rereview.md`
- Code-side handoff-ready; post-rebase production-handoff evidence supplied in `build/gradle-run-logs/20260709T063116920132015-pid690837-production-handoff.log`