### PR TITLE
architecture: add non-blocking platform runtime

### DIFF
--- a/bootstrap/AppBootstrap.java
+++ b/bootstrap/AppBootstrap.java
@@ -4,6 +4,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.SystemLoggerDiagnostics;
+import platform.execution.ExecutionLane;
+import platform.execution.SerialExecutionLane;
+import platform.ui.JavaFxUiDispatcher;
+import platform.ui.UiDispatcher;
 import shell.api.ShellBinding;
 import shell.api.ShellContribution;
 import shell.api.ShellContributionSpec;
@@ -45,10 +51,28 @@ import src.view.statetabs.encounter.EncounterStateContribution;
 import src.view.statetabs.travel.TravelStateContribution;
 
 /** Explicit production composition root. */
-public final class AppBootstrap {
+public final class AppBootstrap implements AutoCloseable {
+
+    private final Diagnostics diagnostics;
+    private final ExecutionLane executionLane;
+    private final UiDispatcher uiDispatcher;
+
+    public AppBootstrap() {
+        this(new SystemLoggerDiagnostics());
+    }
+
+    private AppBootstrap(Diagnostics diagnostics) {
+        this(diagnostics, new SerialExecutionLane(diagnostics), new JavaFxUiDispatcher());
+    }
+
+    AppBootstrap(Diagnostics diagnostics, ExecutionLane executionLane, UiDispatcher uiDispatcher) {
+        this.diagnostics = java.util.Objects.requireNonNull(diagnostics, "diagnostics");
+        this.executionLane = java.util.Objects.requireNonNull(executionLane, "executionLane");
+        this.uiDispatcher = java.util.Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+    }
 
     public AppShell createShell() {
-        AppShell shell = new AppShell();
+        AppShell shell = new AppShell(diagnostics);
         Components components = createComponents();
         List<ResolvedContribution> contributions = bindContributions(shell, components);
         contributions.stream()
@@ -64,14 +88,20 @@ public final class AppBootstrap {
     private Components createComponents() {
         CreatureCatalogPort creatureCatalog = new SqliteCreatureCatalogQueryAdapter();
         EncounterTableCatalogPort encounterTableCatalog = new SqliteEncounterTableCatalogAdapter();
-        CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(creatureCatalog);
+        CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(
+                creatureCatalog, executionLane, uiDispatcher, diagnostics);
         EncounterTableServiceAssembly.Component encounterTables =
-                EncounterTableServiceAssembly.create(encounterTableCatalog);
-        PartyServiceAssembly.Component party = PartyServiceAssembly.create(new SqlitePartyRosterRepository());
+                EncounterTableServiceAssembly.create(
+                        encounterTableCatalog, executionLane, uiDispatcher, diagnostics);
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                new SqlitePartyRosterRepository(), executionLane, uiDispatcher, diagnostics);
 
         WorldPlannerServiceAssembly worldAssembly = new WorldPlannerServiceAssembly(
                 new SqliteWorldPlannerRepository(),
-                WorldPlannerReferenceAssembly.catalogReferences(creatures.references(), encounterTables.references()));
+                WorldPlannerReferenceAssembly.catalogReferences(creatures.references(), encounterTables.references()),
+                executionLane,
+                uiDispatcher,
+                diagnostics);
         WorldPlannerApplicationService worldApplication = worldAssembly.createApplicationService();
         WorldPlannerSnapshotModel worldSnapshot = worldAssembly.snapshotModel();
 
@@ -87,16 +117,23 @@ public final class AppBootstrap {
                 party.activeComposition(),
                 party.adventuringDaySummary(),
                 party.mutation(),
-                new SqliteEncounterPlanRepository());
+                new SqliteEncounterPlanRepository(),
+                executionLane,
+                uiDispatcher,
+                diagnostics);
 
         DungeonServiceAssembly.Component dungeon = DungeonServiceAssembly.create(
                 new SqliteDungeonMapRepository(),
                 party.activeParty(),
                 party.travelPositions(),
                 party.application(),
-                party.mutation());
+                party.mutation(),
+                executionLane,
+                uiDispatcher,
+                diagnostics);
         HexServiceAssembly hex = new HexServiceAssembly(
-                new SqliteHexMapRepository(), party.travelPositions(), party.application());
+                new SqliteHexMapRepository(), party.travelPositions(), party.application(),
+                executionLane, uiDispatcher, diagnostics);
         SessionPlannerServiceAssembly session = new SessionPlannerServiceAssembly(
                 new SqliteSessionPlanRepository(),
                 party.application(),
@@ -105,7 +142,10 @@ public final class AppBootstrap {
                 encounter.application(),
                 encounter.savedPlans(),
                 encounter.planBudget(),
-                worldSnapshot);
+                worldSnapshot,
+                executionLane,
+                uiDispatcher,
+                diagnostics);
         return new Components(
                 creatures, encounterTables, party, worldApplication, worldSnapshot,
                 encounter, dungeon, hex, session);
@@ -123,7 +163,9 @@ public final class AppBootstrap {
         DungeonEditorRuntimeDependencies dungeonEditorDependencies = new DungeonEditorRuntimeDependencies(
                 new DungeonEditorRuntimeDependencies.CompatibilityReadbackModels(
                         dungeon.editorControls(), dungeon.editorMapSurface(), dungeon.editorState()),
-                dungeon.editor());
+                dungeon.editor(),
+                executionLane,
+                uiDispatcher);
 
         List<ShellContribution> manifest = List.of(
                 new AdventuringDayTopBarContribution(
@@ -210,6 +252,11 @@ public final class AppBootstrap {
     }
 
     private record ResolvedContribution(ShellContributionSpec spec, ShellBinding binding) {
+    }
+
+    @Override
+    public void close() {
+        executionLane.close();
     }
 
 }

--- a/bootstrap/SaltMarcherApp.java
+++ b/bootstrap/SaltMarcherApp.java
@@ -12,11 +12,14 @@ import shell.host.AppShell;
  */
 public final class SaltMarcherApp extends Application {
 
+    private AppBootstrap bootstrap;
+
     @Override
     public void start(Stage primaryStage) {
         Platform.setImplicitExit(true);
 
-        AppShell shell = new AppBootstrap().createShell();
+        bootstrap = new AppBootstrap();
+        AppShell shell = bootstrap.createShell();
         Scene scene = new Scene(shell, 1150, 700);
         scene.getStylesheets().add(SaltMarcherApp.class.getResource("/salt-marcher.css").toExternalForm());
 
@@ -34,5 +37,12 @@ public final class SaltMarcherApp extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+    @Override
+    public void stop() {
+        if (bootstrap != null) {
+            bootstrap.close();
+        }
     }
 }

--- a/docs/project/delivery/README.md
+++ b/docs/project/delivery/README.md
@@ -13,25 +13,37 @@ Java roots; feature collaboration uses provider APIs; explicit composition,
 versioned SQLite recovery, local diagnostics, green CI, independent review, and
 owner acceptance are complete; this file is deleted.
 
-Current tree: `codex/greenfield-r1-explicit-composition` at R1 Explicit
-Composition. R0 Rule Cutover is merged by PR #471 at `869e14566`.
+Current tree: `codex/greenfield-r2-platform-runtime` at the integrated R2
+Platform Runtime candidate, based on merged R1 commit `6878a5cad`.
 
-R1 candidate: `AppBootstrap` owns one deterministic manifest and wires
-feature-owned typed components into passive constructor-injected shell
-contributions. The four classpath-discovery helpers, sixteen service
-contributions, `ServiceRegistry`, and `ShellRuntimeContext` are deleted. Tests
-exercise the same production assemblies and exact startup manifest. Horizontal
-package moves remain owned by R4.
+Completed: R0 Rule Cutover merged by PR #471. R1 Explicit Composition merged
+by PR #473 with required CI green; discovery, service location, and service
+contributions are deleted, and cross-feature references use typed provider
+APIs.
 
-Current proof: `git diff --cached --check` passes with no output. The direct
-panel's supported behavior, documentation, and cross-feature boundary findings
-are repaired. Provider-owned typed read APIs preserve the failing-provider
-no-write route; focused tests are `BUILD SUCCESSFUL in 12s`, and the exact full
-`check` is `BUILD SUCCESSFUL in 3m 13s` with one task executed. The focused
-architecture review of that exact boundary is clean; R1 is publication-ready.
+R2 candidate: one application-owned serial execution lane, explicit JavaFX UI
+dispatch, revisioned latest-state publication, and payload-free local
+diagnostics are wired through production composition. Material persistence
+commands run off JavaFX; feature state and immutable Dungeon frames cross the
+UI seam explicitly; stale Creature, Hex, Dungeon, catalog-event, and Session
+failure routes have deterministic regression coverage. Application shutdown
+closes the lane. R3 still owns SQLite lifecycle/recovery; R4 still owns
+vertical package moves.
 
-Publication gate: `git diff --cached --check`, literal green full `./gradlew
-check --console=plain`, and a clean independent review of that exact staged
-state. Push and merge only after required PR CI is green.
+Proof: after two direct review passes, all supported R2 state ownership,
+ordering, startup-I/O, shutdown-drain, and failure-publication findings were
+repaired with deterministic regressions. The final integrated regression set
+passed in 15s and full `./gradlew check --console=plain` passed in 4m 6s.
+Pre-existing multi-step SQLite recovery remains R3-owned. The exact final
+staged state still requires refreshed proof before publication.
 
-Next action: publish R1, then start R2 from updated `main`.
+Publication gate per migration slice: `git diff --cached --check` and literal
+green full `./gradlew check --console=plain`. Push and merge only after required
+PR CI is green. Do not run another slice review after the current R2 closure
+fixes; complete R3 through R5 first, then run one independent direct review
+panel over the fully migrated system before final installation and owner
+acceptance.
+
+Next action: publish the proved R2 pull request. Then execute R3 through R5
+without intermediate review-polish loops; review the combined final
+architecture once.

--- a/platform/diagnostics/DiagnosticId.java
+++ b/platform/diagnostics/DiagnosticId.java
@@ -1,0 +1,13 @@
+package platform.diagnostics;
+
+import java.util.Objects;
+
+public record DiagnosticId(String value) {
+
+    public DiagnosticId {
+        value = Objects.requireNonNull(value, "value");
+        if (!value.matches("[a-z0-9]+(?:[.-][a-z0-9]+)*")) {
+            throw new IllegalArgumentException("diagnostic id must be a stable lowercase code");
+        }
+    }
+}

--- a/platform/diagnostics/Diagnostics.java
+++ b/platform/diagnostics/Diagnostics.java
@@ -1,0 +1,6 @@
+package platform.diagnostics;
+
+public interface Diagnostics {
+
+    void failure(DiagnosticId id, Class<? extends Throwable> failureType);
+}

--- a/platform/diagnostics/NoopDiagnostics.java
+++ b/platform/diagnostics/NoopDiagnostics.java
@@ -1,0 +1,9 @@
+package platform.diagnostics;
+
+public enum NoopDiagnostics implements Diagnostics {
+    INSTANCE;
+
+    @Override
+    public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+    }
+}

--- a/platform/diagnostics/SystemLoggerDiagnostics.java
+++ b/platform/diagnostics/SystemLoggerDiagnostics.java
@@ -1,0 +1,25 @@
+package platform.diagnostics;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class SystemLoggerDiagnostics implements Diagnostics {
+
+    private final Consumer<String> warningSink;
+
+    public SystemLoggerDiagnostics() {
+        this(message -> System.getLogger(SystemLoggerDiagnostics.class.getName())
+                .log(System.Logger.Level.WARNING, message));
+    }
+
+    SystemLoggerDiagnostics(Consumer<String> warningSink) {
+        this.warningSink = Objects.requireNonNull(warningSink, "warningSink");
+    }
+
+    @Override
+    public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+        warningSink.accept(Objects.requireNonNull(id, "id").value()
+                + " failure="
+                + Objects.requireNonNull(failureType, "failureType").getName());
+    }
+}

--- a/platform/execution/DirectExecutionLane.java
+++ b/platform/execution/DirectExecutionLane.java
@@ -1,0 +1,16 @@
+package platform.execution;
+
+import java.util.Objects;
+
+public enum DirectExecutionLane implements ExecutionLane {
+    INSTANCE;
+
+    @Override
+    public void execute(Runnable work) {
+        Objects.requireNonNull(work, "work").run();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/platform/execution/ExecutionLane.java
+++ b/platform/execution/ExecutionLane.java
@@ -1,0 +1,9 @@
+package platform.execution;
+
+public interface ExecutionLane extends AutoCloseable {
+
+    void execute(Runnable work);
+
+    @Override
+    void close();
+}

--- a/platform/execution/SerialExecutionLane.java
+++ b/platform/execution/SerialExecutionLane.java
@@ -1,0 +1,74 @@
+package platform.execution;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+
+public final class SerialExecutionLane implements ExecutionLane {
+
+    private static final DiagnosticId TASK_FAILURE = new DiagnosticId("execution.task-failure");
+
+    private final Diagnostics diagnostics;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AtomicReference<Thread> worker = new AtomicReference<>();
+    private final ExecutorService executor;
+
+    public SerialExecutionLane(Diagnostics diagnostics) {
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        executor = Executors.newSingleThreadExecutor(task -> {
+            Thread thread = new Thread(task, "salt-marcher-runtime");
+            thread.setDaemon(true);
+            worker.set(thread);
+            return thread;
+        });
+    }
+
+    @Override
+    public void execute(Runnable work) {
+        Runnable safeWork = Objects.requireNonNull(work, "work");
+        if (Thread.currentThread() == worker.get()) {
+            runSafely(safeWork);
+            return;
+        }
+        if (closed.get()) {
+            throw new RejectedExecutionException("execution lane is closed");
+        }
+        executor.execute(() -> runSafely(safeWork));
+    }
+
+    private void runSafely(Runnable work) {
+        try {
+            work.run();
+        } catch (RuntimeException exception) {
+            diagnostics.failure(TASK_FAILURE, exception.getClass());
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            executor.shutdown();
+        }
+        if (Thread.currentThread() == worker.get()) {
+            return;
+        }
+
+        boolean interrupted = false;
+        while (!executor.isTerminated()) {
+            try {
+                executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException exception) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/platform/state/LatestState.java
+++ b/platform/state/LatestState.java
@@ -1,0 +1,61 @@
+package platform.state;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class LatestState<T> {
+
+    private final Map<Long, Consumer<StateSnapshot<T>>> subscribers = new LinkedHashMap<>();
+    private long issuedRevision;
+    private long subscriberId;
+    private StateSnapshot<T> current;
+
+    public LatestState(T initialValue) {
+        current = new StateSnapshot<>(0L, initialValue);
+    }
+
+    public synchronized UpdateToken beginUpdate() {
+        issuedRevision++;
+        return new UpdateToken(issuedRevision);
+    }
+
+    public synchronized boolean publish(UpdateToken token, T value) {
+        UpdateToken safeToken = Objects.requireNonNull(token, "token");
+        if (safeToken.revision() != issuedRevision || safeToken.revision() <= current.revision()) {
+            return false;
+        }
+        current = new StateSnapshot<>(safeToken.revision(), value);
+        for (Consumer<StateSnapshot<T>> subscriber : List.copyOf(subscribers.values())) {
+            subscriber.accept(current);
+        }
+        return true;
+    }
+
+    public synchronized boolean replace(UpdateToken token, T value) {
+        UpdateToken safeToken = Objects.requireNonNull(token, "token");
+        if (safeToken.revision() != issuedRevision || safeToken.revision() <= current.revision()) {
+            return false;
+        }
+        current = new StateSnapshot<>(safeToken.revision(), value);
+        return true;
+    }
+
+    public synchronized StateSnapshot<T> current() {
+        return current;
+    }
+
+    public synchronized Runnable subscribe(Consumer<StateSnapshot<T>> subscriber) {
+        Consumer<StateSnapshot<T>> safeSubscriber = Objects.requireNonNull(subscriber, "subscriber");
+        long id = ++subscriberId;
+        subscribers.put(id, safeSubscriber);
+        safeSubscriber.accept(current);
+        return () -> unsubscribe(id);
+    }
+
+    private synchronized void unsubscribe(long id) {
+        subscribers.remove(id);
+    }
+}

--- a/platform/state/StateSnapshot.java
+++ b/platform/state/StateSnapshot.java
@@ -1,0 +1,13 @@
+package platform.state;
+
+import java.util.Objects;
+
+public record StateSnapshot<T>(long revision, T value) {
+
+    public StateSnapshot {
+        if (revision < 0L) {
+            throw new IllegalArgumentException("revision must not be negative");
+        }
+        value = Objects.requireNonNull(value, "value");
+    }
+}

--- a/platform/state/UpdateToken.java
+++ b/platform/state/UpdateToken.java
@@ -1,0 +1,10 @@
+package platform.state;
+
+public record UpdateToken(long revision) {
+
+    public UpdateToken {
+        if (revision <= 0L) {
+            throw new IllegalArgumentException("revision must be positive");
+        }
+    }
+}

--- a/platform/ui/DirectUiDispatcher.java
+++ b/platform/ui/DirectUiDispatcher.java
@@ -1,0 +1,12 @@
+package platform.ui;
+
+import java.util.Objects;
+
+public enum DirectUiDispatcher implements UiDispatcher {
+    INSTANCE;
+
+    @Override
+    public void dispatch(Runnable update) {
+        Objects.requireNonNull(update, "update").run();
+    }
+}

--- a/platform/ui/JavaFxUiDispatcher.java
+++ b/platform/ui/JavaFxUiDispatcher.java
@@ -1,0 +1,17 @@
+package platform.ui;
+
+import java.util.Objects;
+import javafx.application.Platform;
+
+public final class JavaFxUiDispatcher implements UiDispatcher {
+
+    @Override
+    public void dispatch(Runnable update) {
+        Runnable safeUpdate = Objects.requireNonNull(update, "update");
+        if (Platform.isFxApplicationThread()) {
+            safeUpdate.run();
+        } else {
+            Platform.runLater(safeUpdate);
+        }
+    }
+}

--- a/platform/ui/UiDispatcher.java
+++ b/platform/ui/UiDispatcher.java
@@ -1,0 +1,7 @@
+package platform.ui;
+
+@FunctionalInterface
+public interface UiDispatcher {
+
+    void dispatch(Runnable update);
+}

--- a/shell/host/AppShell.java
+++ b/shell/host/AppShell.java
@@ -5,6 +5,8 @@ import org.jspecify.annotations.Nullable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
 import shell.api.ContributionKey;
 import shell.api.InspectorSink;
 import shell.api.ShellBinding;
@@ -22,10 +24,15 @@ public final class AppShell extends BorderPane {
     private final Map<ContributionKey, ShellStateTabSpec> stateTabItems = new LinkedHashMap<>();
     private final ShellNavigationSidebar navigationSidebar = new ShellNavigationSidebar();
     private final ShellToolbarStrip toolbar = new ShellToolbarStrip();
-    private final ShellWorkspacePane workspace = new ShellWorkspacePane();
+    private final ShellWorkspacePane workspace;
     private @Nullable ContributionKey activeTabKey;
 
     public AppShell() {
+        this(NoopDiagnostics.INSTANCE);
+    }
+
+    public AppShell(Diagnostics diagnostics) {
+        workspace = new ShellWorkspacePane(Objects.requireNonNull(diagnostics, "diagnostics"));
         setTop(toolbar);
         setLeft(navigationSidebar);
         setCenter(workspace);

--- a/shell/host/InspectorPane.java
+++ b/shell/host/InspectorPane.java
@@ -13,6 +13,8 @@ import javafx.scene.layout.VBox;
 import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.function.Supplier;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
 import shell.api.InspectorEntrySpec;
 import shell.api.InspectorSink;
 
@@ -20,6 +22,9 @@ import shell.api.InspectorSink;
  * Top-right shared history-aware inspector for read-mostly detail content.
  */
 final class InspectorPane extends VBox implements InspectorSink {
+
+    private static final DiagnosticId SUPPLIER_FAILURE =
+            new DiagnosticId("shell.inspector-supplier-failure");
 
     private final Label detailTitle = new Label();
     private final VBox detailContent = new VBox();
@@ -32,8 +37,10 @@ final class InspectorPane extends VBox implements InspectorSink {
     private final Button closeBtn = new Button("\u00d7");
 
     private final InspectorHistory history = new InspectorHistory();
+    private final Diagnostics diagnostics;
 
-    InspectorPane() {
+    InspectorPane(Diagnostics diagnostics) {
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
         setPrefWidth(380);
         setMinWidth(320);
         getStyleClass().add("surface-root");
@@ -114,7 +121,7 @@ final class InspectorPane extends VBox implements InspectorSink {
         try {
             return supplier.get();
         } catch (IllegalArgumentException | IllegalStateException exception) {
-            // The shell should stay passive and resilient if a view publishes invalid content.
+            diagnostics.failure(SUPPLIER_FAILURE, exception.getClass());
             return null;
         }
     }

--- a/shell/host/ShellWorkspacePane.java
+++ b/shell/host/ShellWorkspacePane.java
@@ -15,6 +15,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
 import shell.api.ContributionKey;
 import shell.api.ShellLeftBarTabMode;
 
@@ -30,7 +32,7 @@ final class ShellWorkspacePane extends SplitPane {
     private final StackPane mainPanel = new StackPane();
     private final StackPane detailsContainer = new StackPane();
     private final StackPane stateContainer = new StackPane();
-    private final InspectorPane inspectorPane = new InspectorPane();
+    private final InspectorPane inspectorPane;
     private final StateTabPane stateTabPane = new StateTabPane();
     private final Node editorStatePlaceholder = createPlaceholderPane("Status", "Kein lokaler Zustand");
     private final Node emptyStateTabPlaceholder = createPlaceholderPane("Status", "Keine State-Tabs registriert");
@@ -42,6 +44,11 @@ final class ShellWorkspacePane extends SplitPane {
     private @Nullable ShellSlotContent activeSlotContent;
 
     ShellWorkspacePane() {
+        this(NoopDiagnostics.INSTANCE);
+    }
+
+    ShellWorkspacePane(Diagnostics diagnostics) {
+        inspectorPane = new InspectorPane(Objects.requireNonNull(diagnostics, "diagnostics"));
         controlsPanel.getStyleClass().add("control-panel");
         controlsPanel.setPrefWidth(240);
         controlsPanel.setMinWidth(200);

--- a/src/domain/creatures/CreaturesApplicationService.java
+++ b/src/domain/creatures/CreaturesApplicationService.java
@@ -5,6 +5,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.state.LatestState;
+import platform.state.UpdateToken;
 import src.domain.creatures.model.catalog.CreatureCatalogData;
 import src.domain.creatures.model.catalog.CreatureCatalogData.CatalogSortField;
 import src.domain.creatures.model.catalog.CreatureCatalogData.CreatureProfile;
@@ -38,6 +45,12 @@ public final class CreaturesApplicationService {
     private static final int MAX_ENCOUNTER_CANDIDATE_LIMIT = 1000;
     private static final String DESCENDING_SORT_DIRECTION = "DESCENDING";
     private static final String COMMAND_PARAMETER = "command";
+    private static final DiagnosticId FILTER_OPTIONS_FAILURE =
+            new DiagnosticId("creatures.filter-options.storage-failure");
+    private static final DiagnosticId CATALOG_FAILURE = new DiagnosticId("creatures.catalog.storage-failure");
+    private static final DiagnosticId DETAIL_FAILURE = new DiagnosticId("creatures.detail.storage-failure");
+    private static final DiagnosticId ENCOUNTER_CANDIDATES_FAILURE =
+            new DiagnosticId("creatures.encounter-candidates.storage-failure");
 
     private static final List<String> CHALLENGE_RATINGS = List.of(
             "0", "1/8", "1/4", "1/2",
@@ -86,6 +99,10 @@ public final class CreaturesApplicationService {
     private final CreatureCatalogModel catalogModel;
     private final CreatureDetailModel detailModel;
     private final CreatureEncounterCandidatesModel encounterCandidatesModel;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
+    private final LatestState<Long> catalogRequests = new LatestState<>(0L);
+    private final Object catalogPublicationLock = new Object();
 
     public CreaturesApplicationService(
             CreatureCatalogPort lookup,
@@ -94,15 +111,40 @@ public final class CreaturesApplicationService {
             CreatureDetailModel detailModel,
             CreatureEncounterCandidatesModel encounterCandidatesModel
     ) {
+        this(
+                lookup,
+                filterOptionsModel,
+                catalogModel,
+                detailModel,
+                encounterCandidatesModel,
+                DirectExecutionLane.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public CreaturesApplicationService(
+            CreatureCatalogPort lookup,
+            CreatureFilterOptionsModel filterOptionsModel,
+            CreatureCatalogModel catalogModel,
+            CreatureDetailModel detailModel,
+            CreatureEncounterCandidatesModel encounterCandidatesModel,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
+    ) {
         this.lookup = Objects.requireNonNull(lookup, "lookup");
         this.filterOptionsModel = Objects.requireNonNull(filterOptionsModel, "filterOptionsModel");
         this.catalogModel = Objects.requireNonNull(catalogModel, "catalogModel");
         this.detailModel = Objects.requireNonNull(detailModel, "detailModel");
         this.encounterCandidatesModel = Objects.requireNonNull(encounterCandidatesModel, "encounterCandidatesModel");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public void refreshFilterOptions(RefreshCreatureFilterOptionsCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executionLane.execute(this::refreshFilterOptionsInLane);
+    }
+
+    private void refreshFilterOptionsInLane() {
         try {
             filterOptionsModel.publish(new CreatureFilterOptionsResult(
                     CreatureReadStatus.SUCCESS,
@@ -110,6 +152,7 @@ public final class CreaturesApplicationService {
                             lookup.loadFilterValues(),
                             CHALLENGE_RATINGS)));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(FILTER_OPTIONS_FAILURE, exception.getClass());
             filterOptionsModel.publish(new CreatureFilterOptionsResult(
                     CreatureReadStatus.STORAGE_ERROR,
                     CreatureCatalogProjection.filterOptions(
@@ -120,18 +163,31 @@ public final class CreaturesApplicationService {
 
     public void refreshCatalog(RefreshCreatureCatalogCommand command) {
         CatalogRequest request = CatalogRequest.from(command);
+        UpdateToken requestToken;
+        synchronized (catalogPublicationLock) {
+            requestToken = catalogRequests.beginUpdate();
+        }
+        executionLane.execute(() -> refreshCatalogInLane(request, requestToken));
+    }
+
+    private void refreshCatalogInLane(CatalogRequest request, UpdateToken requestToken) {
         try {
             if (!request.hasValidChallengeRatingRange()) {
-                publishCatalog(CreatureQueryStatus.INVALID_QUERY, request.emptyPage());
+                publishCatalog(requestToken, CreatureQueryStatus.INVALID_QUERY, request.emptyPage());
                 return;
             }
-            publishCatalog(CreatureQueryStatus.SUCCESS, lookup.searchCatalog(request.spec()));
+            publishCatalog(requestToken, CreatureQueryStatus.SUCCESS, lookup.searchCatalog(request.spec()));
         } catch (IllegalStateException exception) {
-            publishCatalog(CreatureQueryStatus.STORAGE_ERROR, request.emptyPage());
+            diagnostics.failure(CATALOG_FAILURE, exception.getClass());
+            publishCatalog(requestToken, CreatureQueryStatus.STORAGE_ERROR, request.emptyPage());
         }
     }
 
     public void selectCreatureDetail(SelectCreatureDetailCommand command) {
+        executionLane.execute(() -> selectCreatureDetailInLane(command));
+    }
+
+    private void selectCreatureDetailInLane(SelectCreatureDetailCommand command) {
         try {
             long creatureId = command == null ? NO_CREATURE_ID : command.creatureId();
             if (creatureId <= 0) {
@@ -141,12 +197,17 @@ public final class CreaturesApplicationService {
             CreatureProfile detail = lookup.loadCreatureDetail(creatureId);
             publishDetail(detail == null ? CreatureLookupStatus.NOT_FOUND : CreatureLookupStatus.SUCCESS, detail);
         } catch (IllegalStateException exception) {
+            diagnostics.failure(DETAIL_FAILURE, exception.getClass());
             publishDetail(CreatureLookupStatus.STORAGE_ERROR, null);
         }
     }
 
     public void refreshEncounterCandidates(RefreshCreatureEncounterCandidatesCommand command) {
         EncounterCandidateRequest request = EncounterCandidateRequest.from(command);
+        executionLane.execute(() -> refreshEncounterCandidatesInLane(request));
+    }
+
+    private void refreshEncounterCandidatesInLane(EncounterCandidateRequest request) {
         try {
             if (!request.hasValidXpRange()) {
                 publishEncounterCandidates(CreatureQueryStatus.INVALID_QUERY, List.of());
@@ -154,14 +215,23 @@ public final class CreaturesApplicationService {
             }
             publishEncounterCandidates(CreatureQueryStatus.SUCCESS, lookup.loadEncounterCandidates(request.spec()));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(ENCOUNTER_CANDIDATES_FAILURE, exception.getClass());
             publishEncounterCandidates(CreatureQueryStatus.STORAGE_ERROR, List.of());
         }
     }
 
-    private void publishCatalog(CreatureQueryStatus status, CreatureCatalogData.CatalogPageData page) {
-        catalogModel.publish(new CreatureCatalogPageResult(
-                status,
-                CreatureCatalogProjection.catalogPage(page)));
+    private void publishCatalog(
+            UpdateToken requestToken,
+            CreatureQueryStatus status,
+            CreatureCatalogData.CatalogPageData page
+    ) {
+        synchronized (catalogPublicationLock) {
+            if (catalogRequests.replace(requestToken, requestToken.revision())) {
+                catalogModel.publish(new CreatureCatalogPageResult(
+                        status,
+                        CreatureCatalogProjection.catalogPage(page)));
+            }
+        }
     }
 
     private void publishDetail(

--- a/src/domain/creatures/CreaturesServiceAssembly.java
+++ b/src/domain/creatures/CreaturesServiceAssembly.java
@@ -1,5 +1,13 @@
 package src.domain.creatures;
 
+import java.util.Objects;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.creatures.model.catalog.port.CreatureCatalogPort;
 import src.domain.creatures.published.CreatureCatalogModel;
 import src.domain.creatures.published.CreatureDetailModel;
@@ -11,26 +19,52 @@ import src.domain.creatures.published.CreatureReferenceApi;
 
 public final class CreaturesServiceAssembly {
 
+    private static final DiagnosticId REFERENCE_FAILURE = new DiagnosticId("creatures.reference.storage-failure");
+
     private CreaturesServiceAssembly() {
     }
 
     public static Component create(CreatureCatalogPort catalogPort) {
-        CreatureFilterOptionsModel filterOptions = new CreatureFilterOptionsModel();
-        CreatureCatalogModel catalog = new CreatureCatalogModel();
-        CreatureDetailModel detail = new CreatureDetailModel();
-        CreatureEncounterCandidatesModel encounterCandidates = new CreatureEncounterCandidatesModel();
+        return create(
+                catalogPort,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public static Component create(
+            CreatureCatalogPort catalogPort,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        CreatureCatalogPort safeCatalogPort = Objects.requireNonNull(catalogPort, "catalogPort");
+        ExecutionLane safeExecutionLane = Objects.requireNonNull(executionLane, "executionLane");
+        UiDispatcher safeUiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        Diagnostics safeDiagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        CreatureFilterOptionsModel filterOptions = new CreatureFilterOptionsModel(safeUiDispatcher);
+        CreatureCatalogModel catalog = new CreatureCatalogModel(safeUiDispatcher);
+        CreatureDetailModel detail = new CreatureDetailModel(safeUiDispatcher);
+        CreatureEncounterCandidatesModel encounterCandidates = new CreatureEncounterCandidatesModel(safeUiDispatcher);
         CreaturesApplicationService application = new CreaturesApplicationService(
-                catalogPort, filterOptions, catalog, detail, encounterCandidates);
+                safeCatalogPort,
+                filterOptions,
+                catalog,
+                detail,
+                encounterCandidates,
+                safeExecutionLane,
+                safeDiagnostics);
         CreatureReferenceApi references = creatureId -> {
             if (creatureId <= 0L) {
                 return new CreatureDetailResult(CreatureLookupStatus.NOT_FOUND, null);
             }
             try {
-                var found = catalogPort.loadCreatureDetail(creatureId);
+                var found = safeCatalogPort.loadCreatureDetail(creatureId);
                 return new CreatureDetailResult(
                         found == null ? CreatureLookupStatus.NOT_FOUND : CreatureLookupStatus.SUCCESS,
                         CreatureCatalogProjection.creatureDetail(found));
             } catch (IllegalStateException exception) {
+                safeDiagnostics.failure(REFERENCE_FAILURE, exception.getClass());
                 return new CreatureDetailResult(CreatureLookupStatus.STORAGE_ERROR, null);
             }
         };

--- a/src/domain/creatures/published/CreatureCatalogModel.java
+++ b/src/domain/creatures/published/CreatureCatalogModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class CreatureCatalogModel {
@@ -14,6 +15,10 @@ public final class CreatureCatalogModel {
 
     public CreatureCatalogModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public CreatureCatalogModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private CreatureCatalogModel(PublishedState<CreatureCatalogPageResult> store) {

--- a/src/domain/creatures/published/CreatureDetailModel.java
+++ b/src/domain/creatures/published/CreatureDetailModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class CreatureDetailModel {
@@ -14,6 +15,10 @@ public final class CreatureDetailModel {
 
     public CreatureDetailModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public CreatureDetailModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private CreatureDetailModel(PublishedState<CreatureDetailResult> store) {

--- a/src/domain/creatures/published/CreatureEncounterCandidatesModel.java
+++ b/src/domain/creatures/published/CreatureEncounterCandidatesModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class CreatureEncounterCandidatesModel {
@@ -15,6 +16,10 @@ public final class CreatureEncounterCandidatesModel {
 
     public CreatureEncounterCandidatesModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public CreatureEncounterCandidatesModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private CreatureEncounterCandidatesModel(PublishedState<CreatureEncounterCandidatesResult> store) {

--- a/src/domain/creatures/published/CreatureFilterOptionsModel.java
+++ b/src/domain/creatures/published/CreatureFilterOptionsModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class CreatureFilterOptionsModel {
@@ -14,6 +15,10 @@ public final class CreatureFilterOptionsModel {
 
     public CreatureFilterOptionsModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public CreatureFilterOptionsModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private CreatureFilterOptionsModel(PublishedState<CreatureFilterOptionsResult> store) {

--- a/src/domain/dungeon/DungeonAuthoredPublishedState.java
+++ b/src/domain/dungeon/DungeonAuthoredPublishedState.java
@@ -1,6 +1,14 @@
 package src.domain.dungeon;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.dungeon.published.DungeonAuthoredMutationModel;
 import src.domain.dungeon.published.DungeonAuthoredMutationResult;
 import src.domain.dungeon.published.DungeonAuthoredReadModel;
@@ -11,18 +19,28 @@ import src.domain.shared.published.PublishedState;
 
 class DungeonAuthoredPublishedState {
 
-    private final PublishedState<DungeonAuthoredReadResult> authoredRead =
-            new PublishedState<>(DungeonAuthoredReadProjectionServiceAssembly.defaultRead());
-    private final PublishedState<DungeonAuthoredMutationResult> authoredMutation =
-            new PublishedState<>(DungeonAuthoredMutationProjectionServiceAssembly.defaultMutation());
-    private final PublishedState<DungeonMapCatalogResponse> mapCatalog =
-            new PublishedState<>(new DungeonMapCatalogResponse.MapList(List.of()));
-    private final DungeonAuthoredReadModel authoredReadModel =
-            new DungeonAuthoredReadModel(authoredRead::current, authoredRead::subscribe);
-    private final DungeonAuthoredMutationModel authoredMutationModel =
-            new DungeonAuthoredMutationModel(authoredMutation::current, authoredMutation::subscribe);
-    private final DungeonMapCatalogModel mapCatalogModel =
-            new DungeonMapCatalogModel(mapCatalog::current, mapCatalog::subscribe);
+    private final PublishedState<DungeonAuthoredReadResult> authoredRead;
+    private final PublishedState<DungeonAuthoredMutationResult> authoredMutation;
+    private final PublishedState<DungeonMapCatalogResponse> mapCatalog;
+    private final PublishedEvents<DungeonMapCatalogResponse.MapMutation> mapCatalogMutations;
+    private final DungeonAuthoredReadModel authoredReadModel;
+    private final DungeonAuthoredMutationModel authoredMutationModel;
+    private final DungeonMapCatalogModel mapCatalogModel;
+
+    DungeonAuthoredPublishedState() {
+        this(DirectUiDispatcher.INSTANCE);
+    }
+
+    DungeonAuthoredPublishedState(UiDispatcher dispatcher) {
+        authoredRead = new PublishedState<>(DungeonAuthoredReadProjectionServiceAssembly.defaultRead(), dispatcher);
+        authoredMutation = new PublishedState<>(
+                DungeonAuthoredMutationProjectionServiceAssembly.defaultMutation(), dispatcher);
+        mapCatalog = new PublishedState<>(new DungeonMapCatalogResponse.MapList(List.of()), dispatcher);
+        mapCatalogMutations = new PublishedEvents<>(dispatcher);
+        authoredReadModel = new DungeonAuthoredReadModel(authoredRead::current, authoredRead::subscribe);
+        authoredMutationModel = new DungeonAuthoredMutationModel(authoredMutation::current, authoredMutation::subscribe);
+        mapCatalogModel = new DungeonMapCatalogModel(mapCatalog::current, this::subscribeMapCatalog);
+    }
 
     DungeonAuthoredReadModel authoredReadModel() {
         return authoredReadModel;
@@ -61,20 +79,95 @@ class DungeonAuthoredPublishedState {
     }
 
     void publishCreated(DungeonAuthoredPublication.MapMutation mutation) {
-        mapCatalog.publish(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
+        publishCatalogMutation(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
                 DungeonMapCatalogResponse.MutationKind.CREATED,
                 mutation));
     }
 
     void publishRenamed(DungeonAuthoredPublication.MapMutation mutation) {
-        mapCatalog.publish(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
+        publishCatalogMutation(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
                 DungeonMapCatalogResponse.MutationKind.RENAMED,
                 mutation));
     }
 
     void publishDeleted(DungeonAuthoredPublication.MapMutation mutation) {
-        mapCatalog.publish(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
+        publishCatalogMutation(DungeonAuthoredCatalogProjectionServiceAssembly.mapMutation(
                 DungeonMapCatalogResponse.MutationKind.DELETED,
                 mutation));
+    }
+
+    private void publishCatalogMutation(DungeonMapCatalogResponse mutation) {
+        if (mutation instanceof DungeonMapCatalogResponse.MapMutation mapMutation) {
+            mapCatalogMutations.publish(mapMutation);
+        }
+    }
+
+    private Runnable subscribeMapCatalog(Consumer<DungeonMapCatalogResponse> listener) {
+        Consumer<DungeonMapCatalogResponse> safeListener = Objects.requireNonNull(listener, "listener");
+        Runnable unsubscribeSnapshots = mapCatalog.subscribe(safeListener);
+        Runnable unsubscribeMutations = mapCatalogMutations.subscribe(safeListener);
+        return () -> {
+            unsubscribeSnapshots.run();
+            unsubscribeMutations.run();
+        };
+    }
+
+    private static final class PublishedEvents<T> {
+
+        private final Map<Consumer<? super T>, Registration<T>> subscribers = new LinkedHashMap<>();
+        private final UiDispatcher dispatcher;
+
+        private PublishedEvents(UiDispatcher dispatcher) {
+            this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher");
+        }
+
+        private Runnable subscribe(Consumer<? super T> subscriber) {
+            Consumer<? super T> safeSubscriber = Objects.requireNonNull(subscriber, "subscriber");
+            synchronized (subscribers) {
+                subscribers.computeIfAbsent(safeSubscriber, Registration::new);
+            }
+            return () -> unsubscribe(safeSubscriber);
+        }
+
+        private void publish(T event) {
+            T safeEvent = Objects.requireNonNull(event, "event");
+            List<Registration<T>> currentSubscribers;
+            synchronized (subscribers) {
+                currentSubscribers = new ArrayList<>(subscribers.values());
+            }
+            for (Registration<T> registration : currentSubscribers) {
+                dispatcher.dispatch(() -> registration.deliver(safeEvent));
+            }
+        }
+
+        private void unsubscribe(Consumer<? super T> subscriber) {
+            Registration<T> registration;
+            synchronized (subscribers) {
+                registration = subscribers.remove(subscriber);
+            }
+            if (registration != null) {
+                registration.close();
+            }
+        }
+
+        private static final class Registration<T> {
+
+            private final Consumer<? super T> subscriber;
+            private final AtomicBoolean active = new AtomicBoolean(true);
+
+            private Registration(Consumer<? super T> subscriber) {
+                this.subscriber = subscriber;
+            }
+
+            private void deliver(T event) {
+                if (active.get()) {
+                    subscriber.accept(event);
+                }
+            }
+
+            private void close() {
+                active.set(false);
+            }
+        }
     }
 }

--- a/src/domain/dungeon/DungeonEditorPublishedState.java
+++ b/src/domain/dungeon/DungeonEditorPublishedState.java
@@ -8,21 +8,30 @@ import src.domain.dungeon.published.DungeonEditorMapSurfaceSnapshot;
 import src.domain.dungeon.published.DungeonEditorStateModel;
 import src.domain.dungeon.published.DungeonEditorStateSnapshot;
 import src.domain.shared.published.PublishedState;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 
 final class DungeonEditorPublishedState {
 
-    private final PublishedState<DungeonEditorControlsSnapshot> controls =
-            PublishedState.retainingDuplicateSubscribers(DungeonEditorControlsSnapshot.empty(""));
-    private final PublishedState<DungeonEditorMapSurfaceSnapshot> mapSurface =
-            PublishedState.retainingDuplicateSubscribers(DungeonEditorMapSurfaceSnapshot.empty());
-    private final PublishedState<DungeonEditorStateSnapshot> state =
-            PublishedState.retainingDuplicateSubscribers(DungeonEditorStateSnapshot.empty(""));
-    private final DungeonEditorControlsModel controlsModel =
-            new DungeonEditorControlsModel(controls::current, controls::subscribe);
-    private final DungeonEditorMapSurfaceModel mapSurfaceModel =
-            new DungeonEditorMapSurfaceModel(mapSurface::current, mapSurface::subscribe);
-    private final DungeonEditorStateModel stateModel =
-            new DungeonEditorStateModel(state::current, state::subscribe);
+    private final PublishedState<DungeonEditorControlsSnapshot> controls;
+    private final PublishedState<DungeonEditorMapSurfaceSnapshot> mapSurface;
+    private final PublishedState<DungeonEditorStateSnapshot> state;
+    private final DungeonEditorControlsModel controlsModel;
+    private final DungeonEditorMapSurfaceModel mapSurfaceModel;
+    private final DungeonEditorStateModel stateModel;
+
+    DungeonEditorPublishedState() {
+        this(DirectUiDispatcher.INSTANCE);
+    }
+
+    DungeonEditorPublishedState(UiDispatcher dispatcher) {
+        controls = new PublishedState<>(DungeonEditorControlsSnapshot.empty(""), dispatcher);
+        mapSurface = new PublishedState<>(DungeonEditorMapSurfaceSnapshot.empty(), dispatcher);
+        state = new PublishedState<>(DungeonEditorStateSnapshot.empty(""), dispatcher);
+        controlsModel = new DungeonEditorControlsModel(controls::current, controls::subscribe);
+        mapSurfaceModel = new DungeonEditorMapSurfaceModel(mapSurface::current, mapSurface::subscribe);
+        stateModel = new DungeonEditorStateModel(state::current, state::subscribe);
+    }
 
     DungeonEditorControlsModel controlsModel() {
         return controlsModel;

--- a/src/domain/dungeon/DungeonServiceAssembly.java
+++ b/src/domain/dungeon/DungeonServiceAssembly.java
@@ -1,5 +1,12 @@
 package src.domain.dungeon;
 
+import java.util.Objects;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.dungeon.model.core.repository.DungeonMapRepository;
 import src.domain.dungeon.published.TravelDungeonModel;
 import src.domain.party.PartyApplicationService;
@@ -15,10 +22,35 @@ public final class DungeonServiceAssembly {
             PartyApplicationService party,
             PartyMutationModel partyMutation
     ) {
-        DungeonEditorPublishedState editorPublishedState = new DungeonEditorPublishedState();
-        DungeonAuthoredPublishedState authoredPublishedState = new DungeonAuthoredPublishedState();
+        return create(
+                repository,
+                activeParty,
+                partyTravelPositions,
+                party,
+                partyMutation,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public static Component create(
+            DungeonMapRepository repository,
+            ActivePartyModel activeParty,
+            PartyTravelPositionsModel partyTravelPositions,
+            PartyApplicationService party,
+            PartyMutationModel partyMutation,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        ExecutionLane lane = Objects.requireNonNull(executionLane, "executionLane");
+        UiDispatcher dispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        Objects.requireNonNull(diagnostics, "diagnostics");
+        DungeonEditorPublishedState editorPublishedState = new DungeonEditorPublishedState(dispatcher);
+        DungeonAuthoredPublishedState authoredPublishedState = new DungeonAuthoredPublishedState(dispatcher);
         DungeonAuthoredApplicationService authoredMaps =
-                new DungeonAuthoredApplicationService(repository, authoredPublishedState);
+                new DungeonAuthoredApplicationService(
+                        Objects.requireNonNull(repository, "repository"), authoredPublishedState);
         DungeonEditorRuntimeApplicationService editor =
                 new DungeonEditorRuntimeApplicationService(authoredMaps, editorPublishedState);
         DungeonTravelPartyGateway partyGateway = new DungeonTravelPartyGateway(
@@ -27,11 +59,11 @@ public final class DungeonServiceAssembly {
                 new DungeonTravelSurfaceLoader(authoredMaps, partyGateway);
         DungeonTravelNavigator navigator =
                 new DungeonTravelNavigator(authoredMaps, partyGateway, surfaceLoader);
-        DungeonTravelPublishedState publishedState = new DungeonTravelPublishedState();
+        DungeonTravelPublishedState publishedState = new DungeonTravelPublishedState(dispatcher);
         return new Component(
                 authoredMaps,
                 editor,
-                new DungeonTravelRuntimeApplicationService(surfaceLoader, navigator, publishedState),
+                new DungeonTravelRuntimeApplicationService(surfaceLoader, navigator, publishedState, lane),
                 authoredPublishedState.authoredReadModel(),
                 authoredPublishedState.authoredMutationModel(),
                 authoredPublishedState.mapCatalogModel(),

--- a/src/domain/dungeon/DungeonTravelPublishedState.java
+++ b/src/domain/dungeon/DungeonTravelPublishedState.java
@@ -4,13 +4,22 @@ import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSnaps
 import src.domain.dungeon.published.TravelDungeonModel;
 import src.domain.dungeon.published.TravelDungeonSnapshot;
 import src.domain.shared.published.PublishedState;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 
 final class DungeonTravelPublishedState {
 
-    private final PublishedState<TravelDungeonSnapshot> snapshots =
-            PublishedState.retainingDuplicateSubscribers(TravelDungeonSnapshot.empty());
-    private final TravelDungeonModel travelModel =
-            new TravelDungeonModel(snapshots::current, snapshots::subscribe);
+    private final PublishedState<TravelDungeonSnapshot> snapshots;
+    private final TravelDungeonModel travelModel;
+
+    DungeonTravelPublishedState() {
+        this(DirectUiDispatcher.INSTANCE);
+    }
+
+    DungeonTravelPublishedState(UiDispatcher dispatcher) {
+        snapshots = new PublishedState<>(TravelDungeonSnapshot.empty(), dispatcher);
+        travelModel = new TravelDungeonModel(snapshots::current, snapshots::subscribe);
+    }
 
     TravelDungeonModel travelModel() {
         return travelModel;

--- a/src/domain/dungeon/DungeonTravelRuntimeApplicationService.java
+++ b/src/domain/dungeon/DungeonTravelRuntimeApplicationService.java
@@ -2,6 +2,8 @@ package src.domain.dungeon;
 
 import java.util.List;
 import java.util.Objects;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
 import src.domain.dungeon.model.runtime.travel.projection.TravelActionFacts.SelectedAction;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSession;
 import src.domain.dungeon.model.runtime.travel.session.TravelDungeonSessionSurface.OverlayMode;
@@ -17,23 +19,42 @@ public final class DungeonTravelRuntimeApplicationService {
     private final DungeonTravelSurfaceLoader surfaceLoader;
     private final DungeonTravelNavigator navigator;
     private final DungeonTravelPublishedState publishedState;
+    private final ExecutionLane executionLane;
 
     public DungeonTravelRuntimeApplicationService(
             DungeonTravelSurfaceLoader surfaceLoader,
             DungeonTravelNavigator navigator,
             DungeonTravelPublishedState publishedState
     ) {
+        this(surfaceLoader, navigator, publishedState, DirectExecutionLane.INSTANCE);
+    }
+
+    DungeonTravelRuntimeApplicationService(
+            DungeonTravelSurfaceLoader surfaceLoader,
+            DungeonTravelNavigator navigator,
+            DungeonTravelPublishedState publishedState,
+            ExecutionLane executionLane
+    ) {
         this.surfaceLoader = Objects.requireNonNull(surfaceLoader, "surfaceLoader");
         this.navigator = Objects.requireNonNull(navigator, "navigator");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
     }
 
     public void refresh() {
+        executionLane.execute(this::refreshOnLane);
+    }
+
+    private void refreshOnLane() {
         session.applySurface(surfaceLoader.loadCurrentPosition(session.currentPosition()));
         publishSnapshot();
     }
 
     public void performAction(int selectedActionRowIndex) {
+        executionLane.execute(() -> performActionOnLane(selectedActionRowIndex));
+    }
+
+    private void performActionOnLane(int selectedActionRowIndex) {
         session.applySurface(navigator.move(
                 session.currentPosition(),
                 session.currentSurface(),
@@ -42,6 +63,10 @@ public final class DungeonTravelRuntimeApplicationService {
     }
 
     public void selectMap(long mapId) {
+        executionLane.execute(() -> selectMapOnLane(mapId));
+    }
+
+    private void selectMapOnLane(long mapId) {
         if (mapId > NO_MAP_ID) {
             session.applySurface(surfaceLoader.loadSelectedMap(mapId));
         }
@@ -49,11 +74,19 @@ public final class DungeonTravelRuntimeApplicationService {
     }
 
     public void shiftProjectionLevel(int projectionLevelShift) {
+        executionLane.execute(() -> shiftProjectionLevelOnLane(projectionLevelShift));
+    }
+
+    private void shiftProjectionLevelOnLane(int projectionLevelShift) {
         session.setProjectionLevel(session.projectionLevel() + projectionLevelShift);
         publishSnapshot();
     }
 
     public void setOverlay(DungeonOverlaySettings overlaySettings) {
+        executionLane.execute(() -> setOverlayOnLane(overlaySettings));
+    }
+
+    private void setOverlayOnLane(DungeonOverlaySettings overlaySettings) {
         DungeonOverlaySettings safeOverlay = overlaySettings == null
                 ? DungeonOverlaySettings.defaults()
                 : overlaySettings;

--- a/src/domain/encounter/EncounterApplicationService.java
+++ b/src/domain/encounter/EncounterApplicationService.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Map;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
 import src.domain.encounter.model.generation.EncounterGenerationInputs;
 import src.domain.encounter.model.generation.EncounterCreatureFilters;
 import src.domain.encounter.model.generation.EncounterRequestedDifficulty;
@@ -51,29 +53,37 @@ public final class EncounterApplicationService {
             Map.entry(Integer.valueOf(21), EncounterSessionCommand.Action.MUTATE_HP));
 
     private final CommandActions commands;
+    private final ExecutionLane executionLane;
 
     EncounterApplicationService(
             EncounterSessionRuntimeAccess runtimeAccess,
             EncounterPlanGateway plans,
-            EncounterPublishedState publishedState
+            EncounterPublishedState publishedState,
+            ExecutionLane executionLane
     ) {
-        this(RuntimeCommandActions.create(runtimeAccess, plans, publishedState));
+        this(RuntimeCommandActions.create(runtimeAccess, plans, publishedState), executionLane);
     }
 
     EncounterApplicationService(CommandActions commands) {
+        this(commands, DirectExecutionLane.INSTANCE);
+    }
+
+    EncounterApplicationService(CommandActions commands, ExecutionLane executionLane) {
         this.commands = Objects.requireNonNull(commands, "commands");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.executionLane.execute(commands::initialize);
     }
 
     public void applyState(ApplyEncounterStateCommand command) {
-        commands.applyState(command);
+        executionLane.execute(() -> commands.applyState(command));
     }
 
     public void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command) {
-        commands.updateBuilderInputs(command);
+        executionLane.execute(() -> commands.updateBuilderInputs(command));
     }
 
     public void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command) {
-        commands.refreshPlanBudget(command);
+        executionLane.execute(() -> commands.refreshPlanBudget(command));
     }
 
     private static EncounterSessionCommand toSessionCommand(ApplyEncounterStateCommand command) {
@@ -147,6 +157,9 @@ public final class EncounterApplicationService {
 
     interface CommandActions {
 
+        default void initialize() {
+        }
+
         void applyState(ApplyEncounterStateCommand command);
 
         void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command);
@@ -176,12 +189,11 @@ public final class EncounterApplicationService {
                 EncounterPlanGateway plans,
                 EncounterPublishedState publishedState
         ) {
-            RuntimeCommandActions actions = new RuntimeCommandActions(runtimeAccess, plans, publishedState);
-            actions.initialize();
-            return actions;
+            return new RuntimeCommandActions(runtimeAccess, plans, publishedState);
         }
 
-        private void initialize() {
+        @Override
+        public void initialize() {
             session.apply(EncounterSessionCommand.refresh(), runtimeAccess);
             publishCurrentSession();
             publishSavedPlans();

--- a/src/domain/encounter/EncounterPlanGateway.java
+++ b/src/domain/encounter/EncounterPlanGateway.java
@@ -2,6 +2,8 @@ package src.domain.encounter;
 
 import java.util.List;
 import java.util.Optional;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
 import src.domain.encounter.model.generation.EncounterBudgetSummary;
 import src.domain.encounter.model.generation.helper.EncounterDifficultyMathHelper;
 import src.domain.encounter.model.generation.helper.EncounterDifficultyTargetHelper;
@@ -19,6 +21,8 @@ import src.domain.encounter.model.session.PlanOutcome;
 
 final class EncounterPlanGateway {
 
+    private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("encounter.storage-failure");
+
     private static final long MIN_PLAN_ID = 1L;
     private static final String STORAGE_NOT_REGISTERED_MESSAGE = "Encounter plan storage is not registered.";
     private static final String PLAN_INVALID_MESSAGE = "Encounter plan is invalid.";
@@ -29,10 +33,12 @@ final class EncounterPlanGateway {
 
     private final EncounterPlanRepository plans;
     private final EncounterForeignFacts facts;
+    private final Diagnostics diagnostics;
 
-    EncounterPlanGateway(EncounterPlanRepository plans, EncounterForeignFacts facts) {
+    EncounterPlanGateway(EncounterPlanRepository plans, EncounterForeignFacts facts, Diagnostics diagnostics) {
         this.plans = java.util.Objects.requireNonNull(plans, "plans");
         this.facts = java.util.Objects.requireNonNull(facts, "facts");
+        this.diagnostics = java.util.Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     Optional<BudgetData> loadBudget() {
@@ -65,6 +71,7 @@ final class EncounterPlanGateway {
         } catch (IllegalArgumentException exception) {
             return new PlanOutcome(Optional.empty(), defaultMessage(exception.getMessage(), PLAN_INVALID_MESSAGE));
         } catch (IllegalStateException exception) {
+            reportStorageFailure(exception);
             return new PlanOutcome(Optional.empty(), defaultMessage(exception.getMessage(), PLAN_SAVE_FAILED_MESSAGE));
         }
     }
@@ -78,6 +85,7 @@ final class EncounterPlanGateway {
         } catch (IllegalArgumentException exception) {
             return new PlanOutcome(Optional.empty(), defaultMessage(exception.getMessage(), PLAN_ID_INVALID_MESSAGE));
         } catch (IllegalStateException exception) {
+            reportStorageFailure(exception);
             return new PlanOutcome(Optional.empty(), defaultMessage(exception.getMessage(), PLAN_LOAD_FAILED_MESSAGE));
         }
     }
@@ -91,6 +99,7 @@ final class EncounterPlanGateway {
         try {
             return SavedEncounterPlansLoadResult.success(plans.list());
         } catch (IllegalStateException exception) {
+            reportStorageFailure(exception);
             return SavedEncounterPlansLoadResult.storageError("Encounter plans could not be loaded.");
         }
     }
@@ -99,6 +108,7 @@ final class EncounterPlanGateway {
         try {
             return loadPlanBudget(planId);
         } catch (IllegalStateException exception) {
+            reportStorageFailure(exception);
             return EncounterPlanBudgetLoadResult.storageError(PLAN_BUDGET_LOAD_FAILED);
         }
     }
@@ -172,6 +182,10 @@ final class EncounterPlanGateway {
 
     private static String defaultMessage(String message, String fallback) {
         return message == null || message.isBlank() ? fallback : message;
+    }
+
+    private void reportStorageFailure(IllegalStateException exception) {
+        diagnostics.failure(STORAGE_FAILURE, exception.getClass());
     }
 
     private static String difficultyLabel(int adjustedXp, EncounterDifficultyThresholds thresholds) {

--- a/src/domain/encounter/EncounterPublishedState.java
+++ b/src/domain/encounter/EncounterPublishedState.java
@@ -1,5 +1,6 @@
 package src.domain.encounter;
 
+import platform.ui.UiDispatcher;
 import src.domain.encounter.model.plan.EncounterPlanBudgetLoadResult;
 import src.domain.encounter.model.plan.SavedEncounterPlansLoadResult;
 import src.domain.encounter.model.session.EncounterSession;
@@ -22,25 +23,29 @@ final class EncounterPublishedState {
     private static final String PLAN_STORAGE_NOT_REGISTERED = "Encounter plan storage is not registered.";
     private static final String PLAN_BUDGET_NOT_REGISTERED = "Encounter plan budget service is not registered.";
 
-    private final PublishedState<EncounterStateSnapshot> state =
-            new PublishedState<>(EncounterStateSnapshot.empty(SESSION_NOT_REGISTERED));
-    private final PublishedState<EncounterBuilderInputs> builderInputs =
-            new PublishedState<>(EncounterBuilderInputs.empty());
-    private final PublishedState<EncounterTuningPreviewResult> tuningPreview =
-            new PublishedState<>(EncounterProjection.emptyTuningPreview());
-    private final PublishedState<SavedEncounterPlanListResult> savedPlans =
-            new PublishedState<>(EncounterProjection.emptySavedPlans());
-    private final PublishedState<EncounterPlanBudgetResult> planBudget =
-            new PublishedState<>(EncounterProjection.emptyPlanBudget());
-    private final EncounterStateModel stateModel = new EncounterStateModel(state::current, state::subscribe);
-    private final EncounterBuilderInputsModel builderInputsModel =
-            new EncounterBuilderInputsModel(builderInputs::current, builderInputs::subscribe);
-    private final EncounterTuningPreviewModel tuningPreviewModel =
-            new EncounterTuningPreviewModel(tuningPreview::current, tuningPreview::subscribe);
-    private final SavedEncounterPlanListModel savedPlansModel =
-            new SavedEncounterPlanListModel(savedPlans::current, savedPlans::subscribe);
-    private final EncounterPlanBudgetModel planBudgetModel =
-            new EncounterPlanBudgetModel(planBudget::current, planBudget::subscribe);
+    private final PublishedState<EncounterStateSnapshot> state;
+    private final PublishedState<EncounterBuilderInputs> builderInputs;
+    private final PublishedState<EncounterTuningPreviewResult> tuningPreview;
+    private final PublishedState<SavedEncounterPlanListResult> savedPlans;
+    private final PublishedState<EncounterPlanBudgetResult> planBudget;
+    private final EncounterStateModel stateModel;
+    private final EncounterBuilderInputsModel builderInputsModel;
+    private final EncounterTuningPreviewModel tuningPreviewModel;
+    private final SavedEncounterPlanListModel savedPlansModel;
+    private final EncounterPlanBudgetModel planBudgetModel;
+
+    EncounterPublishedState(UiDispatcher dispatcher) {
+        state = new PublishedState<>(EncounterStateSnapshot.empty(SESSION_NOT_REGISTERED), dispatcher);
+        builderInputs = new PublishedState<>(EncounterBuilderInputs.empty(), dispatcher);
+        tuningPreview = new PublishedState<>(EncounterProjection.emptyTuningPreview(), dispatcher);
+        savedPlans = new PublishedState<>(EncounterProjection.emptySavedPlans(), dispatcher);
+        planBudget = new PublishedState<>(EncounterProjection.emptyPlanBudget(), dispatcher);
+        stateModel = new EncounterStateModel(state::current, state::subscribe);
+        builderInputsModel = new EncounterBuilderInputsModel(builderInputs::current, builderInputs::subscribe);
+        tuningPreviewModel = new EncounterTuningPreviewModel(tuningPreview::current, tuningPreview::subscribe);
+        savedPlansModel = new SavedEncounterPlanListModel(savedPlans::current, savedPlans::subscribe);
+        planBudgetModel = new EncounterPlanBudgetModel(planBudget::current, planBudget::subscribe);
+    }
 
     EncounterStateModel stateModel() {
         return stateModel;

--- a/src/domain/encounter/EncounterServiceAssembly.java
+++ b/src/domain/encounter/EncounterServiceAssembly.java
@@ -1,6 +1,12 @@
 package src.domain.encounter;
 
 import org.jspecify.annotations.Nullable;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.creatures.CreaturesApplicationService;
 import src.domain.creatures.published.CreatureDetailModel;
 import src.domain.creatures.published.CreatureEncounterCandidatesModel;
@@ -31,16 +37,42 @@ public final class EncounterServiceAssembly {
             PartyMutationModel partyMutation,
             EncounterPlanRepository planRepository
     ) {
-        EncounterPublishedState publishedState = new EncounterPublishedState();
+        return create(
+                creatures, creatureDetails, creatureCandidates, encounterTables, tableCandidates,
+                worldPlanner, party, activeParty, activePartyComposition, daySummary, partyMutation,
+                planRepository, DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE, NoopDiagnostics.INSTANCE);
+    }
+
+    public static Component create(
+            CreaturesApplicationService creatures,
+            CreatureDetailModel creatureDetails,
+            CreatureEncounterCandidatesModel creatureCandidates,
+            EncounterTableApplicationService encounterTables,
+            EncounterTableCandidatesModel tableCandidates,
+            @Nullable WorldPlannerSnapshotModel worldPlanner,
+            PartyApplicationService party,
+            ActivePartyModel activeParty,
+            ActivePartyCompositionModel activePartyComposition,
+            AdventuringDaySummaryModel daySummary,
+            PartyMutationModel partyMutation,
+            EncounterPlanRepository planRepository,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        EncounterPublishedState publishedState = new EncounterPublishedState(
+                java.util.Objects.requireNonNull(uiDispatcher, "uiDispatcher"));
         EncounterForeignFacts facts = new EncounterForeignFacts(
                 creatures, creatureDetails, creatureCandidates, encounterTables, tableCandidates,
                 worldPlanner, party, activeParty, activePartyComposition, daySummary, partyMutation);
-        EncounterPlanGateway plans = new EncounterPlanGateway(planRepository, facts);
+        EncounterPlanGateway plans = new EncounterPlanGateway(
+                planRepository, facts, java.util.Objects.requireNonNull(diagnostics, "diagnostics"));
         EncounterSessionRuntimeAccess runtime = new EncounterSessionRuntimeAccess(
                 facts,
                 plans,
                 new EncounterGenerator(facts));
-        EncounterApplicationService application = new EncounterApplicationService(runtime, plans, publishedState);
+        EncounterApplicationService application = new EncounterApplicationService(
+                runtime, plans, publishedState, java.util.Objects.requireNonNull(executionLane, "executionLane"));
         return new Component(
                 application,
                 publishedState.stateModel(),

--- a/src/domain/encountertable/EncounterTableApplicationService.java
+++ b/src/domain/encountertable/EncounterTableApplicationService.java
@@ -2,6 +2,11 @@ package src.domain.encountertable;
 
 import java.util.List;
 import java.util.Objects;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
 import src.domain.encountertable.model.catalog.port.EncounterTableCatalogPort;
 import src.domain.encountertable.published.EncounterTableCandidatesModel;
 import src.domain.encountertable.published.EncounterTableCandidatesResult;
@@ -13,32 +18,65 @@ import src.domain.encountertable.published.RefreshEncounterTableCandidatesComman
 
 public final class EncounterTableApplicationService {
 
+    private static final DiagnosticId CATALOG_FAILURE =
+            new DiagnosticId("encountertable.catalog.storage-failure");
+    private static final DiagnosticId CANDIDATES_FAILURE =
+            new DiagnosticId("encountertable.candidates.storage-failure");
+
     private final EncounterTableCatalogPort catalog;
     private final EncounterTableCatalogModel catalogModel;
     private final EncounterTableCandidatesModel candidatesModel;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
 
     public EncounterTableApplicationService(
             EncounterTableCatalogPort catalog,
             EncounterTableCatalogModel catalogModel,
             EncounterTableCandidatesModel candidatesModel
     ) {
+        this(
+                catalog,
+                catalogModel,
+                candidatesModel,
+                DirectExecutionLane.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public EncounterTableApplicationService(
+            EncounterTableCatalogPort catalog,
+            EncounterTableCatalogModel catalogModel,
+            EncounterTableCandidatesModel candidatesModel,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
+    ) {
         this.catalog = Objects.requireNonNull(catalog, "catalog");
         this.catalogModel = Objects.requireNonNull(catalogModel, "catalogModel");
         this.candidatesModel = Objects.requireNonNull(candidatesModel, "candidatesModel");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public void refreshCatalog(RefreshEncounterTableCatalogCommand command) {
         Objects.requireNonNull(command, "command");
+        executionLane.execute(this::refreshCatalogInLane);
+    }
+
+    private void refreshCatalogInLane() {
         try {
             catalogModel.publish(new EncounterTableCatalogResult(
                     EncounterTableReadStatus.SUCCESS,
                     EncounterTableCatalogProjection.summaries(catalog.loadSummaries())));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(CATALOG_FAILURE, exception.getClass());
             catalogModel.publish(new EncounterTableCatalogResult(EncounterTableReadStatus.STORAGE_ERROR, List.of()));
         }
     }
 
     public void refreshCandidates(RefreshEncounterTableCandidatesCommand command) {
+        executionLane.execute(() -> refreshCandidatesInLane(command));
+    }
+
+    private void refreshCandidatesInLane(RefreshEncounterTableCandidatesCommand command) {
         try {
             if (command == null) {
                 publishStorageError();
@@ -50,6 +88,7 @@ public final class EncounterTableApplicationService {
                             command.tableIds(),
                             normalizedMaximumXp(command.maximumXp())))));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(CANDIDATES_FAILURE, exception.getClass());
             publishStorageError();
         }
     }

--- a/src/domain/encountertable/EncounterTableServiceAssembly.java
+++ b/src/domain/encountertable/EncounterTableServiceAssembly.java
@@ -1,5 +1,13 @@
 package src.domain.encountertable;
 
+import java.util.Objects;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.encountertable.model.catalog.port.EncounterTableCatalogPort;
 import src.domain.encountertable.published.EncounterTableCandidatesModel;
 import src.domain.encountertable.published.EncounterTableCatalogModel;
@@ -9,23 +17,49 @@ import src.domain.encountertable.published.EncounterTableReferenceApi;
 
 public final class EncounterTableServiceAssembly {
 
+    private static final DiagnosticId REFERENCE_FAILURE =
+            new DiagnosticId("encountertable.reference.storage-failure");
+
     private EncounterTableServiceAssembly() {
     }
 
     public static Component create(EncounterTableCatalogPort catalogPort) {
-        EncounterTableCatalogModel catalog = new EncounterTableCatalogModel();
-        EncounterTableCandidatesModel candidates = new EncounterTableCandidatesModel();
+        return create(
+                catalogPort,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public static Component create(
+            EncounterTableCatalogPort catalogPort,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        EncounterTableCatalogPort safeCatalogPort = Objects.requireNonNull(catalogPort, "catalogPort");
+        ExecutionLane safeExecutionLane = Objects.requireNonNull(executionLane, "executionLane");
+        UiDispatcher safeUiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        Diagnostics safeDiagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        EncounterTableCatalogModel catalog = new EncounterTableCatalogModel(safeUiDispatcher);
+        EncounterTableCandidatesModel candidates = new EncounterTableCandidatesModel(safeUiDispatcher);
         EncounterTableReferenceApi references = () -> {
             try {
                 return new EncounterTableCatalogResult(
                         EncounterTableReadStatus.SUCCESS,
-                        EncounterTableCatalogProjection.summaries(catalogPort.loadSummaries()));
+                        EncounterTableCatalogProjection.summaries(safeCatalogPort.loadSummaries()));
             } catch (IllegalStateException exception) {
+                safeDiagnostics.failure(REFERENCE_FAILURE, exception.getClass());
                 return new EncounterTableCatalogResult(EncounterTableReadStatus.STORAGE_ERROR, java.util.List.of());
             }
         };
         return new Component(
-                new EncounterTableApplicationService(catalogPort, catalog, candidates),
+                new EncounterTableApplicationService(
+                        safeCatalogPort,
+                        catalog,
+                        candidates,
+                        safeExecutionLane,
+                        safeDiagnostics),
                 references,
                 catalog,
                 candidates);

--- a/src/domain/encountertable/published/EncounterTableCandidatesModel.java
+++ b/src/domain/encountertable/published/EncounterTableCandidatesModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class EncounterTableCandidatesModel {
@@ -15,6 +16,10 @@ public final class EncounterTableCandidatesModel {
 
     public EncounterTableCandidatesModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public EncounterTableCandidatesModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private EncounterTableCandidatesModel(PublishedState<EncounterTableCandidatesResult> store) {

--- a/src/domain/encountertable/published/EncounterTableCatalogModel.java
+++ b/src/domain/encountertable/published/EncounterTableCatalogModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class EncounterTableCatalogModel {
@@ -15,6 +16,10 @@ public final class EncounterTableCatalogModel {
 
     public EncounterTableCatalogModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public EncounterTableCatalogModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private EncounterTableCatalogModel(PublishedState<EncounterTableCatalogResult> store) {

--- a/src/domain/hex/HexEditorApplicationService.java
+++ b/src/domain/hex/HexEditorApplicationService.java
@@ -3,6 +3,9 @@ package src.domain.hex;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
 import src.domain.hex.model.map.HexCoordinate;
 import src.domain.hex.model.map.HexEditorMode;
 import src.domain.hex.model.map.HexEditorState;
@@ -17,6 +20,7 @@ import src.domain.hex.model.map.HexTerrain;
 import src.domain.hex.model.map.repository.HexMapRepository;
 import src.domain.hex.published.CreateHexMapCommand;
 import src.domain.hex.published.HexEditorModel;
+import src.domain.hex.published.HexEditorModel.ToolIntent;
 import src.domain.hex.published.LoadHexEditorCommand;
 import src.domain.hex.published.PaintHexTerrainCommand;
 import src.domain.hex.published.RenameHexMapCommand;
@@ -28,77 +32,110 @@ import src.domain.hex.published.UpdateHexMapCommand;
 
 public final class HexEditorApplicationService {
 
+    private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("hex.storage-failure");
+    private static final String STORAGE_FAILURE_TEXT = "Hex-Daten konnten nicht geladen oder gespeichert werden.";
+
     private final EditorMutations mutations;
+    private final ExecutionLane executionLane;
 
     HexEditorApplicationService(
             HexMapRepository repository,
             HexEditorWorkspace workspace,
-            HexEditorModel model
+            HexEditorModel model,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
     ) {
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
         mutations = new EditorMutations(
                 Objects.requireNonNull(repository, "repository"),
                 new EditorPublisher(
                         Objects.requireNonNull(repository, "repository"),
                         Objects.requireNonNull(workspace, "workspace"),
-                        Objects.requireNonNull(model, "model")));
+                        Objects.requireNonNull(model, "model")),
+                Objects.requireNonNull(diagnostics, "diagnostics"));
     }
 
     public void createMap(CreateHexMapCommand command) {
-        mutations.createMap(command.displayName(), command.radius());
+        CreateHexMapCommand safeCommand = Objects.requireNonNull(command, "command");
+        executionLane.execute(() -> mutations.createMap(safeCommand.displayName(), safeCommand.radius()));
     }
 
     public void loadEditor(LoadHexEditorCommand command) {
         Objects.requireNonNull(command, "command");
-        mutations.loadEditorState();
+        executionLane.execute(mutations::loadEditorState);
     }
 
     public void selectMap(SelectHexMapCommand command) {
-        mutations.selectMap(command.mapId());
+        SelectHexMapCommand safeCommand = Objects.requireNonNull(command, "command");
+        executionLane.execute(() -> mutations.selectMap(safeCommand.mapId()));
+    }
+
+    public void reloadAndSelectMap(LoadHexEditorCommand loadCommand, SelectHexMapCommand selectCommand) {
+        Objects.requireNonNull(loadCommand, "loadCommand");
+        SelectHexMapCommand safeSelect = Objects.requireNonNull(selectCommand, "selectCommand");
+        executionLane.execute(() -> {
+            mutations.loadEditorState();
+            mutations.selectMap(safeSelect.mapId());
+        });
     }
 
     public void updateMap(UpdateHexMapCommand command) {
-        mutations.updateMap(
-                command.mapId(),
-                command.displayName(),
-                command.radius(),
-                command.confirmDestructiveShrink());
+        UpdateHexMapCommand safeCommand = Objects.requireNonNull(command, "command");
+        executionLane.execute(() -> mutations.updateMap(
+                safeCommand.mapId(),
+                safeCommand.displayName(),
+                safeCommand.radius(),
+                safeCommand.confirmDestructiveShrink()));
     }
 
     public void renameMap(RenameHexMapCommand command) {
-        mutations.renameMap(command.mapId(), command.displayName());
+        RenameHexMapCommand safeCommand = Objects.requireNonNull(command, "command");
+        executionLane.execute(() -> mutations.renameMap(safeCommand.mapId(), safeCommand.displayName()));
     }
 
     public void selectTile(SelectHexTileCommand command) {
-        mutations.selectTile(command.mapId(), command.q(), command.r());
+        SelectHexTileCommand safeCommand = Objects.requireNonNull(command, "command");
+        ToolIntent toolIntent = mutations.currentToolIntent();
+        executionLane.execute(() -> mutations.selectTile(
+                safeCommand.mapId(), safeCommand.q(), safeCommand.r(), toolIntent));
     }
 
     public void paintTerrain(PaintHexTerrainCommand command) {
-        mutations.paintTerrain(command.mapId(), command.q(), command.r(), command.terrain());
+        PaintHexTerrainCommand safeCommand = Objects.requireNonNull(command, "command");
+        ToolIntent toolIntent = mutations.currentToolIntent();
+        executionLane.execute(() -> mutations.paintTerrain(
+                safeCommand.mapId(), safeCommand.q(), safeCommand.r(), safeCommand.terrain(), toolIntent));
     }
 
     public void saveMarker(SaveHexMarkerCommand command) {
-        mutations.saveMarker(
-                command.mapId(),
-                command.markerId(),
-                command.q(),
-                command.r(),
-                command.name(),
-                command.type(),
-                command.note());
+        SaveHexMarkerCommand safeCommand = Objects.requireNonNull(command, "command");
+        ToolIntent toolIntent = mutations.currentToolIntent();
+        executionLane.execute(() -> mutations.saveMarker(
+                safeCommand.mapId(),
+                safeCommand.markerId(),
+                safeCommand.q(),
+                safeCommand.r(),
+                safeCommand.name(),
+                safeCommand.type(),
+                safeCommand.note(),
+                toolIntent));
     }
 
     public void setActiveTool(SetHexEditorToolCommand command) {
-        mutations.setActiveTool(command.tool(), command.terrain());
+        SetHexEditorToolCommand safeCommand = Objects.requireNonNull(command, "command");
+        mutations.setActiveTool(safeCommand.tool(), safeCommand.terrain());
     }
 
     private static final class EditorMutations {
 
         private final HexMapRepository repository;
         private final EditorPublisher publisher;
+        private final Diagnostics diagnostics;
 
-        EditorMutations(HexMapRepository repository, EditorPublisher publisher) {
+        EditorMutations(HexMapRepository repository, EditorPublisher publisher, Diagnostics diagnostics) {
             this.repository = repository;
             this.publisher = publisher;
+            this.diagnostics = diagnostics;
         }
 
         void createMap(String displayName, int radius) {
@@ -107,16 +144,20 @@ public final class HexEditorApplicationService {
                 HexMap savedMap = repository.save(HexMap.create(mapId, displayName, radius));
                 repository.setSelectedMap(savedMap.mapId());
                 publisher.publishLoaded(Optional.of(savedMap), Optional.empty(), "Hex map created.", "", "");
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
         void loadEditorState() {
             try {
                 publisher.publishLoaded(repository.loadSelected(), publisher.currentState().selectedTile(), "", "", "");
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
                 publisher.publish(publisher.currentState().withFailure(exception.getMessage()));
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
@@ -130,8 +171,10 @@ public final class HexEditorApplicationService {
                 }
                 repository.setSelectedMap(mapId);
                 publisher.publishLoaded(selectedMap, Optional.empty(), "Hex map selected.", "", "");
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
@@ -144,8 +187,10 @@ public final class HexEditorApplicationService {
                     return;
                 }
                 updateLoadedMap(loaded.get(), displayName, radius, confirmDestructiveShrink);
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
@@ -164,12 +209,14 @@ public final class HexEditorApplicationService {
                         "Hex map renamed.",
                         "",
                         "");
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
-        void selectTile(long mapIdValue, int q, int r) {
+        void selectTile(long mapIdValue, int q, int r, ToolIntent submittedToolIntent) {
             try {
                 HexMapIdentity mapId = new HexMapIdentity(mapIdValue);
                 HexCoordinate coordinate = new HexCoordinate(q, r);
@@ -180,18 +227,15 @@ public final class HexEditorApplicationService {
                 }
                 HexMap map = loaded.get();
                 map.requireInside(coordinate);
-                publisher.publishLoadedWithActiveTool(
-                        Optional.of(map),
-                        Optional.of(coordinate),
-                        "Hex tile selected.",
-                        HexEditorMode.defaultMode(),
-                        publisher.currentState().activeTerrain());
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+                publishSelectedTile(map, coordinate, submittedToolIntent);
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
-        void paintTerrain(long mapIdValue, int q, int r, String terrainName) {
+        void paintTerrain(long mapIdValue, int q, int r, String terrainName, ToolIntent submittedToolIntent) {
             try {
                 HexMapIdentity mapId = new HexMapIdentity(mapIdValue);
                 HexCoordinate coordinate = new HexCoordinate(q, r);
@@ -203,18 +247,30 @@ public final class HexEditorApplicationService {
                 }
                 HexMap paintedMap = loaded.get().paintTerrain(coordinate, terrain);
                 HexMap savedMap = repository.saveTerrain(paintedMap.mapId(), coordinate, terrain);
-                publisher.publishLoadedWithActiveTool(
+                publisher.publishLoadedCompletion(
                         Optional.of(savedMap),
                         Optional.of(coordinate),
                         "Hex terrain painted.",
                         HexEditorMode.PAINT_TERRAIN,
-                        terrain);
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+                        terrain,
+                        submittedToolIntent.revision());
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
-        void saveMarker(long mapIdValue, long markerIdValue, int q, int r, String name, String typeName, String note) {
+        void saveMarker(
+                long mapIdValue,
+                long markerIdValue,
+                int q,
+                int r,
+                String name,
+                String typeName,
+                String note,
+                ToolIntent submittedToolIntent
+        ) {
             try {
                 HexMapIdentity mapId = new HexMapIdentity(mapIdValue);
                 HexCoordinate coordinate = new HexCoordinate(q, r);
@@ -224,17 +280,51 @@ public final class HexEditorApplicationService {
                     publisher.publishMissingMap();
                     return;
                 }
-                MarkerPersistence.save(repository, publisher, mapId, markerIdValue, coordinate, name, type, note, loaded.get());
-            } catch (IllegalArgumentException | IllegalStateException exception) {
+                MarkerPersistence.save(
+                        repository,
+                        publisher,
+                        mapId,
+                        markerIdValue,
+                        coordinate,
+                        name,
+                        type,
+                        note,
+                        loaded.get(),
+                        submittedToolIntent);
+            } catch (IllegalArgumentException exception) {
                 publisher.publishFailure(exception.getMessage());
+            } catch (IllegalStateException exception) {
+                publishStorageFailure(exception);
             }
         }
 
+        ToolIntent currentToolIntent() {
+            return publisher.currentToolIntent();
+        }
+
         void setActiveTool(String modeName, String terrainName) {
-            HexEditorState loaded = publisher.currentState();
-            publisher.publish(loaded.withActiveTool(
+            publisher.publishImmediateToolIntent(
                     EditorKeys.mode(modeName),
-                    EditorKeys.terrain(terrainName)).withStatus("Hex editor tool selected."));
+                    EditorKeys.terrain(terrainName));
+        }
+
+        private void publishSelectedTile(
+                HexMap map,
+                HexCoordinate coordinate,
+                ToolIntent submittedToolIntent
+        ) {
+            publisher.publishLoadedCompletion(
+                    Optional.of(map),
+                    Optional.of(coordinate),
+                    "Hex tile selected.",
+                    HexEditorMode.defaultMode(),
+                    EditorKeys.terrain(submittedToolIntent.activeTerrain()),
+                    submittedToolIntent.revision());
+        }
+
+        private void publishStorageFailure(IllegalStateException exception) {
+            diagnostics.failure(STORAGE_FAILURE, exception.getClass());
+            publisher.publishFailure(STORAGE_FAILURE_TEXT);
         }
 
         private void updateLoadedMap(
@@ -271,7 +361,8 @@ public final class HexEditorApplicationService {
                 String name,
                 HexMarkerKind type,
                 String note,
-                HexMap map
+                HexMap map,
+                ToolIntent submittedToolIntent
         ) {
             HexMarkerIdentity resolvedMarkerId = markerIdValue <= 0L
                     ? new HexMarkerIdentity(repository.nextMarkerId(mapId))
@@ -279,12 +370,13 @@ public final class HexEditorApplicationService {
             HexMarker marker = new HexMarker(resolvedMarkerId, coordinate, name, type, note);
             HexMap markerMap = map.saveMarker(resolvedMarkerId, coordinate, name, type, note);
             HexMap savedMap = repository.saveMarker(markerMap.mapId(), marker);
-            publisher.publishLoadedWithActiveTool(
+            publisher.publishLoadedCompletion(
                     Optional.of(savedMap),
                     Optional.of(coordinate),
                     "Hex marker saved.",
                     HexEditorMode.PLACE_MARKER,
-                    publisher.currentState().activeTerrain());
+                    EditorKeys.terrain(submittedToolIntent.activeTerrain()),
+                    submittedToolIntent.revision());
         }
     }
 
@@ -326,12 +418,13 @@ public final class HexEditorApplicationService {
             return publish(nextState);
         }
 
-        HexEditorState publishLoadedWithActiveTool(
+        HexEditorState publishLoadedCompletion(
                 Optional<HexMap> selectedMap,
                 Optional<HexCoordinate> selectedTile,
                 String statusText,
                 HexEditorMode activeMode,
-                HexTerrain activeTerrain
+                HexTerrain activeTerrain,
+                long submittedToolRevision
         ) {
             HexEditorState previous = workspace.state();
             Optional<HexMap> safeSelectedMap = selectedMap == null ? Optional.empty() : selectedMap;
@@ -345,7 +438,7 @@ public final class HexEditorApplicationService {
                     statusText,
                     "",
                     "");
-            return publish(nextState);
+            return publishCompletion(nextState, submittedToolRevision);
         }
 
         HexEditorState publishFailure(String failureText) {
@@ -360,6 +453,20 @@ public final class HexEditorApplicationService {
             HexEditorState nextState = workspace.replace(state);
             model.publish(HexEditorSnapshotProjection.project(nextState));
             return nextState;
+        }
+
+        private HexEditorState publishCompletion(HexEditorState state, long submittedToolRevision) {
+            HexEditorState nextState = workspace.replace(state);
+            model.publishCompletion(HexEditorSnapshotProjection.project(nextState), submittedToolRevision);
+            return nextState;
+        }
+
+        ToolIntent currentToolIntent() {
+            return model.currentToolIntent();
+        }
+
+        void publishImmediateToolIntent(HexEditorMode activeMode, HexTerrain activeTerrain) {
+            model.publishImmediateToolIntent(activeMode.name(), activeTerrain.name());
         }
 
         HexEditorState currentState() {

--- a/src/domain/hex/HexServiceAssembly.java
+++ b/src/domain/hex/HexServiceAssembly.java
@@ -1,6 +1,12 @@
 package src.domain.hex;
 
 import java.util.Objects;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.hex.model.map.HexEditorWorkspace;
 import src.domain.hex.model.map.repository.HexMapRepository;
 import src.domain.hex.published.HexEditorModel;
@@ -12,23 +18,49 @@ public final class HexServiceAssembly {
 
     private final HexEditorApplicationService editorApplicationService;
     private final HexTravelApplicationService travelApplicationService;
-    private final HexEditorModel editorModel = new HexEditorModel();
-    private final HexTravelModel travelModel = new HexTravelModel();
+    private final HexEditorModel editorModel;
+    private final HexTravelModel travelModel;
 
     public HexServiceAssembly(
             HexMapRepository repository,
             PartyTravelPositionsModel partyTravelPositions,
             PartyApplicationService partyApplicationService
     ) {
+        this(
+                repository,
+                partyTravelPositions,
+                partyApplicationService,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public HexServiceAssembly(
+            HexMapRepository repository,
+            PartyTravelPositionsModel partyTravelPositions,
+            PartyApplicationService partyApplicationService,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
         HexMapRepository safeRepository = Objects.requireNonNull(repository, "repository");
+        ExecutionLane lane = Objects.requireNonNull(executionLane, "executionLane");
+        UiDispatcher dispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        Diagnostics safeDiagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        editorModel = new HexEditorModel(dispatcher);
+        travelModel = new HexTravelModel(dispatcher);
         editorApplicationService = new HexEditorApplicationService(
                 safeRepository,
                 new HexEditorWorkspace(),
-                editorModel);
+                editorModel,
+                lane,
+                safeDiagnostics);
         travelApplicationService = new HexTravelApplicationService(
                 safeRepository,
                 Objects.requireNonNull(partyApplicationService, "partyApplicationService"),
-                travelModel);
+                travelModel,
+                lane,
+                safeDiagnostics);
         registerTravelReadback(Objects.requireNonNull(partyTravelPositions, "partyTravelPositions"));
     }
 

--- a/src/domain/hex/HexTravelApplicationService.java
+++ b/src/domain/hex/HexTravelApplicationService.java
@@ -3,6 +3,9 @@ package src.domain.hex;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
 import src.domain.hex.model.map.HexCoordinate;
 import src.domain.hex.model.map.HexMapIdentity;
 import src.domain.hex.model.map.HexMapSummary;
@@ -21,49 +24,71 @@ public final class HexTravelApplicationService {
 
     private static final long FIRST_PERSISTED_MAP_ID = 1L;
     private static final String NO_HEX_TRAVEL_SELECTED = "Keine Hex-Reiseposition ausgewaehlt.";
+    private static final String STORAGE_FAILURE_TEXT = "Hex-Reise konnte nicht geladen werden.";
+    private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("hex.storage-failure");
 
     private final HexMapRepository repository;
     private final PartyApplicationService party;
     private final HexTravelModel model;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
 
     HexTravelApplicationService(
             HexMapRepository repository,
             PartyApplicationService party,
-            HexTravelModel model
+            HexTravelModel model,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.party = Objects.requireNonNull(party, "party");
         this.model = Objects.requireNonNull(model, "model");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public void movePartyToken(MoveHexPartyTokenCommand command) {
         if (command == null) {
             return;
         }
-        movePartyToken(
+        executionLane.execute(() -> movePartyToken(
                 command.mapId(),
                 command.q(),
                 command.r(),
-                command.partyTokenCharacterIds());
+                command.partyTokenCharacterIds()));
     }
 
     void acceptPartyTravelPosition(PartyTravelPositionsResult result) {
-        model.publish(toSnapshot(projectTravel(result)));
+        executionLane.execute(() -> publishTravelPosition(result));
+    }
+
+    private void publishTravelPosition(PartyTravelPositionsResult result) {
+        try {
+            model.publish(toSnapshot(projectTravel(result)));
+        } catch (IllegalStateException exception) {
+            diagnostics.failure(STORAGE_FAILURE, exception.getClass());
+            model.publish(HexTravelSnapshot.empty(STORAGE_FAILURE_TEXT));
+        }
     }
 
     private void movePartyToken(long mapId, int q, int r, List<Long> characterIds) {
-        if (mapId < FIRST_PERSISTED_MAP_ID || characterIds == null || characterIds.isEmpty()) {
-            return;
+        try {
+            if (mapId < FIRST_PERSISTED_MAP_ID || characterIds == null || characterIds.isEmpty()) {
+                return;
+            }
+            HexCoordinate coordinate = new HexCoordinate(q, r);
+            Optional<HexMapSummary> summary = repository.loadSummaryById(new HexMapIdentity(mapId));
+            if (summary.isEmpty() || !coordinate.insideRadius(summary.get().radius())) {
+                return;
+            }
+            party.moveCharacters(new MovePartyCharactersCommand(
+                    characterIds,
+                    new PartyOverworldTravelLocationSnapshot(mapId, coordinate.stableTileId()),
+                    true));
+        } catch (IllegalStateException exception) {
+            diagnostics.failure(STORAGE_FAILURE, exception.getClass());
+            model.publish(HexTravelSnapshot.empty(STORAGE_FAILURE_TEXT));
         }
-        HexCoordinate coordinate = new HexCoordinate(q, r);
-        Optional<HexMapSummary> summary = repository.loadSummaryById(new HexMapIdentity(mapId));
-        if (summary.isEmpty() || !coordinate.insideRadius(summary.get().radius())) {
-            return;
-        }
-        party.moveCharacters(new MovePartyCharactersCommand(
-                characterIds,
-                new PartyOverworldTravelLocationSnapshot(mapId, coordinate.stableTileId()),
-                true));
     }
 
     private HexTravelPositionState projectTravel(PartyTravelPositionsResult result) {

--- a/src/domain/hex/model/map/HexEditorWorkspace.java
+++ b/src/domain/hex/model/map/HexEditorWorkspace.java
@@ -1,20 +1,18 @@
 package src.domain.hex.model.map;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 
 public final class HexEditorWorkspace {
 
-    private final AtomicReference<HexEditorState> currentState =
-            new AtomicReference<>(HexEditorState.empty("No Hex map loaded."));
+    private HexEditorState currentState = HexEditorState.empty("No Hex map loaded.");
 
     public HexEditorState state() {
-        return currentState.get();
+        return currentState;
     }
 
     public HexEditorState replace(HexEditorState state) {
         HexEditorState nextState = Objects.requireNonNull(state, "state");
-        currentState.set(nextState);
+        currentState = nextState;
         return nextState;
     }
 }

--- a/src/domain/hex/published/HexEditorModel.java
+++ b/src/domain/hex/published/HexEditorModel.java
@@ -6,17 +6,29 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
+import src.domain.shared.published.PublishedState;
 
 public final class HexEditorModel {
 
     private final Supplier<HexEditorSnapshot> currentSupplier;
     private final Function<Consumer<HexEditorSnapshot>, Runnable> subscribeAction;
     private final List<Consumer<HexEditorSnapshot>> listeners = new ArrayList<>();
-    private HexEditorSnapshot current = HexEditorSnapshot.empty("No Hex map loaded.");
+    private HexEditorSnapshot current = emptySnapshot();
+    private PublishedState<HexEditorSnapshot> statefulStore;
+    private ToolIntent toolIntent = new ToolIntent(0L, "SELECT", "GRASSLAND");
 
     public HexEditorModel() {
-        currentSupplier = this::localCurrent;
-        subscribeAction = this::localSubscribe;
+        this(new PublishedState<>(emptySnapshot()));
+    }
+
+    public HexEditorModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptySnapshot(), dispatcher));
+    }
+
+    private HexEditorModel(PublishedState<HexEditorSnapshot> store) {
+        this(store::current, store::subscribe);
+        statefulStore = store;
     }
 
     public HexEditorModel(
@@ -39,8 +51,44 @@ public final class HexEditorModel {
         return subscribeAction.apply(Objects.requireNonNull(listener, "listener"));
     }
 
-    public void publish(HexEditorSnapshot snapshot) {
-        current = snapshot == null ? HexEditorSnapshot.empty("Hex editor service is not registered.") : snapshot;
+    public synchronized ToolIntent currentToolIntent() {
+        return toolIntent;
+    }
+
+    public synchronized void publishImmediateToolIntent(String activeTool, String activeTerrain) {
+        HexEditorSnapshot base = safeSnapshot(current());
+        toolIntent = new ToolIntent(toolIntent.revision() + 1L, activeTool, activeTerrain);
+        publishDirect(withToolIntent(
+                base,
+                toolIntent,
+                "Hex editor tool selected.",
+                "",
+                ""));
+    }
+
+    public synchronized void publish(HexEditorSnapshot snapshot) {
+        publishDirect(withToolIntent(safeSnapshot(snapshot), toolIntent));
+    }
+
+    public synchronized void publishCompletion(HexEditorSnapshot snapshot, long submittedToolRevision) {
+        HexEditorSnapshot safeSnapshot = safeSnapshot(snapshot);
+        if (toolIntent.revision() == submittedToolRevision) {
+            toolIntent = new ToolIntent(
+                    toolIntent.revision(),
+                    safeSnapshot.activeTool(),
+                    safeSnapshot.activeTerrain());
+            publishDirect(safeSnapshot);
+            return;
+        }
+        publishDirect(withToolIntent(safeSnapshot, toolIntent));
+    }
+
+    private void publishDirect(HexEditorSnapshot snapshot) {
+        if (statefulStore != null) {
+            statefulStore.publish(snapshot);
+            return;
+        }
+        current = snapshot;
         for (Consumer<HexEditorSnapshot> listener : List.copyOf(listeners)) {
             listener.accept(current);
         }
@@ -55,5 +103,62 @@ public final class HexEditorModel {
         listeners.add(safeListener);
         safeListener.accept(current);
         return () -> listeners.remove(safeListener);
+    }
+
+    private static HexEditorSnapshot emptySnapshot() {
+        return HexEditorSnapshot.empty("No Hex map loaded.");
+    }
+
+    private static HexEditorSnapshot safeSnapshot(HexEditorSnapshot snapshot) {
+        return snapshot == null ? emptySnapshot() : snapshot;
+    }
+
+    private static HexEditorSnapshot withToolIntent(HexEditorSnapshot snapshot, ToolIntent intent) {
+        return withToolIntent(
+                snapshot,
+                intent,
+                snapshot.statusText(),
+                snapshot.failureText(),
+                snapshot.warningText());
+    }
+
+    private static HexEditorSnapshot withToolIntent(
+            HexEditorSnapshot snapshot,
+            ToolIntent intent,
+            String statusText,
+            String failureText,
+            String warningText
+    ) {
+        return new HexEditorSnapshot(
+                snapshot.catalog(),
+                snapshot.selectedMap(),
+                snapshot.tiles(),
+                snapshot.selectedTile(),
+                intent.activeTool(),
+                intent.activeTerrain(),
+                statusText,
+                failureText,
+                warningText);
+    }
+
+    public record ToolIntent(long revision, String activeTool, String activeTerrain) {
+
+        public ToolIntent {
+            if (revision < 0L) {
+                throw new IllegalArgumentException("tool intent revision must not be negative");
+            }
+            HexEditorSnapshot normalized = new HexEditorSnapshot(
+                    List.of(),
+                    java.util.Optional.empty(),
+                    List.of(),
+                    java.util.Optional.empty(),
+                    activeTool,
+                    activeTerrain,
+                    "",
+                    "",
+                    "");
+            activeTool = normalized.activeTool();
+            activeTerrain = normalized.activeTerrain();
+        }
     }
 }

--- a/src/domain/hex/published/HexTravelModel.java
+++ b/src/domain/hex/published/HexTravelModel.java
@@ -6,17 +6,28 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
+import src.domain.shared.published.PublishedState;
 
 public final class HexTravelModel {
 
     private final Supplier<HexTravelSnapshot> currentSupplier;
     private final Function<Consumer<HexTravelSnapshot>, Runnable> subscribeAction;
     private final List<Consumer<HexTravelSnapshot>> listeners = new ArrayList<>();
-    private HexTravelSnapshot current = HexTravelSnapshot.empty("Keine Hex-Reiseposition ausgewaehlt.");
+    private HexTravelSnapshot current = emptySnapshot();
+    private PublishedState<HexTravelSnapshot> statefulStore;
 
     public HexTravelModel() {
-        currentSupplier = this::localCurrent;
-        subscribeAction = this::localSubscribe;
+        this(new PublishedState<>(emptySnapshot()));
+    }
+
+    public HexTravelModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptySnapshot(), dispatcher));
+    }
+
+    private HexTravelModel(PublishedState<HexTravelSnapshot> store) {
+        this(store::current, store::subscribe);
+        statefulStore = store;
     }
 
     public HexTravelModel(
@@ -38,6 +49,10 @@ public final class HexTravelModel {
     }
 
     public void publish(HexTravelSnapshot snapshot) {
+        if (statefulStore != null) {
+            statefulStore.publish(snapshot == null ? emptySnapshot() : snapshot);
+            return;
+        }
         current = snapshot == null
                 ? HexTravelSnapshot.empty("Keine Hex-Reiseposition ausgewaehlt.")
                 : snapshot;
@@ -55,5 +70,9 @@ public final class HexTravelModel {
         listeners.add(safeListener);
         safeListener.accept(current);
         return () -> listeners.remove(safeListener);
+    }
+
+    private static HexTravelSnapshot emptySnapshot() {
+        return HexTravelSnapshot.empty("Keine Hex-Reiseposition ausgewaehlt.");
     }
 }

--- a/src/domain/party/PartyApplicationService.java
+++ b/src/domain/party/PartyApplicationService.java
@@ -5,6 +5,9 @@ import static src.domain.party.published.PartyDungeonTravelLocationKind.TRANSITI
 import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
 import src.domain.party.model.roster.PartyCharacterDraft;
 import src.domain.party.model.roster.PartyDungeonTravelLocationKind;
 import src.domain.party.model.roster.PartyMembership;
@@ -16,11 +19,8 @@ import src.domain.party.model.roster.PartyTravelLocation;
 import src.domain.party.model.roster.helper.AdventuringDayProgressCalculationHelper;
 import src.domain.party.model.roster.repository.PartyRosterRepository;
 import src.domain.party.published.ActivePartyCompositionModel;
-import src.domain.party.published.ActivePartyCompositionResult;
 import src.domain.party.published.ActivePartyModel;
-import src.domain.party.published.ActivePartyResult;
 import src.domain.party.published.AdjustPartyXpCommand;
-import src.domain.party.published.AdventuringDayResult;
 import src.domain.party.published.AdventuringDayCalculationModel;
 import src.domain.party.published.AdventuringDaySummaryModel;
 import src.domain.party.published.AwardPartyXpCommand;
@@ -33,10 +33,8 @@ import src.domain.party.published.PartyDungeonTravelLocationSnapshot;
 import src.domain.party.published.PartyMutationModel;
 import src.domain.party.published.PartyOverworldTravelLocationSnapshot;
 import src.domain.party.published.PartySnapshotModel;
-import src.domain.party.published.PartySnapshotResult;
 import src.domain.party.published.PartyTravelLocationSnapshot;
 import src.domain.party.published.PartyTravelPositionsModel;
-import src.domain.party.published.PartyTravelPositionsResult;
 import src.domain.party.published.PartyTravelTile;
 import src.domain.party.published.PerformPartyRestCommand;
 import src.domain.party.published.RestType;
@@ -48,6 +46,8 @@ import src.domain.party.published.UpdateCharacterCommand;
  */
 public final class PartyApplicationService {
 
+    private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("party.storage-failure");
+
     private final PartyRosterRepository repository;
     private final PartySnapshotModel partySnapshotModel;
     private final ActivePartyModel activePartyModel;
@@ -56,6 +56,8 @@ public final class PartyApplicationService {
     private final PartyTravelPositionsModel partyTravelPositionsModel;
     private final PartyMutationModel partyMutationModel;
     private final AdventuringDayCalculationModel adventuringDayCalculationModel;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
     private final AdventuringDayProgressCalculationHelper adventuringDayProgress =
             new AdventuringDayProgressCalculationHelper();
 
@@ -67,7 +69,9 @@ public final class PartyApplicationService {
             AdventuringDaySummaryModel adventuringDaySummaryModel,
             PartyTravelPositionsModel partyTravelPositionsModel,
             PartyMutationModel partyMutationModel,
-            AdventuringDayCalculationModel adventuringDayCalculationModel
+            AdventuringDayCalculationModel adventuringDayCalculationModel,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.partySnapshotModel = Objects.requireNonNull(partySnapshotModel, "partySnapshotModel");
@@ -80,69 +84,76 @@ public final class PartyApplicationService {
         this.partyMutationModel = Objects.requireNonNull(partyMutationModel, "partyMutationModel");
         this.adventuringDayCalculationModel =
                 Objects.requireNonNull(adventuringDayCalculationModel, "adventuringDayCalculationModel");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     void refreshPublishedState() {
-        replaceRepositoryBackedState();
+        executionLane.execute(this::publishRepositoryBackedStateFromRepository);
     }
 
     public void createCharacter(CreateCharacterCommand command) {
-        runRosterMutation(roster -> roster.createCharacter(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.createCharacter(
                 new PartyCharacterDraft(
                         command == null ? null : command.createDraftName(),
                         command == null ? null : command.createDraftPlayerName(),
                         command == null ? 0 : command.createDraftLevel(),
                         command == null ? 0 : command.createDraftPassivePerception(),
                         command == null ? 0 : command.createDraftArmorClass()),
-                command == null ? PartyMembership.RESERVE : membership(command.membership())));
+                command == null ? PartyMembership.RESERVE : membership(command.membership()))));
     }
 
     public void updateCharacter(UpdateCharacterCommand command) {
-        runRosterMutation(roster -> roster.updateCharacter(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.updateCharacter(
                 command == null ? 0L : command.id(),
                 new PartyCharacterDraft(
                         command == null ? null : command.updateDraftName(),
                         command == null ? null : command.updateDraftPlayerName(),
                         command == null ? 0 : command.updateDraftLevel(),
                         command == null ? 0 : command.updateDraftPassivePerception(),
-                        command == null ? 0 : command.updateDraftArmorClass())));
+                        command == null ? 0 : command.updateDraftArmorClass()))));
     }
 
     public void deleteCharacter(DeleteCharacterCommand command) {
-        runRosterMutation(roster -> roster.deleteCharacter(command == null ? 0L : command.id()));
+        executionLane.execute(() -> runRosterMutation(
+                roster -> roster.deleteCharacter(command == null ? 0L : command.id())));
     }
 
     public void setMembership(SetPartyMembershipCommand command) {
-        runRosterMutation(roster -> roster.setMembership(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.setMembership(
                 command == null ? 0L : command.id(),
-                command == null ? PartyMembership.RESERVE : membership(command.membership())));
+                command == null ? PartyMembership.RESERVE : membership(command.membership()))));
     }
 
     public void awardXp(AwardPartyXpCommand command) {
-        runRosterMutation(roster -> roster.adjustXp(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.adjustXp(
                 command == null ? List.of() : command.ids(),
-                command == null ? 0 : Math.max(0, command.xpPerCharacter())));
+                command == null ? 0 : Math.max(0, command.xpPerCharacter()))));
     }
 
     public void adjustXp(AdjustPartyXpCommand command) {
-        runRosterMutation(roster -> roster.adjustXp(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.adjustXp(
                 command == null ? List.of() : command.ids(),
-                command == null ? 0 : command.xpDelta()));
+                command == null ? 0 : command.xpDelta())));
     }
 
     public void performRest(PerformPartyRestCommand command) {
-        runRosterMutation(roster -> roster.performRest(
-                command == null ? PartyRestType.SHORT_REST : restType(command.restType())));
+        executionLane.execute(() -> runRosterMutation(roster -> roster.performRest(
+                command == null ? PartyRestType.SHORT_REST : restType(command.restType()))));
     }
 
     public void moveCharacters(MovePartyCharactersCommand command) {
-        runRosterMutation(roster -> roster.moveCharacters(
+        executionLane.execute(() -> runRosterMutation(roster -> roster.moveCharacters(
                 command == null ? List.of() : command.characterIds(),
                 travelLocation(command == null ? null : command.target()),
-                command == null || command.attachToPartyToken()));
+                command == null || command.attachToPartyToken())));
     }
 
     public void calculateAdventuringDay(CalculateAdventuringDayCommand command) {
+        executionLane.execute(() -> calculateAdventuringDayOnLane(command));
+    }
+
+    private void calculateAdventuringDayOnLane(CalculateAdventuringDayCommand command) {
         try {
             adventuringDayCalculationModel.publish(PartyPublishedProjection.adventuringDayCalculationResult(
                     command == null ? List.of() : command.levels(),
@@ -161,67 +172,33 @@ public final class PartyApplicationService {
             PartyRosterMutation mutation = action.apply(repository.load());
             if (mutation.successful()) {
                 repository.save(mutation.roster());
-                publishRepositoryBackedState();
+                publishRepositoryBackedState(mutation.roster());
             }
             partyMutationModel.publish(PartyPublishedProjection.mutationResult(mutation.status()));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(STORAGE_FAILURE, exception.getClass());
             partyMutationModel.publish(PartyPublishedProjection.storageErrorMutationResult());
         }
     }
 
-    private void publishRepositoryBackedState() {
-        partySnapshotModel.publish(snapshotResult());
-        activePartyModel.publish(activePartyResult());
-        activePartyCompositionModel.publish(activePartyCompositionResult());
-        adventuringDaySummaryModel.publish(adventuringDaySummaryResult());
-        partyTravelPositionsModel.publish(partyTravelPositionsResult());
+    private void publishRepositoryBackedState(PartyRoster roster) {
+        partySnapshotModel.publish(PartyPublishedProjection.snapshotResult(roster));
+        activePartyModel.publish(PartyPublishedProjection.activePartyResult(roster));
+        activePartyCompositionModel.publish(PartyPublishedProjection.activePartyCompositionResult(roster));
+        adventuringDaySummaryModel.publish(PartyPublishedProjection.adventuringDaySummaryResult(roster));
+        partyTravelPositionsModel.publish(PartyPublishedProjection.partyTravelPositionsResult(roster));
     }
 
-    private void replaceRepositoryBackedState() {
-        partySnapshotModel.replace(snapshotResult());
-        activePartyModel.replace(activePartyResult());
-        activePartyCompositionModel.replace(activePartyCompositionResult());
-        adventuringDaySummaryModel.replace(adventuringDaySummaryResult());
-        partyTravelPositionsModel.replace(partyTravelPositionsResult());
-    }
-
-    private PartySnapshotResult snapshotResult() {
+    private void publishRepositoryBackedStateFromRepository() {
         try {
-            return PartyPublishedProjection.snapshotResult(repository.load());
+            publishRepositoryBackedState(repository.load());
         } catch (IllegalStateException exception) {
-            return PartyPublishedProjection.failedSnapshotResult();
-        }
-    }
-
-    private ActivePartyResult activePartyResult() {
-        try {
-            return PartyPublishedProjection.activePartyResult(repository.load());
-        } catch (IllegalStateException exception) {
-            return PartyPublishedProjection.failedActivePartyResult();
-        }
-    }
-
-    private ActivePartyCompositionResult activePartyCompositionResult() {
-        try {
-            return PartyPublishedProjection.activePartyCompositionResult(repository.load());
-        } catch (IllegalStateException exception) {
-            return PartyPublishedProjection.failedActivePartyCompositionResult();
-        }
-    }
-
-    private AdventuringDayResult adventuringDaySummaryResult() {
-        try {
-            return PartyPublishedProjection.adventuringDaySummaryResult(repository.load());
-        } catch (IllegalStateException exception) {
-            return PartyPublishedProjection.failedAdventuringDaySummaryResult();
-        }
-    }
-
-    private PartyTravelPositionsResult partyTravelPositionsResult() {
-        try {
-            return PartyPublishedProjection.partyTravelPositionsResult(repository.load());
-        } catch (IllegalStateException exception) {
-            return PartyPublishedProjection.failedPartyTravelPositionsResult();
+            diagnostics.failure(STORAGE_FAILURE, exception.getClass());
+            partySnapshotModel.publish(PartyPublishedProjection.failedSnapshotResult());
+            activePartyModel.publish(PartyPublishedProjection.failedActivePartyResult());
+            activePartyCompositionModel.publish(PartyPublishedProjection.failedActivePartyCompositionResult());
+            adventuringDaySummaryModel.publish(PartyPublishedProjection.failedAdventuringDaySummaryResult());
+            partyTravelPositionsModel.publish(PartyPublishedProjection.failedPartyTravelPositionsResult());
         }
     }
 

--- a/src/domain/party/PartyServiceAssembly.java
+++ b/src/domain/party/PartyServiceAssembly.java
@@ -1,6 +1,12 @@
 package src.domain.party;
 
 import java.util.Objects;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.party.model.roster.repository.PartyRosterRepository;
 import src.domain.party.published.ActivePartyCompositionModel;
 import src.domain.party.published.ActivePartyModel;
@@ -16,13 +22,27 @@ public final class PartyServiceAssembly {
     }
 
     public static Component create(PartyRosterRepository repository) {
-        PartySnapshotModel snapshot = new PartySnapshotModel();
-        ActivePartyModel activeParty = new ActivePartyModel();
-        ActivePartyCompositionModel activeComposition = new ActivePartyCompositionModel();
-        AdventuringDaySummaryModel daySummary = new AdventuringDaySummaryModel();
-        PartyTravelPositionsModel travelPositions = new PartyTravelPositionsModel();
-        PartyMutationModel mutation = new PartyMutationModel();
-        AdventuringDayCalculationModel dayCalculation = new AdventuringDayCalculationModel();
+        return create(
+                repository,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public static Component create(
+            PartyRosterRepository repository,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        UiDispatcher dispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        PartySnapshotModel snapshot = new PartySnapshotModel(dispatcher);
+        ActivePartyModel activeParty = new ActivePartyModel(dispatcher);
+        ActivePartyCompositionModel activeComposition = new ActivePartyCompositionModel(dispatcher);
+        AdventuringDaySummaryModel daySummary = new AdventuringDaySummaryModel(dispatcher);
+        PartyTravelPositionsModel travelPositions = new PartyTravelPositionsModel(dispatcher);
+        PartyMutationModel mutation = new PartyMutationModel(dispatcher);
+        AdventuringDayCalculationModel dayCalculation = new AdventuringDayCalculationModel(dispatcher);
         PartyApplicationService application = new PartyApplicationService(
                 Objects.requireNonNull(repository, "repository"),
                 snapshot,
@@ -31,7 +51,9 @@ public final class PartyServiceAssembly {
                 daySummary,
                 travelPositions,
                 mutation,
-                dayCalculation);
+                dayCalculation,
+                Objects.requireNonNull(executionLane, "executionLane"),
+                Objects.requireNonNull(diagnostics, "diagnostics"));
         application.refreshPublishedState();
         return new Component(application, snapshot, activeParty, activeComposition, daySummary,
                 travelPositions, mutation, dayCalculation);

--- a/src/domain/party/published/ActivePartyCompositionModel.java
+++ b/src/domain/party/published/ActivePartyCompositionModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class ActivePartyCompositionModel {
@@ -15,6 +16,10 @@ public final class ActivePartyCompositionModel {
 
     public ActivePartyCompositionModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public ActivePartyCompositionModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private ActivePartyCompositionModel(PublishedState<ActivePartyCompositionResult> store) {

--- a/src/domain/party/published/ActivePartyModel.java
+++ b/src/domain/party/published/ActivePartyModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class ActivePartyModel {
@@ -14,6 +15,10 @@ public final class ActivePartyModel {
 
     public ActivePartyModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public ActivePartyModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private ActivePartyModel(PublishedState<ActivePartyResult> store) {

--- a/src/domain/party/published/AdventuringDayCalculationModel.java
+++ b/src/domain/party/published/AdventuringDayCalculationModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class AdventuringDayCalculationModel {
@@ -14,6 +15,10 @@ public final class AdventuringDayCalculationModel {
 
     public AdventuringDayCalculationModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public AdventuringDayCalculationModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private AdventuringDayCalculationModel(PublishedState<AdventuringDayCalculationResult> store) {

--- a/src/domain/party/published/AdventuringDaySummaryModel.java
+++ b/src/domain/party/published/AdventuringDaySummaryModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class AdventuringDaySummaryModel {
@@ -15,6 +16,10 @@ public final class AdventuringDaySummaryModel {
 
     public AdventuringDaySummaryModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public AdventuringDaySummaryModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private AdventuringDaySummaryModel(PublishedState<AdventuringDayResult> store) {

--- a/src/domain/party/published/PartyMutationModel.java
+++ b/src/domain/party/published/PartyMutationModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class PartyMutationModel {
@@ -14,6 +15,10 @@ public final class PartyMutationModel {
 
     public PartyMutationModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public PartyMutationModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private PartyMutationModel(PublishedState<MutationResult> store) {

--- a/src/domain/party/published/PartySnapshotModel.java
+++ b/src/domain/party/published/PartySnapshotModel.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class PartySnapshotModel {
@@ -15,6 +16,10 @@ public final class PartySnapshotModel {
 
     public PartySnapshotModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public PartySnapshotModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private PartySnapshotModel(PublishedState<PartySnapshotResult> store) {

--- a/src/domain/party/published/PartyTravelPositionsModel.java
+++ b/src/domain/party/published/PartyTravelPositionsModel.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
 import src.domain.shared.published.PublishedState;
 
 public final class PartyTravelPositionsModel {
@@ -14,6 +15,10 @@ public final class PartyTravelPositionsModel {
 
     public PartyTravelPositionsModel() {
         this(new PublishedState<>(emptyResult()));
+    }
+
+    public PartyTravelPositionsModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(emptyResult(), dispatcher));
     }
 
     private PartyTravelPositionsModel(PublishedState<PartyTravelPositionsResult> store) {

--- a/src/domain/sessionplanner/SessionPlannerApplicationService.java
+++ b/src/domain/sessionplanner/SessionPlannerApplicationService.java
@@ -4,6 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.UnaryOperator;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
 import src.domain.sessionplanner.model.session.EncounterDays;
 import src.domain.sessionplanner.model.session.SessionActivePartyMembersFact;
 import src.domain.sessionplanner.model.session.SessionPartyMemberProfile;
@@ -27,59 +33,177 @@ import src.domain.sessionplanner.published.UpdateSessionEncounterSceneCommand;
 
 public final class SessionPlannerApplicationService {
 
+    private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("sessionplanner.storage-failure");
+
     private static final String COMMAND_PARAMETER = "command";
     private static final long INITIAL_SESSION_ID = 1L;
     private static final long NO_SESSION_ID = 0L;
-    private static final String LOAD_FAILURE_STATUS = "Session konnte nicht geladen werden.";
     private static final String SAVE_FAILURE_STATUS = "Session konnte nicht gespeichert werden.";
 
     private final SessionPlanRepository repository;
     private final SessionPlannerForeignFacts facts;
     private final SessionPlannerPublishedState publishedState;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
+    private final AtomicBoolean initializationRequested = new AtomicBoolean();
 
     SessionPlannerApplicationService(
             SessionPlanRepository repository,
             SessionPlannerForeignFacts facts,
-            SessionPlannerPublishedState publishedState
+            SessionPlannerPublishedState publishedState,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.facts = Objects.requireNonNull(facts, "facts");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+    }
+
+    public void initialize() {
+        if (initializationRequested.compareAndSet(false, true)) {
+            executeStorageCommand(publishedState::initialize);
+        }
+    }
+
+    void refreshForeignFacts() {
+        executeStorageCommand(publishedState::publishLoadedCurrentSession);
     }
 
     public void createSession(SessionPlannerCatalogCommand.CreateSessionCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> createSessionOnLane(command));
+    }
+
+    public void selectSession(SessionPlannerCatalogCommand.SelectSessionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> selectSessionOnLane(command));
+    }
+
+    public void renameSession(SessionPlannerCatalogCommand.RenameSessionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> renameSessionOnLane(command));
+    }
+
+    public void deleteSession(SessionPlannerCatalogCommand.DeleteSessionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> deleteSessionOnLane(command));
+    }
+
+    public void addParticipant(SessionPlannerParticipantCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.addParticipant(command.characterId())));
+    }
+
+    public void removeParticipant(SessionPlannerParticipantCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.removeParticipant(command.characterId())));
+    }
+
+    public void setEncounterDays(SetSessionEncounterDaysCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(
+                session -> session.setEncounterDays(new EncounterDays(command.encounterDays()))));
+    }
+
+    public void addScene(AddSessionSceneCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(SessionPlan::addScene));
+    }
+
+    public void attachEncounter(AttachSessionEncounterCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.attachEncounter(command.encounterPlanId())));
+    }
+
+    public void removeEncounter(SessionPlannerEncounterCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.removeEncounter(command.encounterId())));
+    }
+
+    public void moveEncounterUp(SessionPlannerEncounterCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.moveEncounterUp(command.encounterId())));
+    }
+
+    public void moveEncounterDown(SessionPlannerEncounterCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.moveEncounterDown(command.encounterId())));
+    }
+
+    public void selectEncounter(SessionPlannerEncounterCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.selectEncounter(command.encounterId())));
+    }
+
+    public void setEncounterAllocation(SessionPlannerEncounterAllocationCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.setEncounterAllocation(
+                command.encounterId(),
+                command.budgetPercentage())));
+    }
+
+    public void updateEncounterScene(UpdateSessionEncounterSceneCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> updateEncounterSceneOnLane(command));
+    }
+
+    public void setRestGap(SetSessionRestGapCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.setRestPlacement(toRestPlacement(
+                command.leftEncounterId(),
+                command.rightEncounterId(),
+                command.restKind()))));
+    }
+
+    public void clearRestGap(ClearSessionRestGapCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.clearRestPlacement(
+                command.leftEncounterId(),
+                command.rightEncounterId())));
+    }
+
+    public void addLootPlaceholder(AddSessionLootPlaceholderCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.addLootPlaceholder(command.encounterId())));
+    }
+
+    public void removeLootPlaceholder(RemoveSessionLootPlaceholderCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        executeStorageCommand(() -> mutateCurrent(session -> session.removeLootPlaceholder(command.lootId())));
+    }
+
+    private void createSessionOnLane(SessionPlannerCatalogCommand.CreateSessionCommand command) {
+        OptionalLong nextId = nextSessionId();
+        if (nextId.isEmpty()) {
+            return;
+        }
         String requestedName = command.displayName();
-        SessionPlan seeded = seedSession(nextSessionId());
+        SessionPlan seeded = seedSession(nextId.getAsLong());
         if (!requestedName.isBlank()) {
             seeded = seeded.rename(requestedName);
         }
         saveNewCurrent(seeded.withStatus("Neue Session erstellt."));
     }
 
-    public void selectSession(SessionPlannerCatalogCommand.SelectSessionCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
+    private void selectSessionOnLane(SessionPlannerCatalogCommand.SelectSessionCommand command) {
         long sessionId = command.sessionId();
-        if (sessionId <= NO_SESSION_ID) {
-            return;
+        if (sessionId > NO_SESSION_ID) {
+            repository.loadById(sessionId).ifPresent(this::selectLoadedSession);
         }
-        Optional<SessionPlan> loaded = repository.loadById(sessionId);
-        loaded.ifPresent(this::selectLoadedSession);
     }
 
-    public void renameSession(SessionPlannerCatalogCommand.RenameSessionCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
+    private void renameSessionOnLane(SessionPlannerCatalogCommand.RenameSessionCommand command) {
         if (command.sessionId() <= NO_SESSION_ID || command.displayName().isBlank()) {
             return;
         }
         repository.rename(command.sessionId(), command.displayName());
-        Optional<SessionPlan> loaded = repository.loadById(command.sessionId());
-        loaded.ifPresent(session -> publishedState.publishCurrentSession(
+        repository.loadById(command.sessionId()).ifPresent(session -> publishedState.publishCurrentSession(
                 session.clearStatus().withStatus("Session umbenannt.")));
     }
 
-    public void deleteSession(SessionPlannerCatalogCommand.DeleteSessionCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
+    private void deleteSessionOnLane(SessionPlannerCatalogCommand.DeleteSessionCommand command) {
         long sessionId = command.sessionId();
         if (sessionId <= NO_SESSION_ID) {
             return;
@@ -90,99 +214,28 @@ public final class SessionPlannerApplicationService {
             saveNewCurrent(seedSession(repository.nextSessionId()).withStatus("Session geloescht."));
             return;
         }
-        Optional<SessionPlan> fallback = repository.loadById(remaining.get(0).sessionId());
-        fallback.ifPresent(session -> selectFallback(session.clearStatus().withStatus("Session geloescht.")));
+        repository.loadById(remaining.get(0).sessionId())
+                .ifPresent(session -> selectFallback(session.clearStatus().withStatus("Session geloescht.")));
     }
 
-    public void addParticipant(SessionPlannerParticipantCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().addParticipant(command.characterId()));
+    private void updateEncounterSceneOnLane(UpdateSessionEncounterSceneCommand command) {
+        mutateCurrent(session -> {
+            if (command.locationId() > 0L && !facts.locationExists(command.locationId())) {
+                return session.withStatus("Location nicht gefunden.");
+            }
+            return session.updateEncounterScene(
+                    command.encounterId(), command.sceneTitle(), command.sceneNotes(), command.locationId());
+        });
     }
 
-    public void removeParticipant(SessionPlannerParticipantCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().removeParticipant(command.characterId()));
-    }
-
-    public void setEncounterDays(SetSessionEncounterDaysCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().setEncounterDays(new EncounterDays(command.encounterDays())));
-    }
-
-    public void addScene(AddSessionSceneCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().addScene());
-    }
-
-    public void attachEncounter(AttachSessionEncounterCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().attachEncounter(command.encounterPlanId()));
-    }
-
-    public void removeEncounter(SessionPlannerEncounterCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().removeEncounter(command.encounterId()));
-    }
-
-    public void moveEncounterUp(SessionPlannerEncounterCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().moveEncounterUp(command.encounterId()));
-    }
-
-    public void moveEncounterDown(SessionPlannerEncounterCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().moveEncounterDown(command.encounterId()));
-    }
-
-    public void selectEncounter(SessionPlannerEncounterCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().selectEncounter(command.encounterId()));
-    }
-
-    public void setEncounterAllocation(SessionPlannerEncounterAllocationCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().setEncounterAllocation(
-                command.encounterId(),
-                command.budgetPercentage()));
-    }
-
-    public void updateEncounterScene(UpdateSessionEncounterSceneCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        SessionPlan session = loadCurrentSession();
-        if (command.locationId() > 0L && !facts.locationExists(command.locationId())) {
-            saveCurrent(session.withStatus("Location nicht gefunden."));
-            return;
-        }
-        saveCurrent(session.updateEncounterScene(
-                command.encounterId(),
-                command.sceneTitle(),
-                command.sceneNotes(),
-                command.locationId()));
-    }
-
-    public void setRestGap(SetSessionRestGapCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().setRestPlacement(toRestPlacement(
-                command.leftEncounterId(),
-                command.rightEncounterId(),
-                command.restKind())));
-    }
-
-    public void clearRestGap(ClearSessionRestGapCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().clearRestPlacement(
-                command.leftEncounterId(),
-                command.rightEncounterId()));
-    }
-
-    public void addLootPlaceholder(AddSessionLootPlaceholderCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().addLootPlaceholder(command.encounterId()));
-    }
-
-    public void removeLootPlaceholder(RemoveSessionLootPlaceholderCommand command) {
-        Objects.requireNonNull(command, COMMAND_PARAMETER);
-        saveCurrent(loadCurrentSession().removeLootPlaceholder(command.lootId()));
+    private void executeStorageCommand(Runnable command) {
+        executionLane.execute(() -> {
+            try {
+                command.run();
+            } catch (IllegalStateException exception) {
+                reportStorageFailure(exception);
+            }
+        });
     }
 
     private void selectLoadedSession(SessionPlan sessionPlan) {
@@ -195,37 +248,51 @@ public final class SessionPlannerApplicationService {
         publishedState.publishCurrentSession(sessionPlan);
     }
 
-    private SessionPlan loadCurrentSession() {
+    private Optional<SessionPlan> loadCurrentSession() {
         try {
             Optional<SessionPlan> currentSession = repository.loadCurrent();
             if (currentSession.isPresent()) {
-                return currentSession.get().clearStatus();
+                return Optional.of(currentSession.get().clearStatus());
             }
-            return seedSession(INITIAL_SESSION_ID);
+            return Optional.of(seedSession(INITIAL_SESSION_ID));
         } catch (IllegalStateException exception) {
-            return seedSession(INITIAL_SESSION_ID).withStatus(LOAD_FAILURE_STATUS);
+            reportStorageFailure(exception);
+            return Optional.empty();
         }
     }
 
-    private void saveCurrent(SessionPlan sessionPlan) {
-        publishedState.publishCurrentSession(persist(sessionPlan, false));
+    private void mutateCurrent(UnaryOperator<SessionPlan> mutation) {
+        Optional<SessionPlan> loaded = loadCurrentSession();
+        if (loaded.isEmpty()) {
+            return;
+        }
+        SessionPlan stable = loaded.get();
+        saveCurrent(stable, mutation.apply(stable));
+    }
+
+    private void saveCurrent(SessionPlan stableSession, SessionPlan candidate) {
+        SessionPlan saved;
+        try {
+            saved = repository.save(Objects.requireNonNull(candidate, "candidate"));
+        } catch (IllegalStateException exception) {
+            reportStorageFailure(exception);
+            publishedState.publishCurrentSessionWithoutCatalogRefresh(
+                    stableSession.withStatus(SAVE_FAILURE_STATUS));
+            return;
+        }
+        publishedState.publishCurrentSession(saved);
     }
 
     private void saveNewCurrent(SessionPlan sessionPlan) {
-        publishedState.publishCurrentSession(persist(sessionPlan, true));
-    }
-
-    private SessionPlan persist(SessionPlan sessionPlan, boolean persistAsCurrent) {
-        SessionPlan candidate = Objects.requireNonNull(sessionPlan, "sessionPlan");
+        SessionPlan saved;
         try {
-            SessionPlan saved = repository.save(candidate);
-            if (persistAsCurrent) {
-                repository.setCurrentSessionId(saved.sessionId());
-            }
-            return saved;
+            saved = repository.save(Objects.requireNonNull(sessionPlan, "sessionPlan"));
+            repository.setCurrentSessionId(saved.sessionId());
         } catch (IllegalStateException exception) {
-            return candidate.clearStatus().withStatus(SAVE_FAILURE_STATUS);
+            reportStorageFailure(exception);
+            return;
         }
+        publishedState.publishCurrentSession(saved);
     }
 
     private SessionPlan seedSession(long sessionId) {
@@ -240,12 +307,17 @@ public final class SessionPlannerApplicationService {
         }
     }
 
-    private long nextSessionId() {
+    private OptionalLong nextSessionId() {
         try {
-            return Math.max(INITIAL_SESSION_ID, repository.nextSessionId());
+            return OptionalLong.of(Math.max(INITIAL_SESSION_ID, repository.nextSessionId()));
         } catch (IllegalStateException exception) {
-            return INITIAL_SESSION_ID;
+            reportStorageFailure(exception);
+            return OptionalLong.empty();
         }
+    }
+
+    private void reportStorageFailure(IllegalStateException exception) {
+        diagnostics.failure(STORAGE_FAILURE, exception.getClass());
     }
 
     private static List<Long> participantRefs(SessionActivePartyMembersFact activeParty) {

--- a/src/domain/sessionplanner/SessionPlannerForeignFacts.java
+++ b/src/domain/sessionplanner/SessionPlannerForeignFacts.java
@@ -36,12 +36,12 @@ final class SessionPlannerForeignFacts {
     private static final long NO_LOCATION_ID = 0L;
 
     private final PartyApplicationService party;
+    private final ActivePartyModel activeParty;
+    private final AdventuringDayCalculationModel adventuringDay;
     private final EncounterApplicationService encounters;
+    private final SavedEncounterPlanListModel savedPlans;
+    private final EncounterPlanBudgetModel planBudget;
     private final @Nullable WorldPlannerSnapshotModel worldPlanner;
-    private SessionActivePartyMembersFact currentActivePartyMembers;
-    private SessionAdventuringDayBudgetFact currentAdventuringDayFact;
-    private SessionEncounterPlanListFact currentEncounterPlans;
-    private EncounterPlanBudgetResult currentPlanBudget;
 
     SessionPlannerForeignFacts(
             PartyApplicationService party,
@@ -53,39 +53,30 @@ final class SessionPlannerForeignFacts {
             @Nullable WorldPlannerSnapshotModel worldPlanner
     ) {
         this.party = Objects.requireNonNull(party, "party");
+        activeParty = Objects.requireNonNull(activePartyModel, "activePartyModel");
+        adventuringDay = Objects.requireNonNull(adventuringDayCalculationModel, "adventuringDayCalculationModel");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
+        savedPlans = Objects.requireNonNull(savedPlansModel, "savedPlansModel");
+        planBudget = Objects.requireNonNull(planBudgetModel, "planBudgetModel");
         this.worldPlanner = worldPlanner;
-        ActivePartyModel activeParty = Objects.requireNonNull(activePartyModel, "activePartyModel");
-        AdventuringDayCalculationModel adventuringDay =
-                Objects.requireNonNull(adventuringDayCalculationModel, "adventuringDayCalculationModel");
-        SavedEncounterPlanListModel savedPlans = Objects.requireNonNull(savedPlansModel, "savedPlansModel");
-        EncounterPlanBudgetModel planBudget = Objects.requireNonNull(planBudgetModel, "planBudgetModel");
-        currentActivePartyMembers = toActivePartyMembersFact(activeParty.current());
-        currentAdventuringDayFact = toAdventuringDayFact(adventuringDay.current());
-        currentEncounterPlans = toEncounterPlanListFact(savedPlans.current());
-        currentPlanBudget = planBudget.current();
-        activeParty.subscribe(result -> currentActivePartyMembers = toActivePartyMembersFact(result));
-        adventuringDay.subscribe(result -> currentAdventuringDayFact = toAdventuringDayFact(result));
-        savedPlans.subscribe(result -> currentEncounterPlans = toEncounterPlanListFact(result));
-        planBudget.subscribe(result -> currentPlanBudget = result);
     }
 
     SessionActivePartyMembersFact activePartyMembers() {
-        return currentActivePartyMembers;
+        return toActivePartyMembersFact(activeParty.current());
     }
 
     SessionAdventuringDayBudgetFact calculateAdventuringDay(List<Integer> levels, int plannedEncounterXp) {
         party.calculateAdventuringDay(new CalculateAdventuringDayCommand(levels, plannedEncounterXp));
-        return currentAdventuringDayFact;
+        return toAdventuringDayFact(adventuringDay.current());
     }
 
     SessionEncounterPlanListFact encounterPlans() {
-        return currentEncounterPlans;
+        return toEncounterPlanListFact(savedPlans.current());
     }
 
     SessionEncounterPlanFact loadEncounterPlan(long encounterPlanId) {
         encounters.refreshPlanBudget(new RefreshEncounterPlanBudgetCommand(encounterPlanId));
-        return encounterPlan(encounterPlanId);
+        return encounterPlan(encounterPlanId, planBudget.current());
     }
 
     List<SessionLocationReference> availableLocations() {
@@ -108,8 +99,10 @@ final class SessionPlannerForeignFacts {
         }
     }
 
-    private SessionEncounterPlanFact encounterPlan(long encounterPlanId) {
-        EncounterPlanBudgetResult result = currentPlanBudget;
+    private static SessionEncounterPlanFact encounterPlan(
+            long encounterPlanId,
+            EncounterPlanBudgetResult result
+    ) {
         if (result == null || result.status() != EncounterPlanBudgetStatus.SUCCESS || result.summary() == null) {
             String message = result == null || result.message().isBlank()
                     ? "Encounter-Plan konnte nicht geladen werden."

--- a/src/domain/sessionplanner/SessionPlannerPublishedState.java
+++ b/src/domain/sessionplanner/SessionPlannerPublishedState.java
@@ -2,6 +2,7 @@ package src.domain.sessionplanner;
 
 import java.util.Objects;
 import java.util.Optional;
+import platform.ui.UiDispatcher;
 import src.domain.sessionplanner.model.session.SessionPlan;
 import src.domain.sessionplanner.model.session.repository.SessionPlanRepository;
 import src.domain.sessionplanner.published.SessionPlannerCatalogModel;
@@ -23,36 +24,39 @@ final class SessionPlannerPublishedState {
     private final SessionPlanRepository repository;
     private final SessionPlannerForeignFacts facts;
     private final SessionPlannerProjection projection;
-    private final PublishedState<SessionPlannerSessionSnapshot> sessions =
-            new PublishedState<>(SessionPlannerSessionSnapshot.empty("Session ist noch nicht geladen."));
-    private final PublishedState<SessionPlannerCatalogSnapshot> catalog =
-            new PublishedState<>(SessionPlannerCatalogSnapshot.empty());
-    private final PublishedState<SessionPlannerParticipantsProjection> participants =
-            new PublishedState<>(SessionPlannerParticipantsProjection.empty());
-    private final PublishedState<SessionPlannerSceneTimelineProjection> sceneTimeline =
-            new PublishedState<>(SessionPlannerSceneTimelineProjection.empty());
-    private final PublishedState<SessionPlannerStatePanelProjection> statePanel =
-            new PublishedState<>(SessionPlannerStatePanelProjection.empty());
-    private final SessionPlannerCurrentSessionModel currentSessionModel =
-            new SessionPlannerCurrentSessionModel(this::currentSession, sessions::subscribe);
-    private final SessionPlannerCatalogModel catalogModel =
-            new SessionPlannerCatalogModel(this::currentCatalog, catalog::subscribe);
-    private final SessionPlannerParticipantsModel participantsModel =
-            new SessionPlannerParticipantsModel(this::currentParticipants, participants::subscribe);
-    private final SessionPlannerSceneTimelineModel sceneTimelineModel =
-            new SessionPlannerSceneTimelineModel(this::currentSceneTimeline, sceneTimeline::subscribe);
-    private final SessionPlannerStatePanelModel statePanelModel =
-            new SessionPlannerStatePanelModel(this::currentStatePanel, statePanel::subscribe);
+    private final PublishedState<SessionPlannerSessionSnapshot> sessions;
+    private final PublishedState<SessionPlannerCatalogSnapshot> catalog;
+    private final PublishedState<SessionPlannerParticipantsProjection> participants;
+    private final PublishedState<SessionPlannerSceneTimelineProjection> sceneTimeline;
+    private final PublishedState<SessionPlannerStatePanelProjection> statePanel;
+    private final SessionPlannerCurrentSessionModel currentSessionModel;
+    private final SessionPlannerCatalogModel catalogModel;
+    private final SessionPlannerParticipantsModel participantsModel;
+    private final SessionPlannerSceneTimelineModel sceneTimelineModel;
+    private final SessionPlannerStatePanelModel statePanelModel;
     private boolean loaded;
 
     SessionPlannerPublishedState(
             SessionPlanRepository repository,
             SessionPlannerForeignFacts facts,
-            SessionPlannerProjection projection
+            SessionPlannerProjection projection,
+            UiDispatcher dispatcher
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.facts = Objects.requireNonNull(facts, "facts");
         this.projection = Objects.requireNonNull(projection, "projection");
+        UiDispatcher uiDispatcher = Objects.requireNonNull(dispatcher, "dispatcher");
+        sessions = new PublishedState<>(
+                SessionPlannerSessionSnapshot.empty("Session ist noch nicht geladen."), uiDispatcher);
+        catalog = new PublishedState<>(SessionPlannerCatalogSnapshot.empty(), uiDispatcher);
+        participants = new PublishedState<>(SessionPlannerParticipantsProjection.empty(), uiDispatcher);
+        sceneTimeline = new PublishedState<>(SessionPlannerSceneTimelineProjection.empty(), uiDispatcher);
+        statePanel = new PublishedState<>(SessionPlannerStatePanelProjection.empty(), uiDispatcher);
+        currentSessionModel = new SessionPlannerCurrentSessionModel(sessions::current, sessions::subscribe);
+        catalogModel = new SessionPlannerCatalogModel(catalog::current, catalog::subscribe);
+        participantsModel = new SessionPlannerParticipantsModel(participants::current, participants::subscribe);
+        sceneTimelineModel = new SessionPlannerSceneTimelineModel(sceneTimeline::current, sceneTimeline::subscribe);
+        statePanelModel = new SessionPlannerStatePanelModel(statePanel::current, statePanel::subscribe);
     }
 
     SessionPlannerCurrentSessionModel currentSessionModel() {
@@ -78,6 +82,14 @@ final class SessionPlannerPublishedState {
     void publishCurrentSession(SessionPlan sessionPlan) {
         SessionPlan safeSession = Objects.requireNonNull(sessionPlan, "sessionPlan");
         publishCatalog(safeSession.sessionId(), safeSession.statusText());
+        publishSessionProjections(safeSession);
+    }
+
+    void publishCurrentSessionWithoutCatalogRefresh(SessionPlan sessionPlan) {
+        publishSessionProjections(Objects.requireNonNull(sessionPlan, "sessionPlan"));
+    }
+
+    private void publishSessionProjections(SessionPlan safeSession) {
         sessions.publish(projection.session(safeSession, facts));
         participants.publish(projection.participants(safeSession, facts));
         sceneTimeline.publish(projection.sceneTimeline(safeSession, facts));
@@ -93,32 +105,7 @@ final class SessionPlannerPublishedState {
         currentSession.ifPresent(this::publishCurrentSession);
     }
 
-    private SessionPlannerSessionSnapshot currentSession() {
-        loadPublishedState();
-        return sessions.current();
-    }
-
-    private SessionPlannerCatalogSnapshot currentCatalog() {
-        loadPublishedState();
-        return catalog.current();
-    }
-
-    private SessionPlannerParticipantsProjection currentParticipants() {
-        loadPublishedState();
-        return participants.current();
-    }
-
-    private SessionPlannerSceneTimelineProjection currentSceneTimeline() {
-        loadPublishedState();
-        return sceneTimeline.current();
-    }
-
-    private SessionPlannerStatePanelProjection currentStatePanel() {
-        loadPublishedState();
-        return statePanel.current();
-    }
-
-    private void loadPublishedState() {
+    void initialize() {
         if (loaded) {
             return;
         }

--- a/src/domain/sessionplanner/SessionPlannerServiceAssembly.java
+++ b/src/domain/sessionplanner/SessionPlannerServiceAssembly.java
@@ -2,6 +2,12 @@ package src.domain.sessionplanner;
 
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.encounter.EncounterApplicationService;
 import src.domain.encounter.published.EncounterPlanBudgetModel;
 import src.domain.encounter.published.SavedEncounterPlanListModel;
@@ -30,15 +36,42 @@ public final class SessionPlannerServiceAssembly {
             EncounterPlanBudgetModel planBudget,
             @Nullable WorldPlannerSnapshotModel worldPlanner
     ) {
+        this(repository, party, activeParty, dayCalculation, encounters, savedPlans, planBudget, worldPlanner,
+                DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE, NoopDiagnostics.INSTANCE);
+    }
+
+    public SessionPlannerServiceAssembly(
+            SessionPlanRepository repository,
+            PartyApplicationService party,
+            ActivePartyModel activeParty,
+            AdventuringDayCalculationModel dayCalculation,
+            EncounterApplicationService encounters,
+            SavedEncounterPlanListModel savedPlans,
+            EncounterPlanBudgetModel planBudget,
+            @Nullable WorldPlannerSnapshotModel worldPlanner,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
         SessionPlanRepository safeRepository = Objects.requireNonNull(repository, "repository");
         SessionPlannerForeignFacts facts = new SessionPlannerForeignFacts(
                 party, activeParty, dayCalculation, encounters, savedPlans, planBudget, worldPlanner);
         SessionPlannerPublishedState publishedState =
-                new SessionPlannerPublishedState(safeRepository, facts, new SessionPlannerProjection());
-        facts.subscribeLocationRefresh(publishedState::publishLoadedCurrentSession);
+                new SessionPlannerPublishedState(
+                        safeRepository,
+                        facts,
+                        new SessionPlannerProjection(),
+                        Objects.requireNonNull(uiDispatcher, "uiDispatcher"));
+        SessionPlannerApplicationService application = new SessionPlannerApplicationService(
+                safeRepository,
+                facts,
+                publishedState,
+                Objects.requireNonNull(executionLane, "executionLane"),
+                Objects.requireNonNull(diagnostics, "diagnostics"));
+        facts.subscribeLocationRefresh(application::refreshForeignFacts);
         runtime = new Runtime(
                 publishedState,
-                new SessionPlannerApplicationService(safeRepository, facts, publishedState));
+                application);
     }
 
     public SessionPlannerApplicationService application() {

--- a/src/domain/shared/published/PublishedState.java
+++ b/src/domain/shared/published/PublishedState.java
@@ -1,48 +1,97 @@
 package src.domain.shared.published;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import platform.state.LatestState;
+import platform.state.UpdateToken;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 
 public final class PublishedState<T> {
 
-    private final Collection<Consumer<T>> listeners;
-    private T current;
+    private final LatestState<T> state;
+    private final UiDispatcher dispatcher;
+    private final boolean retainDuplicateSubscribers;
+    private final Map<Consumer<T>, Runnable> uniqueSubscriptions = new LinkedHashMap<>();
 
     public PublishedState(T initialValue) {
-        this(initialValue, new LinkedHashSet<>());
+        this(initialValue, DirectUiDispatcher.INSTANCE, false);
+    }
+
+    public PublishedState(T initialValue, UiDispatcher dispatcher) {
+        this(initialValue, dispatcher, false);
+    }
+
+    private PublishedState(T initialValue, UiDispatcher dispatcher, boolean retainDuplicateSubscribers) {
+        state = new LatestState<>(Objects.requireNonNull(initialValue, "initialValue"));
+        this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher");
+        this.retainDuplicateSubscribers = retainDuplicateSubscribers;
     }
 
     public static <T> PublishedState<T> retainingDuplicateSubscribers(T initialValue) {
-        return new PublishedState<>(initialValue, new ArrayList<>());
-    }
-
-    private PublishedState(T initialValue, Collection<Consumer<T>> listeners) {
-        this.listeners = Objects.requireNonNull(listeners, "listeners");
-        current = Objects.requireNonNull(initialValue, "initialValue");
+        return new PublishedState<>(initialValue, DirectUiDispatcher.INSTANCE, true);
     }
 
     public T current() {
-        return current;
+        return state.current().value();
+    }
+
+    public long revision() {
+        return state.current().revision();
     }
 
     public Runnable subscribe(Consumer<T> listener) {
         Consumer<T> subscriber = Objects.requireNonNull(listener, "listener");
-        listeners.add(subscriber);
-        return () -> listeners.remove(subscriber);
+        if (retainDuplicateSubscribers) {
+            return subscribeDistinct(subscriber);
+        }
+        synchronized (uniqueSubscriptions) {
+            if (!uniqueSubscriptions.containsKey(subscriber)) {
+                uniqueSubscriptions.put(subscriber, subscribeDistinct(subscriber));
+            }
+        }
+        return () -> unsubscribeUnique(subscriber);
     }
 
-    public void publish(T nextValue) {
-        current = Objects.requireNonNull(nextValue, "nextValue");
-        for (Consumer<T> listener : List.copyOf(listeners)) {
-            listener.accept(current);
+    private Runnable subscribeDistinct(Consumer<T> subscriber) {
+        AtomicBoolean initialReplay = new AtomicBoolean(true);
+        AtomicBoolean active = new AtomicBoolean(true);
+        Runnable unsubscribe = state.subscribe(snapshot -> {
+            if (initialReplay.getAndSet(false)) {
+                return;
+            }
+            dispatcher.dispatch(() -> {
+                if (active.get() && snapshot.revision() == state.current().revision()) {
+                    subscriber.accept(snapshot.value());
+                }
+            });
+        });
+        return () -> {
+            active.set(false);
+            unsubscribe.run();
+        };
+    }
+
+    private void unsubscribeUnique(Consumer<T> subscriber) {
+        Runnable unsubscribe;
+        synchronized (uniqueSubscriptions) {
+            unsubscribe = uniqueSubscriptions.remove(subscriber);
+        }
+        if (unsubscribe != null) {
+            unsubscribe.run();
         }
     }
 
+    public void publish(T nextValue) {
+        UpdateToken token = state.beginUpdate();
+        state.publish(token, Objects.requireNonNull(nextValue, "nextValue"));
+    }
+
     public void replace(T nextValue) {
-        current = Objects.requireNonNull(nextValue, "nextValue");
+        UpdateToken token = state.beginUpdate();
+        state.replace(token, Objects.requireNonNull(nextValue, "nextValue"));
     }
 }

--- a/src/domain/worldplanner/WorldPlannerApplicationService.java
+++ b/src/domain/worldplanner/WorldPlannerApplicationService.java
@@ -4,6 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
 import src.domain.worldplanner.model.world.WorldFaction;
 import src.domain.worldplanner.model.world.WorldFactionInventoryLimit;
 import src.domain.worldplanner.model.world.WorldLocation;
@@ -31,29 +36,51 @@ public final class WorldPlannerApplicationService {
     private static final String LOAD_FAILURE = "World Planner konnte nicht geladen werden.";
     private static final String SAVE_FAILURE = "World Planner konnte nicht gespeichert werden.";
     private static final String REFERENCE_FAILURE = "World Planner Referenzen konnten nicht geladen werden.";
+    private static final DiagnosticId LOAD_DIAGNOSTIC = new DiagnosticId("worldplanner.load.storage-failure");
+    private static final DiagnosticId SAVE_DIAGNOSTIC = new DiagnosticId("worldplanner.save.storage-failure");
+    private static final DiagnosticId REFERENCE_DIAGNOSTIC = new DiagnosticId("worldplanner.reference.failure");
 
     private final WorldPlannerRepository repository;
     private final WorldPlannerReferencePort referenceValidator;
     private final WorldPlannerSnapshotModel snapshotModel;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
 
     WorldPlannerApplicationService(
             WorldPlannerRepository repository,
             WorldPlannerReferencePort referenceValidator,
             WorldPlannerSnapshotModel snapshotModel
     ) {
+        this(
+                repository,
+                referenceValidator,
+                snapshotModel,
+                DirectExecutionLane.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public WorldPlannerApplicationService(
+            WorldPlannerRepository repository,
+            WorldPlannerReferencePort referenceValidator,
+            WorldPlannerSnapshotModel snapshotModel,
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
+    ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.referenceValidator = Objects.requireNonNull(referenceValidator, "referenceValidator");
         this.snapshotModel = Objects.requireNonNull(snapshotModel, "snapshotModel");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public void refresh(RefreshWorldPlannerCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(this::load);
+        execute(this::load);
     }
 
     public void createNpc(CreateWorldNpcCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             long statblockId = command.creatureStatblockId();
             if (!WorldPlannerIds.isPositive(statblockId)
@@ -88,7 +115,7 @@ public final class WorldPlannerApplicationService {
 
     public void updateNpcNotes(UpdateWorldNpcNotesCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldNpc npc = state.npc(command.npcId());
             if (npc == null) {
@@ -106,7 +133,7 @@ public final class WorldPlannerApplicationService {
 
     public void setNpcLifecycleStatus(SetWorldNpcLifecycleStatusCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             if (command.status() == null) {
                 save(state.withStatus("NPC Status nicht gefunden."));
@@ -136,7 +163,7 @@ public final class WorldPlannerApplicationService {
 
     public void createFaction(CreateWorldFactionCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             long tableId = command.primaryEncounterTableId();
             if (!WorldPlannerIds.isPositive(tableId)
@@ -164,7 +191,7 @@ public final class WorldPlannerApplicationService {
 
     public void addFactionNpc(AddWorldFactionNpcCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldFaction faction = state.faction(command.factionId());
             if (faction == null || state.npc(command.npcId()) == null) {
@@ -181,7 +208,7 @@ public final class WorldPlannerApplicationService {
 
     public void setFactionInventoryLimit(SetWorldFactionInventoryLimitCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldFaction faction = state.faction(command.factionId());
             long statblockId = command.creatureStatblockId();
@@ -203,7 +230,7 @@ public final class WorldPlannerApplicationService {
 
     public void createLocation(CreateWorldLocationCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldLocation location =
                     new WorldLocation(state.nextLocationId(), command.displayName(), command.notes(), List.of(), List.of());
@@ -220,7 +247,7 @@ public final class WorldPlannerApplicationService {
 
     public void addLocationFaction(AddWorldLocationFactionCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldLocation location = state.location(command.locationId());
             if (location == null || state.faction(command.factionId()) == null) {
@@ -237,7 +264,7 @@ public final class WorldPlannerApplicationService {
 
     public void addLocationEncounterTable(AddWorldLocationEncounterTableCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
-        runIgnoringStorageFailure(() -> {
+        execute(() -> {
             WorldPlannerState state = load();
             WorldLocation location = state.location(command.locationId());
             long tableId = command.encounterTableId();
@@ -261,6 +288,7 @@ public final class WorldPlannerApplicationService {
             snapshotModel.publish(WorldPlannerSnapshotProjection.from(state));
             return state;
         } catch (IllegalStateException exception) {
+            diagnostics.failure(LOAD_DIAGNOSTIC, exception.getClass());
             snapshotModel.publishStorageError(LOAD_FAILURE);
             throw exception;
         }
@@ -270,6 +298,7 @@ public final class WorldPlannerApplicationService {
         try {
             snapshotModel.publish(WorldPlannerSnapshotProjection.from(repository.save(state)));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(SAVE_DIAGNOSTIC, exception.getClass());
             snapshotModel.publishStorageError(SAVE_FAILURE);
             throw exception;
         }
@@ -278,23 +307,24 @@ public final class WorldPlannerApplicationService {
     private boolean referenceExists(BooleanSupplier lookup) {
         try {
             return lookup.getAsBoolean();
+        } catch (WorldPlannerReferenceAssembly.ReferenceProviderUnavailableException exception) {
+            snapshotModel.publishStorageError(REFERENCE_FAILURE);
+            throw exception;
         } catch (IllegalStateException exception) {
+            diagnostics.failure(REFERENCE_DIAGNOSTIC, exception.getClass());
             snapshotModel.publishStorageError(REFERENCE_FAILURE);
             throw exception;
         }
     }
 
-    private static void ignoreStorageFailure(IllegalStateException exception) {
-        System.getLogger(WorldPlannerApplicationService.class.getName())
-                .log(System.Logger.Level.DEBUG, "World Planner storage failure", exception);
-    }
-
-    private static void runIgnoringStorageFailure(StorageAction action) {
-        try {
-            action.execute();
-        } catch (IllegalStateException exception) {
-            ignoreStorageFailure(exception);
-        }
+    private void execute(StorageAction action) {
+        executionLane.execute(() -> {
+            try {
+                action.execute();
+            } catch (IllegalStateException exception) {
+                // The terminal load, save, or reference boundary already published and diagnosed the failure.
+            }
+        });
     }
 
     private static WorldPlannerState replaceNpc(WorldPlannerState state, WorldNpc replacement, String statusText) {

--- a/src/domain/worldplanner/WorldPlannerReferenceAssembly.java
+++ b/src/domain/worldplanner/WorldPlannerReferenceAssembly.java
@@ -35,7 +35,7 @@ public final class WorldPlannerReferenceAssembly {
             }
             var result = creatures.find(creatureStatblockId);
             if (result.status() == CreatureLookupStatus.STORAGE_ERROR) {
-                throw unavailable("Creatures");
+                throw unavailable();
             }
             return result.status() == CreatureLookupStatus.SUCCESS
                     && result.detail() != null
@@ -49,14 +49,22 @@ public final class WorldPlannerReferenceAssembly {
             }
             var result = encounterTables.catalog();
             if (result.status() == EncounterTableReadStatus.STORAGE_ERROR) {
-                throw unavailable("Encounter Tables");
+                throw unavailable();
             }
             return result.tables().stream()
                     .anyMatch(table -> table.tableId() == encounterTableId);
         }
 
-        private static IllegalStateException unavailable(String provider) {
-            return new IllegalStateException(provider + " reference provider unavailable");
+        private static ReferenceProviderUnavailableException unavailable() {
+            return new ReferenceProviderUnavailableException();
+        }
+    }
+
+    static final class ReferenceProviderUnavailableException extends IllegalStateException {
+
+        private static final long serialVersionUID = 1L;
+
+        private ReferenceProviderUnavailableException() {
         }
     }
 }

--- a/src/domain/worldplanner/WorldPlannerServiceAssembly.java
+++ b/src/domain/worldplanner/WorldPlannerServiceAssembly.java
@@ -1,6 +1,13 @@
 package src.domain.worldplanner;
 
 import java.util.Objects;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.worldplanner.model.world.port.WorldPlannerReferencePort;
 import src.domain.worldplanner.model.world.repository.WorldPlannerRepository;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
@@ -8,39 +15,70 @@ import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
 public final class WorldPlannerServiceAssembly {
 
     private static final String LOAD_FAILURE = "World Planner konnte nicht geladen werden.";
+    private static final DiagnosticId LOAD_DIAGNOSTIC = new DiagnosticId("worldplanner.load.storage-failure");
 
     private final WorldPlannerRepository repository;
     private final WorldPlannerReferencePort referenceValidator;
-    private final WorldPlannerSnapshotModel snapshotModel = new WorldPlannerSnapshotModel();
-    private boolean initialSnapshotPublished;
+    private final WorldPlannerSnapshotModel snapshotModel;
+    private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
+    private boolean initialSnapshotScheduled;
 
     public WorldPlannerServiceAssembly(
             WorldPlannerRepository repository,
             WorldPlannerReferencePort referenceValidator
     ) {
+        this(
+                repository,
+                referenceValidator,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+    }
+
+    public WorldPlannerServiceAssembly(
+            WorldPlannerRepository repository,
+            WorldPlannerReferencePort referenceValidator,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.referenceValidator = Objects.requireNonNull(referenceValidator, "referenceValidator");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        snapshotModel = new WorldPlannerSnapshotModel(Objects.requireNonNull(uiDispatcher, "uiDispatcher"));
     }
 
     public WorldPlannerApplicationService createApplicationService() {
-        publishInitialSnapshot();
-        return new WorldPlannerApplicationService(repository, referenceValidator, snapshotModel);
+        scheduleInitialSnapshot();
+        return new WorldPlannerApplicationService(
+                repository,
+                referenceValidator,
+                snapshotModel,
+                executionLane,
+                diagnostics);
     }
 
     public WorldPlannerSnapshotModel snapshotModel() {
-        publishInitialSnapshot();
+        scheduleInitialSnapshot();
         return snapshotModel;
     }
 
-    private void publishInitialSnapshot() {
-        if (initialSnapshotPublished) {
+    private synchronized void scheduleInitialSnapshot() {
+        if (initialSnapshotScheduled) {
             return;
         }
+        initialSnapshotScheduled = true;
+        executionLane.execute(this::publishInitialSnapshot);
+    }
+
+    private void publishInitialSnapshot() {
         try {
             snapshotModel.publish(WorldPlannerSnapshotProjection.from(repository.load()));
         } catch (IllegalStateException exception) {
+            diagnostics.failure(LOAD_DIAGNOSTIC, exception.getClass());
             snapshotModel.publishStorageError(LOAD_FAILURE);
         }
-        initialSnapshotPublished = true;
     }
 }

--- a/src/domain/worldplanner/published/WorldPlannerSnapshotModel.java
+++ b/src/domain/worldplanner/published/WorldPlannerSnapshotModel.java
@@ -5,18 +5,24 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import platform.ui.UiDispatcher;
+import src.domain.shared.published.PublishedState;
 
 public final class WorldPlannerSnapshotModel {
 
     private final Supplier<WorldPlannerSnapshot> currentSupplier;
     private final Function<Consumer<WorldPlannerSnapshot>, Runnable> subscribeAction;
-    private StatefulSnapshotStore statefulStore;
+    private PublishedState<WorldPlannerSnapshot> statefulStore;
 
     public WorldPlannerSnapshotModel() {
-        this(new StatefulSnapshotStore());
+        this(new PublishedState<>(initialSnapshot()));
     }
 
-    private WorldPlannerSnapshotModel(StatefulSnapshotStore store) {
+    public WorldPlannerSnapshotModel(UiDispatcher dispatcher) {
+        this(new PublishedState<>(initialSnapshot(), dispatcher));
+    }
+
+    private WorldPlannerSnapshotModel(PublishedState<WorldPlannerSnapshot> store) {
         this(store::current, store::subscribe);
         statefulStore = store;
     }
@@ -43,13 +49,21 @@ public final class WorldPlannerSnapshotModel {
 
     public void publish(WorldPlannerSnapshot snapshot) {
         if (statefulStore != null) {
-            statefulStore.publish(snapshot);
+            statefulStore.publish(snapshot == null ? initialSnapshot() : snapshot);
         }
     }
 
     public void publishStorageError(String message) {
         if (statefulStore != null) {
-            statefulStore.publishStorageError(message);
+            WorldPlannerSnapshot current = statefulStore.current();
+            statefulStore.publish(new WorldPlannerSnapshot(
+                    WorldPlannerReadStatus.STORAGE_ERROR,
+                    current.npcs(),
+                    current.factions(),
+                    current.locations(),
+                    message == null || message.isBlank()
+                            ? "World Planner konnte nicht geladen werden."
+                            : message));
         }
     }
 
@@ -57,48 +71,12 @@ public final class WorldPlannerSnapshotModel {
         return new WorldPlannerSnapshot(WorldPlannerReadStatus.STORAGE_ERROR, List.of(), List.of(), List.of(), "");
     }
 
-    private static final class StatefulSnapshotStore {
-
-        private final List<Consumer<WorldPlannerSnapshot>> listeners = new java.util.ArrayList<>();
-        private WorldPlannerSnapshot current = new WorldPlannerSnapshot(
+    private static WorldPlannerSnapshot initialSnapshot() {
+        return new WorldPlannerSnapshot(
                 WorldPlannerReadStatus.SUCCESS,
                 List.of(),
                 List.of(),
                 List.of(),
                 "");
-
-        void publish(WorldPlannerSnapshot snapshot) {
-            current = snapshot == null
-                    ? new WorldPlannerSnapshot(WorldPlannerReadStatus.SUCCESS, List.of(), List.of(), List.of(), "")
-                    : snapshot;
-            notifyListeners();
-        }
-
-        void publishStorageError(String message) {
-            current = new WorldPlannerSnapshot(
-                    WorldPlannerReadStatus.STORAGE_ERROR,
-                    current.npcs(),
-                    current.factions(),
-                    current.locations(),
-                    message == null || message.isBlank()
-                            ? "World Planner konnte nicht geladen werden."
-                            : message);
-            notifyListeners();
-        }
-
-        private WorldPlannerSnapshot current() {
-            return current;
-        }
-
-        private Runnable subscribe(Consumer<WorldPlannerSnapshot> listener) {
-            listeners.add(listener);
-            return () -> listeners.remove(listener);
-        }
-
-        private void notifyListeners() {
-            for (Consumer<WorldPlannerSnapshot> listener : List.copyOf(listeners)) {
-                listener.accept(current);
-            }
-        }
     }
 }

--- a/src/features/dungeon/runtime/DungeonEditorFeatureRuntimeRoot.java
+++ b/src/features/dungeon/runtime/DungeonEditorFeatureRuntimeRoot.java
@@ -23,14 +23,15 @@ public final class DungeonEditorFeatureRuntimeRoot
         DungeonEditorRuntimeDependencies.CompatibilityReadbackModels readback =
                 safeDependencies.compatibilityReadbackModels();
         DungeonEditorMainViewInteractionState interactionState = new DungeonEditorMainViewInteractionState();
-        DungeonEditorRuntimeContext.Startup startup =
+        DungeonEditorRuntimeContext context =
                 DungeonEditorRuntimeContext.create(safeDependencies, interactionState);
         return new DungeonEditorFeatureRuntimeRoot(
                 readback.controlsModel(),
                 readback.mapSurfaceModel(),
                 readback.stateModel(),
                 interactionState,
-                startup.context());
+                context,
+                safeDependencies.executionLane());
     }
 
     private DungeonEditorFeatureRuntimeRoot(
@@ -38,7 +39,8 @@ public final class DungeonEditorFeatureRuntimeRoot
             src.domain.dungeon.published.DungeonEditorMapSurfaceModel mapSurfaceModel,
             src.domain.dungeon.published.DungeonEditorStateModel stateModel,
             DungeonEditorMainViewInteractionState interactionState,
-            DungeonEditorRuntimeContext context
+            DungeonEditorRuntimeContext context,
+            platform.execution.ExecutionLane executionLane
     ) {
         src.domain.dungeon.published.DungeonEditorControlsModel safeControlsModel =
                 Objects.requireNonNull(controlsModel, "controlsModel");
@@ -49,12 +51,15 @@ public final class DungeonEditorFeatureRuntimeRoot
         DungeonEditorMainViewInteractionState safeInteractionState =
                 Objects.requireNonNull(interactionState, "interactionState");
         DungeonEditorRuntimeContext safeContext = Objects.requireNonNull(context, "context");
+        platform.execution.ExecutionLane safeExecutionLane =
+                Objects.requireNonNull(executionLane, "executionLane");
         DungeonEditorRuntimeDraftSession draftSession = new DungeonEditorRuntimeDraftSession();
         framePublisher = new DungeonEditorRuntimeFramePublisher(
                 safeControlsModel,
                 safeMapSurfaceModel,
                 safeStateModel,
-                draftSession);
+                draftSession,
+                safeExecutionLane);
         DungeonEditorStairDraftRuntimeOperation stairDraftOperation =
                 new DungeonEditorStairDraftRuntimeOperation(safeContext);
         DungeonEditorSelectedHandleRuntimeOperation selectedHandleOperation =
@@ -68,7 +73,8 @@ public final class DungeonEditorFeatureRuntimeRoot
                 draftSession,
                 framePublisher,
                 stairDraftOperation,
-                selectedHandleOperation);
+                selectedHandleOperation,
+                safeExecutionLane);
         pointerWorkflow = new DungeonEditorPointerWorkflow(
                 new DungeonEditorPointerWorkflow.RuntimeFamilies(
                         new DungeonEditorRoomPaintRuntimeOperation(safeContext),
@@ -82,6 +88,7 @@ public final class DungeonEditorFeatureRuntimeRoot
                         selectedHandleOperation),
                 commands);
         commands.bindPointerOperations(pointerWorkflow);
+        commands.apply(safeContext::publishCurrent);
     }
 
     public DungeonEditorRuntimeOperations operations() {

--- a/src/features/dungeon/runtime/DungeonEditorPointerWorkflow.java
+++ b/src/features/dungeon/runtime/DungeonEditorPointerWorkflow.java
@@ -25,7 +25,7 @@ final class DungeonEditorPointerWorkflow implements DungeonEditorPointerInteract
         PointerWorkflowIntent intent =
                 DungeonEditorPointerWorkflowIntentResolver.resolve(safeRequest.selectedTool(), safeRequest.gesture());
         if (!intent.workflowAccepted()) {
-            clearPointerSession();
+            commandPublisher.execute(pointerSession::clear);
             return PointerInteractionResult.ignored();
         }
         PointerInteractionTargets targets = safeRequest.targets();
@@ -47,26 +47,33 @@ final class DungeonEditorPointerWorkflow implements DungeonEditorPointerInteract
                 hoverTarget,
                 safeRequest.projectionLevel());
         PointerSample sample = DungeonEditorPointerSamplePolicy.pointerSample(targets, sampleTarget, intent);
-        boolean accepted = pointerSession.accept(
-                safeRequest.action(),
-                intent.effectiveTool(),
-                sample,
-                safeRequest.projectionLevel());
-        boolean dispatched = accepted && safeRequest.action() != null;
-        if (dispatched) {
-            commandPublisher.apply(() -> applyPointer(
-                    safeRequest.action(),
-                    intent.effectiveTool(),
-                    sample,
-                    intent.wallSingleClickMode(),
-                    safeRequest.transitionDestination()));
-        }
+        commandPublisher.execute(() -> applyPointerInExecutionLane(safeRequest, intent, sample));
         return new PointerInteractionResult(true, hoverTarget);
     }
 
     @Override
     public void clearPointerSession() {
-        pointerSession.clear();
+        commandPublisher.execute(pointerSession::clear);
+    }
+
+    private void applyPointerInExecutionLane(
+            PointerInteractionRequest request,
+            PointerWorkflowIntent intent,
+            PointerSample sample
+    ) {
+        boolean accepted = pointerSession.accept(
+                request.action(),
+                intent.effectiveTool(),
+                sample,
+                request.projectionLevel());
+        if (accepted && request.action() != null) {
+            commandPublisher.applyInExecutionLane(() -> applyPointer(
+                    request.action(),
+                    intent.effectiveTool(),
+                    sample,
+                    intent.wallSingleClickMode(),
+                    request.transitionDestination()));
+        }
     }
 
     private static PointerInteractionRequest emptyRequest() {

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeCommands.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeCommands.java
@@ -3,6 +3,7 @@ package src.features.dungeon.runtime;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import platform.execution.ExecutionLane;
 import src.domain.dungeon.published.DungeonEditorControlsModel;
 import src.domain.dungeon.published.DungeonEditorMapSurfaceModel;
 import src.domain.dungeon.published.DungeonEditorPreview;
@@ -26,6 +27,7 @@ final class DungeonEditorRuntimeCommands
     private final DungeonEditorRuntimeFramePublisher framePublisher;
     private final DungeonEditorStairDraftRuntimeOperation stairDraftOperation;
     private final DungeonEditorSelectedHandleRuntimeOperation selectedHandleOperation;
+    private final ExecutionLane executionLane;
     private DungeonEditorPointerInteractionOperations pointerOperations;
 
     DungeonEditorRuntimeCommands(
@@ -37,7 +39,8 @@ final class DungeonEditorRuntimeCommands
             DungeonEditorRuntimeDraftSession draftSession,
             DungeonEditorRuntimeFramePublisher framePublisher,
             DungeonEditorStairDraftRuntimeOperation stairDraftOperation,
-            DungeonEditorSelectedHandleRuntimeOperation selectedHandleOperation
+            DungeonEditorSelectedHandleRuntimeOperation selectedHandleOperation,
+            ExecutionLane executionLane
     ) {
         this.context = Objects.requireNonNull(context, "context");
         this.controlsModel = Objects.requireNonNull(controlsModel, "controlsModel");
@@ -48,6 +51,7 @@ final class DungeonEditorRuntimeCommands
         this.framePublisher = Objects.requireNonNull(framePublisher, "framePublisher");
         this.stairDraftOperation = Objects.requireNonNull(stairDraftOperation, "stairDraftOperation");
         this.selectedHandleOperation = Objects.requireNonNull(selectedHandleOperation, "selectedHandleOperation");
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
     }
 
     void bindPointerOperations(DungeonEditorPointerInteractionOperations pointerOperations) {
@@ -56,18 +60,22 @@ final class DungeonEditorRuntimeCommands
 
     @Override
     public void selectMap(long mapIdValue) {
-        interactionState.clear();
-        draftSession.clearInlineLabelEditSession();
-        framePublisher.markDraftSessionChanged();
-        stairDraftOperation.clear();
-        apply(() -> context.selectMap(mapIdValue));
+        execute(() -> {
+            interactionState.clear();
+            draftSession.clearInlineLabelEditSession();
+            framePublisher.markDraftSessionChanged();
+            stairDraftOperation.clear();
+            applyInExecutionLane(() -> context.selectMap(mapIdValue));
+        });
     }
 
     @Override
     public void createMap(String mapName) {
-        interactionState.clear();
-        stairDraftOperation.clear();
-        apply(() -> context.createMap(mapName));
+        execute(() -> {
+            interactionState.clear();
+            stairDraftOperation.clear();
+            applyInExecutionLane(() -> context.createMap(mapName));
+        });
     }
 
     @Override
@@ -77,38 +85,46 @@ final class DungeonEditorRuntimeCommands
 
     @Override
     public void deleteMap(long mapIdValue) {
-        interactionState.clear();
-        stairDraftOperation.clear();
-        apply(() -> context.deleteMap(mapIdValue));
+        execute(() -> {
+            interactionState.clear();
+            stairDraftOperation.clear();
+            applyInExecutionLane(() -> context.deleteMap(mapIdValue));
+        });
     }
 
     @Override
     public void setViewMode(DungeonEditorViewMode viewMode) {
-        clearActiveInteraction();
-        stairDraftOperation.clear();
-        apply(() -> context.setViewMode(viewMode));
+        execute(() -> {
+            clearActiveInteraction();
+            stairDraftOperation.clear();
+            applyInExecutionLane(() -> context.setViewMode(viewMode));
+        });
     }
 
     @Override
     public void setTool(DungeonEditorTool tool) {
-        clearActiveInteraction();
-        stairDraftOperation.clear();
-        if (activePublishedMapInteraction()) {
-            apply(() -> context.setToolAndPublishSnapshot(tool));
-            return;
-        }
-        apply(() -> context.setTool(tool));
+        execute(() -> {
+            clearActiveInteraction();
+            stairDraftOperation.clear();
+            if (activePublishedMapInteraction()) {
+                applyInExecutionLane(() -> context.setToolAndPublishSnapshot(tool));
+                return;
+            }
+            applyInExecutionLane(() -> context.setTool(tool));
+        });
     }
 
     @Override
     public void cancelActivePreviewSession() {
-        clearActiveInteraction();
-        stairDraftOperation.clear();
-        if (!activePublishedMapInteraction()) {
-            apply(() -> context.setTool(DungeonEditorTool.SELECT));
-            return;
-        }
-        apply(context::cancelActivePreviewSession);
+        execute(() -> {
+            clearActiveInteraction();
+            stairDraftOperation.clear();
+            if (!activePublishedMapInteraction()) {
+                applyInExecutionLane(() -> context.setTool(DungeonEditorTool.SELECT));
+                return;
+            }
+            applyInExecutionLane(context::cancelActivePreviewSession);
+        });
     }
 
     @Override
@@ -132,20 +148,26 @@ final class DungeonEditorRuntimeCommands
 
     @Override
     public void updateStatePanelRoomNarrationDraft(RoomNarrationDraftInput input) {
-        draftSession.updateRoomNarrationDraft(currentSelectedMapIdValue(), input);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateRoomNarrationDraft(currentSelectedMapIdValue(), input);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void updateStatePanelLabelNameDraft(DungeonEditorRuntimeLabelTarget target, String name) {
-        draftSession.updateLabelNameDraft(currentSelectedMapIdValue(), target, name);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateLabelNameDraft(currentSelectedMapIdValue(), target, name);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void updateStatePanelCorridorPointDraft(String q, String r) {
-        draftSession.updateCorridorPointDraft(currentSelectedMapIdValue(), currentStateSelection(), q, r);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateCorridorPointDraft(currentSelectedMapIdValue(), currentStateSelection(), q, r);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
@@ -160,68 +182,89 @@ final class DungeonEditorRuntimeCommands
 
     @Override
     public void updateStatePanelTransitionDescriptionDraft(long transitionId, String description) {
-        draftSession.updateTransitionDescriptionDraft(currentSelectedMapIdValue(), transitionId, description);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateTransitionDescriptionDraft(currentSelectedMapIdValue(), transitionId, description);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void updateStatePanelTransitionDestinationDraft(TransitionDestinationDraftInput input) {
-        draftSession.updateTransitionDestinationDraft(
-                currentSelectedMapIdValue(),
-                controlsModel.current(),
-                stateModel.current(),
-                input);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateTransitionDestinationDraft(
+                    currentSelectedMapIdValue(),
+                    controlsModel.current(),
+                    stateModel.current(),
+                    input);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void updateStatePanelStairGeometryDraft(StairGeometryDraftInput input) {
-        draftSession.updateStairGeometryDraft(currentSelectedMapIdValue(), input);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateStairGeometryDraft(currentSelectedMapIdValue(), input);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void beginInlineLabelEdit(DungeonEditorInlineLabelEditSession session) {
-        draftSession.beginInlineLabelEdit(session);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.beginInlineLabelEdit(session);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void updateInlineLabelEditDraft(String text) {
-        draftSession.updateInlineLabelEditDraft(text);
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.updateInlineLabelEditDraft(text);
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void cancelInlineLabelEdit() {
-        draftSession.clearInlineLabelEditSession();
-        framePublisher.publishDraftSessionChanged();
+        execute(() -> {
+            draftSession.clearInlineLabelEditSession();
+            framePublisher.publishDraftSessionChanged();
+        });
     }
 
     @Override
     public void commitInlineLabelEdit(String text) {
-        DungeonEditorInlineLabelEditSession editSession = draftSession.takeInlineLabelEditSession();
-        framePublisher.publishDraftSessionChanged();
-        if (!editSession.active() || !editSession.target().present() || text == null || text.isBlank()) {
-            return;
-        }
-        saveLabelName(editSession.target(), text);
+        execute(() -> {
+            DungeonEditorInlineLabelEditSession editSession = draftSession.takeInlineLabelEditSession();
+            framePublisher.publishDraftSessionChanged();
+            if (!editSession.active() || !editSession.target().present() || text == null || text.isBlank()) {
+                return;
+            }
+            saveLabelNameInExecutionLane(editSession.target(), text);
+        });
     }
 
     @Override
     public void saveRoomNarration(RoomNarration narration) {
-        long roomId = narration == null ? 0L : narration.roomId();
-        draftSession.clearRoomNarrationDraft(currentSelectedMapIdValue(), roomId);
-        framePublisher.markDraftSessionChanged();
-        apply(() -> context.saveRoomNarration(narration));
+        execute(() -> {
+            long roomId = narration == null ? 0L : narration.roomId();
+            draftSession.clearRoomNarrationDraft(currentSelectedMapIdValue(), roomId);
+            framePublisher.markDraftSessionChanged();
+            applyInExecutionLane(() -> context.saveRoomNarration(narration));
+        });
     }
 
     @Override
     public void saveLabelName(DungeonEditorRuntimeLabelTarget target, String name) {
         DungeonEditorRuntimeLabelTarget safeTarget = DungeonEditorRuntimeLabelTarget.orEmpty(target);
+        execute(() -> saveLabelNameInExecutionLane(safeTarget, name));
+    }
+
+    private void saveLabelNameInExecutionLane(DungeonEditorRuntimeLabelTarget target, String name) {
+        DungeonEditorRuntimeLabelTarget safeTarget = DungeonEditorRuntimeLabelTarget.orEmpty(target);
         draftSession.clearLabelNameDraft(currentSelectedMapIdValue(), safeTarget);
         framePublisher.markDraftSessionChanged();
-        apply(() -> context.saveLabelName(safeTarget, name));
+        applyInExecutionLane(() -> context.saveLabelName(safeTarget, name));
     }
 
     @Override
@@ -229,20 +272,24 @@ final class DungeonEditorRuntimeCommands
         TransitionDestinationDraftInput safeInput = input == null
                 ? TransitionDestinationDraftInput.unlinkedEntrance()
                 : input;
-        long selectedMapIdValue = currentSelectedMapIdValue();
-        apply(
-                () -> context.saveTransitionLink(sourceTransitionId, safeInput),
-                result -> clearTransitionDestinationDraftWhenCommitted(
-                        selectedMapIdValue,
-                        sourceTransitionId,
-                        result));
+        execute(() -> {
+            long selectedMapIdValue = currentSelectedMapIdValue();
+            applyInExecutionLane(
+                    () -> context.saveTransitionLink(sourceTransitionId, safeInput),
+                    result -> clearTransitionDestinationDraftWhenCommitted(
+                            selectedMapIdValue,
+                            sourceTransitionId,
+                            result));
+        });
     }
 
     @Override
     public void saveTransitionDescription(long transitionId, String description) {
-        draftSession.clearTransitionDescriptionDraft(currentSelectedMapIdValue(), transitionId);
-        framePublisher.markDraftSessionChanged();
-        apply(() -> context.saveTransitionDescription(transitionId, description));
+        execute(() -> {
+            draftSession.clearTransitionDescriptionDraft(currentSelectedMapIdValue(), transitionId);
+            framePublisher.markDraftSessionChanged();
+            applyInExecutionLane(() -> context.saveTransitionDescription(transitionId, description));
+        });
     }
 
     @Override
@@ -251,9 +298,11 @@ final class DungeonEditorRuntimeCommands
         if (!safeInput.completeForSave()) {
             return;
         }
-        draftSession.clearStairGeometryDraft(currentSelectedMapIdValue(), safeInput.stairId());
-        framePublisher.markDraftSessionChanged();
-        apply(() -> context.saveStairGeometry(safeInput));
+        execute(() -> {
+            draftSession.clearStairGeometryDraft(currentSelectedMapIdValue(), safeInput.stairId());
+            framePublisher.markDraftSessionChanged();
+            applyInExecutionLane(() -> context.saveStairGeometry(safeInput));
+        });
     }
 
     void apply(Supplier<DungeonEditorRuntimeContext.Result> action) {
@@ -264,16 +313,40 @@ final class DungeonEditorRuntimeCommands
             Supplier<DungeonEditorRuntimeContext.Result> action,
             Consumer<DungeonEditorRuntimeContext.Result> beforePublish
     ) {
+        Supplier<DungeonEditorRuntimeContext.Result> safeAction = Objects.requireNonNull(action, "action");
         Consumer<DungeonEditorRuntimeContext.Result> safeBeforePublish =
                 Objects.requireNonNull(beforePublish, "beforePublish");
+        execute(() -> applyOnLane(safeAction, safeBeforePublish));
+    }
+
+    void applyInExecutionLane(Supplier<DungeonEditorRuntimeContext.Result> action) {
+        applyInExecutionLane(action, ignored -> { });
+    }
+
+    private void applyInExecutionLane(
+            Supplier<DungeonEditorRuntimeContext.Result> action,
+            Consumer<DungeonEditorRuntimeContext.Result> beforePublish
+    ) {
+        applyOnLane(
+                Objects.requireNonNull(action, "action"),
+                Objects.requireNonNull(beforePublish, "beforePublish"));
+    }
+
+    void execute(Runnable command) {
+        executionLane.execute(Objects.requireNonNull(command, "command"));
+    }
+
+    private void applyOnLane(
+            Supplier<DungeonEditorRuntimeContext.Result> action,
+            Consumer<DungeonEditorRuntimeContext.Result> beforePublish
+    ) {
         DungeonEditorRuntimeFramePublisher.StateModelFrameDeferral<DungeonEditorRuntimeContext.Result> result =
-                framePublisher.deferStateModelFramePublication(
-                        Objects.requireNonNull(action, "action"));
+                framePublisher.deferStateModelFramePublication(action);
         DungeonEditorRuntimeContext.Result operationResult = result.result() == null
                 ? DungeonEditorRuntimeContext.Result.none()
                 : result.result();
         if (operationResult.shouldPublish(result.stateModelFrameSuppressed())) {
-            safeBeforePublish.accept(operationResult);
+            beforePublish.accept(operationResult);
             framePublisher.publishCurrentToSubscribers();
         }
     }

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeContext.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeContext.java
@@ -31,7 +31,7 @@ final class DungeonEditorRuntimeContext {
         this.mainViewInterpreter = Objects.requireNonNull(mainViewInterpreter, "mainViewInterpreter");
     }
 
-    static Startup create(
+    static DungeonEditorRuntimeContext create(
             DungeonEditorRuntimeDependencies dependencies,
             DungeonEditorMainViewInteractionState interactionState
     ) {
@@ -44,11 +44,7 @@ final class DungeonEditorRuntimeContext {
                 new InterpretDungeonEditorMainViewInputUseCase(safeInteractionState);
         return safeDependencies.editorRuntimeApplicationService().openSession(
                 dungeonState,
-                runtimeSession -> {
-                    DungeonEditorRuntimeContext context =
-                            new DungeonEditorRuntimeContext(runtimeSession, interpreter);
-                    return new Startup(context, context.fromSnapshot(runtimeSession.publishCurrent()));
-                });
+                runtimeSession -> new DungeonEditorRuntimeContext(runtimeSession, interpreter));
     }
 
     boolean hasSelectedMap() {
@@ -408,13 +404,6 @@ final class DungeonEditorRuntimeContext {
             case CLUSTER -> DungeonAuthoredApplicationService.LabelTargetKind.CLUSTER;
             case EMPTY -> DungeonAuthoredApplicationService.LabelTargetKind.EMPTY;
         };
-    }
-
-    record Startup(DungeonEditorRuntimeContext context, Result initialResult) {
-        Startup {
-            context = Objects.requireNonNull(context, "context");
-            initialResult = initialResult == null ? Result.none() : initialResult;
-        }
     }
 
     record Result(

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeDependencies.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeDependencies.java
@@ -1,6 +1,10 @@
 package src.features.dungeon.runtime;
 
 import java.util.Objects;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
 import src.domain.dungeon.DungeonEditorRuntimeApplicationService;
 import src.domain.dungeon.published.DungeonEditorControlsModel;
 import src.domain.dungeon.published.DungeonEditorMapSurfaceModel;
@@ -8,13 +12,25 @@ import src.domain.dungeon.published.DungeonEditorStateModel;
 
 public record DungeonEditorRuntimeDependencies(
         CompatibilityReadbackModels compatibilityReadbackModels,
-        DungeonEditorRuntimeApplicationService editorRuntimeApplicationService
+        DungeonEditorRuntimeApplicationService editorRuntimeApplicationService,
+        ExecutionLane executionLane,
+        UiDispatcher uiDispatcher
 ) {
+    public DungeonEditorRuntimeDependencies(
+            CompatibilityReadbackModels compatibilityReadbackModels,
+            DungeonEditorRuntimeApplicationService editorRuntimeApplicationService
+    ) {
+        this(compatibilityReadbackModels, editorRuntimeApplicationService,
+                DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE);
+    }
+
     public DungeonEditorRuntimeDependencies {
         compatibilityReadbackModels =
                 Objects.requireNonNull(compatibilityReadbackModels, "compatibilityReadbackModels");
         editorRuntimeApplicationService =
                 Objects.requireNonNull(editorRuntimeApplicationService, "editorRuntimeApplicationService");
+        executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
     public record CompatibilityReadbackModels(

--- a/src/features/dungeon/runtime/DungeonEditorRuntimeFramePublisher.java
+++ b/src/features/dungeon/runtime/DungeonEditorRuntimeFramePublisher.java
@@ -3,11 +3,15 @@ package src.features.dungeon.runtime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import platform.execution.ExecutionLane;
 import src.domain.dungeon.published.DungeonEditorControlsModel;
 import src.domain.dungeon.published.DungeonEditorMapSurfaceModel;
 import src.domain.dungeon.published.DungeonEditorStateModel;
+import src.domain.dungeon.published.DungeonEditorStateSnapshot;
 
 final class DungeonEditorRuntimeFramePublisher {
     private static final long MIN_DRAFT_SESSION_REVISION = 0L;
@@ -16,9 +20,12 @@ final class DungeonEditorRuntimeFramePublisher {
     private final DungeonEditorMapSurfaceModel mapSurfaceModel;
     private final DungeonEditorStateModel stateModel;
     private final DungeonEditorRuntimeDraftSession draftSession;
+    private final ExecutionLane executionLane;
     private final DungeonEditorRuntimeFrameFactsAssembler frameFactsAssembler =
             new DungeonEditorRuntimeFrameFactsAssembler();
     private final List<Consumer<DungeonEditorRenderFrame>> subscribers = new ArrayList<>();
+    private volatile DungeonEditorRenderFrame latestFrame;
+    private DungeonEditorStateSnapshot lastPublishedState;
     private long runtimeFramePublicationCount;
     private long draftSessionRevision;
     private int stateModelFrameDeferralDepth;
@@ -28,30 +35,48 @@ final class DungeonEditorRuntimeFramePublisher {
             DungeonEditorControlsModel controlsModel,
             DungeonEditorMapSurfaceModel mapSurfaceModel,
             DungeonEditorStateModel stateModel,
-            DungeonEditorRuntimeDraftSession draftSession
+            DungeonEditorRuntimeDraftSession draftSession,
+            ExecutionLane executionLane
     ) {
         this.controlsModel = Objects.requireNonNull(controlsModel, "controlsModel");
         this.mapSurfaceModel = Objects.requireNonNull(mapSurfaceModel, "mapSurfaceModel");
         this.stateModel = Objects.requireNonNull(stateModel, "stateModel");
         this.draftSession = Objects.requireNonNull(draftSession, "draftSession");
-        this.stateModel.subscribe(ignored -> publishStateModelFrame());
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        latestFrame = assembleCurrentFrame();
+        lastPublishedState = this.stateModel.current();
+        this.stateModel.subscribe(ignored -> executeIfOpen(this::publishStateModelFrame));
     }
 
     Runnable subscribe(Consumer<DungeonEditorRenderFrame> subscriber) {
         Consumer<DungeonEditorRenderFrame> safeSubscriber =
                 Objects.requireNonNull(subscriber, "subscriber");
-        subscribers.add(safeSubscriber);
-        return () -> subscribers.remove(safeSubscriber);
+        AtomicBoolean active = new AtomicBoolean(true);
+        DungeonEditorRenderFrame frameAtRequest = latestFrame;
+        executeIfOpen(() -> {
+            if (active.get()) {
+                subscribers.add(safeSubscriber);
+                if (latestFrame != frameAtRequest) {
+                    safeSubscriber.accept(latestFrame);
+                }
+            }
+        });
+        return () -> {
+            if (active.compareAndSet(true, false)) {
+                executeIfOpen(() -> subscribers.remove(safeSubscriber));
+            }
+        };
     }
 
     /*
-     * This runtime channel is caller-affine: subscriber callbacks run
-     * synchronously on the caller of publishCurrentToSubscribers().
-     * Thread-bound consumers must route delivery at their own seam.
+     * This runtime channel is execution-lane-affine. Thread-bound consumers
+     * receive only the completed immutable frame and route it at their seam.
      */
     void publishCurrentToSubscribers() {
         runtimeFramePublicationCount++;
-        DungeonEditorRenderFrame frame = currentFrame();
+        DungeonEditorRenderFrame frame = assembleCurrentFrame();
+        latestFrame = frame;
+        lastPublishedState = stateModel.current();
         for (Consumer<DungeonEditorRenderFrame> subscriber : List.copyOf(subscribers)) {
             subscriber.accept(frame);
         }
@@ -85,6 +110,9 @@ final class DungeonEditorRuntimeFramePublisher {
     }
 
     private void publishStateModelFrame() {
+        if (Objects.equals(lastPublishedState, stateModel.current())) {
+            return;
+        }
         if (stateModelFrameDeferralDepth > 0) {
             stateModelFrameSuppressedDuringDeferral = true;
             return;
@@ -93,6 +121,10 @@ final class DungeonEditorRuntimeFramePublisher {
     }
 
     DungeonEditorRenderFrame currentFrame() {
+        return latestFrame;
+    }
+
+    private DungeonEditorRenderFrame assembleCurrentFrame() {
         DungeonEditorRuntimeReadbackFrameInputs readbackInputs =
                 DungeonEditorRuntimeReadbackFrameInputs.from(controlsModel, mapSurfaceModel, stateModel);
         verifyCurrentDraftSessionRevision();
@@ -107,6 +139,14 @@ final class DungeonEditorRuntimeFramePublisher {
                         drafts),
                 drafts.inlineLabelEditSession(),
                 frameFactsAssembler.measurementSnapshot(runtimeFramePublicationCount));
+    }
+
+    private void executeIfOpen(Runnable work) {
+        try {
+            executionLane.execute(work);
+        } catch (RejectedExecutionException ignored) {
+            // A queued JavaFX model callback may arrive after application shutdown closed the lane.
+        }
     }
 
     private void verifyCurrentDraftSessionRevision() {

--- a/src/features/dungeon/shell/DungeonEditorFeatureShellBinding.java
+++ b/src/features/dungeon/shell/DungeonEditorFeatureShellBinding.java
@@ -2,7 +2,8 @@ package src.features.dungeon.shell;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javafx.application.Platform;
+import java.util.concurrent.atomic.AtomicLong;
+import platform.ui.UiDispatcher;
 import src.features.dungeon.runtime.DungeonEditorFeatureRuntimeRoot;
 import src.features.dungeon.runtime.DungeonEditorRenderFrame;
 import src.features.dungeon.runtime.DungeonEditorRuntimeDependencies;
@@ -10,10 +11,13 @@ import src.features.dungeon.runtime.DungeonEditorRuntimeOperations;
 
 public final class DungeonEditorFeatureShellBinding {
     private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final UiDispatcher uiDispatcher;
 
     public DungeonEditorFeatureShellBinding(DungeonEditorRuntimeDependencies dependencies) {
-        runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(
-                Objects.requireNonNull(dependencies, "dependencies"));
+        DungeonEditorRuntimeDependencies safeDependencies =
+                Objects.requireNonNull(dependencies, "dependencies");
+        runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
+        uiDispatcher = safeDependencies.uiDispatcher();
     }
 
     public DungeonEditorRuntimeOperations operations() {
@@ -22,7 +26,7 @@ public final class DungeonEditorFeatureShellBinding {
 
     public Runnable subscribe(PublicationSink sink) {
         PublicationSink safeSink = Objects.requireNonNull(sink, "sink");
-        JavaFxPublicationDelivery delivery = new JavaFxPublicationDelivery(safeSink);
+        PublicationDelivery delivery = new PublicationDelivery(safeSink, uiDispatcher);
         Runnable unsubscribeRuntime = runtimeRoot.subscribe(delivery::deliver);
         return () -> {
             delivery.close();
@@ -31,35 +35,36 @@ public final class DungeonEditorFeatureShellBinding {
     }
 
     public void publishCurrent(PublicationSink sink) {
-        JavaFxPublicationDelivery delivery =
-                new JavaFxPublicationDelivery(Objects.requireNonNull(sink, "sink"));
+        PublicationDelivery delivery =
+                new PublicationDelivery(Objects.requireNonNull(sink, "sink"), uiDispatcher);
         delivery.deliver(runtimeRoot.currentFrame());
     }
 
-    private static final class JavaFxPublicationDelivery {
+    static final class PublicationDelivery {
         private final PublicationSink sink;
+        private final UiDispatcher uiDispatcher;
         private final AtomicBoolean open = new AtomicBoolean(true);
+        private final AtomicLong deliveryRevision = new AtomicLong();
 
-        private JavaFxPublicationDelivery(PublicationSink sink) {
-            this.sink = sink;
+        PublicationDelivery(PublicationSink sink, UiDispatcher uiDispatcher) {
+            this.sink = Objects.requireNonNull(sink, "sink");
+            this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
         }
 
-        private void deliver(DungeonEditorRenderFrame frame) {
-            if (Platform.isFxApplicationThread()) {
-                applyIfOpen(frame);
-                return;
-            }
-            Platform.runLater(() -> applyIfOpen(frame));
+        void deliver(DungeonEditorRenderFrame frame) {
+            long revision = deliveryRevision.incrementAndGet();
+            uiDispatcher.dispatch(() -> applyIfCurrent(revision, frame));
         }
 
-        private void applyIfOpen(DungeonEditorRenderFrame frame) {
-            if (open.get()) {
+        private void applyIfCurrent(long revision, DungeonEditorRenderFrame frame) {
+            if (open.get() && revision == deliveryRevision.get()) {
                 sink.apply(frame);
             }
         }
 
-        private void close() {
+        void close() {
             open.set(false);
+            deliveryRevision.incrementAndGet();
         }
     }
 

--- a/src/view/leftbartabs/hexmap/HexMapBinder.java
+++ b/src/view/leftbartabs/hexmap/HexMapBinder.java
@@ -201,8 +201,10 @@ final class HexMapBinder {
             return true;
         }
         if (!event.reloadItemId().isBlank()) {
-            editor.loadEditor(new LoadHexEditorCommand());
-            selectMap(editor, parseId(event.reloadItemId()));
+            long mapId = parseId(event.reloadItemId());
+            if (mapId > UNRESOLVED_ID) {
+                editor.reloadAndSelectMap(new LoadHexEditorCommand(), new SelectHexMapCommand(mapId));
+            }
             return true;
         }
         if (!event.openItemId().isBlank()) {

--- a/src/view/leftbartabs/sessionplanner/SessionPlannerBinder.java
+++ b/src/view/leftbartabs/sessionplanner/SessionPlannerBinder.java
@@ -82,6 +82,7 @@ final class SessionPlannerBinder {
                 participantsModel,
                 sceneTimelineModel,
                 statePanelModel);
+        planner.initialize();
         return new Binding(ShellControls.stack(catalogView, controlsView), timelineView, stateView);
     }
 

--- a/test/architecture/system/PlatformDiagnosticsArchitectureTest.java
+++ b/test/architecture/system/PlatformDiagnosticsArchitectureTest.java
@@ -1,0 +1,46 @@
+package architecture.system;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import architecture.AnalyzeMainClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.Diagnostics;
+
+@AnalyzeMainClasses
+public final class PlatformDiagnosticsArchitectureTest {
+
+    @ArchTest
+    static final ArchRule diagnosticsRemainLocalAndMechanismFree =
+            noClasses()
+                    .that()
+                    .resideInAPackage("platform.diagnostics..")
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            "java.net..",
+                            "java.net.http..",
+                            "java.sql..",
+                            "java.io..",
+                            "java.nio.file..",
+                            "shell..",
+                            "features..",
+                            "src..");
+
+    @Test
+    void diagnosticsApiCannotAcceptFreeFormPayloadsOrThrowables() {
+        for (Method method : Diagnostics.class.getDeclaredMethods()) {
+            assertFalse(Arrays.stream(method.getParameterTypes()).anyMatch(type ->
+                            type == String.class
+                                    || type == Object.class
+                                    || type == Map.class
+                                    || Throwable.class.isAssignableFrom(type)),
+                    () -> method + " must accept only stable diagnostic ids and failure types");
+        }
+    }
+}

--- a/test/platform/diagnostics/SystemLoggerDiagnosticsTest.java
+++ b/test/platform/diagnostics/SystemLoggerDiagnosticsTest.java
@@ -1,0 +1,25 @@
+package platform.diagnostics;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class SystemLoggerDiagnosticsTest {
+
+    @Test
+    void emitsOnlyStableIdAndFailureType() {
+        List<String> messages = new ArrayList<>();
+        SystemLoggerDiagnostics diagnostics = new SystemLoggerDiagnostics(messages::add);
+        String sensitive = "/home/user/game.db secret authored SQL";
+
+        diagnostics.failure(new DiagnosticId("worldplanner.load-failure"),
+                new IllegalStateException(sensitive).getClass());
+
+        assertTrue(messages.getFirst().contains("worldplanner.load-failure"));
+        assertTrue(messages.getFirst().contains(IllegalStateException.class.getName()));
+        assertFalse(messages.getFirst().contains(sensitive));
+    }
+}

--- a/test/platform/execution/SerialExecutionLaneTest.java
+++ b/test/platform/execution/SerialExecutionLaneTest.java
@@ -1,0 +1,154 @@
+package platform.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.Diagnostics;
+
+final class SerialExecutionLaneTest {
+
+    @Test
+    void runsOffCallerInFifoOrderAndKeepsNestedWorkInline() throws Exception {
+        List<Integer> order = new ArrayList<>();
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(1);
+        Thread caller = Thread.currentThread();
+        List<Thread> observed = new ArrayList<>();
+        SerialExecutionLane lane = new SerialExecutionLane(noopDiagnostics());
+        try {
+            lane.execute(() -> {
+                observed.add(Thread.currentThread());
+                await(release);
+                order.add(1);
+                lane.execute(() -> order.add(2));
+            });
+            lane.execute(() -> {
+                order.add(3);
+                finished.countDown();
+            });
+
+            assertTrue(order.isEmpty());
+            release.countDown();
+            assertTrue(finished.await(5L, TimeUnit.SECONDS));
+            assertFalse(observed.getFirst() == caller);
+            assertEquals(List.of(1, 2, 3), order);
+        } finally {
+            lane.close();
+        }
+    }
+
+    @Test
+    void reportsFailureContinuesAndRejectsAfterClose() throws Exception {
+        List<Class<? extends Throwable>> failures = new ArrayList<>();
+        CountDownLatch continued = new CountDownLatch(1);
+        SerialExecutionLane lane = new SerialExecutionLane((id, type) -> failures.add(type));
+        lane.execute(() -> {
+            throw new IllegalStateException("payload must not reach diagnostics");
+        });
+        lane.execute(continued::countDown);
+
+        assertTrue(continued.await(5L, TimeUnit.SECONDS));
+        lane.close();
+        assertEquals(List.of(IllegalStateException.class), failures);
+        assertThrows(RejectedExecutionException.class, () -> lane.execute(() -> { }));
+    }
+
+    @Test
+    void closeRejectsExternalWorkAndPreservesAcceptedWorkWhenTheCloserIsInterrupted() throws Exception {
+        CountDownLatch outerStarted = new CountDownLatch(1);
+        CountDownLatch releaseOuter = new CountDownLatch(1);
+        CountDownLatch queuedFinished = new CountDownLatch(1);
+        AtomicBoolean workerInterrupted = new AtomicBoolean();
+        AtomicBoolean closerInterruptPreserved = new AtomicBoolean();
+        SerialExecutionLane lane = new SerialExecutionLane(noopDiagnostics());
+        lane.execute(() -> {
+            outerStarted.countDown();
+            try {
+                releaseOuter.await();
+            } catch (InterruptedException exception) {
+                workerInterrupted.set(true);
+                Thread.currentThread().interrupt();
+            }
+        });
+        lane.execute(queuedFinished::countDown);
+        assertTrue(outerStarted.await(5L, TimeUnit.SECONDS));
+
+        Thread closer = new Thread(() -> {
+            lane.close();
+            closerInterruptPreserved.set(Thread.currentThread().isInterrupted());
+        });
+        closer.start();
+        try {
+            awaitExternalRejection(lane);
+            closer.interrupt();
+            assertTrue(closer.isAlive(), "interruption must not abandon the accepted queue");
+            releaseOuter.countDown();
+
+            assertTrue(queuedFinished.await(5L, TimeUnit.SECONDS));
+            closer.join(TimeUnit.SECONDS.toMillis(5L));
+            assertFalse(closer.isAlive());
+            assertFalse(workerInterrupted.get(), "closing must not interrupt active work");
+            assertTrue(closerInterruptPreserved.get(), "the closer interrupt status must be restored after draining");
+        } finally {
+            releaseOuter.countDown();
+            closer.join(TimeUnit.SECONDS.toMillis(5L));
+            lane.close();
+        }
+    }
+
+    @Test
+    void closeFromTheWorkerDoesNotDeadlockAndAcceptedWorkStillDrains() throws Exception {
+        CountDownLatch allowWorkerClose = new CountDownLatch(1);
+        CountDownLatch nestedFinished = new CountDownLatch(1);
+        CountDownLatch queuedFinished = new CountDownLatch(1);
+        SerialExecutionLane lane = new SerialExecutionLane(noopDiagnostics());
+        lane.execute(() -> {
+            await(allowWorkerClose);
+            lane.close();
+            lane.execute(nestedFinished::countDown);
+        });
+        lane.execute(queuedFinished::countDown);
+
+        allowWorkerClose.countDown();
+
+        assertTrue(nestedFinished.await(5L, TimeUnit.SECONDS));
+        assertTrue(queuedFinished.await(5L, TimeUnit.SECONDS));
+        assertThrows(RejectedExecutionException.class, () -> lane.execute(() -> { }));
+        lane.close();
+    }
+
+    private static Diagnostics noopDiagnostics() {
+        return (id, type) -> { };
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("test interrupted");
+        }
+    }
+
+    private static void awaitExternalRejection(SerialExecutionLane lane) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5L);
+        while (System.nanoTime() < deadline) {
+            try {
+                lane.execute(() -> { });
+                Thread.yield();
+            } catch (RejectedExecutionException expected) {
+                return;
+            }
+        }
+        throw new AssertionError("execution lane kept accepting external work after close began");
+    }
+}

--- a/test/platform/state/LatestStateTest.java
+++ b/test/platform/state/LatestStateTest.java
@@ -1,0 +1,35 @@
+package platform.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class LatestStateTest {
+
+    @Test
+    void rejectsLateResultsAndReplaysCurrentAtomically() {
+        LatestState<String> state = new LatestState<>("initial");
+        UpdateToken older = state.beginUpdate();
+        UpdateToken newer = state.beginUpdate();
+        List<StateSnapshot<String>> first = new ArrayList<>();
+
+        Runnable unsubscribe = state.subscribe(first::add);
+        assertTrue(state.publish(newer, "newer"));
+        assertFalse(state.publish(older, "older"));
+
+        List<StateSnapshot<String>> second = new ArrayList<>();
+        state.subscribe(second::add);
+        unsubscribe.run();
+        UpdateToken latest = state.beginUpdate();
+        assertTrue(state.publish(latest, "latest"));
+
+        assertEquals(List.of("initial", "newer"), first.stream().map(StateSnapshot::value).toList());
+        assertEquals(List.of("newer", "latest"), second.stream().map(StateSnapshot::value).toList());
+        assertEquals(3L, state.current().revision());
+        assertEquals("latest", state.current().value());
+    }
+}

--- a/test/platform/ui/JavaFxUiDispatcherTest.java
+++ b/test/platform/ui/JavaFxUiDispatcherTest.java
@@ -1,0 +1,40 @@
+package platform.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testsupport.JavaFxRuntime;
+
+final class JavaFxUiDispatcherTest {
+
+    @BeforeAll
+    static void startJavaFx() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        JavaFxRuntime.startup(started::countDown);
+        assertTrue(started.await(5L, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void dispatchesWorkerUpdatesExactlyOnceOnJavaFxThread() throws Exception {
+        JavaFxUiDispatcher dispatcher = new JavaFxUiDispatcher();
+        CountDownLatch finished = new CountDownLatch(1);
+        List<Boolean> fxThreads = new ArrayList<>();
+
+        Thread worker = new Thread(() -> dispatcher.dispatch(() -> {
+            fxThreads.add(Platform.isFxApplicationThread());
+            finished.countDown();
+        }));
+        worker.start();
+        worker.join();
+
+        assertTrue(finished.await(5L, TimeUnit.SECONDS));
+        assertEquals(List.of(true), fxThreads);
+    }
+}

--- a/test/src/bootstrap/SmokeStartupTest.java
+++ b/test/src/bootstrap/SmokeStartupTest.java
@@ -37,45 +37,47 @@ public final class SmokeStartupTest {
         Instant deadline = Instant.now().plus(TIMEOUT);
         testsupport.JavaFxRuntime.startup(() -> {
         });
-        AppShell shell = new AppBootstrap().createShell();
-        new Scene(shell, 1150, 700);
-        shell.applyCss();
-        shell.layout();
-        List<ToggleButton> navigation = navigationButtons(shell);
-        require(
-                navigation.stream().map(Node::getAccessibleText).toList().equals(List.of(
-                        "Session Planner",
-                        "World Planner",
-                        "Dungeon-Editor",
-                        "Dungeon-Reise",
-                        "Hex-Karte",
-                        "Encounter-Planer")),
-                "Expected exact explicit navigation manifest in shell order.");
-        require(
-                shell.lookup(".title-large") instanceof Label title && "Dungeon-Editor".equals(title.getText()),
-                "Expected Dungeon-Editor as explicit default landing.");
-        require(
-                navigation.stream().filter(ToggleButton::isSelected).map(Node::getAccessibleText).toList()
-                        .equals(List.of("Dungeon-Editor")),
-                "Expected only the default landing navigation entry to be selected.");
-        require(
-                shell.lookup(".toolbar") instanceof Pane toolbar && toolbar.getChildren().size() == 4,
-                "Expected title, spacer, and exactly two explicit top-bar contributions.");
-        List<String> topBarTooltips = shell.lookupAll(".toolbar .button").stream()
-                .filter(Button.class::isInstance)
-                .map(Button.class::cast)
-                .map(Button::getTooltip)
-                .filter(java.util.Objects::nonNull)
-                .map(javafx.scene.control.Tooltip::getText)
-                .sorted()
-                .toList();
-        require(topBarTooltips.equals(List.of(
-                        "Adventuring-Day-Rechner öffnen",
-                        "Party-Panel öffnen (Alt+P)")),
-                "Expected distinct Adventuring Day and Party top-bar surfaces, but was " + topBarTooltips + ".");
-        assertStateTabManifest(shell, navigation);
-        openTempSqliteConnection();
-        require(Instant.now().isBefore(deadline), "Smoke startup exceeded timeout.");
+        try (AppBootstrap bootstrap = new AppBootstrap()) {
+            AppShell shell = bootstrap.createShell();
+            new Scene(shell, 1150, 700);
+            shell.applyCss();
+            shell.layout();
+            List<ToggleButton> navigation = navigationButtons(shell);
+            require(
+                    navigation.stream().map(Node::getAccessibleText).toList().equals(List.of(
+                            "Session Planner",
+                            "World Planner",
+                            "Dungeon-Editor",
+                            "Dungeon-Reise",
+                            "Hex-Karte",
+                            "Encounter-Planer")),
+                    "Expected exact explicit navigation manifest in shell order.");
+            require(
+                    shell.lookup(".title-large") instanceof Label title && "Dungeon-Editor".equals(title.getText()),
+                    "Expected Dungeon-Editor as explicit default landing.");
+            require(
+                    navigation.stream().filter(ToggleButton::isSelected).map(Node::getAccessibleText).toList()
+                            .equals(List.of("Dungeon-Editor")),
+                    "Expected only the default landing navigation entry to be selected.");
+            require(
+                    shell.lookup(".toolbar") instanceof Pane toolbar && toolbar.getChildren().size() == 4,
+                    "Expected title, spacer, and exactly two explicit top-bar contributions.");
+            List<String> topBarTooltips = shell.lookupAll(".toolbar .button").stream()
+                    .filter(Button.class::isInstance)
+                    .map(Button.class::cast)
+                    .map(Button::getTooltip)
+                    .filter(java.util.Objects::nonNull)
+                    .map(javafx.scene.control.Tooltip::getText)
+                    .sorted()
+                    .toList();
+            require(topBarTooltips.equals(List.of(
+                            "Adventuring-Day-Rechner öffnen",
+                            "Party-Panel öffnen (Alt+P)")),
+                    "Expected distinct Adventuring Day and Party top-bar surfaces, but was " + topBarTooltips + ".");
+            assertStateTabManifest(shell, navigation);
+            openTempSqliteConnection();
+            require(Instant.now().isBefore(deadline), "Smoke startup exceeded timeout.");
+        }
     }
 
     private static List<ToggleButton> navigationButtons(AppShell shell) {

--- a/test/src/domain/creatures/CreaturesRuntimeBoundaryTest.java
+++ b/test/src/domain/creatures/CreaturesRuntimeBoundaryTest.java
@@ -1,0 +1,173 @@
+package src.domain.creatures;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.creatures.model.catalog.CreatureCatalogData;
+import src.domain.creatures.model.catalog.port.CreatureCatalogPort;
+import src.domain.creatures.published.CreatureLookupStatus;
+import src.domain.creatures.published.CreatureQueryStatus;
+import src.domain.creatures.published.RefreshCreatureCatalogCommand;
+
+final class CreaturesRuntimeBoundaryTest {
+
+    @Test
+    void catalogWorkIsQueuedDispatchedAndLatestRequestWins() {
+        ControllableLane lane = new ControllableLane();
+        QueuedUiDispatcher ui = new QueuedUiDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingPort port = new RecordingPort();
+        CreaturesServiceAssembly.Component component =
+                CreaturesServiceAssembly.create(port, lane, ui, diagnostics);
+        List<String> observedNames = new ArrayList<>();
+        component.catalog().subscribe(result -> observedNames.add(firstName(result)));
+
+        component.application().refreshCatalog(command("older"));
+        component.application().refreshCatalog(command("newer"));
+
+        assertEquals(0, port.searchCount, "commands do not touch storage on the caller");
+        lane.run(1);
+        assertEquals("newer", firstName(component.catalog().current()), "newer completion is current");
+        assertEquals(List.of(), observedNames, "publication callback waits for UI dispatch");
+        lane.run(0);
+        assertEquals("newer", firstName(component.catalog().current()), "older completion cannot replace newer state");
+        assertEquals(1, ui.size(), "stale completion does not enqueue another UI update");
+
+        ui.runAll();
+        assertEquals(List.of("newer"), observedNames, "callback runs through the supplied UI dispatcher");
+
+        component.application().refreshCatalog(command("fail"));
+        lane.run(0);
+        assertEquals(CreatureQueryStatus.STORAGE_ERROR, component.catalog().current().status());
+        port.failDetail = true;
+        assertEquals(CreatureLookupStatus.STORAGE_ERROR, component.references().find(7L).status());
+        assertEquals(
+                List.of("creatures.catalog.storage-failure", "creatures.reference.storage-failure"),
+                diagnostics.ids());
+    }
+
+    private static RefreshCreatureCatalogCommand command(String query) {
+        return new RefreshCreatureCatalogCommand(
+                query,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                50,
+                0);
+    }
+
+    private static String firstName(src.domain.creatures.published.CreatureCatalogPageResult result) {
+        return result.page().rows().isEmpty() ? "" : result.page().rows().getFirst().name();
+    }
+
+    private static final class RecordingPort implements CreatureCatalogPort {
+
+        private int searchCount;
+        private boolean failDetail;
+
+        @Override
+        public CreatureCatalogData.DistinctFilterValues loadFilterValues() {
+            return CreatureCatalogData.emptyFilterValues();
+        }
+
+        @Override
+        public CreatureCatalogData.CatalogPageData searchCatalog(CreatureCatalogData.CatalogSearchSpec spec) {
+            searchCount++;
+            if ("fail".equals(spec.nameQuery())) {
+                throw new IllegalStateException("fixture payload must not reach diagnostics");
+            }
+            return new CreatureCatalogData.CatalogPageData(
+                    List.of(new CreatureCatalogData.CatalogRowData(
+                            searchCount,
+                            spec.nameQuery(),
+                            "Medium",
+                            "Humanoid",
+                            "N",
+                            "1",
+                            200,
+                            10,
+                            12)),
+                    1,
+                    spec.pageSize(),
+                    spec.pageOffset());
+        }
+
+        @Override
+        public CreatureCatalogData.CreatureProfile loadCreatureDetail(long creatureId) {
+            if (failDetail) {
+                throw new IllegalStateException("fixture payload must not reach diagnostics");
+            }
+            return null;
+        }
+
+        @Override
+        public List<CreatureCatalogData.EncounterCandidateProfile> loadEncounterCandidates(
+                CreatureCatalogData.EncounterCandidateSpec spec
+        ) {
+            return List.of();
+        }
+    }
+
+    private static final class ControllableLane implements ExecutionLane {
+
+        private final List<Runnable> work = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.add(task);
+        }
+
+        void run(int index) {
+            work.remove(index).run();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class QueuedUiDispatcher implements UiDispatcher {
+
+        private final List<Runnable> updates = new ArrayList<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.add(update);
+        }
+
+        int size() {
+            return updates.size();
+        }
+
+        void runAll() {
+            List.copyOf(updates).forEach(Runnable::run);
+            updates.clear();
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+
+        private final List<String> ids = new ArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            ids.add(id.value());
+        }
+
+        List<String> ids() {
+            return List.copyOf(ids);
+        }
+    }
+}

--- a/test/src/domain/dungeon/DungeonPublishedStatePlatformAdoptionTest.java
+++ b/test/src/domain/dungeon/DungeonPublishedStatePlatformAdoptionTest.java
@@ -1,0 +1,88 @@
+package src.domain.dungeon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import platform.ui.UiDispatcher;
+import src.domain.dungeon.model.core.structure.DungeonMapIdentity;
+import src.domain.dungeon.published.DungeonMapCatalogResponse;
+
+final class DungeonPublishedStatePlatformAdoptionTest {
+
+    @Test
+    void subscribersUseTheUiDispatcherAndMutationAcknowledgementsDoNotReplaceCatalogTruth() {
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        DungeonAuthoredPublishedState state = new DungeonAuthoredPublishedState(dispatcher);
+        List<DungeonMapCatalogResponse> deliveries = new ArrayList<>();
+        List<DungeonMapCatalogResponse> currentWhileDispatching = new ArrayList<>();
+        state.mapCatalogModel().subscribe(deliveries::add);
+        dispatcher.beforeDispatch(() -> currentWhileDispatching.add(state.mapCatalogModel().current()));
+        DungeonMapIdentity mapId = new DungeonMapIdentity(7L);
+
+        state.publishSearch(new DungeonAuthoredPublication.Catalog(List.of(
+                new DungeonAuthoredPublication.MapSummary(mapId, "Current", 4L))));
+        currentWhileDispatching.clear();
+        state.publishRenamed(new DungeonAuthoredPublication.MapMutation(mapId));
+
+        DungeonMapCatalogResponse.MapList currentDuringMutationDispatch = assertInstanceOf(
+                DungeonMapCatalogResponse.MapList.class,
+                currentWhileDispatching.getFirst());
+        assertEquals("Current", currentDuringMutationDispatch.maps().getFirst().mapName());
+        DungeonMapCatalogResponse.MapList current = assertInstanceOf(
+                DungeonMapCatalogResponse.MapList.class,
+                state.mapCatalogModel().current());
+        assertEquals("Current", current.maps().getFirst().mapName());
+        assertEquals(0, deliveries.size());
+        dispatcher.runAll();
+        assertEquals(2, deliveries.size());
+        assertInstanceOf(DungeonMapCatalogResponse.MapMutation.class, deliveries.get(1));
+    }
+
+    @Test
+    void mutationEventsDeduplicateSubscribersAndCancelQueuedDeliveryAfterUnsubscribe() {
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        DungeonAuthoredPublishedState state = new DungeonAuthoredPublishedState(dispatcher);
+        List<DungeonMapCatalogResponse> deliveries = new ArrayList<>();
+        Consumer<DungeonMapCatalogResponse> subscriber = deliveries::add;
+        Runnable unsubscribe = state.mapCatalogModel().subscribe(subscriber);
+        state.mapCatalogModel().subscribe(subscriber);
+        DungeonAuthoredPublication.MapMutation mutation = new DungeonAuthoredPublication.MapMutation(
+                new DungeonMapIdentity(9L));
+
+        state.publishRenamed(mutation);
+        dispatcher.runAll();
+        assertEquals(1, deliveries.size());
+
+        state.publishDeleted(mutation);
+        unsubscribe.run();
+        dispatcher.runAll();
+        assertEquals(1, deliveries.size());
+    }
+
+    private static final class QueuedDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+        private Runnable beforeDispatch = () -> { };
+
+        @Override
+        public void dispatch(Runnable update) {
+            beforeDispatch.run();
+            updates.addLast(update);
+        }
+
+        void beforeDispatch(Runnable action) {
+            beforeDispatch = action;
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+}

--- a/test/src/domain/encounter/EncounterRuntimeMechanismsTest.java
+++ b/test/src/domain/encounter/EncounterRuntimeMechanismsTest.java
@@ -1,0 +1,143 @@
+package src.domain.encounter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.encounter.model.plan.SavedEncounterPlansLoadResult;
+import src.domain.encounter.published.ApplyEncounterStateCommand;
+import src.domain.encounter.published.EncounterBuilderInputs;
+import src.domain.encounter.published.RefreshEncounterPlanBudgetCommand;
+import src.domain.encounter.published.SavedEncounterPlanStatus;
+import src.domain.encounter.published.UpdateEncounterBuilderInputsCommand;
+
+final class EncounterRuntimeMechanismsTest {
+
+    @Test
+    void commandsEnterLaneAndStateBuilderTuningCallbacksKeepPublicationOrder() {
+        RecordingLane lane = new RecordingLane();
+        RecordingActions actions = new RecordingActions();
+        EncounterApplicationService application = new EncounterApplicationService(actions, lane);
+
+        assertEquals(1, lane.pending());
+        assertTrue(actions.calls.isEmpty());
+        lane.runNext();
+        assertEquals(List.of("initialize"), actions.calls);
+
+        application.applyState(ApplyEncounterStateCommand.action(ApplyEncounterStateCommand.Action.REFRESH));
+        application.updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(EncounterBuilderInputs.empty()));
+        application.refreshPlanBudget(new RefreshEncounterPlanBudgetCommand(1L));
+        assertEquals(3, lane.pending());
+        lane.runAll();
+        assertEquals(List.of("initialize", "state", "builder", "budget"), actions.calls);
+
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        EncounterPublishedState publishedState = new EncounterPublishedState(dispatcher);
+        List<String> callbackOrder = new ArrayList<>();
+        publishedState.stateModel().subscribe(ignored -> callbackOrder.add("state"));
+        publishedState.builderInputsModel().subscribe(ignored -> callbackOrder.add("builder"));
+        publishedState.tuningPreviewModel().subscribe(ignored -> callbackOrder.add("tuning"));
+
+        lane.execute(() -> publishedState.publishCurrentSession(null, null));
+        lane.runNext();
+        assertTrue(callbackOrder.isEmpty());
+        assertEquals(3, dispatcher.pending());
+        dispatcher.runAll();
+        assertEquals(List.of("state", "builder", "tuning"), callbackOrder);
+    }
+
+    @Test
+    void savedPlanCallbackUsesSuppliedUiDispatcher() {
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        EncounterPublishedState publishedState = new EncounterPublishedState(dispatcher);
+        List<Boolean> observed = new ArrayList<>();
+        publishedState.savedPlansModel().subscribe(
+                result -> observed.add(result.status() == SavedEncounterPlanStatus.SUCCESS));
+
+        publishedState.publishSavedPlans(SavedEncounterPlansLoadResult.success(List.of()));
+
+        assertTrue(observed.isEmpty());
+        assertEquals(1, dispatcher.pending());
+        dispatcher.runAll();
+        assertEquals(List.of(true), observed);
+    }
+
+    private static final class RecordingActions implements EncounterApplicationService.CommandActions {
+
+        private final List<String> calls = new ArrayList<>();
+
+        @Override
+        public void initialize() {
+            calls.add("initialize");
+        }
+
+        @Override
+        public void applyState(ApplyEncounterStateCommand command) {
+            calls.add("state");
+        }
+
+        @Override
+        public void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command) {
+            calls.add("builder");
+        }
+
+        @Override
+        public void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command) {
+            calls.add("budget");
+        }
+    }
+
+    private static final class RecordingLane implements ExecutionLane {
+
+        private final ArrayDeque<Runnable> work = new ArrayDeque<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.addLast(task);
+        }
+
+        int pending() {
+            return work.size();
+        }
+
+        void runNext() {
+            work.removeFirst().run();
+        }
+
+        void runAll() {
+            while (!work.isEmpty()) {
+                runNext();
+            }
+        }
+
+        @Override
+        public void close() {
+            work.clear();
+        }
+    }
+
+    private static final class RecordingDispatcher implements UiDispatcher {
+
+        private final ArrayDeque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        int pending() {
+            return updates.size();
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+}

--- a/test/src/domain/encountertable/EncounterTableRuntimeBoundaryTest.java
+++ b/test/src/domain/encountertable/EncounterTableRuntimeBoundaryTest.java
@@ -1,0 +1,121 @@
+package src.domain.encountertable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.encountertable.model.catalog.EncounterTableCandidateData;
+import src.domain.encountertable.model.catalog.EncounterTableSummaryData;
+import src.domain.encountertable.model.catalog.port.EncounterTableCatalogPort;
+import src.domain.encountertable.published.EncounterTableReadStatus;
+import src.domain.encountertable.published.RefreshEncounterTableCandidatesCommand;
+import src.domain.encountertable.published.RefreshEncounterTableCatalogCommand;
+
+final class EncounterTableRuntimeBoundaryTest {
+
+    @Test
+    void readsEnterTheLaneAndPublicationsUseTheUiDispatcher() {
+        ControllableLane lane = new ControllableLane();
+        QueuedUiDispatcher ui = new QueuedUiDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingPort port = new RecordingPort();
+        EncounterTableServiceAssembly.Component component =
+                EncounterTableServiceAssembly.create(port, lane, ui, diagnostics);
+        List<EncounterTableReadStatus> observed = new ArrayList<>();
+        component.catalog().subscribe(result -> observed.add(result.status()));
+
+        component.application().refreshCatalog(new RefreshEncounterTableCatalogCommand());
+        component.application().refreshCandidates(new RefreshEncounterTableCandidatesCommand(List.of(1L), 100));
+        assertEquals(0, port.readCount, "construction and commands do not read on the caller");
+
+        lane.runNext();
+        assertEquals(1, port.readCount);
+        assertEquals(List.of(), observed, "callback waits for UI dispatch");
+        ui.runAll();
+        assertEquals(List.of(EncounterTableReadStatus.SUCCESS), observed);
+
+        lane.runNext();
+        assertEquals(2, port.readCount);
+        port.fail = true;
+        component.application().refreshCatalog(new RefreshEncounterTableCatalogCommand());
+        lane.runNext();
+        assertEquals(EncounterTableReadStatus.STORAGE_ERROR, component.catalog().current().status());
+        assertEquals(EncounterTableReadStatus.STORAGE_ERROR, component.references().catalog().status());
+        assertEquals(
+                List.of("encountertable.catalog.storage-failure", "encountertable.reference.storage-failure"),
+                diagnostics.ids());
+    }
+
+    private static final class RecordingPort implements EncounterTableCatalogPort {
+
+        private int readCount;
+        private boolean fail;
+
+        @Override
+        public List<EncounterTableSummaryData> loadSummaries() {
+            readCount++;
+            if (fail) {
+                throw new IllegalStateException("fixture payload must not reach diagnostics");
+            }
+            return List.of(new EncounterTableSummaryData(1L, "Ambush", null));
+        }
+
+        @Override
+        public List<EncounterTableCandidateData> loadGenerationCandidates(List<Long> tableIds, int maximumXp) {
+            readCount++;
+            return List.of();
+        }
+    }
+
+    private static final class ControllableLane implements ExecutionLane {
+
+        private final List<Runnable> work = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.add(task);
+        }
+
+        void runNext() {
+            work.removeFirst().run();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class QueuedUiDispatcher implements UiDispatcher {
+
+        private final List<Runnable> updates = new ArrayList<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.add(update);
+        }
+
+        void runAll() {
+            List.copyOf(updates).forEach(Runnable::run);
+            updates.clear();
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+
+        private final List<String> ids = new ArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            ids.add(id.value());
+        }
+
+        List<String> ids() {
+            return List.copyOf(ids);
+        }
+    }
+}

--- a/test/src/domain/hex/HexRuntimePlatformAdoptionTest.java
+++ b/test/src/domain/hex/HexRuntimePlatformAdoptionTest.java
@@ -1,0 +1,294 @@
+package src.domain.hex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.hex.model.map.HexCoordinate;
+import src.domain.hex.model.map.HexEditorWorkspace;
+import src.domain.hex.model.map.HexMap;
+import src.domain.hex.model.map.HexMapIdentity;
+import src.domain.hex.model.map.HexMapSummary;
+import src.domain.hex.model.map.HexMarker;
+import src.domain.hex.model.map.HexTerrain;
+import src.domain.hex.model.map.repository.HexMapRepository;
+import src.domain.hex.published.HexEditorModel;
+import src.domain.hex.published.LoadHexEditorCommand;
+import src.domain.hex.published.PaintHexTerrainCommand;
+import src.domain.hex.published.SaveHexMarkerCommand;
+import src.domain.hex.published.SelectHexMapCommand;
+import src.domain.hex.published.SelectHexTileCommand;
+import src.domain.hex.published.SetHexEditorToolCommand;
+
+final class HexRuntimePlatformAdoptionTest {
+
+    @Test
+    void persistenceWorkRunsOnTheSuppliedLaneAndPublishesThroughTheUiDispatcher() {
+        QueuedLane lane = new QueuedLane();
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        RecordingRepository repository = new RecordingRepository();
+        HexEditorModel model = new HexEditorModel(dispatcher);
+        HexEditorApplicationService service = service(repository, model, lane, new RecordingDiagnostics());
+        List<String> deliveredStatuses = new ArrayList<>();
+        model.subscribe(snapshot -> deliveredStatuses.add(snapshot.statusText()));
+
+        service.loadEditor(new LoadHexEditorCommand());
+
+        assertTrue(repository.events.isEmpty(), "repository access must not run on the caller");
+        lane.runNext();
+        assertFalse(repository.events.isEmpty(), "queued work must enter the repository on the lane");
+        assertTrue(deliveredStatuses.isEmpty(), "published state must wait for the supplied UI dispatcher");
+        dispatcher.runAll();
+        assertEquals(1, deliveredStatuses.size());
+    }
+
+    @Test
+    void reloadAndSelectionAreSubmittedAsOneOrderedLaneOperation() {
+        QueuedLane lane = new QueuedLane();
+        RecordingRepository repository = new RecordingRepository();
+        HexEditorApplicationService service = service(
+                repository,
+                new HexEditorModel(),
+                lane,
+                new RecordingDiagnostics());
+
+        service.reloadAndSelectMap(new LoadHexEditorCommand(), new SelectHexMapCommand(1L));
+
+        assertEquals(1, lane.size());
+        lane.runNext();
+        assertTrue(repository.events.indexOf("loadSelected") < repository.events.indexOf("loadById"));
+        assertTrue(repository.events.indexOf("loadById") < repository.events.indexOf("setSelectedMap"));
+    }
+
+    @Test
+    void storageFailureUsesGenericTextAndPayloadFreeDiagnostics() {
+        QueuedLane lane = new QueuedLane();
+        RecordingRepository repository = new RecordingRepository();
+        repository.failure = new IllegalStateException("authored secret payload");
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        HexEditorModel model = new HexEditorModel();
+        HexEditorApplicationService service = service(repository, model, lane, diagnostics);
+
+        service.loadEditor(new LoadHexEditorCommand());
+        lane.runNext();
+
+        assertEquals("Hex-Daten konnten nicht geladen oder gespeichert werden.", model.current().failureText());
+        assertFalse(model.current().failureText().contains("secret"));
+        assertEquals(new DiagnosticId("hex.storage-failure"), diagnostics.id);
+        assertEquals(IllegalStateException.class, diagnostics.failureType);
+    }
+
+    @Test
+    void immediateToolIntentDoesNotEnterThePersistenceLaneOrMutateLaneOwnedWorkspace() {
+        QueuedLane lane = new QueuedLane();
+        HexEditorModel model = new HexEditorModel();
+        HexEditorWorkspace workspace = new HexEditorWorkspace();
+        HexEditorApplicationService service = new HexEditorApplicationService(
+                new RecordingRepository(), workspace, model, lane, new RecordingDiagnostics());
+
+        service.setActiveTool(new SetHexEditorToolCommand("PAINT_TERRAIN", "WATER"));
+
+        assertEquals(0, lane.size());
+        assertEquals("PAINT_TERRAIN", model.current().activeTool());
+        assertEquals("WATER", model.current().activeTerrain());
+        assertEquals("SELECT", workspace.state().activeMode().name());
+        assertEquals("GRASSLAND", workspace.state().activeTerrain().name());
+    }
+
+    @Test
+    void queuedTileSelectionCannotOverwriteNewerImmediateMarkerToolDraft() {
+        QueuedLane lane = new QueuedLane();
+        HexEditorModel model = new HexEditorModel();
+        HexEditorApplicationService service = service(
+                new RecordingRepository(), model, lane, new RecordingDiagnostics());
+
+        service.selectTile(new SelectHexTileCommand(1L, 0, 0));
+        service.setActiveTool(new SetHexEditorToolCommand("PLACE_MARKER", "WATER"));
+        lane.runNext();
+
+        assertEquals("PLACE_MARKER", model.current().activeTool());
+        assertEquals("WATER", model.current().activeTerrain());
+        assertEquals(0, model.current().selectedTile().orElseThrow().q());
+        assertEquals(0, model.current().selectedTile().orElseThrow().r());
+    }
+
+    @Test
+    void queuedPaintCompletionCannotOverwriteNewerImmediateMarkerToolIntent() {
+        QueuedLane lane = new QueuedLane();
+        HexEditorModel model = new HexEditorModel();
+        HexEditorApplicationService service = service(
+                new RecordingRepository(), model, lane, new RecordingDiagnostics());
+
+        service.paintTerrain(new PaintHexTerrainCommand(1L, 0, 0, "WATER"));
+        service.setActiveTool(new SetHexEditorToolCommand("PLACE_MARKER", "FOREST"));
+        lane.runNext();
+
+        assertEquals("PLACE_MARKER", model.current().activeTool());
+        assertEquals("FOREST", model.current().activeTerrain());
+        assertEquals("WATER", model.current().tiles().stream()
+                .filter(tile -> tile.q() == 0 && tile.r() == 0)
+                .findFirst()
+                .orElseThrow()
+                .terrain());
+    }
+
+    @Test
+    void queuedMarkerCompletionCannotOverwriteNewerImmediateMoveToolIntent() {
+        QueuedLane lane = new QueuedLane();
+        HexEditorModel model = new HexEditorModel();
+        HexEditorApplicationService service = service(
+                new RecordingRepository(), model, lane, new RecordingDiagnostics());
+
+        service.saveMarker(new SaveHexMarkerCommand(
+                1L, 0L, 0, 0, "Harbor", "LANDMARK", "Safe anchorage"));
+        service.setActiveTool(new SetHexEditorToolCommand("MOVE_PARTY", "DESERT"));
+        lane.runNext();
+
+        assertEquals("MOVE_PARTY", model.current().activeTool());
+        assertEquals("DESERT", model.current().activeTerrain());
+        assertEquals("Harbor", model.current().tiles().stream()
+                .filter(tile -> tile.q() == 0 && tile.r() == 0)
+                .findFirst()
+                .orElseThrow()
+                .markers()
+                .getFirst()
+                .name());
+    }
+
+    private static HexEditorApplicationService service(
+            HexMapRepository repository,
+            HexEditorModel model,
+            ExecutionLane lane,
+            Diagnostics diagnostics
+    ) {
+        return new HexEditorApplicationService(
+                repository, new HexEditorWorkspace(), model, lane, diagnostics);
+    }
+
+    private static final class QueuedLane implements ExecutionLane {
+        private final Deque<Runnable> work = new ArrayDeque<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.addLast(task);
+        }
+
+        int size() {
+            return work.size();
+        }
+
+        void runNext() {
+            work.removeFirst().run();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class QueuedDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+        private DiagnosticId id;
+        private Class<? extends Throwable> failureType;
+
+        @Override
+        public void failure(DiagnosticId diagnosticId, Class<? extends Throwable> type) {
+            id = diagnosticId;
+            failureType = type;
+        }
+    }
+
+    private static final class RecordingRepository implements HexMapRepository {
+        private final List<String> events = new ArrayList<>();
+        private final HexMap map = HexMap.create(new HexMapIdentity(1L), "Map", 2);
+        private IllegalStateException failure;
+
+        @Override
+        public Optional<HexMap> loadSelected() {
+            events.add("loadSelected");
+            failIfRequested();
+            return Optional.of(map);
+        }
+
+        @Override
+        public Optional<HexMap> loadById(HexMapIdentity mapId) {
+            events.add("loadById");
+            return Optional.of(map);
+        }
+
+        @Override
+        public Optional<HexMapSummary> loadSummaryById(HexMapIdentity mapId) {
+            return Optional.of(summary());
+        }
+
+        @Override
+        public List<HexMapSummary> listMaps() {
+            events.add("listMaps");
+            return List.of(summary());
+        }
+
+        @Override
+        public HexMap save(HexMap savedMap) {
+            return savedMap;
+        }
+
+        @Override
+        public HexMap saveTerrain(HexMapIdentity mapId, HexCoordinate coordinate, HexTerrain terrain) {
+            return map.paintTerrain(coordinate, terrain);
+        }
+
+        @Override
+        public HexMap saveMarker(HexMapIdentity mapId, HexMarker marker) {
+            return map.saveMarker(marker.markerId(), marker.coordinate(), marker.name(), marker.type(), marker.note());
+        }
+
+        @Override
+        public long nextMapId() {
+            return 2L;
+        }
+
+        @Override
+        public long nextMarkerId(HexMapIdentity mapId) {
+            return 1L;
+        }
+
+        @Override
+        public void setSelectedMap(HexMapIdentity mapId) {
+            events.add("setSelectedMap");
+        }
+
+        private void failIfRequested() {
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        private HexMapSummary summary() {
+            return new HexMapSummary(map.mapId(), map.displayName(), map.radius());
+        }
+    }
+}

--- a/test/src/domain/party/PartyRuntimeMechanismsTest.java
+++ b/test/src/domain/party/PartyRuntimeMechanismsTest.java
@@ -1,0 +1,232 @@
+package src.domain.party;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.party.model.roster.PartyCharacterDraft;
+import src.domain.party.model.roster.PartyMembership;
+import src.domain.party.model.roster.PartyRoster;
+import src.domain.party.model.roster.repository.PartyRosterRepository;
+import src.domain.party.model.roster.PartyTravelLocation;
+import src.domain.party.published.CharacterDraft;
+import src.domain.party.published.CreateCharacterCommand;
+import src.domain.party.published.MembershipState;
+import src.domain.party.published.MutationStatus;
+import src.domain.party.published.PartyOverworldTravelLocationSnapshot;
+import src.domain.party.published.PartyTravelPositionsResult;
+import src.domain.party.published.ReadStatus;
+
+final class PartyRuntimeMechanismsTest {
+
+    @Test
+    void queuedInitializationPublishesPersistedRosterAndHexTravelToExistingSubscribers() {
+        RecordingLane lane = new RecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingRepository repository = new RecordingRepository();
+        repository.seedOverworldTravel();
+
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                repository, lane, dispatcher, new RecordingDiagnostics());
+        List<Integer> observedActiveCounts = new ArrayList<>();
+        List<PartyTravelPositionsResult> observedTravel = new ArrayList<>();
+        party.snapshot().subscribe(result -> observedActiveCounts.add(
+                result.snapshot().summary().activeCount()));
+        party.travelPositions().subscribe(observedTravel::add);
+
+        assertEquals(0, repository.loads);
+        assertEquals(1, lane.pending());
+        lane.runNext();
+
+        assertEquals(1, repository.loads, "initial refresh reads the persisted roster once");
+        assertEquals(1, party.snapshot().current().snapshot().summary().activeCount());
+        PartyOverworldTravelLocationSnapshot currentLocation =
+                (PartyOverworldTravelLocationSnapshot) party.travelPositions().current().partyTokenLocation();
+        assertEquals(7L, currentLocation.mapId());
+        assertEquals(42L, currentLocation.tileId());
+        assertTrue(observedActiveCounts.isEmpty(), "initial roster delivery waits for the UI dispatcher");
+        assertTrue(observedTravel.isEmpty(), "initial travel delivery waits for the UI dispatcher");
+
+        dispatcher.runAll();
+
+        assertEquals(List.of(1), observedActiveCounts);
+        assertEquals(1, observedTravel.size());
+        PartyOverworldTravelLocationSnapshot deliveredLocation =
+                (PartyOverworldTravelLocationSnapshot) observedTravel.getFirst().partyTokenLocation();
+        assertEquals(7L, deliveredLocation.mapId());
+        assertEquals(42L, deliveredLocation.tileId());
+    }
+
+    @Test
+    void queuedInitializationPublishesStorageFailureToExistingSubscribers() {
+        RecordingLane lane = new RecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingRepository repository = new RecordingRepository();
+        repository.failLoads = true;
+
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                repository, lane, dispatcher, diagnostics);
+        List<ReadStatus> snapshotStatuses = new ArrayList<>();
+        List<ReadStatus> travelStatuses = new ArrayList<>();
+        party.snapshot().subscribe(result -> snapshotStatuses.add(result.status()));
+        party.travelPositions().subscribe(result -> travelStatuses.add(result.status()));
+
+        lane.runNext();
+        assertTrue(snapshotStatuses.isEmpty(), "initial failure delivery waits for the UI dispatcher");
+        assertTrue(travelStatuses.isEmpty(), "initial travel failure waits for the UI dispatcher");
+        dispatcher.runAll();
+
+        assertEquals(List.of(ReadStatus.STORAGE_ERROR), snapshotStatuses);
+        assertEquals(List.of(ReadStatus.STORAGE_ERROR), travelStatuses);
+        assertEquals(List.of("party.storage-failure"), diagnostics.ids);
+        assertEquals(List.of(IllegalStateException.class), diagnostics.failureTypes);
+    }
+
+    @Test
+    void partyUsesOneLaneReadAndDispatcherForOneCoherentRosterRevision() {
+        RecordingLane lane = new RecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingRepository repository = new RecordingRepository();
+
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                repository, lane, dispatcher, diagnostics);
+
+        assertEquals(0, repository.loads);
+        assertEquals(1, lane.pending());
+        lane.runNext();
+        assertEquals(1, repository.loads, "initial refresh reads the roster once");
+
+        List<Integer> observedActiveCounts = new ArrayList<>();
+        party.snapshot().subscribe(result -> observedActiveCounts.add(
+                result.snapshot().summary().activeCount()));
+        party.application().createCharacter(new CreateCharacterCommand(
+                new CharacterDraft("Aria", "Mira", 3, 14, 16),
+                MembershipState.ACTIVE));
+
+        assertEquals(1, lane.pending(), "persistence-backed command enters the lane");
+        assertEquals(1, repository.loads, "repository is untouched before lane execution");
+        lane.runNext();
+
+        assertEquals(2, repository.loads, "mutation reads one roster revision");
+        assertEquals(1, repository.saves);
+        assertEquals(1, party.snapshot().current().snapshot().summary().activeCount());
+        assertEquals(List.of(3), party.activeComposition().current().composition().activePartyLevels());
+        assertTrue(observedActiveCounts.isEmpty(), "callback waits for the UI dispatcher");
+        dispatcher.runAll();
+        assertEquals(List.of(1), observedActiveCounts);
+        assertTrue(diagnostics.ids.isEmpty());
+    }
+
+    @Test
+    void partyReportsOnePayloadFreeDiagnosticForTerminalStorageFailure() {
+        RecordingLane lane = new RecordingLane();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingRepository repository = new RecordingRepository();
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                repository, lane, update -> update.run(), diagnostics);
+        lane.runNext();
+        repository.failLoads = true;
+
+        party.application().createCharacter(new CreateCharacterCommand(
+                new CharacterDraft("Aria", "Mira", 3, 14, 16),
+                MembershipState.ACTIVE));
+        lane.runNext();
+
+        assertEquals(List.of("party.storage-failure"), diagnostics.ids);
+        assertEquals(List.of(IllegalStateException.class), diagnostics.failureTypes);
+        assertEquals(MutationStatus.STORAGE_ERROR, party.mutation().current().status());
+    }
+
+    private static final class RecordingRepository implements PartyRosterRepository {
+
+        private PartyRoster roster = new PartyRoster(1L, List.of());
+        private int loads;
+        private int saves;
+        private boolean failLoads;
+
+        void seedOverworldTravel() {
+            roster = roster.createCharacter(
+                    new PartyCharacterDraft("Aria", "Mira", 3, 14, 16),
+                    PartyMembership.ACTIVE).roster();
+            roster = roster.moveCharacters(
+                    List.of(1L),
+                    PartyTravelLocation.overworld(7L, 42L),
+                    true).roster();
+        }
+
+        @Override
+        public PartyRoster load() {
+            loads++;
+            if (failLoads) {
+                throw new IllegalStateException("user-authored roster payload must not enter diagnostics");
+            }
+            return roster;
+        }
+
+        @Override
+        public void save(PartyRoster nextRoster) {
+            saves++;
+            roster = nextRoster;
+        }
+    }
+
+    private static final class RecordingLane implements ExecutionLane {
+
+        private final ArrayDeque<Runnable> work = new ArrayDeque<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.addLast(task);
+        }
+
+        int pending() {
+            return work.size();
+        }
+
+        void runNext() {
+            work.removeFirst().run();
+        }
+
+        @Override
+        public void close() {
+            work.clear();
+        }
+    }
+
+    private static final class RecordingDispatcher implements UiDispatcher {
+
+        private final ArrayDeque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+
+        private final List<String> ids = new ArrayList<>();
+        private final List<Class<? extends Throwable>> failureTypes = new ArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            ids.add(id.value());
+            failureTypes.add(failureType);
+        }
+    }
+}

--- a/test/src/domain/sessionplanner/SessionPlannerRuntimeMechanismsTest.java
+++ b/test/src/domain/sessionplanner/SessionPlannerRuntimeMechanismsTest.java
@@ -1,0 +1,399 @@
+package src.domain.sessionplanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.encounter.EncounterApplicationServiceFakes;
+import src.domain.encounter.published.EncounterPlanBudgetModel;
+import src.domain.encounter.published.EncounterPlanBudgetResult;
+import src.domain.encounter.published.EncounterPlanBudgetStatus;
+import src.domain.encounter.published.SavedEncounterPlanListModel;
+import src.domain.encounter.published.SavedEncounterPlanListResult;
+import src.domain.encounter.published.SavedEncounterPlanStatus;
+import src.domain.party.PartyServiceAssembly;
+import src.domain.party.model.roster.PartyRoster;
+import src.domain.party.model.roster.repository.PartyRosterRepository;
+import src.domain.party.published.CharacterDraft;
+import src.domain.party.published.CreateCharacterCommand;
+import src.domain.party.published.MembershipState;
+import src.domain.sessionplanner.model.session.EncounterDays;
+import src.domain.sessionplanner.model.session.SessionPlan;
+import src.domain.sessionplanner.model.session.SessionPlanSummary;
+import src.domain.sessionplanner.model.session.repository.SessionPlanRepository;
+import src.domain.sessionplanner.published.SessionPlannerCatalogCommand;
+import src.domain.sessionplanner.published.SetSessionEncounterDaysCommand;
+
+final class SessionPlannerRuntimeMechanismsTest {
+
+    @Test
+    void currentIsIoFreeAndExplicitInitializationPublishesAfterSubscription() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(
+                SessionPlan.seeded(1L, List.of(1L), EncounterDays.one()));
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+
+        assertEquals(0, repository.reads);
+        assertEquals(0L, planner.currentSessionModel().current().session().sessionId());
+        assertTrue(planner.catalogModel().current().sessions().isEmpty());
+        assertEquals(0, repository.reads, "all lazy current suppliers are I/O-free");
+
+        List<Long> observedSessions = new ArrayList<>();
+        planner.currentSessionModel().subscribe(snapshot -> observedSessions.add(snapshot.session().sessionId()));
+        planner.application().initialize();
+        assertEquals(0, repository.reads);
+        assertEquals(1, lane.pending());
+        lane.runAll();
+
+        assertEquals(2, repository.reads, "initialization loads current session and catalog on the lane");
+        assertEquals(1L, planner.currentSessionModel().current().session().sessionId());
+        assertTrue(planner.currentSessionModel().current().xpBudget().available(),
+                "nested Party command-to-current read completes inline on the shared lane");
+        assertTrue(observedSessions.isEmpty(), "published callback waits for the supplied UI dispatcher");
+        dispatcher.runAll();
+        assertEquals(List.of(1L), observedSessions);
+        assertTrue(diagnostics.ids.isEmpty());
+    }
+
+    @Test
+    void initializationReportsOnePayloadFreeStorageDiagnostic() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(null);
+        repository.failReads = true;
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+
+        planner.application().initialize();
+        lane.runAll();
+
+        assertEquals(List.of("sessionplanner.storage-failure"), diagnostics.ids);
+        assertEquals(List.of(IllegalStateException.class), diagnostics.failureTypes);
+        assertFalse(planner.currentSessionModel().current().xpBudget().available());
+    }
+
+    @Test
+    void mutationLoadFailureAbortsWithoutSavingOrReplacingStableState() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(
+                SessionPlan.seeded(7L, List.of(1L), EncounterDays.one()));
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+        planner.application().initialize();
+        lane.runAll();
+        var stable = planner.currentSessionModel().current();
+        repository.failCurrentLoads = true;
+
+        planner.application().setEncounterDays(new SetSessionEncounterDaysCommand(new BigDecimal("2")));
+        lane.runAll();
+
+        assertEquals(0, repository.saves);
+        assertEquals(stable, planner.currentSessionModel().current());
+        assertEquals(List.of("sessionplanner.storage-failure"), diagnostics.ids);
+    }
+
+    @Test
+    void nextIdFailureAbortsCreateWithoutSavingFallbackIdentity() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(
+                SessionPlan.seeded(7L, List.of(1L), EncounterDays.one()));
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+        planner.application().initialize();
+        lane.runAll();
+        var stable = planner.currentSessionModel().current();
+        repository.failNextId = true;
+
+        planner.application().createSession(new SessionPlannerCatalogCommand.CreateSessionCommand("Next"));
+        lane.runAll();
+
+        assertEquals(0, repository.saves);
+        assertEquals(stable, planner.currentSessionModel().current());
+        assertEquals(7L, repository.current.sessionId());
+        assertEquals(List.of("sessionplanner.storage-failure"), diagnostics.ids);
+    }
+
+    @Test
+    void failedSavePublishesFailureStatusOverLastStableSessionContent() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(
+                SessionPlan.seeded(7L, List.of(1L), EncounterDays.one()));
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+        planner.application().initialize();
+        lane.runAll();
+        repository.failSaves = true;
+
+        planner.application().setEncounterDays(new SetSessionEncounterDaysCommand(new BigDecimal("2")));
+        lane.runAll();
+
+        assertEquals(1, repository.saves);
+        assertEquals(BigDecimal.ONE, repository.current.encounterDays().value());
+        assertEquals(BigDecimal.ONE,
+                planner.currentSessionModel().current().session().encounterDays());
+        assertEquals("Session konnte nicht gespeichert werden.",
+                planner.currentSessionModel().current().status());
+        assertEquals(List.of("sessionplanner.storage-failure"), diagnostics.ids);
+    }
+
+    @Test
+    void failedSavePublishesStableFailureWithoutFollowUpStorageRead() {
+        ReentrantRecordingLane lane = new ReentrantRecordingLane();
+        RecordingDispatcher dispatcher = new RecordingDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        PartyServiceAssembly.Component party = createParty(lane, dispatcher);
+        RecordingSessionRepository repository = new RecordingSessionRepository(
+                SessionPlan.seeded(7L, List.of(1L), EncounterDays.one()));
+        SessionPlannerServiceAssembly planner = createPlanner(
+                repository, party, lane, dispatcher, diagnostics);
+        planner.application().initialize();
+        lane.runAll();
+        var stableCatalog = planner.catalogModel().current();
+        repository.failSaves = true;
+        repository.failLists = true;
+
+        planner.application().setEncounterDays(new SetSessionEncounterDaysCommand(new BigDecimal("2")));
+        lane.runAll();
+
+        assertEquals(BigDecimal.ONE,
+                planner.currentSessionModel().current().session().encounterDays());
+        assertEquals("Session konnte nicht gespeichert werden.",
+                planner.currentSessionModel().current().status());
+        assertEquals(stableCatalog, planner.catalogModel().current());
+        assertEquals(List.of("sessionplanner.storage-failure"), diagnostics.ids);
+    }
+
+    private static PartyServiceAssembly.Component createParty(
+            ReentrantRecordingLane lane,
+            RecordingDispatcher dispatcher
+    ) {
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                new InMemoryPartyRepository(), lane, dispatcher, (id, type) -> { });
+        lane.runAll();
+        party.application().createCharacter(new CreateCharacterCommand(
+                new CharacterDraft("Aria", "Mira", 3, 14, 16), MembershipState.ACTIVE));
+        lane.runAll();
+        return party;
+    }
+
+    private static SessionPlannerServiceAssembly createPlanner(
+            SessionPlanRepository repository,
+            PartyServiceAssembly.Component party,
+            ExecutionLane lane,
+            UiDispatcher dispatcher,
+            Diagnostics diagnostics
+    ) {
+        SavedEncounterPlanListModel savedPlans = new SavedEncounterPlanListModel(
+                () -> new SavedEncounterPlanListResult(SavedEncounterPlanStatus.SUCCESS, List.of(), ""),
+                listener -> () -> { });
+        EncounterPlanBudgetModel planBudget = new EncounterPlanBudgetModel(
+                () -> new EncounterPlanBudgetResult(EncounterPlanBudgetStatus.STORAGE_ERROR, null, ""),
+                listener -> () -> { });
+        return new SessionPlannerServiceAssembly(
+                repository,
+                party.application(),
+                party.activeParty(),
+                party.adventuringDayCalculation(),
+                EncounterApplicationServiceFakes.noOp(),
+                savedPlans,
+                planBudget,
+                null,
+                lane,
+                dispatcher,
+                diagnostics);
+    }
+
+    private static final class InMemoryPartyRepository implements PartyRosterRepository {
+
+        private PartyRoster roster = new PartyRoster(1L, List.of());
+
+        @Override
+        public PartyRoster load() {
+            return roster;
+        }
+
+        @Override
+        public void save(PartyRoster nextRoster) {
+            roster = nextRoster;
+        }
+    }
+
+    private static final class RecordingSessionRepository implements SessionPlanRepository {
+
+        private SessionPlan current;
+        private int reads;
+        private int saves;
+        private boolean failReads;
+        private boolean failCurrentLoads;
+        private boolean failNextId;
+        private boolean failSaves;
+        private boolean failLists;
+
+        private RecordingSessionRepository(SessionPlan current) {
+            this.current = current;
+        }
+
+        @Override
+        public Optional<SessionPlan> loadCurrent() {
+            reads++;
+            if (failCurrentLoads) {
+                throw storageFailure();
+            }
+            failIfRequested();
+            return Optional.ofNullable(current);
+        }
+
+        @Override
+        public Optional<SessionPlan> loadById(long sessionId) {
+            reads++;
+            failIfRequested();
+            return current != null && current.sessionId() == sessionId ? Optional.of(current) : Optional.empty();
+        }
+
+        @Override
+        public List<SessionPlanSummary> listSessions() {
+            reads++;
+            if (failLists) {
+                throw storageFailure();
+            }
+            failIfRequested();
+            return current == null
+                    ? List.of()
+                    : List.of(new SessionPlanSummary(current.sessionId(), current.displayName()));
+        }
+
+        @Override
+        public SessionPlan save(SessionPlan sessionPlan) {
+            saves++;
+            if (failSaves) {
+                throw storageFailure();
+            }
+            current = sessionPlan;
+            return current;
+        }
+
+        @Override
+        public void rename(long sessionId, String displayName) {
+            if (current != null && current.sessionId() == sessionId) {
+                current = current.rename(displayName);
+            }
+        }
+
+        @Override
+        public void delete(long sessionId) {
+            if (current != null && current.sessionId() == sessionId) {
+                current = null;
+            }
+        }
+
+        @Override
+        public long nextSessionId() {
+            if (failNextId) {
+                throw storageFailure();
+            }
+            return current == null ? 1L : current.sessionId() + 1L;
+        }
+
+        @Override
+        public void setCurrentSessionId(long sessionId) {
+        }
+
+        private void failIfRequested() {
+            if (failReads) {
+                throw storageFailure();
+            }
+        }
+
+        private static IllegalStateException storageFailure() {
+            return new IllegalStateException("user-authored session payload must not enter diagnostics");
+        }
+    }
+
+    private static final class ReentrantRecordingLane implements ExecutionLane {
+
+        private final ArrayDeque<Runnable> work = new ArrayDeque<>();
+        private boolean running;
+
+        @Override
+        public void execute(Runnable task) {
+            if (running) {
+                task.run();
+            } else {
+                work.addLast(task);
+            }
+        }
+
+        int pending() {
+            return work.size();
+        }
+
+        void runAll() {
+            while (!work.isEmpty()) {
+                running = true;
+                try {
+                    work.removeFirst().run();
+                } finally {
+                    running = false;
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            work.clear();
+        }
+    }
+
+    private static final class RecordingDispatcher implements UiDispatcher {
+
+        private final ArrayDeque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+
+        private final List<String> ids = new ArrayList<>();
+        private final List<Class<? extends Throwable>> failureTypes = new ArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            ids.add(id.value());
+            failureTypes.add(failureType);
+        }
+    }
+}

--- a/test/src/domain/shared/published/PublishedStateTest.java
+++ b/test/src/domain/shared/published/PublishedStateTest.java
@@ -1,0 +1,111 @@
+package src.domain.shared.published;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import platform.ui.UiDispatcher;
+
+final class PublishedStateTest {
+
+    @Test
+    void defaultSubscriptionDeduplicatesAndUnsubscribesOnce() {
+        PublishedState<String> state = new PublishedState<>("initial");
+        List<String> delivered = new ArrayList<>();
+        Consumer<String> subscriber = delivered::add;
+
+        Runnable firstUnsubscribe = state.subscribe(subscriber);
+        state.subscribe(subscriber);
+        state.publish("one");
+        firstUnsubscribe.run();
+        state.publish("two");
+
+        assertEquals(List.of("one"), delivered);
+    }
+
+    @Test
+    void retainingSubscriptionDeliversDuplicateRegistrations() {
+        PublishedState<String> state = PublishedState.retainingDuplicateSubscribers("initial");
+        List<String> delivered = new ArrayList<>();
+        Consumer<String> subscriber = delivered::add;
+
+        state.subscribe(subscriber);
+        state.subscribe(subscriber);
+        state.publish("one");
+
+        assertEquals(List.of("one", "one"), delivered);
+    }
+
+    @Test
+    void unsubscribeCancelsAlreadyQueuedDelivery() {
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        PublishedState<String> state = new PublishedState<>("initial", dispatcher);
+        List<String> delivered = new ArrayList<>();
+        Runnable unsubscribe = state.subscribe(delivered::add);
+
+        state.publish("queued");
+        unsubscribe.run();
+        dispatcher.runAll();
+
+        assertEquals(List.of(), delivered);
+    }
+
+    @Test
+    void olderQueuedRevisionDoesNotFollowNewerInlineRevision() {
+        ControlledDispatcher dispatcher = new ControlledDispatcher();
+        PublishedState<String> state = new PublishedState<>("initial", dispatcher);
+        List<String> delivered = new ArrayList<>();
+        state.subscribe(delivered::add);
+
+        state.publish("older-worker-result");
+        dispatcher.dispatchInline();
+        state.publish("newer-inline-result");
+
+        assertEquals(List.of("newer-inline-result"), delivered);
+        dispatcher.runAll();
+        assertEquals(List.of("newer-inline-result"), delivered);
+    }
+
+    private static final class QueuedDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+
+    private static final class ControlledDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+        private boolean inline;
+
+        @Override
+        public void dispatch(Runnable update) {
+            if (inline) {
+                update.run();
+            } else {
+                updates.addLast(update);
+            }
+        }
+
+        void dispatchInline() {
+            inline = true;
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+}

--- a/test/src/domain/worldplanner/WorldPlannerRuntimeBoundaryTest.java
+++ b/test/src/domain/worldplanner/WorldPlannerRuntimeBoundaryTest.java
@@ -1,0 +1,143 @@
+package src.domain.worldplanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.execution.ExecutionLane;
+import platform.ui.UiDispatcher;
+import src.domain.worldplanner.model.world.WorldPlannerState;
+import src.domain.worldplanner.model.world.port.WorldPlannerReferencePort;
+import src.domain.worldplanner.model.world.repository.WorldPlannerRepository;
+import src.domain.worldplanner.published.CreateWorldLocationCommand;
+import src.domain.worldplanner.published.CreateWorldNpcCommand;
+import src.domain.worldplanner.published.WorldPlannerReadStatus;
+
+final class WorldPlannerRuntimeBoundaryTest {
+
+    @Test
+    void startupCommandsAndStableFailureStateRespectRuntimeBoundaries() {
+        ControllableLane lane = new ControllableLane();
+        QueuedUiDispatcher ui = new QueuedUiDispatcher();
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        RecordingRepository repository = new RecordingRepository();
+        WorldPlannerServiceAssembly assembly = new WorldPlannerServiceAssembly(
+                repository,
+                new FailingCreatureReferences(),
+                lane,
+                ui,
+                diagnostics);
+        WorldPlannerApplicationService application = assembly.createApplicationService();
+        var model = assembly.snapshotModel();
+        List<WorldPlannerReadStatus> observed = new ArrayList<>();
+        model.subscribe(snapshot -> observed.add(snapshot.status()));
+
+        assertEquals(0, repository.loadCount, "assembly access does not load on the caller");
+        assertEquals(1, lane.size(), "initial load is queued once");
+        lane.runNext();
+        assertEquals(1, repository.loadCount);
+        assertEquals(List.of(), observed, "initial publication waits for UI dispatch");
+        ui.runAll();
+        assertEquals(List.of(WorldPlannerReadStatus.SUCCESS), observed);
+
+        application.createLocation(new CreateWorldLocationCommand("Harbor", ""));
+        assertEquals(0, repository.saveCount, "mutation does not load or save on the caller");
+        lane.runNext();
+        assertEquals(1, repository.saveCount);
+        assertEquals(1, model.current().locations().size());
+
+        application.createNpc(new CreateWorldNpcCommand("Blocked", 7L, "", "", "", ""));
+        lane.runNext();
+        assertEquals(1, repository.saveCount, "reference failure performs no write");
+        assertEquals(WorldPlannerReadStatus.STORAGE_ERROR, model.current().status());
+        assertEquals(1, model.current().locations().size(), "last stable state is preserved");
+        assertEquals(List.of("worldplanner.reference.failure"), diagnostics.ids());
+    }
+
+    private static final class RecordingRepository implements WorldPlannerRepository {
+
+        private WorldPlannerState state = WorldPlannerState.empty();
+        private int loadCount;
+        private int saveCount;
+
+        @Override
+        public WorldPlannerState load() {
+            loadCount++;
+            return state;
+        }
+
+        @Override
+        public WorldPlannerState save(WorldPlannerState nextState) {
+            saveCount++;
+            state = nextState;
+            return state;
+        }
+    }
+
+    private static final class FailingCreatureReferences implements WorldPlannerReferencePort {
+
+        @Override
+        public boolean creatureStatblockExists(long creatureStatblockId) {
+            throw new IllegalStateException("fixture payload must not reach diagnostics");
+        }
+
+        @Override
+        public boolean encounterTableExists(long encounterTableId) {
+            return true;
+        }
+    }
+
+    private static final class ControllableLane implements ExecutionLane {
+
+        private final List<Runnable> work = new ArrayList<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.add(task);
+        }
+
+        int size() {
+            return work.size();
+        }
+
+        void runNext() {
+            work.removeFirst().run();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class QueuedUiDispatcher implements UiDispatcher {
+
+        private final List<Runnable> updates = new ArrayList<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.add(update);
+        }
+
+        void runAll() {
+            List.copyOf(updates).forEach(Runnable::run);
+            updates.clear();
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+
+        private final List<String> ids = new ArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            ids.add(id.value());
+        }
+
+        List<String> ids() {
+            return List.copyOf(ids);
+        }
+    }
+}

--- a/test/src/features/dungeon/runtime/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/src/features/dungeon/runtime/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -1,0 +1,345 @@
+package src.features.dungeon.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import platform.execution.DirectExecutionLane;
+import platform.execution.ExecutionLane;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.UiDispatcher;
+import src.domain.dungeon.DungeonServiceAssembly;
+import src.domain.dungeon.model.core.repository.DungeonMapRepository;
+import src.domain.dungeon.model.core.structure.DungeonMap;
+import src.domain.dungeon.model.core.structure.DungeonMapAuthoring;
+import src.domain.dungeon.model.core.structure.DungeonMapIdentity;
+import src.domain.party.PartyServiceAssembly;
+import src.domain.party.model.roster.PartyRoster;
+import src.domain.party.model.roster.repository.PartyRosterRepository;
+
+final class DungeonEditorRuntimeThreadOwnershipTest {
+
+    @Test
+    void constructionDefersInitialReadbackAndDeliversTheCompletedOwnerFrame() {
+        QueuedExecutionLane lane = new QueuedExecutionLane();
+        QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntime(repository, lane, dispatcher);
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+        runtime.subscribe(delivered::add);
+
+        assertEquals(0, repository.reads,
+                "runtime construction must not perform persistence-backed readback on the caller");
+        assertEquals(0L, runtime.currentFrame().preparedFacts().selectedMapIdValue());
+        assertEquals(2, lane.pending(), "initialization must precede queued subscriber registration");
+
+        lane.runNext();
+
+        assertTrue(repository.reads > 0, "initial readback must run on the supplied execution lane");
+        assertEquals(1, runtime.currentFrame().preparedFacts().mapEntries().size());
+        assertEquals("Only", runtime.currentFrame().preparedFacts().mapEntries().getFirst().mapName());
+        assertTrue(delivered.isEmpty(), "subscriber registration is still queued behind initialization");
+
+        lane.runNext();
+
+        assertEquals(1, delivered.size());
+        assertEquals("Only", delivered.getFirst().preparedFacts().mapEntries().getFirst().mapName());
+        dispatcher.runAll();
+        lane.runAll();
+        assertEquals(1, delivered.size(), "deferred model callbacks must not duplicate the completed frame");
+    }
+
+    @Test
+    void directLanePreservesSynchronousInitialReadback() {
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntimeDirect(repository);
+
+        assertTrue(repository.reads > 0);
+        assertEquals("Only", runtime.currentFrame().preparedFacts().mapEntries().getFirst().mapName());
+    }
+
+    @Test
+    void queuesMapSwitchDraftAndSubscriptionLifecycleOnOneOwner() {
+        QueuedExecutionLane lane = new QueuedExecutionLane();
+        QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "First");
+        repository.seed(2L, "Second");
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntime(repository, lane, dispatcher);
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+
+        Runnable unsubscribe = runtime.subscribe(delivered::add);
+        lane.runNext();
+        lane.runNext();
+        runtime.selectMap(2L);
+        runtime.beginInlineLabelEdit(activeEdit("before-owner-run"));
+
+        assertFalse(runtime.currentFrame().inlineLabelEditSession().active(),
+                "caller methods must not mutate the cached frame before owner execution");
+        assertEquals(2, lane.pending());
+
+        lane.runNext();
+        assertEquals(2L, runtime.currentFrame().preparedFacts().selectedMapIdValue());
+        assertFalse(runtime.currentFrame().inlineLabelEditSession().active());
+        assertTrue(repository.reads > 0, "map switch must exercise repository-backed readback on the owner lane");
+
+        lane.runNext();
+        assertTrue(runtime.currentFrame().inlineLabelEditSession().active());
+        assertEquals("before-owner-run", runtime.currentFrame().inlineLabelEditSession().draftText());
+        assertEquals(2L, runtime.currentFrame().preparedFacts().selectedMapIdValue());
+
+        dispatcher.runAll();
+        lane.runAll();
+        int deliveredBeforeClose = delivered.size();
+        unsubscribe.run();
+        runtime.updateInlineLabelEditDraft("after-close");
+        lane.runAll();
+
+        assertEquals(deliveredBeforeClose, delivered.size(),
+                "queued unsubscribe must close runtime delivery before later owner publications");
+        assertEquals("after-close", runtime.currentFrame().inlineLabelEditSession().draftText());
+    }
+
+    @Test
+    void unsubscribeBeforeQueuedRegistrationNeverOpensDelivery() {
+        QueuedExecutionLane lane = new QueuedExecutionLane();
+        QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntime(repository, lane, dispatcher);
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+
+        Runnable unsubscribe = runtime.subscribe(delivered::add);
+        unsubscribe.run();
+        lane.runAll();
+        runtime.selectMap(1L);
+        lane.runAll();
+
+        assertTrue(delivered.isEmpty());
+    }
+
+    @Test
+    void queuedRegistrationReplaysAnOwnerFrameThatCompletedAheadOfIt() {
+        QueuedExecutionLane lane = new QueuedExecutionLane();
+        QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntime(repository, lane, dispatcher);
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+
+        runtime.selectMap(1L);
+        runtime.subscribe(delivered::add);
+        lane.runAll();
+
+        assertEquals(1, delivered.size());
+        assertEquals(1L, delivered.getFirst().preparedFacts().selectedMapIdValue());
+    }
+
+    private static DungeonEditorFeatureRuntimeRoot createRuntime(
+            DungeonMapRepository repository,
+            QueuedExecutionLane lane,
+            UiDispatcher dispatcher
+    ) {
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                new InMemoryPartyRepository(), lane, dispatcher, (id, type) -> { });
+        lane.runAll();
+        DungeonServiceAssembly.Component dungeon = DungeonServiceAssembly.create(
+                repository,
+                party.activeParty(),
+                party.travelPositions(),
+                party.application(),
+                party.mutation(),
+                lane,
+                dispatcher,
+                (id, type) -> { });
+        return DungeonEditorFeatureRuntimeRoot.create(new DungeonEditorRuntimeDependencies(
+                new DungeonEditorRuntimeDependencies.CompatibilityReadbackModels(
+                        dungeon.editorControls(), dungeon.editorMapSurface(), dungeon.editorState()),
+                dungeon.editor(),
+                lane,
+                dispatcher));
+    }
+
+    private static DungeonEditorFeatureRuntimeRoot createRuntimeDirect(DungeonMapRepository repository) {
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                new InMemoryPartyRepository(),
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                (id, type) -> { });
+        DungeonServiceAssembly.Component dungeon = DungeonServiceAssembly.create(
+                repository,
+                party.activeParty(),
+                party.travelPositions(),
+                party.application(),
+                party.mutation(),
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                (id, type) -> { });
+        return DungeonEditorFeatureRuntimeRoot.create(new DungeonEditorRuntimeDependencies(
+                new DungeonEditorRuntimeDependencies.CompatibilityReadbackModels(
+                        dungeon.editorControls(), dungeon.editorMapSurface(), dungeon.editorState()),
+                dungeon.editor(),
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE));
+    }
+
+    private static DungeonEditorInlineLabelEditSession activeEdit(String text) {
+        return DungeonEditorInlineLabelEditSession.active(
+                new DungeonEditorInlineLabelEditSession.Target(
+                        DungeonEditorRuntimeLabelTarget.room(11L),
+                        "ROOM",
+                        11L,
+                        0L,
+                        "ROOM",
+                        11L),
+                text,
+                new DungeonEditorInlineLabelEditSession.Placement(1.0, 1.0, 4.0, 1.0, 0.0));
+    }
+
+    private static final class QueuedExecutionLane implements ExecutionLane {
+        private final Deque<Runnable> work = new ArrayDeque<>();
+        private boolean running;
+
+        @Override
+        public void execute(Runnable task) {
+            if (running) {
+                task.run();
+            } else {
+                work.addLast(task);
+            }
+        }
+
+        int pending() {
+            return work.size();
+        }
+
+        void runNext() {
+            if (work.isEmpty()) {
+                return;
+            }
+            running = true;
+            try {
+                work.removeFirst().run();
+            } finally {
+                running = false;
+            }
+        }
+
+        void runAll() {
+            while (!work.isEmpty()) {
+                runNext();
+            }
+        }
+
+        @Override
+        public void close() {
+            work.clear();
+        }
+    }
+
+    private static final class QueuedUiDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+
+    private static final class InMemoryPartyRepository implements PartyRosterRepository {
+        private PartyRoster roster = new PartyRoster(1L, List.of());
+
+        @Override
+        public PartyRoster load() {
+            return roster;
+        }
+
+        @Override
+        public void save(PartyRoster nextRoster) {
+            roster = nextRoster;
+        }
+    }
+
+    private static final class InMemoryDungeonRepository implements DungeonMapRepository {
+        private final Map<Long, DungeonMap> maps = new LinkedHashMap<>();
+        private int reads;
+
+        void seed(long mapId, String name) {
+            DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), name);
+            maps.put(mapId, map);
+        }
+
+        @Override
+        public DungeonMapIdentity nextMapId() {
+            return new DungeonMapIdentity(maps.keySet().stream().mapToLong(Long::longValue).max().orElse(0L) + 1L);
+        }
+
+        @Override
+        public long nextStairId() {
+            return 1L;
+        }
+
+        @Override
+        public long nextTransitionId() {
+            return 1L;
+        }
+
+        @Override
+        public Optional<DungeonMap> findById(DungeonMapIdentity mapId) {
+            reads++;
+            return Optional.ofNullable(maps.get(mapId.value()));
+        }
+
+        @Override
+        public List<DungeonMap> searchByName(String query) {
+            reads++;
+            String safeQuery = query == null ? "" : query.toLowerCase(java.util.Locale.ROOT);
+            return maps.values().stream()
+                    .filter(map -> map.metadata().mapName().toLowerCase(java.util.Locale.ROOT).contains(safeQuery))
+                    .toList();
+        }
+
+        @Override
+        public Optional<DungeonMap> firstMap() {
+            reads++;
+            return maps.values().stream().findFirst();
+        }
+
+        @Override
+        public DungeonMap save(DungeonMap dungeonMap) {
+            maps.put(dungeonMap.metadata().mapId().value(), dungeonMap);
+            return dungeonMap;
+        }
+
+        @Override
+        public List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps) {
+            for (DungeonMap dungeonMap : dungeonMaps) {
+                save(dungeonMap);
+            }
+            return List.copyOf(dungeonMaps);
+        }
+
+        @Override
+        public void delete(DungeonMapIdentity mapId) {
+            maps.remove(mapId.value());
+        }
+    }
+}

--- a/test/src/features/dungeon/shell/DungeonEditorPublicationDeliveryTest.java
+++ b/test/src/features/dungeon/shell/DungeonEditorPublicationDeliveryTest.java
@@ -1,0 +1,61 @@
+package src.features.dungeon.shell;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import platform.ui.UiDispatcher;
+import src.features.dungeon.runtime.DungeonEditorRenderFrame;
+
+final class DungeonEditorPublicationDeliveryTest {
+
+    @Test
+    void queuedDeliveryRejectsStaleFrames() {
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+        DungeonEditorFeatureShellBinding.PublicationDelivery delivery =
+                new DungeonEditorFeatureShellBinding.PublicationDelivery(delivered::add, dispatcher);
+        DungeonEditorRenderFrame stale = DungeonEditorRenderFrame.empty();
+        DungeonEditorRenderFrame current = DungeonEditorRenderFrame.empty();
+
+        delivery.deliver(stale);
+        delivery.deliver(current);
+        dispatcher.runAll();
+
+        assertEquals(1, delivered.size());
+        assertSame(current, delivered.getFirst());
+    }
+
+    @Test
+    void queuedDeliveryRejectsFramesAfterClose() {
+        QueuedDispatcher dispatcher = new QueuedDispatcher();
+        List<DungeonEditorRenderFrame> delivered = new ArrayList<>();
+        DungeonEditorFeatureShellBinding.PublicationDelivery delivery =
+                new DungeonEditorFeatureShellBinding.PublicationDelivery(delivered::add, dispatcher);
+
+        delivery.deliver(DungeonEditorRenderFrame.empty());
+        delivery.close();
+        dispatcher.runAll();
+
+        assertEquals(0, delivered.size());
+    }
+
+    private static final class QueuedDispatcher implements UiDispatcher {
+        private final Deque<Runnable> updates = new ArrayDeque<>();
+
+        @Override
+        public void dispatch(Runnable update) {
+            updates.addLast(update);
+        }
+
+        void runAll() {
+            while (!updates.isEmpty()) {
+                updates.removeFirst().run();
+            }
+        }
+    }
+}

--- a/test/src/view/leftbartabs/hexmap/HexMapEditorBehaviorTest.java
+++ b/test/src/view/leftbartabs/hexmap/HexMapEditorBehaviorTest.java
@@ -764,12 +764,12 @@ public final class HexMapEditorBehaviorTest {
         try {
             consumeMapSave(runtime, viewModel, requiredMapSave(emitted, "HEX-EDITOR-013 expected map save state event."));
             HexEditorSnapshot failed = runtime.current();
-            assertContains(failed.failureText(), "Failed to save Hex map to SQLite",
+            assertContains(failed.failureText(), "Hex-Daten konnten nicht geladen oder gespeichert werden.",
                     "HEX-EDITOR-013 save failure published through snapshot");
             assertEquals(persistedName, runtime.database().mapName(mapId),
                     "HEX-EDITOR-013 failed save leaves persisted map name unchanged");
             viewModel.applySnapshot(failed);
-            assertVisibleLabelContains(view, "Failed to save Hex map to SQLite",
+            assertVisibleLabelContains(view, "Hex-Daten konnten nicht geladen oder gespeichert werden.",
                     "HEX-EDITOR-013 save failure visible in state pane");
         } finally {
             runtime.database().dropFailingMapUpdateTrigger();


### PR DESCRIPTION
## What changed

- adds feature-neutral serial execution, JavaFX dispatch, revisioned state, and payload-free diagnostics
- wires one application-owned runtime through production composition and closes it from application shutdown
- moves material persistence-backed commands off JavaFX while preserving immediate UI intent through revision-aware publication
- adds deterministic coverage for stale completion, initialization, failure publication, runtime ownership, and shutdown drain

## Why

R2 establishes the non-blocking runtime boundary required by the target source architecture before SQLite lifecycle work and vertical feature migration.

## Validation

- integrated R2 regression set: BUILD SUCCESSFUL in 15s
- ./gradlew check --console=plain: BUILD SUCCESSFUL in 4m 6s
- exact-content refresh: BUILD SUCCESSFUL in 4s
- git diff --cached --check: clean before commit

Independent architecture review is intentionally deferred until R3 through R5 are complete, so the final panel reviews the fully migrated system rather than temporary intermediate structure.
