### PR TITLE
Type dungeon travel action selection

### DIFF
--- a/src/domain/dungeon/DungeonTravelRuntimeApplicationService.java
+++ b/src/domain/dungeon/DungeonTravelRuntimeApplicationService.java
@@ -21,24 +21,14 @@ public final class DungeonTravelRuntimeApplicationService {
 
     public void applyDungeonTravelSession(ApplyTravelDungeonSessionCommand command) {
         Objects.requireNonNull(command, "command");
-        publishTravelDungeonSessionUseCase.execute(toUseCaseCommand(command));
-    }
-
-    private static Command toUseCaseCommand(
-            ApplyTravelDungeonSessionCommand command
-    ) {
-        return switch (command.action().name()) {
-            case "REFRESH" -> Command.refresh();
-            case "ACTION" -> Command.travelAction(command.actionId());
-            case "SELECT_MAP" -> Command.selectMap(command.actionId());
-            case "SET_PROJECTION_LEVEL" -> Command.setProjectionLevel(command.projectionLevel());
-            case "SHIFT_PROJECTION_LEVEL" -> Command.shiftProjectionLevel(command.projectionLevel());
-            case "SET_OVERLAY" -> Command.setOverlay(
-                    command.overlaySettings().modeKey(),
-                    command.overlaySettings().levelRange(),
-                    command.overlaySettings().opacity(),
-                    command.overlaySettings().selectedLevels());
-            default -> throw new IllegalStateException("Unhandled travel dungeon session action.");
-        };
+        publishTravelDungeonSessionUseCase.execute(Command.fromBoundary(
+                command.actionCode(),
+                command.selectedActionRowIndex(),
+                command.mapId(),
+                command.projectionLevel(),
+                command.overlaySettings().modeKey(),
+                command.overlaySettings().levelRange(),
+                command.overlaySettings().opacity(),
+                command.overlaySettings().selectedLevels()));
     }
 }

--- a/src/domain/dungeon/DungeonTravelRuntimeSurfaceProjectionServiceAssembly.java
+++ b/src/domain/dungeon/DungeonTravelRuntimeSurfaceProjectionServiceAssembly.java
@@ -102,7 +102,6 @@ final class DungeonTravelRuntimeSurfaceProjectionServiceAssembly {
             src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSurface.AvailableAction action
     ) {
         return new src.domain.dungeon.published.DungeonTravelActionSnapshot(
-                action.id(),
                 src.domain.dungeon.published.DungeonTravelActionKind.valueOf(action.kind().name()),
                 action.label(),
                 action.destinationLabel(),
@@ -113,7 +112,6 @@ final class DungeonTravelRuntimeSurfaceProjectionServiceAssembly {
             src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSurface.AvailableAction action
     ) {
         return new src.domain.dungeon.published.TravelDungeonAction(
-                action.id(),
                 action.displayLabel(),
                 action.helpText());
     }

--- a/src/domain/dungeon/model/runtime/travel/projection/TravelActionFacts.java
+++ b/src/domain/dungeon/model/runtime/travel/projection/TravelActionFacts.java
@@ -1,5 +1,6 @@
 package src.domain.dungeon.model.runtime.travel.projection;
 
+import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 public record TravelActionFacts(
@@ -11,7 +12,6 @@ public record TravelActionFacts(
         @Nullable TravelPositionFacts targetPosition,
         TravelTransitionTarget transitionTarget
 ) {
-
     public TravelActionFacts {
         kind = kind == null ? TravelActionKind.defaultKind() : kind;
         actionId = cleanText(actionId);
@@ -27,5 +27,28 @@ public record TravelActionFacts(
 
     private static String cleanText(String value) {
         return value == null ? "" : value.trim();
+    }
+
+    public record SelectedAction(int rowIndex) {
+
+        public SelectedAction {
+            rowIndex = Math.max(-1, rowIndex);
+        }
+
+        public static SelectedAction invalid() {
+            return new SelectedAction(-1);
+        }
+
+        public static SelectedAction atRow(int rowIndex) {
+            return new SelectedAction(rowIndex);
+        }
+
+        public static SelectedAction safe(SelectedAction selectedAction) {
+            return selectedAction == null ? invalid() : selectedAction;
+        }
+
+        public boolean isWithin(List<TravelActionFacts> actions) {
+            return rowIndex >= 0 && actions != null && rowIndex < actions.size();
+        }
     }
 }

--- a/src/domain/dungeon/model/runtime/travel/projection/TravelSurfaceFacts.java
+++ b/src/domain/dungeon/model/runtime/travel/projection/TravelSurfaceFacts.java
@@ -2,8 +2,9 @@ package src.domain.dungeon.model.runtime.travel.projection;
 
 
 import java.util.List;
-import org.jspecify.annotations.Nullable;
+import java.util.Optional;
 import src.domain.dungeon.model.core.geometry.Cell;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSurface;
 
 public record TravelSurfaceFacts(
@@ -41,14 +42,12 @@ public record TravelSurfaceFacts(
         return immutableActions(actions);
     }
 
-    public @Nullable TravelActionFacts action(String actionId) {
-        String requestedActionId = actionId == null ? "" : actionId.trim();
-        for (TravelActionFacts candidate : actions) {
-            if (candidate.actionId().equals(requestedActionId)) {
-                return candidate;
-            }
+    public Optional<TravelActionFacts> action(SelectedAction selectedAction) {
+        SelectedAction requestedAction = SelectedAction.safe(selectedAction);
+        if (!requestedAction.isWithin(actions)) {
+            return Optional.empty();
         }
-        return null;
+        return Optional.of(actions.get(requestedAction.rowIndex()));
     }
 
     private static TravelDungeonSessionSurface.MapData defaultMap(TravelDungeonSessionSurface.MapData map) {

--- a/src/domain/dungeon/model/runtime/travel/session/TravelDungeonSessionCommand.java
+++ b/src/domain/dungeon/model/runtime/travel/session/TravelDungeonSessionCommand.java
@@ -1,6 +1,7 @@
 package src.domain.dungeon.model.runtime.travel.session;
 
 import java.util.List;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 
 public final class TravelDungeonSessionCommand {
 
@@ -14,8 +15,8 @@ public final class TravelDungeonSessionCommand {
         return new TravelDungeonSessionCommand(new Refresh());
     }
 
-    public static TravelDungeonSessionCommand travelAction(String actionId) {
-        return new TravelDungeonSessionCommand(new TravelAction(actionId));
+    public static TravelDungeonSessionCommand travelAction(SelectedAction selectedAction) {
+        return new TravelDungeonSessionCommand(new TravelAction(selectedAction));
     }
 
     public static TravelDungeonSessionCommand selectMap(String mapIdValue) {
@@ -51,9 +52,9 @@ public final class TravelDungeonSessionCommand {
     public record Refresh() implements Variant {
     }
 
-    public record TravelAction(String actionId) implements Variant {
+    public record TravelAction(SelectedAction selectedAction) implements Variant {
         public TravelAction {
-            actionId = normalizeText(actionId);
+            selectedAction = SelectedAction.safe(selectedAction);
         }
     }
 

--- a/src/domain/dungeon/model/runtime/usecase/ApplyTravelDungeonMovementUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/ApplyTravelDungeonMovementUseCase.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.model.runtime.repository.TravelPartyStateRepository;
 import src.domain.dungeon.model.runtime.repository.TravelPartyPositionRepository;
 import src.domain.dungeon.model.runtime.travel.projection.TravelDungeonSessionProjectionMapper;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonActiveState;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonActiveState.ActiveTravelStateData;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionMovement;
@@ -37,7 +38,7 @@ public final class ApplyTravelDungeonMovementUseCase {
     public SurfaceData move(
             @Nullable PositionData requestedTravelPosition,
             @Nullable SurfaceData currentSurface,
-            String actionId
+            SelectedAction selectedAction
     ) {
         ActiveTravelStateData activeTravel = partyStateRepository.loadActiveTravelState();
         @Nullable PositionData effectivePosition =
@@ -50,7 +51,7 @@ public final class ApplyTravelDungeonMovementUseCase {
         MoveResultData result = TravelDungeonSessionMovement.safe(
                 moveDungeonTravelActionUseCase.execute(new MoveDungeonTravelActionUseCase.Input(
                         TravelDungeonSessionProjectionMapper.toRuntimePositionFacts(effectivePosition),
-                        actionId)));
+                        selectedAction)));
         return applyResult(
                 effectivePosition,
                 activeTravel,

--- a/src/domain/dungeon/model/runtime/usecase/ApplyTravelDungeonSessionUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/ApplyTravelDungeonSessionUseCase.java
@@ -2,6 +2,7 @@ package src.domain.dungeon.model.runtime.usecase;
 
 import java.util.List;
 import java.util.Objects;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSession;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionCommand;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSnapshot.SnapshotData;
@@ -41,7 +42,7 @@ public final class ApplyTravelDungeonSessionUseCase {
             return refresh();
         }
         if (variant instanceof TravelDungeonSessionCommand.TravelAction travelAction) {
-            return move(travelAction.actionId());
+            return move(travelAction.selectedAction());
         }
         if (variant instanceof TravelDungeonSessionCommand.SelectMap selectMap) {
             return selectMap(selectMap.mapIdValue());
@@ -67,11 +68,11 @@ public final class ApplyTravelDungeonSessionUseCase {
         return snapshot();
     }
 
-    private SnapshotData move(String actionId) {
+    private SnapshotData move(SelectedAction selectedAction) {
         session.applySurface(applyTravelDungeonMovementUseCase.move(
                 session.currentPosition(),
                 session.currentSurface(),
-                actionId));
+                selectedAction));
         return snapshot();
     }
 

--- a/src/domain/dungeon/model/runtime/usecase/MoveDungeonTravelActionUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/MoveDungeonTravelActionUseCase.java
@@ -3,6 +3,7 @@ package src.domain.dungeon.model.runtime.usecase;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.projection.TravelActionKind;
 import src.domain.dungeon.model.runtime.travel.projection.TravelAuthoredSurface;
 import src.domain.dungeon.model.runtime.travel.projection.TravelAuthoredSurfaceProjectionMapper;
@@ -28,22 +29,22 @@ public final class MoveDungeonTravelActionUseCase {
 
     public static final class Input {
         private final @Nullable TravelPositionFacts position;
-        private final String actionId;
+        private final SelectedAction selectedAction;
 
         public Input(
                 @Nullable TravelPositionFacts position,
-                String actionId
+                SelectedAction selectedAction
         ) {
             this.position = position;
-            this.actionId = actionId == null ? "" : actionId.trim();
+            this.selectedAction = SelectedAction.safe(selectedAction);
         }
 
         public @Nullable TravelPositionFacts position() {
             return position;
         }
 
-        public String actionId() {
-            return actionId;
+        public SelectedAction selectedAction() {
+            return selectedAction;
         }
     }
 
@@ -64,11 +65,11 @@ public final class MoveDungeonTravelActionUseCase {
 
     public MoveResultData execute(Input input) {
         TravelPositionFacts position = input == null ? null : input.position();
-        String actionId = input == null ? "" : input.actionId();
+        SelectedAction selectedAction = input == null ? SelectedAction.invalid() : input.selectedAction();
         DungeonMap currentMap = loadMap(position);
         TravelAuthoredSurface currentSurface =
                 TravelAuthoredSurfaceProjectionMapper.from(currentMap, deriveState.execute(currentMap));
-        return new MoveResolver(currentSurface, position).move(actionId);
+        return new MoveResolver(currentSurface, position).move(selectedAction);
     }
 
     private DungeonMap loadMap(@Nullable TravelPositionFacts position) {
@@ -91,19 +92,20 @@ public final class MoveDungeonTravelActionUseCase {
             this.currentSurface = projectSurface(currentSurfaceInput, requestedPosition, "");
         }
 
-        private MoveResultData move(String actionId) {
-            TravelActionFacts action = currentSurface.action(actionId);
-            if (action == null) {
+        private MoveResultData move(SelectedAction selectedAction) {
+            java.util.Optional<TravelActionFacts> action = currentSurface.action(selectedAction);
+            if (action.isEmpty()) {
                 return new MoveResultData(
                         MoveStatus.INVALID_ACTION,
                         TravelDungeonSessionProjectionMapper.toRuntimeSurface(
                                 projectCurrentMap(requestedPosition, "Aktion ist nicht verfügbar.")),
                         null);
             }
-            if (action.kind() == TravelActionKind.TRAVERSAL) {
-                return moveTraversal(action);
+            TravelActionFacts selected = action.get();
+            if (selected.kind() == TravelActionKind.TRAVERSAL) {
+                return moveTraversal(selected);
             }
-            return moveTransition(action);
+            return moveTransition(selected);
         }
 
         private MoveResultData moveTraversal(TravelActionFacts action) {

--- a/src/domain/dungeon/model/runtime/usecase/PublishTravelDungeonSessionUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/PublishTravelDungeonSessionUseCase.java
@@ -3,6 +3,7 @@ package src.domain.dungeon.model.runtime.usecase;
 import java.util.List;
 import java.util.Objects;
 import src.domain.dungeon.model.runtime.repository.TravelDungeonSessionPublishedStateRepository;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionCommand;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSnapshot.SnapshotData;
 
@@ -34,12 +35,36 @@ public final class PublishTravelDungeonSessionUseCase {
             this.travelCommand = Objects.requireNonNull(travelCommand, "travelCommand");
         }
 
+        public static Command fromBoundary(
+                int actionCode,
+                int selectedActionRowIndex,
+                long mapId,
+                int projectionLevel,
+                String overlayModeKey,
+                int overlayLevelRange,
+                double overlayOpacity,
+                List<Integer> overlaySelectedLevels
+        ) {
+            return switch (ActionKind.fromCode(actionCode)) {
+                case REFRESH -> refresh();
+                case ACTION -> travelAction(selectedActionRowIndex);
+                case SELECT_MAP -> selectMap(Long.toString(mapId));
+                case SET_PROJECTION_LEVEL -> setProjectionLevel(projectionLevel);
+                case SHIFT_PROJECTION_LEVEL -> shiftProjectionLevel(projectionLevel);
+                case SET_OVERLAY -> setOverlay(
+                        overlayModeKey,
+                        overlayLevelRange,
+                        overlayOpacity,
+                        overlaySelectedLevels);
+            };
+        }
+
         public static Command refresh() {
             return new Command(TravelDungeonSessionCommand.refresh());
         }
 
-        public static Command travelAction(String actionId) {
-            return new Command(TravelDungeonSessionCommand.travelAction(actionId));
+        public static Command travelAction(int selectedActionRowIndex) {
+            return new Command(TravelDungeonSessionCommand.travelAction(SelectedAction.atRow(selectedActionRowIndex)));
         }
 
         public static Command selectMap(String mapIdValue) {
@@ -65,6 +90,30 @@ public final class PublishTravelDungeonSessionUseCase {
                     overlayLevelRange,
                     overlayOpacity,
                     overlaySelectedLevels));
+        }
+
+        private enum ActionKind {
+            REFRESH(0),
+            ACTION(1),
+            SELECT_MAP(2),
+            SET_PROJECTION_LEVEL(3),
+            SHIFT_PROJECTION_LEVEL(4),
+            SET_OVERLAY(5);
+
+            private final int code;
+
+            ActionKind(int code) {
+                this.code = code;
+            }
+
+            private static ActionKind fromCode(int actionCode) {
+                for (ActionKind kind : values()) {
+                    if (kind.code == actionCode) {
+                        return kind;
+                    }
+                }
+                return REFRESH;
+            }
         }
     }
 }

--- a/src/domain/dungeon/published/ApplyTravelDungeonSessionCommand.java
+++ b/src/domain/dungeon/published/ApplyTravelDungeonSessionCommand.java
@@ -2,7 +2,8 @@ package src.domain.dungeon.published;
 
 public record ApplyTravelDungeonSessionCommand(
         Action action,
-        String actionId,
+        int selectedActionRowIndex,
+        long mapId,
         int projectionLevel,
         DungeonOverlaySettings overlaySettings
 ) {
@@ -10,7 +11,8 @@ public record ApplyTravelDungeonSessionCommand(
     public static ApplyTravelDungeonSessionCommand projectionLevelShift(int projectionLevelShift) {
         return new ApplyTravelDungeonSessionCommand(
                 Action.SHIFT_PROJECTION_LEVEL,
-                "",
+                -1,
+                0L,
                 projectionLevelShift,
                 DungeonOverlaySettings.defaults());
     }
@@ -18,15 +20,17 @@ public record ApplyTravelDungeonSessionCommand(
     public static ApplyTravelDungeonSessionCommand overlay(DungeonOverlaySettings overlaySettings) {
         return new ApplyTravelDungeonSessionCommand(
                 Action.SET_OVERLAY,
-                "",
+                -1,
+                0L,
                 0,
                 overlaySettings);
     }
 
-    public static ApplyTravelDungeonSessionCommand action(String actionId) {
+    public static ApplyTravelDungeonSessionCommand action(int selectedActionRowIndex) {
         return new ApplyTravelDungeonSessionCommand(
                 Action.ACTION,
-                actionId,
+                selectedActionRowIndex,
+                0L,
                 0,
                 DungeonOverlaySettings.defaults());
     }
@@ -34,23 +38,39 @@ public record ApplyTravelDungeonSessionCommand(
     public static ApplyTravelDungeonSessionCommand selectMap(long mapId) {
         return new ApplyTravelDungeonSessionCommand(
                 Action.SELECT_MAP,
-                Long.toString(Math.max(0L, mapId)),
+                -1,
+                Math.max(0L, mapId),
                 0,
                 DungeonOverlaySettings.defaults());
     }
 
     public ApplyTravelDungeonSessionCommand {
         action = action == null ? Action.REFRESH : action;
-        actionId = actionId == null ? "" : actionId.trim();
+        selectedActionRowIndex = Math.max(-1, selectedActionRowIndex);
+        mapId = Math.max(0L, mapId);
         overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
     }
 
+    public int actionCode() {
+        return action.code();
+    }
+
     public enum Action {
-        REFRESH,
-        ACTION,
-        SELECT_MAP,
-        SET_PROJECTION_LEVEL,
-        SHIFT_PROJECTION_LEVEL,
-        SET_OVERLAY
+        REFRESH(0),
+        ACTION(1),
+        SELECT_MAP(2),
+        SET_PROJECTION_LEVEL(3),
+        SHIFT_PROJECTION_LEVEL(4),
+        SET_OVERLAY(5);
+
+        private final int code;
+
+        Action(int code) {
+            this.code = code;
+        }
+
+        private int code() {
+            return code;
+        }
     }
 }

--- a/src/domain/dungeon/published/DungeonTravelActionSnapshot.java
+++ b/src/domain/dungeon/published/DungeonTravelActionSnapshot.java
@@ -1,7 +1,6 @@
 package src.domain.dungeon.published;
 
 public record DungeonTravelActionSnapshot(
-        String actionId,
         DungeonTravelActionKind kind,
         String label,
         String destinationLabel,
@@ -9,7 +8,6 @@ public record DungeonTravelActionSnapshot(
 ) {
 
     public DungeonTravelActionSnapshot {
-        actionId = actionId == null ? "" : actionId.trim();
         kind = kind == null ? DungeonTravelActionKind.TRAVERSAL : kind;
         label = label == null || label.isBlank() ? kind.name() : label.trim();
         destinationLabel = destinationLabel == null ? "" : destinationLabel.trim();

--- a/src/domain/dungeon/published/TravelDungeonAction.java
+++ b/src/domain/dungeon/published/TravelDungeonAction.java
@@ -1,13 +1,11 @@
 package src.domain.dungeon.published;
 
 public record TravelDungeonAction(
-        String actionId,
         String label,
         String description
 ) {
 
     public TravelDungeonAction {
-        actionId = actionId == null ? "" : actionId.trim();
         label = label == null || label.isBlank() ? "Aktion" : label.trim();
         description = description == null ? "" : description.trim();
     }

--- a/src/view/leftbartabs/dungeontravel/DungeonTravelContributionModel.java
+++ b/src/view/leftbartabs/dungeontravel/DungeonTravelContributionModel.java
@@ -1,7 +1,6 @@
 package src.view.leftbartabs.dungeontravel;
 
 import java.util.List;
-import java.util.Optional;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
@@ -54,18 +53,6 @@ public final class DungeonTravelContributionModel {
         mapCatalogContentModel = contentModel;
     }
 
-    Optional<String> actionIdForRow(int rowIndex) {
-        List<ActionProjection> currentActions = actions.get();
-        if (rowIndex < 0 || currentActions == null || rowIndex >= currentActions.size()) {
-            return Optional.empty();
-        }
-        String actionId = currentActions.get(rowIndex).actionId();
-        if (actionId.isBlank()) {
-            return Optional.empty();
-        }
-        return Optional.of(actionId);
-    }
-
     void applyMapCatalog(DungeonMapCatalogResponse response, long selectedMapId) {
         if (mapCatalogContentModel == null || !(response instanceof DungeonMapCatalogResponse.MapList mapList)) {
             return;
@@ -114,12 +101,10 @@ public final class DungeonTravelContributionModel {
 
     static final class ActionProjection {
 
-        private final String actionId;
         private final String buttonLabel;
         private final String descriptionText;
 
-        private ActionProjection(String actionId, String buttonLabel, String descriptionText) {
-            this.actionId = actionId == null ? "" : actionId.trim();
+        private ActionProjection(String buttonLabel, String descriptionText) {
             this.buttonLabel = buttonLabel == null || buttonLabel.isBlank()
                     ? "Aktion"
                     : buttonLabel.trim();
@@ -128,13 +113,9 @@ public final class DungeonTravelContributionModel {
 
         static ActionProjection from(TravelDungeonAction action) {
             if (action == null) {
-                return new ActionProjection("", "Aktion", "");
+                return new ActionProjection("Aktion", "");
             }
-            return new ActionProjection(action.actionId(), action.label(), action.description());
-        }
-
-        String actionId() {
-            return actionId;
+            return new ActionProjection(action.label(), action.description());
         }
 
         String buttonLabel() {

--- a/src/view/leftbartabs/dungeontravel/DungeonTravelIntentHandler.java
+++ b/src/view/leftbartabs/dungeontravel/DungeonTravelIntentHandler.java
@@ -82,9 +82,8 @@ final class DungeonTravelIntentHandler {
         if (event == null) {
             return;
         }
-        presentationModel.actionIdForRow(event.selectedActionRowIndex())
-                .ifPresent(actionId -> travel.applyDungeonTravelSession(
-                        ApplyTravelDungeonSessionCommand.action(actionId)));
+        travel.applyDungeonTravelSession(
+                ApplyTravelDungeonSessionCommand.action(event.selectedActionRowIndex()));
     }
 
     private static List<Integer> parseLevels(String rawLevelsText) {

--- a/test/src/view/leftbartabs/dungeoneditor/DungeonRuntimeProjectionInvariantHarness.java
+++ b/test/src/view/leftbartabs/dungeoneditor/DungeonRuntimeProjectionInvariantHarness.java
@@ -22,6 +22,7 @@ import src.domain.dungeon.model.core.structure.DungeonMapIdentity;
 import src.domain.dungeon.model.core.structure.transition.TransitionDestination;
 import src.domain.dungeon.model.core.structure.transition.TransitionDestinationTarget;
 import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts;
+import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.projection.TravelActionKind;
 import src.domain.dungeon.model.runtime.travel.projection.TravelAuthoredSurface;
 import src.domain.dungeon.model.runtime.travel.projection.TravelAuthoredSurfaceProjectionMapper;
@@ -223,12 +224,16 @@ final class DungeonRuntimeProjectionInvariantHarness {
                 "runtime transition projection explains missing unlinked entrance destination");
         assertEquals(TravelTransitionTarget.absent(), unlinkedTransition.transitionTarget(),
                 "runtime transition projection blocks travel target for unlinked entrance");
-        assertUnlinkedTransitionMovementBlocked(unlinkedMap, unlinkedTransition);
+        assertUnlinkedTransitionMovementBlocked(
+                unlinkedMap,
+                unlinkedTransition,
+                SelectedAction.atRow(indexOfAction(unlinkedSurface, unlinkedTransition)));
     }
 
     private static void assertUnlinkedTransitionMovementBlocked(
             DungeonMap unlinkedMap,
-            TravelActionFacts unlinkedTransition
+            TravelActionFacts unlinkedTransition,
+            SelectedAction selectedAction
     ) {
         DungeonMapRepository repository = repositoryOf(
                 unlinkedMap,
@@ -251,7 +256,7 @@ final class DungeonRuntimeProjectionInvariantHarness {
 
         MoveResultData moveResult = moveUseCase.execute(new MoveDungeonTravelActionUseCase.Input(
                 position,
-                unlinkedTransition.actionId()));
+                selectedAction));
         assertEquals(MoveStatus.TARGET_UNAVAILABLE, moveResult.status(),
                 "runtime unlinked entrance movement must report missing destination");
         assertContains(moveResult.surface().statusLabel(), "Übergangsziel ist nicht verfügbar.",
@@ -280,7 +285,7 @@ final class DungeonRuntimeProjectionInvariantHarness {
         SurfaceData applied = applyUseCase.move(
                 currentSurface.position(),
                 currentSurface,
-                unlinkedTransition.actionId());
+                selectedAction);
         assertContains(applied.statusLabel(), "Übergangsziel ist nicht verfügbar.",
                 "runtime unlinked entrance apply path explains missing destination");
         assertEquals(0, partyPositions.savedDungeonPositions(),
@@ -679,6 +684,16 @@ final class DungeonRuntimeProjectionInvariantHarness {
             }
         }
         return null;
+    }
+
+    private static int indexOfAction(TravelSurfaceFacts surface, TravelActionFacts expected) {
+        List<TravelActionFacts> actions = surface.actions();
+        for (int index = 0; index < actions.size(); index++) {
+            if (actions.get(index).equals(expected)) {
+                return index;
+            }
+        }
+        return -1;
     }
 
     private static void assertEquals(Object expected, Object actual, String message) {

--- a/test/src/view/leftbartabs/dungeoneditor/DungeonTravelProjectionLevelHarness.java
+++ b/test/src/view/leftbartabs/dungeoneditor/DungeonTravelProjectionLevelHarness.java
@@ -111,7 +111,7 @@ public final class DungeonTravelProjectionLevelHarness {
                 invalidActionSnapshot.workspaceState() != null
                         && invalidActionSnapshot.workspaceState().statusLabel().contains("Aktion ist nicht verfügbar."),
                 "DT-ACT-INVALID typed invalid selected action reports invalid action");
-        assertNoTravelTruthMutation(runtime, mapId, geometryRowsBefore, "DT-ACT-INVALID");
+        assertNoTravelTruthMutation(runtime, mapId, geometryRowsBefore, partyPositionsBefore, "DT-ACT-INVALID");
 
         results.add("OwnerSuite=" + OWNER + "; ProofType=RealRoute; "
                 + "DT-LVL-001 Ready: DungeonTravelControlsView + button -> SQLite/party unchanged"

--- a/test/src/view/leftbartabs/dungeoneditor/DungeonTravelProjectionLevelHarness.java
+++ b/test/src/view/leftbartabs/dungeoneditor/DungeonTravelProjectionLevelHarness.java
@@ -61,7 +61,8 @@ public final class DungeonTravelProjectionLevelHarness {
         runtime.context().services().require(DungeonTravelRuntimeApplicationService.class)
                 .applyDungeonTravelSession(new ApplyTravelDungeonSessionCommand(
                         ApplyTravelDungeonSessionCommand.Action.REFRESH,
-                        "",
+                        -1,
+                        0L,
                         0,
                         DungeonOverlaySettings.defaults()));
         long geometryRowsBefore = runtime.database().countAuthoredGeometryRows(mapId);
@@ -103,12 +104,24 @@ public final class DungeonTravelProjectionLevelHarness {
         assertRenderedLevel(binding.mapContentModel(), 0, "DT-LVL-002 renders level 0");
         assertNoTravelTruthMutation(runtime, mapId, geometryRowsBefore, partyPositionsBefore, "DT-LVL-002");
 
+        runtime.context().services().require(DungeonTravelRuntimeApplicationService.class)
+                .applyDungeonTravelSession(ApplyTravelDungeonSessionCommand.action(-1));
+        TravelDungeonSnapshot invalidActionSnapshot = travelModel.current();
+        DungeonEditorBehaviorHarnessSupport.assertTrue(
+                invalidActionSnapshot.workspaceState() != null
+                        && invalidActionSnapshot.workspaceState().statusLabel().contains("Aktion ist nicht verfügbar."),
+                "DT-ACT-INVALID typed invalid selected action reports invalid action");
+        assertNoTravelTruthMutation(runtime, mapId, geometryRowsBefore, "DT-ACT-INVALID");
+
         results.add("OwnerSuite=" + OWNER + "; ProofType=RealRoute; "
                 + "DT-LVL-001 Ready: DungeonTravelControlsView + button -> SQLite/party unchanged"
                 + " -> published projection z=1 -> rendered level 1");
         results.add("OwnerSuite=" + OWNER + "; ProofType=RealRoute; "
                 + "DT-LVL-002 Ready: DungeonTravelControlsView - button -> SQLite/party unchanged"
                 + " -> published projection z=0 -> rendered level 0");
+        results.add("OwnerSuite=" + OWNER + "; ProofType=RealRoute; "
+                + "DT-ACT-INVALID Ready: typed invalid selected action -> ApplicationService"
+                + " -> INVALID_ACTION status -> SQLite/party unchanged");
     }
 
     private static HarnessBinding bindHarness(HarnessRuntime runtime) {


### PR DESCRIPTION
## Summary
- Remove raw travel action IDs from the published action-selection route.
- Keep Dungeon Travel view selection as a technical row index and resolve selected actions inside domain runtime facts/use cases.
- Extend invalid-action proof so no SQLite/Party travel mutation occurs for invalid selected rows.

## Risk
- Risk class: R1
- Task label: `task:architecture`

## Verification
- `git diff --check`: clean
- `./gradlew dungeonTravelProjectionLevelHarness --console=plain`: `BUILD SUCCESSFUL in 16s`
- `tools/gradle/run-staged-verification.sh focused-handoff ...`: `BUILD SUCCESSFUL in 5m 42s`, retained `Result: success`
- `tools/gradle/run-staged-verification.sh production-handoff`: `BUILD SUCCESSFUL in 10m 29s`, retained `Result: success`

## Review
- Central review report: `build/agent-pass-logs/2026-07-09-architecture-goal-completion-audit/s2-travel-typed-action-review.md`
- Must Fix Before Handoff: None
- Rebase/final proof details: `build/agent-pass-logs/2026-07-09-architecture-goal-completion-audit/s2-travel-typed-action-implementation.md`