### PR TITLE
Szenenlaufzeit und getrennte Encounter-Kontexte

### DIFF
--- a/bootstrap/AppBootstrap.java
+++ b/bootstrap/AppBootstrap.java
@@ -15,11 +15,13 @@ import shell.host.AppShell;
 import src.data.creatures.query.SqliteCreatureCatalogQueryAdapter;
 import src.data.dungeon.repository.SqliteDungeonMapRepository;
 import src.data.encounter.repository.SqliteEncounterPlanRepository;
+import src.data.encounter.runtime.SqliteEncounterRuntimeStateRepository;
 import src.data.encountertable.query.SqliteEncounterTableCatalogAdapter;
 import src.data.hex.repository.SqliteHexMapRepository;
 import src.data.items.SqliteItemCatalogAdapter;
 import src.data.party.repository.SqlitePartyRosterRepository;
 import src.data.sessionplanner.repository.SqliteSessionPlanRepository;
+import src.data.scene.SqliteSceneWorkspaceRepository;
 import src.data.worldplanner.repository.SqliteWorldPlannerRepository;
 import src.domain.creatures.CreaturesServiceAssembly;
 import src.domain.creatures.model.catalog.port.CreatureCatalogPort;
@@ -31,6 +33,7 @@ import src.domain.hex.HexServiceAssembly;
 import src.domain.items.ItemsServiceAssembly;
 import src.domain.party.PartyServiceAssembly;
 import src.domain.sessionplanner.SessionPlannerServiceAssembly;
+import src.domain.scene.SceneServiceAssembly;
 import src.domain.worldplanner.WorldPlannerApplicationService;
 import src.domain.worldplanner.WorldPlannerReferenceAssembly;
 import src.domain.worldplanner.WorldPlannerServiceAssembly;
@@ -43,6 +46,7 @@ import src.view.leftbartabs.dungeoneditor.DungeonEditorContribution;
 import src.view.leftbartabs.dungeontravel.DungeonTravelContribution;
 import src.view.leftbartabs.hexmap.HexMapContribution;
 import src.view.leftbartabs.sessionplanner.SessionPlannerContribution;
+import src.view.leftbartabs.scene.SceneContribution;
 import src.view.statetabs.encounter.EncounterStateContribution;
 import src.view.statetabs.travel.TravelStateContribution;
 
@@ -92,7 +96,8 @@ public final class AppBootstrap {
                 party.activeComposition(),
                 party.adventuringDaySummary(),
                 party.mutation(),
-                new SqliteEncounterPlanRepository());
+                new SqliteEncounterPlanRepository(),
+                new SqliteEncounterRuntimeStateRepository());
 
         DungeonServiceAssembly.Component dungeon = DungeonServiceAssembly.create(
                 new SqliteDungeonMapRepository(),
@@ -111,9 +116,15 @@ public final class AppBootstrap {
                 encounter.savedPlans(),
                 encounter.planBudget(),
                 worldSnapshot);
+        SceneServiceAssembly scenes = new SceneServiceAssembly(
+                new SqliteSceneWorkspaceRepository(),
+                party.activeParty(),
+                worldSnapshot,
+                session.preparedScenes(),
+                encounter.runtimeContexts());
         return new Components(
                 creatures, encounterTables, items, party, worldApplication, worldSnapshot,
-                encounter, dungeon, hex, session);
+                encounter, dungeon, hex, session, scenes);
     }
 
     private List<ResolvedContribution> bindContributions(AppShell shell, Components components) {
@@ -125,6 +136,7 @@ public final class AppBootstrap {
         var dungeon = components.dungeon();
         var hex = components.hex();
         var session = components.session();
+        var scenes = components.scenes();
         var inspector = shell.inspector();
         DungeonEditorRuntimeDependencies dungeonEditorDependencies = new DungeonEditorRuntimeDependencies(
                 new DungeonEditorRuntimeDependencies.CompatibilityReadbackModels(
@@ -149,6 +161,7 @@ public final class AppBootstrap {
                 new SessionPlannerContribution(
                         session.application(), session.currentSessionModel(), session.catalogModel(),
                         session.participantsModel(), session.sceneTimelineModel(), session.statePanelModel()),
+                new SceneContribution(scenes),
                 new EncounterStateContribution(
                         creatures.detail(), creatures.application(), encounter.state(), encounter.application(),
                         components.worldApplication(), inspector),
@@ -211,7 +224,8 @@ public final class AppBootstrap {
             EncounterServiceAssembly.Component encounter,
             DungeonServiceAssembly.Component dungeon,
             HexServiceAssembly hex,
-            SessionPlannerServiceAssembly session
+            SessionPlannerServiceAssembly session,
+            SceneServiceAssembly scenes
     ) {
     }
 

--- a/docs/encounter/README.md
+++ b/docs/encounter/README.md
@@ -21,6 +21,7 @@ only the user-accepted roster when the user saves a plan.
 - [Plan Budget Contract](contract/contract-encounter-plan-budget.md)
 - [Builder Inputs Contract](contract/contract-encounter-builder-inputs.md)
 - [Encounter State Contract](contract/contract-encounter-state.md)
+- [Runtime Session Contract](contract/contract-encounter-runtime-sessions.md)
 - [Encounter Table Feature README](../encountertable/README.md)
 - [Encounter UI](requirements/requirements-encounter-state-tab.md)
 
@@ -41,3 +42,4 @@ Out of scope:
 - persisting initiative, combat, result, or loot state as encounter-plan truth
 - dungeon room placement or biome ownership
 - bootstrap or shell policy
+- runtime-scene composition or focus

--- a/docs/encounter/contract/contract-encounter-runtime-sessions.md
+++ b/docs/encounter/contract/contract-encounter-runtime-sessions.md
@@ -1,0 +1,36 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Keyed Encounter runtime-session persistence contract.
+
+# Encounter Runtime Session Contract
+
+## Purpose
+
+Encounter owns one restart-safe runtime session per external context key. Scene
+is the first context provider, but the contract contains no Scene-owned types.
+
+## Boundary
+
+`EncounterRuntimeContextApi` synchronizes a revision, focused key, PC IDs,
+optional World Planner location ID, and World NPC facts. Synchronization creates,
+updates, focuses, and removes keyed sessions idempotently.
+
+## Stored State
+
+The Encounter adapter stores format version, Builder inputs and roster,
+generator alternatives and selection, pending undo, active saved-plan reference,
+initiative rows, combatants, HP, initiative, round, active turn, result rows,
+and XP-award status. Party and World Planner details remain derived foreign
+facts and are refreshed on restoration.
+
+Rows are stored as ordered, versioned textual memento sections. Unknown format
+versions or malformed rows return a storage error and MUST NOT be overwritten
+with an empty session.
+
+## Consistency And Errors
+
+Every Encounter command persists all changed context mementos transactionally.
+PC transfers affecting two contexts are saved together. A failed save leaves
+the last committed mementos intact. The caller exposes synchronization failure
+instead of continuing against stale state.

--- a/docs/encounter/contract/contract-encounter-state.md
+++ b/docs/encounter/contract/contract-encounter-state.md
@@ -16,6 +16,8 @@ state tab.
   the builder, initiative, combat, and resolution panes plus one status line
 - consumers may read the current state and observe later revisions without
   depending on an implementation-owned model handle
+- the read surface represents the focused runtime context; switching context
+  republishes it without discarding other persisted Encounter sessions
 
 ## Write Surface
 

--- a/docs/encounter/domain/domain-encounter.md
+++ b/docs/encounter/domain/domain-encounter.md
@@ -109,9 +109,9 @@ It derives:
 Generated alternatives remain ephemeral derived state until the user saves the
 current roster as an encounter plan.
 
-The current builder, initiative, combat, and result session state is
-domain-owned runtime state. It is not persisted as a saved encounter plan, but
-it is also not view-owned mutable state.
+Builder, initiative, combat, and result state is domain-owned runtime state.
+It is persisted separately per runtime context for restart recovery and never
+becomes saved encounter-plan truth or view-owned mutable state.
 
 ## Aggregate Model
 
@@ -207,4 +207,5 @@ runtime state.
 - [Encounter Builder Inputs Contract](../contract/contract-encounter-builder-inputs.md)
 - [Encounter Saved Plans Contract](../contract/contract-encounter-saved-plans.md)
 - [Encounter State Contract](../contract/contract-encounter-state.md)
+- [Runtime Session Contract](../contract/contract-encounter-runtime-sessions.md)
 - [Encounter UI](../requirements/requirements-encounter-state-tab.md)

--- a/docs/scene/README.md
+++ b/docs/scene/README.md
@@ -1,0 +1,27 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Entry point and document map for runtime scenes.
+
+# Runtime Scene Feature
+
+## Purpose
+
+`scene` owns the GM's running-scene workspace: which scene is focused, which
+active PCs are in each scene, and which World Planner NPC and location
+references are currently present. Encounter remains the owner of builder,
+initiative, combat, and result state.
+
+## Documents
+
+- [Requirements](requirements/requirements-scene.md)
+- [Domain](domain/domain-scene.md)
+- [Architecture](architecture/architecture-scene.md)
+- [Persistence](contract/contract-scene-persistence.md)
+
+## References
+
+- [Session Planner](../sessionplanner/README.md)
+- [Encounter](../encounter/README.md)
+- [World Planner](../worldplanner/README.md)
+- [Party](../party/README.md)

--- a/docs/scene/architecture/architecture-scene.md
+++ b/docs/scene/architecture/architecture-scene.md
@@ -1,0 +1,57 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Runtime-scene boundaries and cross-feature data flow.
+
+# Runtime Scene Architecture
+
+## Entity And Concerns
+
+This specification serves maintainers of the GM runtime workspace, Encounter
+state switching, and Scene persistence. It answers how parallel scenes share
+foreign facts without sharing mutable feature internals and how restart-safe
+combat remains Encounter-owned.
+
+## Current And Target Shape
+
+The stable implementation remains in the migration-era `src/domain`,
+`src/data`, and `src/view` roots. Its internal roles follow the target feature
+boundary so the later move to `features/scene/{api,domain,application,adapter}`
+is mechanical rather than a redesign.
+
+## Context View
+
+```text
+Party API ---------\
+World Planner API --+--> Scene application --> Scene persistence
+Session Planner API-/          |
+                               +--> Encounter runtime-context API
+                                          |
+                                          +--> Encounter runtime persistence
+```
+
+Scene may consume only published foreign facts. It MUST NOT read foreign
+repositories or persist copied foreign details. Encounter accepts generic
+context keys and MUST NOT depend on Scene types.
+
+## Decisions
+
+- Runtime scenes are separate from authored Session Planner scenes because
+  planning edits and live play have different consistency and lifecycle needs.
+- Encounter sessions are keyed and persisted by Encounter because moving their
+  mutable combat internals into Scene would split Encounter ownership.
+- Scene sends a complete revisioned context snapshot. This makes recovery after
+  a partial local storage failure idempotent and exposes stale synchronization.
+- The Scene JavaFX contribution uses controls and main slots but no state slot,
+  preserving simultaneous access to the Encounter state tab.
+
+Rejected alternatives are one global Encounter, live-linked planner scenes,
+and Scene-owned combat snapshots. Each would prevent independent party-split
+state or duplicate another feature's truth.
+
+## Quality And Enforcement
+
+SQLite writes are transactional inside each owner. Cross-feature synchronization
+is retryable rather than described as an atomic transaction. Production-route
+tests own restart and reconciliation proof; `architectureTest` remains the
+mechanical owner of project dependency rules.

--- a/docs/scene/contract/contract-scene-persistence.md
+++ b/docs/scene/contract/contract-scene-persistence.md
@@ -1,0 +1,34 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Runtime-scene SQLite storage and recovery semantics.
+
+# Runtime Scene Persistence Contract
+
+## Purpose And Ownership
+
+The Scene SQLite adapter persists only Scene-owned workspace truth. Consumers
+use the Scene application boundary; SQL records do not cross the feature.
+
+## Stored Truth
+
+- workspace revision, next scene ID, Standardszene ID, focused scene ID, status
+- scene ID, title, notes, optional planner provenance, optional linked plan ID,
+  optional World Planner location ID, and order
+- ordered Party character IDs and ordered World Planner NPC IDs
+
+Party details, World Planner details, disposition, creature statblocks, and
+Encounter workflow state MUST NOT be stored in Scene tables.
+
+## Validation And Errors
+
+Scene IDs and all present foreign references must be positive. The database
+enforces one row per scene/PC and global uniqueness of PC assignment. Writes
+replace one complete workspace in a transaction. Failed writes retain the last
+committed workspace and return `STORAGE_ERROR`.
+
+## Compatibility
+
+The schema is additive and begins at the first runtime-scene version. There is
+no previous Scene data migration. Missing foreign records remain visible as
+unresolved references until the GM removes or replaces them.

--- a/docs/scene/domain/domain-scene.md
+++ b/docs/scene/domain/domain-scene.md
@@ -1,0 +1,47 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Runtime-scene ownership, write model, and invariants.
+
+# Runtime Scene Domain Model
+
+## Context Role
+
+Context Name: Scene
+
+Scene owns running-scene composition and focus. It does not own Party
+characters, World Planner NPC/location details, prepared session records,
+creature statblocks, or Encounter workflow state.
+
+## Write Model
+
+`SceneWorkspace` is the aggregate root. It owns a monotonically increasing
+revision, the Standardszene ID, the focused-scene ID, scene identity allocation,
+and the collection of `RunningScene` records.
+
+Each `RunningScene` owns its title, notes, optional Session Planner provenance,
+one optional World Planner location reference, ordered PC references, and
+ordered World Planner NPC references.
+
+## Invariants
+
+- At least one scene always exists.
+- Standardszene and focused scene always identify existing scenes.
+- Standardszene cannot be deleted.
+- A PC reference can occur in at most one running scene.
+- A running scene has zero or one location and any number of NPC references.
+- Imported planner data is copied once and never becomes a live link.
+
+## Published Language
+
+`SceneModel` publishes immutable scene cards, resolved foreign choices,
+unassigned PCs, prepared-scene choices, synchronization status, and revision.
+`SceneCommand` owns all scene mutations. Typed mutation results distinguish
+invalid input, missing references, Standardszene protection, and storage error.
+
+## Consistency
+
+Scene persistence is authoritative for context membership. Encounter receives
+an idempotent full-workspace synchronization carrying context keys and foreign
+IDs. Foreign names, levels, lifecycle, and disposition are re-read from their
+owning features.

--- a/docs/scene/requirements/requirements-scene.md
+++ b/docs/scene/requirements/requirements-scene.md
@@ -1,0 +1,54 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-16
+Source of Truth: Observable runtime-scene behavior and acceptance criteria.
+
+# Runtime Scene Requirements
+
+## Goal
+
+Give the GM one runtime tab for maintaining parallel running scenes, switching
+between split-party contexts, and keeping the matching Encounter session in
+view.
+
+## Non-Goals
+
+- editing Party, World Planner, creature, or saved Encounter truth
+- writing runtime changes back into Session Planner scenes
+- allowing more than one location in a running scene
+
+## Primary Flow
+
+1. On first use, a Standardszene exists and contains every currently active PC.
+2. The GM creates another scene or loads a prepared Session Planner scene.
+3. PCs are moved between scenes; one PC can be in at most one running scene.
+4. The GM selects one World Planner location and any number of World Planner
+   NPCs for the focused scene.
+5. Switching scenes immediately switches the visible Encounter session.
+6. Every scene and Encounter session is restored after an application restart.
+
+Prepared-scene import is a one-time copy of title, notes, location, participant
+references, and linked saved Encounter plan. Only active, currently unassigned
+participants are imported. Later planner edits do not update the runtime scene.
+
+## Visible Behavior
+
+- The Standardszene cannot be deleted but can be renamed.
+- Newly activated PCs appear as unassigned instead of moving automatically.
+- Friendly NPCs enter the scene Encounter as allies, hostile NPCs as enemies,
+  and neutral NPCs remain visible context without joining combat.
+- The scene location automatically constrains later Encounter generation.
+- PC and NPC changes during initiative or combat reconcile immediately while
+  retaining existing initiative, HP, round, and active turn where applicable.
+- A failed Encounter synchronization is visible and blocks use of stale
+  Encounter state until synchronization succeeds.
+
+## Acceptance Criteria
+
+- A logical `no scene` state cannot be produced through the UI or domain API.
+- Split scenes keep independent Builder, Initiative, Combat, and Result state.
+- XP balancing and awards use only PCs assigned to that scene.
+- Scene persistence stores foreign IDs, not copied Party or World Planner data.
+- A restart restores focus, scene contents, generated alternatives, initiative,
+  combatants, HP, round, turn, result, and XP-award status.
+- The Scene tab leaves the global Encounter state pane visible.

--- a/docs/sessionplanner/domain/domain-session-planner.md
+++ b/docs/sessionplanner/domain/domain-session-planner.md
@@ -24,6 +24,8 @@ revisioned planner state.
 - the feature publishes planner-owned workflows and one immutable state surface
 - it does not publish encounter persistence carriers, creature-detail carriers,
   or party mutation carriers; those stay owned by their original contexts
+- it publishes a read-only prepared-scene catalog for one-time runtime import;
+  reading it does not change the planner's current-session pointer
 
 ## Application Boundary
 

--- a/docs/sessionplanner/requirements/requirements-session-planner.md
+++ b/docs/sessionplanner/requirements/requirements-session-planner.md
@@ -35,6 +35,7 @@ Provide one session-owned planning surface that:
 - copying World Planner location details into sessionplanner-owned truth
 - deriving gold budgets from provisional heuristics
 - replacing the encounter state tab or the party dropdown
+- owning live runtime-scene state
 
 ## Primary User Flow
 
@@ -121,6 +122,8 @@ Target state:
 - placed rests can appear only between adjacent scenes
 - loot placeholders stay visible while gold budgeting remains explicitly marked
   as unavailable
+- prepared scenes are available through a read-only runtime import surface
+  without changing the planner's current-session pointer
 
 ## References
 

--- a/docs/worldplanner/contract/contract-world-planner-persistence.md
+++ b/docs/worldplanner/contract/contract-world-planner-persistence.md
@@ -28,9 +28,10 @@ location, lifecycle, note, link, source-constraint, and inventory-limit truth.
 World Planner persistence stores:
 
 - NPC identity, display name, creature statblock reference, lifecycle status,
-  appearance notes, behavior notes, history notes, and general notes
+  appearance notes, behavior notes, history notes, general notes, and bounded
+  PC-disposition modifier
 - faction identity, display name, notes, primary encounter-table reference,
-  and NPC membership
+  bounded PC-disposition base, and NPC membership
 - faction statblock inventory limit rows, including whether a statblock is
   finite or unlimited
 - location identity, display name, notes, linked factions, and linked
@@ -59,6 +60,7 @@ World Planner persistence does not store:
 - Missing optional source constraints mean unconstrained.
 - Missing statblock inventory limits mean unlimited.
 - Explicit finite inventory limit `0` means none available for that statblock.
+- NPC membership rows enforce at most one faction for each NPC.
 
 ## Validation And Error Behavior
 
@@ -66,6 +68,7 @@ World Planner persistence does not store:
   encounter-table references.
 - Writes must reject duplicate membership or duplicate link rows instead of
   silently persisting ambiguous truth.
+- Disposition values must remain between `-50` and `+50`.
 - Finite inventory limits must be non-negative.
 - A faction must not persist more than one primary encounter-table reference.
 - Candidate combat losses must not mutate durable NPC lifecycle or faction

--- a/docs/worldplanner/domain/domain-world-planner.md
+++ b/docs/worldplanner/domain/domain-world-planner.md
@@ -45,6 +45,7 @@ World Planner has three authored aggregate centers.
 - appearance, behavior, history, and notes
 - lifecycle status: active or defeated
 - optional last known faction/location references
+- a bounded `-50..+50` disposition modifier toward the PCs
 
 `WorldFaction` owns:
 
@@ -53,6 +54,7 @@ World Planner has three authored aggregate centers.
 - one primary encounter-table reference
 - NPC memberships
 - optional finite statblock inventory limits
+- a bounded `-50..+50` base disposition toward the PCs
 
 `WorldLocation` owns:
 
@@ -98,6 +100,10 @@ Commands entering the model include:
 - confirm post-combat losses
 
 Core invariants:
+
+- one NPC belongs to at most one faction
+- effective PC disposition is the clamped faction base plus NPC modifier;
+  `<= -15` is hostile, `>= +15` friendly, and the values between are neutral
 
 - NPC statblock references point to creature-owned statblocks and do not copy
   creature truth.

--- a/docs/worldplanner/requirements/requirements-world-planner.md
+++ b/docs/worldplanner/requirements/requirements-world-planner.md
@@ -86,6 +86,8 @@ Inspector surfaces so the user can:
 - reactivate a defeated named NPC
 - expose location choices through a public boundary for future
   Session Planner-owned integration
+- store faction disposition and NPC modifiers toward the PCs so runtime scenes
+  can derive friendly, neutral, and hostile Encounter roles
 
 ## Acceptance Criteria
 
@@ -108,6 +110,8 @@ Inspector surfaces so the user can:
   reactivated.
 - World Planner exposes location references without storing or defining
   Session Planner-owned records.
+- an NPC belongs to at most one faction and its effective disposition is the
+  clamped sum of faction base and NPC modifier
 - Creature statblocks, encounter-table membership, encounter rosters, party
   members, combat HP, dungeon maps, and hex maps stay in their owning
   contexts.

--- a/resources/salt-marcher.css
+++ b/resources/salt-marcher.css
@@ -139,6 +139,68 @@
     -fx-font-weight: bold;
 }
 
+/* Runtime scene board: a compact GM pinboard with one strong focus rail. */
+.scene-runtime-controls {
+    -fx-background-color: -sm-bg-panel;
+    -fx-border-color: transparent transparent -sm-border-subtle transparent;
+}
+.scene-runtime-eyebrow {
+    -fx-text-fill: -sm-accent-hover;
+    -fx-font-size: 10px;
+    -fx-font-weight: bold;
+    -fx-letter-spacing: 1.2px;
+}
+.scene-runtime-switch {
+    -fx-alignment: center-left;
+    -fx-background-color: -sm-bg-card;
+    -fx-border-color: -sm-border-subtle;
+    -fx-padding: 8 10;
+}
+.scene-runtime-switch:selected {
+    -fx-background-color: -sm-active-bg-card;
+    -fx-border-color: -sm-medium;
+    -fx-border-width: 0 0 0 4;
+}
+.scene-runtime-header {
+    -fx-background-color: linear-gradient(to right, -sm-bg-panel, -sm-bg-card);
+    -fx-border-color: transparent transparent -sm-border-subtle transparent;
+}
+.scene-runtime-scene-mark {
+    -fx-text-fill: -sm-medium;
+    -fx-font-size: 10px;
+    -fx-font-weight: bold;
+    -fx-padding: 7 0 0 0;
+}
+.scene-runtime-title-input {
+    -fx-font-size: 17px;
+    -fx-font-weight: bold;
+}
+.scene-runtime-panel {
+    -fx-background-color: -sm-bg-card;
+    -fx-border-color: -sm-border-subtle;
+    -fx-background-radius: 6;
+    -fx-border-radius: 6;
+}
+.scene-runtime-panel-title {
+    -fx-font-size: 15px;
+    -fx-font-weight: bold;
+}
+.scene-runtime-row {
+    -fx-background-color: -sm-bg-panel;
+    -fx-padding: 7;
+    -fx-background-radius: 4;
+}
+.scene-runtime-row-label { -fx-font-size: 12px; }
+.scene-runtime-location {
+    -fx-text-fill: -sm-medium;
+    -fx-font-weight: bold;
+    -fx-font-size: 14px;
+}
+.scene-runtime-divider {
+    -fx-min-height: 1px;
+    -fx-background-color: -sm-border-subtle;
+}
+
 .button {
     -fx-background-color: -sm-bg-elevated;
     -fx-text-fill: -sm-text-primary;

--- a/resources/view/leftbartabs/scene/navigation-icon.svg
+++ b/resources/view/leftbartabs/scene/navigation-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 5.5h16v13H4z"/>
+  <path d="M8 3v5M16 3v5M7.5 12h3M13.5 12h3M7.5 15.5h3"/>
+</svg>

--- a/src/data/encounter/runtime/EncounterRuntimeTextCodec.java
+++ b/src/data/encounter/runtime/EncounterRuntimeTextCodec.java
@@ -1,0 +1,178 @@
+package src.data.encounter.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import src.domain.encounter.model.generation.EncounterGenerationInputs;
+import src.domain.encounter.model.generation.EncounterRequestedDifficulty;
+import src.domain.encounter.model.generation.EncounterTuningIntent;
+import src.domain.encounter.model.session.Combatant;
+import src.domain.encounter.model.session.CombatantKind;
+import src.domain.encounter.model.session.EncounterCreatureData;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+import src.domain.encounter.model.session.GeneratedEncounterData;
+import src.domain.encounter.model.session.InitiativeEntryData;
+import src.domain.encounter.model.session.RemovedRosterEntryData;
+import src.domain.encounter.model.session.ResultEnemyData;
+import src.domain.encounter.model.session.ResultStateData;
+
+final class EncounterRuntimeTextCodec {
+    private static final String SEPARATOR = "|";
+
+    List<String> encode(EncounterSessionMemento value) {
+        List<String> rows = new ArrayList<>();
+        rows.add(join("H", value.mode(), text(value.status()), value.nextUndoToken(),
+                list(value.generatedAdvisories()), value.selectedAlternativeIndex(), value.generatedAdjustedXp(),
+                text(value.generatedDifficulty()), text(value.generatedTitle()), value.generationHistoryPresent(),
+                value.activeSavedPlanId(), value.currentTurnIndex(), value.round()));
+        EncounterGenerationInputs input = value.builderInputs();
+        rows.add(join("I", input.targetDifficulty().name(), input.tuning().balanceLevel(), input.tuning().amountValue(),
+                input.tuning().diversityLevel(), input.worldLocationId(), list(input.creatureTypes()),
+                list(input.creatureSubtypes()), list(input.biomes()), longs(input.encounterTableIds()),
+                longs(input.worldFactionIds()), caps(input.finiteCreatureStockCaps())));
+        for (EncounterCreatureData creature : value.roster()) {
+            rows.add("R" + SEPARATOR + creature(creature));
+        }
+        value.pendingUndo().ifPresent(undo -> rows.add(join("U", undo.token(), undo.index())
+                + SEPARATOR + creature(undo.creature())));
+        for (int index = 0; index < value.generatedAlternatives().size(); index++) {
+            GeneratedEncounterData alternative = value.generatedAlternatives().get(index);
+            rows.add(join("A", index, text(alternative.title()), text(alternative.difficultyLabel()),
+                    alternative.adjustedXp(), list(alternative.advisoryMessages())));
+            for (EncounterCreatureData creature : alternative.roster()) {
+                rows.add(join("AR", index) + SEPARATOR + creature(creature));
+            }
+        }
+        for (InitiativeEntryData entry : value.initiativeEntries()) {
+            rows.add(join("Q", text(entry.id()), text(entry.label()), entry.kind().name(), entry.initiative()));
+        }
+        for (Combatant combatant : value.combatants()) {
+            rows.add(join("C", text(combatant.id()), text(combatant.name()), combatant.kind().name(),
+                    combatant.creatureId(), combatant.worldNpcId(), combatant.currentHp(), combatant.maxHp(),
+                    combatant.ac(), combatant.initiative(), combatant.count(), combatant.xp(), text(combatant.detail()),
+                    text(combatant.loot()), combatant.order()));
+        }
+        ResultStateData result = value.resultState();
+        rows.add(join("E", result.defeatedCount(), result.eligibleXp(), result.perPlayerXp(),
+                text(result.goldSummary()), text(result.lootDetail()), text(result.awardStatus()),
+                result.xpAwarded(), result.canAwardXp(), result.partySize()));
+        for (ResultEnemyData enemy : result.enemies()) {
+            rows.add(join("ER", text(enemy.name()), enemy.creatureId(), enemy.worldNpcId(), text(enemy.status()),
+                    enemy.hpLoss(), enemy.xp(), enemy.defeatedByDefault(), text(enemy.loot())));
+        }
+        return List.copyOf(rows);
+    }
+
+    EncounterSessionMemento decode(List<String> rows) {
+        Header header = null;
+        EncounterGenerationInputs inputs = EncounterGenerationInputs.empty();
+        List<EncounterCreatureData> roster = new ArrayList<>();
+        Optional<RemovedRosterEntryData> undo = Optional.empty();
+        Map<Integer, AlternativeBuilder> alternatives = new LinkedHashMap<>();
+        List<InitiativeEntryData> initiatives = new ArrayList<>();
+        List<Combatant> combatants = new ArrayList<>();
+        ResultHeader resultHeader = ResultHeader.empty();
+        List<ResultEnemyData> resultEnemies = new ArrayList<>();
+        for (String row : rows == null ? List.<String>of() : rows) {
+            String[] fields = row.split("\\|", -1);
+            switch (fields[0]) {
+                case "H" -> header = Header.parse(fields);
+                case "I" -> inputs = input(fields);
+                case "R" -> roster.add(creature(fields, 1));
+                case "U" -> undo = Optional.of(new RemovedRosterEntryData(longValue(fields[1]), intValue(fields[2]), creature(fields, 3)));
+                case "A" -> alternatives.put(intValue(fields[1]), AlternativeBuilder.parse(fields));
+                case "AR" -> alternatives.computeIfAbsent(intValue(fields[1]), ignored -> AlternativeBuilder.empty())
+                        .roster.add(creature(fields, 2));
+                case "Q" -> initiatives.add(new InitiativeEntryData(string(fields[1]), string(fields[2]),
+                        CombatantKind.valueOf(fields[3]), intValue(fields[4])));
+                case "C" -> combatants.add(combatant(fields));
+                case "E" -> resultHeader = ResultHeader.parse(fields);
+                case "ER" -> resultEnemies.add(resultEnemy(fields));
+                default -> { }
+            }
+        }
+        if (header == null) {
+            throw new IllegalArgumentException("Encounter runtime header missing");
+        }
+        List<GeneratedEncounterData> generated = alternatives.values().stream().map(AlternativeBuilder::build).toList();
+        return new EncounterSessionMemento(EncounterSessionMemento.CURRENT_FORMAT_VERSION, header.mode, header.status,
+                inputs, roster, undo, header.nextUndoToken, generated, header.generatedAdvisories,
+                header.selectedAlternativeIndex, header.generatedAdjustedXp, header.generatedDifficulty,
+                header.generatedTitle, header.history, header.activePlanId, initiatives, combatants,
+                header.turnIndex, header.round,
+                new ResultStateData(resultEnemies, resultHeader.defeated, resultHeader.eligibleXp,
+                        resultHeader.perPlayerXp, resultHeader.gold, resultHeader.loot, resultHeader.award,
+                        resultHeader.awarded, resultHeader.canAward, resultHeader.partySize));
+    }
+
+    private static EncounterGenerationInputs input(String[] f) {
+        return new EncounterGenerationInputs(strings(f[6]), strings(f[7]), strings(f[8]),
+                EncounterRequestedDifficulty.valueOf(f[1]),
+                new EncounterTuningIntent(intValue(f[2]), doubleValue(f[3]), intValue(f[4])),
+                longList(f[9]), longList(f[10]), longValue(f[5]), capMap(f[11]));
+    }
+
+    private static Combatant combatant(String[] f) {
+        return new Combatant(string(f[1]), string(f[2]), CombatantKind.valueOf(f[3]), longValue(f[4]),
+                longValue(f[5]), intValue(f[6]), intValue(f[7]), intValue(f[8]), intValue(f[9]),
+                intValue(f[10]), intValue(f[11]), string(f[12]), string(f[13]), intValue(f[14]));
+    }
+
+    private static ResultEnemyData resultEnemy(String[] f) {
+        return new ResultEnemyData(string(f[1]), longValue(f[2]), longValue(f[3]), string(f[4]),
+                intValue(f[5]), intValue(f[6]), Boolean.parseBoolean(f[7]), string(f[8]));
+    }
+
+    private static String creature(EncounterCreatureData c) {
+        return join(text(c.id()), c.creatureId(), c.worldNpcId(), text(c.name()), text(c.challengeRating()), c.xp(),
+                c.hp(), c.armorClass(), c.initiativeBonus(), text(c.creatureType()), text(c.encounterRole()),
+                c.count(), list(c.tags()));
+    }
+
+    private static EncounterCreatureData creature(String[] f, int offset) {
+        return new EncounterCreatureData(string(f[offset]), longValue(f[offset + 1]), longValue(f[offset + 2]),
+                string(f[offset + 3]), string(f[offset + 4]), intValue(f[offset + 5]), intValue(f[offset + 6]),
+                intValue(f[offset + 7]), intValue(f[offset + 8]), string(f[offset + 9]), string(f[offset + 10]),
+                intValue(f[offset + 11]), strings(f[offset + 12]));
+    }
+
+    private static String join(Object... values) {
+        return java.util.Arrays.stream(values).map(String::valueOf).collect(java.util.stream.Collectors.joining(SEPARATOR));
+    }
+    private static String text(String value) { return Base64.getUrlEncoder().withoutPadding().encodeToString((value == null ? "" : value).getBytes(StandardCharsets.UTF_8)); }
+    private static String string(String value) { return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8); }
+    private static String list(List<String> values) { return values == null ? "" : values.stream().map(EncounterRuntimeTextCodec::text).collect(java.util.stream.Collectors.joining(",")); }
+    private static List<String> strings(String value) { return value == null || value.isBlank() ? List.of() : java.util.Arrays.stream(value.split(",", -1)).map(EncounterRuntimeTextCodec::string).toList(); }
+    private static String longs(List<Long> values) { return values == null ? "" : values.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(",")); }
+    private static List<Long> longList(String value) { return value == null || value.isBlank() ? List.of() : java.util.Arrays.stream(value.split(",")).map(Long::valueOf).toList(); }
+    private static String caps(Map<Long, Integer> values) { return values.entrySet().stream().map(entry -> entry.getKey() + ":" + entry.getValue()).collect(java.util.stream.Collectors.joining(",")); }
+    private static Map<Long, Integer> capMap(String value) { Map<Long, Integer> result = new LinkedHashMap<>(); if (value != null && !value.isBlank()) for (String pair : value.split(",")) { String[] p = pair.split(":"); result.put(Long.valueOf(p[0]), Integer.valueOf(p[1])); } return Map.copyOf(result); }
+    private static int intValue(String value) { return Integer.parseInt(value); }
+    private static long longValue(String value) { return Long.parseLong(value); }
+    private static double doubleValue(String value) { return Double.parseDouble(value); }
+
+    private record Header(int mode, String status, long nextUndoToken, List<String> generatedAdvisories,
+            int selectedAlternativeIndex, int generatedAdjustedXp, String generatedDifficulty, String generatedTitle,
+            boolean history, long activePlanId, int turnIndex, int round) {
+        static Header parse(String[] f) { return new Header(intValue(f[1]), string(f[2]), longValue(f[3]), strings(f[4]),
+                intValue(f[5]), intValue(f[6]), string(f[7]), string(f[8]), Boolean.parseBoolean(f[9]),
+                longValue(f[10]), intValue(f[11]), intValue(f[12])); }
+    }
+    private static final class AlternativeBuilder {
+        private String title = ""; private String difficulty = ""; private int xp; private List<String> advisories = List.of();
+        private final List<EncounterCreatureData> roster = new ArrayList<>();
+        static AlternativeBuilder parse(String[] f) { AlternativeBuilder b = new AlternativeBuilder(); b.title = string(f[2]); b.difficulty = string(f[3]); b.xp = intValue(f[4]); b.advisories = strings(f[5]); return b; }
+        static AlternativeBuilder empty() { return new AlternativeBuilder(); }
+        GeneratedEncounterData build() { return new GeneratedEncounterData(title, difficulty, xp, roster, advisories); }
+    }
+    private record ResultHeader(long defeated, int eligibleXp, int perPlayerXp, String gold, String loot,
+            String award, boolean awarded, boolean canAward, int partySize) {
+        static ResultHeader parse(String[] f) { return new ResultHeader(longValue(f[1]), intValue(f[2]), intValue(f[3]),
+                string(f[4]), string(f[5]), string(f[6]), Boolean.parseBoolean(f[7]), Boolean.parseBoolean(f[8]), intValue(f[9])); }
+        static ResultHeader empty() { return new ResultHeader(0, 0, 0, "", "", "", false, false, 1); }
+    }
+}

--- a/src/data/encounter/runtime/SqliteEncounterRuntimeStateRepository.java
+++ b/src/data/encounter/runtime/SqliteEncounterRuntimeStateRepository.java
@@ -1,0 +1,87 @@
+package src.data.encounter.runtime;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import src.data.persistencecore.sqlite.AbstractSqliteConnectionFactory;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+import src.domain.encounter.model.session.repository.EncounterRuntimeStateRepository;
+
+public final class SqliteEncounterRuntimeStateRepository implements EncounterRuntimeStateRepository {
+    private static final String TABLE = "encounter_runtime_state_rows";
+    private final ConnectionFactory connections = new ConnectionFactory();
+    private final EncounterRuntimeTextCodec codec = new EncounterRuntimeTextCodec();
+
+    @Override
+    public Map<String, EncounterSessionMemento> loadAll() {
+        try (Connection connection = ready()) {
+            Map<String, List<String>> rows = new LinkedHashMap<>();
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT context_key, row_value FROM " + TABLE + " ORDER BY context_key, row_order");
+                    ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    rows.computeIfAbsent(result.getString("context_key"), ignored -> new ArrayList<>())
+                            .add(result.getString("row_value"));
+                }
+            }
+            Map<String, EncounterSessionMemento> state = new LinkedHashMap<>();
+            for (Map.Entry<String, List<String>> entry : rows.entrySet()) {
+                state.put(entry.getKey(), codec.decode(entry.getValue()));
+            }
+            return Map.copyOf(state);
+        } catch (SQLException | IllegalArgumentException exception) {
+            throw new IllegalStateException("Failed to load encounter runtime state.", exception);
+        }
+    }
+
+    @Override
+    public void saveAll(Map<String, EncounterSessionMemento> sessions) {
+        try (Connection connection = ready()) {
+            boolean autoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try (Statement clear = connection.createStatement()) {
+                clear.executeUpdate("DELETE FROM " + TABLE);
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO " + TABLE + " (context_key, row_order, row_value) VALUES (?, ?, ?)")) {
+                    for (Map.Entry<String, EncounterSessionMemento> entry : sessions.entrySet()) {
+                        List<String> rows = codec.encode(entry.getValue());
+                        for (int index = 0; index < rows.size(); index++) {
+                            statement.setString(1, entry.getKey()); statement.setInt(2, index);
+                            statement.setString(3, rows.get(index)); statement.addBatch();
+                        }
+                    }
+                    statement.executeBatch();
+                }
+                connection.commit();
+            } catch (SQLException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(autoCommit);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to save encounter runtime state.", exception);
+        }
+    }
+
+    private Connection ready() throws SQLException {
+        Connection connection = connections.openConnection();
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS " + TABLE + " (context_key TEXT NOT NULL, "
+                    + "row_order INTEGER NOT NULL, row_value TEXT NOT NULL, PRIMARY KEY(context_key, row_order))");
+        } catch (SQLException exception) {
+            connection.close(); throw exception;
+        }
+        return connection;
+    }
+
+    private static final class ConnectionFactory extends AbstractSqliteConnectionFactory {
+        private ConnectionFactory() { super(resolveDatabasePath("game.db")); }
+    }
+}

--- a/src/data/scene/SqliteSceneWorkspaceRepository.java
+++ b/src/data/scene/SqliteSceneWorkspaceRepository.java
@@ -1,0 +1,179 @@
+package src.data.scene;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import src.data.persistencecore.sqlite.AbstractSqliteConnectionFactory;
+import src.domain.scene.model.RunningScene;
+import src.domain.scene.model.SceneWorkspace;
+import src.domain.scene.model.repository.SceneWorkspaceRepository;
+
+public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepository {
+    private static final String SCENES = "runtime_scenes";
+    private static final String WORKSPACE = "runtime_scene_workspace";
+    private static final String PARTY = "runtime_scene_party_members";
+    private static final String NPCS = "runtime_scene_npcs";
+    private final ConnectionFactory connections = new ConnectionFactory();
+
+    @Override
+    public Optional<SceneWorkspace> load() {
+        try (Connection connection = readyConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT revision, next_scene_id, default_scene_id, focused_scene_id, status_text FROM " + WORKSPACE
+                            + " WHERE singleton_id = 1");
+                    ResultSet result = statement.executeQuery()) {
+                if (!result.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(new SceneWorkspace(
+                        result.getLong("revision"), result.getLong("next_scene_id"),
+                        result.getLong("default_scene_id"), result.getLong("focused_scene_id"),
+                        loadScenes(connection), result.getString("status_text")));
+            }
+        } catch (SQLException | IllegalArgumentException exception) {
+            throw new IllegalStateException("Failed to load runtime scenes from SQLite.", exception);
+        }
+    }
+
+    @Override
+    public SceneWorkspace save(SceneWorkspace workspace) {
+        if (workspace == null) {
+            throw new IllegalArgumentException("workspace must be present");
+        }
+        try (Connection connection = readyConnection()) {
+            boolean autoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                clear(connection);
+                saveScenes(connection, workspace.scenes());
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO " + WORKSPACE
+                                + " (singleton_id, revision, next_scene_id, default_scene_id, focused_scene_id, status_text)"
+                                + " VALUES (1, ?, ?, ?, ?, ?)")) {
+                    statement.setLong(1, workspace.revision());
+                    statement.setLong(2, workspace.nextSceneId());
+                    statement.setLong(3, workspace.defaultSceneId());
+                    statement.setLong(4, workspace.focusedSceneId());
+                    statement.setString(5, workspace.statusText());
+                    statement.executeUpdate();
+                }
+                connection.commit();
+                return workspace;
+            } catch (SQLException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(autoCommit);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to save runtime scenes to SQLite.", exception);
+        }
+    }
+
+    private Connection readyConnection() throws SQLException {
+        Connection connection = connections.openConnection();
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA foreign_keys = ON");
+            statement.execute("CREATE TABLE IF NOT EXISTS " + SCENES + " ("
+                    + "scene_id INTEGER PRIMARY KEY, title TEXT NOT NULL, notes TEXT NOT NULL, "
+                    + "source_session_id INTEGER NOT NULL DEFAULT 0, source_scene_id INTEGER NOT NULL DEFAULT 0, "
+                    + "source_encounter_plan_id INTEGER NOT NULL DEFAULT 0, location_id INTEGER NOT NULL DEFAULT 0, "
+                    + "sort_order INTEGER NOT NULL)");
+            statement.execute("CREATE TABLE IF NOT EXISTS " + WORKSPACE + " ("
+                    + "singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1), revision INTEGER NOT NULL, "
+                    + "next_scene_id INTEGER NOT NULL, default_scene_id INTEGER NOT NULL REFERENCES " + SCENES + "(scene_id), "
+                    + "focused_scene_id INTEGER NOT NULL REFERENCES " + SCENES + "(scene_id), status_text TEXT NOT NULL)");
+            statement.execute("CREATE TABLE IF NOT EXISTS " + PARTY + " ("
+                    + "scene_id INTEGER NOT NULL REFERENCES " + SCENES + "(scene_id) ON DELETE CASCADE, "
+                    + "character_id INTEGER NOT NULL UNIQUE, sort_order INTEGER NOT NULL, PRIMARY KEY(scene_id, character_id))");
+            statement.execute("CREATE TABLE IF NOT EXISTS " + NPCS + " ("
+                    + "scene_id INTEGER NOT NULL REFERENCES " + SCENES + "(scene_id) ON DELETE CASCADE, "
+                    + "npc_id INTEGER NOT NULL, sort_order INTEGER NOT NULL, PRIMARY KEY(scene_id, npc_id))");
+        } catch (SQLException exception) {
+            connection.close();
+            throw exception;
+        }
+        return connection;
+    }
+
+    private static List<RunningScene> loadScenes(Connection connection) throws SQLException {
+        List<RunningScene> scenes = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT scene_id, title, notes, source_session_id, source_scene_id, source_encounter_plan_id, location_id"
+                        + " FROM " + SCENES + " ORDER BY sort_order");
+                ResultSet result = statement.executeQuery()) {
+            while (result.next()) {
+                long id = result.getLong("scene_id");
+                scenes.add(new RunningScene(id, result.getString("title"), result.getString("notes"),
+                        result.getLong("source_session_id"), result.getLong("source_scene_id"),
+                        result.getLong("source_encounter_plan_id"), result.getLong("location_id"),
+                        loadIds(connection, PARTY, "character_id", id), loadIds(connection, NPCS, "npc_id", id)));
+            }
+        }
+        return List.copyOf(scenes);
+    }
+
+    private static List<Long> loadIds(Connection connection, String table, String column, long sceneId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT " + column + " FROM " + table + " WHERE scene_id = ? ORDER BY sort_order")) {
+            statement.setLong(1, sceneId);
+            try (ResultSet result = statement.executeQuery()) {
+                List<Long> ids = new ArrayList<>();
+                while (result.next()) {
+                    ids.add(result.getLong(column));
+                }
+                return List.copyOf(ids);
+            }
+        }
+    }
+
+    private static void clear(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("DELETE FROM " + WORKSPACE);
+            statement.executeUpdate("DELETE FROM " + PARTY);
+            statement.executeUpdate("DELETE FROM " + NPCS);
+            statement.executeUpdate("DELETE FROM " + SCENES);
+        }
+    }
+
+    private static void saveScenes(Connection connection, List<RunningScene> scenes) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO " + SCENES
+                        + " (scene_id, title, notes, source_session_id, source_scene_id, source_encounter_plan_id, location_id, sort_order)"
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) {
+            for (int index = 0; index < scenes.size(); index++) {
+                RunningScene scene = scenes.get(index);
+                statement.setLong(1, scene.sceneId()); statement.setString(2, scene.title());
+                statement.setString(3, scene.notes()); statement.setLong(4, scene.sourceSessionId());
+                statement.setLong(5, scene.sourceSceneId()); statement.setLong(6, scene.sourceEncounterPlanId());
+                statement.setLong(7, scene.locationId()); statement.setInt(8, index); statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+        for (RunningScene scene : scenes) {
+            saveIds(connection, PARTY, "character_id", scene.sceneId(), scene.partyMemberIds());
+            saveIds(connection, NPCS, "npc_id", scene.sceneId(), scene.npcIds());
+        }
+    }
+
+    private static void saveIds(Connection connection, String table, String column, long sceneId, List<Long> ids)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO " + table + " (scene_id, " + column + ", sort_order) VALUES (?, ?, ?)")) {
+            for (int index = 0; index < ids.size(); index++) {
+                statement.setLong(1, sceneId); statement.setLong(2, ids.get(index));
+                statement.setInt(3, index); statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
+    private static final class ConnectionFactory extends AbstractSqliteConnectionFactory {
+        private ConnectionFactory() { super(resolveDatabasePath("game.db")); }
+    }
+}

--- a/src/data/worldplanner/gateway/local/SqliteWorldPlannerReader.java
+++ b/src/data/worldplanner/gateway/local/SqliteWorldPlannerReader.java
@@ -29,7 +29,7 @@ final class SqliteWorldPlannerReader {
 
     private List<WorldNpcRecord> loadNpcs(Connection connection) throws SQLException {
         String sql = "SELECT npc_id, display_name, creature_statblock_id, appearance_notes, behavior_notes, "
-                + "history_notes, general_notes, status FROM "
+                + "history_notes, general_notes, disposition_modifier, status FROM "
                 + WorldPlannerPersistenceSchema.NPCS_TABLE
                 + " ORDER BY npc_id";
         try (PreparedStatement statement = connection.prepareStatement(sql);
@@ -44,6 +44,7 @@ final class SqliteWorldPlannerReader {
                         result.getString("behavior_notes"),
                         result.getString("history_notes"),
                         result.getString("general_notes"),
+                        result.getInt("disposition_modifier"),
                         result.getString("status")));
             }
             return records;
@@ -51,7 +52,7 @@ final class SqliteWorldPlannerReader {
     }
 
     private List<WorldFactionRecord> loadFactions(Connection connection) throws SQLException {
-        String sql = "SELECT faction_id, display_name, notes, primary_encounter_table_id FROM "
+        String sql = "SELECT faction_id, display_name, notes, primary_encounter_table_id, disposition FROM "
                 + WorldPlannerPersistenceSchema.FACTIONS_TABLE
                 + " ORDER BY faction_id";
         try (PreparedStatement statement = connection.prepareStatement(sql);
@@ -64,6 +65,7 @@ final class SqliteWorldPlannerReader {
                         result.getString("display_name"),
                         result.getString("notes"),
                         result.getLong("primary_encounter_table_id"),
+                        result.getInt("disposition"),
                         loadFactionNpcIds(connection, factionId),
                         loadFactionLimits(connection, factionId)));
             }

--- a/src/data/worldplanner/gateway/local/SqliteWorldPlannerWriter.java
+++ b/src/data/worldplanner/gateway/local/SqliteWorldPlannerWriter.java
@@ -57,7 +57,7 @@ final class SqliteWorldPlannerWriter {
     ) throws SQLException {
         String sql = INSERT_PREFIX + WorldPlannerPersistenceSchema.NPCS_TABLE
                 + " (npc_id, display_name, creature_statblock_id, appearance_notes, behavior_notes, "
-                + "history_notes, general_notes, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+                + "history_notes, general_notes, disposition_modifier, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (WorldNpcRecord npc : npcs) {
                 statement.setLong(1, npc.npcId());
@@ -67,7 +67,8 @@ final class SqliteWorldPlannerWriter {
                 statement.setString(5, npc.behaviorNotes());
                 statement.setString(6, npc.historyNotes());
                 statement.setString(7, npc.generalNotes());
-                statement.setString(8, npc.status());
+                statement.setInt(8, npc.dispositionModifier());
+                statement.setString(9, npc.status());
                 statement.addBatch();
             }
             statement.executeBatch();
@@ -79,13 +80,14 @@ final class SqliteWorldPlannerWriter {
             List<WorldFactionRecord> factions
     ) throws SQLException {
         String sql = INSERT_PREFIX + WorldPlannerPersistenceSchema.FACTIONS_TABLE
-                + " (faction_id, display_name, notes, primary_encounter_table_id) VALUES (?, ?, ?, ?)";
+                + " (faction_id, display_name, notes, primary_encounter_table_id, disposition) VALUES (?, ?, ?, ?, ?)";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (WorldFactionRecord faction : factions) {
                 statement.setLong(1, faction.factionId());
                 statement.setString(2, faction.displayName());
                 statement.setString(3, faction.notes());
                 statement.setLong(4, faction.primaryEncounterTableId());
+                statement.setInt(5, faction.disposition());
                 statement.addBatch();
             }
             statement.executeBatch();

--- a/src/data/worldplanner/gateway/local/WorldPlannerSchemaMigrator.java
+++ b/src/data/worldplanner/gateway/local/WorldPlannerSchemaMigrator.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import src.data.worldplanner.model.WorldPlannerPersistenceSchema;
+import src.data.persistencecore.sqlite.SqliteSchemaColumnSupport;
 
 final class WorldPlannerSchemaMigrator {
 
@@ -16,6 +17,25 @@ final class WorldPlannerSchemaMigrator {
             statement.execute(WorldPlannerPersistenceSchema.CREATE_LOCATIONS_SQL);
             statement.execute(WorldPlannerPersistenceSchema.CREATE_LOCATION_FACTIONS_SQL);
             statement.execute(WorldPlannerPersistenceSchema.CREATE_LOCATION_TABLES_SQL);
+            addDispositionColumnIfMissing(
+                    connection, statement, WorldPlannerPersistenceSchema.NPCS_TABLE,
+                    WorldPlannerPersistenceSchema.NPC_DISPOSITION_COLUMN);
+            addDispositionColumnIfMissing(
+                    connection, statement, WorldPlannerPersistenceSchema.FACTIONS_TABLE,
+                    WorldPlannerPersistenceSchema.FACTION_DISPOSITION_COLUMN);
+            statement.execute(WorldPlannerPersistenceSchema.CREATE_FACTION_NPC_UNIQUE_INDEX_SQL);
+        }
+    }
+
+    private static void addDispositionColumnIfMissing(
+            Connection connection,
+            Statement statement,
+            String table,
+            String column
+    ) throws SQLException {
+        if (!SqliteSchemaColumnSupport.hasColumn(connection, table, column)) {
+            statement.execute("ALTER TABLE " + table + " ADD COLUMN " + column
+                    + " INTEGER NOT NULL DEFAULT 0 CHECK(" + column + " BETWEEN -50 AND 50)");
         }
     }
 }

--- a/src/data/worldplanner/mapper/WorldPlannerMapper.java
+++ b/src/data/worldplanner/mapper/WorldPlannerMapper.java
@@ -61,6 +61,7 @@ public final class WorldPlannerMapper {
                 record.behaviorNotes(),
                 record.historyNotes(),
                 record.generalNotes(),
+                record.dispositionModifier(),
                 toStatus(record.status()));
     }
 
@@ -73,6 +74,7 @@ public final class WorldPlannerMapper {
                 record.displayName(),
                 record.notes(),
                 record.primaryEncounterTableId(),
+                record.disposition(),
                 record.npcIds(),
                 record.inventoryLimits().stream()
                         .map(limit -> new WorldFactionInventoryLimit(
@@ -103,6 +105,7 @@ public final class WorldPlannerMapper {
                 npc.behaviorNotes(),
                 npc.historyNotes(),
                 npc.generalNotes(),
+                npc.dispositionModifier(),
                 npc.status().name());
     }
 
@@ -115,6 +118,7 @@ public final class WorldPlannerMapper {
                 faction.displayName(),
                 faction.notes(),
                 faction.primaryEncounterTableId(),
+                faction.disposition(),
                 faction.npcIds(),
                 faction.inventoryLimits().stream()
                         .map(limit -> new WorldFactionInventoryLimitRecord(

--- a/src/data/worldplanner/model/WorldFactionRecord.java
+++ b/src/data/worldplanner/model/WorldFactionRecord.java
@@ -7,9 +7,21 @@ public record WorldFactionRecord(
         String displayName,
         String notes,
         long primaryEncounterTableId,
+        int disposition,
         List<Long> npcIds,
         List<WorldFactionInventoryLimitRecord> inventoryLimits
 ) {
+
+    public WorldFactionRecord(
+            long factionId,
+            String displayName,
+            String notes,
+            long primaryEncounterTableId,
+            List<Long> npcIds,
+            List<WorldFactionInventoryLimitRecord> inventoryLimits
+    ) {
+        this(factionId, displayName, notes, primaryEncounterTableId, 0, npcIds, inventoryLimits);
+    }
 
     public WorldFactionRecord {
         npcIds = npcIds == null ? List.of() : List.copyOf(npcIds);

--- a/src/data/worldplanner/model/WorldNpcRecord.java
+++ b/src/data/worldplanner/model/WorldNpcRecord.java
@@ -8,5 +8,20 @@ public record WorldNpcRecord(
         String behaviorNotes,
         String historyNotes,
         String generalNotes,
+        int dispositionModifier,
         String status
-) { }
+) {
+    public WorldNpcRecord(
+            long npcId,
+            String displayName,
+            long creatureStatblockId,
+            String appearanceNotes,
+            String behaviorNotes,
+            String historyNotes,
+            String generalNotes,
+            String status
+    ) {
+        this(npcId, displayName, creatureStatblockId, appearanceNotes, behaviorNotes,
+                historyNotes, generalNotes, 0, status);
+    }
+}

--- a/src/data/worldplanner/model/WorldPlannerPersistenceSchema.java
+++ b/src/data/worldplanner/model/WorldPlannerPersistenceSchema.java
@@ -10,6 +10,8 @@ public final class WorldPlannerPersistenceSchema {
     public static final String LOCATIONS_TABLE = "world_planner_locations";
     public static final String LOCATION_FACTIONS_TABLE = "world_planner_location_factions";
     public static final String LOCATION_TABLES_TABLE = "world_planner_location_encounter_tables";
+    public static final String NPC_DISPOSITION_COLUMN = "disposition_modifier";
+    public static final String FACTION_DISPOSITION_COLUMN = "disposition";
     private static final String CREATE_TABLE_IF_NOT_EXISTS = "CREATE TABLE IF NOT EXISTS ";
 
     public static final String CREATE_NPCS_SQL =
@@ -21,6 +23,8 @@ public final class WorldPlannerPersistenceSchema {
                     + "behavior_notes TEXT NOT NULL, "
                     + "history_notes TEXT NOT NULL, "
                     + "general_notes TEXT NOT NULL, "
+                    + NPC_DISPOSITION_COLUMN + " INTEGER NOT NULL DEFAULT 0 CHECK("
+                    + NPC_DISPOSITION_COLUMN + " BETWEEN -50 AND 50), "
                     + "status TEXT NOT NULL"
                     + ")";
 
@@ -29,6 +33,8 @@ public final class WorldPlannerPersistenceSchema {
                     + "faction_id INTEGER PRIMARY KEY, "
                     + "display_name TEXT NOT NULL, "
                     + "notes TEXT NOT NULL, "
+                    + FACTION_DISPOSITION_COLUMN + " INTEGER NOT NULL DEFAULT 0 CHECK("
+                    + FACTION_DISPOSITION_COLUMN + " BETWEEN -50 AND 50), "
                     + "primary_encounter_table_id INTEGER NOT NULL"
                     + ")";
 
@@ -39,6 +45,10 @@ public final class WorldPlannerPersistenceSchema {
                     + "sort_order INTEGER NOT NULL, "
                     + "PRIMARY KEY(faction_id, npc_id)"
                     + ")";
+
+    public static final String CREATE_FACTION_NPC_UNIQUE_INDEX_SQL =
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_world_planner_npc_single_faction ON "
+                    + FACTION_NPCS_TABLE + "(npc_id)";
 
     public static final String CREATE_FACTION_LIMITS_SQL =
             CREATE_TABLE_IF_NOT_EXISTS + FACTION_LIMITS_TABLE + " ("

--- a/src/domain/encounter/EncounterApplicationService.java
+++ b/src/domain/encounter/EncounterApplicationService.java
@@ -16,6 +16,10 @@ import src.domain.encounter.published.ApplyEncounterStateCommand;
 import src.domain.encounter.published.EncounterBuilderInputs;
 import src.domain.encounter.published.RefreshEncounterPlanBudgetCommand;
 import src.domain.encounter.published.UpdateEncounterBuilderInputsCommand;
+import src.domain.encounter.published.EncounterRuntimeContextApi;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+import src.domain.encounter.model.session.SceneNpcData;
+import src.domain.encounter.model.session.repository.EncounterRuntimeStateRepository;
 
 /**
  * Public encounter command boundary below the view layer.
@@ -55,9 +59,10 @@ public final class EncounterApplicationService {
     EncounterApplicationService(
             EncounterSessionRuntimeAccess runtimeAccess,
             EncounterPlanGateway plans,
-            EncounterPublishedState publishedState
+            EncounterPublishedState publishedState,
+            EncounterRuntimeStateRepository runtimeStates
     ) {
-        this(RuntimeCommandActions.create(runtimeAccess, plans, publishedState));
+        this(RuntimeCommandActions.create(runtimeAccess, plans, publishedState, runtimeStates));
     }
 
     EncounterApplicationService(CommandActions commands) {
@@ -74,6 +79,13 @@ public final class EncounterApplicationService {
 
     public void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command) {
         commands.refreshPlanBudget(command);
+    }
+
+    public EncounterRuntimeContextApi runtimeContexts() {
+        if (commands instanceof EncounterRuntimeContextApi api) {
+            return api;
+        }
+        return command -> new EncounterRuntimeContextApi.SyncResult(false, "Encounter-Kontexte sind nicht verfügbar.");
     }
 
     private static EncounterSessionCommand toSessionCommand(ApplyEncounterStateCommand command) {
@@ -154,35 +166,44 @@ public final class EncounterApplicationService {
         void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command);
     }
 
-    private static final class RuntimeCommandActions implements CommandActions {
+    private static final class RuntimeCommandActions implements CommandActions, EncounterRuntimeContextApi {
 
         private final EncounterSessionRuntimeAccess runtimeAccess;
         private final EncounterPlanGateway plans;
         private final EncounterPublishedState publishedState;
-        private final EncounterSession session = new EncounterSession();
+        private final EncounterRuntimeStateRepository runtimeStates;
+        private final Map<String, EncounterSessionMemento> restoredStates;
+        private final Map<String, ContextRuntime> contexts = new java.util.LinkedHashMap<>();
+        private String focusedContextKey = "legacy";
 
         private RuntimeCommandActions(
                 EncounterSessionRuntimeAccess runtimeAccess,
                 EncounterPlanGateway plans,
-                EncounterPublishedState publishedState
+                EncounterPublishedState publishedState,
+                EncounterRuntimeStateRepository runtimeStates
         ) {
             this.runtimeAccess = Objects.requireNonNull(runtimeAccess, "runtimeAccess");
             this.plans = Objects.requireNonNull(plans, "plans");
             this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
+            this.runtimeStates = Objects.requireNonNull(runtimeStates, "runtimeStates");
+            this.restoredStates = new java.util.LinkedHashMap<>(runtimeStates.loadAll());
         }
 
         private static RuntimeCommandActions create(
                 EncounterSessionRuntimeAccess runtimeAccess,
                 EncounterPlanGateway plans,
-                EncounterPublishedState publishedState
+                EncounterPublishedState publishedState,
+                EncounterRuntimeStateRepository runtimeStates
         ) {
-            RuntimeCommandActions actions = new RuntimeCommandActions(runtimeAccess, plans, publishedState);
+            RuntimeCommandActions actions = new RuntimeCommandActions(runtimeAccess, plans, publishedState, runtimeStates);
             actions.initialize();
             return actions;
         }
 
         private void initialize() {
-            session.apply(EncounterSessionCommand.refresh(), runtimeAccess);
+            ContextRuntime legacy = new ContextRuntime(new EncounterSession(), runtimeAccess, List.of(), false);
+            legacy.session.apply(EncounterSessionCommand.refresh(), legacy.access);
+            contexts.put(focusedContextKey, legacy);
             publishCurrentSession();
             publishSavedPlans();
             publishPlanBudget(0L);
@@ -191,7 +212,10 @@ public final class EncounterApplicationService {
         @Override
         public void applyState(ApplyEncounterStateCommand command) {
             EncounterSessionCommand effective = toSessionCommand(command);
-            session.apply(effective, runtimeAccess);
+            ContextRuntime current = current();
+            current.session.apply(effective, current.access);
+            current.reconcileSceneNpcs();
+            persist();
             publishCurrentSession();
             if (effective.action().republishesSavedPlans()) {
                 publishSavedPlans();
@@ -200,7 +224,10 @@ public final class EncounterApplicationService {
 
         @Override
         public void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command) {
-            session.apply(EncounterSessionCommand.updateBuilderInputs(toGenerationInputs(command)), runtimeAccess);
+            ContextRuntime current = current();
+            current.session.apply(EncounterSessionCommand.updateBuilderInputs(toGenerationInputs(command)), current.access);
+            current.reconcileSceneNpcs();
+            persist();
             publishCurrentSession();
         }
 
@@ -210,7 +237,7 @@ public final class EncounterApplicationService {
         }
 
         private void publishCurrentSession() {
-            publishedState.publishCurrentSession(session, plans);
+            publishedState.publishCurrentSession(current().session, plans);
         }
 
         private void publishSavedPlans() {
@@ -219,6 +246,106 @@ public final class EncounterApplicationService {
 
         private void publishPlanBudget(long planId) {
             publishedState.publishPlanBudget(plans.loadPlanBudgetForPublication(planId));
+        }
+
+        @Override
+        public SyncResult synchronize(SynchronizeEncounterContextsCommand command) {
+            if (command == null || command.contexts().isEmpty()) {
+                return new SyncResult(false, "Mindestens ein Encounter-Kontext ist erforderlich.");
+            }
+            try {
+                java.util.Set<String> retained = new java.util.LinkedHashSet<>();
+                for (Context context : command.contexts()) {
+                    if (context.key().isBlank()) {
+                        continue;
+                    }
+                    retained.add(context.key());
+                    ContextRuntime runtime = contexts.get(context.key());
+                    EncounterSessionRuntimeAccess scoped = runtimeAccess.scoped(
+                            context.partyMemberIds(), context.worldLocationId());
+                    if (runtime == null) {
+                        runtime = new ContextRuntime(new EncounterSession(), scoped, sceneNpcs(context), true);
+                        EncounterSessionMemento restored = restoredStates.remove(context.key());
+                        if (restored == null) {
+                            runtime.session.apply(EncounterSessionCommand.refresh(), scoped);
+                            if (context.initialEncounterPlanId() > 0L) {
+                                runtime.session.apply(toSessionCommand(
+                                        ApplyEncounterStateCommand.openSavedPlan(context.initialEncounterPlanId())), scoped);
+                            }
+                        } else {
+                            runtime.session.restore(restored, scoped);
+                            runtime.session.reconcileParty(scoped);
+                        }
+                        contexts.put(context.key(), runtime);
+                    } else {
+                        runtime.access = scoped;
+                        runtime.sceneNpcs = sceneNpcs(context);
+                        runtime.session.reconcileParty(scoped);
+                    }
+                    runtime.reconcileSceneNpcs();
+                }
+                contexts.keySet().removeIf(key -> !retained.contains(key));
+                if (!contexts.containsKey(command.focusedContextKey())) {
+                    return new SyncResult(false, "Fokussierter Encounter-Kontext fehlt.");
+                }
+                focusedContextKey = command.focusedContextKey();
+                persist();
+                publishCurrentSession();
+                return new SyncResult(true, "Encounter-Kontexte synchronisiert.");
+            } catch (IllegalStateException exception) {
+                return new SyncResult(false, "Encounter-Kontexte konnten nicht synchronisiert werden.");
+            }
+        }
+
+        private ContextRuntime current() {
+            ContextRuntime runtime = contexts.get(focusedContextKey);
+            if (runtime == null) {
+                throw new IllegalStateException("Focused encounter context is missing.");
+            }
+            return runtime;
+        }
+
+        private static List<SceneNpcData> sceneNpcs(Context context) {
+            return context.npcs().stream()
+                    .map(npc -> new SceneNpcData(
+                            npc.worldNpcId(), npc.creatureId(),
+                            SceneNpcData.Role.valueOf(npc.role().name()), npc.active()))
+                    .toList();
+        }
+
+        private void persist() {
+            Map<String, EncounterSessionMemento> snapshots = new java.util.LinkedHashMap<>();
+            for (Map.Entry<String, ContextRuntime> entry : contexts.entrySet()) {
+                if (!"legacy".equals(entry.getKey())) {
+                    snapshots.put(entry.getKey(), entry.getValue().session.memento());
+                }
+            }
+            runtimeStates.saveAll(snapshots);
+        }
+
+        private static final class ContextRuntime {
+            private final EncounterSession session;
+            private EncounterSessionRuntimeAccess access;
+            private List<SceneNpcData> sceneNpcs;
+            private final boolean sceneManaged;
+
+            private ContextRuntime(
+                    EncounterSession session,
+                    EncounterSessionRuntimeAccess access,
+                    List<SceneNpcData> sceneNpcs,
+                    boolean sceneManaged
+            ) {
+                this.session = session;
+                this.access = access;
+                this.sceneNpcs = List.copyOf(sceneNpcs);
+                this.sceneManaged = sceneManaged;
+            }
+
+            private void reconcileSceneNpcs() {
+                if (sceneManaged) {
+                    session.reconcileSceneNpcs(sceneNpcs, access);
+                }
+            }
         }
     }
 

--- a/src/domain/encounter/EncounterForeignFacts.java
+++ b/src/domain/encounter/EncounterForeignFacts.java
@@ -142,6 +142,39 @@ final class EncounterForeignFacts implements EncounterGenerator.ForeignFacts {
         return List.copyOf(members);
     }
 
+    List<PartyMemberData> loadActiveParty(List<Long> selectedIds) {
+        List<Long> ids = selectedIds == null ? List.of() : List.copyOf(selectedIds);
+        return loadActiveParty().stream().filter(member -> ids.contains(member.numericId())).toList();
+    }
+
+    PartyBudgetFacts loadPartyBudgetFacts(List<Long> selectedIds) {
+        List<PartyMemberData> members = loadActiveParty(selectedIds);
+        if (members.isEmpty()) {
+            return PartyBudgetFacts.noActiveParty();
+        }
+        List<Integer> levels = members.stream().map(PartyMemberData::level).toList();
+        int average = (int) Math.round(levels.stream().mapToInt(Integer::intValue).average().orElse(1.0));
+        AdventuringDayResult day = adventuringDaySummary.current();
+        int consumed = day.status() == ReadStatus.SUCCESS ? day.summary().consumedXp() : 0;
+        int total = day.status() == ReadStatus.SUCCESS ? day.summary().totalBudgetXp() : 0;
+        int globalSize = Math.max(1, loadActiveParty().size());
+        return PartyBudgetFacts.success(levels, average,
+                Math.max(0, consumed * members.size() / globalSize),
+                Math.max(0, total * members.size() / globalSize));
+    }
+
+    EncounterGenerationRequest withWorldLocation(EncounterGenerationRequest request, long locationId) {
+        if (request == null || locationId <= 0L) {
+            return request;
+        }
+        EncounterGenerationInputs input = request.inputs();
+        EncounterGenerationInputs scoped = new EncounterGenerationInputs(
+                input.creatureTypes(), input.creatureSubtypes(), input.biomes(), input.targetDifficulty(),
+                input.tuning(), input.encounterTableIds(), input.worldFactionIds(), locationId, input.finiteCreatureStockCaps());
+        return new EncounterGenerationRequest(scoped, request.alternativeCount(), request.generationSeed(),
+                request.excludedCreatureIds(), request.lockedCreatures());
+    }
+
     boolean awardXp(List<Long> partyMemberIds, int xpPerCharacter) {
         party.awardXp(new AwardPartyXpCommand(partyMemberIds, xpPerCharacter));
         return partyMutation.current().status() == MutationStatus.SUCCESS;

--- a/src/domain/encounter/EncounterPlanGateway.java
+++ b/src/domain/encounter/EncounterPlanGateway.java
@@ -40,6 +40,14 @@ final class EncounterPlanGateway {
         return result.status().isSuccess() ? Optional.of(toSessionBudget(result.budget())) : Optional.empty();
     }
 
+    Optional<BudgetData> loadBudget(PartyBudgetFacts facts) {
+        if (facts == null || !facts.status().isSuccess()) {
+            return Optional.empty();
+        }
+        return Optional.of(toSessionBudget(EncounterDifficultyMathHelper.summarizeBudget(
+                facts.activePartyLevels(), facts.consumedDailyXp(), facts.totalBudgetXp())));
+    }
+
     BudgetResult loadBudgetForTuningPreview() {
         PartyBudgetFacts budgetFacts = facts.loadPartyBudgetFacts();
         if (budgetFacts.status().isStorageError()) {

--- a/src/domain/encounter/EncounterServiceAssembly.java
+++ b/src/domain/encounter/EncounterServiceAssembly.java
@@ -14,6 +14,8 @@ import src.domain.party.published.ActivePartyModel;
 import src.domain.party.published.AdventuringDaySummaryModel;
 import src.domain.party.published.PartyMutationModel;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
+import src.domain.encounter.model.session.repository.EncounterRuntimeStateRepository;
+import src.domain.encounter.model.session.repository.InMemoryEncounterRuntimeStateRepository;
 
 public final class EncounterServiceAssembly {
 
@@ -31,6 +33,26 @@ public final class EncounterServiceAssembly {
             PartyMutationModel partyMutation,
             EncounterPlanRepository planRepository
     ) {
+        return create(creatures, creatureDetails, creatureCandidates, encounterTables, tableCandidates,
+                worldPlanner, party, activeParty, activePartyComposition, daySummary, partyMutation,
+                planRepository, new InMemoryEncounterRuntimeStateRepository());
+    }
+
+    public static Component create(
+            CreaturesApplicationService creatures,
+            CreatureDetailModel creatureDetails,
+            CreatureEncounterCandidatesModel creatureCandidates,
+            EncounterTableApplicationService encounterTables,
+            EncounterTableCandidatesModel tableCandidates,
+            @Nullable WorldPlannerSnapshotModel worldPlanner,
+            PartyApplicationService party,
+            ActivePartyModel activeParty,
+            ActivePartyCompositionModel activePartyComposition,
+            AdventuringDaySummaryModel daySummary,
+            PartyMutationModel partyMutation,
+            EncounterPlanRepository planRepository,
+            EncounterRuntimeStateRepository runtimeStates
+    ) {
         EncounterPublishedState publishedState = new EncounterPublishedState();
         EncounterForeignFacts facts = new EncounterForeignFacts(
                 creatures, creatureDetails, creatureCandidates, encounterTables, tableCandidates,
@@ -40,7 +62,7 @@ public final class EncounterServiceAssembly {
                 facts,
                 plans,
                 new EncounterGenerator(facts));
-        EncounterApplicationService application = new EncounterApplicationService(runtime, plans, publishedState);
+        EncounterApplicationService application = new EncounterApplicationService(runtime, plans, publishedState, runtimeStates);
         return new Component(
                 application,
                 publishedState.stateModel(),
@@ -58,6 +80,9 @@ public final class EncounterServiceAssembly {
             src.domain.encounter.published.SavedEncounterPlanListModel savedPlans,
             src.domain.encounter.published.EncounterPlanBudgetModel planBudget
     ) {
+        public src.domain.encounter.published.EncounterRuntimeContextApi runtimeContexts() {
+            return application.runtimeContexts();
+        }
     }
 
 }

--- a/src/domain/encounter/EncounterSessionRuntimeAccess.java
+++ b/src/domain/encounter/EncounterSessionRuntimeAccess.java
@@ -26,31 +26,54 @@ final class EncounterSessionRuntimeAccess implements EncounterSession.SessionRep
     private final EncounterForeignFacts facts;
     private final EncounterPlanGateway plans;
     private final src.domain.encounter.model.generation.EncounterGenerator generator;
+    private final List<Long> partyMemberIds;
+    private final long worldLocationId;
+    private final boolean scoped;
 
     EncounterSessionRuntimeAccess(
             EncounterForeignFacts facts,
             EncounterPlanGateway plans,
             src.domain.encounter.model.generation.EncounterGenerator generator
     ) {
+        this(facts, plans, generator, List.of(), 0L, false);
+    }
+
+    private EncounterSessionRuntimeAccess(
+            EncounterForeignFacts facts,
+            EncounterPlanGateway plans,
+            src.domain.encounter.model.generation.EncounterGenerator generator,
+            List<Long> partyMemberIds,
+            long worldLocationId,
+            boolean scoped
+    ) {
         this.facts = java.util.Objects.requireNonNull(facts, "facts");
         this.plans = java.util.Objects.requireNonNull(plans, "plans");
         this.generator = java.util.Objects.requireNonNull(generator, "generator");
+        this.partyMemberIds = partyMemberIds == null ? List.of() : List.copyOf(partyMemberIds);
+        this.worldLocationId = Math.max(0L, worldLocationId);
+        this.scoped = scoped;
+    }
+
+    EncounterSessionRuntimeAccess scoped(List<Long> memberIds, long locationId) {
+        return new EncounterSessionRuntimeAccess(facts, plans, generator, memberIds, locationId, true);
     }
 
     @Override
     public List<PartyMemberData> loadActiveParty() {
-        return facts.loadActiveParty();
+        return scoped ? facts.loadActiveParty(partyMemberIds) : facts.loadActiveParty();
     }
 
     @Override
     public Optional<BudgetData> loadBudget() {
-        return plans.loadBudget();
+        return scoped ? plans.loadBudget(facts.loadPartyBudgetFacts(partyMemberIds)) : plans.loadBudget();
     }
 
     @Override
     public GenerationResultData generate(EncounterGenerationRequest request) {
         try {
-            EncounterGenerationResult result = generator.generate(facts.resolveWorldSource(request));
+            EncounterGenerationRequest scopedRequest = facts.withWorldLocation(request, worldLocationId);
+            EncounterGenerationResult result = generator.generate(
+                    facts.resolveWorldSource(scopedRequest), scoped ? facts.loadPartyBudgetFacts(partyMemberIds) : null);
             return generationData(result);
         } catch (IllegalStateException exception) {
             return new GenerationResultData(false, List.of(), "Encounter generation failed.", Optional.empty(), false);

--- a/src/domain/encounter/model/generation/EncounterGenerator.java
+++ b/src/domain/encounter/model/generation/EncounterGenerator.java
@@ -33,7 +33,11 @@ public final class EncounterGenerator {
     }
 
     public EncounterGenerationResult generate(EncounterGenerationRequest request) {
-        Preparation preparation = prepare(request, SEARCH_LIMIT);
+        return generate(request, null);
+    }
+
+    public EncounterGenerationResult generate(EncounterGenerationRequest request, PartyBudgetFacts scopedParty) {
+        Preparation preparation = prepare(request, SEARCH_LIMIT, scopedParty);
         if (!preparation.success()) {
             return new EncounterGenerationResult(
                     false,
@@ -52,8 +56,8 @@ public final class EncounterGenerator {
                 preparation.fallbackUsed());
     }
 
-    private Preparation prepare(EncounterGenerationRequest request, int searchLimit) {
-        PartyLoad partyLoad = loadPartyState();
+    private Preparation prepare(EncounterGenerationRequest request, int searchLimit, PartyBudgetFacts scopedParty) {
+        PartyLoad partyLoad = loadPartyState(scopedParty);
         if (!partyLoad.success()) {
             return partyLoad.failure();
         }
@@ -90,8 +94,8 @@ public final class EncounterGenerator {
                 search.fallbackUsed());
     }
 
-    private PartyLoad loadPartyState() {
-        PartyBudgetFacts budgetFacts = facts.loadPartyBudgetFacts();
+    private PartyLoad loadPartyState(PartyBudgetFacts scopedParty) {
+        PartyBudgetFacts budgetFacts = scopedParty == null ? facts.loadPartyBudgetFacts() : scopedParty;
         if (budgetFacts.status().isStorageError()) {
             return PartyLoad.failure("Party data could not be loaded.");
         }

--- a/src/domain/encounter/model/session/CombatInitiativeTracker.java
+++ b/src/domain/encounter/model/session/CombatInitiativeTracker.java
@@ -18,6 +18,10 @@ final class CombatInitiativeTracker {
     }
 
     void open(EncounterSessionContext context, List<EncounterCreatureData> roster) {
+        open(context, roster, List.of());
+    }
+
+    void open(EncounterSessionContext context, List<EncounterCreatureData> roster, List<EncounterCreatureData> allies) {
         if (roster.isEmpty()) {
             context.setStatus(OPEN_INITIATIVE_NEEDS_CREATURE_STATUS);
             return;
@@ -46,6 +50,11 @@ final class CombatInitiativeTracker {
                     label + " (" + signed(creature.initiativeBonus()) + ")",
                     CombatantKind.MONSTER,
                     rolled));
+        }
+        for (EncounterCreatureData ally : allies) {
+            pendingRows.add(new InitiativeEntryData(
+                    ally.id(), ally.name(), CombatantKind.ALLY_NPC,
+                    CombatRosterBuilder.defaultMonsterInitiative(ally.initiativeBonus())));
         }
         context.enterMode(Mode.INITIATIVE, INITIATIVE_READY_STATUS);
     }
@@ -79,7 +88,12 @@ final class CombatInitiativeTracker {
             if (creature == null) {
                 continue;
             }
-            fallbackIndex = combatRosterBuilder.addMonsters(combatRoster, creature, input.initiative(), fallbackIndex);
+            if (entry.kind().alliedNpc()) {
+                combatRosterBuilder.addAlly(combatRoster, creature, input.initiative());
+                fallbackIndex++;
+            } else {
+                fallbackIndex = combatRosterBuilder.addMonsters(combatRoster, creature, input.initiative(), fallbackIndex);
+            }
         }
         combatRoster.sort();
         combatTurnTracker.beginCombat(combatTurns, combatRoster);
@@ -88,6 +102,29 @@ final class CombatInitiativeTracker {
 
     List<InitiativeEntryData> entries() {
         return List.copyOf(pendingRows);
+    }
+
+    void reconcileParty(List<PartyMemberData> party) {
+        List<InitiativeEntryData> next = new ArrayList<>();
+        List<PartyMemberData> members = party == null ? List.of() : List.copyOf(party);
+        for (int index = 0; index < members.size(); index++) {
+            PartyMemberData member = members.get(index);
+            InitiativeEntryData existing = pendingRows.stream()
+                    .filter(row -> row.id().equals(member.id()) && row.kind().playerCharacter())
+                    .findFirst().orElse(null);
+            next.add(existing == null
+                    ? new InitiativeEntryData(member.id(), member.name() + " (Lv. " + member.level() + ")",
+                            CombatantKind.playerCharacterKind(), CombatRosterBuilder.defaultPlayerInitiative(index))
+                    : existing);
+        }
+        pendingRows.stream().filter(row -> !row.kind().playerCharacter()).forEach(next::add);
+        pendingRows.clear();
+        pendingRows.addAll(next);
+    }
+
+    void restore(List<InitiativeEntryData> entries) {
+        pendingRows.clear();
+        pendingRows.addAll(entries == null ? List.of() : entries);
     }
 
     private static Optional<InitiativeEntryData> initiativeEntry(List<InitiativeEntryData> entries, String id) {

--- a/src/domain/encounter/model/session/CombatResolutionTracker.java
+++ b/src/domain/encounter/model/session/CombatResolutionTracker.java
@@ -61,4 +61,8 @@ final class CombatResolutionTracker {
     ResultStateData resultState() {
         return resultState;
     }
+
+    void restore(ResultStateData state) {
+        resultState = state == null ? ResultStateData.empty() : state;
+    }
 }

--- a/src/domain/encounter/model/session/CombatRoster.java
+++ b/src/domain/encounter/model/session/CombatRoster.java
@@ -36,4 +36,41 @@ public final class CombatRoster {
     public void sort() {
         combatants.sort(Combatant::compareByTurnOrder);
     }
+
+    public void reconcilePlayers(List<PartyMemberData> party, CombatRosterBuilder builder) {
+        List<PartyMemberData> members = party == null ? List.of() : List.copyOf(party);
+        List<String> retainedIds = members.stream().map(PartyMemberData::id).toList();
+        combatants.removeIf(combatant -> combatant.isPlayerCharacter() && !retainedIds.contains(combatant.id()));
+        for (int index = 0; index < members.size(); index++) {
+            PartyMemberData member = members.get(index);
+            if (!containsId(CombatantId.from(member.id()))) {
+                builder.addPlayerToRunningCombat(
+                        this, member.id(), member.name(), CombatRosterBuilder.defaultPlayerInitiative(index));
+            }
+        }
+        sort();
+    }
+
+    public void reconcileSceneNpcs(
+            List<EncounterCreatureData> hostile,
+            List<EncounterCreatureData> friendly,
+            CombatRosterBuilder builder
+    ) {
+        List<Long> retained = new java.util.ArrayList<>();
+        hostile.forEach(value -> retained.add(value.worldNpcId()));
+        friendly.forEach(value -> retained.add(value.worldNpcId()));
+        combatants.removeIf(value -> value.worldNpcId() > 0L && !retained.contains(value.worldNpcId()));
+        for (EncounterCreatureData ally : friendly) {
+            combatants.removeIf(value -> value.worldNpcId() == ally.worldNpcId() && value.kind().enemy());
+            builder.addAlly(this, ally, CombatRosterBuilder.defaultMonsterInitiative(ally.initiativeBonus()));
+        }
+        for (EncounterCreatureData enemy : hostile) {
+            boolean exists = combatants.stream().anyMatch(value -> value.worldNpcId() == enemy.worldNpcId());
+            if (!exists) {
+                builder.addMonsters(this, enemy, CombatRosterBuilder.defaultMonsterInitiative(enemy.initiativeBonus()),
+                        combatants.size());
+            }
+        }
+        sort();
+    }
 }

--- a/src/domain/encounter/model/session/CombatRosterBuilder.java
+++ b/src/domain/encounter/model/session/CombatRosterBuilder.java
@@ -58,6 +58,16 @@ public final class CombatRosterBuilder {
         return true;
     }
 
+    public void addAlly(CombatRoster roster, EncounterCreatureData creature, int initiative) {
+        if (roster.combatants().stream().anyMatch(value -> value.worldNpcId() == creature.worldNpcId())) {
+            return;
+        }
+        roster.add(Combatant.allyNpc(creature.id(), creature.name(),
+                MonsterCombatProfile.fromEncounterCreature(creature), creature.worldNpcId(), initiative,
+                nextOrder(roster.combatants())));
+        roster.sort();
+    }
+
     private static int addMonsterMembers(
             CombatRoster roster,
             MonsterCombatProfile profile,

--- a/src/domain/encounter/model/session/CombatRosterMutation.java
+++ b/src/domain/encounter/model/session/CombatRosterMutation.java
@@ -41,7 +41,7 @@ public final class CombatRosterMutation {
     public List<ResultEnemyData> resultEnemies(CombatRoster roster) {
         List<ResultEnemyData> enemies = new ArrayList<>();
         for (Combatant combatant : roster.combatants()) {
-            if (combatant.isPlayerCharacter()) {
+            if (!combatant.kind().enemy()) {
                 continue;
             }
             enemies.add(new ResultEnemyData(

--- a/src/domain/encounter/model/session/CombatTurn.java
+++ b/src/domain/encounter/model/session/CombatTurn.java
@@ -59,7 +59,7 @@ public final class CombatTurn {
         int totalEnemies = 0;
         int aliveEnemies = 0;
         for (Combatant combatant : combatants) {
-            if (!combatant.isPlayerCharacter()) {
+            if (combatant.kind().enemy()) {
                 totalEnemies++;
                 if (combatant.isAlive()) {
                     aliveEnemies++;

--- a/src/domain/encounter/model/session/CombatTurnTracker.java
+++ b/src/domain/encounter/model/session/CombatTurnTracker.java
@@ -52,6 +52,19 @@ final class CombatTurnTracker {
         return projection;
     }
 
+    int currentTurnIndex() {
+        return currentTurnIndex.orElse(CombatTurn.NO_ACTIVE_TURN_INDEX);
+    }
+
+    int round() {
+        return round;
+    }
+
+    void restoreState(int turnIndex, int restoredRound) {
+        currentTurnIndex = toOptionalTurnIndex(turnIndex);
+        round = Math.max(1, restoredRound);
+    }
+
     private static OptionalInt toOptionalTurnIndex(int turnIndex) {
         return turnIndex < 0 ? OptionalInt.empty() : OptionalInt.of(turnIndex);
     }

--- a/src/domain/encounter/model/session/Combatant.java
+++ b/src/domain/encounter/model/session/Combatant.java
@@ -65,6 +65,19 @@ public record Combatant(
                 order);
     }
 
+    public static Combatant allyNpc(
+            String sourceId,
+            String displayName,
+            MonsterCombatProfile profile,
+            long worldNpcId,
+            int initiative,
+            int order
+    ) {
+        return new Combatant(sourceId + ":1", displayName, CombatantKind.ALLY_NPC, profile.creatureId(),
+                worldNpcId, profile.maxHp(), profile.maxHp(), profile.armorClass(), initiative, 1, 0,
+                "Verbündeter · " + profile.detail(), "", order);
+    }
+
     public boolean isPlayerCharacter() {
         return kind.playerCharacter();
     }
@@ -74,7 +87,8 @@ public record Combatant(
     }
 
     public boolean sharesMobBucketWith(Combatant other) {
-        return worldNpcId == 0L && other.worldNpcId() == 0L && creatureId == other.creatureId() && initiative == other.initiative();
+        return kind == other.kind() && worldNpcId == 0L && other.worldNpcId() == 0L
+                && creatureId == other.creatureId() && initiative == other.initiative();
     }
 
     public String mobName() {

--- a/src/domain/encounter/model/session/CombatantKind.java
+++ b/src/domain/encounter/model/session/CombatantKind.java
@@ -2,6 +2,7 @@ package src.domain.encounter.model.session;
 
 public enum CombatantKind {
     PLAYER_CHARACTER("SC"),
+    ALLY_NPC("Verbündeter"),
     MONSTER("Monster");
 
     private final String label;
@@ -25,4 +26,7 @@ public enum CombatantKind {
     public static CombatantKind monsterKind() {
         return MONSTER;
     }
+
+    public boolean alliedNpc() { return this == ALLY_NPC; }
+    public boolean enemy() { return this == MONSTER; }
 }

--- a/src/domain/encounter/model/session/EncounterSession.java
+++ b/src/domain/encounter/model/session/EncounterSession.java
@@ -44,6 +44,7 @@ public final class EncounterSession {
     private final CombatInitiativeTracker combatInitiative = new CombatInitiativeTracker();
     private final CombatTurnTracker combatTurnTracker = new CombatTurnTracker();
     private final CombatResolutionTracker combatResolution = new CombatResolutionTracker();
+    private final List<EncounterCreatureData> sceneAllies = new java.util.ArrayList<>();
 
     public EncounterSession apply(EncounterSessionCommand command, SessionRepository access) {
         EncounterSessionCommand effective = command == null ? EncounterSessionCommand.refresh() : command;
@@ -65,6 +66,90 @@ public final class EncounterSession {
                 combatProjection,
                 context.missingCombatPartyMembers(combatProjection),
                 combatResolution.resultState());
+    }
+
+    public void reconcileParty(SessionRepository access) {
+        var activeTurnId = combatTurnTracker.activeTurnId(combatTurns, combatRoster);
+        context.refresh(access);
+        if (context.mode() == Mode.INITIATIVE) {
+            combatInitiative.reconcileParty(context.activeParty());
+        } else if (context.mode() == Mode.COMBAT) {
+            combatRoster.reconcilePlayers(context.activeParty(), combatRosterBuilder);
+            combatTurnTracker.restore(combatTurns, combatRoster, activeTurnId);
+        }
+    }
+
+    public void reconcileSceneNpcs(List<SceneNpcData> npcs, SessionRepository access) {
+        List<SceneNpcData> values = npcs == null ? List.of() : List.copyOf(npcs);
+        List<EncounterCreatureData> hostile = new java.util.ArrayList<>();
+        List<EncounterCreatureData> friendly = new java.util.ArrayList<>();
+        for (SceneNpcData npc : values) {
+            if (!npc.active() || npc.role() == SceneNpcData.Role.NEUTRAL) {
+                continue;
+            }
+            CreatureDetailData detail = access.loadCreature(npc.creatureId()).orElse(null);
+            if (detail == null) {
+                continue;
+            }
+            EncounterCreatureData creature = EncounterSessionCreatureRows.worldNpc(detail, npc.worldNpcId());
+            if (npc.role() == SceneNpcData.Role.FRIENDLY) {
+                friendly.add(creature);
+            } else {
+                hostile.add(creature);
+            }
+        }
+        sceneAllies.clear();
+        sceneAllies.addAll(friendly);
+        builder.retainSceneEnemies(hostile.stream().map(EncounterCreatureData::worldNpcId).toList());
+        if (context.mode() == Mode.BUILDER) {
+            for (EncounterCreatureData creature : hostile) {
+                if (!builder.containsWorldNpc(creature.worldNpcId())) {
+                    builder.addSceneWorldNpc(creature, context);
+                }
+            }
+        } else if (context.mode() == Mode.INITIATIVE) {
+            combatInitiative.open(context, combinedRoster(), sceneAllies);
+        } else if (context.mode() == Mode.COMBAT) {
+            var activeTurnId = combatTurnTracker.activeTurnId(combatTurns, combatRoster);
+            combatRoster.reconcileSceneNpcs(hostile, friendly, combatRosterBuilder);
+            combatTurnTracker.restore(combatTurns, combatRoster, activeTurnId);
+        }
+    }
+
+    private List<EncounterCreatureData> combinedRoster() {
+        List<EncounterCreatureData> combined = new java.util.ArrayList<>(builder.roster());
+        combined.addAll(sceneAllies);
+        return List.copyOf(combined);
+    }
+
+    public EncounterSessionMemento memento() {
+        EncounterSessionMemento.BuilderSlice slice = builder.memento();
+        return new EncounterSessionMemento(
+                EncounterSessionMemento.CURRENT_FORMAT_VERSION,
+                context.mode(), context.status(), slice.builderInputs(), slice.roster(), slice.pendingUndo(),
+                slice.nextUndoToken(), slice.generatedAlternatives(), slice.generatedAdvisories(),
+                slice.selectedAlternativeIndex(), slice.generatedAdjustedXp(), slice.generatedDifficulty(),
+                slice.generatedTitle(), slice.generationHistoryPresent(), slice.activeSavedPlanId(),
+                combatInitiative.entries(), combatRoster.combatants(), combatTurnTracker.currentTurnIndex(),
+                combatTurnTracker.round(), combatResolution.resultState());
+    }
+
+    public void restore(EncounterSessionMemento memento, SessionRepository access) {
+        if (memento == null) {
+            apply(EncounterSessionCommand.refresh(), access);
+            return;
+        }
+        context.refresh(access);
+        context.restore(memento.mode(), memento.status());
+        builder.restore(new EncounterSessionMemento.BuilderSlice(
+                memento.builderInputs(), memento.roster(), memento.pendingUndo(), memento.nextUndoToken(),
+                memento.generatedAlternatives(), memento.generatedAdvisories(), memento.selectedAlternativeIndex(),
+                memento.generatedAdjustedXp(), memento.generatedDifficulty(), memento.generatedTitle(),
+                memento.generationHistoryPresent(), memento.activeSavedPlanId()));
+        combatInitiative.restore(memento.initiativeEntries());
+        combatRoster.replaceAll(memento.combatants());
+        combatTurnTracker.restoreState(memento.currentTurnIndex(), memento.round());
+        combatResolution.restore(memento.resultState());
     }
 
     private void addCreature(SessionRepository access, long creatureId, long worldNpcId) {
@@ -191,7 +276,7 @@ public final class EncounterSession {
             handlers.put(EncounterSessionCommand.Action.UNDO_REMOVE, (session, command, access) ->
                     session.builder.mutateCreature(command, session.context));
             handlers.put(EncounterSessionCommand.Action.OPEN_INITIATIVE, (session, command, access) ->
-                    session.combatInitiative.open(session.context, session.builder.roster()));
+                    session.combatInitiative.open(session.context, session.builder.roster(), session.sceneAllies));
             handlers.put(EncounterSessionCommand.Action.BACK_TO_BUILDER, (session, command, access) ->
                     session.context.enterMode(
                             Mode.BUILDER,
@@ -199,7 +284,7 @@ public final class EncounterSession {
             handlers.put(EncounterSessionCommand.Action.CONFIRM_INITIATIVE, (session, command, access) ->
                     session.combatInitiative.confirm(
                             command.initiativeInputs(),
-                            session.builder.roster(),
+                            session.combinedRoster(),
                             session.combatRoster,
                             session.combatRosterBuilder,
                             session.combatTurnTracker,

--- a/src/domain/encounter/model/session/EncounterSessionBuilder.java
+++ b/src/domain/encounter/model/session/EncounterSessionBuilder.java
@@ -74,4 +74,28 @@ final class EncounterSessionBuilder {
                 generation.state(),
                 savedPlans.hasActivePlan());
     }
+
+    EncounterSessionMemento.BuilderSlice memento() {
+        EncounterSessionRosterState rosterState = roster.snapshot();
+        EncounterSessionGenerationState generationState = generation.state();
+        return new EncounterSessionMemento.BuilderSlice(
+                generationState.builderInputs(), rosterState.creatures(), rosterState.pendingUndo(), roster.nextUndoToken(),
+                generation.alternatives(), generationState.generatedAdvisories(), generationState.selectedAlternativeIndex(),
+                generationState.generatedAdjustedXp(), generationState.generatedDifficulty(), generationState.generatedTitle(),
+                generationState.generationHistoryPresent(), savedPlans.activeSavedPlanId());
+    }
+
+    void restore(EncounterSessionMemento.BuilderSlice slice) {
+        roster.restore(slice.roster(), slice.pendingUndo(), slice.nextUndoToken());
+        generation.restore(slice.builderInputs(), slice.generatedAlternatives(), slice.generatedAdvisories(),
+                slice.selectedAlternativeIndex(), slice.generatedAdjustedXp(), slice.generatedDifficulty(),
+                slice.generatedTitle(), slice.generationHistoryPresent());
+        savedPlans.restore(slice.activeSavedPlanId());
+    }
+
+    void retainSceneEnemies(List<Long> worldNpcIds) { roster.removeWorldNpcsExcept(worldNpcIds); }
+    boolean containsWorldNpc(long worldNpcId) { return roster.containsWorldNpc(worldNpcId); }
+    void addSceneWorldNpc(EncounterCreatureData creature, EncounterSessionContext context) {
+        roster.addSceneWorldNpc(creature, context);
+    }
 }

--- a/src/domain/encounter/model/session/EncounterSessionContext.java
+++ b/src/domain/encounter/model/session/EncounterSessionContext.java
@@ -64,4 +64,8 @@ final class EncounterSessionContext {
         status = nextStatus;
     }
 
+    void restore(int restoredMode, String restoredStatus) {
+        mode = restoredMode;
+        status = restoredStatus == null ? DEFAULT_STATUS : restoredStatus;
+    }
 }

--- a/src/domain/encounter/model/session/EncounterSessionGeneration.java
+++ b/src/domain/encounter/model/session/EncounterSessionGeneration.java
@@ -106,6 +106,32 @@ final class EncounterSessionGeneration {
                 generationHistoryPresent);
     }
 
+    List<GeneratedEncounterData> alternatives() {
+        return List.copyOf(generatedAlternatives);
+    }
+
+    void restore(
+            EncounterGenerationInputs inputs,
+            List<GeneratedEncounterData> alternatives,
+            List<String> advisories,
+            int selectedIndex,
+            int adjustedXp,
+            String difficulty,
+            String title,
+            boolean historyPresent
+    ) {
+        builderInputs = inputs == null ? EncounterGenerationInputs.empty() : inputs;
+        generatedAlternatives.clear();
+        generatedAlternatives.addAll(alternatives == null ? List.of() : alternatives);
+        generatedAdvisories = advisories == null ? List.of() : List.copyOf(advisories);
+        selectedAlternativeIndex = generatedAlternatives.isEmpty()
+                ? 0 : Math.floorMod(selectedIndex, generatedAlternatives.size());
+        generatedAdjustedXp = Math.max(0, adjustedXp);
+        generatedDifficulty = difficulty == null ? "" : difficulty;
+        generatedTitle = title == null ? "" : title;
+        generationHistoryPresent = historyPresent;
+    }
+
     private void clearGeneratedEncounterState() {
         generatedAlternatives.clear();
         selectedAlternativeIndex = 0;

--- a/src/domain/encounter/model/session/EncounterSessionMemento.java
+++ b/src/domain/encounter/model/session/EncounterSessionMemento.java
@@ -1,0 +1,74 @@
+package src.domain.encounter.model.session;
+
+import java.util.List;
+import java.util.Optional;
+import src.domain.encounter.model.generation.EncounterGenerationInputs;
+
+/** Complete owned runtime state for one encounter context. */
+public record EncounterSessionMemento(
+        int formatVersion,
+        int mode,
+        String status,
+        EncounterGenerationInputs builderInputs,
+        List<EncounterCreatureData> roster,
+        Optional<RemovedRosterEntryData> pendingUndo,
+        long nextUndoToken,
+        List<GeneratedEncounterData> generatedAlternatives,
+        List<String> generatedAdvisories,
+        int selectedAlternativeIndex,
+        int generatedAdjustedXp,
+        String generatedDifficulty,
+        String generatedTitle,
+        boolean generationHistoryPresent,
+        long activeSavedPlanId,
+        List<InitiativeEntryData> initiativeEntries,
+        List<Combatant> combatants,
+        int currentTurnIndex,
+        int round,
+        ResultStateData resultState
+) {
+    public static final int CURRENT_FORMAT_VERSION = 1;
+
+    public EncounterSessionMemento {
+        if (formatVersion != CURRENT_FORMAT_VERSION) {
+            throw new IllegalArgumentException("Unsupported encounter runtime format");
+        }
+        status = status == null ? "" : status;
+        builderInputs = builderInputs == null ? EncounterGenerationInputs.empty() : builderInputs;
+        roster = copy(roster);
+        pendingUndo = pendingUndo == null ? Optional.empty() : pendingUndo;
+        generatedAlternatives = copy(generatedAlternatives);
+        generatedAdvisories = copy(generatedAdvisories);
+        generatedDifficulty = generatedDifficulty == null ? "" : generatedDifficulty;
+        generatedTitle = generatedTitle == null ? "" : generatedTitle;
+        initiativeEntries = copy(initiativeEntries);
+        combatants = copy(combatants);
+        resultState = resultState == null ? ResultStateData.empty() : resultState;
+    }
+
+    private static <T> List<T> copy(List<T> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+
+    record BuilderSlice(
+            EncounterGenerationInputs builderInputs,
+            List<EncounterCreatureData> roster,
+            Optional<RemovedRosterEntryData> pendingUndo,
+            long nextUndoToken,
+            List<GeneratedEncounterData> generatedAlternatives,
+            List<String> generatedAdvisories,
+            int selectedAlternativeIndex,
+            int generatedAdjustedXp,
+            String generatedDifficulty,
+            String generatedTitle,
+            boolean generationHistoryPresent,
+            long activeSavedPlanId
+    ) {
+        BuilderSlice {
+            roster = copy(roster);
+            pendingUndo = pendingUndo == null ? Optional.empty() : pendingUndo;
+            generatedAlternatives = copy(generatedAlternatives);
+            generatedAdvisories = copy(generatedAdvisories);
+        }
+    }
+}

--- a/src/domain/encounter/model/session/EncounterSessionRosterMutation.java
+++ b/src/domain/encounter/model/session/EncounterSessionRosterMutation.java
@@ -109,6 +109,34 @@ final class EncounterSessionRosterMutation {
         return new EncounterSessionRosterState(roster, pendingUndo);
     }
 
+    long nextUndoToken() {
+        return nextUndoToken;
+    }
+
+    void restore(List<EncounterCreatureData> creatures, Optional<RemovedRosterEntryData> undo, long nextToken) {
+        roster.clear();
+        roster.addAll(creatures == null ? List.of() : creatures);
+        pendingUndo = undo == null ? Optional.empty() : undo;
+        nextUndoToken = Math.max(0L, nextToken);
+    }
+
+    void removeWorldNpcsExcept(List<Long> retainedIds) {
+        List<Long> retained = retainedIds == null ? List.of() : retainedIds;
+        roster.removeIf(creature -> creature.worldNpcId() > 0L && !retained.contains(creature.worldNpcId()));
+    }
+
+    boolean containsWorldNpc(long worldNpcId) {
+        return roster.stream().anyMatch(creature -> creature.worldNpcId() == worldNpcId);
+    }
+
+    void addSceneWorldNpc(EncounterCreatureData creature, EncounterSessionContext context) {
+        if (creature != null && creature.worldNpcId() > 0L && !containsWorldNpc(creature.worldNpcId())) {
+            roster.add(creature);
+            pendingUndo = Optional.empty();
+            context.setStatus(creature.name() + " ist als Szenen-NPC im Encounter.");
+        }
+    }
+
     void clearPendingUndo() {
         pendingUndo = Optional.empty();
     }

--- a/src/domain/encounter/model/session/EncounterSessionSavedPlans.java
+++ b/src/domain/encounter/model/session/EncounterSessionSavedPlans.java
@@ -25,6 +25,14 @@ final class EncounterSessionSavedPlans {
         return activeSavedPlanId.isPresent();
     }
 
+    long activeSavedPlanId() {
+        return activeSavedPlanId.orElse(0L);
+    }
+
+    void restore(long planId) {
+        activeSavedPlanId = planId > 0L ? OptionalLong.of(planId) : OptionalLong.empty();
+    }
+
     void saveCurrentPlan(
             EncounterSession.SessionRepository access,
             EncounterSessionContext context,

--- a/src/domain/encounter/model/session/SceneNpcData.java
+++ b/src/domain/encounter/model/session/SceneNpcData.java
@@ -1,0 +1,6 @@
+package src.domain.encounter.model.session;
+
+public record SceneNpcData(long worldNpcId, long creatureId, Role role, boolean active) {
+    public SceneNpcData { role = role == null ? Role.NEUTRAL : role; }
+    public enum Role { HOSTILE, NEUTRAL, FRIENDLY }
+}

--- a/src/domain/encounter/model/session/repository/EncounterRuntimeStateRepository.java
+++ b/src/domain/encounter/model/session/repository/EncounterRuntimeStateRepository.java
@@ -1,0 +1,9 @@
+package src.domain.encounter.model.session.repository;
+
+import java.util.Map;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+
+public interface EncounterRuntimeStateRepository {
+    Map<String, EncounterSessionMemento> loadAll();
+    void saveAll(Map<String, EncounterSessionMemento> sessions);
+}

--- a/src/domain/encounter/model/session/repository/InMemoryEncounterRuntimeStateRepository.java
+++ b/src/domain/encounter/model/session/repository/InMemoryEncounterRuntimeStateRepository.java
@@ -1,0 +1,13 @@
+package src.domain.encounter.model.session.repository;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+
+public final class InMemoryEncounterRuntimeStateRepository implements EncounterRuntimeStateRepository {
+    private Map<String, EncounterSessionMemento> state = Map.of();
+    @Override public Map<String, EncounterSessionMemento> loadAll() { return state; }
+    @Override public void saveAll(Map<String, EncounterSessionMemento> sessions) {
+        state = Map.copyOf(new LinkedHashMap<>(sessions == null ? Map.of() : sessions));
+    }
+}

--- a/src/domain/encounter/published/EncounterRuntimeContextApi.java
+++ b/src/domain/encounter/published/EncounterRuntimeContextApi.java
@@ -1,0 +1,47 @@
+package src.domain.encounter.published;
+
+import java.util.List;
+
+/** Scene-neutral boundary for selecting and reconciling encounter runtime contexts. */
+public interface EncounterRuntimeContextApi {
+
+    SyncResult synchronize(SynchronizeEncounterContextsCommand command);
+
+    record SynchronizeEncounterContextsCommand(
+            long revision,
+            String focusedContextKey,
+            List<Context> contexts
+    ) {
+        public SynchronizeEncounterContextsCommand {
+            focusedContextKey = focusedContextKey == null ? "" : focusedContextKey;
+            contexts = contexts == null ? List.of() : List.copyOf(contexts);
+        }
+    }
+
+    record Context(
+            String key,
+            List<Long> partyMemberIds,
+            long worldLocationId,
+            long initialEncounterPlanId,
+            List<Npc> npcs
+    ) {
+        public Context {
+            key = key == null ? "" : key;
+            partyMemberIds = partyMemberIds == null ? List.of() : List.copyOf(partyMemberIds);
+            worldLocationId = Math.max(0L, worldLocationId);
+            initialEncounterPlanId = Math.max(0L, initialEncounterPlanId);
+            npcs = npcs == null ? List.of() : List.copyOf(npcs);
+        }
+    }
+
+    record Npc(long worldNpcId, long creatureId, Role role, boolean active) {
+        public Npc {
+            role = role == null ? Role.NEUTRAL : role;
+        }
+    }
+
+    enum Role { HOSTILE, NEUTRAL, FRIENDLY }
+    record SyncResult(boolean success, String message) {
+        public SyncResult { message = message == null ? "" : message; }
+    }
+}

--- a/src/domain/scene/SceneApplicationService.java
+++ b/src/domain/scene/SceneApplicationService.java
@@ -1,0 +1,319 @@
+package src.domain.scene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import src.domain.encounter.published.EncounterRuntimeContextApi;
+import src.domain.party.published.ActivePartyModel;
+import src.domain.party.published.ActivePartyResult;
+import src.domain.party.published.PartyMemberSummary;
+import src.domain.party.published.ReadStatus;
+import src.domain.scene.model.RunningScene;
+import src.domain.scene.model.SceneWorkspace;
+import src.domain.scene.model.repository.SceneWorkspaceRepository;
+import src.domain.scene.published.SceneCommand;
+import src.domain.scene.published.SceneMutationResult;
+import src.domain.scene.published.SceneSnapshot;
+import src.domain.sessionplanner.published.PreparedSceneCatalog;
+import src.domain.sessionplanner.published.PreparedSceneSource;
+import src.domain.worldplanner.published.WorldDispositionKind;
+import src.domain.worldplanner.published.WorldLocationSummary;
+import src.domain.worldplanner.published.WorldNpcLifecycleStatus;
+import src.domain.worldplanner.published.WorldNpcSummary;
+import src.domain.worldplanner.published.WorldPlannerSnapshot;
+import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
+
+public final class SceneApplicationService {
+    private final SceneWorkspaceRepository repository;
+    private final ActivePartyModel party;
+    private final WorldPlannerSnapshotModel world;
+    private final PreparedSceneSource preparedScenes;
+    private final EncounterRuntimeContextApi encounters;
+    private boolean encounterSynchronized = true;
+
+    SceneApplicationService(
+            SceneWorkspaceRepository repository,
+            ActivePartyModel party,
+            WorldPlannerSnapshotModel world,
+            PreparedSceneSource preparedScenes,
+            EncounterRuntimeContextApi encounters
+    ) {
+        this.repository = Objects.requireNonNull(repository, "repository");
+        this.party = Objects.requireNonNull(party, "party");
+        this.world = Objects.requireNonNull(world, "world");
+        this.preparedScenes = Objects.requireNonNull(preparedScenes, "preparedScenes");
+        this.encounters = Objects.requireNonNull(encounters, "encounters");
+        ensureWorkspace();
+        synchronize(repository.load().orElseThrow());
+    }
+
+    public SceneMutationResult apply(SceneCommand command) {
+        if (command == null) {
+            return result(SceneMutationResult.Status.INVALID, "Szenenaktion fehlt.");
+        }
+        try {
+            SceneWorkspace current = workspaceWithoutInactiveMembers(repository.load().orElseThrow());
+            SceneWorkspace changed = mutate(current, command);
+            repository.save(changed);
+            synchronize(changed);
+            return result(SceneMutationResult.Status.SUCCESS, changed.statusText());
+        } catch (SceneFailure failure) {
+            return result(failure.status, failure.getMessage());
+        } catch (IllegalArgumentException exception) {
+            return result(SceneMutationResult.Status.INVALID, exception.getMessage());
+        } catch (IllegalStateException exception) {
+            encounterSynchronized = false;
+            return result(SceneMutationResult.Status.STORAGE_ERROR, "Szene konnte nicht gespeichert werden.");
+        }
+    }
+
+    public SceneSnapshot current() {
+        SceneWorkspace workspace = repository.load().orElseGet(this::ensureWorkspace);
+        return project(workspaceWithoutInactiveMembers(workspace));
+    }
+
+    public void refreshForeignFacts() {
+        try {
+            SceneWorkspace workspace = workspaceWithoutInactiveMembers(repository.load().orElseThrow());
+            repository.save(workspace);
+            synchronize(workspace);
+        } catch (IllegalStateException ignored) {
+            encounterSynchronized = false;
+        }
+    }
+
+    private SceneWorkspace mutate(SceneWorkspace workspace, SceneCommand command) {
+        if (command instanceof SceneCommand.Create create) {
+            long id = workspace.nextSceneId();
+            RunningScene scene = new RunningScene(id, create.title(), "", 0L, 0L, 0L, 0L, List.of(), List.of());
+            return workspace.replace(append(workspace.scenes(), scene), id, id + 1L, "Szene erstellt.");
+        }
+        if (command instanceof SceneCommand.ImportPrepared imported) {
+            return importPrepared(workspace, imported);
+        }
+        if (command instanceof SceneCommand.Focus focus) {
+            requireScene(workspace, focus.sceneId());
+            return workspace.replace(workspace.scenes(), focus.sceneId(), workspace.nextSceneId(), "Szene gewechselt.");
+        }
+        if (command instanceof SceneCommand.UpdateDetails details) {
+            RunningScene scene = requireScene(workspace, details.sceneId());
+            return replace(workspace, scene.withDetails(details.title(), details.notes()), workspace.focusedSceneId(), "Szene aktualisiert.");
+        }
+        if (command instanceof SceneCommand.Delete delete) {
+            if (delete.sceneId() == workspace.defaultSceneId()) {
+                throw failure(SceneMutationResult.Status.DEFAULT_SCENE, "Die Standardszene kann nicht gelöscht werden.");
+            }
+            requireScene(workspace, delete.sceneId());
+            List<RunningScene> remaining = workspace.scenes().stream().filter(scene -> scene.sceneId() != delete.sceneId()).toList();
+            long focus = workspace.focusedSceneId() == delete.sceneId() ? workspace.defaultSceneId() : workspace.focusedSceneId();
+            return workspace.replace(remaining, focus, workspace.nextSceneId(), "Szene gelöscht.");
+        }
+        if (command instanceof SceneCommand.AssignPc assign) {
+            requireActivePc(assign.partyMemberId());
+            requireScene(workspace, assign.sceneId());
+            List<RunningScene> scenes = workspace.scenes().stream().map(scene -> {
+                List<Long> ids = new ArrayList<>(scene.partyMemberIds());
+                ids.remove(assign.partyMemberId());
+                if (scene.sceneId() == assign.sceneId()) {
+                    ids.add(assign.partyMemberId());
+                }
+                return scene.withPartyMembers(ids);
+            }).toList();
+            return workspace.replace(scenes, workspace.focusedSceneId(), workspace.nextSceneId(), "PC verschoben.");
+        }
+        if (command instanceof SceneCommand.UnassignPc unassign) {
+            List<RunningScene> scenes = workspace.scenes().stream()
+                    .map(scene -> scene.withPartyMembers(scene.partyMemberIds().stream()
+                            .filter(id -> id != unassign.partyMemberId()).toList()))
+                    .toList();
+            return workspace.replace(scenes, workspace.focusedSceneId(), workspace.nextSceneId(), "PC ist unzugeordnet.");
+        }
+        if (command instanceof SceneCommand.AddNpc add) {
+            requireNpc(add.npcId());
+            RunningScene scene = requireScene(workspace, add.sceneId());
+            List<Long> ids = new ArrayList<>(scene.npcIds());
+            ids.add(add.npcId());
+            return replace(workspace, scene.withNpcs(ids), workspace.focusedSceneId(), "NPC hinzugefügt.");
+        }
+        if (command instanceof SceneCommand.RemoveNpc remove) {
+            RunningScene scene = requireScene(workspace, remove.sceneId());
+            return replace(workspace, scene.withNpcs(scene.npcIds().stream()
+                    .filter(id -> id != remove.npcId()).toList()), workspace.focusedSceneId(), "NPC entfernt.");
+        }
+        SceneCommand.SetLocation location = (SceneCommand.SetLocation) command;
+        if (location.locationId() > 0L) {
+            requireLocation(location.locationId());
+        }
+        RunningScene scene = requireScene(workspace, location.sceneId());
+        return replace(workspace, scene.withLocation(location.locationId()), workspace.focusedSceneId(), "Ort aktualisiert.");
+    }
+
+    private SceneWorkspace importPrepared(SceneWorkspace workspace, SceneCommand.ImportPrepared command) {
+        PreparedSceneCatalog.PreparedScene source = preparedScenes.list().scenes().stream()
+                .filter(scene -> scene.sessionId() == command.sessionId() && scene.sceneId() == command.sceneId())
+                .findFirst().orElseThrow(() -> failure(SceneMutationResult.Status.NOT_FOUND, "Vorbereitete Szene nicht gefunden."));
+        List<Long> activeIds = activeParty().stream().map(PartyMemberSummary::id).toList();
+        var assigned = workspace.assignedPartyMemberIds();
+        List<Long> importedPcs = source.participantIds().stream()
+                .filter(activeIds::contains).filter(id -> !assigned.contains(id)).toList();
+        long id = workspace.nextSceneId();
+        RunningScene scene = new RunningScene(
+                id, source.title(), source.notes(), source.sessionId(), source.sceneId(), source.encounterPlanId(),
+                source.locationId(), importedPcs, List.of());
+        return workspace.replace(append(workspace.scenes(), scene), id, id + 1L,
+                importedPcs.size() == source.participantIds().size()
+                        ? "Vorbereitete Szene geladen."
+                        : "Vorbereitete Szene geladen; bereits zugeordnete oder inaktive PCs wurden übersprungen.");
+    }
+
+    private SceneWorkspace workspaceWithoutInactiveMembers(SceneWorkspace workspace) {
+        List<Long> activeIds = activeParty().stream().map(PartyMemberSummary::id).toList();
+        List<RunningScene> scenes = workspace.scenes().stream()
+                .map(scene -> scene.withPartyMembers(scene.partyMemberIds().stream().filter(activeIds::contains).toList()))
+                .toList();
+        if (scenes.equals(workspace.scenes())) {
+            return workspace;
+        }
+        return workspace.replace(scenes, workspace.focusedSceneId(), workspace.nextSceneId(), "Inaktive PCs wurden entfernt.");
+    }
+
+    private SceneWorkspace ensureWorkspace() {
+        return repository.load().orElseGet(() -> repository.save(SceneWorkspace.initial(
+                activeParty().stream().map(PartyMemberSummary::id).toList())));
+    }
+
+    private void synchronize(SceneWorkspace workspace) {
+        WorldPlannerSnapshot worldSnapshot = world.current();
+        List<EncounterRuntimeContextApi.Context> contexts = workspace.scenes().stream()
+                .map(scene -> new EncounterRuntimeContextApi.Context(
+                        contextKey(scene.sceneId()), scene.partyMemberIds(), scene.locationId(),
+                        scene.sourceEncounterPlanId(),
+                        scene.npcIds().stream().map(id -> encounterNpc(id, worldSnapshot)).filter(Objects::nonNull).toList()))
+                .toList();
+        EncounterRuntimeContextApi.SyncResult result = encounters.synchronize(
+                new EncounterRuntimeContextApi.SynchronizeEncounterContextsCommand(
+                        workspace.revision(), contextKey(workspace.focusedSceneId()), contexts));
+        encounterSynchronized = result.success();
+    }
+
+    private static EncounterRuntimeContextApi.Npc encounterNpc(long id, WorldPlannerSnapshot world) {
+        WorldNpcSummary npc = world.npcs().stream().filter(value -> value.npcId() == id).findFirst().orElse(null);
+        if (npc == null) {
+            return null;
+        }
+        return new EncounterRuntimeContextApi.Npc(
+                npc.npcId(), npc.creatureStatblockId(),
+                EncounterRuntimeContextApi.Role.valueOf(npc.disposition().name()),
+                npc.status() == WorldNpcLifecycleStatus.ACTIVE);
+    }
+
+    private SceneSnapshot project(SceneWorkspace workspace) {
+        ActivePartyResult partyResult = party.current();
+        List<PartyMemberSummary> members = activeParty();
+        WorldPlannerSnapshot worlds = world.current();
+        List<SceneSnapshot.SceneEntry> entries = workspace.scenes().stream()
+                .map(scene -> sceneEntry(workspace, scene, members, worlds)).toList();
+        List<SceneSnapshot.PartyChoice> allPcs = members.stream().map(member -> partyChoice(member, sceneForPc(workspace, member.id()))).toList();
+        List<SceneSnapshot.PartyChoice> unassigned = allPcs.stream().filter(choice -> choice.sceneId() == 0L).toList();
+        List<SceneSnapshot.NpcChoice> npcs = worlds.npcs().stream().map(npc -> npcChoice(npc, sceneForNpc(workspace, npc.npcId()))).toList();
+        List<SceneSnapshot.LocationChoice> locations = worlds.locations().stream()
+                .map(location -> new SceneSnapshot.LocationChoice(location.locationId(), location.displayName(), sceneForLocation(workspace, location.locationId())))
+                .toList();
+        List<SceneSnapshot.PreparedChoice> prepared = preparedScenes.list().scenes().stream()
+                .map(scene -> new SceneSnapshot.PreparedChoice(scene.sessionId(), scene.sceneId(), scene.sessionName(), scene.title())).toList();
+        String status = partyResult.status() == ReadStatus.SUCCESS ? workspace.statusText() : "Party konnte nicht geladen werden.";
+        if (!encounterSynchronized) {
+            status = status + " Encounter-Synchronisierung ausstehend.";
+        }
+        return new SceneSnapshot(workspace.revision(), workspace.defaultSceneId(), workspace.focusedSceneId(), entries,
+                unassigned, allPcs, npcs, locations, prepared, encounterSynchronized, status);
+    }
+
+    private static SceneSnapshot.SceneEntry sceneEntry(
+            SceneWorkspace workspace, RunningScene scene, List<PartyMemberSummary> members, WorldPlannerSnapshot world
+    ) {
+        WorldLocationSummary location = world.locations().stream().filter(value -> value.locationId() == scene.locationId()).findFirst().orElse(null);
+        List<SceneSnapshot.PartyChoice> pcs = members.stream().filter(member -> scene.partyMemberIds().contains(member.id()))
+                .map(member -> partyChoice(member, scene.sceneId())).toList();
+        List<SceneSnapshot.NpcChoice> npcs = world.npcs().stream().filter(npc -> scene.npcIds().contains(npc.npcId()))
+                .map(npc -> npcChoice(npc, scene.sceneId())).toList();
+        return new SceneSnapshot.SceneEntry(scene.sceneId(), scene.title(), scene.notes(),
+                scene.sceneId() == workspace.defaultSceneId(), scene.sceneId() == workspace.focusedSceneId(),
+                scene.sourceSessionId(), scene.sourceSceneId(), scene.locationId(),
+                location == null ? "" : location.displayName(), pcs, npcs);
+    }
+
+    private static SceneSnapshot.PartyChoice partyChoice(PartyMemberSummary member, long sceneId) {
+        return new SceneSnapshot.PartyChoice(member.id(), member.name(), member.level(), sceneId);
+    }
+
+    private static SceneSnapshot.NpcChoice npcChoice(WorldNpcSummary npc, long sceneId) {
+        return new SceneSnapshot.NpcChoice(npc.npcId(), npc.displayName(), npc.creatureStatblockId(),
+                npc.disposition(), npc.effectiveDisposition(), npc.status() == WorldNpcLifecycleStatus.ACTIVE, sceneId);
+    }
+
+    private List<PartyMemberSummary> activeParty() {
+        ActivePartyResult result = party.current();
+        return result.status() == ReadStatus.SUCCESS ? result.members() : List.of();
+    }
+
+    private void requireActivePc(long id) {
+        if (activeParty().stream().noneMatch(member -> member.id() == id)) {
+            throw failure(SceneMutationResult.Status.NOT_FOUND, "Aktiver PC nicht gefunden.");
+        }
+    }
+
+    private void requireNpc(long id) {
+        if (world.current().npcs().stream().noneMatch(npc -> npc.npcId() == id)) {
+            throw failure(SceneMutationResult.Status.NOT_FOUND, "NPC nicht gefunden.");
+        }
+    }
+
+    private void requireLocation(long id) {
+        if (world.current().locations().stream().noneMatch(location -> location.locationId() == id)) {
+            throw failure(SceneMutationResult.Status.NOT_FOUND, "Ort nicht gefunden.");
+        }
+    }
+
+    private static RunningScene requireScene(SceneWorkspace workspace, long id) {
+        RunningScene scene = workspace.scene(id);
+        if (scene == null) {
+            throw failure(SceneMutationResult.Status.NOT_FOUND, "Szene nicht gefunden.");
+        }
+        return scene;
+    }
+
+    private static SceneWorkspace replace(SceneWorkspace workspace, RunningScene replacement, long focus, String status) {
+        List<RunningScene> scenes = workspace.scenes().stream()
+                .map(scene -> scene.sceneId() == replacement.sceneId() ? replacement : scene).toList();
+        return workspace.replace(scenes, focus, workspace.nextSceneId(), status);
+    }
+
+    private static <T> List<T> append(List<T> values, T value) {
+        List<T> result = new ArrayList<>(values); result.add(value); return List.copyOf(result);
+    }
+
+    private static long sceneForPc(SceneWorkspace workspace, long id) {
+        return workspace.scenes().stream().filter(scene -> scene.partyMemberIds().contains(id))
+                .mapToLong(RunningScene::sceneId).findFirst().orElse(0L);
+    }
+
+    private static long sceneForNpc(SceneWorkspace workspace, long id) {
+        return workspace.scenes().stream().filter(scene -> scene.npcIds().contains(id))
+                .mapToLong(RunningScene::sceneId).findFirst().orElse(0L);
+    }
+
+    private static long sceneForLocation(SceneWorkspace workspace, long id) {
+        return workspace.scenes().stream().filter(scene -> scene.locationId() == id)
+                .mapToLong(RunningScene::sceneId).findFirst().orElse(0L);
+    }
+
+    private static String contextKey(long sceneId) { return "scene:" + sceneId; }
+    private static SceneMutationResult result(SceneMutationResult.Status status, String message) { return new SceneMutationResult(status, message); }
+    private static SceneFailure failure(SceneMutationResult.Status status, String message) { return new SceneFailure(status, message); }
+
+    private static final class SceneFailure extends RuntimeException {
+        private final SceneMutationResult.Status status;
+        private SceneFailure(SceneMutationResult.Status status, String message) { super(message); this.status = status; }
+    }
+}

--- a/src/domain/scene/SceneServiceAssembly.java
+++ b/src/domain/scene/SceneServiceAssembly.java
@@ -1,0 +1,53 @@
+package src.domain.scene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import src.domain.encounter.published.EncounterRuntimeContextApi;
+import src.domain.party.published.ActivePartyModel;
+import src.domain.scene.model.repository.SceneWorkspaceRepository;
+import src.domain.scene.published.SceneModel;
+import src.domain.scene.published.SceneSnapshot;
+import src.domain.sessionplanner.published.PreparedSceneSource;
+import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
+
+public final class SceneServiceAssembly {
+    private final SceneApplicationService application;
+    private final List<Consumer<SceneSnapshot>> listeners = new ArrayList<>();
+    private final SceneModel model;
+
+    public SceneServiceAssembly(
+            SceneWorkspaceRepository repository,
+            ActivePartyModel party,
+            WorldPlannerSnapshotModel world,
+            PreparedSceneSource preparedScenes,
+            EncounterRuntimeContextApi encounters
+    ) {
+        application = new SceneApplicationService(repository, party, world, preparedScenes, encounters);
+        model = new SceneModel(application::current, this::subscribe);
+        party.subscribe(ignored -> refresh());
+        world.subscribe(ignored -> refresh());
+    }
+
+    public SceneApplicationService application() { return application; }
+    public SceneModel model() { return model; }
+
+    public void publish() { notifyListeners(); }
+
+    private void refresh() {
+        application.refreshForeignFacts();
+        notifyListeners();
+    }
+
+    private Runnable subscribe(Consumer<SceneSnapshot> listener) {
+        listeners.add(listener);
+        return () -> listeners.remove(listener);
+    }
+
+    private void notifyListeners() {
+        SceneSnapshot snapshot = application.current();
+        for (Consumer<SceneSnapshot> listener : List.copyOf(listeners)) {
+            listener.accept(snapshot);
+        }
+    }
+}

--- a/src/domain/scene/model/RunningScene.java
+++ b/src/domain/scene/model/RunningScene.java
@@ -1,0 +1,57 @@
+package src.domain.scene.model;
+
+import java.util.List;
+
+public record RunningScene(
+        long sceneId,
+        String title,
+        String notes,
+        long sourceSessionId,
+        long sourceSceneId,
+        long sourceEncounterPlanId,
+        long locationId,
+        List<Long> partyMemberIds,
+        List<Long> npcIds
+) {
+    public RunningScene {
+        if (sceneId <= 0L) {
+            throw new IllegalArgumentException("sceneId must be positive");
+        }
+        title = title == null || title.isBlank() ? "Szene " + sceneId : title.trim();
+        notes = notes == null ? "" : notes.trim();
+        sourceSessionId = Math.max(0L, sourceSessionId);
+        sourceSceneId = Math.max(0L, sourceSceneId);
+        sourceEncounterPlanId = Math.max(0L, sourceEncounterPlanId);
+        locationId = Math.max(0L, locationId);
+        partyMemberIds = normalize(partyMemberIds);
+        npcIds = normalize(npcIds);
+    }
+
+    public RunningScene withDetails(String nextTitle, String nextNotes) {
+        return copy(nextTitle, nextNotes, locationId, partyMemberIds, npcIds);
+    }
+
+    public RunningScene withLocation(long nextLocationId) {
+        return copy(title, notes, Math.max(0L, nextLocationId), partyMemberIds, npcIds);
+    }
+
+    public RunningScene withPartyMembers(List<Long> ids) {
+        return copy(title, notes, locationId, ids, npcIds);
+    }
+
+    public RunningScene withNpcs(List<Long> ids) {
+        return copy(title, notes, locationId, partyMemberIds, ids);
+    }
+
+    private RunningScene copy(String nextTitle, String nextNotes, long nextLocationId, List<Long> pcs, List<Long> npcs) {
+        return new RunningScene(sceneId, nextTitle, nextNotes, sourceSessionId, sourceSceneId,
+                sourceEncounterPlanId, nextLocationId, pcs, npcs);
+    }
+
+    private static List<Long> normalize(List<Long> ids) {
+        if (ids == null) {
+            return List.of();
+        }
+        return ids.stream().filter(id -> id != null && id > 0L).distinct().toList();
+    }
+}

--- a/src/domain/scene/model/SceneWorkspace.java
+++ b/src/domain/scene/model/SceneWorkspace.java
@@ -1,0 +1,63 @@
+package src.domain.scene.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public record SceneWorkspace(
+        long revision,
+        long nextSceneId,
+        long defaultSceneId,
+        long focusedSceneId,
+        List<RunningScene> scenes,
+        String statusText
+) {
+    public SceneWorkspace {
+        revision = Math.max(1L, revision);
+        nextSceneId = Math.max(2L, nextSceneId);
+        scenes = scenes == null ? List.of() : List.copyOf(scenes);
+        statusText = statusText == null ? "" : statusText;
+        validate(defaultSceneId, focusedSceneId, scenes);
+    }
+
+    public static SceneWorkspace initial(List<Long> activePartyIds) {
+        RunningScene standard = new RunningScene(1L, "Standardszene", "", 0L, 0L, 0L, 0L,
+                activePartyIds, List.of());
+        return new SceneWorkspace(1L, 2L, 1L, 1L, List.of(standard), "Standardszene bereit.");
+    }
+
+    public RunningScene focusedScene() {
+        return scene(focusedSceneId);
+    }
+
+    public RunningScene scene(long id) {
+        return scenes.stream().filter(scene -> scene.sceneId() == id).findFirst().orElse(null);
+    }
+
+    public Set<Long> assignedPartyMemberIds() {
+        Set<Long> result = new HashSet<>();
+        for (RunningScene scene : scenes) {
+            result.addAll(scene.partyMemberIds());
+        }
+        return Set.copyOf(result);
+    }
+
+    public SceneWorkspace replace(List<RunningScene> nextScenes, long focus, long nextId, String status) {
+        return new SceneWorkspace(revision + 1L, nextId, defaultSceneId, focus, nextScenes, status);
+    }
+
+    private static void validate(long defaultId, long focusedId, List<RunningScene> values) {
+        if (values.isEmpty() || values.stream().noneMatch(scene -> scene.sceneId() == defaultId)
+                || values.stream().noneMatch(scene -> scene.sceneId() == focusedId)) {
+            throw new IllegalArgumentException("default and focused scene must exist");
+        }
+        Set<Long> pcIds = new HashSet<>();
+        for (RunningScene scene : values) {
+            for (Long pcId : scene.partyMemberIds()) {
+                if (!pcIds.add(pcId)) {
+                    throw new IllegalArgumentException("PC may belong to at most one running scene");
+                }
+            }
+        }
+    }
+}

--- a/src/domain/scene/model/repository/SceneWorkspaceRepository.java
+++ b/src/domain/scene/model/repository/SceneWorkspaceRepository.java
@@ -1,0 +1,9 @@
+package src.domain.scene.model.repository;
+
+import java.util.Optional;
+import src.domain.scene.model.SceneWorkspace;
+
+public interface SceneWorkspaceRepository {
+    Optional<SceneWorkspace> load();
+    SceneWorkspace save(SceneWorkspace workspace);
+}

--- a/src/domain/scene/published/SceneCommand.java
+++ b/src/domain/scene/published/SceneCommand.java
@@ -1,0 +1,18 @@
+package src.domain.scene.published;
+
+public sealed interface SceneCommand permits SceneCommand.Create, SceneCommand.ImportPrepared,
+        SceneCommand.Focus, SceneCommand.UpdateDetails, SceneCommand.Delete,
+        SceneCommand.AssignPc, SceneCommand.UnassignPc, SceneCommand.AddNpc,
+        SceneCommand.RemoveNpc, SceneCommand.SetLocation {
+
+    record Create(String title) implements SceneCommand { }
+    record ImportPrepared(long sessionId, long sceneId) implements SceneCommand { }
+    record Focus(long sceneId) implements SceneCommand { }
+    record UpdateDetails(long sceneId, String title, String notes) implements SceneCommand { }
+    record Delete(long sceneId) implements SceneCommand { }
+    record AssignPc(long sceneId, long partyMemberId) implements SceneCommand { }
+    record UnassignPc(long partyMemberId) implements SceneCommand { }
+    record AddNpc(long sceneId, long npcId) implements SceneCommand { }
+    record RemoveNpc(long sceneId, long npcId) implements SceneCommand { }
+    record SetLocation(long sceneId, long locationId) implements SceneCommand { }
+}

--- a/src/domain/scene/published/SceneModel.java
+++ b/src/domain/scene/published/SceneModel.java
@@ -1,0 +1,19 @@
+package src.domain.scene.published;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class SceneModel {
+    private final Supplier<SceneSnapshot> current;
+    private final Function<Consumer<SceneSnapshot>, Runnable> subscribe;
+
+    public SceneModel(Supplier<SceneSnapshot> current, Function<Consumer<SceneSnapshot>, Runnable> subscribe) {
+        this.current = Objects.requireNonNull(current, "current");
+        this.subscribe = Objects.requireNonNull(subscribe, "subscribe");
+    }
+
+    public SceneSnapshot current() { return current.get(); }
+    public Runnable subscribe(Consumer<SceneSnapshot> listener) { return subscribe.apply(listener); }
+}

--- a/src/domain/scene/published/SceneMutationResult.java
+++ b/src/domain/scene/published/SceneMutationResult.java
@@ -1,0 +1,10 @@
+package src.domain.scene.published;
+
+public record SceneMutationResult(Status status, String message) {
+    public SceneMutationResult {
+        status = status == null ? Status.STORAGE_ERROR : status;
+        message = message == null ? "" : message;
+    }
+
+    public enum Status { SUCCESS, NOT_FOUND, INVALID, DEFAULT_SCENE, STORAGE_ERROR }
+}

--- a/src/domain/scene/published/SceneSnapshot.java
+++ b/src/domain/scene/published/SceneSnapshot.java
@@ -1,0 +1,85 @@
+package src.domain.scene.published;
+
+import java.util.List;
+import src.domain.worldplanner.published.WorldDispositionKind;
+
+public record SceneSnapshot(
+        long revision,
+        long defaultSceneId,
+        long focusedSceneId,
+        List<SceneEntry> scenes,
+        List<PartyChoice> unassignedPartyMembers,
+        List<PartyChoice> activePartyMembers,
+        List<NpcChoice> availableNpcs,
+        List<LocationChoice> availableLocations,
+        List<PreparedChoice> preparedScenes,
+        boolean encounterSynchronized,
+        String statusText
+) {
+    public SceneSnapshot {
+        scenes = copy(scenes);
+        unassignedPartyMembers = copy(unassignedPartyMembers);
+        activePartyMembers = copy(activePartyMembers);
+        availableNpcs = copy(availableNpcs);
+        availableLocations = copy(availableLocations);
+        preparedScenes = copy(preparedScenes);
+        statusText = statusText == null ? "" : statusText;
+    }
+
+    public record SceneEntry(
+            long sceneId,
+            String title,
+            String notes,
+            boolean defaultScene,
+            boolean focused,
+            long sourceSessionId,
+            long sourceSceneId,
+            long locationId,
+            String locationName,
+            List<PartyChoice> partyMembers,
+            List<NpcChoice> npcs
+    ) {
+        public SceneEntry {
+            title = text(title);
+            notes = text(notes);
+            locationName = text(locationName);
+            partyMembers = copy(partyMembers);
+            npcs = copy(npcs);
+        }
+    }
+
+    public record PartyChoice(long id, String name, int level, long sceneId) {
+        public PartyChoice { name = text(name); }
+    }
+
+    public record NpcChoice(
+            long id,
+            String name,
+            long creatureId,
+            WorldDispositionKind disposition,
+            int effectiveDisposition,
+            boolean active,
+            long sceneId
+    ) {
+        public NpcChoice {
+            name = text(name);
+            disposition = disposition == null ? WorldDispositionKind.NEUTRAL : disposition;
+        }
+    }
+
+    public record LocationChoice(long id, String name, long sceneId) {
+        public LocationChoice { name = text(name); }
+    }
+
+    public record PreparedChoice(long sessionId, long sceneId, String sessionName, String title) {
+        public PreparedChoice { sessionName = text(sessionName); title = text(title); }
+    }
+
+    private static <T> List<T> copy(List<T> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/domain/sessionplanner/SessionPlannerServiceAssembly.java
+++ b/src/domain/sessionplanner/SessionPlannerServiceAssembly.java
@@ -14,11 +14,14 @@ import src.domain.sessionplanner.published.SessionPlannerCurrentSessionModel;
 import src.domain.sessionplanner.published.SessionPlannerParticipantsModel;
 import src.domain.sessionplanner.published.SessionPlannerSceneTimelineModel;
 import src.domain.sessionplanner.published.SessionPlannerStatePanelModel;
+import src.domain.sessionplanner.published.PreparedSceneCatalog;
+import src.domain.sessionplanner.published.PreparedSceneSource;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
 
 public final class SessionPlannerServiceAssembly {
 
     private final Runtime runtime;
+    private final PreparedSceneSource preparedScenes;
 
     public SessionPlannerServiceAssembly(
             SessionPlanRepository repository,
@@ -39,6 +42,25 @@ public final class SessionPlannerServiceAssembly {
         runtime = new Runtime(
                 publishedState,
                 new SessionPlannerApplicationService(safeRepository, facts, publishedState));
+        preparedScenes = () -> {
+            try {
+                java.util.List<PreparedSceneCatalog.PreparedScene> scenes = new java.util.ArrayList<>();
+                for (var summary : safeRepository.listSessions()) {
+                    var plan = safeRepository.loadById(summary.sessionId()).orElse(null);
+                    if (plan == null) {
+                        continue;
+                    }
+                    for (var scene : plan.encounters()) {
+                        scenes.add(new PreparedSceneCatalog.PreparedScene(
+                                plan.sessionId(), plan.displayName(), scene.encounterId(), scene.sceneTitle(),
+                                scene.sceneNotes(), scene.locationId(), scene.encounterPlanId(), plan.participantRefs()));
+                    }
+                }
+                return new PreparedSceneCatalog(scenes, "");
+            } catch (IllegalStateException exception) {
+                return new PreparedSceneCatalog(java.util.List.of(), "Vorbereitete Szenen konnten nicht geladen werden.");
+            }
+        };
     }
 
     public SessionPlannerApplicationService application() {
@@ -63,6 +85,10 @@ public final class SessionPlannerServiceAssembly {
 
     public SessionPlannerStatePanelModel statePanelModel() {
         return runtime.publishedState().statePanelModel();
+    }
+
+    public PreparedSceneSource preparedScenes() {
+        return preparedScenes;
     }
 
     private record Runtime(

--- a/src/domain/sessionplanner/published/PreparedSceneCatalog.java
+++ b/src/domain/sessionplanner/published/PreparedSceneCatalog.java
@@ -1,0 +1,29 @@
+package src.domain.sessionplanner.published;
+
+import java.util.List;
+
+/** Read-only runtime import choices owned by Session Planner. */
+public record PreparedSceneCatalog(List<PreparedScene> scenes, String statusText) {
+    public PreparedSceneCatalog {
+        scenes = scenes == null ? List.of() : List.copyOf(scenes);
+        statusText = statusText == null ? "" : statusText;
+    }
+
+    public record PreparedScene(
+            long sessionId,
+            String sessionName,
+            long sceneId,
+            String title,
+            String notes,
+            long locationId,
+            long encounterPlanId,
+            List<Long> participantIds
+    ) {
+        public PreparedScene {
+            sessionName = sessionName == null ? "" : sessionName;
+            title = title == null ? "" : title;
+            notes = notes == null ? "" : notes;
+            participantIds = participantIds == null ? List.of() : List.copyOf(participantIds);
+        }
+    }
+}

--- a/src/domain/sessionplanner/published/PreparedSceneSource.java
+++ b/src/domain/sessionplanner/published/PreparedSceneSource.java
@@ -1,0 +1,5 @@
+package src.domain.sessionplanner.published;
+
+public interface PreparedSceneSource {
+    PreparedSceneCatalog list();
+}

--- a/src/domain/worldplanner/WorldPlannerApplicationService.java
+++ b/src/domain/worldplanner/WorldPlannerApplicationService.java
@@ -21,7 +21,9 @@ import src.domain.worldplanner.published.CreateWorldLocationCommand;
 import src.domain.worldplanner.published.CreateWorldNpcCommand;
 import src.domain.worldplanner.published.RefreshWorldPlannerCommand;
 import src.domain.worldplanner.published.SetWorldFactionInventoryLimitCommand;
+import src.domain.worldplanner.published.SetWorldFactionDispositionCommand;
 import src.domain.worldplanner.published.SetWorldNpcLifecycleStatusCommand;
+import src.domain.worldplanner.published.SetWorldNpcDispositionModifierCommand;
 import src.domain.worldplanner.published.UpdateWorldNpcNotesCommand;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
 
@@ -74,6 +76,7 @@ public final class WorldPlannerApplicationService {
                     notes.behaviorNotes(),
                     notes.historyNotes(),
                     notes.generalNotes(),
+                    0,
                     WorldNpcLifecycleState.ACTIVE);
             save(new WorldPlannerState(
                     append(state.npcs(), npc),
@@ -149,6 +152,7 @@ public final class WorldPlannerApplicationService {
                     command.displayName(),
                     command.notes(),
                     tableId,
+                    0,
                     List.of(),
                     List.of());
             save(new WorldPlannerState(
@@ -175,7 +179,50 @@ public final class WorldPlannerApplicationService {
                 save(state.withStatus("NPC ist bereits Teil der Fraktion."));
                 return;
             }
-            save(replaceFaction(state, faction.addNpc(command.npcId()), "NPC zur Fraktion hinzugefuegt."));
+            List<WorldFaction> reassigned = new ArrayList<>();
+            for (WorldFaction existing : state.factions()) {
+                WorldFaction withoutNpc = existing.npcIds().contains(command.npcId())
+                        ? existing.removeNpc(command.npcId())
+                        : existing;
+                reassigned.add(withoutNpc.factionId() == faction.factionId()
+                        ? withoutNpc.addNpc(command.npcId())
+                        : withoutNpc);
+            }
+            save(new WorldPlannerState(
+                    state.npcs(), reassigned, state.locations(), state.nextNpcId(),
+                    state.nextFactionId(), state.nextLocationId(), "NPC-Fraktion aktualisiert."));
+        });
+    }
+
+    public void setFactionDisposition(SetWorldFactionDispositionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        runIgnoringStorageFailure(() -> {
+            WorldPlannerState state = load();
+            WorldFaction faction = state.faction(command.factionId());
+            if (faction == null) {
+                save(state.withStatus("Fraktion nicht gefunden."));
+                return;
+            }
+            save(replaceFaction(
+                    state,
+                    faction.withDisposition(command.disposition()),
+                    "Fraktionshaltung aktualisiert."));
+        });
+    }
+
+    public void setNpcDispositionModifier(SetWorldNpcDispositionModifierCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        runIgnoringStorageFailure(() -> {
+            WorldPlannerState state = load();
+            WorldNpc npc = state.npc(command.npcId());
+            if (npc == null) {
+                save(state.withStatus("NPC nicht gefunden."));
+                return;
+            }
+            save(replaceNpc(
+                    state,
+                    npc.withDispositionModifier(command.modifier()),
+                    "NPC-Haltung aktualisiert."));
         });
     }
 

--- a/src/domain/worldplanner/WorldPlannerSnapshotProjection.java
+++ b/src/domain/worldplanner/WorldPlannerSnapshotProjection.java
@@ -6,6 +6,7 @@ import src.domain.worldplanner.published.WorldFactionSummary;
 import src.domain.worldplanner.published.WorldLocationSummary;
 import src.domain.worldplanner.published.WorldNpcLifecycleStatus;
 import src.domain.worldplanner.published.WorldNpcSummary;
+import src.domain.worldplanner.published.WorldDispositionKind;
 import src.domain.worldplanner.published.WorldPlannerReadStatus;
 import src.domain.worldplanner.published.WorldPlannerSnapshot;
 
@@ -24,6 +25,12 @@ final class WorldPlannerSnapshotProjection {
                                 npc.behaviorNotes(),
                                 npc.historyNotes(),
                                 npc.generalNotes(),
+                                safeState.factionIdForNpc(npc.npcId()),
+                                npc.dispositionModifier(),
+                                safeState.effectiveDisposition(npc),
+                                WorldDispositionKind.valueOf(
+                                        src.domain.worldplanner.model.world.WorldDisposition
+                                                .kind(safeState.effectiveDisposition(npc)).name()),
                                 WorldNpcLifecycleStatus.fromName(npc.status().name())))
                         .toList(),
                 safeState.factions().stream()
@@ -32,6 +39,7 @@ final class WorldPlannerSnapshotProjection {
                                 faction.displayName(),
                                 faction.notes(),
                                 faction.primaryEncounterTableId(),
+                                faction.disposition(),
                                 faction.npcIds(),
                                 faction.inventoryLimits().stream()
                                         .map(limit -> new WorldFactionInventoryLimitSummary(

--- a/src/domain/worldplanner/model/world/WorldDisposition.java
+++ b/src/domain/worldplanner/model/world/WorldDisposition.java
@@ -1,0 +1,34 @@
+package src.domain.worldplanner.model.world;
+
+/** Numeric friendliness toward the player characters. */
+public final class WorldDisposition {
+
+    public static final int MINIMUM = -50;
+    public static final int MAXIMUM = 50;
+    public static final int HOSTILE_MAXIMUM = -15;
+    public static final int FRIENDLY_MINIMUM = 15;
+
+    private WorldDisposition() {
+    }
+
+    public static int clamp(int value) {
+        return Math.max(MINIMUM, Math.min(MAXIMUM, value));
+    }
+
+    public static Kind kind(int value) {
+        int clamped = clamp(value);
+        if (clamped <= HOSTILE_MAXIMUM) {
+            return Kind.HOSTILE;
+        }
+        if (clamped >= FRIENDLY_MINIMUM) {
+            return Kind.FRIENDLY;
+        }
+        return Kind.NEUTRAL;
+    }
+
+    public enum Kind {
+        HOSTILE,
+        NEUTRAL,
+        FRIENDLY
+    }
+}

--- a/src/domain/worldplanner/model/world/WorldFaction.java
+++ b/src/domain/worldplanner/model/world/WorldFaction.java
@@ -9,9 +9,21 @@ public record WorldFaction(
         String displayName,
         String notes,
         long primaryEncounterTableId,
+        int disposition,
         List<Long> npcIds,
         List<WorldFactionInventoryLimit> inventoryLimits
 ) {
+    public WorldFaction(
+            long factionId,
+            String displayName,
+            String notes,
+            long primaryEncounterTableId,
+            List<Long> npcIds,
+            List<WorldFactionInventoryLimit> inventoryLimits
+    ) {
+        this(factionId, displayName, notes, primaryEncounterTableId, 0, npcIds, inventoryLimits);
+    }
+
     public WorldFaction {
         if (!WorldPlannerIds.isPositive(factionId)) {
             throw new IllegalArgumentException("factionId must be positive");
@@ -21,6 +33,7 @@ public record WorldFaction(
         }
         displayName = WorldNpc.normalize(displayName, "Faction #" + factionId);
         notes = WorldNpc.text(notes);
+        disposition = WorldDisposition.clamp(disposition);
         npcIds = WorldPlannerIds.normalize(npcIds);
         inventoryLimits = normalizeInventoryLimits(inventoryLimits);
     }
@@ -47,8 +60,20 @@ public record WorldFaction(
                 displayName,
                 notes,
                 primaryEncounterTableId,
+                disposition,
                 WorldPlannerIds.addUnique(npcIds, npcId),
                 inventoryLimits);
+    }
+
+    public WorldFaction removeNpc(long npcId) {
+        return new WorldFaction(
+                factionId, displayName, notes, primaryEncounterTableId, disposition,
+                npcIds.stream().filter(id -> id != npcId).toList(), inventoryLimits);
+    }
+
+    public WorldFaction withDisposition(int value) {
+        return new WorldFaction(
+                factionId, displayName, notes, primaryEncounterTableId, value, npcIds, inventoryLimits);
     }
 
     public WorldFaction setInventoryLimit(WorldFactionInventoryLimit limit) {
@@ -65,6 +90,7 @@ public record WorldFaction(
                 displayName,
                 notes,
                 primaryEncounterTableId,
+                disposition,
                 npcIds,
                 nextLimits);
     }

--- a/src/domain/worldplanner/model/world/WorldNpc.java
+++ b/src/domain/worldplanner/model/world/WorldNpc.java
@@ -8,8 +8,23 @@ public record WorldNpc(
         String behaviorNotes,
         String historyNotes,
         String generalNotes,
+        int dispositionModifier,
         WorldNpcLifecycleState status
 ) {
+    public WorldNpc(
+            long npcId,
+            String displayName,
+            long creatureStatblockId,
+            String appearanceNotes,
+            String behaviorNotes,
+            String historyNotes,
+            String generalNotes,
+            WorldNpcLifecycleState status
+    ) {
+        this(npcId, displayName, creatureStatblockId, appearanceNotes, behaviorNotes,
+                historyNotes, generalNotes, 0, status);
+    }
+
     public WorldNpc {
         if (!WorldPlannerIds.isPositive(npcId)) {
             throw new IllegalArgumentException("npcId must be positive");
@@ -22,6 +37,7 @@ public record WorldNpc(
         behaviorNotes = text(behaviorNotes);
         historyNotes = text(historyNotes);
         generalNotes = text(generalNotes);
+        dispositionModifier = WorldDisposition.clamp(dispositionModifier);
         if (status == null) {
             throw new IllegalArgumentException("status must be present");
         }
@@ -37,7 +53,14 @@ public record WorldNpc(
                 safeNotes.behaviorNotes(),
                 safeNotes.historyNotes(),
                 safeNotes.generalNotes(),
+                dispositionModifier,
                 status);
+    }
+
+    public WorldNpc withDispositionModifier(int modifier) {
+        return new WorldNpc(
+                npcId, displayName, creatureStatblockId, appearanceNotes, behaviorNotes,
+                historyNotes, generalNotes, modifier, status);
     }
 
     public WorldNpc markDefeated() {
@@ -57,6 +80,7 @@ public record WorldNpc(
                 behaviorNotes,
                 historyNotes,
                 generalNotes,
+                dispositionModifier,
                 nextStatus);
     }
 

--- a/src/domain/worldplanner/model/world/WorldPlannerState.java
+++ b/src/domain/worldplanner/model/world/WorldPlannerState.java
@@ -16,10 +16,39 @@ public record WorldPlannerState(
         npcs = npcs == null ? List.of() : List.copyOf(npcs);
         factions = factions == null ? List.of() : List.copyOf(factions);
         locations = locations == null ? List.of() : List.copyOf(locations);
+        validateSingleFactionMembership(factions);
         nextNpcId = Math.max(1L, nextNpcId);
         nextFactionId = Math.max(1L, nextFactionId);
         nextLocationId = Math.max(1L, nextLocationId);
         statusText = WorldNpc.text(statusText);
+    }
+
+    public long factionIdForNpc(long npcId) {
+        return factions.stream()
+                .filter(faction -> faction.npcIds().contains(npcId))
+                .mapToLong(WorldFaction::factionId)
+                .findFirst()
+                .orElse(0L);
+    }
+
+    public int effectiveDisposition(WorldNpc npc) {
+        if (npc == null) {
+            return 0;
+        }
+        WorldFaction faction = faction(factionIdForNpc(npc.npcId()));
+        int base = faction == null ? 0 : faction.disposition();
+        return WorldDisposition.clamp(base + npc.dispositionModifier());
+    }
+
+    private static void validateSingleFactionMembership(List<WorldFaction> factions) {
+        java.util.Set<Long> assigned = new java.util.HashSet<>();
+        for (WorldFaction faction : factions) {
+            for (Long npcId : faction.npcIds()) {
+                if (!assigned.add(npcId)) {
+                    throw new IllegalArgumentException("NPC may belong to at most one faction");
+                }
+            }
+        }
     }
 
     public static WorldPlannerState empty() {

--- a/src/domain/worldplanner/published/SetWorldFactionDispositionCommand.java
+++ b/src/domain/worldplanner/published/SetWorldFactionDispositionCommand.java
@@ -1,0 +1,3 @@
+package src.domain.worldplanner.published;
+
+public record SetWorldFactionDispositionCommand(long factionId, int disposition) { }

--- a/src/domain/worldplanner/published/SetWorldNpcDispositionModifierCommand.java
+++ b/src/domain/worldplanner/published/SetWorldNpcDispositionModifierCommand.java
@@ -1,0 +1,3 @@
+package src.domain.worldplanner.published;
+
+public record SetWorldNpcDispositionModifierCommand(long npcId, int modifier) { }

--- a/src/domain/worldplanner/published/WorldDispositionKind.java
+++ b/src/domain/worldplanner/published/WorldDispositionKind.java
@@ -1,0 +1,7 @@
+package src.domain.worldplanner.published;
+
+public enum WorldDispositionKind {
+    HOSTILE,
+    NEUTRAL,
+    FRIENDLY
+}

--- a/src/domain/worldplanner/published/WorldFactionSummary.java
+++ b/src/domain/worldplanner/published/WorldFactionSummary.java
@@ -7,9 +7,21 @@ public record WorldFactionSummary(
         String displayName,
         String notes,
         long primaryEncounterTableId,
+        int disposition,
         List<Long> npcIds,
         List<WorldFactionInventoryLimitSummary> inventoryLimits
 ) {
+
+    public WorldFactionSummary(
+            long factionId,
+            String displayName,
+            String notes,
+            long primaryEncounterTableId,
+            List<Long> npcIds,
+            List<WorldFactionInventoryLimitSummary> inventoryLimits
+    ) {
+        this(factionId, displayName, notes, primaryEncounterTableId, 0, npcIds, inventoryLimits);
+    }
 
     public WorldFactionSummary {
         npcIds = npcIds == null ? List.of() : List.copyOf(npcIds);

--- a/src/domain/worldplanner/published/WorldNpcSummary.java
+++ b/src/domain/worldplanner/published/WorldNpcSummary.java
@@ -8,5 +8,27 @@ public record WorldNpcSummary(
         String behaviorNotes,
         String historyNotes,
         String generalNotes,
+        long factionId,
+        int dispositionModifier,
+        int effectiveDisposition,
+        WorldDispositionKind disposition,
         WorldNpcLifecycleStatus status
-) { }
+) {
+    public WorldNpcSummary(
+            long npcId,
+            String displayName,
+            long creatureStatblockId,
+            String appearanceNotes,
+            String behaviorNotes,
+            String historyNotes,
+            String generalNotes,
+            WorldNpcLifecycleStatus status
+    ) {
+        this(npcId, displayName, creatureStatblockId, appearanceNotes, behaviorNotes,
+                historyNotes, generalNotes, 0L, 0, 0, WorldDispositionKind.NEUTRAL, status);
+    }
+
+    public WorldNpcSummary {
+        disposition = disposition == null ? WorldDispositionKind.NEUTRAL : disposition;
+    }
+}

--- a/src/view/leftbartabs/scene/SceneBinder.java
+++ b/src/view/leftbartabs/scene/SceneBinder.java
@@ -1,0 +1,302 @@
+package src.view.leftbartabs.scene;
+
+import java.util.HashMap;
+import java.util.Map;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import shell.api.ShellBinding;
+import shell.api.ShellSlot;
+import src.domain.scene.SceneServiceAssembly;
+import src.domain.scene.published.SceneCommand;
+import src.domain.scene.published.SceneSnapshot;
+
+final class SceneBinder {
+    private final SceneServiceAssembly scenes;
+    private final VBox controls = new VBox(10);
+    private final BorderPane main = new BorderPane();
+    private final ToggleGroup sceneGroup = new ToggleGroup();
+    private Runnable unsubscribe = () -> { };
+
+    SceneBinder(SceneServiceAssembly scenes) {
+        this.scenes = scenes;
+    }
+
+    ShellBinding bind() {
+        controls.getStyleClass().add("scene-runtime-controls");
+        controls.setPadding(new Insets(10));
+        main.getStyleClass().add("scene-runtime-main");
+        render(scenes.model().current());
+        unsubscribe = scenes.model().subscribe(this::render);
+        return new Binding(controls, main, () -> unsubscribe.run());
+    }
+
+    private void render(SceneSnapshot snapshot) {
+        renderControls(snapshot);
+        SceneSnapshot.SceneEntry focused = snapshot.scenes().stream()
+                .filter(SceneSnapshot.SceneEntry::focused).findFirst().orElse(null);
+        if (focused == null) {
+            main.setCenter(message("Szenen konnten nicht geladen werden."));
+            return;
+        }
+        main.setTop(sceneHeader(focused));
+        main.setCenter(sceneBoard(snapshot, focused));
+    }
+
+    private void renderControls(SceneSnapshot snapshot) {
+        controls.getChildren().clear();
+        Label eyebrow = label("LAUFENDE SZENEN", "scene-runtime-eyebrow");
+        Label title = label("Am Spieltisch", "title-large");
+        VBox switcher = new VBox(5);
+        sceneGroup.getToggles().clear();
+        for (SceneSnapshot.SceneEntry scene : snapshot.scenes()) {
+            ToggleButton button = new ToggleButton(scene.title());
+            button.setMaxWidth(Double.MAX_VALUE);
+            button.getStyleClass().add("scene-runtime-switch");
+            button.setToggleGroup(sceneGroup);
+            button.setSelected(scene.focused());
+            button.setOnAction(event -> apply(new SceneCommand.Focus(scene.sceneId())));
+            switcher.getChildren().add(button);
+        }
+
+        TextField newTitle = new TextField();
+        newTitle.setPromptText("Neue Szene");
+        Button create = action("Szene anlegen", () -> {
+            apply(new SceneCommand.Create(newTitle.getText()));
+            newTitle.clear();
+        }, "accent-action");
+
+        ComboBox<PreparedChoice> prepared = new ComboBox<>();
+        prepared.setMaxWidth(Double.MAX_VALUE);
+        snapshot.preparedScenes().forEach(choice -> prepared.getItems().add(new PreparedChoice(choice)));
+        prepared.setPromptText("Vorbereitete Szene");
+        Button load = action("Aus Planer laden", () -> {
+            PreparedChoice choice = prepared.getValue();
+            if (choice != null) {
+                apply(new SceneCommand.ImportPrepared(choice.value.sessionId(), choice.value.sceneId()));
+            }
+        }, "flat-action");
+
+        Label status = label(snapshot.statusText(), snapshot.encounterSynchronized() ? "text-secondary" : "text-warning");
+        status.setWrapText(true);
+        controls.getChildren().addAll(eyebrow, title, switcher, divider(), newTitle, create,
+                label("Schnellauswahl", "section-header"), prepared, load, status);
+    }
+
+    private Node sceneHeader(SceneSnapshot.SceneEntry scene) {
+        TextField title = new TextField(scene.title());
+        title.getStyleClass().add("scene-runtime-title-input");
+        TextArea notes = new TextArea(scene.notes());
+        notes.setPromptText("Was ist in dieser Szene wichtig?");
+        notes.setPrefRowCount(2);
+        Button save = action("Szene speichern", () -> apply(
+                new SceneCommand.UpdateDetails(scene.sceneId(), title.getText(), notes.getText())), "accent-action");
+        Button delete = action(scene.defaultScene() ? "Standardszene" : "Szene löschen", () -> {
+            if (!scene.defaultScene()) {
+                apply(new SceneCommand.Delete(scene.sceneId()));
+            }
+        }, scene.defaultScene() ? "flat-action" : "danger-action");
+        delete.setDisable(scene.defaultScene());
+        VBox header = new VBox(8,
+                new HBox(8, label(scene.defaultScene() ? "STANDARD" : "AKTIV", "scene-runtime-scene-mark"), title),
+                notes,
+                new HBox(8, save, delete));
+        header.setPadding(new Insets(14));
+        header.getStyleClass().add("scene-runtime-header");
+        HBox.setHgrow(title, Priority.ALWAYS);
+        return header;
+    }
+
+    private Node sceneBoard(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        GridPane board = new GridPane();
+        board.setHgap(10);
+        board.setPadding(new Insets(10));
+        for (int i = 0; i < 3; i++) {
+            ColumnConstraints column = new ColumnConstraints();
+            column.setPercentWidth(100.0 / 3.0);
+            column.setHgrow(Priority.ALWAYS);
+            board.getColumnConstraints().add(column);
+        }
+        board.add(partyPanel(snapshot, scene), 0, 0);
+        board.add(npcPanel(snapshot, scene), 1, 0);
+        board.add(locationPanel(snapshot, scene), 2, 0);
+        return board;
+    }
+
+    private Node partyPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        VBox rows = panel("PCs", "Wer spielt hier gerade?");
+        for (SceneSnapshot.PartyChoice pc : scene.partyMembers()) {
+            rows.getChildren().add(row(pc.name() + " · Stufe " + pc.level(), "Entfernen",
+                    () -> apply(new SceneCommand.UnassignPc(pc.id()))));
+        }
+        for (SceneSnapshot.PartyChoice pc : snapshot.activePartyMembers()) {
+            if (pc.sceneId() == scene.sceneId()) {
+                continue;
+            }
+            String assignment = pc.sceneId() == 0L
+                    ? "unzugeordnet"
+                    : "in " + sceneTitle(snapshot, pc.sceneId());
+            rows.getChildren().add(row(pc.name() + " · " + assignment, "Hierher",
+                    () -> apply(new SceneCommand.AssignPc(scene.sceneId(), pc.id()))));
+        }
+        if (snapshot.activePartyMembers().isEmpty()) {
+            rows.getChildren().add(empty("Keine aktiven PCs verfügbar."));
+        }
+        return scroll(rows);
+    }
+
+    private static String sceneTitle(SceneSnapshot snapshot, long sceneId) {
+        return snapshot.scenes().stream()
+                .filter(scene -> scene.sceneId() == sceneId)
+                .map(SceneSnapshot.SceneEntry::title)
+                .findFirst()
+                .orElse("anderer Szene");
+    }
+
+    private Node npcPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        VBox rows = panel("NPCs", "Haltung bestimmt die Kampfseite.");
+        for (SceneSnapshot.NpcChoice npc : scene.npcs()) {
+            String disposition = switch (npc.disposition()) {
+                case HOSTILE -> "Feindlich";
+                case FRIENDLY -> "Freundlich";
+                case NEUTRAL -> "Neutral";
+            };
+            rows.getChildren().add(row(npc.name() + " · " + disposition + " " + signed(npc.effectiveDisposition()),
+                    "Entfernen", () -> apply(new SceneCommand.RemoveNpc(scene.sceneId(), npc.id()))));
+        }
+        for (SceneSnapshot.NpcChoice npc : snapshot.availableNpcs()) {
+            if (scene.npcs().stream().noneMatch(selected -> selected.id() == npc.id())) {
+                rows.getChildren().add(row(npc.name(), "Hinzufügen",
+                        () -> apply(new SceneCommand.AddNpc(scene.sceneId(), npc.id()))));
+            }
+        }
+        if (snapshot.availableNpcs().isEmpty()) {
+            rows.getChildren().add(empty("NPCs zuerst im World Planner anlegen."));
+        }
+        return scroll(rows);
+    }
+
+    private Node locationPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        VBox rows = panel("Ort", "Genau ein Ort steuert die Encounter-Quelle.");
+        ComboBox<LocationChoice> choices = new ComboBox<>();
+        choices.setMaxWidth(Double.MAX_VALUE);
+        choices.getItems().add(new LocationChoice(0L, "Kein Ort"));
+        snapshot.availableLocations().forEach(location -> choices.getItems().add(new LocationChoice(location.id(), location.name())));
+        choices.getSelectionModel().select(choices.getItems().stream()
+                .filter(choice -> choice.id == scene.locationId()).findFirst().orElse(choices.getItems().getFirst()));
+        Button apply = action("Ort übernehmen", () -> {
+            LocationChoice choice = choices.getValue();
+            if (choice != null) {
+                apply(new SceneCommand.SetLocation(scene.sceneId(), choice.id));
+            }
+        }, "accent-action");
+        rows.getChildren().addAll(label(scene.locationName().isBlank() ? "Kein Ort gesetzt" : scene.locationName(), "scene-runtime-location"), choices, apply);
+        return scroll(rows);
+    }
+
+    private static VBox panel(String title, String subtitle) {
+        VBox box = new VBox(8, label(title, "scene-runtime-panel-title"), label(subtitle, "text-secondary"));
+        box.setPadding(new Insets(12));
+        box.getStyleClass().add("scene-runtime-panel");
+        return box;
+    }
+
+    private static Node scroll(VBox content) {
+        ScrollPane scroll = new ScrollPane(content);
+        scroll.setFitToWidth(true);
+        scroll.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+        GridPane.setHgrow(scroll, Priority.ALWAYS);
+        GridPane.setVgrow(scroll, Priority.ALWAYS);
+        return scroll;
+    }
+
+    private static HBox row(String text, String action, Runnable handler) {
+        Label label = label(text, "scene-runtime-row-label");
+        label.setWrapText(true);
+        Button button = action(action, handler, "flat-action");
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox row = new HBox(6, label, spacer, button);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().add("scene-runtime-row");
+        return row;
+    }
+
+    private static Button action(String text, Runnable handler, String style) {
+        Button button = new Button(text);
+        button.getStyleClass().add(style);
+        button.setOnAction(event -> handler.run());
+        return button;
+    }
+
+    private void apply(SceneCommand command) {
+        scenes.application().apply(command);
+        scenes.publish();
+    }
+
+    private static Label label(String text, String style) {
+        Label label = new Label(text == null ? "" : text);
+        label.getStyleClass().add(style);
+        return label;
+    }
+
+    private static Label empty(String text) {
+        Label label = label(text, "text-muted");
+        label.setWrapText(true);
+        return label;
+    }
+
+    private static Region divider() {
+        Region divider = new Region();
+        divider.getStyleClass().add("scene-runtime-divider");
+        return divider;
+    }
+
+    private static Node message(String text) {
+        Label label = empty(text);
+        BorderPane pane = new BorderPane(label);
+        pane.setPadding(new Insets(20));
+        return pane;
+    }
+
+    private static String signed(int value) { return value >= 0 ? "+" + value : String.valueOf(value); }
+
+    private record Binding(Node controls, Node main, Runnable dispose) implements ShellBinding {
+        @Override public String title() { return "Szenen"; }
+        @Override public Map<ShellSlot, Node> slotContent() {
+            Map<ShellSlot, Node> slots = new HashMap<>();
+            slots.put(ShellSlot.COCKPIT_CONTROLS, controls);
+            slots.put(ShellSlot.COCKPIT_MAIN, main);
+            return Map.copyOf(slots);
+        }
+        @Override public void onDeactivate() { }
+    }
+
+    private static final class PreparedChoice {
+        private final SceneSnapshot.PreparedChoice value;
+        private PreparedChoice(SceneSnapshot.PreparedChoice value) { this.value = value; }
+        @Override public String toString() { return value.sessionName() + " · " + value.title(); }
+    }
+
+    private static final class LocationChoice {
+        private final long id;
+        private final String name;
+        private LocationChoice(long id, String name) { this.id = id; this.name = name; }
+        @Override public String toString() { return name; }
+    }
+}

--- a/src/view/leftbartabs/scene/SceneContribution.java
+++ b/src/view/leftbartabs/scene/SceneContribution.java
@@ -1,0 +1,36 @@
+package src.view.leftbartabs.scene;
+
+import java.util.Objects;
+import shell.api.ContributionKey;
+import shell.api.NavigationGraphicResource;
+import shell.api.NavigationGroupSpec;
+import shell.api.ShellBinding;
+import shell.api.ShellContribution;
+import shell.api.ShellContributionSpec;
+import shell.api.ShellLeftBarTabMode;
+import shell.api.ShellLeftBarTabSpec;
+import src.domain.scene.SceneServiceAssembly;
+
+public final class SceneContribution implements ShellContribution {
+    private final SceneServiceAssembly scenes;
+
+    public SceneContribution(SceneServiceAssembly scenes) {
+        this.scenes = Objects.requireNonNull(scenes, "scenes");
+    }
+
+    @Override
+    public ShellContributionSpec registrationSpec() {
+        return new ShellLeftBarTabSpec(
+                new ContributionKey("runtime-scenes"),
+                new NavigationGroupSpec("play", "Spielbetrieb", 5),
+                10,
+                false,
+                NavigationGraphicResource.of("/view/leftbartabs/scene/navigation-icon.svg"),
+                ShellLeftBarTabMode.RUNTIME);
+    }
+
+    @Override
+    public ShellBinding bind() {
+        return new SceneBinder(scenes).bind();
+    }
+}

--- a/src/view/leftbartabs/worldplanner/WorldPlannerBinder.java
+++ b/src/view/leftbartabs/worldplanner/WorldPlannerBinder.java
@@ -24,7 +24,9 @@ import src.domain.worldplanner.published.CreateWorldFactionCommand;
 import src.domain.worldplanner.published.CreateWorldLocationCommand;
 import src.domain.worldplanner.published.CreateWorldNpcCommand;
 import src.domain.worldplanner.published.SetWorldFactionInventoryLimitCommand;
+import src.domain.worldplanner.published.SetWorldFactionDispositionCommand;
 import src.domain.worldplanner.published.SetWorldNpcLifecycleStatusCommand;
+import src.domain.worldplanner.published.SetWorldNpcDispositionModifierCommand;
 import src.domain.worldplanner.published.UpdateWorldNpcNotesCommand;
 import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
 import src.view.slotcontent.controls.searchfilter.SearchFilterControlsView;
@@ -143,6 +145,9 @@ public final class WorldPlannerBinder {
             worldPlanner.setNpcLifecycleStatus(SetWorldNpcLifecycleStatusCommand.active(viewModel.selectedNpcId()));
         } else if (actions.addToEncounterRequested()) {
             addNpcToEncounter(viewModel);
+        } else if (actions.setNpcDispositionRequested()) {
+            worldPlanner.setNpcDispositionModifier(new SetWorldNpcDispositionModifierCommand(
+                    viewModel.selectedNpcId(), parseDisposition(snapshot.dispositionModifierText())));
         }
     }
 
@@ -166,6 +171,9 @@ public final class WorldPlannerBinder {
                     viewModel.factionStatblockChoiceId(snapshot.inventoryStatblockChoiceIndex()),
                     snapshot.finiteInventory(),
                     parseQuantity(snapshot.inventoryQuantityText())));
+        } else if (actions.setFactionDispositionRequested()) {
+            worldPlanner.setFactionDisposition(new SetWorldFactionDispositionCommand(
+                    viewModel.selectedFactionId(), parseDisposition(snapshot.dispositionText())));
         }
     }
 
@@ -251,6 +259,14 @@ public final class WorldPlannerBinder {
             case LOCATIONS -> "Ort";
             default -> "NPC";
         };
+    }
+
+    private static int parseDisposition(String value) {
+        try {
+            return Math.max(-50, Math.min(50, Integer.parseInt(value == null ? "" : value.trim())));
+        } catch (NumberFormatException exception) {
+            return 0;
+        }
     }
 
     public static final class CatalogModule {

--- a/src/view/leftbartabs/worldplanner/WorldPlannerStateView.java
+++ b/src/view/leftbartabs/worldplanner/WorldPlannerStateView.java
@@ -32,12 +32,14 @@ public final class WorldPlannerStateView extends VBox {
     private final TextArea behaviorNotes = notesArea();
     private final TextArea historyNotes = notesArea();
     private final TextArea generalNotes = notesArea();
+    private final TextField npcDisposition = new TextField("0");
     private final TextField factionName = new TextField();
     private final ComboBox<String> primaryEncounterTableChoice = new ComboBox<>();
     private final ComboBox<String> npcChoice = new ComboBox<>();
     private final ComboBox<String> inventoryStatblockChoice = new ComboBox<>();
     private final CheckBox finiteInventory = new CheckBox("Finite");
     private final TextField inventoryQuantity = new TextField();
+    private final TextField factionDisposition = new TextField("0");
     private final TextField locationName = new TextField();
     private final ComboBox<String> factionChoice = new ComboBox<>();
     private final ComboBox<String> locationTableChoice = new ComboBox<>();
@@ -77,6 +79,8 @@ public final class WorldPlannerStateView extends VBox {
         npcChoice.setPromptText("NPC waehlen");
         inventoryStatblockChoice.setPromptText("Bestand-Statblock waehlen");
         inventoryQuantity.setPromptText("Anzahl");
+        npcDisposition.setPromptText("Haltungsmodifikator -50 bis 50");
+        factionDisposition.setPromptText("Fraktionshaltung -50 bis 50");
         locationName.setPromptText("Location Name");
         factionChoice.setPromptText("Fraktion waehlen");
         locationTableChoice.setPromptText("Location-Tabelle waehlen");
@@ -128,6 +132,7 @@ public final class WorldPlannerStateView extends VBox {
         fields.addRow(0, npcName, statblockChoice);
         fields.addRow(1, labelled("Aussehen", appearanceNotes), labelled("Verhalten", behaviorNotes));
         fields.addRow(2, labelled("History", historyNotes), labelled("Notizen", generalNotes));
+        fields.addRow(3, labelled("Haltungsmodifikator", npcDisposition));
         return fields;
     }
 
@@ -136,6 +141,7 @@ public final class WorldPlannerStateView extends VBox {
         fields.addRow(0, factionName, primaryEncounterTableChoice);
         fields.addRow(1, npcChoice, inventoryStatblockChoice);
         fields.addRow(2, finiteInventory, inventoryQuantity);
+        fields.addRow(3, labelled("Haltung zu den PCs", factionDisposition));
         return fields;
     }
 
@@ -155,7 +161,9 @@ public final class WorldPlannerStateView extends VBox {
         Button reactivate = action(NPCS, "Aktiv", actions(false, false, false, true, false, false, false, false, false));
         Button addToEncounter = action(NPCS, "Zum Encounter",
                 actions(false, false, false, false, true, false, false, false, false));
-        return new HBox(8, create, updateNotes, defeat, reactivate, addToEncounter);
+        Button disposition = action(NPCS, "Haltung setzen",
+                new ActionSnapshot(false, false, false, false, false, false, false, false, false, true, false));
+        return new HBox(8, create, updateNotes, disposition, defeat, reactivate, addToEncounter);
     }
 
     private Node factionActions() {
@@ -165,7 +173,9 @@ public final class WorldPlannerStateView extends VBox {
                 actions(false, false, false, false, false, true, false, false, false));
         Button limit = action(FACTIONS, "Bestand setzen",
                 actions(false, false, false, false, false, false, true, false, false));
-        return new HBox(8, create, addNpc, limit);
+        Button disposition = action(FACTIONS, "Haltung setzen",
+                new ActionSnapshot(false, false, false, false, false, false, false, false, false, false, true));
+        return new HBox(8, create, addNpc, disposition, limit);
     }
 
     private Node locationActions() {
@@ -196,14 +206,16 @@ public final class WorldPlannerStateView extends VBox {
                         appearanceNotes.getText(),
                         behaviorNotes.getText(),
                         historyNotes.getText(),
-                        generalNotes.getText()),
+                        generalNotes.getText(),
+                        npcDisposition.getText()),
                 new FactionSnapshot(
                         factionName.getText(),
                         primaryEncounterTableChoice.getSelectionModel().getSelectedIndex(),
                         npcChoice.getSelectionModel().getSelectedIndex(),
                         inventoryStatblockChoice.getSelectionModel().getSelectedIndex(),
                         finiteInventory.isSelected(),
-                        inventoryQuantity.getText()),
+                        inventoryQuantity.getText(),
+                        factionDisposition.getText()),
                 new LocationSnapshot(
                         locationName.getText(),
                         factionChoice.getSelectionModel().getSelectedIndex(),

--- a/src/view/leftbartabs/worldplanner/WorldPlannerViewModel.java
+++ b/src/view/leftbartabs/worldplanner/WorldPlannerViewModel.java
@@ -385,11 +385,11 @@ record StateInput(
 ) {
     StateInput {
         activeModuleIndex = Math.max(0, activeModuleIndex);
-        npc = npc == null ? new NpcSnapshot("", -1, "", "", "", "") : npc;
-        faction = faction == null ? new FactionSnapshot("", -1, -1, -1, false, "") : faction;
+        npc = npc == null ? new NpcSnapshot("", -1, "", "", "", "", "0") : npc;
+        faction = faction == null ? new FactionSnapshot("", -1, -1, -1, false, "", "0") : faction;
         location = location == null ? new LocationSnapshot("", -1, -1) : location;
         actions = actions == null
-                ? new ActionSnapshot(false, false, false, false, false, false, false, false, false)
+                ? new ActionSnapshot(false, false, false, false, false, false, false, false, false, false, false)
                 : actions;
     }
 }
@@ -400,8 +400,13 @@ record NpcSnapshot(
         String appearanceNotes,
         String behaviorNotes,
         String historyNotes,
-        String generalNotes
+        String generalNotes,
+        String dispositionModifierText
 ) {
+    NpcSnapshot(String displayName, int statblockChoiceIndex, String appearanceNotes, String behaviorNotes,
+            String historyNotes, String generalNotes) {
+        this(displayName, statblockChoiceIndex, appearanceNotes, behaviorNotes, historyNotes, generalNotes, "0");
+    }
     NpcSnapshot {
         displayName = WorldPlannerVocabulary.text(displayName);
         statblockChoiceIndex = Math.max(-1, statblockChoiceIndex);
@@ -409,6 +414,7 @@ record NpcSnapshot(
         behaviorNotes = WorldPlannerVocabulary.text(behaviorNotes);
         historyNotes = WorldPlannerVocabulary.text(historyNotes);
         generalNotes = WorldPlannerVocabulary.text(generalNotes);
+        dispositionModifierText = WorldPlannerVocabulary.text(dispositionModifierText);
     }
 }
 
@@ -418,14 +424,21 @@ record FactionSnapshot(
         int npcChoiceIndex,
         int inventoryStatblockChoiceIndex,
         boolean finiteInventory,
-        String inventoryQuantityText
+        String inventoryQuantityText,
+        String dispositionText
 ) {
+    FactionSnapshot(String displayName, int primaryEncounterTableChoiceIndex, int npcChoiceIndex,
+            int inventoryStatblockChoiceIndex, boolean finiteInventory, String inventoryQuantityText) {
+        this(displayName, primaryEncounterTableChoiceIndex, npcChoiceIndex, inventoryStatblockChoiceIndex,
+                finiteInventory, inventoryQuantityText, "0");
+    }
     FactionSnapshot {
         displayName = WorldPlannerVocabulary.text(displayName);
         primaryEncounterTableChoiceIndex = Math.max(-1, primaryEncounterTableChoiceIndex);
         npcChoiceIndex = Math.max(-1, npcChoiceIndex);
         inventoryStatblockChoiceIndex = Math.max(-1, inventoryStatblockChoiceIndex);
         inventoryQuantityText = WorldPlannerVocabulary.text(inventoryQuantityText);
+        dispositionText = WorldPlannerVocabulary.text(dispositionText);
     }
 }
 
@@ -450,8 +463,16 @@ record ActionSnapshot(
         boolean addNpcRequested,
         boolean setInventoryLimitRequested,
         boolean linkFactionRequested,
-        boolean linkTableRequested
+        boolean linkTableRequested,
+        boolean setNpcDispositionRequested,
+        boolean setFactionDispositionRequested
 ) {
+    ActionSnapshot(boolean createRequested, boolean saveNotesRequested, boolean defeatRequested,
+            boolean reactivateRequested, boolean addToEncounterRequested, boolean addNpcRequested,
+            boolean setInventoryLimitRequested, boolean linkFactionRequested, boolean linkTableRequested) {
+        this(createRequested, saveNotesRequested, defeatRequested, reactivateRequested, addToEncounterRequested,
+                addNpcRequested, setInventoryLimitRequested, linkFactionRequested, linkTableRequested, false, false);
+    }
 }
 
 record NpcProjection(

--- a/test/src/bootstrap/SmokeStartupTest.java
+++ b/test/src/bootstrap/SmokeStartupTest.java
@@ -44,6 +44,7 @@ public final class SmokeStartupTest {
         List<ToggleButton> navigation = navigationButtons(shell);
         require(
                 navigation.stream().map(Node::getAccessibleText).toList().equals(List.of(
+                        "Szenen",
                         "Session Planner",
                         "Dungeon-Editor",
                         "Dungeon-Reise",

--- a/test/src/data/encounter/runtime/EncounterRuntimePersistenceTest.java
+++ b/test/src/data/encounter/runtime/EncounterRuntimePersistenceTest.java
@@ -1,0 +1,57 @@
+package src.data.encounter.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import src.domain.encounter.model.generation.EncounterGenerationInputs;
+import src.domain.encounter.model.session.Combatant;
+import src.domain.encounter.model.session.EncounterCreatureData;
+import src.domain.encounter.model.session.EncounterSessionMemento;
+import src.domain.encounter.model.session.GeneratedEncounterData;
+import src.domain.encounter.model.session.InitiativeEntryData;
+import src.domain.encounter.model.session.CombatantKind;
+import src.domain.encounter.model.session.ResultStateData;
+
+class EncounterRuntimePersistenceTest {
+    @Test
+    void completeContextMementoSurvivesSqliteRoundTrip() {
+        EncounterCreatureData creature = new EncounterCreatureData(
+                "world-npc-8", 101L, 8L, "Wache", "1", 200, 18, 14, 2,
+                "Humanoid", "Szenen-NPC", 1, List.of("guard"));
+        EncounterSessionMemento expected = new EncounterSessionMemento(
+                EncounterSessionMemento.CURRENT_FORMAT_VERSION,
+                2,
+                "Kampf läuft",
+                EncounterGenerationInputs.empty(),
+                List.of(creature),
+                Optional.empty(),
+                3L,
+                List.of(new GeneratedEncounterData("Torwache", "Medium", 200, List.of(creature), List.of("Hinweis"))),
+                List.of("Aktiver Ort"),
+                0,
+                200,
+                "Medium",
+                "Torwache",
+                true,
+                4L,
+                List.of(new InitiativeEntryData("pc-1", "Held", CombatantKind.PLAYER_CHARACTER, 16)),
+                List.of(Combatant.playerCharacter("pc-1", "Held", 16, 0)),
+                0,
+                3,
+                ResultStateData.empty());
+        SqliteEncounterRuntimeStateRepository repository = new SqliteEncounterRuntimeStateRepository();
+
+        repository.saveAll(Map.of("scene:901", expected));
+        EncounterSessionMemento restored = repository.loadAll().get("scene:901");
+
+        assertEquals(expected.status(), restored.status());
+        assertEquals(3, restored.round());
+        assertEquals("Wache", restored.roster().getFirst().name());
+        assertEquals("Torwache", restored.generatedAlternatives().getFirst().title());
+        assertTrue(restored.generationHistoryPresent());
+    }
+}

--- a/test/src/domain/scene/SceneRuntimeTest.java
+++ b/test/src/domain/scene/SceneRuntimeTest.java
@@ -1,0 +1,121 @@
+package src.domain.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import src.domain.encounter.published.EncounterRuntimeContextApi;
+import src.domain.party.published.ActivePartyModel;
+import src.domain.party.published.ActivePartyResult;
+import src.domain.party.published.PartyMemberSummary;
+import src.domain.party.published.ReadStatus;
+import src.domain.scene.model.SceneWorkspace;
+import src.domain.scene.model.repository.SceneWorkspaceRepository;
+import src.domain.scene.published.SceneCommand;
+import src.domain.scene.published.SceneMutationResult;
+import src.domain.sessionplanner.published.PreparedSceneCatalog;
+import src.domain.worldplanner.published.WorldDispositionKind;
+import src.domain.worldplanner.published.WorldLocationSummary;
+import src.domain.worldplanner.published.WorldNpcLifecycleStatus;
+import src.domain.worldplanner.published.WorldNpcSummary;
+import src.domain.worldplanner.published.WorldPlannerReadStatus;
+import src.domain.worldplanner.published.WorldPlannerSnapshot;
+import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
+
+class SceneRuntimeTest {
+
+    @Test
+    void defaultScenePartitionsPcsAndSynchronizesWorldContext() {
+        ActivePartyModel party = party(1L, 2L);
+        WorldPlannerSnapshotModel world = world();
+        CapturingEncounterContexts encounters = new CapturingEncounterContexts();
+        SceneApplicationService service = new SceneApplicationService(
+                new MemoryRepository(), party, world, () -> new PreparedSceneCatalog(List.of(), ""), encounters);
+
+        assertEquals(List.of(1L, 2L), service.current().scenes().getFirst().partyMembers().stream()
+                .map(choice -> choice.id()).toList());
+        assertEquals("scene:1", encounters.last.focusedContextKey());
+
+        service.apply(new SceneCommand.Create("Getrennte Gruppe"));
+        service.apply(new SceneCommand.AssignPc(2L, 2L));
+        assertEquals(List.of(1L), service.current().scenes().getFirst().partyMembers().stream()
+                .map(choice -> choice.id()).toList());
+        assertEquals(List.of(2L), service.current().scenes().get(1).partyMembers().stream()
+                .map(choice -> choice.id()).toList());
+        assertTrue(service.current().encounterSynchronized());
+    }
+
+    @Test
+    void preparedImportCopiesOnlyUnassignedActiveParticipants() {
+        ActivePartyModel party = party(1L, 2L, 3L);
+        CapturingEncounterContexts encounters = new CapturingEncounterContexts();
+        PreparedSceneCatalog.PreparedScene prepared = new PreparedSceneCatalog.PreparedScene(
+                9L, "Abend", 4L, "Torhaus", "Wachen", 7L, 12L, List.of(1L, 2L, 99L));
+        SceneApplicationService service = new SceneApplicationService(
+                new MemoryRepository(), party, world(), () -> new PreparedSceneCatalog(List.of(prepared), ""),
+                encounters);
+        service.apply(new SceneCommand.UnassignPc(2L));
+
+        SceneMutationResult result = service.apply(new SceneCommand.ImportPrepared(9L, 4L));
+
+        assertEquals(SceneMutationResult.Status.SUCCESS, result.status());
+        var imported = service.current().scenes().getLast();
+        assertEquals("Torhaus", imported.title());
+        assertEquals(7L, imported.locationId());
+        assertEquals(List.of(2L), imported.partyMembers().stream().map(choice -> choice.id()).toList());
+        assertEquals(12L, encounters.last.contexts().getLast().initialEncounterPlanId());
+        assertTrue(service.current().statusText().contains("übersprungen"));
+    }
+
+    @Test
+    void npcDispositionAndSingleLocationReachEncounterContext() {
+        CapturingEncounterContexts encounters = new CapturingEncounterContexts();
+        SceneApplicationService service = new SceneApplicationService(
+                new MemoryRepository(), party(1L), world(), () -> new PreparedSceneCatalog(List.of(), ""), encounters);
+
+        service.apply(new SceneCommand.AddNpc(1L, 10L));
+        service.apply(new SceneCommand.SetLocation(1L, 20L));
+
+        var context = encounters.last.contexts().getFirst();
+        assertEquals(20L, context.worldLocationId());
+        assertEquals(EncounterRuntimeContextApi.Role.HOSTILE, context.npcs().getFirst().role());
+        assertTrue(context.npcs().getFirst().active());
+        assertEquals(SceneMutationResult.Status.DEFAULT_SCENE, service.apply(new SceneCommand.Delete(1L)).status());
+    }
+
+    private static ActivePartyModel party(long... ids) {
+        ActivePartyModel model = new ActivePartyModel();
+        List<PartyMemberSummary> members = java.util.Arrays.stream(ids)
+                .mapToObj(id -> new PartyMemberSummary(id, "PC " + id, (int) id + 1)).toList();
+        model.publish(new ActivePartyResult(ReadStatus.SUCCESS, members));
+        return model;
+    }
+
+    private static WorldPlannerSnapshotModel world() {
+        WorldPlannerSnapshotModel model = new WorldPlannerSnapshotModel();
+        model.publish(new WorldPlannerSnapshot(
+                WorldPlannerReadStatus.SUCCESS,
+                List.of(new WorldNpcSummary(10L, "Rivalin", 101L, "", "", "", "", 1L, 5, -25,
+                        WorldDispositionKind.HOSTILE, WorldNpcLifecycleStatus.ACTIVE)),
+                List.of(),
+                List.of(new WorldLocationSummary(20L, "Torhaus", "", List.of(), List.of())),
+                ""));
+        return model;
+    }
+
+    private static final class MemoryRepository implements SceneWorkspaceRepository {
+        private SceneWorkspace state;
+        @Override public Optional<SceneWorkspace> load() { return Optional.ofNullable(state); }
+        @Override public SceneWorkspace save(SceneWorkspace workspace) { state = workspace; return workspace; }
+    }
+
+    private static final class CapturingEncounterContexts implements EncounterRuntimeContextApi {
+        private SynchronizeEncounterContextsCommand last;
+        @Override public SyncResult synchronize(SynchronizeEncounterContextsCommand command) {
+            last = command;
+            return new SyncResult(true, "");
+        }
+    }
+}

--- a/test/src/domain/worldplanner/WorldDispositionTest.java
+++ b/test/src/domain/worldplanner/WorldDispositionTest.java
@@ -1,0 +1,33 @@
+package src.domain.worldplanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import src.domain.worldplanner.model.world.WorldDisposition;
+import src.domain.worldplanner.model.world.WorldFaction;
+import src.domain.worldplanner.model.world.WorldNpc;
+import src.domain.worldplanner.model.world.WorldNpcLifecycleState;
+import src.domain.worldplanner.model.world.WorldPlannerState;
+
+class WorldDispositionTest {
+    @Test
+    void factionAndNpcValuesComposeWithinBoundedScale() {
+        WorldNpc npc = new WorldNpc(1L, "Rivalin", 10L, "", "", "", "", 5, WorldNpcLifecycleState.ACTIVE);
+        WorldFaction faction = new WorldFaction(1L, "Garde", "", 20L, -30, List.of(1L), List.of());
+        WorldPlannerState state = new WorldPlannerState(List.of(npc), List.of(faction), List.of(), 2L, 2L, 1L, "");
+        assertEquals(-25, state.effectiveDisposition(npc));
+        assertEquals(WorldDisposition.Kind.HOSTILE, WorldDisposition.kind(state.effectiveDisposition(npc)));
+        assertEquals(50, WorldDisposition.clamp(80));
+    }
+
+    @Test
+    void npcCannotBelongToTwoFactions() {
+        WorldNpc npc = new WorldNpc(1L, "Rivalin", 10L, "", "", "", "", WorldNpcLifecycleState.ACTIVE);
+        WorldFaction first = new WorldFaction(1L, "A", "", 20L, List.of(1L), List.of());
+        WorldFaction second = new WorldFaction(2L, "B", "", 21L, List.of(1L), List.of());
+        assertThrows(IllegalArgumentException.class,
+                () -> new WorldPlannerState(List.of(npc), List.of(first, second), List.of(), 2L, 3L, 1L, ""));
+    }
+}

--- a/test/src/view/leftbartabs/scene/SceneUiTest.java
+++ b/test/src/view/leftbartabs/scene/SceneUiTest.java
@@ -1,0 +1,168 @@
+package src.view.leftbartabs.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextField;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import shell.api.ShellBinding;
+import shell.api.ShellSlot;
+import src.domain.party.published.ActivePartyModel;
+import src.domain.party.published.ActivePartyResult;
+import src.domain.party.published.PartyMemberSummary;
+import src.domain.party.published.ReadStatus;
+import src.domain.scene.SceneServiceAssembly;
+import src.domain.scene.model.SceneWorkspace;
+import src.domain.scene.model.repository.SceneWorkspaceRepository;
+import src.domain.sessionplanner.published.PreparedSceneCatalog;
+import src.domain.worldplanner.published.WorldPlannerReadStatus;
+import src.domain.worldplanner.published.WorldPlannerSnapshot;
+import src.domain.worldplanner.published.WorldPlannerSnapshotModel;
+
+@org.junit.jupiter.api.Tag("ui")
+final class SceneUiTest {
+    private static final int AWAIT_SECONDS = 60;
+    private static final AtomicBoolean FX_STARTED = new AtomicBoolean();
+
+    @AfterAll
+    static void stopFx() {
+        if (FX_STARTED.get()) {
+            testsupport.JavaFxRuntime.shutdown();
+        }
+    }
+
+    @Test
+    void sceneTabCreatesSplitAndMovesPcDirectly() throws Exception {
+        runOnFxThread(() -> {
+            SceneServiceAssembly scenes = services();
+            ShellBinding binding = new SceneContribution(scenes).bind();
+            Parent controls = (Parent) binding.slotContent().get(ShellSlot.COCKPIT_CONTROLS);
+            Parent main = (Parent) binding.slotContent().get(ShellSlot.COCKPIT_MAIN);
+
+            assertTrue(labels(main).containsAll(List.of("PCs", "NPCs", "Ort")));
+            textField(controls, "Neue Szene").setText("Spähtrupp");
+            button(controls, "Szene anlegen").fire();
+            button(main, "Hierher").fire();
+
+            assertEquals(2L, scenes.model().current().activePartyMembers().getFirst().sceneId());
+            assertTrue(labels(main).stream().anyMatch(text -> text.contains("PC 1 · Stufe 3")));
+        });
+    }
+
+    private static SceneServiceAssembly services() {
+        ActivePartyModel party = new ActivePartyModel();
+        party.publish(new ActivePartyResult(
+                ReadStatus.SUCCESS,
+                List.of(new PartyMemberSummary(1L, "PC 1", 3))));
+        WorldPlannerSnapshotModel world = new WorldPlannerSnapshotModel();
+        world.publish(new WorldPlannerSnapshot(
+                WorldPlannerReadStatus.SUCCESS, List.of(), List.of(), List.of(), ""));
+        return new SceneServiceAssembly(
+                new MemoryRepository(),
+                party,
+                world,
+                () -> new PreparedSceneCatalog(List.of(), ""),
+                command -> new src.domain.encounter.published.EncounterRuntimeContextApi.SyncResult(true, ""));
+    }
+
+    private static TextField textField(Parent root, String prompt) {
+        return descendants(root).stream()
+                .filter(TextField.class::isInstance)
+                .map(TextField.class::cast)
+                .filter(field -> prompt.equals(field.getPromptText()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static Button button(Parent root, String text) {
+        return descendants(root).stream()
+                .filter(Button.class::isInstance)
+                .map(Button.class::cast)
+                .filter(button -> text.equals(button.getText()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static List<String> labels(Parent root) {
+        return descendants(root).stream()
+                .filter(Label.class::isInstance)
+                .map(Label.class::cast)
+                .map(Label::getText)
+                .toList();
+    }
+
+    private static List<Node> descendants(Parent root) {
+        List<Node> nodes = new ArrayList<>();
+        for (Node child : root.getChildrenUnmodifiable()) {
+            nodes.add(child);
+            if (child instanceof ScrollPane scroll && scroll.getContent() instanceof Parent content) {
+                nodes.add(content);
+                nodes.addAll(descendants(content));
+            }
+            if (child instanceof Parent parent) {
+                nodes.addAll(descendants(parent));
+            }
+        }
+        return nodes;
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        startFx();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable throwable) {
+                failure.set(throwable);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(AWAIT_SECONDS, TimeUnit.SECONDS)) {
+            throw new AssertionError("FX test timed out.");
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("FX test failed.", failure.get());
+        }
+    }
+
+    private static void startFx() throws InterruptedException {
+        if (FX_STARTED.compareAndSet(false, true)) {
+            CountDownLatch latch = new CountDownLatch(1);
+            testsupport.JavaFxRuntime.startup(latch::countDown);
+            if (!latch.await(AWAIT_SECONDS, TimeUnit.SECONDS)) {
+                throw new AssertionError("FX startup timed out.");
+            }
+        }
+    }
+
+    private static final class MemoryRepository implements SceneWorkspaceRepository {
+        private SceneWorkspace state;
+
+        @Override
+        public Optional<SceneWorkspace> load() {
+            return Optional.ofNullable(state);
+        }
+
+        @Override
+        public SceneWorkspace save(SceneWorkspace workspace) {
+            state = workspace;
+            return workspace;
+        }
+    }
+}


### PR DESCRIPTION
## Was geändert wurde

- Neuer Szenen-Tab für laufende GM-Szenen mit schneller Szenenauswahl, Notizen sowie getrennten Bereichen für PCs, NPCs und genau einen Ort.
- Party-Splits mit atomarem PC-Wechsel zwischen Szenen; nur PCs der fokussierten Szene werden in den Encounter-Kontext geladen.
- Dauerhafte Encounter-Kontexte pro Szene einschließlich Builder, Initiative, Kampf und Ergebnis; vorbereitete Session-Planner-Szenen werden als unabhängige Laufzeitkopie übernommen.
- World-Planner-Haltungen für Fraktionen und NPCs; feindliche bzw. freundliche Szenen-NPCs werden automatisch als Gegner bzw. Verbündete abgeglichen.
- SQLite-Persistenz, Domänen-/Architektur-/Vertragsdokumentation und neue Domain-, Persistenz-, Startup- und JavaFX-UI-Tests.

## Warum

Der GM benötigt eine Laufzeitoberfläche, die den aktuellen Szeneninhalt als eigene Wahrheit verwaltet und Party-Splits ohne Verlust des jeweiligen Encounter-Zustands unterstützt.

## Auswirkung

Szenen lassen sich während des Spiels schnell wechseln. PCs, Ort und NPC-Haltung steuern den jeweils sichtbaren Encounter-Kontext; andere Szenen behalten ihren Stand über Wechsel und Neustarts hinweg.

## Verifikation

- `git diff --check`
- `./gradlew check --console=plain` — BUILD SUCCESSFUL in 3m 15s auf Basis `codex/catalog-consolidation`
- `./gradlew installDesktopApp --console=plain` — BUILD SUCCESSFUL
