### PR TITLE
test: rehearse world planner area touch

### DIFF
--- a/test/src/domain/worldplanner/WorldPlannerBackendHarness.java
+++ b/test/src/domain/worldplanner/WorldPlannerBackendHarness.java
@@ -34,6 +34,7 @@ import src.domain.worldplanner.published.WorldPlannerSnapshot;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
 
 public final class WorldPlannerBackendHarness {
+    // T4 area-touch rehearsal marker; does not change scenario semantics.
 
     private WorldPlannerBackendHarness() {
     }


### PR DESCRIPTION
## Summary
- add a no-op comment to the dedicated World Planner backend harness source set for the T4 area-touch CI cache rehearsal
- no production code, assertions, inputs, or scenario semantics change

## Verification
- pre-commit gate accepted staged tree b6b12284db8127755b29b0b9d5257748acfaccde: BUILD SUCCESSFUL in 17m 56s, 74 actionable tasks: 54 executed, 19 from cache, 1 up-to-date
- git diff --check passed

This PR is intended as a T4 rehearsal artifact. It should demonstrate that a one-area touch physically re-runs the affected World Planner harness tasks while unrelated tasks are restored from CI cache.