### PR TITLE
scene: card board with mobs and live participant state

### DIFF
--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -145,6 +145,8 @@ public final class AppBootstrap implements AutoCloseable {
                 world.snapshot(),
                 session.preparedScenes(),
                 encounter.runtimeContexts(),
+                creatures.catalog(),
+                creatures.application(),
                 executionLane,
                 uiDispatcher,
                 diagnostics);
@@ -193,7 +195,7 @@ public final class AppBootstrap implements AutoCloseable {
                 dungeon.travelContribution(),
                 hex.mapContribution(),
                 session.contribution(),
-                scene.contribution(),
+                scene.contribution(creatureId -> creatures.openInspector(inspector, creatureId)),
                 encounter.stateContribution(
                         creatures.application(), world.application(),
                         creatureId -> creatures.openInspector(inspector, creatureId)),

--- a/features/scene/SceneFeature.java
+++ b/features/scene/SceneFeature.java
@@ -1,5 +1,7 @@
 package features.scene;
 
+import features.creatures.api.CreatureCatalogModel;
+import features.creatures.api.CreaturesApi;
 import features.encounter.api.EncounterRuntimeContextApi;
 import features.party.api.ActivePartyModel;
 import features.scene.adapter.javafx.SceneContribution;
@@ -26,6 +28,8 @@ public final class SceneFeature {
             WorldPlannerSnapshotModel world,
             PreparedSceneCatalogModel preparedScenes,
             EncounterRuntimeContextApi encounters,
+            CreatureCatalogModel creatureCatalog,
+            CreaturesApi creatures,
             ExecutionLane executionLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
@@ -36,6 +40,8 @@ public final class SceneFeature {
                 world,
                 preparedScenes,
                 encounters,
+                creatureCatalog,
+                creatures,
                 executionLane,
                 uiDispatcher,
                 diagnostics);
@@ -49,8 +55,8 @@ public final class SceneFeature {
             model = Objects.requireNonNull(model, "model");
         }
 
-        public ShellContribution contribution() {
-            return new SceneContribution(application, model);
+        public ShellContribution contribution(java.util.function.LongConsumer openStatblock) {
+            return new SceneContribution(application, model, openStatblock);
         }
     }
 }

--- a/features/scene/adapter/javafx/SceneBinder.java
+++ b/features/scene/adapter/javafx/SceneBinder.java
@@ -3,6 +3,7 @@ package features.scene.adapter.javafx;
 import features.scene.api.SceneApi;
 import features.scene.api.SceneCommand;
 import features.scene.api.SceneModel;
+import features.scene.api.SceneParticipantKind;
 import features.scene.api.SceneSnapshot;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.LongConsumer;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -20,7 +22,6 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -32,6 +33,7 @@ final class SceneBinder {
 
     private final SceneApi scenes;
     private final SceneModel model;
+    private final LongConsumer openStatblock;
     private final VBox controls = new VBox(10.0);
     private final BorderPane main = new BorderPane();
     private final Map<Long, SceneDraft> sceneDrafts = new HashMap<>();
@@ -40,9 +42,10 @@ final class SceneBinder {
     private String newSceneDraft = "";
     private long pendingDeleteSceneId;
 
-    SceneBinder(SceneApi scenes, SceneModel model) {
+    SceneBinder(SceneApi scenes, SceneModel model, LongConsumer openStatblock) {
         this.scenes = Objects.requireNonNull(scenes, "scenes");
         this.model = Objects.requireNonNull(model, "model");
+        this.openStatblock = Objects.requireNonNull(openStatblock, "openStatblock");
     }
 
     ShellBinding bind() {
@@ -140,8 +143,10 @@ final class SceneBinder {
             main.setCenter(message("Keine fokussierte Szene verfügbar."));
             return;
         }
-        VBox content = new VBox(12.0, details(focused), assignmentGrid(snapshot, focused));
+        Node board = board(snapshot, focused);
+        VBox content = new VBox(12.0, locationBanner(snapshot, focused), details(focused), board);
         content.setFillWidth(true);
+        VBox.setVgrow(board, Priority.ALWAYS);
         main.setCenter(content);
     }
 
@@ -164,85 +169,248 @@ final class SceneBinder {
         return box;
     }
 
-    private Node assignmentGrid(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
-        GridPane grid = new GridPane();
-        grid.setHgap(10.0);
-        grid.setVgap(10.0);
-        grid.add(partyPanel(snapshot, scene), 0, 0);
-        grid.add(npcPanel(snapshot, scene), 1, 0);
-        grid.add(locationPanel(snapshot, scene), 2, 0);
-        for (int column = 0; column < 3; column++) {
-            GridPane.setHgrow(grid.getChildren().get(column), Priority.ALWAYS);
-            GridPane.setVgrow(grid.getChildren().get(column), Priority.ALWAYS);
-        }
-        return grid;
-    }
-
-    private Node partyPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
-        VBox rows = panel("PCs");
-        for (SceneSnapshot.PartyChoice member : snapshot.activePartyMembers()) {
-            boolean assignedHere = member.sceneId() == scene.sceneId();
-            String action = assignedHere ? "Entfernen" : "Hierher";
-            Runnable command = assignedHere
-                    ? () -> execute(new SceneCommand.UnassignPc(member.id()))
-                    : () -> execute(new SceneCommand.AssignPc(scene.sceneId(), member.id()));
-            rows.getChildren().add(row(member.name() + " · Stufe " + member.level(), action, command));
-        }
-        if (snapshot.activePartyMembers().isEmpty()) {
-            rows.getChildren().add(status("Keine aktiven PCs."));
-        }
-        return scroll(rows);
-    }
-
-    private Node npcPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
-        VBox rows = panel("NPCs");
-        for (SceneSnapshot.NpcChoice npc : scene.npcs()) {
-            rows.getChildren().add(row(npc.name(), "Entfernen",
-                    () -> execute(new SceneCommand.UnassignNpc(npc.id()))));
-        }
-        for (SceneSnapshot.NpcChoice npc : snapshot.availableNpcs()) {
-            if (scene.npcs().stream().noneMatch(selected -> selected.id() == npc.id())) {
-                rows.getChildren().add(row(npc.name(), "Hierher",
-                        () -> execute(new SceneCommand.AssignNpc(scene.sceneId(), npc.id()))));
-            }
-        }
-        if (scene.npcs().isEmpty() && snapshot.availableNpcs().isEmpty()) {
-            rows.getChildren().add(status("Keine World-Planner-NPCs."));
-        }
-        return scroll(rows);
-    }
-
-    private Node locationPanel(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
-        VBox rows = panel("Ort");
+    private Node locationBanner(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
         ComboBox<LocationChoice> choices = new ComboBox<>();
-        choices.setMaxWidth(Double.MAX_VALUE);
         choices.getItems().add(new LocationChoice(0L, "Kein Ort"));
         snapshot.availableLocations().stream()
                 .map(location -> new LocationChoice(location.id(), location.name()))
                 .forEach(choices.getItems()::add);
         choices.getSelectionModel().select(choices.getItems().stream()
-                .filter(choice -> choice.id == scene.locationId())
+                .filter(choice -> choice.id() == scene.locationId())
                 .findFirst().orElse(choices.getItems().getFirst()));
-        rows.getChildren().addAll(
-                status(scene.locationName().isBlank() ? "Kein Ort gesetzt" : scene.locationName()),
-                choices,
-                button("Ort übernehmen", () -> {
-                    LocationChoice selected = choices.getValue();
-                    if (selected != null) {
-                        execute(new SceneCommand.SetLocation(scene.sceneId(), selected.id));
-                    }
-                }));
-        return scroll(rows);
+        Button apply = button("Ort übernehmen", () -> {
+            LocationChoice selected = choices.getValue();
+            if (selected != null) {
+                execute(new SceneCommand.SetLocation(scene.sceneId(), selected.id()));
+            }
+        });
+        Label pin = title("📍 " + (scene.locationName().isBlank() ? "Kein Ort gesetzt" : scene.locationName()));
+        HBox banner = new HBox(10.0, pin, choices, apply);
+        banner.setAlignment(Pos.CENTER_LEFT);
+        banner.setPadding(new Insets(10.0));
+        banner.getStyleClass().add("scene-board-location");
+        return banner;
     }
 
-    private static HBox row(String text, String action, Runnable handler) {
-        Label label = new Label(text);
-        label.setWrapText(true);
-        Region spacer = new Region();
-        HBox.setHgrow(spacer, Priority.ALWAYS);
-        HBox row = new HBox(6.0, label, spacer, button(action, handler));
+    private Node board(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        Node party = partyBoard(snapshot, scene);
+        Node npcs = npcBoard(snapshot, scene);
+        Node mobs = mobBoard(snapshot, scene);
+        VBox right = new VBox(12.0, npcs, mobs);
+        right.setFillWidth(true);
+        right.setPrefWidth(340.0);
+        right.setMinWidth(280.0);
+        VBox.setVgrow(npcs, Priority.ALWAYS);
+        VBox.setVgrow(mobs, Priority.ALWAYS);
+        HBox body = new HBox(12.0, party, right);
+        body.setFillHeight(true);
+        HBox.setHgrow(party, Priority.ALWAYS);
+        return body;
+    }
+
+    private Node partyBoard(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        HBox cards = new HBox(8.0);
+        cards.setAlignment(Pos.CENTER_LEFT);
+        for (SceneSnapshot.PartyChoice member : snapshot.activePartyMembers()) {
+            cards.getChildren().add(pcCard(scene, member));
+        }
+        if (snapshot.activePartyMembers().isEmpty()) {
+            cards.getChildren().add(status("Keine aktiven PCs."));
+        }
+        ScrollPane horizontal = new ScrollPane(cards);
+        horizontal.setFitToHeight(true);
+        horizontal.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        horizontal.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        VBox box = panel("Party");
+        box.getChildren().add(horizontal);
+        VBox.setVgrow(horizontal, Priority.ALWAYS);
+        return box;
+    }
+
+    private Node pcCard(SceneSnapshot.SceneEntry scene, SceneSnapshot.PartyChoice member) {
+        boolean assignedHere = member.sceneId() == scene.sceneId();
+        boolean assignedElsewhere = member.sceneId() > 0L && !assignedHere;
+        Runnable command = assignedHere
+                ? () -> execute(new SceneCommand.UnassignPc(member.id()))
+                : () -> execute(new SceneCommand.AssignPc(scene.sceneId(), member.id()));
+        VBox card = card(member.name());
+        card.getChildren().add(status("Stufe " + member.level()));
+        if (assignedElsewhere) {
+            card.getChildren().add(status("In anderer Szene"));
+        }
+        card.getChildren().add(button(assignedHere ? "Entfernen" : "Hierher", command));
+        if (assignedHere) {
+            decorateWithState(card, scene, SceneParticipantKind.PC, member.id());
+        }
+        return card;
+    }
+
+    private Node npcBoard(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        VBox rows = new VBox(8.0);
+        for (SceneSnapshot.NpcChoice npc : scene.npcs()) {
+            rows.getChildren().add(npcCard(scene, npc, true));
+        }
+        for (SceneSnapshot.NpcChoice npc : snapshot.availableNpcs()) {
+            if (scene.npcs().stream().noneMatch(selected -> selected.id() == npc.id())) {
+                rows.getChildren().add(npcCard(scene, npc, false));
+            }
+        }
+        if (scene.npcs().isEmpty() && snapshot.availableNpcs().isEmpty()) {
+            rows.getChildren().add(status("Keine World-Planner-NPCs."));
+        }
+        ScrollPane scroll = scroll(rows);
+        VBox box = panel("NPCs");
+        box.getChildren().add(scroll);
+        VBox.setVgrow(scroll, Priority.ALWAYS);
+        return box;
+    }
+
+    private Node npcCard(SceneSnapshot.SceneEntry scene, SceneSnapshot.NpcChoice npc, boolean assignedHere) {
+        VBox card = card(npc.name());
+        card.getChildren().add(status(npc.active() ? "Aktiv" : "Inaktiv"));
+        HBox actions = new HBox(6.0);
+        actions.setAlignment(Pos.CENTER_LEFT);
+        if (npc.statblockId() > 0L) {
+            actions.getChildren().add(button("Statblock", () -> openStatblock.accept(npc.statblockId())));
+        }
+        actions.getChildren().add(button(assignedHere ? "Entfernen" : "Hierher",
+                assignedHere
+                        ? () -> execute(new SceneCommand.UnassignNpc(npc.id()))
+                        : () -> execute(new SceneCommand.AssignNpc(scene.sceneId(), npc.id()))));
+        card.getChildren().add(actions);
+        if (assignedHere) {
+            decorateWithState(card, scene, SceneParticipantKind.NPC, npc.id());
+        }
+        return card;
+    }
+
+    private Node mobBoard(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        VBox rows = new VBox(8.0);
+        for (SceneSnapshot.MobChoice mob : scene.mobs()) {
+            rows.getChildren().add(mobCard(scene, mob));
+        }
+        if (scene.mobs().isEmpty()) {
+            rows.getChildren().add(status("Noch keine Mobs in dieser Szene."));
+        }
+        ScrollPane scroll = scroll(rows);
+        VBox box = panel("Mobs");
+        box.getChildren().add(mobAddControl(snapshot, scene));
+        box.getChildren().add(scroll);
+        VBox.setVgrow(scroll, Priority.ALWAYS);
+        return box;
+    }
+
+    private Node mobAddControl(SceneSnapshot snapshot, SceneSnapshot.SceneEntry scene) {
+        ComboBox<CreaturePick> choices = new ComboBox<>();
+        choices.setMaxWidth(Double.MAX_VALUE);
+        snapshot.availableCreatures().stream().map(CreaturePick::new).forEach(choices.getItems()::add);
+        if (!choices.getItems().isEmpty()) {
+            choices.getSelectionModel().selectFirst();
+        }
+        TextField count = new TextField("1");
+        count.setPrefColumnCount(3);
+        Button add = button("Mob hinzufügen", () -> {
+            CreaturePick selected = choices.getValue();
+            if (selected != null) {
+                execute(new SceneCommand.AssignMob(scene.sceneId(), selected.value.id(), parseCount(count.getText())));
+            }
+        });
+        add.setDisable(choices.getItems().isEmpty());
+        if (choices.getItems().isEmpty()) {
+            return new VBox(6.0, status("Kreaturen-Katalog wird geladen …"));
+        }
+        HBox row = new HBox(6.0, choices, count, add);
         row.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(choices, Priority.ALWAYS);
         return row;
+    }
+
+    private Node mobCard(SceneSnapshot.SceneEntry scene, SceneSnapshot.MobChoice mob) {
+        VBox card = card(mob.name() + "  ×" + mob.count());
+        card.getChildren().add(status(mobStats(mob)));
+        HBox actions = new HBox(6.0);
+        actions.setAlignment(Pos.CENTER_LEFT);
+        if (mob.creatureId() > 0L) {
+            actions.getChildren().add(button("Statblock", () -> openStatblock.accept(mob.creatureId())));
+        }
+        actions.getChildren().addAll(
+                button("−", () -> execute(new SceneCommand.SetMobCount(
+                        scene.sceneId(), mob.creatureId(), mob.count() - 1))),
+                button("+", () -> execute(new SceneCommand.SetMobCount(
+                        scene.sceneId(), mob.creatureId(), mob.count() + 1))),
+                button("Entfernen", () -> execute(new SceneCommand.UnassignMob(
+                        scene.sceneId(), mob.creatureId()))));
+        card.getChildren().add(actions);
+        decorateWithState(card, scene, SceneParticipantKind.MOB, mob.creatureId());
+        return card;
+    }
+
+    private void decorateWithState(
+            VBox card, SceneSnapshot.SceneEntry scene, SceneParticipantKind kind, long refId) {
+        SceneSnapshot.ParticipantStateView state = scene.participantState(kind, refId);
+        if (state.defeated()) {
+            card.getStyleClass().add("scene-board-card-defeated");
+            card.getChildren().add(status("Besiegt"));
+        }
+        Button toggle = button(
+                state.defeated() ? "Aktivieren" : "Besiegt",
+                () -> execute(new SceneCommand.SetParticipantDefeated(
+                        scene.sceneId(), kind, refId, !state.defeated())));
+        TextField note = new TextField(state.notes());
+        note.setPromptText("Notiz");
+        note.setOnAction(event -> commitNote(scene, kind, refId, note.getText(), state.notes()));
+        note.focusedProperty().addListener((observable, hadFocus, hasFocus) -> {
+            if (hadFocus && !hasFocus) {
+                commitNote(scene, kind, refId, note.getText(), state.notes());
+            }
+        });
+        card.getChildren().addAll(toggle, note);
+    }
+
+    private void commitNote(
+            SceneSnapshot.SceneEntry scene, SceneParticipantKind kind, long refId, String text, String previous) {
+        if (!text.trim().equals(previous)) {
+            execute(new SceneCommand.SetParticipantNotes(scene.sceneId(), kind, refId, text));
+        }
+    }
+
+    private static String mobStats(SceneSnapshot.MobChoice mob) {
+        StringBuilder builder = new StringBuilder();
+        if (!mob.challengeRating().isBlank()) {
+            builder.append("CR ").append(mob.challengeRating());
+        }
+        if (mob.hitPoints() > 0) {
+            append(builder, "HP " + mob.hitPoints());
+        }
+        if (mob.armorClass() > 0) {
+            append(builder, "AC " + mob.armorClass());
+        }
+        return builder.isEmpty() ? "Keine Statblock-Werte geladen." : builder.toString();
+    }
+
+    private static void append(StringBuilder builder, String value) {
+        if (!builder.isEmpty()) {
+            builder.append(" · ");
+        }
+        builder.append(value);
+    }
+
+    private static int parseCount(String text) {
+        try {
+            return Math.max(1, Integer.parseInt(text.trim()));
+        } catch (NumberFormatException exception) {
+            return 1;
+        }
+    }
+
+    private static VBox card(String name) {
+        Label heading = new Label(name);
+        heading.setWrapText(true);
+        heading.getStyleClass().add("scene-board-card-title");
+        VBox card = new VBox(4.0, heading);
+        card.setMinWidth(150.0);
+        card.getStyleClass().addAll("entity-card", "scene-board-card");
+        return card;
     }
 
     private static VBox panel(String heading) {
@@ -374,6 +542,15 @@ final class SceneBinder {
         @Override
         public String toString() {
             return name;
+        }
+    }
+
+    private record CreaturePick(SceneSnapshot.CreatureChoice value) {
+        @Override
+        public String toString() {
+            return value.challengeRating().isBlank()
+                    ? value.name()
+                    : value.name() + " (CR " + value.challengeRating() + ")";
         }
     }
 

--- a/features/scene/adapter/javafx/SceneContribution.java
+++ b/features/scene/adapter/javafx/SceneContribution.java
@@ -3,6 +3,7 @@ package features.scene.adapter.javafx;
 import features.scene.api.SceneApi;
 import features.scene.api.SceneModel;
 import java.util.Objects;
+import java.util.function.LongConsumer;
 import shell.api.ContributionKey;
 import shell.api.NavigationGraphicResource;
 import shell.api.NavigationGroupSpec;
@@ -16,10 +17,12 @@ public final class SceneContribution implements ShellContribution {
 
     private final SceneApi scenes;
     private final SceneModel model;
+    private final LongConsumer openStatblock;
 
-    public SceneContribution(SceneApi scenes, SceneModel model) {
+    public SceneContribution(SceneApi scenes, SceneModel model, LongConsumer openStatblock) {
         this.scenes = Objects.requireNonNull(scenes, "scenes");
         this.model = Objects.requireNonNull(model, "model");
+        this.openStatblock = Objects.requireNonNull(openStatblock, "openStatblock");
     }
 
     @Override
@@ -35,6 +38,6 @@ public final class SceneContribution implements ShellContribution {
 
     @Override
     public ShellBinding bind() {
-        return new SceneBinder(scenes, model).bind();
+        return new SceneBinder(scenes, model, openStatblock).bind();
     }
 }

--- a/features/scene/adapter/sqlite/SqliteSceneWorkspaceRepository.java
+++ b/features/scene/adapter/sqlite/SqliteSceneWorkspaceRepository.java
@@ -2,6 +2,9 @@ package features.scene.adapter.sqlite;
 
 import features.scene.application.SceneWorkspaceRepository;
 import features.scene.domain.RunningScene;
+import features.scene.domain.SceneMob;
+import features.scene.domain.SceneParticipantKind;
+import features.scene.domain.SceneParticipantState;
 import features.scene.domain.SceneWorkspace;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -25,12 +28,18 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
     private static final String SCENE_TABLE = "scene_running_scene";
     private static final String PC_TABLE = "scene_party_member";
     private static final String NPC_TABLE = "scene_npc";
+    private static final String MOB_TABLE = "scene_mob";
+    private static final String STATE_TABLE = "scene_participant_state";
 
     private final SqliteConnectionSource connections;
 
     public SqliteSceneWorkspaceRepository(SqliteDatabase database) {
         connections = Objects.requireNonNull(database, "database")
-                .connections(OWNER, new SqliteMigration(1, SqliteSceneWorkspaceRepository::createSchema));
+                .connections(
+                        OWNER,
+                        new SqliteMigration(1, SqliteSceneWorkspaceRepository::createSchema),
+                        new SqliteMigration(2, SqliteSceneWorkspaceRepository::createMobSchema),
+                        new SqliteMigration(3, SqliteSceneWorkspaceRepository::createParticipantStateSchema));
     }
 
     @Override
@@ -43,6 +52,8 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
             Map<Long, StoredScene> scenes = loadScenes(connection);
             loadAssignments(connection, PC_TABLE, scenes, true);
             loadAssignments(connection, NPC_TABLE, scenes, false);
+            loadMobs(connection, scenes);
+            loadParticipantStates(connection, scenes);
             List<RunningScene> runningScenes = scenes.values().stream().map(StoredScene::toDomain).toList();
             return Optional.of(workspace.toDomain(runningScenes));
         } catch (SQLException | IllegalArgumentException exception) {
@@ -92,6 +103,32 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
                     + "sort_order INTEGER NOT NULL CHECK(sort_order>=0))");
             statement.execute(assignmentTableSql(PC_TABLE, "party_member_external_id"));
             statement.execute(assignmentTableSql(NPC_TABLE, "npc_external_id"));
+        }
+    }
+
+    private static void createMobSchema(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS " + MOB_TABLE + " ("
+                    + "scene_id INTEGER NOT NULL, "
+                    + "creature_external_id INTEGER NOT NULL CHECK(creature_external_id>0), "
+                    + "count INTEGER NOT NULL CHECK(count>0), "
+                    + "sort_order INTEGER NOT NULL CHECK(sort_order>=0), "
+                    + "PRIMARY KEY(scene_id,creature_external_id), "
+                    + "FOREIGN KEY(scene_id) REFERENCES " + SCENE_TABLE + "(scene_id) ON DELETE CASCADE)");
+        }
+    }
+
+    private static void createParticipantStateSchema(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS " + STATE_TABLE + " ("
+                    + "scene_id INTEGER NOT NULL, "
+                    + "participant_kind TEXT NOT NULL CHECK(participant_kind IN ('PC','NPC','MOB')), "
+                    + "participant_ref_id INTEGER NOT NULL CHECK(participant_ref_id>0), "
+                    + "defeated INTEGER NOT NULL CHECK(defeated IN (0,1)), "
+                    + "notes TEXT NOT NULL, "
+                    + "sort_order INTEGER NOT NULL CHECK(sort_order>=0), "
+                    + "PRIMARY KEY(scene_id,participant_kind,participant_ref_id), "
+                    + "FOREIGN KEY(scene_id) REFERENCES " + SCENE_TABLE + "(scene_id) ON DELETE CASCADE)");
         }
     }
 
@@ -165,6 +202,38 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
         }
     }
 
+    private static void loadMobs(Connection connection, Map<Long, StoredScene> scenes) throws SQLException {
+        String sql = "SELECT scene_id,creature_external_id,count FROM " + MOB_TABLE + " ORDER BY scene_id,sort_order";
+        try (Statement statement = connection.createStatement(); ResultSet rows = statement.executeQuery(sql)) {
+            while (rows.next()) {
+                StoredScene scene = scenes.get(rows.getLong("scene_id"));
+                if (scene == null) {
+                    throw new SQLException("Scene mob references a missing owned scene");
+                }
+                scene.mobs.add(new SceneMob(rows.getLong("creature_external_id"), rows.getInt("count")));
+            }
+        }
+    }
+
+    private static void loadParticipantStates(
+            Connection connection, Map<Long, StoredScene> scenes) throws SQLException {
+        String sql = "SELECT scene_id,participant_kind,participant_ref_id,defeated,notes FROM " + STATE_TABLE
+                + " ORDER BY scene_id,sort_order";
+        try (Statement statement = connection.createStatement(); ResultSet rows = statement.executeQuery(sql)) {
+            while (rows.next()) {
+                StoredScene scene = scenes.get(rows.getLong("scene_id"));
+                if (scene == null) {
+                    throw new SQLException("Scene participant state references a missing owned scene");
+                }
+                scene.participantStates.add(new SceneParticipantState(
+                        SceneParticipantKind.valueOf(rows.getString("participant_kind")),
+                        rows.getLong("participant_ref_id"),
+                        rows.getInt("defeated") == 1,
+                        rows.getString("notes")));
+            }
+        }
+    }
+
     private static void writeWorkspace(Connection connection, SceneWorkspace workspace) throws SQLException {
         String sql = "INSERT INTO " + WORKSPACE_TABLE
                 + "(workspace_id,revision,next_scene_id,default_scene_id,focused_scene_id,"
@@ -187,12 +256,16 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
     private static void replaceScenes(Connection connection, List<RunningScene> scenes) throws SQLException {
         deleteAll(connection, PC_TABLE);
         deleteAll(connection, NPC_TABLE);
+        deleteAll(connection, MOB_TABLE);
+        deleteAll(connection, STATE_TABLE);
         deleteAll(connection, SCENE_TABLE);
         for (int index = 0; index < scenes.size(); index++) {
             RunningScene scene = scenes.get(index);
             insertScene(connection, scene, index);
             insertAssignments(connection, PC_TABLE, "party_member_external_id", scene.sceneId(), scene.partyMemberIds());
             insertAssignments(connection, NPC_TABLE, "npc_external_id", scene.sceneId(), scene.npcIds());
+            insertMobs(connection, scene.sceneId(), scene.mobs());
+            insertParticipantStates(connection, scene.sceneId(), scene.participantStates());
         }
     }
 
@@ -239,6 +312,40 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
         }
     }
 
+    private static void insertMobs(Connection connection, long sceneId, List<SceneMob> mobs) throws SQLException {
+        String sql = "INSERT INTO " + MOB_TABLE + "(scene_id,creature_external_id,count,sort_order) VALUES(?,?,?,?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (int index = 0; index < mobs.size(); index++) {
+                SceneMob mob = mobs.get(index);
+                statement.setLong(1, sceneId);
+                statement.setLong(2, mob.creatureId());
+                statement.setInt(3, mob.count());
+                statement.setInt(4, index);
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
+    private static void insertParticipantStates(
+            Connection connection, long sceneId, List<SceneParticipantState> states) throws SQLException {
+        String sql = "INSERT INTO " + STATE_TABLE
+                + "(scene_id,participant_kind,participant_ref_id,defeated,notes,sort_order) VALUES(?,?,?,?,?,?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (int index = 0; index < states.size(); index++) {
+                SceneParticipantState state = states.get(index);
+                statement.setLong(1, sceneId);
+                statement.setString(2, state.kind().name());
+                statement.setLong(3, state.refId());
+                statement.setInt(4, state.defeated() ? 1 : 0);
+                statement.setString(5, state.notes());
+                statement.setInt(6, index);
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
     private static void rollback(Connection connection, Exception original) {
         try {
             connection.rollback();
@@ -272,6 +379,8 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
         private final long locationId;
         private final List<Long> partyMemberIds = new ArrayList<>();
         private final List<Long> npcIds = new ArrayList<>();
+        private final List<SceneMob> mobs = new ArrayList<>();
+        private final List<SceneParticipantState> participantStates = new ArrayList<>();
 
         private StoredScene(
                 long sceneId,
@@ -295,7 +404,8 @@ public final class SqliteSceneWorkspaceRepository implements SceneWorkspaceRepos
 
         private RunningScene toDomain() {
             return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
-                    sourceSessionName, initialEncounterPlanId, locationId, partyMemberIds, npcIds);
+                    sourceSessionName, initialEncounterPlanId, locationId,
+                    partyMemberIds, npcIds, mobs, participantStates);
         }
     }
 }

--- a/features/scene/api/SceneCommand.java
+++ b/features/scene/api/SceneCommand.java
@@ -35,4 +35,20 @@ public sealed interface SceneCommand {
     record UnassignNpc(long npcId) implements SceneCommand { }
 
     record SetLocation(long sceneId, long locationId) implements SceneCommand { }
+
+    record AssignMob(long sceneId, long creatureId, int count) implements SceneCommand { }
+
+    record UnassignMob(long sceneId, long creatureId) implements SceneCommand { }
+
+    record SetMobCount(long sceneId, long creatureId, int count) implements SceneCommand { }
+
+    record SetParticipantDefeated(
+            long sceneId, SceneParticipantKind kind, long refId, boolean defeated) implements SceneCommand { }
+
+    record SetParticipantNotes(
+            long sceneId, SceneParticipantKind kind, long refId, String notes) implements SceneCommand {
+        public SetParticipantNotes {
+            notes = notes == null ? "" : notes.trim();
+        }
+    }
 }

--- a/features/scene/api/SceneParticipantKind.java
+++ b/features/scene/api/SceneParticipantKind.java
@@ -1,0 +1,8 @@
+package features.scene.api;
+
+/** Kind of a scene participant addressed by live-status and note commands. */
+public enum SceneParticipantKind {
+    PC,
+    NPC,
+    MOB
+}

--- a/features/scene/api/SceneSnapshot.java
+++ b/features/scene/api/SceneSnapshot.java
@@ -10,6 +10,7 @@ public record SceneSnapshot(
         List<PartyChoice> activePartyMembers,
         List<NpcChoice> availableNpcs,
         List<LocationChoice> availableLocations,
+        List<CreatureChoice> availableCreatures,
         List<PreparedChoice> preparedScenes,
         boolean initialized,
         boolean encounterSynchronized,
@@ -24,13 +25,14 @@ public record SceneSnapshot(
         activePartyMembers = copy(activePartyMembers);
         availableNpcs = copy(availableNpcs);
         availableLocations = copy(availableLocations);
+        availableCreatures = copy(availableCreatures);
         preparedScenes = copy(preparedScenes);
         statusText = statusText == null ? "" : statusText;
     }
 
     public static SceneSnapshot uninitialized() {
         return new SceneSnapshot(0L, 0L, 0L, List.of(), List.of(), List.of(), List.of(), List.of(),
-                false, false, "Szenen werden geladen.");
+                List.of(), false, false, "Szenen werden geladen.");
     }
 
     public record SceneEntry(
@@ -44,7 +46,9 @@ public record SceneSnapshot(
             long locationId,
             String locationName,
             List<PartyChoice> partyMembers,
-            List<NpcChoice> npcs
+            List<NpcChoice> npcs,
+            List<MobChoice> mobs,
+            List<ParticipantStateView> participantStates
     ) {
         public SceneEntry {
             title = normalized(title, "Szene " + sceneId);
@@ -53,6 +57,22 @@ public record SceneSnapshot(
             locationName = locationName == null ? "" : locationName;
             partyMembers = copy(partyMembers);
             npcs = copy(npcs);
+            mobs = copy(mobs);
+            participantStates = copy(participantStates);
+        }
+
+        public ParticipantStateView participantState(SceneParticipantKind kind, long refId) {
+            return participantStates.stream()
+                    .filter(state -> state.kind() == kind && state.refId() == refId)
+                    .findFirst()
+                    .orElse(new ParticipantStateView(kind, refId, false, ""));
+        }
+    }
+
+    public record ParticipantStateView(SceneParticipantKind kind, long refId, boolean defeated, String notes) {
+        public ParticipantStateView {
+            refId = Math.max(0L, refId);
+            notes = notes == null ? "" : notes;
         }
     }
 
@@ -92,6 +112,34 @@ public record SceneSnapshot(
         public LocationChoice {
             name = normalized(name, "Ort #" + id);
             sceneIds = copy(sceneIds);
+        }
+    }
+
+    public record CreatureChoice(
+            long id,
+            String name,
+            String challengeRating,
+            int hitPoints,
+            int armorClass
+    ) {
+        public CreatureChoice {
+            name = normalized(name, "Kreatur #" + id);
+            challengeRating = challengeRating == null ? "" : challengeRating;
+        }
+    }
+
+    public record MobChoice(
+            long creatureId,
+            String name,
+            int count,
+            String challengeRating,
+            int hitPoints,
+            int armorClass
+    ) {
+        public MobChoice {
+            name = normalized(name, "Kreatur #" + creatureId);
+            count = Math.max(0, count);
+            challengeRating = challengeRating == null ? "" : challengeRating;
         }
     }
 

--- a/features/scene/application/SceneApplicationService.java
+++ b/features/scene/application/SceneApplicationService.java
@@ -1,5 +1,9 @@
 package features.scene.application;
 
+import features.creatures.api.CreatureCatalogModel;
+import features.creatures.api.CreatureQueryStatus;
+import features.creatures.api.CreaturesApi;
+import features.creatures.api.RefreshCreatureCatalogCommand;
 import features.encounter.api.EncounterRuntimeContextApi;
 import features.encounter.api.EncounterRuntimeContextId;
 import features.encounter.api.EncounterRuntimeContextSpec;
@@ -15,6 +19,7 @@ import features.scene.api.SceneApi;
 import features.scene.api.SceneCommand;
 import features.scene.api.SceneModel;
 import features.scene.api.SceneMutationResult;
+import features.scene.api.SceneParticipantKind;
 import features.scene.api.SceneSnapshot;
 import features.scene.domain.RunningScene;
 import features.scene.domain.SceneWorkspace;
@@ -46,6 +51,8 @@ public final class SceneApplicationService implements SceneApi {
     private final WorldPlannerSnapshotModel world;
     private final PreparedSceneCatalogModel preparedScenes;
     private final EncounterRuntimeContextApi encounters;
+    private final CreatureCatalogModel creatureCatalog;
+    private final CreaturesApi creatures;
     private final ExecutionLane executionLane;
     private final Diagnostics diagnostics;
     private final SceneProjection projection = new SceneProjection();
@@ -59,6 +66,8 @@ public final class SceneApplicationService implements SceneApi {
             WorldPlannerSnapshotModel world,
             PreparedSceneCatalogModel preparedScenes,
             EncounterRuntimeContextApi encounters,
+            CreatureCatalogModel creatureCatalog,
+            CreaturesApi creatures,
             ExecutionLane executionLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
@@ -68,6 +77,8 @@ public final class SceneApplicationService implements SceneApi {
         this.world = Objects.requireNonNull(world, "world");
         this.preparedScenes = Objects.requireNonNull(preparedScenes, "preparedScenes");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
+        this.creatureCatalog = Objects.requireNonNull(creatureCatalog, "creatureCatalog");
+        this.creatures = Objects.requireNonNull(creatures, "creatures");
         this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
         this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
         publishedState = new ScenePublishedState(Objects.requireNonNull(uiDispatcher, "uiDispatcher"));
@@ -159,6 +170,27 @@ public final class SceneApplicationService implements SceneApi {
         }
         if (command instanceof SceneCommand.UnassignNpc unassign) {
             return current.unassignNpc(unassign.npcId());
+        }
+        if (command instanceof SceneCommand.AssignMob assign) {
+            requireCreature(assign.creatureId());
+            return current.assignMob(assign.sceneId(), assign.creatureId(), assign.count());
+        }
+        if (command instanceof SceneCommand.UnassignMob unassign) {
+            return current.unassignMob(unassign.sceneId(), unassign.creatureId());
+        }
+        if (command instanceof SceneCommand.SetMobCount setCount) {
+            if (setCount.count() > 0) {
+                requireCreature(setCount.creatureId());
+            }
+            return current.setMobCount(setCount.sceneId(), setCount.creatureId(), setCount.count());
+        }
+        if (command instanceof SceneCommand.SetParticipantDefeated defeated) {
+            return current.setParticipantDefeated(
+                    defeated.sceneId(), domainKind(defeated.kind()), defeated.refId(), defeated.defeated());
+        }
+        if (command instanceof SceneCommand.SetParticipantNotes notes) {
+            return current.setParticipantNotes(
+                    notes.sceneId(), domainKind(notes.kind()), notes.refId(), notes.notes());
         }
         SceneCommand.SetLocation location = (SceneCommand.SetLocation) command;
         if (location.locationId() > 0L) {
@@ -370,6 +402,14 @@ public final class SceneApplicationService implements SceneApi {
         }
     }
 
+    private void requireCreature(long id) {
+        boolean known = creatureCatalog.current().status() == CreatureQueryStatus.SUCCESS
+                && creatureCatalog.current().page().rows().stream().anyMatch(row -> row.id() == id);
+        if (!known) {
+            throw new MissingForeignReferenceException("Kreatur nicht gefunden.");
+        }
+    }
+
     private void publishCurrent() {
         if (workspace == null) {
             return;
@@ -378,7 +418,8 @@ public final class SceneApplicationService implements SceneApi {
                 workspace,
                 party.current(),
                 world.current(),
-                preparedScenes.current()));
+                preparedScenes.current(),
+                creatureCatalog.current()));
     }
 
     private void scheduleProjectionRefresh() {
@@ -397,6 +438,22 @@ public final class SceneApplicationService implements SceneApi {
         party.subscribe(ignored -> execute(new SceneCommand.Refresh()));
         world.subscribe(ignored -> execute(new SceneCommand.Refresh()));
         preparedScenes.subscribe(ignored -> scheduleProjectionRefresh());
+        creatureCatalog.subscribe(ignored -> scheduleProjectionRefresh());
+        creatures.refreshCatalog(catalogRefreshCommand());
+    }
+
+    private static features.scene.domain.SceneParticipantKind domainKind(SceneParticipantKind kind) {
+        return switch (kind) {
+            case PC -> features.scene.domain.SceneParticipantKind.PC;
+            case NPC -> features.scene.domain.SceneParticipantKind.NPC;
+            case MOB -> features.scene.domain.SceneParticipantKind.MOB;
+        };
+    }
+
+    private static RefreshCreatureCatalogCommand catalogRefreshCommand() {
+        return new RefreshCreatureCatalogCommand(
+                null, null, null, List.of(), List.of(), List.of(), List.of(), List.of(),
+                null, null, 500, 0);
     }
 
     private SceneMutationResult storageError(RuntimeException exception) {

--- a/features/scene/application/SceneProjection.java
+++ b/features/scene/application/SceneProjection.java
@@ -1,17 +1,25 @@
 package features.scene.application;
 
+import features.creatures.api.CreatureCatalogPageResult;
+import features.creatures.api.CreatureCatalogRow;
+import features.creatures.api.CreatureQueryStatus;
 import features.party.api.ActivePartyResult;
 import features.party.api.PartyMemberSummary;
 import features.party.api.ReadStatus;
+import features.scene.api.SceneParticipantKind;
 import features.scene.api.SceneSnapshot;
 import features.scene.domain.RunningScene;
+import features.scene.domain.SceneMob;
+import features.scene.domain.SceneParticipantState;
 import features.scene.domain.SceneWorkspace;
 import features.sessionplanner.api.PreparedSceneCatalogSnapshot;
 import features.worldplanner.api.WorldLocationSummary;
 import features.worldplanner.api.WorldNpcLifecycleStatus;
 import features.worldplanner.api.WorldNpcSummary;
 import features.worldplanner.api.WorldPlannerSnapshot;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 final class SceneProjection {
 
@@ -19,11 +27,13 @@ final class SceneProjection {
             SceneWorkspace workspace,
             ActivePartyResult party,
             WorldPlannerSnapshot world,
-            PreparedSceneCatalogSnapshot prepared
+            PreparedSceneCatalogSnapshot prepared,
+            CreatureCatalogPageResult catalog
     ) {
         List<PartyMemberSummary> members = party.status() == ReadStatus.SUCCESS ? party.members() : List.of();
+        Map<Long, CreatureCatalogRow> creaturesById = creatureIndex(catalog);
         List<SceneSnapshot.SceneEntry> scenes = workspace.scenes().stream()
-                .map(scene -> sceneEntry(workspace, scene, members, world))
+                .map(scene -> sceneEntry(workspace, scene, members, world, creaturesById))
                 .toList();
         List<SceneSnapshot.PartyChoice> partyChoices = members.stream()
                 .map(member -> partyChoice(member, sceneForPc(workspace, member.id())))
@@ -33,6 +43,9 @@ final class SceneProjection {
                 .toList();
         List<SceneSnapshot.LocationChoice> locationChoices = world.locations().stream()
                 .map(location -> locationChoice(workspace, location))
+                .toList();
+        List<SceneSnapshot.CreatureChoice> creatureChoices = creaturesById.values().stream()
+                .map(SceneProjection::creatureChoice)
                 .toList();
         List<SceneSnapshot.PreparedChoice> preparedChoices = prepared.scenes().stream()
                 .map(source -> new SceneSnapshot.PreparedChoice(
@@ -46,23 +59,44 @@ final class SceneProjection {
                 partyChoices,
                 npcChoices,
                 locationChoices,
+                creatureChoices,
                 preparedChoices,
                 true,
                 workspace.encounterSynchronized(),
                 status(workspace, party));
     }
 
+    private static Map<Long, CreatureCatalogRow> creatureIndex(CreatureCatalogPageResult catalog) {
+        Map<Long, CreatureCatalogRow> index = new LinkedHashMap<>();
+        if (catalog != null && catalog.status() == CreatureQueryStatus.SUCCESS) {
+            catalog.page().rows().forEach(row -> index.putIfAbsent(row.id(), row));
+        }
+        return index;
+    }
+
+    private static SceneSnapshot.CreatureChoice creatureChoice(CreatureCatalogRow row) {
+        return new SceneSnapshot.CreatureChoice(
+                row.id(), row.name(), row.challengeRating(), row.hitPoints(), row.armorClass());
+    }
+
     private static SceneSnapshot.SceneEntry sceneEntry(
             SceneWorkspace workspace,
             RunningScene scene,
             List<PartyMemberSummary> members,
-            WorldPlannerSnapshot world
+            WorldPlannerSnapshot world,
+            Map<Long, CreatureCatalogRow> creaturesById
     ) {
         List<SceneSnapshot.PartyChoice> sceneMembers = scene.partyMemberIds().stream()
                 .map(id -> partyChoice(findMember(members, id), scene.sceneId()))
                 .toList();
         List<SceneSnapshot.NpcChoice> sceneNpcs = scene.npcIds().stream()
                 .map(id -> npcChoice(findNpc(world, id), id, scene.sceneId()))
+                .toList();
+        List<SceneSnapshot.MobChoice> sceneMobs = scene.mobs().stream()
+                .map(mob -> mobChoice(mob, creaturesById.get(mob.creatureId())))
+                .toList();
+        List<SceneSnapshot.ParticipantStateView> states = scene.participantStates().stream()
+                .map(SceneProjection::participantStateView)
                 .toList();
         return new SceneSnapshot.SceneEntry(
                 scene.sceneId(),
@@ -76,7 +110,31 @@ final class SceneProjection {
                 scene.locationId(),
                 locationName(world, scene.locationId()),
                 sceneMembers,
-                sceneNpcs);
+                sceneNpcs,
+                sceneMobs,
+                states);
+    }
+
+    private static SceneSnapshot.ParticipantStateView participantStateView(SceneParticipantState state) {
+        return new SceneSnapshot.ParticipantStateView(
+                apiKind(state.kind()), state.refId(), state.defeated(), state.notes());
+    }
+
+    private static SceneParticipantKind apiKind(features.scene.domain.SceneParticipantKind kind) {
+        return switch (kind) {
+            case PC -> SceneParticipantKind.PC;
+            case NPC -> SceneParticipantKind.NPC;
+            case MOB -> SceneParticipantKind.MOB;
+        };
+    }
+
+    private static SceneSnapshot.MobChoice mobChoice(SceneMob mob, CreatureCatalogRow row) {
+        return row == null
+                ? new SceneSnapshot.MobChoice(
+                        mob.creatureId(), "Kreatur #" + mob.creatureId(), mob.count(), "", 0, 0)
+                : new SceneSnapshot.MobChoice(
+                        mob.creatureId(), row.name(), mob.count(),
+                        row.challengeRating(), row.hitPoints(), row.armorClass());
     }
 
     private static PartyMemberSummary findMember(List<PartyMemberSummary> members, long id) {

--- a/features/scene/domain/RunningScene.java
+++ b/features/scene/domain/RunningScene.java
@@ -1,5 +1,7 @@
 package features.scene.domain;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public record RunningScene(
@@ -12,7 +14,9 @@ public record RunningScene(
         long initialEncounterPlanId,
         long locationId,
         List<Long> partyMemberIds,
-        List<Long> npcIds
+        List<Long> npcIds,
+        List<SceneMob> mobs,
+        List<SceneParticipantState> participantStates
 ) {
 
     public RunningScene {
@@ -28,31 +32,69 @@ public record RunningScene(
         locationId = Math.max(0L, locationId);
         partyMemberIds = positiveDistinct(partyMemberIds);
         npcIds = positiveDistinct(npcIds);
+        mobs = normalizeMobs(mobs);
+        participantStates = normalizeStates(participantStates, partyMemberIds, npcIds, mobs);
     }
 
     public static RunningScene defaultScene(List<Long> activePartyMemberIds) {
         return new RunningScene(1L, "Standardszene", "", 0L, 0L, "", 0L, 0L,
-                activePartyMemberIds, List.of());
+                activePartyMemberIds, List.of(), List.of(), List.of());
     }
 
     public RunningScene withDetails(String nextTitle, String nextNotes) {
         return new RunningScene(sceneId, nextTitle, nextNotes, sourceSessionId, sourceSceneId,
-                sourceSessionName, initialEncounterPlanId, locationId, partyMemberIds, npcIds);
+                sourceSessionName, initialEncounterPlanId, locationId,
+                partyMemberIds, npcIds, mobs, participantStates);
     }
 
     public RunningScene withPartyMembers(List<Long> ids) {
         return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
-                sourceSessionName, initialEncounterPlanId, locationId, ids, npcIds);
+                sourceSessionName, initialEncounterPlanId, locationId,
+                ids, npcIds, mobs, participantStates);
     }
 
     public RunningScene withNpcs(List<Long> ids) {
         return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
-                sourceSessionName, initialEncounterPlanId, locationId, partyMemberIds, ids);
+                sourceSessionName, initialEncounterPlanId, locationId,
+                partyMemberIds, ids, mobs, participantStates);
+    }
+
+    public RunningScene withMobs(List<SceneMob> nextMobs) {
+        return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
+                sourceSessionName, initialEncounterPlanId, locationId,
+                partyMemberIds, npcIds, nextMobs, participantStates);
     }
 
     public RunningScene withLocation(long id) {
         return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
-                sourceSessionName, initialEncounterPlanId, id, partyMemberIds, npcIds);
+                sourceSessionName, initialEncounterPlanId, id,
+                partyMemberIds, npcIds, mobs, participantStates);
+    }
+
+    public RunningScene withParticipantState(SceneParticipantState state) {
+        List<SceneParticipantState> next = new ArrayList<>();
+        boolean replaced = false;
+        for (SceneParticipantState existing : participantStates) {
+            if (existing.addressesSameParticipant(state.kind(), state.refId())) {
+                next.add(state);
+                replaced = true;
+            } else {
+                next.add(existing);
+            }
+        }
+        if (!replaced) {
+            next.add(state);
+        }
+        return new RunningScene(sceneId, title, notes, sourceSessionId, sourceSceneId,
+                sourceSessionName, initialEncounterPlanId, locationId,
+                partyMemberIds, npcIds, mobs, next);
+    }
+
+    public SceneParticipantState participantState(SceneParticipantKind kind, long refId) {
+        return participantStates.stream()
+                .filter(state -> state.addressesSameParticipant(kind, refId))
+                .findFirst()
+                .orElse(new SceneParticipantState(kind, refId, false, ""));
     }
 
     private static String normalizeTitle(String value, long id) {
@@ -65,5 +107,49 @@ public record RunningScene(
                 .filter(id -> id != null && id.longValue() > 0L)
                 .distinct()
                 .toList();
+    }
+
+    private static List<SceneMob> normalizeMobs(List<SceneMob> values) {
+        if (values == null) {
+            return List.of();
+        }
+        LinkedHashMap<Long, SceneMob> byCreature = new LinkedHashMap<>();
+        for (SceneMob mob : values) {
+            if (mob != null) {
+                byCreature.put(mob.creatureId(), mob);
+            }
+        }
+        return List.copyOf(byCreature.values());
+    }
+
+    private static List<SceneParticipantState> normalizeStates(
+            List<SceneParticipantState> values,
+            List<Long> partyMemberIds,
+            List<Long> npcIds,
+            List<SceneMob> mobs
+    ) {
+        if (values == null) {
+            return List.of();
+        }
+        LinkedHashMap<String, SceneParticipantState> byParticipant = new LinkedHashMap<>();
+        for (SceneParticipantState state : values) {
+            if (state != null && isPresent(state, partyMemberIds, npcIds, mobs)) {
+                byParticipant.put(state.kind() + ":" + state.refId(), state);
+            }
+        }
+        return List.copyOf(byParticipant.values());
+    }
+
+    private static boolean isPresent(
+            SceneParticipantState state,
+            List<Long> partyMemberIds,
+            List<Long> npcIds,
+            List<SceneMob> mobs
+    ) {
+        return switch (state.kind()) {
+            case PC -> partyMemberIds.contains(state.refId());
+            case NPC -> npcIds.contains(state.refId());
+            case MOB -> mobs.stream().anyMatch(mob -> mob.creatureId() == state.refId());
+        };
     }
 }

--- a/features/scene/domain/SceneMob.java
+++ b/features/scene/domain/SceneMob.java
@@ -1,0 +1,18 @@
+package features.scene.domain;
+
+/** A nameless mob group in a scene: a catalog creature with a headcount. */
+public record SceneMob(long creatureId, int count) {
+
+    public SceneMob {
+        if (creatureId <= 0L) {
+            throw new IllegalArgumentException("creatureId must be positive");
+        }
+        if (count <= 0) {
+            throw new IllegalArgumentException("count must be positive");
+        }
+    }
+
+    public SceneMob withCount(int nextCount) {
+        return new SceneMob(creatureId, nextCount);
+    }
+}

--- a/features/scene/domain/SceneParticipantKind.java
+++ b/features/scene/domain/SceneParticipantKind.java
@@ -1,0 +1,8 @@
+package features.scene.domain;
+
+/** Kind of a scene participant that can carry live status and notes. */
+public enum SceneParticipantKind {
+    PC,
+    NPC,
+    MOB
+}

--- a/features/scene/domain/SceneParticipantState.java
+++ b/features/scene/domain/SceneParticipantState.java
@@ -1,0 +1,24 @@
+package features.scene.domain;
+
+/** Per-scene live state for one participant: defeated flag and a quick note. */
+public record SceneParticipantState(
+        SceneParticipantKind kind,
+        long refId,
+        boolean defeated,
+        String notes
+) {
+
+    public SceneParticipantState {
+        if (kind == null) {
+            throw new IllegalArgumentException("kind is required");
+        }
+        if (refId <= 0L) {
+            throw new IllegalArgumentException("refId must be positive");
+        }
+        notes = notes == null ? "" : notes.trim();
+    }
+
+    public boolean addressesSameParticipant(SceneParticipantKind otherKind, long otherRefId) {
+        return kind == otherKind && refId == otherRefId;
+    }
+}

--- a/features/scene/domain/SceneWorkspace.java
+++ b/features/scene/domain/SceneWorkspace.java
@@ -41,7 +41,7 @@ public record SceneWorkspace(
 
     public SceneWorkspace create(String title) {
         RunningScene created = new RunningScene(nextSceneId, title, "", 0L, 0L, "", 0L, 0L,
-                List.of(), List.of());
+                List.of(), List.of(), List.of(), List.of());
         return changed(append(scenes, created), nextSceneId, nextSceneId + 1L, "Szene erstellt.");
     }
 
@@ -57,7 +57,8 @@ public record SceneWorkspace(
             String status
     ) {
         RunningScene imported = new RunningScene(nextSceneId, title, notes, sourceSessionId, sourceSceneId,
-                sourceSessionName, initialEncounterPlanId, locationId, partyMemberIds, List.of());
+                sourceSessionName, initialEncounterPlanId, locationId,
+                partyMemberIds, List.of(), List.of(), List.of());
         return changed(append(scenes, imported), nextSceneId, nextSceneId + 1L, status);
     }
 
@@ -120,6 +121,91 @@ public record SceneWorkspace(
             throw new IllegalArgumentException("locationId must not be negative");
         }
         return replace(requireScene(sceneId).withLocation(locationId), focusedSceneId, "Ort aktualisiert.");
+    }
+
+    public SceneWorkspace assignMob(long sceneId, long creatureId, int count) {
+        RunningScene scene = requireScene(sceneId);
+        requirePositive(creatureId, "creatureId");
+        if (count <= 0) {
+            throw new IllegalArgumentException("count must be positive");
+        }
+        List<SceneMob> mobs = new ArrayList<>(scene.mobs());
+        int index = indexOfMob(mobs, creatureId);
+        if (index >= 0) {
+            mobs.set(index, mobs.get(index).withCount(mobs.get(index).count() + count));
+        } else {
+            mobs.add(new SceneMob(creatureId, count));
+        }
+        return replace(scene.withMobs(List.copyOf(mobs)), focusedSceneId, "Mob hinzugefügt.");
+    }
+
+    public SceneWorkspace unassignMob(long sceneId, long creatureId) {
+        RunningScene scene = requireScene(sceneId);
+        List<SceneMob> mobs = scene.mobs().stream()
+                .filter(mob -> mob.creatureId() != creatureId)
+                .toList();
+        return replace(scene.withMobs(mobs), focusedSceneId, "Mob entfernt.");
+    }
+
+    public SceneWorkspace setMobCount(long sceneId, long creatureId, int count) {
+        RunningScene scene = requireScene(sceneId);
+        List<SceneMob> mobs;
+        if (count <= 0) {
+            mobs = scene.mobs().stream().filter(mob -> mob.creatureId() != creatureId).toList();
+        } else {
+            List<SceneMob> updated = new ArrayList<>();
+            boolean found = false;
+            for (SceneMob mob : scene.mobs()) {
+                if (mob.creatureId() == creatureId) {
+                    updated.add(mob.withCount(count));
+                    found = true;
+                } else {
+                    updated.add(mob);
+                }
+            }
+            if (!found) {
+                updated.add(new SceneMob(creatureId, count));
+            }
+            mobs = List.copyOf(updated);
+        }
+        return replace(scene.withMobs(mobs), focusedSceneId, "Mob-Anzahl aktualisiert.");
+    }
+
+    private static int indexOfMob(List<SceneMob> mobs, long creatureId) {
+        for (int index = 0; index < mobs.size(); index++) {
+            if (mobs.get(index).creatureId() == creatureId) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    public SceneWorkspace setParticipantDefeated(
+            long sceneId, SceneParticipantKind kind, long refId, boolean defeated) {
+        RunningScene scene = requireScene(sceneId);
+        requireKind(kind);
+        requirePositive(refId, "refId");
+        SceneParticipantState current = scene.participantState(kind, refId);
+        RunningScene updated = scene.withParticipantState(
+                new SceneParticipantState(kind, refId, defeated, current.notes()));
+        return replace(updated, focusedSceneId, defeated ? "Als besiegt markiert." : "Als aktiv markiert.");
+    }
+
+    public SceneWorkspace setParticipantNotes(
+            long sceneId, SceneParticipantKind kind, long refId, String notes) {
+        RunningScene scene = requireScene(sceneId);
+        requireKind(kind);
+        requirePositive(refId, "refId");
+        SceneParticipantState current = scene.participantState(kind, refId);
+        RunningScene updated = scene.withParticipantState(
+                new SceneParticipantState(kind, refId, current.defeated(), notes));
+        return replace(updated, focusedSceneId, "Notiz gespeichert.");
+    }
+
+    private static void requireKind(SceneParticipantKind kind) {
+        if (kind == null) {
+            throw new IllegalArgumentException("kind must be present");
+        }
     }
 
     public SceneWorkspace retainActivePartyMembers(Set<Long> activeIds) {

--- a/resources/salt-marcher.css
+++ b/resources/salt-marcher.css
@@ -1043,6 +1043,23 @@
     -fx-background-radius: 3;
     -fx-padding: 8 12 8 12;
 }
+.scene-board-location {
+    -fx-background-color: -sm-bg-elevated;
+    -fx-background-radius: 6;
+    -fx-border-color: -sm-border-subtle;
+    -fx-border-radius: 6;
+}
+.scene-board-card {
+    -fx-spacing: 4;
+}
+.scene-board-card-title {
+    -fx-font-weight: bold;
+    -fx-text-fill: -sm-text-primary;
+}
+.scene-board-card-defeated {
+    -fx-opacity: 0.55;
+    -fx-border-color: -sm-hp-critical;
+}
 .panel-title {
     -fx-font-size: 13px;
     -fx-font-weight: bold;

--- a/test/features/scene/adapter/javafx/SceneContributionTest.java
+++ b/test/features/scene/adapter/javafx/SceneContributionTest.java
@@ -4,6 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import features.creatures.api.CreatureCatalogModel;
+import features.creatures.api.CreatureCatalogPage;
+import features.creatures.api.CreatureCatalogPageResult;
+import features.creatures.api.CreatureCatalogRow;
+import features.creatures.api.CreatureQueryStatus;
+import features.creatures.api.CreaturesApi;
+import features.creatures.api.RefreshCreatureCatalogCommand;
+import features.creatures.api.RefreshCreatureEncounterCandidatesCommand;
+import features.creatures.api.RefreshCreatureFilterOptionsCommand;
+import features.creatures.api.SelectCreatureDetailCommand;
 import features.encounter.api.EncounterRuntimeContextApi;
 import features.encounter.api.EncounterRuntimeContextSyncResult;
 import features.party.api.ActivePartyModel;
@@ -59,7 +69,7 @@ final class SceneContributionTest {
     void contributionInitializesCreatesAndMovesPcThroughProductionCommands() throws Exception {
         runOnFxThread(() -> {
             SceneApplicationService application = application();
-            ShellBinding binding = new SceneContribution(application, application.model()).bind();
+            ShellBinding binding = new SceneContribution(application, application.model(), statblockId -> { }).bind();
             assertFalse(binding.slotContent().containsKey(ShellSlot.COCKPIT_STATE));
 
             binding.onActivate();
@@ -71,8 +81,9 @@ final class SceneContributionTest {
 
             assertEquals(2L, application.model().current().activePartyMembers().getFirst().sceneId());
             assertEquals("", textField(controls, "Neue Szene").getText());
-            assertTrue(labels(main).containsAll(List.of("PCs", "NPCs", "Ort")));
-            assertTrue(labels(main).stream().anyMatch(text -> text.contains("PC 1 · Stufe 3")));
+            assertTrue(labels(main).containsAll(List.of("Party", "NPCs", "Mobs")));
+            assertTrue(labels(main).contains("PC 1"));
+            assertTrue(labels(main).stream().anyMatch(text -> text.contains("Stufe 3")));
         });
     }
 
@@ -80,7 +91,7 @@ final class SceneContributionTest {
     void deleteRequiresExplicitConfirmationAndCancelKeepsScene() throws Exception {
         runOnFxThread(() -> {
             SceneApplicationService application = application();
-            ShellBinding binding = new SceneContribution(application, application.model()).bind();
+            ShellBinding binding = new SceneContribution(application, application.model(), statblockId -> { }).bind();
             binding.onActivate();
             Parent controls = (Parent) binding.slotContent().get(ShellSlot.COCKPIT_CONTROLS);
 
@@ -104,7 +115,7 @@ final class SceneContributionTest {
     void foreignFactPublicationKeepsUnsavedSceneAndCreationDrafts() throws Exception {
         runOnFxThread(() -> {
             SceneApplicationService application = application();
-            ShellBinding binding = new SceneContribution(application, application.model()).bind();
+            ShellBinding binding = new SceneContribution(application, application.model(), statblockId -> { }).bind();
             binding.onActivate();
             Parent controls = (Parent) binding.slotContent().get(ShellSlot.COCKPIT_CONTROLS);
             Parent main = (Parent) binding.slotContent().get(ShellSlot.COCKPIT_MAIN);
@@ -149,9 +160,37 @@ final class SceneContributionTest {
                 worldModel,
                 prepared,
                 encounters,
+                catalog(),
+                creatures(),
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
+    }
+
+    private static CreatureCatalogModel catalog() {
+        CreatureCatalogPageResult result = new CreatureCatalogPageResult(
+                CreatureQueryStatus.SUCCESS,
+                new CreatureCatalogPage(
+                        List.of(new CreatureCatalogRow(
+                                101L, "Goblin", "Klein", "Humanoid", "neutral böse", "1/4", 50, 7, 15)),
+                        1, 50, 0));
+        return new CreatureCatalogModel(() -> result, ignored -> () -> { });
+    }
+
+    private static CreaturesApi creatures() {
+        return new CreaturesApi() {
+            @Override
+            public void refreshFilterOptions(RefreshCreatureFilterOptionsCommand command) { }
+
+            @Override
+            public void refreshCatalog(RefreshCreatureCatalogCommand command) { }
+
+            @Override
+            public void selectCreatureDetail(SelectCreatureDetailCommand command) { }
+
+            @Override
+            public void refreshEncounterCandidates(RefreshCreatureEncounterCandidatesCommand command) { }
+        };
     }
 
     private static TextField textField(Parent root, String prompt) {

--- a/test/features/scene/adapter/sqlite/SqliteSceneWorkspaceRepositoryTest.java
+++ b/test/features/scene/adapter/sqlite/SqliteSceneWorkspaceRepositoryTest.java
@@ -3,6 +3,9 @@ package features.scene.adapter.sqlite;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import features.scene.domain.RunningScene;
+import features.scene.domain.SceneMob;
+import features.scene.domain.SceneParticipantKind;
+import features.scene.domain.SceneParticipantState;
 import features.scene.domain.SceneWorkspace;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -38,10 +41,13 @@ class SqliteSceneWorkspaceRepositoryTest {
 
     private static SceneWorkspace workspace() {
         RunningScene defaultScene = new RunningScene(
-                1L, "Standard", "", 0L, 0L, "", 0L, 20L, List.of(1001L), List.of(2001L));
+                1L, "Standard", "", 0L, 0L, "", 0L, 20L, List.of(1001L), List.of(2001L), List.of(), List.of());
         RunningScene imported = new RunningScene(
                 2L, "Torhaus", "Wachen", 91L, 44L, "Abend", 301L, 20L,
-                List.of(1002L), List.of(2002L));
+                List.of(1002L), List.of(2002L), List.of(new SceneMob(5001L, 5)),
+                List.of(
+                        new SceneParticipantState(SceneParticipantKind.PC, 1002L, true, "verwundet"),
+                        new SceneParticipantState(SceneParticipantKind.MOB, 5001L, false, "in Deckung")));
         return new SceneWorkspace(8L, 3L, 1L, 2L, false, "Ausstehend", List.of(defaultScene, imported));
     }
 

--- a/test/features/scene/application/SceneApplicationServiceTest.java
+++ b/test/features/scene/application/SceneApplicationServiceTest.java
@@ -4,6 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import features.creatures.api.CreatureCatalogModel;
+import features.creatures.api.CreatureCatalogPage;
+import features.creatures.api.CreatureCatalogPageResult;
+import features.creatures.api.CreatureCatalogRow;
+import features.creatures.api.CreatureQueryStatus;
+import features.creatures.api.CreaturesApi;
+import features.creatures.api.RefreshCreatureCatalogCommand;
+import features.creatures.api.RefreshCreatureEncounterCandidatesCommand;
+import features.creatures.api.RefreshCreatureFilterOptionsCommand;
+import features.creatures.api.SelectCreatureDetailCommand;
 import features.encounter.api.EncounterRuntimeContextApi;
 import features.encounter.api.EncounterRuntimeContextSyncResult;
 import features.encounter.api.SynchronizeEncounterRuntimeContextsCommand;
@@ -13,6 +23,7 @@ import features.party.api.PartyMemberSummary;
 import features.party.api.ReadStatus;
 import features.scene.api.SceneCommand;
 import features.scene.api.SceneMutationResult;
+import features.scene.api.SceneParticipantKind;
 import features.scene.api.SceneSnapshot;
 import features.scene.domain.SceneWorkspace;
 import features.sessionplanner.api.PreparedSceneCatalogModel;
@@ -135,6 +146,49 @@ class SceneApplicationServiceTest {
     }
 
     @Test
+    void mobsAreCuratedFromTheCreatureCatalogAndResolveStats() {
+        SceneApplicationService service = service(
+                new MemoryRepository(), party(1L), world(), prepared(), new CapturingEncounters());
+        await(service.execute(new SceneCommand.Initialize()));
+
+        await(service.execute(new SceneCommand.AssignMob(1L, 101L, 3)));
+        await(service.execute(new SceneCommand.AssignMob(1L, 101L, 2)));
+
+        SceneSnapshot.MobChoice mob = service.model().current().scenes().getFirst().mobs().getFirst();
+        assertEquals(101L, mob.creatureId());
+        assertEquals("Goblin", mob.name());
+        assertEquals(5, mob.count());
+        assertEquals(15, mob.armorClass());
+
+        SceneMutationResult unknown = await(service.execute(new SceneCommand.AssignMob(1L, 999L, 1)));
+        assertEquals(SceneMutationResult.Status.NOT_FOUND, unknown.status());
+
+        await(service.execute(new SceneCommand.SetMobCount(1L, 101L, 0)));
+        assertTrue(service.model().current().scenes().getFirst().mobs().isEmpty());
+    }
+
+    @Test
+    void participantLiveStateTracksDefeatedAndNotesAndPrunesOnLeave() {
+        SceneApplicationService service = service(
+                new MemoryRepository(), party(1L, 2L), world(), prepared(), new CapturingEncounters());
+        await(service.execute(new SceneCommand.Initialize()));
+
+        await(service.execute(new SceneCommand.SetParticipantDefeated(1L, SceneParticipantKind.PC, 1L, true)));
+        await(service.execute(new SceneCommand.SetParticipantNotes(1L, SceneParticipantKind.PC, 1L, "geflohen")));
+
+        SceneSnapshot.ParticipantStateView state = service.model().current().scenes().getFirst()
+                .participantState(SceneParticipantKind.PC, 1L);
+        assertTrue(state.defeated());
+        assertEquals("geflohen", state.notes());
+
+        await(service.execute(new SceneCommand.Create("Nebenraum")));
+        await(service.execute(new SceneCommand.AssignPc(2L, 1L)));
+
+        assertFalse(service.model().current().scenes().getFirst()
+                .participantState(SceneParticipantKind.PC, 1L).defeated());
+    }
+
+    @Test
     void defaultSceneCannotBeDeleted() {
         SceneApplicationService service = service(
                 new MemoryRepository(), party(1L), world(), prepared(), new CapturingEncounters());
@@ -169,9 +223,37 @@ class SceneApplicationServiceTest {
                 world,
                 prepared,
                 encounters,
+                catalog(),
+                creatures(),
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
+    }
+
+    private static CreatureCatalogModel catalog() {
+        CreatureCatalogPageResult result = new CreatureCatalogPageResult(
+                CreatureQueryStatus.SUCCESS,
+                new CreatureCatalogPage(
+                        List.of(new CreatureCatalogRow(
+                                101L, "Goblin", "Klein", "Humanoid", "neutral böse", "1/4", 50, 7, 15)),
+                        1, 50, 0));
+        return new CreatureCatalogModel(() -> result, ignored -> () -> { });
+    }
+
+    private static CreaturesApi creatures() {
+        return new CreaturesApi() {
+            @Override
+            public void refreshFilterOptions(RefreshCreatureFilterOptionsCommand command) { }
+
+            @Override
+            public void refreshCatalog(RefreshCreatureCatalogCommand command) { }
+
+            @Override
+            public void selectCreatureDetail(SelectCreatureDetailCommand command) { }
+
+            @Override
+            public void refreshEncounterCandidates(RefreshCreatureEncounterCandidatesCommand command) { }
+        };
     }
 
     private static PartyFacts party(long... ids) {


### PR DESCRIPTION
Redesigns the **Szenen (scene) tab** into a card board and extends it with catalog mobs and per-participant live state. Slices 1–3 of the board redesign; each was verified with a green `./gradlew check`.

## What changed
- **Layout (Slice 1):** main panel is now a board — current-location banner, a horizontal party strip, and stacked **NPC / Mob** columns on the right. Entities render as cards (`entity-card`) instead of text rows. NPC/Mob cards open the full statblock in the **inspector** (`SceneFeature.contribution` takes an `openStatblock` callback wired to `creatures.openInspector`). The State panel stays unbound (reserved for the Encounter tab).
- **Mobs (Slice 2):** nameless mobs sourced from the **creature catalog** with a headcount. New `SceneMob` + `RunningScene.mobs`, `scene_mob` table (migration v2), `AssignMob/UnassignMob/SetMobCount` commands, `SceneSnapshot.availableCreatures` + `SceneEntry.mobs`; catalog wired via `CreatureCatalogModel` + `CreaturesApi` (self-refresh on init). Cards show CR/HP/AC, +/− count, remove, and statblock.
- **Card interactions (Slice 3):** per-participant **defeated toggle** and **quick note**, persisted as an orthogonal per-scene participant-state store (`SceneParticipantState`, `scene_participant_state` table, migration v3) that self-prunes to present participants. `api`/`domain` `SceneParticipantKind` mapped in the application layer.

## Out of scope (deliberate)
Routing raw catalog **mobs into combat** is **not** included: the encounter runtime-context contract (`contract-encounter-runtime-contexts.md`) intentionally excludes mobs. That handoff needs an Encounter-owned contract + schema-v4 change (mob foreign-facts + combat-roster expansion) and should be a separate, focused change. Hostile world-NPCs already flow to combat today.

## Verification
`./gradlew check` green after each slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)