### PR TITLE
Type dungeon editor state panel facts

### DIFF
--- a/src/domain/dungeon/DungeonAuthoredReadProjectionServiceAssembly.java
+++ b/src/domain/dungeon/DungeonAuthoredReadProjectionServiceAssembly.java
@@ -37,7 +37,52 @@ final class DungeonAuthoredReadProjectionServiceAssembly {
                 inspector.title(),
                 inspector.description(),
                 inspector.facts(),
+                statePanelFacts(inspector.statePanelFacts()),
                 roomNarrations(inspector));
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.StatePanelFacts statePanelFacts(
+            src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StatePanelFacts facts
+    ) {
+        src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StatePanelFacts
+                safeFacts = facts == null
+                        ? src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StatePanelFacts.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.StatePanelFacts(
+                stairGeometryFacts(safeFacts.stairGeometry()),
+                transitionDestinationFacts(safeFacts.transitionDestination()));
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.StairGeometryFacts stairGeometryFacts(
+            src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StairGeometryPublication facts
+    ) {
+        src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StairGeometryPublication
+                safeFacts = facts == null
+                        ? src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.StairGeometryPublication.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.StairGeometryFacts(
+                safeFacts.present(),
+                safeFacts.stairId(),
+                safeFacts.shapeName(),
+                safeFacts.directionName(),
+                safeFacts.dimension1(),
+                safeFacts.dimension2());
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.TransitionDestinationFacts
+            transitionDestinationFacts(
+                    src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.TransitionDestinationPublication facts
+            ) {
+        src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.TransitionDestinationPublication
+                safeFacts = facts == null
+                        ? src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository.TransitionDestinationPublication.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.TransitionDestinationFacts(
+                safeFacts.present(),
+                safeFacts.destinationTypeKey(),
+                safeFacts.mapId(),
+                safeFacts.tileId(),
+                safeFacts.transitionId());
     }
 
     private static String aggregateSummary(src.domain.dungeon.model.core.projection.DungeonState aggregate) {

--- a/src/domain/dungeon/DungeonEditorInspectorProjectionServiceAssembly.java
+++ b/src/domain/dungeon/DungeonEditorInspectorProjectionServiceAssembly.java
@@ -18,7 +18,52 @@ final class DungeonEditorInspectorProjectionServiceAssembly {
                 inspector.title(),
                 inspector.summary(),
                 inspector.facts(),
+                statePanelFacts(inspector.statePanelFacts()),
                 cards(inspector.roomNarrations()));
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.StatePanelFacts statePanelFacts(
+            src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStatePanelState facts
+    ) {
+        src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStatePanelState safeFacts =
+                facts == null
+                        ? src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStatePanelState.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.StatePanelFacts(
+                stairGeometryFacts(safeFacts.stairGeometryState()),
+                transitionDestinationFacts(safeFacts.transitionDestinationState()));
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.StairGeometryFacts stairGeometryFacts(
+            src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStairGeometryState facts
+    ) {
+        src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStairGeometryState safeFacts =
+                facts == null
+                        ? src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorStairGeometryState.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.StairGeometryFacts(
+                safeFacts.selected(),
+                safeFacts.selectedStairId(),
+                safeFacts.authoredShapeName(),
+                safeFacts.authoredDirectionName(),
+                safeFacts.firstDimension(),
+                safeFacts.secondDimension());
+    }
+
+    private static src.domain.dungeon.published.DungeonInspectorSnapshot.TransitionDestinationFacts
+            transitionDestinationFacts(
+                    src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorTransitionDestinationState facts
+            ) {
+        src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorTransitionDestinationState
+                safeFacts = facts == null
+                        ? src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues.InspectorTransitionDestinationState.empty()
+                        : facts;
+        return new src.domain.dungeon.published.DungeonInspectorSnapshot.TransitionDestinationFacts(
+                safeFacts.linked(),
+                safeFacts.targetKindKey(),
+                safeFacts.targetMapId(),
+                safeFacts.targetTileId(),
+                safeFacts.targetTransitionId());
     }
 
     private static List<src.domain.dungeon.published.DungeonInspectorSnapshot.RoomNarrationCard> cards(

--- a/src/domain/dungeon/model/core/projection/DungeonFeatureFacts.java
+++ b/src/domain/dungeon/model/core/projection/DungeonFeatureFacts.java
@@ -3,8 +3,12 @@ package src.domain.dungeon.model.core.projection;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.model.core.geometry.Cell;
+import src.domain.dungeon.model.core.geometry.Direction;
 import src.domain.dungeon.model.core.geometry.Edge;
 import src.domain.dungeon.model.core.graph.DungeonTopologyRef;
+import src.domain.dungeon.model.core.structure.stair.StairShape;
+import src.domain.dungeon.model.core.structure.transition.TransitionDestination;
+import src.domain.dungeon.model.core.structure.transition.TransitionDestinationType;
 
 public record DungeonFeatureFacts(
         DungeonFeatureType kind,
@@ -14,6 +18,7 @@ public record DungeonFeatureFacts(
         String description,
         String destinationLabel,
         List<String> facts,
+        StatePanelFacts statePanelFacts,
         DungeonTopologyRef topologyRef,
         @Nullable Edge anchorEdge
 ) {
@@ -28,7 +33,21 @@ public record DungeonFeatureFacts(
             List<String> facts,
             DungeonTopologyRef topologyRef
     ) {
-        this(kind, id, label, cells, description, destinationLabel, facts, topologyRef, null);
+        this(kind, id, label, cells, description, destinationLabel, facts, StatePanelFacts.empty(), topologyRef, null);
+    }
+
+    public DungeonFeatureFacts(
+            DungeonFeatureType kind,
+            long id,
+            String label,
+            List<Cell> cells,
+            String description,
+            String destinationLabel,
+            List<String> facts,
+            StatePanelFacts statePanelFacts,
+            DungeonTopologyRef topologyRef
+    ) {
+        this(kind, id, label, cells, description, destinationLabel, facts, statePanelFacts, topologyRef, null);
     }
 
     public DungeonFeatureFacts {
@@ -39,6 +58,7 @@ public record DungeonFeatureFacts(
         description = description == null ? "" : description.trim();
         destinationLabel = destinationLabel == null ? "" : destinationLabel.trim();
         facts = copyFacts(facts);
+        statePanelFacts = statePanelFacts == null ? StatePanelFacts.empty() : statePanelFacts;
         topologyRef = topologyRef == null ? DungeonTopologyRef.empty() : topologyRef;
     }
 
@@ -59,6 +79,111 @@ public record DungeonFeatureFacts(
             }
         }
         return List.copyOf(result);
+    }
+
+    public record StatePanelFacts(
+            StairGeometryFacts stairGeometry,
+            TransitionDestinationFacts transitionDestination
+    ) {
+        public StatePanelFacts {
+            stairGeometry = stairGeometry == null ? StairGeometryFacts.empty() : stairGeometry;
+            transitionDestination =
+                    transitionDestination == null ? TransitionDestinationFacts.empty() : transitionDestination;
+        }
+
+        public static StatePanelFacts empty() {
+            return new StatePanelFacts(StairGeometryFacts.empty(), TransitionDestinationFacts.empty());
+        }
+
+        public static StatePanelFacts stair(
+                long stairId,
+                StairShape shape,
+                Direction direction,
+                int dimension1,
+                int dimension2
+        ) {
+            return new StatePanelFacts(
+                    new StairGeometryFacts(true, stairId, shapeName(shape), directionName(direction),
+                            dimension1, dimension2),
+                    TransitionDestinationFacts.empty());
+        }
+
+        public static StatePanelFacts transition(TransitionDestination destination) {
+            return new StatePanelFacts(
+                    StairGeometryFacts.empty(),
+                    TransitionDestinationFacts.from(destination));
+        }
+
+        private static String shapeName(StairShape shape) {
+            return shape == null ? StairShape.STRAIGHT.name() : shape.name();
+        }
+
+        private static String directionName(Direction direction) {
+            return direction == null ? Direction.NORTH.name() : direction.name();
+        }
+    }
+
+    public record StairGeometryFacts(
+            boolean present,
+            long stairId,
+            String shapeName,
+            String directionName,
+            int dimension1,
+            int dimension2
+    ) {
+        public StairGeometryFacts {
+            stairId = Math.max(0L, stairId);
+            shapeName = shapeName == null || shapeName.isBlank() ? StairShape.STRAIGHT.name() : shapeName.strip();
+            directionName = directionName == null || directionName.isBlank()
+                    ? Direction.NORTH.name()
+                    : directionName.strip();
+            dimension1 = Math.max(0, dimension1);
+            dimension2 = Math.max(0, dimension2);
+            present = present && stairId > 0L;
+        }
+
+        public static StairGeometryFacts empty() {
+            return new StairGeometryFacts(false, 0L, "", "", 0, 0);
+        }
+    }
+
+    public record TransitionDestinationFacts(
+            boolean present,
+            String destinationTypeKey,
+            long mapId,
+            long tileId,
+            long transitionId
+    ) {
+        public TransitionDestinationFacts {
+            destinationTypeKey = destinationTypeKey == null || destinationTypeKey.isBlank()
+                    ? TransitionDestinationType.UNLINKED_ENTRANCE.name()
+                    : destinationTypeKey.strip();
+            mapId = Math.max(0L, mapId);
+            tileId = Math.max(0L, tileId);
+            transitionId = Math.max(0L, transitionId);
+        }
+
+        public static TransitionDestinationFacts empty() {
+            return new TransitionDestinationFacts(
+                    false,
+                    TransitionDestinationType.UNLINKED_ENTRANCE.name(),
+                    0L,
+                    0L,
+                    0L);
+        }
+
+        public static TransitionDestinationFacts from(TransitionDestination destination) {
+            TransitionDestination safeDestination = destination == null
+                    ? TransitionDestination.unlinkedEntrance()
+                    : destination;
+            Long transitionId = safeDestination.transitionId();
+            return new TransitionDestinationFacts(
+                    true,
+                    safeDestination.type().name(),
+                    safeDestination.mapId(),
+                    safeDestination.tileId(),
+                    transitionId == null ? 0L : transitionId);
+        }
     }
 
 }

--- a/src/domain/dungeon/model/core/projection/DungeonStairFeatureProjection.java
+++ b/src/domain/dungeon/model/core/projection/DungeonStairFeatureProjection.java
@@ -42,6 +42,12 @@ final class DungeonStairFeatureProjection {
                 stairDescription(stair, exits),
                 stairDestinationLabel(exits),
                 stairFacts(stair),
+                DungeonFeatureFacts.StatePanelFacts.stair(
+                        stair.stairId(),
+                        stair.shape(),
+                        stair.direction(),
+                        stair.dimension1(),
+                        stair.dimension2()),
                 new DungeonTopologyRef(DungeonTopologyElementKind.STAIR, stair.stairId())));
         if (stair.corridorId() != null) {
             relations.add(new DungeonRelationGraph.FeatureRelation(

--- a/src/domain/dungeon/model/core/projection/DungeonTransitionFeatureProjection.java
+++ b/src/domain/dungeon/model/core/projection/DungeonTransitionFeatureProjection.java
@@ -37,6 +37,7 @@ final class DungeonTransitionFeatureProjection {
                     transitionDescription(transition),
                     destinationLabel(destination),
                     transitionFacts(destination),
+                    DungeonFeatureFacts.StatePanelFacts.transition(destination),
                     transitionTopologyRef(transition),
                     transitionAnchorEdge(transition)));
             if (relation != null) {

--- a/src/domain/dungeon/model/runtime/editor/session/DungeonEditorWorkspaceValues.java
+++ b/src/domain/dungeon/model/runtime/editor/session/DungeonEditorWorkspaceValues.java
@@ -494,12 +494,20 @@ public final class DungeonEditorWorkspaceValues {
         private final String title;
         private final String summary;
         private final List<String> facts;
+        private final InspectorStatePanelState statePanelFacts;
         private final List<RoomNarrationCard> roomNarrations;
 
-        public Inspector(String title, String summary, List<String> facts, List<RoomNarrationCard> roomNarrations) {
+        public Inspector(
+                String title,
+                String summary,
+                List<String> facts,
+                InspectorStatePanelState statePanelFacts,
+                List<RoomNarrationCard> roomNarrations
+        ) {
             this.title = title == null || title.isBlank() ? "Dungeon" : title;
             this.summary = summary == null ? "" : summary;
             this.facts = facts == null ? List.of() : List.copyOf(facts);
+            this.statePanelFacts = statePanelFacts == null ? InspectorStatePanelState.empty() : statePanelFacts;
             this.roomNarrations = roomNarrations == null ? List.of() : List.copyOf(roomNarrations);
         }
 
@@ -513,6 +521,10 @@ public final class DungeonEditorWorkspaceValues {
 
         public List<String> facts() {
             return List.copyOf(facts);
+        }
+
+        public InspectorStatePanelState statePanelFacts() {
+            return statePanelFacts;
         }
 
         public List<RoomNarrationCard> roomNarrations() {
@@ -530,18 +542,84 @@ public final class DungeonEditorWorkspaceValues {
             return Objects.equals(title, that.title)
                     && Objects.equals(summary, that.summary)
                     && Objects.equals(facts, that.facts)
+                    && Objects.equals(statePanelFacts, that.statePanelFacts)
                     && Objects.equals(roomNarrations, that.roomNarrations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(title, summary, facts, roomNarrations);
+            return Objects.hash(title, summary, facts, statePanelFacts, roomNarrations);
         }
 
         @Override
         public String toString() {
-            return "Inspector[title=%s, summary=%s, facts=%s, roomNarrations=%s]"
-                    .formatted(title, summary, facts, roomNarrations);
+            return "Inspector[title=%s, summary=%s, facts=%s, statePanelFacts=%s, roomNarrations=%s]"
+                    .formatted(title, summary, facts, statePanelFacts, roomNarrations);
+        }
+    }
+
+    public record InspectorStatePanelState(
+            InspectorStairGeometryState stairGeometryState,
+            InspectorTransitionDestinationState transitionDestinationState
+    ) {
+        public InspectorStatePanelState {
+            stairGeometryState =
+                    stairGeometryState == null ? InspectorStairGeometryState.empty() : stairGeometryState;
+            transitionDestinationState = transitionDestinationState == null
+                    ? InspectorTransitionDestinationState.empty()
+                    : transitionDestinationState;
+        }
+
+        public static InspectorStatePanelState empty() {
+            return new InspectorStatePanelState(
+                    InspectorStairGeometryState.empty(),
+                    InspectorTransitionDestinationState.empty());
+        }
+    }
+
+    public record InspectorStairGeometryState(
+            boolean selected,
+            long selectedStairId,
+            String authoredShapeName,
+            String authoredDirectionName,
+            int firstDimension,
+            int secondDimension
+    ) {
+        public InspectorStairGeometryState {
+            selectedStairId = Math.max(0L, selectedStairId);
+            authoredShapeName =
+                    authoredShapeName == null || authoredShapeName.isBlank() ? "STRAIGHT" : authoredShapeName.strip();
+            authoredDirectionName = authoredDirectionName == null || authoredDirectionName.isBlank()
+                    ? "NORTH"
+                    : authoredDirectionName.strip();
+            firstDimension = Math.max(0, firstDimension);
+            secondDimension = Math.max(0, secondDimension);
+            selected = selected && selectedStairId > 0L;
+        }
+
+        public static InspectorStairGeometryState empty() {
+            return new InspectorStairGeometryState(false, 0L, "", "", 0, 0);
+        }
+    }
+
+    public record InspectorTransitionDestinationState(
+            boolean linked,
+            String targetKindKey,
+            long targetMapId,
+            long targetTileId,
+            long targetTransitionId
+    ) {
+        public InspectorTransitionDestinationState {
+            targetKindKey = targetKindKey == null || targetKindKey.isBlank()
+                    ? "UNLINKED_ENTRANCE"
+                    : targetKindKey.strip();
+            targetMapId = Math.max(0L, targetMapId);
+            targetTileId = Math.max(0L, targetTileId);
+            targetTransitionId = Math.max(0L, targetTransitionId);
+        }
+
+        public static InspectorTransitionDestinationState empty() {
+            return new InspectorTransitionDestinationState(false, "UNLINKED_ENTRANCE", 0L, 0L, 0L);
         }
     }
 

--- a/src/domain/dungeon/model/runtime/repository/DungeonAuthoredPublishedStateRepository.java
+++ b/src/domain/dungeon/model/runtime/repository/DungeonAuthoredPublishedStateRepository.java
@@ -86,17 +86,20 @@ public interface DungeonAuthoredPublishedStateRepository {
         private final String title;
         private final String description;
         private final List<String> facts;
+        private final StatePanelFacts statePanelFacts;
         private final List<RoomNarrationPublication> roomNarrations;
 
         public InspectorPublication(
                 String title,
                 String description,
                 List<String> facts,
+                StatePanelFacts statePanelFacts,
                 List<RoomNarrationPublication> roomNarrations
         ) {
             this.title = title == null ? "" : title;
             this.description = description == null ? "" : description;
             this.facts = facts == null ? List.of() : List.copyOf(facts);
+            this.statePanelFacts = statePanelFacts == null ? StatePanelFacts.empty() : statePanelFacts;
             this.roomNarrations = roomNarrations == null ? List.of() : List.copyOf(roomNarrations);
         }
 
@@ -112,6 +115,10 @@ public interface DungeonAuthoredPublishedStateRepository {
             return facts;
         }
 
+        public StatePanelFacts statePanelFacts() {
+            return statePanelFacts;
+        }
+
         public List<RoomNarrationPublication> roomNarrations() {
             return roomNarrations;
         }
@@ -122,12 +129,13 @@ public interface DungeonAuthoredPublishedStateRepository {
                     && Objects.equals(title, that.title)
                     && Objects.equals(description, that.description)
                     && Objects.equals(facts, that.facts)
+                    && Objects.equals(statePanelFacts, that.statePanelFacts)
                     && Objects.equals(roomNarrations, that.roomNarrations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(title, description, facts, roomNarrations);
+            return Objects.hash(title, description, facts, statePanelFacts, roomNarrations);
         }
 
         @Override
@@ -135,7 +143,67 @@ public interface DungeonAuthoredPublishedStateRepository {
             return "InspectorPublication[title=" + title
                     + ", description=" + description
                     + ", facts=" + facts
+                    + ", statePanelFacts=" + statePanelFacts
                     + ", roomNarrations=" + roomNarrations + "]";
+        }
+    }
+
+    record StatePanelFacts(
+            StairGeometryPublication stairGeometry,
+            TransitionDestinationPublication transitionDestination
+    ) {
+        public StatePanelFacts {
+            stairGeometry = stairGeometry == null ? StairGeometryPublication.empty() : stairGeometry;
+            transitionDestination = transitionDestination == null
+                    ? TransitionDestinationPublication.empty()
+                    : transitionDestination;
+        }
+
+        public static StatePanelFacts empty() {
+            return new StatePanelFacts(StairGeometryPublication.empty(), TransitionDestinationPublication.empty());
+        }
+    }
+
+    record StairGeometryPublication(
+            boolean present,
+            long stairId,
+            String shapeName,
+            String directionName,
+            int dimension1,
+            int dimension2
+    ) {
+        public StairGeometryPublication {
+            stairId = Math.max(0L, stairId);
+            shapeName = shapeName == null || shapeName.isBlank() ? "STRAIGHT" : shapeName.strip();
+            directionName = directionName == null || directionName.isBlank() ? "NORTH" : directionName.strip();
+            dimension1 = Math.max(0, dimension1);
+            dimension2 = Math.max(0, dimension2);
+            present = present && stairId > 0L;
+        }
+
+        public static StairGeometryPublication empty() {
+            return new StairGeometryPublication(false, 0L, "", "", 0, 0);
+        }
+    }
+
+    record TransitionDestinationPublication(
+            boolean present,
+            String destinationTypeKey,
+            long mapId,
+            long tileId,
+            long transitionId
+    ) {
+        public TransitionDestinationPublication {
+            destinationTypeKey = destinationTypeKey == null || destinationTypeKey.isBlank()
+                    ? "UNLINKED_ENTRANCE"
+                    : destinationTypeKey.strip();
+            mapId = Math.max(0L, mapId);
+            tileId = Math.max(0L, tileId);
+            transitionId = Math.max(0L, transitionId);
+        }
+
+        public static TransitionDestinationPublication empty() {
+            return new TransitionDestinationPublication(false, "UNLINKED_ENTRANCE", 0L, 0L, 0L);
         }
     }
 

--- a/src/domain/dungeon/model/runtime/usecase/BuildDungeonSelectionFactsUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/BuildDungeonSelectionFactsUseCase.java
@@ -114,7 +114,9 @@ final class BuildDungeonSelectionFactsUseCase {
                     return new LoadDungeonSnapshotUseCase.InspectorSnapshotData(
                             feature.label(),
                             feature.description(),
-                            facts);
+                            facts,
+                            SelectionFacts.statePanelFacts(feature),
+                            List.of());
                 }
             }
             return null;
@@ -175,6 +177,44 @@ final class BuildDungeonSelectionFactsUseCase {
 
         private static String factLine(String key, Object value) {
             return key + ": " + value;
+        }
+
+        private static LoadDungeonSnapshotUseCase.StatePanelFacts statePanelFacts(DungeonFeatureFacts feature) {
+            DungeonFeatureFacts.StatePanelFacts facts = feature == null
+                    ? DungeonFeatureFacts.StatePanelFacts.empty()
+                    : feature.statePanelFacts();
+            return new LoadDungeonSnapshotUseCase.StatePanelFacts(
+                    stairGeometryFacts(facts.stairGeometry()),
+                    transitionDestinationFacts(facts.transitionDestination()));
+        }
+
+        private static LoadDungeonSnapshotUseCase.StairGeometryPanelFacts stairGeometryFacts(
+                DungeonFeatureFacts.StairGeometryFacts facts
+        ) {
+            DungeonFeatureFacts.StairGeometryFacts safeFacts = facts == null
+                    ? DungeonFeatureFacts.StairGeometryFacts.empty()
+                    : facts;
+            return new LoadDungeonSnapshotUseCase.StairGeometryPanelFacts(
+                    safeFacts.present(),
+                    safeFacts.stairId(),
+                    safeFacts.shapeName(),
+                    safeFacts.directionName(),
+                    safeFacts.dimension1(),
+                    safeFacts.dimension2());
+        }
+
+        private static LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts transitionDestinationFacts(
+                DungeonFeatureFacts.TransitionDestinationFacts facts
+        ) {
+            DungeonFeatureFacts.TransitionDestinationFacts safeFacts = facts == null
+                    ? DungeonFeatureFacts.TransitionDestinationFacts.empty()
+                    : facts;
+            return new LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts(
+                    safeFacts.present(),
+                    safeFacts.destinationTypeKey(),
+                    safeFacts.mapId(),
+                    safeFacts.tileId(),
+                    safeFacts.transitionId());
         }
     }
 }

--- a/src/domain/dungeon/model/runtime/usecase/DungeonInspectorPublicationMapper.java
+++ b/src/domain/dungeon/model/runtime/usecase/DungeonInspectorPublicationMapper.java
@@ -1,0 +1,99 @@
+package src.domain.dungeon.model.runtime.usecase;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository;
+
+final class DungeonInspectorPublicationMapper {
+
+    private DungeonInspectorPublicationMapper() {
+    }
+
+    static DungeonAuthoredPublishedStateRepository.@Nullable InspectorPublication inspectorPublication(
+            LoadDungeonSnapshotUseCase.@Nullable InspectorSnapshotData inspector
+    ) {
+        if (inspector == null) {
+            return null;
+        }
+        return new DungeonAuthoredPublishedStateRepository.InspectorPublication(
+                inspector.title(),
+                inspector.description(),
+                inspector.facts(),
+                statePanelFacts(inspector.statePanelFacts()),
+                roomNarrationPublications(inspector.roomNarrations()));
+    }
+
+    private static DungeonAuthoredPublishedStateRepository.StatePanelFacts statePanelFacts(
+            LoadDungeonSnapshotUseCase.StatePanelFacts facts
+    ) {
+        LoadDungeonSnapshotUseCase.StatePanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.StatePanelFacts.empty()
+                : facts;
+        return new DungeonAuthoredPublishedStateRepository.StatePanelFacts(
+                stairGeometryFacts(safeFacts.stairGeometry()),
+                transitionDestinationFacts(safeFacts.transitionDestination()));
+    }
+
+    private static DungeonAuthoredPublishedStateRepository.StairGeometryPublication stairGeometryFacts(
+            LoadDungeonSnapshotUseCase.StairGeometryPanelFacts facts
+    ) {
+        LoadDungeonSnapshotUseCase.StairGeometryPanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.StairGeometryPanelFacts.empty()
+                : facts;
+        return new DungeonAuthoredPublishedStateRepository.StairGeometryPublication(
+                safeFacts.present(),
+                safeFacts.stairId(),
+                safeFacts.shapeName(),
+                safeFacts.directionName(),
+                safeFacts.dimension1(),
+                safeFacts.dimension2());
+    }
+
+    private static DungeonAuthoredPublishedStateRepository.TransitionDestinationPublication
+            transitionDestinationFacts(LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts facts) {
+        LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts.empty()
+                : facts;
+        return new DungeonAuthoredPublishedStateRepository.TransitionDestinationPublication(
+                safeFacts.present(),
+                safeFacts.destinationTypeKey(),
+                safeFacts.mapId(),
+                safeFacts.tileId(),
+                safeFacts.transitionId());
+    }
+
+    private static List<DungeonAuthoredPublishedStateRepository.RoomNarrationPublication> roomNarrationPublications(
+            List<LoadDungeonSnapshotUseCase.RoomNarrationData> roomNarrations
+    ) {
+        List<DungeonAuthoredPublishedStateRepository.RoomNarrationPublication> result = new ArrayList<>();
+        for (LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration : roomNarrations) {
+            result.add(roomNarrationPublication(roomNarration));
+        }
+        return List.copyOf(result);
+    }
+
+    private static DungeonAuthoredPublishedStateRepository.RoomNarrationPublication roomNarrationPublication(
+            LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration
+    ) {
+        return new DungeonAuthoredPublishedStateRepository.RoomNarrationPublication(
+                roomNarration.roomId(),
+                roomNarration.roomName(),
+                roomNarration.visualDescription(),
+                roomExitPublications(roomNarration.exits()));
+    }
+
+    private static List<DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication> roomExitPublications(
+            List<LoadDungeonSnapshotUseCase.RoomExitNarrationData> exits
+    ) {
+        List<DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication> result = new ArrayList<>();
+        for (LoadDungeonSnapshotUseCase.RoomExitNarrationData exit : exits) {
+            result.add(new DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication(
+                    exit.label(),
+                    exit.cell(),
+                    exit.direction(),
+                    exit.description()));
+        }
+        return List.copyOf(result);
+    }
+}

--- a/src/domain/dungeon/model/runtime/usecase/DungeonInspectorWorkspaceMapper.java
+++ b/src/domain/dungeon/model/runtime/usecase/DungeonInspectorWorkspaceMapper.java
@@ -1,0 +1,104 @@
+package src.domain.dungeon.model.runtime.usecase;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import src.domain.dungeon.model.core.geometry.Cell;
+import src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues;
+
+final class DungeonInspectorWorkspaceMapper {
+
+    private DungeonInspectorWorkspaceMapper() {
+    }
+
+    static DungeonEditorWorkspaceValues.@Nullable Inspector inspectorFacts(
+            LoadDungeonSnapshotUseCase.@Nullable InspectorSnapshotData inspector
+    ) {
+        if (inspector == null) {
+            return null;
+        }
+        return new DungeonEditorWorkspaceValues.Inspector(
+                inspector.title(),
+                inspector.description(),
+                inspector.facts(),
+                statePanelFacts(inspector.statePanelFacts()),
+                roomNarrations(inspector.roomNarrations()));
+    }
+
+    private static DungeonEditorWorkspaceValues.InspectorStatePanelState statePanelFacts(
+            LoadDungeonSnapshotUseCase.StatePanelFacts facts
+    ) {
+        LoadDungeonSnapshotUseCase.StatePanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.StatePanelFacts.empty()
+                : facts;
+        return new DungeonEditorWorkspaceValues.InspectorStatePanelState(
+                stairGeometryFacts(safeFacts.stairGeometry()),
+                transitionDestinationFacts(safeFacts.transitionDestination()));
+    }
+
+    private static DungeonEditorWorkspaceValues.InspectorStairGeometryState stairGeometryFacts(
+            LoadDungeonSnapshotUseCase.StairGeometryPanelFacts facts
+    ) {
+        LoadDungeonSnapshotUseCase.StairGeometryPanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.StairGeometryPanelFacts.empty()
+                : facts;
+        return new DungeonEditorWorkspaceValues.InspectorStairGeometryState(
+                safeFacts.present(),
+                safeFacts.stairId(),
+                safeFacts.shapeName(),
+                safeFacts.directionName(),
+                safeFacts.dimension1(),
+                safeFacts.dimension2());
+    }
+
+    private static DungeonEditorWorkspaceValues.InspectorTransitionDestinationState transitionDestinationFacts(
+            LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts facts
+    ) {
+        LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts safeFacts = facts == null
+                ? LoadDungeonSnapshotUseCase.TransitionDestinationPanelFacts.empty()
+                : facts;
+        return new DungeonEditorWorkspaceValues.InspectorTransitionDestinationState(
+                safeFacts.present(),
+                safeFacts.destinationTypeKey(),
+                safeFacts.mapId(),
+                safeFacts.tileId(),
+                safeFacts.transitionId());
+    }
+
+    private static List<DungeonEditorWorkspaceValues.RoomNarrationCard> roomNarrations(
+            List<LoadDungeonSnapshotUseCase.RoomNarrationData> roomNarrations
+    ) {
+        List<DungeonEditorWorkspaceValues.RoomNarrationCard> result = new ArrayList<>();
+        for (LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration : roomNarrations) {
+            result.add(roomNarration(roomNarration));
+        }
+        return List.copyOf(result);
+    }
+
+    private static DungeonEditorWorkspaceValues.RoomNarrationCard roomNarration(
+            LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration
+    ) {
+        return new DungeonEditorWorkspaceValues.RoomNarrationCard(
+                roomNarration.roomId(),
+                roomNarration.roomName(),
+                roomNarration.visualDescription(),
+                roomExits(roomNarration.exits()));
+    }
+
+    private static List<DungeonEditorWorkspaceValues.RoomExitNarration> roomExits(
+            List<LoadDungeonSnapshotUseCase.RoomExitNarrationData> exits
+    ) {
+        List<DungeonEditorWorkspaceValues.RoomExitNarration> result = new ArrayList<>();
+        for (LoadDungeonSnapshotUseCase.RoomExitNarrationData exit : exits) {
+            Cell cell = exit.cell();
+            result.add(new DungeonEditorWorkspaceValues.RoomExitNarration(
+                    exit.label(),
+                    cell == null
+                            ? DungeonEditorWorkspaceValues.Cell.empty()
+                            : new DungeonEditorWorkspaceValues.Cell(cell.q(), cell.r(), cell.level()),
+                    exit.direction().name(),
+                    exit.description()));
+        }
+        return List.copyOf(result);
+    }
+}

--- a/src/domain/dungeon/model/runtime/usecase/InspectDungeonSelectionUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/InspectDungeonSelectionUseCase.java
@@ -54,6 +54,7 @@ public final class InspectDungeonSelectionUseCase {
                     clusterName(dungeonMap, clusterId),
                     narrationDescription(narrations),
                     factsSnapshot.facts(),
+                    factsSnapshot.statePanelFacts(),
                     narrations);
         }
         if (!narrations.isEmpty() && selectionFacts.isFallbackSelection(factsSnapshot)) {
@@ -61,12 +62,14 @@ public final class InspectDungeonSelectionUseCase {
                     narrationTitle(narrations),
                     narrationDescription(narrations),
                     factsSnapshot.facts(),
+                    factsSnapshot.statePanelFacts(),
                     narrations);
         }
         return new LoadDungeonSnapshotUseCase.InspectorSnapshotData(
                 factsSnapshot.title(),
                 factsSnapshot.description(),
                 factsSnapshot.facts(),
+                factsSnapshot.statePanelFacts(),
                 narrations);
     }
 

--- a/src/domain/dungeon/model/runtime/usecase/LoadDungeonSnapshotUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/LoadDungeonSnapshotUseCase.java
@@ -2,6 +2,7 @@ package src.domain.dungeon.model.runtime.usecase;
 
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.model.core.geometry.Cell;
 import src.domain.dungeon.model.core.geometry.Direction;
 import src.domain.dungeon.model.core.graph.DungeonTopologyRef;
@@ -31,15 +32,75 @@ public final class LoadDungeonSnapshotUseCase {
             String title,
             String description,
             List<String> facts,
+            StatePanelFacts statePanelFacts,
             List<RoomNarrationData> roomNarrations
     ) {
         public InspectorSnapshotData(String title, String description, List<String> facts) {
-            this(title, description, facts, List.of());
+            this(title, description, facts, StatePanelFacts.empty(), List.of());
         }
 
         public InspectorSnapshotData {
             facts = facts == null ? List.of() : List.copyOf(facts);
+            statePanelFacts = statePanelFacts == null ? StatePanelFacts.empty() : statePanelFacts;
             roomNarrations = roomNarrations == null ? List.of() : List.copyOf(roomNarrations);
+        }
+    }
+
+    public record StatePanelFacts(
+            @Nullable StairGeometryPanelFacts stairGeometry,
+            @Nullable TransitionDestinationPanelFacts transitionDestination
+    ) {
+        public StatePanelFacts {
+            stairGeometry = stairGeometry == null ? StairGeometryPanelFacts.empty() : stairGeometry;
+            transitionDestination =
+                    transitionDestination == null ? TransitionDestinationPanelFacts.empty() : transitionDestination;
+        }
+
+        public static StatePanelFacts empty() {
+            return new StatePanelFacts(StairGeometryPanelFacts.empty(), TransitionDestinationPanelFacts.empty());
+        }
+    }
+
+    public record StairGeometryPanelFacts(
+            boolean present,
+            long stairId,
+            String shapeName,
+            String directionName,
+            int dimension1,
+            int dimension2
+    ) {
+        public StairGeometryPanelFacts {
+            stairId = Math.max(0L, stairId);
+            shapeName = shapeName == null || shapeName.isBlank() ? "STRAIGHT" : shapeName.strip();
+            directionName = directionName == null || directionName.isBlank() ? "NORTH" : directionName.strip();
+            dimension1 = Math.max(0, dimension1);
+            dimension2 = Math.max(0, dimension2);
+            present = present && stairId > 0L;
+        }
+
+        public static StairGeometryPanelFacts empty() {
+            return new StairGeometryPanelFacts(false, 0L, "", "", 0, 0);
+        }
+    }
+
+    public record TransitionDestinationPanelFacts(
+            boolean present,
+            String destinationTypeKey,
+            long mapId,
+            long tileId,
+            long transitionId
+    ) {
+        public TransitionDestinationPanelFacts {
+            destinationTypeKey = destinationTypeKey == null || destinationTypeKey.isBlank()
+                    ? "UNLINKED_ENTRANCE"
+                    : destinationTypeKey.strip();
+            mapId = Math.max(0L, mapId);
+            tileId = Math.max(0L, tileId);
+            transitionId = Math.max(0L, transitionId);
+        }
+
+        public static TransitionDestinationPanelFacts empty() {
+            return new TransitionDestinationPanelFacts(false, "UNLINKED_ENTRANCE", 0L, 0L, 0L);
         }
     }
 

--- a/src/domain/dungeon/model/runtime/usecase/PublishDungeonEditorAuthoredInspectorUseCase.java
+++ b/src/domain/dungeon/model/runtime/usecase/PublishDungeonEditorAuthoredInspectorUseCase.java
@@ -1,12 +1,7 @@
 package src.domain.dungeon.model.runtime.usecase;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import org.jspecify.annotations.Nullable;
-import src.domain.dungeon.model.core.geometry.Cell;
 import src.domain.dungeon.model.runtime.editor.session.DungeonEditorDungeonState;
-import src.domain.dungeon.model.runtime.editor.session.DungeonEditorWorkspaceValues;
 import src.domain.dungeon.model.runtime.repository.DungeonAuthoredPublishedStateRepository;
 
 public final class PublishDungeonEditorAuthoredInspectorUseCase {
@@ -24,108 +19,11 @@ public final class PublishDungeonEditorAuthoredInspectorUseCase {
     }
 
     public void execute(LoadDungeonSnapshotUseCase.InspectorSnapshotData inspector) {
-        state.replaceInspector(inspectorFacts(inspector));
+        state.replaceInspector(DungeonInspectorWorkspaceMapper.inspectorFacts(inspector));
         DungeonAuthoredPublishedStateRepository.InspectorPublication publication =
-                inspectorPublication(inspector);
+                DungeonInspectorPublicationMapper.inspectorPublication(inspector);
         if (publication != null) {
             publishedStateRepository.publishInspector(publication);
         }
-    }
-
-    private static DungeonEditorWorkspaceValues.@Nullable Inspector inspectorFacts(
-            LoadDungeonSnapshotUseCase.@Nullable InspectorSnapshotData inspector
-    ) {
-        if (inspector == null) {
-            return null;
-        }
-        return new DungeonEditorWorkspaceValues.Inspector(
-                inspector.title(),
-                inspector.description(),
-                inspector.facts(),
-                roomNarrations(inspector.roomNarrations()));
-    }
-
-    private static DungeonAuthoredPublishedStateRepository.@Nullable InspectorPublication inspectorPublication(
-            LoadDungeonSnapshotUseCase.@Nullable InspectorSnapshotData inspector
-    ) {
-        if (inspector == null) {
-            return null;
-        }
-        return new DungeonAuthoredPublishedStateRepository.InspectorPublication(
-                inspector.title(),
-                inspector.description(),
-                inspector.facts(),
-                roomNarrationPublications(inspector.roomNarrations()));
-    }
-
-    private static List<DungeonAuthoredPublishedStateRepository.RoomNarrationPublication> roomNarrationPublications(
-            List<LoadDungeonSnapshotUseCase.RoomNarrationData> roomNarrations
-    ) {
-        List<DungeonAuthoredPublishedStateRepository.RoomNarrationPublication> result = new ArrayList<>();
-        for (LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration : roomNarrations) {
-            result.add(roomNarrationPublication(roomNarration));
-        }
-        return List.copyOf(result);
-    }
-
-    private static DungeonAuthoredPublishedStateRepository.RoomNarrationPublication roomNarrationPublication(
-            LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration
-    ) {
-        return new DungeonAuthoredPublishedStateRepository.RoomNarrationPublication(
-                roomNarration.roomId(),
-                roomNarration.roomName(),
-                roomNarration.visualDescription(),
-                roomExitPublications(roomNarration.exits()));
-    }
-
-    private static List<DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication> roomExitPublications(
-            List<LoadDungeonSnapshotUseCase.RoomExitNarrationData> exits
-    ) {
-        List<DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication> result = new ArrayList<>();
-        for (LoadDungeonSnapshotUseCase.RoomExitNarrationData exit : exits) {
-            result.add(new DungeonAuthoredPublishedStateRepository.RoomExitNarrationPublication(
-                    exit.label(),
-                    exit.cell(),
-                    exit.direction(),
-                    exit.description()));
-        }
-        return List.copyOf(result);
-    }
-
-    private static List<DungeonEditorWorkspaceValues.RoomNarrationCard> roomNarrations(
-            List<LoadDungeonSnapshotUseCase.RoomNarrationData> roomNarrations
-    ) {
-        List<DungeonEditorWorkspaceValues.RoomNarrationCard> result = new ArrayList<>();
-        for (LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration : roomNarrations) {
-            result.add(roomNarration(roomNarration));
-        }
-        return List.copyOf(result);
-    }
-
-    private static DungeonEditorWorkspaceValues.RoomNarrationCard roomNarration(
-            LoadDungeonSnapshotUseCase.RoomNarrationData roomNarration
-    ) {
-        return new DungeonEditorWorkspaceValues.RoomNarrationCard(
-                roomNarration.roomId(),
-                roomNarration.roomName(),
-                roomNarration.visualDescription(),
-                roomExits(roomNarration.exits()));
-    }
-
-    private static List<DungeonEditorWorkspaceValues.RoomExitNarration> roomExits(
-            List<LoadDungeonSnapshotUseCase.RoomExitNarrationData> exits
-    ) {
-        List<DungeonEditorWorkspaceValues.RoomExitNarration> result = new ArrayList<>();
-        for (LoadDungeonSnapshotUseCase.RoomExitNarrationData exit : exits) {
-            Cell cell = exit.cell();
-            result.add(new DungeonEditorWorkspaceValues.RoomExitNarration(
-                    exit.label(),
-                    cell == null
-                            ? DungeonEditorWorkspaceValues.Cell.empty()
-                            : new DungeonEditorWorkspaceValues.Cell(cell.q(), cell.r(), cell.level()),
-                    exit.direction().name(),
-                    exit.description()));
-        }
-        return List.copyOf(result);
     }
 }

--- a/src/domain/dungeon/published/DungeonInspectorSnapshot.java
+++ b/src/domain/dungeon/published/DungeonInspectorSnapshot.java
@@ -8,15 +8,92 @@ import java.util.List;
 public record DungeonInspectorSnapshot(
         String title,
         String summary,
+        /*
+         * LEGACY_REMOVE_ON_TOUCH: display/debug compatibility only. Remove when
+         * generic inspector displays and legacy selection harness assertions read
+         * title/summary/statePanelFacts instead of key/value fact lines.
+         */
         List<String> facts,
+        StatePanelFacts statePanelFacts,
         List<RoomNarrationCard> roomNarrations
 ) {
+
+    public DungeonInspectorSnapshot(
+            String title,
+            String summary,
+            List<String> facts,
+            List<RoomNarrationCard> roomNarrations
+    ) {
+        this(title, summary, facts, StatePanelFacts.empty(), roomNarrations);
+    }
 
     public DungeonInspectorSnapshot {
         title = title == null || title.isBlank() ? "Dungeon" : title;
         summary = summary == null ? "" : summary;
         facts = facts == null ? List.of() : List.copyOf(facts);
+        statePanelFacts = statePanelFacts == null ? StatePanelFacts.empty() : statePanelFacts;
         roomNarrations = roomNarrations == null ? List.of() : List.copyOf(roomNarrations);
+    }
+
+    public record StatePanelFacts(
+            StairGeometryFacts stairGeometry,
+            TransitionDestinationFacts transitionDestination
+    ) {
+
+        public StatePanelFacts {
+            stairGeometry = stairGeometry == null ? StairGeometryFacts.empty() : stairGeometry;
+            transitionDestination =
+                    transitionDestination == null ? TransitionDestinationFacts.empty() : transitionDestination;
+        }
+
+        public static StatePanelFacts empty() {
+            return new StatePanelFacts(StairGeometryFacts.empty(), TransitionDestinationFacts.empty());
+        }
+    }
+
+    public record StairGeometryFacts(
+            boolean present,
+            long stairId,
+            String shapeName,
+            String directionName,
+            int dimension1,
+            int dimension2
+    ) {
+
+        public StairGeometryFacts {
+            stairId = Math.max(0L, stairId);
+            shapeName = shapeName == null || shapeName.isBlank() ? "STRAIGHT" : shapeName.strip();
+            directionName = directionName == null || directionName.isBlank() ? "NORTH" : directionName.strip();
+            dimension1 = Math.max(0, dimension1);
+            dimension2 = Math.max(0, dimension2);
+            present = present && stairId > 0L;
+        }
+
+        public static StairGeometryFacts empty() {
+            return new StairGeometryFacts(false, 0L, "", "", 0, 0);
+        }
+    }
+
+    public record TransitionDestinationFacts(
+            boolean present,
+            String destinationTypeKey,
+            long mapId,
+            long tileId,
+            long transitionId
+    ) {
+
+        public TransitionDestinationFacts {
+            destinationTypeKey = destinationTypeKey == null || destinationTypeKey.isBlank()
+                    ? "UNLINKED_ENTRANCE"
+                    : destinationTypeKey.strip();
+            mapId = Math.max(0L, mapId);
+            tileId = Math.max(0L, tileId);
+            transitionId = Math.max(0L, transitionId);
+        }
+
+        public static TransitionDestinationFacts empty() {
+            return new TransitionDestinationFacts(false, "UNLINKED_ENTRANCE", 0L, 0L, 0L);
+        }
     }
 
     public record RoomNarrationCard(

--- a/src/features/dungeon/runtime/DungeonEditorAuthoredRuntimeOperations.java
+++ b/src/features/dungeon/runtime/DungeonEditorAuthoredRuntimeOperations.java
@@ -224,15 +224,9 @@ final class DungeonEditorAuthoredRuntimeOperations {
 
     DungeonEditorRuntimeOperationResult saveTransitionLink(
             long sourceTransitionId,
-            long targetMapId,
-            long targetTransitionId,
-            boolean bidirectional
+            TransitionDestinationDraftInput input
     ) {
-        return detailSaveOperations.saveTransitionLink(
-                sourceTransitionId,
-                targetMapId,
-                targetTransitionId,
-                bidirectional);
+        return detailSaveOperations.saveTransitionLink(sourceTransitionId, input);
     }
 
     DungeonEditorRuntimeOperationResult saveTransitionDescription(
@@ -242,18 +236,7 @@ final class DungeonEditorAuthoredRuntimeOperations {
         return detailSaveOperations.saveTransitionDescription(transitionId, description);
     }
 
-    DungeonEditorRuntimeOperationResult saveStairGeometry(
-            long stairId,
-            String shapeName,
-            String directionName,
-            int dimension1,
-            int dimension2
-    ) {
-        return detailSaveOperations.saveStairGeometry(
-                stairId,
-                shapeName,
-                directionName,
-                dimension1,
-                dimension2);
+    DungeonEditorRuntimeOperationResult saveStairGeometry(StairGeometryDraftInput input) {
+        return detailSaveOperations.saveStairGeometry(input);
     }
 }

--- a/src/features/dungeon/runtime/DungeonEditorDetailSaveRuntimeOperations.java
+++ b/src/features/dungeon/runtime/DungeonEditorDetailSaveRuntimeOperations.java
@@ -2,6 +2,7 @@ package src.features.dungeon.runtime;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 import src.domain.dungeon.model.runtime.usecase.SaveDungeonEditorLabelNameUseCase;
 import src.domain.dungeon.model.runtime.usecase.SaveDungeonEditorRoomNarrationUseCase;
 import src.domain.dungeon.model.runtime.usecase.SaveDungeonEditorStairGeometryUseCase;
@@ -69,16 +70,17 @@ final class DungeonEditorDetailSaveRuntimeOperations {
 
     DungeonEditorRuntimeOperationResult saveTransitionLink(
             long sourceTransitionId,
-            long targetMapId,
-            long targetTransitionId,
-            boolean bidirectional
+            TransitionDestinationDraftInput input
     ) {
+        TransitionDestinationDraftInput safeInput = input == null
+                ? TransitionDestinationDraftInput.unlinkedEntrance()
+                : input;
         return DungeonEditorRuntimeResultTranslator.fromOperationResult(
                 saveTransitionLinkUseCase.execute(new SaveDungeonEditorTransitionLinkUseCase.TransitionLinkInput(
                         sourceTransitionId,
-                        targetMapId,
-                        targetTransitionId,
-                        bidirectional)));
+                        safeInput.targetMapId(),
+                        safeInput.targetTransitionId(),
+                        safeInput.bidirectional())));
     }
 
     DungeonEditorRuntimeOperationResult saveTransitionDescription(
@@ -92,19 +94,16 @@ final class DungeonEditorDetailSaveRuntimeOperations {
                                 description)));
     }
 
-    DungeonEditorRuntimeOperationResult saveStairGeometry(
-            long stairId,
-            String shapeName,
-            String directionName,
-            int dimension1,
-            int dimension2
-    ) {
+    DungeonEditorRuntimeOperationResult saveStairGeometry(StairGeometryDraftInput input) {
+        StairGeometryDraftInput safeInput = input == null ? StairGeometryDraftInput.empty() : input;
+        OptionalInt dimension1 = safeInput.dimension1Value();
+        OptionalInt dimension2 = safeInput.dimension2Value();
         return DungeonEditorRuntimeResultTranslator.fromSnapshot(
                 saveStairGeometryUseCase.execute(new SaveDungeonEditorStairGeometryUseCase.StairGeometryInput(
-                        stairId,
-                        shapeName,
-                        directionName,
-                        dimension1,
-                        dimension2)));
+                        safeInput.stairId(),
+                        safeInput.shapeName(),
+                        safeInput.directionName(),
+                        dimension1.orElse(0),
+                        dimension2.orElse(0))));
     }
 }

--- a/src/features/dungeon/runtime/DungeonEditorPreparedFrameFacts.java
+++ b/src/features/dungeon/runtime/DungeonEditorPreparedFrameFacts.java
@@ -989,11 +989,12 @@ public record DungeonEditorPreparedFrameFacts(
                 return TransitionDestination.empty();
             }
             if (runtimeDraft.present()) {
-                return TransitionDestination.fromDraft(
+                return TransitionDestination.fromDraftInput(new TransitionDestinationDraftInput(
                         runtimeDraft.destinationType(),
                         runtimeDraft.mapId(),
                         runtimeDraft.tileId(),
-                        runtimeDraft.transitionId());
+                        runtimeDraft.transitionId(),
+                        runtimeDraft.bidirectional()));
             }
             return TransitionDestination.empty();
         }

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeDraftSession.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeDraftSession.java
@@ -1,6 +1,5 @@
 package src.features.dungeon.runtime;
 
-import src.domain.dungeon.model.core.structure.transition.TransitionDestinationType;
 import src.domain.dungeon.published.DungeonEditorControlsSnapshot;
 import src.domain.dungeon.published.DungeonEditorStateSnapshot;
 
@@ -72,12 +71,7 @@ final class DungeonEditorRuntimeDraftSession {
             TransitionDestinationDraftInput input
     ) {
         TransitionDestinationDraftInput safeInput = input == null
-                ? new TransitionDestinationDraftInput(
-                        TransitionDestinationType.UNLINKED_ENTRANCE,
-                        "",
-                        "",
-                        "",
-                        true)
+                ? TransitionDestinationDraftInput.unlinkedEntrance()
                 : input;
         DungeonEditorStatePanelTransitionDestinationDrafts.Target target =
                 DungeonEditorStatePanelTransitionDestinationDrafts.target(controls, state);

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeTransitionStairPort.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeTransitionStairPort.java
@@ -52,21 +52,17 @@ final class DungeonEditorRuntimeTransitionStairPort implements DungeonEditorTran
     }
 
     @Override
-    public void saveTransitionLink(
-            long sourceTransitionId,
-            long targetMapId,
-            long targetTransitionId,
-            boolean bidirectional
-    ) {
+    public void saveTransitionLink(long sourceTransitionId, TransitionDestinationDraftInput input) {
+        TransitionDestinationDraftInput safeInput = input == null
+                ? TransitionDestinationDraftInput.unlinkedEntrance()
+                : input;
         long selectedMapIdValue = currentSelectedMapIdValue();
         DungeonEditorRuntimeOperationPublisher.apply(
                 store,
                 framePublisher,
                 () -> operationOwner.saveTransitionLink(
                         sourceTransitionId,
-                        targetMapId,
-                        targetTransitionId,
-                        bidirectional),
+                        safeInput),
                 result -> clearTransitionDestinationDraftWhenCommitted(
                         selectedMapIdValue,
                         sourceTransitionId,
@@ -84,24 +80,17 @@ final class DungeonEditorRuntimeTransitionStairPort implements DungeonEditorTran
     }
 
     @Override
-    public void saveStairGeometry(
-            long stairId,
-            String shapeName,
-            String directionName,
-            int dimension1,
-            int dimension2
-    ) {
-        draftSession.clearStairGeometryDraft(currentSelectedMapIdValue(), stairId);
+    public void saveStairGeometry(StairGeometryDraftInput input) {
+        StairGeometryDraftInput safeInput = input == null ? StairGeometryDraftInput.empty() : input;
+        if (!safeInput.completeForSave()) {
+            return;
+        }
+        draftSession.clearStairGeometryDraft(currentSelectedMapIdValue(), safeInput.stairId());
         framePublisher.markDraftSessionChanged();
         DungeonEditorRuntimeOperationPublisher.apply(
                 store,
                 framePublisher,
-                () -> operationOwner.saveStairGeometry(
-                        stairId,
-                        shapeName,
-                        directionName,
-                        dimension1,
-                        dimension2));
+                () -> operationOwner.saveStairGeometry(safeInput));
     }
 
     private boolean transitionLinkCommitted(

--- a/src/features/dungeon/runtime/DungeonEditorStatePanelStairGeometryDrafts.java
+++ b/src/features/dungeon/runtime/DungeonEditorStatePanelStairGeometryDrafts.java
@@ -8,7 +8,7 @@ public final class DungeonEditorStatePanelStairGeometryDrafts {
 
     void update(long selectedMapIdValue, StairGeometryDraftInput input) {
         StairGeometryDraftInput safeInput = input == null
-                ? new StairGeometryDraftInput(0L, "", "", "", "")
+                ? StairGeometryDraftInput.empty()
                 : input;
         Key key = Key.from(selectedMapIdValue, safeInput.stairId());
         if (!key.valid()) {
@@ -96,7 +96,7 @@ public final class DungeonEditorStatePanelStairGeometryDrafts {
 
         static DraftValue from(StairGeometryDraftInput input) {
             StairGeometryDraftInput safeInput = input == null
-                    ? new StairGeometryDraftInput(0L, "", "", "", "")
+                    ? StairGeometryDraftInput.empty()
                     : input;
             return new DraftValue(
                     safeInput.shapeName(),

--- a/src/features/dungeon/runtime/DungeonEditorStatePanelTransitionDestinationDrafts.java
+++ b/src/features/dungeon/runtime/DungeonEditorStatePanelTransitionDestinationDrafts.java
@@ -124,7 +124,7 @@ public final class DungeonEditorStatePanelTransitionDestinationDrafts {
 
         static DraftValue from(TransitionDestinationDraftInput input) {
             TransitionDestinationDraftInput safeInput = input == null
-                    ? new TransitionDestinationDraftInput(DEFAULT_DESTINATION_TYPE, "", "", "", true)
+                    ? TransitionDestinationDraftInput.unlinkedEntrance()
                     : input;
             return new DraftValue(
                     safeInput.destinationType(),

--- a/src/features/dungeon/runtime/DungeonEditorTransitionStairOperations.java
+++ b/src/features/dungeon/runtime/DungeonEditorTransitionStairOperations.java
@@ -5,18 +5,9 @@ public interface DungeonEditorTransitionStairOperations {
 
     void saveLabelName(DungeonEditorRuntimeLabelTarget target, String name);
 
-    void saveTransitionLink(
-            long sourceTransitionId,
-            long targetMapId,
-            long targetTransitionId,
-            boolean bidirectional);
+    void saveTransitionLink(long sourceTransitionId, TransitionDestinationDraftInput input);
 
     void saveTransitionDescription(long transitionId, String description);
 
-    void saveStairGeometry(
-            long stairId,
-            String shapeName,
-            String directionName,
-            int dimension1,
-            int dimension2);
+    void saveStairGeometry(StairGeometryDraftInput input);
 }

--- a/src/features/dungeon/runtime/StairGeometryDraftInput.java
+++ b/src/features/dungeon/runtime/StairGeometryDraftInput.java
@@ -1,5 +1,7 @@
 package src.features.dungeon.runtime;
 
+import java.util.OptionalInt;
+
 public record StairGeometryDraftInput(
         long stairId,
         String shapeName,
@@ -15,7 +17,34 @@ public record StairGeometryDraftInput(
         dimension2 = safeText(dimension2);
     }
 
+    public static StairGeometryDraftInput empty() {
+        return new StairGeometryDraftInput(0L, "", "", "", "");
+    }
+
+    OptionalInt dimension1Value() {
+        return integerValue(dimension1);
+    }
+
+    OptionalInt dimension2Value() {
+        return integerValue(dimension2);
+    }
+
+    public boolean completeForSave() {
+        return stairId > 0L && dimension1Value().isPresent() && dimension2Value().isPresent();
+    }
+
     private static String safeText(String value) {
         return value == null ? "" : value;
+    }
+
+    private static OptionalInt integerValue(String value) {
+        if (value == null || value.isBlank()) {
+            return OptionalInt.empty();
+        }
+        try {
+            return OptionalInt.of(Integer.parseInt(value.strip()));
+        } catch (NumberFormatException ignored) {
+            return OptionalInt.empty();
+        }
     }
 }

--- a/src/features/dungeon/runtime/TransitionDestination.java
+++ b/src/features/dungeon/runtime/TransitionDestination.java
@@ -26,31 +26,19 @@ public record TransitionDestination(
         return new TransitionDestination(TransitionDestinationType.UNLINKED_ENTRANCE, 0L, 0L, 0L);
     }
 
-    static TransitionDestination fromDraft(
-            TransitionDestinationType destinationType,
-            String mapId,
-            String tileId,
-            String transitionId
-    ) {
+    static TransitionDestination fromDraftInput(TransitionDestinationDraftInput input) {
+        TransitionDestinationDraftInput safeInput = input == null
+                ? TransitionDestinationDraftInput.unlinkedEntrance()
+                : input;
         return new TransitionDestination(
-                destinationType,
-                positiveLong(mapId),
-                positiveLong(tileId),
-                TransitionDestinationTarget.fromPositiveId(positiveLong(transitionId)).transitionId());
+                safeInput.destinationType(),
+                safeInput.targetMapId(),
+                safeInput.targetTileId(),
+                TransitionDestinationTarget.fromPositiveId(safeInput.targetTransitionId()).transitionId());
     }
 
     TransitionDestinationTarget targetTransition() {
         return TransitionDestinationTarget.fromPositiveId(targetTransitionId);
     }
 
-    private static long positiveLong(String value) {
-        if (value == null || value.isBlank()) {
-            return 0L;
-        }
-        try {
-            return Math.max(0L, Long.parseLong(value.strip()));
-        } catch (NumberFormatException ignored) {
-            return 0L;
-        }
-    }
 }

--- a/src/features/dungeon/runtime/TransitionDestinationDraftInput.java
+++ b/src/features/dungeon/runtime/TransitionDestinationDraftInput.java
@@ -18,6 +18,10 @@ public record TransitionDestinationDraftInput(
         transitionId = safeText(transitionId);
     }
 
+    public static TransitionDestinationDraftInput unlinkedEntrance() {
+        return new TransitionDestinationDraftInput(TransitionDestinationType.UNLINKED_ENTRANCE, "", "", "", true);
+    }
+
     public static TransitionDestinationDraftInput fromExternalName(ExternalFields fields) {
         ExternalFields safeFields = fields == null ? ExternalFields.empty() : fields;
         return new TransitionDestinationDraftInput(
@@ -26,6 +30,18 @@ public record TransitionDestinationDraftInput(
                 safeFields.tileId(),
                 safeFields.transitionId(),
                 safeFields.bidirectional());
+    }
+
+    long targetMapId() {
+        return positiveLong(mapId);
+    }
+
+    long targetTileId() {
+        return positiveLong(tileId);
+    }
+
+    long targetTransitionId() {
+        return positiveLong(transitionId);
     }
 
     public record ExternalFields(
@@ -49,5 +65,16 @@ public record TransitionDestinationDraftInput(
 
     private static String safeText(String value) {
         return value == null ? "" : value;
+    }
+
+    private static long positiveLong(String value) {
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+        try {
+            return Math.max(0L, Long.parseLong(value.strip()));
+        } catch (NumberFormatException ignored) {
+            return 0L;
+        }
     }
 }

--- a/src/view/leftbartabs/dungeoneditor/DungeonEditorIntentHandler.java
+++ b/src/view/leftbartabs/dungeoneditor/DungeonEditorIntentHandler.java
@@ -234,31 +234,20 @@ final class DungeonEditorIntentHandler {
 
     private void consumeTransitionDestinationWhenPresent(DungeonEditorStateViewInputEvent event) {
         if (event.transitionDestinationInputObserved()) {
-            statePanelDraftOperations.updateStatePanelTransitionDestinationDraft(
-                    TransitionDestinationDraftInput.fromExternalName(
-                            new TransitionDestinationDraftInput.ExternalFields(
-                                    DungeonEditorStateContentModel.transitionDestinationTypeKey(
-                                            event.transitionDestinationTypeOptionIndex()),
-                                    event.transitionDestinationMapId(),
-                                    event.transitionDestinationTileId(),
-                                    event.transitionDestinationTransitionId(),
-                                    event.transitionDestinationBidirectional())));
+            TransitionDestinationDraftInput input = transitionDestinationDraftInput(event);
+            statePanelDraftOperations.updateStatePanelTransitionDestinationDraft(input);
             if (event.transitionDestinationSaveRequested()) {
-                consumeTransitionLinkSave(event);
+                consumeTransitionLinkSave(input);
             }
         }
     }
 
-    private void consumeTransitionLinkSave(DungeonEditorStateViewInputEvent event) {
+    private void consumeTransitionLinkSave(TransitionDestinationDraftInput input) {
         long sourceTransitionId = selectedTransitionId();
         if (sourceTransitionId <= NO_TRANSITION_ID) {
             return;
         }
-        transitionStairOperations.saveTransitionLink(
-                sourceTransitionId,
-                parseLongOrZero(event.transitionDestinationMapId()),
-                parseLongOrZero(event.transitionDestinationTransitionId()),
-                event.transitionDestinationBidirectional());
+        transitionStairOperations.saveTransitionLink(sourceTransitionId, input);
     }
 
     private void consumeStairGeometryWhenPresent(DungeonEditorStateViewInputEvent event) {
@@ -335,26 +324,37 @@ final class DungeonEditorIntentHandler {
     private void consumeStairGeometryInput(
             DungeonEditorStateViewInputEvent event
     ) {
-        statePanelDraftOperations.updateStatePanelStairGeometryDraft(new StairGeometryDraftInput(
+        StairGeometryDraftInput input = stairGeometryDraftInput(event);
+        statePanelDraftOperations.updateStatePanelStairGeometryDraft(input);
+        if (!event.stairGeometrySaveRequested()) {
+            return;
+        }
+        if (!input.completeForSave()) {
+            return;
+        }
+        transitionStairOperations.saveStairGeometry(input);
+    }
+
+    private static TransitionDestinationDraftInput transitionDestinationDraftInput(
+            DungeonEditorStateViewInputEvent event
+    ) {
+        return TransitionDestinationDraftInput.fromExternalName(
+                new TransitionDestinationDraftInput.ExternalFields(
+                        DungeonEditorStateContentModel.transitionDestinationTypeKey(
+                                event.transitionDestinationTypeOptionIndex()),
+                        event.transitionDestinationMapId(),
+                        event.transitionDestinationTileId(),
+                        event.transitionDestinationTransitionId(),
+                        event.transitionDestinationBidirectional()));
+    }
+
+    private static StairGeometryDraftInput stairGeometryDraftInput(DungeonEditorStateViewInputEvent event) {
+        return new StairGeometryDraftInput(
                 event.stairId(),
                 event.stairShapeName(),
                 event.stairDirectionName(),
                 event.stairDimension1(),
-                event.stairDimension2()));
-        if (!event.stairGeometrySaveRequested()) {
-            return;
-        }
-        Optional<Integer> dimension1 = parseInteger(event.stairDimension1());
-        Optional<Integer> dimension2 = parseInteger(event.stairDimension2());
-        if (dimension1.isEmpty() || dimension2.isEmpty()) {
-            return;
-        }
-        transitionStairOperations.saveStairGeometry(
-                event.stairId(),
-                event.stairShapeName(),
-                event.stairDirectionName(),
-                dimension1.orElseThrow(),
-                dimension2.orElseThrow());
+                event.stairDimension2());
     }
 
     private void consumeMapCanvas(DungeonMapViewInputEvent event) {

--- a/src/view/leftbartabs/dungeoneditor/DungeonEditorStateContentModel.java
+++ b/src/view/leftbartabs/dungeoneditor/DungeonEditorStateContentModel.java
@@ -1,9 +1,6 @@
 package src.view.leftbartabs.dungeoneditor;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import org.jspecify.annotations.Nullable;
@@ -65,19 +62,6 @@ final class DungeonEditorStateContentModel {
 
     static String transitionDestinationTypeKey(int optionIndex) {
         return DungeonEditorStateTransitionContentPartModel.transitionDestinationTypeKey(optionIndex);
-    }
-
-    static Map<String, String> factMap(List<String> facts) {
-        Map<String, String> values = new HashMap<>();
-        for (String fact : facts == null ? List.<String>of() : facts) {
-            int separator = fact.indexOf(':');
-            if (separator > 0) {
-                values.put(
-                        fact.substring(0, separator).strip().toLowerCase(Locale.ROOT),
-                        fact.substring(separator + 1).strip());
-            }
-        }
-        return values;
     }
 
     private static @Nullable NameProjection nameProjection(DungeonEditorPreparedFrameFacts.StatePanelFrame frame) {

--- a/src/view/leftbartabs/dungeoneditor/DungeonEditorStateStairGeometryContentPartModel.java
+++ b/src/view/leftbartabs/dungeoneditor/DungeonEditorStateStairGeometryContentPartModel.java
@@ -1,7 +1,5 @@
 package src.view.leftbartabs.dungeoneditor;
 
-import java.util.List;
-import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.published.DungeonEditorTopologyElementRef;
 import src.domain.dungeon.published.DungeonInspectorSnapshot;
@@ -25,7 +23,7 @@ final class DungeonEditorStateStairGeometryContentPartModel {
         if (stairId <= 0L || inspector == null) {
             return null;
         }
-        StairGeometryFacts facts = StairGeometryFacts.from(inspector.facts());
+        StairGeometryFacts facts = StairGeometryFacts.from(inspector.statePanelFacts().stairGeometry());
         if (facts == null) {
             return null;
         }
@@ -85,16 +83,18 @@ final class DungeonEditorStateStairGeometryContentPartModel {
             dimension2 = dimension2 == null ? "" : dimension2.strip();
         }
 
-        private static @Nullable StairGeometryFacts from(List<String> facts) {
-            Map<String, String> values = DungeonEditorStateContentModel.factMap(facts);
-            String shape = values.get("shape");
-            String direction = values.get("direction");
-            String dimension1 = values.get("dimension1");
-            String dimension2 = values.get("dimension2");
-            if (shape == null || direction == null || dimension1 == null || dimension2 == null) {
+        private static @Nullable StairGeometryFacts from(DungeonInspectorSnapshot.StairGeometryFacts facts) {
+            DungeonInspectorSnapshot.StairGeometryFacts safeFacts = facts == null
+                    ? DungeonInspectorSnapshot.StairGeometryFacts.empty()
+                    : facts;
+            if (!safeFacts.present()) {
                 return null;
             }
-            return new StairGeometryFacts(shape, direction, dimension1, dimension2);
+            return new StairGeometryFacts(
+                    safeFacts.shapeName(),
+                    safeFacts.directionName(),
+                    String.valueOf(safeFacts.dimension1()),
+                    String.valueOf(safeFacts.dimension2()));
         }
     }
 }

--- a/src/view/leftbartabs/dungeoneditor/DungeonEditorStateTransitionContentPartModel.java
+++ b/src/view/leftbartabs/dungeoneditor/DungeonEditorStateTransitionContentPartModel.java
@@ -2,7 +2,6 @@ package src.view.leftbartabs.dungeoneditor;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import src.domain.dungeon.published.DungeonEditorTopologyElementRef;
 import src.domain.dungeon.published.DungeonInspectorSnapshot;
@@ -64,7 +63,7 @@ final class DungeonEditorStateTransitionContentPartModel {
         if (!runtimeDraft.targetPresent()) {
             return null;
         }
-        TransitionDestinationDraft baseline = TransitionDestinationDraft.fromInspector(safeFrame.inspector());
+        TransitionDestinationDraft baseline = TransitionDestinationDraft.fromTypedInspector(safeFrame.inspector());
         TransitionDestinationDraft draft = runtimeDraft.present()
                 ? TransitionDestinationDraft.fromRuntimeDraft(runtimeDraft)
                 : baseline;
@@ -263,16 +262,20 @@ final class DungeonEditorStateTransitionContentPartModel {
             return new TransitionDestinationDraft(DESTINATION_UNLINKED_ENTRANCE, "", "", "", true);
         }
 
-        static TransitionDestinationDraft fromInspector(@Nullable DungeonInspectorSnapshot inspector) {
-            if (inspector == null || inspector.facts().isEmpty()) {
+        static TransitionDestinationDraft fromTypedInspector(@Nullable DungeonInspectorSnapshot inspector) {
+            if (inspector == null) {
                 return defaultDraft();
             }
-            Map<String, String> facts = DungeonEditorStateContentModel.factMap(inspector.facts());
+            DungeonInspectorSnapshot.TransitionDestinationFacts facts =
+                    inspector.statePanelFacts().transitionDestination();
+            if (!facts.present()) {
+                return defaultDraft();
+            }
             return new TransitionDestinationDraft(
-                    normalizeDestinationTypeKey(facts.get("destinationtype")),
-                    facts.getOrDefault("destinationmapid", ""),
-                    facts.getOrDefault("destinationtileid", ""),
-                    facts.getOrDefault("destinationtransitionid", ""),
+                    normalizeDestinationTypeKey(facts.destinationTypeKey()),
+                    facts.mapId() > 0L ? String.valueOf(facts.mapId()) : "",
+                    facts.tileId() > 0L ? String.valueOf(facts.tileId()) : "",
+                    facts.transitionId() > 0L ? String.valueOf(facts.transitionId()) : "",
                     true);
         }
 

--- a/test/src/view/leftbartabs/dungeoneditor/DungeonEditorSelectionHarness.java
+++ b/test/src/view/leftbartabs/dungeoneditor/DungeonEditorSelectionHarness.java
@@ -339,9 +339,8 @@ final class DungeonEditorSelectionHarness {
                 "DE-SEL-003 state model selected stair handle topology ref");
         assertTrue(selectedState.inspector() != null, "DE-SEL-003 inspector is published for selected stair");
         assertTrue(selectedState.inspector().title().contains("S1")
-                        || selectedState.inspector().facts().stream()
-                        .anyMatch(fact -> fact.contains("STAIR") || fact.contains(String.valueOf(stairRef.id()))),
-                "DE-SEL-003 inspector identifies selected stair");
+                        || selectedState.inspector().statePanelFacts().stairGeometry().stairId() == stairRef.id(),
+                "DE-SEL-003 inspector typed state-panel facts identify selected stair");
         assertTrue(renderHasSelectedGlyphPrimitive(binding.mapContentModel(), stairRef),
                 "DE-SEL-003 render scene highlights the selected stair marker");
         assertTrue(renderHasSelectedSurfacePrimitive(binding.mapContentModel(), stairRef),


### PR DESCRIPTION
## Summary
- publish typed dungeon state-panel facts through the domain inspector snapshot instead of parsing display fact strings in the view
- route transition destination and stair geometry state-panel saves through explicit runtime draft input records
- keep legacy fact strings as display/debug compatibility only

## Risk
- R1: behavior-neutral architecture/runtime protocol cleanup with harness coverage

## Proof
- git diff --check
- tools/gradle/run-observable-gradle.sh dungeonEditorStairBehaviorHarness dungeonEditorTransitionBehaviorHarness dungeonEditorFeatureBehaviorHarness
- tools/gradle/run-staged-verification.sh focused-handoff --path src/domain/dungeon --area domain --path src/features/dungeon/runtime --area feature-runtime --path src/view/leftbartabs/dungeoneditor --area view
- tools/gradle/run-staged-verification.sh production-handoff
- Final review: build/agent-pass-logs/2026-07-09-architecture-goal-completion-audit/s5-state-panel-protocols-final-review.md PASS