### PR TITLE
[codex] Record scheduled nightly blocker for greenfield M0

### DIFF
--- a/docs/project/architecture/harness-modernization-ledger.md
+++ b/docs/project/architecture/harness-modernization-ledger.md
@@ -29,9 +29,9 @@ modernization unless this ledger advances too.
 | Branch | `main` |
 | Milestone | T4 - CI authority and bespoke-layer deletion |
 | Conversion batch | None |
-| Status | In Flight |
-| Required next proof | Wait for and record one green scheduled nightly `--rerun-tasks` run from the merged `quality-platforms` workflow. |
-| Last status note | `2026-07-12 T3-close-out` |
+| Status | Blocked |
+| Required next proof | Wait for the first scheduled `quality-platforms / nightly-rerun-tasks` run after the 2026-07-14 02:17 UTC cron; record it here only if it is green. |
+| Last status note | `2026-07-14 Nightly-not-yet-fired` |
 
 ## Milestone Ledger
 
@@ -41,7 +41,7 @@ modernization unless this ledger advances too.
 | T1 Fleet conversion | Done on branch | Pending | Pending | Per-batch focused run, forced run, JUnit XML, final `check --rerun-tasks`, Phase 1 Approved, Phase 2 Approved | All registered behavior harness tasks are JUnit `Test` tasks; no JavaExec behavior harness registration, silent Dungeon Editor direct-main entrypoint, or harness-level `outputs.upToDateWhen { false }` remains. |
 | T2 Cache correctness and hermeticity | Done on branch | Pending | Pending | Dungeon Editor and Render Parity cache-hit, classpath re-run, resource re-run, final consecutive `check --rerun-tasks`, Phase 1 Approved, Phase 2 Approved | Relative result paths replace absolute Test system-property result paths for the reviewed converted check-participating Dungeon Editor surfaces. |
 | T3 Commit gate via versioned hooks | Done on branch | Pending | Pending | Rejected untested change naming `:compileTestJava`, accepted tested staged trees through clean worktree `check`, fresh-clone bootstrap set `core.hooksPath=tools/hooks`, dirty worktree isolation passed, Phase 1 Approved, Phase 2 Approved | Versioned `tools/hooks/pre-commit` now verifies the staged tree through a detached clean worktree. |
-| T4 CI authority and bespoke-layer deletion | In Flight | `4946450b3`, `d528d0b13`, `712ac4f87` | `ea6e797d`, `8aa8ed350` | Local structural proof and Phase 1/Phase 2 approved; build-wiring PR CI forced `check --rerun-tasks` green; area-touch PR CI content-addressed cache behavior green; branch-protection readback Qualified; deleted selector files absent on `main` | PR #453 replaced the required CI surface with `check`, adds scheduled `nightly-rerun-tasks`, deletes `harness-map.json`, `select_harnesses.py`, and `behavior-gate`, removes `checkHarnessMapConsistency`, and updates required-check/frozen/governance surfaces. Scheduled nightly green run remains pending. |
+| T4 CI authority and bespoke-layer deletion | Blocked | `4946450b3`, `d528d0b13`, `712ac4f87` | `ea6e797d`, `8aa8ed350` | Local structural proof and Phase 1/Phase 2 approved; build-wiring PR CI forced `check --rerun-tasks` green; area-touch PR CI content-addressed cache behavior green; branch-protection readback Qualified; deleted selector files absent on `main`; `gh run list --workflow quality-platforms --event schedule --limit 10 --json ...` returned `[]`, 2026-07-14; `gh run list --event schedule --limit 20 --json ...` showed only `promote-stable` scheduled runs, 2026-07-14; `date -Is` returned `2026-07-14T00:29:24+02:00`, before the configured `quality-platforms` cron `17 2 * * *`, 2026-07-14 | PR #453 replaced the required CI surface with `check`, adds scheduled `nightly-rerun-tasks`, deletes `harness-map.json`, `select_harnesses.py`, and `behavior-gate`, removes `checkHarnessMapConsistency`, and updates required-check/frozen/governance surfaces. Blocked on external schedule timing, not on a red nightly; do not substitute a manual, PR, or push run for the required scheduled nightly evidence. |
 | T5 Resolution report and honesty reviewer | Pending | Pending | Pending | Pending | Resource policy amendment must precede reviewer calls. |
 | T6 Governance consolidation | Pending | Pending | Pending | Pending | AGENTS/check-entrypoint consolidation waits until the system exists. |
 

--- a/docs/project/architecture/verification-greenfield-ledger.md
+++ b/docs/project/architecture/verification-greenfield-ledger.md
@@ -27,11 +27,11 @@ unless this ledger advances too.
 
 | Field | Value |
 | --- | --- |
-| Branch | `main` |
+| Branch | `codex/verif-greenfield-m0-nightly-t4` |
 | Milestone | M0 - Charter, Local Sync, Baseline, Predecessor Close-Out |
-| Status | In Flight |
-| Required next proof | `Green scheduled nightly run recorded; predecessor T4 closed`: record the first green scheduled `nightly-rerun-tasks` proof and close predecessor T4. |
-| Last status note | `2026-07-13 Charter-docs-merged` |
+| Status | Blocked |
+| Required next proof | Wait for the first scheduled `quality-platforms / nightly-rerun-tasks` run after the 2026-07-14 02:17 UTC cron, then record it and close predecessor T4 if it is green. |
+| Last status note | `2026-07-14 Nightly-not-yet-fired` |
 
 ## Baseline Measurements (owner machine, headless, filled in M0)
 
@@ -61,7 +61,7 @@ unless this ledger advances too.
 | --- | --- | --- | --- | --- | --- |
 | Charter docs committed and indexed | Done | `dbfe28955` | `738ebe6b` | `git diff --check main...HEAD` passed with no output, 2026-07-13; `./gradlew checkDocumentationEnforcement --console=plain` passed with `Documentation checks passed.` and `BUILD SUCCESSFUL in 6s`, 2026-07-13; docs-gate repair PR #458 merged as `735331a11` after green `check`, `warden-freeze`, owner-only `judge-review`, `ckjm-report`, SonarCloud, and CodeScene, 2026-07-13; charter PR #459 merged as `738ebe6b` after green `check`, `warden-freeze`, `judge-review`, `ckjm-report`, SonarCloud, and CodeScene, 2026-07-13 | Roadmap, target design, ledger, owner notes, and index links are merged. Prior blocker cleared by PR #458: the active Documentation Standard now owns size as a non-fatal signal and keeps `Owner` / `Last Reviewed` optional. PR #459 head `dbfe28955` only refreshed the risk-label event after the proof commit; no violation was reported against the verification-greenfield files. |
 | Local checkout on origin/main; in-flight work preserved | Done on branch | Pending | Pending | Pending | Encounter WIP committed on `codex/architecture-migration-m0-charter`; `codex/architecture-roadmap-phase2` pushed to origin 2026-07-13. |
-| Green scheduled nightly run recorded; predecessor T4 closed | Pending | Pending | Pending | Pending | Update predecessor ledger T4 to Done with the nightly evidence. |
+| Green scheduled nightly run recorded; predecessor T4 closed | Blocked | Pending | Pending | `gh run list --workflow quality-platforms --event schedule --limit 10 --json ...` returned `[]`, 2026-07-14; `gh run list --event schedule --limit 20 --json ...` showed only `promote-stable` scheduled runs, 2026-07-14; `date -Is` returned `2026-07-14T00:29:24+02:00`, before the configured `quality-platforms` cron `17 2 * * *`, 2026-07-14 | Blocked on external schedule timing, not on a red nightly. Do not substitute a manual, PR, or push run for the required scheduled `nightly-rerun-tasks` evidence. |
 | Predecessor roadmap deprecated with successor pointer | Pending | Pending | Pending | Pending | `Status: Deprecated` plus pointer under the title. |
 | Baseline measured headless on owner machine | Pending | Pending | Pending | Pending | Four measurements into the baseline table. |
 | Targets calibrated; German status note | Pending | Pending | Pending | Pending | Targets flip Provisional -> Binding. |


### PR DESCRIPTION
## Summary

Records that the current Verification Greenfield M0 step cannot close yet because the required scheduled `quality-platforms / nightly-rerun-tasks` run has not fired.

- Marks the greenfield ledger current position and M0 nightly/T4 row as `Blocked`.
- Marks the predecessor harness-modernization T4 position as `Blocked` for the same external schedule timing reason.
- Records the evidence: no scheduled `quality-platforms` run exists yet; scheduled repo runs currently show only `promote-stable`; local time was before the configured `17 2 * * *` UTC cron.
- Explicitly keeps manual, PR, or push runs out of the required scheduled-nightly proof.

Risk: R0, docs-only ledger status update. No behavior, policy, or frozen-surface changes.

## Validation

- `git diff --check` passed with no output on 2026-07-14.
- `./gradlew checkDocumentationEnforcement --console=plain` passed on 2026-07-14: `Documentation checks passed.`, `BUILD SUCCESSFUL in 10s`, `10 actionable tasks: 1 executed, 9 up-to-date`.