### PR TITLE
[codex] Align documentation enforcement with docs policy

### DIFF
--- a/docs/project/architecture/architecture-migration-dungeon-editor-view-baseline.md
+++ b/docs/project/architecture/architecture-migration-dungeon-editor-view-baseline.md
@@ -1,4 +1,4 @@
-Status: Baseline
+Status: Active
 Owner: SaltMarcher Team
 Last Reviewed: 2026-07-11
 Source of Truth: M4.5 `dungeon-editor-view` baseline metrics for

--- a/docs/project/architecture/architecture-migration-remaining-view-and-shell-baseline.md
+++ b/docs/project/architecture/architecture-migration-remaining-view-and-shell-baseline.md
@@ -1,4 +1,4 @@
-Status: Baseline
+Status: Active
 Owner: SaltMarcher Team
 Last Reviewed: 2026-07-11
 Source of Truth: M5.2 diagnostic baseline metrics for the

--- a/docs/project/architecture/documentation.md
+++ b/docs/project/architecture/documentation.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-30
+Last Reviewed: 2026-07-13
 Source of Truth: Documentation taxonomy, header metadata, and review rules
 for all project documentation outside `AGENTS.md`.
 
@@ -189,6 +189,10 @@ Documentation governance is broader than compile-time enforcement.
 
 - Documentation-only proof is `git diff --check` plus any owner-named proof
   from `AGENTS.md`; removed documentation gates are not acceptance evidence.
+- `checkDocumentationEnforcement` mechanically enforces the required
+  `Status` and `Source of Truth` metadata, legacy-root absence, source-tree
+  Markdown ownership, and non-fatal size signals. `Owner` and `Last Reviewed`
+  remain optional review context, not gate inputs.
 - Header metadata, placement, link integrity, legacy documentation roots, and
   redirect-only source Markdown are review responsibilities unless a current
   owner explicitly names a narrower proof route.

--- a/docs/project/architecture/documentation.md
+++ b/docs/project/architecture/documentation.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-13
+Last Reviewed: 2026-06-30
 Source of Truth: Documentation taxonomy, header metadata, and review rules
 for all project documentation outside `AGENTS.md`.
 
@@ -189,10 +189,6 @@ Documentation governance is broader than compile-time enforcement.
 
 - Documentation-only proof is `git diff --check` plus any owner-named proof
   from `AGENTS.md`; removed documentation gates are not acceptance evidence.
-- `checkDocumentationEnforcement` enforces required `Status` and
-  `Source of Truth` metadata for docs Markdown; `Owner` and `Last Reviewed`
-  remain optional review context, not gate inputs. It emits non-fatal size
-  signals for Markdown over 400 lines.
 - Header metadata, placement, link integrity, legacy documentation roots, and
   redirect-only source Markdown are review responsibilities unless a current
   owner explicitly names a narrower proof route.

--- a/docs/project/architecture/documentation.md
+++ b/docs/project/architecture/documentation.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-30
+Last Reviewed: 2026-07-13
 Source of Truth: Documentation taxonomy, header metadata, and review rules
 for all project documentation outside `AGENTS.md`.
 
@@ -189,6 +189,10 @@ Documentation governance is broader than compile-time enforcement.
 
 - Documentation-only proof is `git diff --check` plus any owner-named proof
   from `AGENTS.md`; removed documentation gates are not acceptance evidence.
+- `checkDocumentationEnforcement` enforces required `Status` and
+  `Source of Truth` metadata for docs Markdown; `Owner` and `Last Reviewed`
+  remain optional review context, not gate inputs. It emits non-fatal size
+  signals for Markdown over 400 lines.
 - Header metadata, placement, link integrity, legacy documentation roots, and
   redirect-only source Markdown are review responsibilities unless a current
   owner explicitly names a narrower proof route.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -405,3 +405,24 @@ and unrelated harness tasks restored from cache. PR #456 was closed after
 evidence collection and not merged.
 Remaining T4 proof: one green scheduled `nightly-rerun-tasks` run from the
 merged workflow.
+
+## 2026-07-13 verification-greenfield-docs-gate
+
+Problem: the Verification Greenfield charter cannot prove its docs-only
+step because `checkDocumentationEnforcement` still enforces retired
+documentation ceremony: a 350-line hard cap and mandatory `Owner` /
+`Last Reviewed` metadata. Current documentation truth treats size as a
+review signal and keeps `Owner` / `Last Reviewed` optional.
+Target state: the documentation checker matches the active Documentation
+Standard: `Status` remains mandatory, `Source of Truth` remains mandatory,
+`Owner` and `Last Reviewed` are optional, and size alone cannot fail the
+build.
+Alternatives considered: compress large migration records, change only the
+two `Status: Baseline` files, or bypass the docs gate for the charter. Those
+keep the stale enforcement contradiction alive or weaken the M0 proof.
+Scope boundary: touch only the documentation checker and the two baseline
+metadata values needed by the active status vocabulary. Do not change frozen
+verification surfaces or the public proof route.
+Done when: `git diff --check` and
+`./gradlew checkDocumentationEnforcement --console=plain` pass, then the
+Verification Greenfield charter branch can rerun the same docs proof.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -416,6 +416,10 @@ review signal and keeps `Owner` / `Last Reviewed` optional.
 Authority: before this repair, the Documentation Standard already required
 only `Status` and `Source of Truth` header metadata and already defined
 Markdown over 400 lines as a size signal rather than a build failure.
+Owner decision: on 2026-07-13 the owner approved this documentation-enforcement
+relaxation to clear the M0 blocker. The owner also offered bypass latitude for
+the guardian, but this repair keeps the normal PR, judge, and CI route and does
+not bypass required checks.
 Target state: the documentation checker matches the active Documentation
 Standard: `Status` remains mandatory, `Source of Truth` remains mandatory,
 `Owner` and `Last Reviewed` are optional, and size alone cannot fail the

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -417,9 +417,10 @@ Authority: before this repair, the Documentation Standard already required
 only `Status` and `Source of Truth` header metadata and already defined
 Markdown over 400 lines as a size signal rather than a build failure.
 Owner decision: on 2026-07-13 the owner approved this documentation-enforcement
-relaxation to clear the M0 blocker. The owner also offered bypass latitude for
-the guardian, but this repair keeps the normal PR, judge, and CI route and does
-not bypass required checks.
+relaxation to clear the M0 blocker and authorized the owner-only
+`judge-override` route if the base judge still rejected the policy change. PR
+#458 uses that governed override label for judge disposition only; all other
+required checks remain binding, and no red required check may merge.
 Target state: the documentation checker matches the active Documentation
 Standard: `Status` remains mandatory, `Source of Truth` remains mandatory,
 `Owner` and `Last Reviewed` are optional, and size alone cannot fail the

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -423,6 +423,9 @@ keep the stale enforcement contradiction alive or weaken the M0 proof.
 Scope boundary: touch only the documentation checker and the two baseline
 metadata values needed by the active status vocabulary. Do not change frozen
 verification surfaces or the public proof route.
+Tooling repair: clear repository-local Git environment variables before the
+pre-commit gate runs Gradle in its temporary clean worktree, so the normal
+hook can prove staged changes without leaking the caller index path.
 Done when: `git diff --check` and
 `./gradlew checkDocumentationEnforcement --console=plain` pass, then the
 Verification Greenfield charter branch can rerun the same docs proof.

--- a/docs/project/journal/2026-07.md
+++ b/docs/project/journal/2026-07.md
@@ -413,6 +413,9 @@ step because `checkDocumentationEnforcement` still enforces retired
 documentation ceremony: a 350-line hard cap and mandatory `Owner` /
 `Last Reviewed` metadata. Current documentation truth treats size as a
 review signal and keeps `Owner` / `Last Reviewed` optional.
+Authority: before this repair, the Documentation Standard already required
+only `Status` and `Source of Truth` header metadata and already defined
+Markdown over 400 lines as a size signal rather than a build failure.
 Target state: the documentation checker matches the active Documentation
 Standard: `Status` remains mandatory, `Source of Truth` remains mandatory,
 `Owner` and `Last Reviewed` are optional, and size alone cannot fail the

--- a/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
+++ b/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
@@ -13,13 +13,7 @@ import saltmarcher.architecture.ViolationSink;
 
 public final class DocumentationHygieneRules implements ArchitectureRule {
 
-    private static final int MAX_MARKDOWN_LINES = 350;
     private static final Set<String> VALID_STATUS = Set.of("Active", "Draft", "Deprecated");
-    private static final List<String> GOVERNED_MARKDOWN_ROOTS = List.of(
-            "AGENTS.md",
-            "docs",
-            "src",
-            "tools/quality");
     private static final List<String> LEGACY_DOCUMENTATION_ROOTS = List.of(
             "docs/architecture",
             "docs/standards",
@@ -37,7 +31,6 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
         validateDocsMetadata(context, violations);
         validateLegacyDocumentationRoots(context, violations);
         validateSourceMarkdown(context, violations);
-        validateMarkdownLineCaps(context, violations);
     }
 
     private static void validateDocsMetadata(ArchitectureContext context, ViolationSink violations) {
@@ -47,15 +40,8 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
             if (lines.isEmpty()) {
                 continue;
             }
-            if (lines.size() < 4) {
-                violations.add(documentPath, "documentation-metadata-presence",
-                        "docs Markdown must start with Status, Owner, Last Reviewed, and Source of Truth metadata.");
-                continue;
-            }
             validateStatusLine(documentPath, lines.get(0), violations);
-            validateMetadataPrefix(documentPath, "Owner: ", lines.get(1), "Owner", violations);
-            validateMetadataPrefix(documentPath, "Last Reviewed: ", lines.get(2), "Last Reviewed", violations);
-            validateMetadataPrefix(documentPath, "Source of Truth: ", lines.get(3), "Source of Truth", violations);
+            validateSourceOfTruthMetadata(documentPath, lines, violations);
         }
     }
 
@@ -73,16 +59,17 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
         }
     }
 
-    private static void validateMetadataPrefix(
+    private static void validateSourceOfTruthMetadata(
             String documentPath,
-            String prefix,
-            String line,
-            String label,
+            List<String> lines,
             ViolationSink violations) {
-        if (!line.startsWith(prefix) || line.substring(prefix.length()).isBlank()) {
-            violations.add(documentPath, "documentation-metadata-presence",
-                    "docs Markdown must include a non-empty " + label + " metadata line.");
+        for (String line : lines.subList(1, Math.min(lines.size(), 5))) {
+            if (line.startsWith("Source of Truth: ") && !line.substring("Source of Truth: ".length()).isBlank()) {
+                return;
+            }
         }
+        violations.add(documentPath, "documentation-metadata-presence",
+                "docs Markdown must include a non-empty Source of Truth metadata line.");
     }
 
     private static void validateLegacyDocumentationRoots(ArchitectureContext context, ViolationSink violations) {
@@ -127,21 +114,6 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
             if (!content.contains(requiredSection)) {
                 violations.add(documentPath, "documentation-source-markdown-content",
                         "DOMAIN.md must remain a content-bearing context document with section '" + requiredSection + "'.");
-            }
-        }
-    }
-
-    private static void validateMarkdownLineCaps(ArchitectureContext context, ViolationSink violations) {
-        for (String root : GOVERNED_MARKDOWN_ROOTS) {
-            Path path = context.repoRoot().resolve(root);
-            for (Path document : markdownFiles(context, path)) {
-                String documentPath = context.relativize(document);
-                List<String> lines = readLines(document, documentPath, violations);
-                if (lines.size() > MAX_MARKDOWN_LINES) {
-                    violations.add(documentPath, "documentation-line-cap",
-                            "Markdown file has " + lines.size()
-                                    + " lines; split, delete, or link before exceeding " + MAX_MARKDOWN_LINES + ".");
-                }
             }
         }
     }

--- a/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
+++ b/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
@@ -70,7 +70,7 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
             String documentPath,
             List<String> lines,
             ViolationSink violations) {
-        for (String line : lines.subList(1, Math.min(lines.size(), 5))) {
+        for (String line : lines.subList(1, Math.min(lines.size(), 4))) {
             if (line.startsWith("Source of Truth: ") && !line.substring("Source of Truth: ".length()).isBlank()) {
                 return;
             }

--- a/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
+++ b/tools/gradle/build-harness/src/main/java/saltmarcher/architecture/documentation/DocumentationHygieneRules.java
@@ -13,7 +13,13 @@ import saltmarcher.architecture.ViolationSink;
 
 public final class DocumentationHygieneRules implements ArchitectureRule {
 
+    private static final int MARKDOWN_SIZE_SIGNAL_LINES = 400;
     private static final Set<String> VALID_STATUS = Set.of("Active", "Draft", "Deprecated");
+    private static final List<String> MARKDOWN_SIZE_SIGNAL_ROOTS = List.of(
+            "AGENTS.md",
+            "docs",
+            "src",
+            "tools/quality");
     private static final List<String> LEGACY_DOCUMENTATION_ROOTS = List.of(
             "docs/architecture",
             "docs/standards",
@@ -31,6 +37,7 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
         validateDocsMetadata(context, violations);
         validateLegacyDocumentationRoots(context, violations);
         validateSourceMarkdown(context, violations);
+        reportMarkdownSizeSignals(context, violations);
     }
 
     private static void validateDocsMetadata(ArchitectureContext context, ViolationSink violations) {
@@ -114,6 +121,21 @@ public final class DocumentationHygieneRules implements ArchitectureRule {
             if (!content.contains(requiredSection)) {
                 violations.add(documentPath, "documentation-source-markdown-content",
                         "DOMAIN.md must remain a content-bearing context document with section '" + requiredSection + "'.");
+            }
+        }
+    }
+
+    private static void reportMarkdownSizeSignals(ArchitectureContext context, ViolationSink violations) {
+        for (String root : MARKDOWN_SIZE_SIGNAL_ROOTS) {
+            Path path = context.repoRoot().resolve(root);
+            for (Path document : markdownFiles(context, path)) {
+                String documentPath = context.relativize(document);
+                List<String> lines = readLines(document, documentPath, violations);
+                if (lines.size() > MARKDOWN_SIZE_SIGNAL_LINES) {
+                    System.out.println("Documentation size signal: " + documentPath
+                            + " has " + lines.size()
+                            + " lines; file or link a doc-split issue before growing scope.");
+                }
             }
         }
     }

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -24,14 +24,18 @@ commit_id="$(printf 'SaltMarcher pre-commit verification\n' | git commit-tree "$
 gate_worktree="$(mktemp -d "${TMPDIR:-/tmp}/saltmarcher-pre-commit.XXXXXX")"
 log_dir="$repo_root/build/pre-commit-gate"
 log_file="$log_dir/${commit_id}.log"
+git_env_clear_args=()
+while IFS= read -r git_env_name; do
+    git_env_clear_args+=("-u" "$git_env_name")
+done < <(git rev-parse --local-env-vars)
 
 cleanup() {
-    git -C "$repo_root" worktree remove --force "$gate_worktree" >/dev/null 2>&1 || rm -rf "$gate_worktree"
+    env "${git_env_clear_args[@]}" git -C "$repo_root" worktree remove --force "$gate_worktree" >/dev/null 2>&1 || rm -rf "$gate_worktree"
 }
 trap cleanup EXIT
 
 mkdir -p "$log_dir"
-git worktree add --detach --quiet "$gate_worktree" "$commit_id"
+env "${git_env_clear_args[@]}" git -C "$repo_root" worktree add --detach --quiet "$gate_worktree" "$commit_id"
 
 echo "pre-commit: verifying staged tree $commit_id in clean worktree."
 echo "pre-commit: log: $log_file"
@@ -39,7 +43,7 @@ echo "pre-commit: log: $log_file"
 set +e
 (
     cd "$gate_worktree"
-    SALTMARCHER_PRE_COMMIT_GATE=1 ./gradlew check --console=plain
+    env "${git_env_clear_args[@]}" SALTMARCHER_PRE_COMMIT_GATE=1 ./gradlew check --console=plain
 ) >"$log_file" 2>&1
 gradle_status=$?
 set -e


### PR DESCRIPTION
## Summary

This repairs the stale documentation enforcement blocker that prevented the Verification Greenfield charter branch from proving its docs-only M0 step.

- Converts the retired 350-line hard Markdown failure in `DocumentationHygieneRules` into a non-fatal 400-line documentation size signal, matching the Documentation Standard.
- Keeps `Status` and `Source of Truth` as required metadata, while treating `Owner` and `Last Reviewed` as optional per the Documentation Standard.
- Tightens the `Source of Truth` scan to lines 2-4: immediately after `Status`, with room only for the optional `Owner` and `Last Reviewed` lines.
- Updates the two remaining `Status: Baseline` architecture baseline headers to `Status: Active` so they match the active status vocabulary without changing their Source of Truth text.
- Clarifies the mechanical `checkDocumentationEnforcement` contract in `docs/project/architecture/documentation.md` and records the authority in the L-tier journal design note.
- Clears repository-local Git environment variables around the pre-commit clean-worktree execution path so the temporary worktree no longer inherits the caller index path.

Risk: R1, intentional verification-enforcement and tooling behavior change. No frozen surfaces are changed.

## Owner Approval

On 2026-07-13, the owner approved this documentation-enforcement relaxation to clear the Verification Greenfield M0 blocker and authorized the repo's owner-only `judge-override` route if the base judge still rejected the policy change. GitHub issue events record the `judge-override` label on PR #458 as set by `ThonkTank` at `2026-07-13T20:40:21Z`, satisfying the owner-only route in `tools/agents/judge_review.py`. This override is for judge disposition only; all other required checks remain binding, and no red required check may merge.

## Validation

- `git diff --check` passed with no output on 2026-07-13 after the owner-override evidence correction.
- `./gradlew checkDocumentationEnforcement --console=plain` passed on 2026-07-13: `Documentation checks passed.`, `BUILD SUCCESSFUL in 7s`, `10 actionable tasks: 1 executed, 9 up-to-date`.
- Earlier branch proofs also passed `git diff --check HEAD~1..HEAD` with no output and `./gradlew checkDocumentationEnforcement --console=plain` with `BUILD SUCCESSFUL in 7s`.
- The docs enforcement output now reports non-fatal size signals for the current over-400-line Markdown files instead of failing the build.