### PR TITLE
feat: rebuild World Planner inside the catalog

### DIFF
--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -192,7 +192,8 @@ public final class AppBootstrap implements AutoCloseable {
                         () -> world.openLocationCreator(
                                 worldEncounter, creatures.catalog(), tables.catalog(), inspector),
                         npcId -> assignNpcToFocusedScene(scene, npcId),
-                        locationId -> setFocusedSceneLocation(scene, locationId)),
+                        locationId -> setFocusedSceneLocation(scene, locationId),
+                        creatureId -> assignMobToFocusedScene(scene, creatureId)),
                 dungeon.editorContribution(),
                 dungeon.travelContribution(),
                 hex.mapContribution(),
@@ -221,6 +222,13 @@ public final class AppBootstrap implements AutoCloseable {
         long sceneId = scene.model().current().focusedSceneId();
         if (sceneId > 0L && locationId > 0L) {
             scene.application().execute(new features.scene.api.SceneCommand.SetLocation(sceneId, locationId));
+        }
+    }
+
+    private static void assignMobToFocusedScene(SceneFeature.Component scene, long creatureId) {
+        long sceneId = scene.model().current().focusedSceneId();
+        if (sceneId > 0L && creatureId > 0L) {
+            scene.application().execute(new features.scene.api.SceneCommand.AssignMob(sceneId, creatureId, 1));
         }
     }
 

--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -190,7 +190,9 @@ public final class AppBootstrap implements AutoCloseable {
                         () -> world.openFactionCreator(
                                 worldEncounter, creatures.catalog(), tables.catalog(), inspector),
                         () -> world.openLocationCreator(
-                                worldEncounter, creatures.catalog(), tables.catalog(), inspector)),
+                                worldEncounter, creatures.catalog(), tables.catalog(), inspector),
+                        npcId -> assignNpcToFocusedScene(scene, npcId),
+                        locationId -> setFocusedSceneLocation(scene, locationId)),
                 dungeon.editorContribution(),
                 dungeon.travelContribution(),
                 hex.mapContribution(),
@@ -206,6 +208,20 @@ public final class AppBootstrap implements AutoCloseable {
             resolved.add(new ResolvedContribution(contribution.registrationSpec(), contribution.bind()));
         }
         return List.copyOf(resolved);
+    }
+
+    private static void assignNpcToFocusedScene(SceneFeature.Component scene, long npcId) {
+        long sceneId = scene.model().current().focusedSceneId();
+        if (sceneId > 0L && npcId > 0L) {
+            scene.application().execute(new features.scene.api.SceneCommand.AssignNpc(sceneId, npcId));
+        }
+    }
+
+    private static void setFocusedSceneLocation(SceneFeature.Component scene, long locationId) {
+        long sceneId = scene.model().current().focusedSceneId();
+        if (sceneId > 0L && locationId > 0L) {
+            scene.application().execute(new features.scene.api.SceneCommand.SetLocation(sceneId, locationId));
+        }
     }
 
     private void register(AppShell shell, ResolvedContribution contribution) {

--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Catalog Feature
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: Entry point for the consolidated reference workspace.
 
 # Catalog Feature

--- a/docs/catalog/architecture/architecture-catalog.md
+++ b/docs/catalog/architecture/architecture-catalog.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: Catalog Feature
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: Catalog presentation boundary and dependency direction.
 
 # Catalog Architecture
@@ -19,6 +19,12 @@ entry point. It consumes only foreign `feature.api` models and commands.
 Provider-owned inspector actions are passed into Catalog by `app`; Catalog
 does not import their adapters. Items callbacks are returned asynchronously and
 are dispatched to JavaFX before view mutation.
+
+`CatalogSectionFrame` owns only shared table chrome. Provider-specific columns,
+commands, and Inspector routes remain injected composition. The controls host
+preserves the established Monster filter surface and swaps only the visible
+category controls. Catalog writes Encounter pool filters through the partial
+pool command and never writes Encounter tuning.
 
 Catalog has no domain, application, or SQLite role because it owns no durable
 truth or orchestration. `app` registers Catalog once and does not register the

--- a/docs/catalog/requirements/requirements-catalog.md
+++ b/docs/catalog/requirements/requirements-catalog.md
@@ -18,7 +18,8 @@ and running-session lookup without taking ownership from provider features.
 - Sections MUST use one horizontal category strip and consistent tabular
   result chrome; the left control slot changes to the selected category.
 - Monster search and encounter-builder controls MUST preserve their accepted
-  behavior, including creature details and adding creatures to Encounter.
+  behavior, including creature details and explicit add-to-Encounter and
+  add-to-focused-Scene actions.
 - Items MUST be read-only, searched asynchronously, distinguish loading,
   unavailable, empty, invalid, and storage-failure outcomes, and open details
   without blocking the JavaFX thread.

--- a/docs/catalog/requirements/requirements-catalog.md
+++ b/docs/catalog/requirements/requirements-catalog.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Catalog Feature
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: User-visible consolidated catalog behavior.
 
 # Catalog Requirements
@@ -15,6 +15,8 @@ and running-session lookup without taking ownership from provider features.
 
 - The workspace MUST expose Monster, Items, Encounter, NPCs, Fraktionen, Orte,
   and Encounter-Tabellen as distinct visible sections.
+- Sections MUST use one horizontal category strip and consistent tabular
+  result chrome; the left control slot changes to the selected category.
 - Monster search and encounter-builder controls MUST preserve their accepted
   behavior, including creature details and adding creatures to Encounter.
 - Items MUST be read-only, searched asynchronously, distinguish loading,
@@ -25,6 +27,13 @@ and running-session lookup without taking ownership from provider features.
   explicit discard confirmation.
 - NPC, faction, and location details and edit actions MUST open through
   World-Planner-owned inspector content.
+- NPCs MUST support explicit Encounter and focused-Scene actions. Factions,
+  locations, and Encounter tables MUST support explicit Encounter-source
+  actions; locations MUST support assigning the focused Scene location.
+- Selecting or opening a row alone MUST NOT mutate Encounter or Scene state.
+- Creature pool filters remain Catalog-owned and constrain Encounter
+  generation. Difficulty, balance, amount, and diversity controls MUST live in
+  a collapsible section in the global Encounter state tab.
 - The separate World Planner navigation entry and local state-panel slot MUST
   not be registered. World data and edit capabilities remain available through
   Catalog and Inspector.
@@ -37,7 +46,8 @@ items, own encounter runtime state, or duplicate provider command logic.
 ## Acceptance Criteria
 
 Automated UI tests MUST prove one Catalog contribution contains all seven
-sections, routes saved-plan confirmation, and renders explicit Items states.
+sections, routes saved-plan confirmation, renders explicit Items states, and
+does not render Encounter tuning inside Catalog controls.
 Architecture proof MUST reject Catalog imports from foreign adapters. Final
 visual and interaction acceptance remains owner manual testing.
 

--- a/docs/creatures/requirements/requirements-creatures-catalog.md
+++ b/docs/creatures/requirements/requirements-creatures-catalog.md
@@ -56,8 +56,8 @@ Catalog only composes its presentation with other providers.
 - Previous and next page controls move in fixed 50-row pages.
 - Clicking a creature name or pressing Enter on a selected row opens that
   creature in the shell Inspector.
-- Clicking a creature row's `+Add` action publishes an add-creature request to
-  the Encounter state tab.
+- Each creature row exposes explicit `+ Encounter` and `+ Scene` actions. The
+  Scene action adds one mob of that statblock to the focused running Scene.
 
 ## Visible States
 
@@ -76,8 +76,8 @@ Catalog only composes its presentation with other providers.
 - changing sort order resets pagination to the first page
 - clicking a creature name or confirming the selected row opens the creature in
   the shell Inspector
-- clicking a row `+Add` action publishes an add-creature request without
-  mutating creature catalog truth
+- clicking `+ Encounter` or `+ Scene` publishes only the selected target
+  command without mutating creature catalog truth
 - an empty encounter-table selection keeps the normal creature-catalog source,
   while a non-empty encounter-table selection publishes selected table ids for
   the Encounter state tab

--- a/docs/creatures/requirements/requirements-creatures-catalog.md
+++ b/docs/creatures/requirements/requirements-creatures-catalog.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-04-26
+Last Reviewed: 2026-07-17
 Source of Truth: Catalog left-bar tab composition, content selection, filter
 controls, list management, and main list behavior.
 
@@ -12,23 +12,22 @@ The catalog tab is the shared reference browser for read-only game catalogs.
 It owns the left-bar tab shell entrypoint and hosts content-specific catalog
 presentations through one shared presentation state.
 
-Current state:
-
-- Creatures is the only functional catalog content.
-- Creature detail display is published to the shell Inspector through the
-  creature detail entry.
+Creature detail display is published to the shell Inspector through the
+creature detail entry. Creatures remains the owner of imported statblock truth;
+Catalog only composes its presentation with other providers.
 
 ## Visible Surfaces
 
-- The shell title for the runtime catalog is `Encounter-Planer`, matching the
-  original encounter-building surface. The left navigation entry is icon-only
-  and uses the crossed-blades encounter graphic from
+- The shell title and single left navigation entry are `Katalog`; the entry is
+  icon-only and uses
   `resources/view/leftbartabs/catalog/navigation-icon.svg`.
-- `COCKPIT_CONTROLS` contains creature filters, active
-  filter chips, encounter difficulty selection, Auto tuning controls, and
-  encounter-table selection.
+- `COCKPIT_CONTROLS` contains creature filters, active filter chips,
+  encounter-table selection, and World Planner source selection while Monster
+  is active.
 - `COCKPIT_MAIN` contains the active catalog list, result count, sort
   selection, and page controls.
+- Difficulty, balance, amount, and diversity controls live in a collapsible
+  section of the global Encounter state tab.
 - Because the Catalog tab does not publish active-tab state content, the shell
   shows the global state-tab strip with `Encounter` and `Reise`.
 - Creature Inspector content is defined separately in
@@ -42,17 +41,10 @@ Current state:
   the query.
 - Size, type, subtype, biome, and alignment filters use searchable multi-select
   popups.
-- Creature type, subtype, biome, encounter difficulty, amount, balance, and
-  diversity selections publish runtime encounter-generation inputs for the
-  Encounter state tab.
-- Encounter difficulty defaults to Auto. The amount, balance, and diversity
-  controls each expose an Auto toggle; while Auto is selected, the slider is
-  disabled and the published value is the Auto sentinel for that tuning field.
-- When a tuning slider is manually enabled, its value label mirrors the
-  original encounter builder: difficulty shows the active party's adjusted XP
-  range, balance shows `Extreme++` through `Durchschnitt++`, amount shows
-  `Boss++` through `Minions++`, and diversity shows `1 Typ` through
-  `4 Typen`.
+- Name, CR, size, type, subtype, biome, alignment, encounter-table, faction,
+  and location selections publish only `EncounterPoolFilters`.
+- Every visible creature filter constrains generation. Encounter-table
+  candidates are intersected with the filtered creature pool.
 - Encounter-table multi-selection publishes selected table IDs for the
   Encounter state tab; an empty selection means normal monster catalog
   generation.
@@ -89,6 +81,7 @@ Current state:
 - an empty encounter-table selection keeps the normal creature-catalog source,
   while a non-empty encounter-table selection publishes selected table ids for
   the Encounter state tab
+- changing Catalog pool filters does not overwrite Encounter-owned tuning
 
 ## References
 

--- a/docs/encounter/contract/contract-encounter-builder-inputs.md
+++ b/docs/encounter/contract/contract-encounter-builder-inputs.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-05-07
+Last Reviewed: 2026-07-17
 Source of Truth: Public builder-input read/write contract for encounter-facing
 catalog controls.
 
@@ -8,25 +8,35 @@ catalog controls.
 
 ## Purpose
 
-This contract defines the flat builder-input surface shared between the catalog
-controls and the encounter runtime session.
+This contract defines the builder-input surface shared by Catalog-owned pool
+filters and Encounter-owned generation tuning.
 
 ## Read Surface
 
 - `EncounterApi` publishes immutable, revisioned builder input state
-- `EncounterBuilderInputs` carries creature-type, subtype, biome, difficulty,
-  tuning, and encounter-table selections only
+- `EncounterBuilderInputs` publishes `EncounterPoolFilters` and
+  `EncounterTuningSettings` as separate immutable values
+- pool filters include name, challenge-rating range, size, type, subtype,
+  biome, alignment, encounter tables, World Planner factions, and location
 
 ## Write Surface
 
-- `UpdateEncounterBuilderInputsCommand` submits a complete replacement snapshot
-  through `EncounterApi`
+- Catalog submits `UpdateEncounterPoolFiltersCommand`
+- Encounter state submits `UpdateEncounterTuningCommand`
+- the application merges either partial update with the current focused
+  runtime context before persistence and publication
+- `UpdateEncounterBuilderInputsCommand` remains a compatibility route for
+  complete snapshots
 
 ## Boundary Rules
 
 - the contract is workflow-oriented, not a mirror of the internal encounter
   session carrier
 - late update results must not overwrite a newer published revision
+- a pool-filter update MUST preserve tuning and a tuning update MUST preserve
+  pool filters
+- all visible pool filters constrain candidate loading; selected Encounter
+  tables are intersected with the filtered creature pool
 - it does not expose saved plans, roster cards, initiative rows, combat
   runtime, or result state
 - it does not expose foreign creature, party, or encounter-table internals

--- a/docs/encounter/requirements/requirements-encounter-state-tab.md
+++ b/docs/encounter/requirements/requirements-encounter-state-tab.md
@@ -1,10 +1,14 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-04-26
+Last Reviewed: 2026-07-17
 Source of Truth: Encounter runtime state-pane dialog composition,
 interactions, and visible states.
 
 # Encounter Runtime State UI
+
+The Builder mode exposes difficulty, balance, amount, and diversity in an
+`Encounter abstimmen` section. The section is collapsed by default and writes
+only `EncounterTuningSettings`; Catalog pool filters remain unchanged.
 
 ## Component Purpose
 

--- a/docs/worldplanner/architecture/architecture-world-planner.md
+++ b/docs/worldplanner/architecture/architecture-world-planner.md
@@ -1,6 +1,6 @@
-Status: Active Target
+Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: World Planner feature ownership, public seams, and target
 dependency direction.
 

--- a/docs/worldplanner/contract/contract-world-planner-persistence.md
+++ b/docs/worldplanner/contract/contract-world-planner-persistence.md
@@ -1,6 +1,6 @@
-Status: Draft
+Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: Persistence boundary, stored truth, reference rules, and
 error behavior for World Planner authored state.
 
@@ -68,6 +68,9 @@ World Planner persistence does not store:
   encounter-table references.
 - Writes must reject duplicate membership or duplicate link rows instead of
   silently persisting ambiguous truth.
+- NPC deletion must remove faction membership in the same saved state.
+- Faction deletion must remove location links in the same saved state.
+- Removing a relationship must leave both referenced records intact.
 - Disposition values must remain between `-50` and `+50`.
 - Finite inventory limits must be non-negative.
 - A faction must not persist more than one primary encounter-table reference.

--- a/docs/worldplanner/requirements/requirements-world-planner.md
+++ b/docs/worldplanner/requirements/requirements-world-planner.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-17
 Source of Truth: User-facing behavior and acceptance criteria for the World
 Planner NPC, faction, location, and encounter-source workflows.
 
@@ -79,6 +79,8 @@ Inspector surfaces so the user can:
 - add or remove NPCs from factions without mutating creature truth
 - configure faction stock as finite or unlimited per creature statblock
 - configure location-to-faction and location-to-table links
+- remove faction membership and location links without deleting the referenced
+  provider records
 - select factions and locations in encounter-generation controls
 - add an NPC to combat while preserving its World Planner identity
 - show a post-combat loss confirmation before durable NPC or inventory state
@@ -112,6 +114,8 @@ Inspector surfaces so the user can:
   Session Planner-owned records.
 - an NPC belongs to at most one faction and its effective disposition is the
   clamped sum of faction base and NPC modifier
+- deleting an NPC removes its faction membership; deleting a faction removes
+  its location links; deleting a location removes only the location
 - Creature statblocks, encounter-table membership, encounter rosters, party
   members, combat HP, dungeon maps, and hex maps stay in their owning
   contexts.

--- a/features/catalog/CatalogServiceAssembly.java
+++ b/features/catalog/CatalogServiceAssembly.java
@@ -43,7 +43,8 @@ public final class CatalogServiceAssembly {
             Runnable createFaction,
             Runnable createLocation,
             java.util.function.LongConsumer addNpcToScene,
-            java.util.function.LongConsumer setSceneLocation
+            java.util.function.LongConsumer setSceneLocation,
+            java.util.function.LongConsumer addCreatureToScene
     ) {
         return new CatalogContribution(
                 creatures,
@@ -66,6 +67,7 @@ public final class CatalogServiceAssembly {
                 createFaction,
                 createLocation,
                 addNpcToScene,
-                setSceneLocation);
+                setSceneLocation,
+                addCreatureToScene);
     }
 }

--- a/features/catalog/CatalogServiceAssembly.java
+++ b/features/catalog/CatalogServiceAssembly.java
@@ -41,7 +41,9 @@ public final class CatalogServiceAssembly {
             java.util.function.LongConsumer openLocationInspector,
             Runnable createNpc,
             Runnable createFaction,
-            Runnable createLocation
+            Runnable createLocation,
+            java.util.function.LongConsumer addNpcToScene,
+            java.util.function.LongConsumer setSceneLocation
     ) {
         return new CatalogContribution(
                 creatures,
@@ -62,6 +64,8 @@ public final class CatalogServiceAssembly {
                 openLocationInspector,
                 createNpc,
                 createFaction,
-                createLocation);
+                createLocation,
+                addNpcToScene,
+                setSceneLocation);
     }
 }

--- a/features/catalog/adapter/javafx/CatalogContribution.java
+++ b/features/catalog/adapter/javafx/CatalogContribution.java
@@ -46,6 +46,7 @@ public final class CatalogContribution implements ShellContribution {
     private final Runnable createLocation;
     private final java.util.function.LongConsumer addNpcToScene;
     private final java.util.function.LongConsumer setSceneLocation;
+    private final java.util.function.LongConsumer addCreatureToScene;
 
     public CatalogContribution(
             CreaturesApi creatures,
@@ -71,7 +72,7 @@ public final class CatalogContribution implements ShellContribution {
         this(creatures, encounterTables, encounters, builderInputs, filterOptions, catalog,
                 encounterTableCatalog, tuningPreview, savedPlans, items, worldPlanner, inspector,
                 openCreatureInspector, openNpcInspector, openFactionInspector, openLocationInspector,
-                createNpc, createFaction, createLocation, ignored -> { }, ignored -> { });
+                createNpc, createFaction, createLocation, ignored -> { }, ignored -> { }, ignored -> { });
     }
 
     public CatalogContribution(
@@ -95,7 +96,8 @@ public final class CatalogContribution implements ShellContribution {
             Runnable createFaction,
             Runnable createLocation,
             java.util.function.LongConsumer addNpcToScene,
-            java.util.function.LongConsumer setSceneLocation
+            java.util.function.LongConsumer setSceneLocation,
+            java.util.function.LongConsumer addCreatureToScene
     ) {
         this.creatures = Objects.requireNonNull(creatures, "creatures");
         this.encounterTables = Objects.requireNonNull(encounterTables, "encounterTables");
@@ -118,6 +120,7 @@ public final class CatalogContribution implements ShellContribution {
         this.createLocation = Objects.requireNonNull(createLocation, "createLocation");
         this.addNpcToScene = Objects.requireNonNull(addNpcToScene, "addNpcToScene");
         this.setSceneLocation = Objects.requireNonNull(setSceneLocation, "setSceneLocation");
+        this.addCreatureToScene = Objects.requireNonNull(addCreatureToScene, "addCreatureToScene");
     }
 
     @Override
@@ -133,7 +136,8 @@ public final class CatalogContribution implements ShellContribution {
 
     @Override
     public ShellBinding bind() {
-        CatalogViewModel viewModel = new CatalogViewModel(creatures, encounterTables, encounters);
+        CatalogViewModel viewModel = new CatalogViewModel(
+                creatures, encounterTables, encounters, addCreatureToScene);
         CatalogControlsHost controls = new CatalogControlsHost();
         CatalogMainView monsters = new CatalogMainView();
 

--- a/features/catalog/adapter/javafx/CatalogContribution.java
+++ b/features/catalog/adapter/javafx/CatalogContribution.java
@@ -44,6 +44,8 @@ public final class CatalogContribution implements ShellContribution {
     private final Runnable createNpc;
     private final Runnable createFaction;
     private final Runnable createLocation;
+    private final java.util.function.LongConsumer addNpcToScene;
+    private final java.util.function.LongConsumer setSceneLocation;
 
     public CatalogContribution(
             CreaturesApi creatures,
@@ -66,6 +68,35 @@ public final class CatalogContribution implements ShellContribution {
             Runnable createFaction,
             Runnable createLocation
     ) {
+        this(creatures, encounterTables, encounters, builderInputs, filterOptions, catalog,
+                encounterTableCatalog, tuningPreview, savedPlans, items, worldPlanner, inspector,
+                openCreatureInspector, openNpcInspector, openFactionInspector, openLocationInspector,
+                createNpc, createFaction, createLocation, ignored -> { }, ignored -> { });
+    }
+
+    public CatalogContribution(
+            CreaturesApi creatures,
+            EncounterTableApi encounterTables,
+            EncounterApi encounters,
+            EncounterBuilderInputsModel builderInputs,
+            CreatureFilterOptionsModel filterOptions,
+            CreatureCatalogModel catalog,
+            EncounterTableCatalogModel encounterTableCatalog,
+            EncounterTuningPreviewModel tuningPreview,
+            SavedEncounterPlanListModel savedPlans,
+            ItemsCatalogApi items,
+            @Nullable WorldPlannerSnapshotModel worldPlanner,
+            InspectorSink inspector,
+            java.util.function.LongConsumer openCreatureInspector,
+            java.util.function.LongConsumer openNpcInspector,
+            java.util.function.LongConsumer openFactionInspector,
+            java.util.function.LongConsumer openLocationInspector,
+            Runnable createNpc,
+            Runnable createFaction,
+            Runnable createLocation,
+            java.util.function.LongConsumer addNpcToScene,
+            java.util.function.LongConsumer setSceneLocation
+    ) {
         this.creatures = Objects.requireNonNull(creatures, "creatures");
         this.encounterTables = Objects.requireNonNull(encounterTables, "encounterTables");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
@@ -85,6 +116,8 @@ public final class CatalogContribution implements ShellContribution {
         this.createNpc = Objects.requireNonNull(createNpc, "createNpc");
         this.createFaction = Objects.requireNonNull(createFaction, "createFaction");
         this.createLocation = Objects.requireNonNull(createLocation, "createLocation");
+        this.addNpcToScene = Objects.requireNonNull(addNpcToScene, "addNpcToScene");
+        this.setSceneLocation = Objects.requireNonNull(setSceneLocation, "setSceneLocation");
     }
 
     @Override
@@ -101,7 +134,7 @@ public final class CatalogContribution implements ShellContribution {
     @Override
     public ShellBinding bind() {
         CatalogViewModel viewModel = new CatalogViewModel(creatures, encounterTables, encounters);
-        CatalogControlsView controls = new CatalogControlsView();
+        CatalogControlsHost controls = new CatalogControlsHost();
         CatalogMainView monsters = new CatalogMainView();
 
         controls.bind(viewModel.controlsContentModel());
@@ -140,6 +173,8 @@ public final class CatalogContribution implements ShellContribution {
                 items,
                 encounters,
                 savedPlans,
+                builderInputs,
+                catalog,
                 encounterTableCatalog,
                 worldPlanner,
                 inspector,
@@ -148,7 +183,9 @@ public final class CatalogContribution implements ShellContribution {
                 openLocationInspector,
                 createNpc,
                 createFaction,
-                createLocation);
+                createLocation,
+                addNpcToScene,
+                setSceneLocation);
         return ShellBinding.cockpit("Katalog", controls, workspace);
     }
 

--- a/features/catalog/adapter/javafx/CatalogControlsContentModel.java
+++ b/features/catalog/adapter/javafx/CatalogControlsContentModel.java
@@ -776,11 +776,17 @@ public final class CatalogControlsContentModel {
     
         boolean applyEncounterBuilderInputs(EncounterBuilderInputs builderInputs) {
             CatalogControlsContentModel.ControlsState previousAuthoritative = authoritativeControls;
+            CatalogControlsContentModel.LocalFilterState previousLocal = localFilters;
+            EncounterBuilderInputs safeInputs = builderInputs == null ? EncounterBuilderInputs.empty() : builderInputs;
             CatalogControlsContentModel.ControlsState next =
-                    CatalogControlsContentModel.ControlsState.fromBuilderInputs(builderInputs, previousAuthoritative);
+                    CatalogControlsContentModel.ControlsState.fromBuilderInputs(safeInputs, previousAuthoritative);
+            localFilters = new CatalogControlsContentModel.LocalFilterState(
+                    safeInputs.nameQuery(), safeInputs.challengeRatingMin(), safeInputs.challengeRatingMax(),
+                    safeInputs.sizes(), safeInputs.alignments()).retainAvailable(filterOptions);
             authoritativeControls = next;
             controlsState = next;
-            return CatalogControlsContentModel.ControlsState.searchControlsChanged(previousAuthoritative, next);
+            return !previousLocal.equals(localFilters)
+                    || CatalogControlsContentModel.ControlsState.searchControlsChanged(previousAuthoritative, next);
         }
     
         void applyEncounterTables(EncounterTableCatalogResult result) {

--- a/features/catalog/adapter/javafx/CatalogControlsHost.java
+++ b/features/catalog/adapter/javafx/CatalogControlsHost.java
@@ -1,0 +1,47 @@
+package features.catalog.adapter.javafx;
+
+import java.util.List;
+import java.util.function.Consumer;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+
+/** Keeps the established monster controls and supplies equivalent category controls. */
+final class CatalogControlsHost extends CatalogControlsView {
+
+    private final List<Node> monsterControls;
+
+    CatalogControlsHost() {
+        monsterControls = List.copyOf(getChildren());
+    }
+
+    void showMonster() {
+        getChildren().setAll(monsterControls);
+    }
+
+    void showSection(
+            String title,
+            String prompt,
+            Consumer<String> search,
+            String createLabel,
+            Runnable create
+    ) {
+        Label heading = new Label(title.toUpperCase(java.util.Locale.ROOT));
+        heading.getStyleClass().add("section-header");
+        TextField query = new TextField();
+        query.setPromptText(prompt);
+        query.setAccessibleText(title + " suchen");
+        query.textProperty().addListener((ignored, before, after) -> search.accept(after));
+        VBox surface = new VBox(8, query);
+        surface.getStyleClass().add("filter-surface");
+        if (createLabel != null && !createLabel.isBlank()) {
+            Button createButton = new Button(createLabel);
+            createButton.getStyleClass().addAll("accent", "compact");
+            createButton.setOnAction(ignored -> create.run());
+            surface.getChildren().add(createButton);
+        }
+        getChildren().setAll(heading, surface);
+    }
+}

--- a/features/catalog/adapter/javafx/CatalogControlsView.java
+++ b/features/catalog/adapter/javafx/CatalogControlsView.java
@@ -28,10 +28,9 @@ import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 import org.jspecify.annotations.Nullable;
 
-public final class CatalogControlsView extends VBox {
+public class CatalogControlsView extends VBox {
 
     private static final String FILTER_SECTION_TITLE = "FILTER";
-    private static final String ENCOUNTER_SECTION_TITLE = "ENCOUNTER";
     private static final String STYLE_COMPACT = "compact";
     private static final String STYLE_FLAT = "flat";
     private static final String STYLE_FILTER_TRIGGER = "filter-trigger";
@@ -203,9 +202,7 @@ public final class CatalogControlsView extends VBox {
                                         worldFactionButton,
                                         new Label("Location"),
                                         worldLocationChoice),
-                                chipControls.node()))),
-                CatalogControlsChrome.separator(),
-                CatalogControlsChrome.section(ENCOUNTER_SECTION_TITLE, tuningControls.node()));
+                                chipControls.node()))));
     }
 
     public void bind(CatalogControlsContentModel contentModel) {

--- a/features/catalog/adapter/javafx/CatalogMainView.java
+++ b/features/catalog/adapter/javafx/CatalogMainView.java
@@ -23,10 +23,9 @@ public final class CatalogMainView extends BorderPane {
     private static final int PREVIOUS_PAGE_SHIFT = -1;
     private static final int NEXT_PAGE_SHIFT = 1;
     private static final long NO_CREATURE_ID = 0L;
-    private static final String ACTION_LABEL = "+Add";
-    private static final String ACTION_TOOLTIP = "Zum Encounter hinzufügen";
+    private static final String ENCOUNTER_ACTION_LABEL = "+ Encounter";
+    private static final String SCENE_ACTION_LABEL = "+ Scene";
     private static final String CREATURE_ACCESSIBLE_TEXT_PREFIX = "Stat Block: ";
-    private static final String ACTION_ACCESSIBLE_TEXT_PREFIX = ACTION_LABEL + ": ";
     private static final String COLUMN_KEY_CHALLENGE_RATING = "cr";
     private static final String COLUMN_KEY_TYPE = "type";
     private static final String COLUMN_KEY_SIZE = "size";
@@ -89,13 +88,15 @@ public final class CatalogMainView extends BorderPane {
                 0));
     }
 
-    private void publishCreatureEvent(long creatureId, boolean addCreature) {
+    private void publishCreatureEvent(long creatureId, CreatureActionKind action) {
         if (creatureId <= NO_CREATURE_ID) {
             return;
         }
-        viewInputEventHandler.accept(addCreature
-                ? new CatalogMainViewInputEvent("", 0L, creatureId, 0)
-                : new CatalogMainViewInputEvent("", creatureId, 0L, 0));
+        viewInputEventHandler.accept(switch (action) {
+            case ENCOUNTER -> new CatalogMainViewInputEvent("", 0L, creatureId, 0L, 0);
+            case SCENE -> new CatalogMainViewInputEvent("", 0L, 0L, creatureId, 0);
+            default -> new CatalogMainViewInputEvent("", creatureId, 0L, 0L, 0);
+        });
     }
 
     private void publishPageShift(int pageShift) {
@@ -160,6 +161,12 @@ public final class CatalogMainView extends BorderPane {
         }
     }
 
+    private enum CreatureActionKind {
+        OPEN,
+        ENCOUNTER,
+        SCENE
+    }
+
     private static final class CatalogTable {
 
         static void configure(
@@ -176,7 +183,10 @@ public final class CatalogMainView extends BorderPane {
                 if (selectedCreatureId <= NO_CREATURE_ID) {
                     return;
                 }
-                action.accept(selectedCreatureId, event.isShiftDown());
+                action.accept(selectedCreatureId,
+                        event.isShiftDown()
+                                ? (event.isControlDown() ? CreatureActionKind.SCENE : CreatureActionKind.ENCOUNTER)
+                                : CreatureActionKind.OPEN);
                 event.consume();
             });
         }
@@ -234,9 +244,9 @@ public final class CatalogMainView extends BorderPane {
 
         private static TableColumn<Object, Object> createActionColumn(CreatureAction action) {
             TableColumn<Object, Object> actionColumn = new TableColumn<>("");
-            actionColumn.setMinWidth(55);
-            actionColumn.setPrefWidth(65);
-            actionColumn.setMaxWidth(75);
+            actionColumn.setMinWidth(150);
+            actionColumn.setPrefWidth(175);
+            actionColumn.setMaxWidth(210);
             actionColumn.setSortable(false);
             actionColumn.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue()));
             actionColumn.setCellFactory(ignored -> new ActionCell(CatalogTable::creatureId, action));
@@ -279,7 +289,7 @@ public final class CatalogMainView extends BorderPane {
     @FunctionalInterface
     private interface CreatureAction {
 
-        void accept(long creatureId, boolean addCreature);
+        void accept(long creatureId, CreatureActionKind action);
     }
 
     private static final class LinkCell extends TableCell<Object, Object> {
@@ -301,7 +311,7 @@ public final class CatalogMainView extends BorderPane {
                 if (owningTable != null && row != null) {
                     owningTable.getSelectionModel().select(row);
                 }
-                action.accept(creatureIdReader.applyAsLong(row), false);
+                action.accept(creatureIdReader.applyAsLong(row), CreatureActionKind.OPEN);
             });
         }
 
@@ -319,7 +329,9 @@ public final class CatalogMainView extends BorderPane {
 
     private static final class ActionCell extends TableCell<Object, Object> {
 
-        private final Button button = new Button(ACTION_LABEL);
+        private final Button encounterButton = new Button(ENCOUNTER_ACTION_LABEL);
+        private final Button sceneButton = new Button(SCENE_ACTION_LABEL);
+        private final HBox actions = new HBox(4, encounterButton, sceneButton);
         private final java.util.function.ToLongFunction<Object> creatureIdReader;
         private final CreatureAction action;
 
@@ -329,26 +341,31 @@ public final class CatalogMainView extends BorderPane {
         ) {
             this.creatureIdReader = creatureIdReader;
             this.action = action;
-            button.getStyleClass().addAll("accent", "compact");
-            button.setTooltip(new Tooltip(ACTION_TOOLTIP));
-            button.setOnAction(event -> {
-                Object row = getItem();
-                TableView<Object> owningTable = getTableView();
-                if (owningTable != null && row != null) {
-                    owningTable.getSelectionModel().select(row);
-                }
-                action.accept(creatureIdReader.applyAsLong(row), true);
-            });
+            encounterButton.getStyleClass().addAll("accent", "compact");
+            sceneButton.getStyleClass().addAll("compact");
+            encounterButton.setTooltip(new Tooltip("Zum Encounter hinzufügen"));
+            sceneButton.setTooltip(new Tooltip("Zur fokussierten Scene hinzufügen"));
+            encounterButton.setOnAction(event -> publish(CreatureActionKind.ENCOUNTER));
+            sceneButton.setOnAction(event -> publish(CreatureActionKind.SCENE));
+        }
+
+        private void publish(CreatureActionKind kind) {
+            Object row = getItem();
+            TableView<Object> owningTable = getTableView();
+            if (owningTable != null && row != null) {
+                owningTable.getSelectionModel().select(row);
+            }
+            action.accept(creatureIdReader.applyAsLong(row), kind);
         }
 
         @Override
         protected void updateItem(Object row, boolean empty) {
             super.updateItem(row, empty);
             Object displayRow = empty ? null : row;
-            button.setAccessibleText(displayRow == null
-                    ? ""
-                    : ACTION_ACCESSIBLE_TEXT_PREFIX + CatalogTable.cellText(displayRow, FIRST_COLUMN_INDEX));
-            setGraphic(displayRow == null ? null : button);
+            String name = displayRow == null ? "" : CatalogTable.cellText(displayRow, FIRST_COLUMN_INDEX);
+            encounterButton.setAccessibleText(displayRow == null ? "" : "+ Encounter: " + name);
+            sceneButton.setAccessibleText(displayRow == null ? "" : "+ Scene: " + name);
+            setGraphic(displayRow == null ? null : actions);
         }
     }
 

--- a/features/catalog/adapter/javafx/CatalogMainViewInputEvent.java
+++ b/features/catalog/adapter/javafx/CatalogMainViewInputEvent.java
@@ -4,8 +4,13 @@ public record CatalogMainViewInputEvent(
         String sortKey,
         long openedCreatureId,
         long actionCreatureId,
+        long sceneCreatureId,
         int pageShift
 ) {
+
+    public CatalogMainViewInputEvent(String sortKey, long openedCreatureId, long actionCreatureId, int pageShift) {
+        this(sortKey, openedCreatureId, actionCreatureId, 0L, pageShift);
+    }
 
     public CatalogMainViewInputEvent {
         sortKey = sortKey == null ? "" : sortKey;

--- a/features/catalog/adapter/javafx/CatalogSectionFrame.java
+++ b/features/catalog/adapter/javafx/CatalogSectionFrame.java
@@ -1,0 +1,153 @@
+package features.catalog.adapter.javafx;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+
+/** Shared catalog table chrome for provider-owned reference rows. */
+final class CatalogSectionFrame<T> extends BorderPane {
+
+    private final String resultLabel;
+    private final Function<T, String> searchableText;
+    private final Consumer<T> primaryAction;
+    private final Label count = new Label();
+    private final Label status = new Label();
+    private final TableView<T> table = new TableView<>();
+    private List<T> source = List.of();
+    private String query = "";
+
+    CatalogSectionFrame(
+            String resultLabel,
+            String emptyText,
+            Function<T, String> searchableText,
+            Consumer<T> primaryAction,
+            String createLabel,
+            Runnable create
+    ) {
+        this.resultLabel = resultLabel;
+        this.searchableText = searchableText;
+        this.primaryAction = primaryAction;
+        getStyleClass().add("surface-root");
+        count.getStyleClass().add("text-secondary");
+        status.getStyleClass().add("text-muted");
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        table.setPlaceholder(new Label(emptyText));
+        table.setOnMouseClicked(event -> {
+            if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
+                openSelected();
+            }
+        });
+        table.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                openSelected();
+                event.consume();
+            }
+        });
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox header = new HBox(8, count, spacer);
+        if (createLabel != null && !createLabel.isBlank()) {
+            Button createButton = new Button(createLabel);
+            createButton.getStyleClass().addAll("accent", "compact");
+            createButton.setOnAction(ignored -> create.run());
+            header.getChildren().add(createButton);
+        }
+        header.getStyleClass().add("catalog-main-topbar");
+        HBox footer = new HBox(8, status);
+        footer.setPadding(new Insets(8));
+        setTop(header);
+        setCenter(table);
+        setBottom(footer);
+    }
+
+    void addTextColumn(String title, double width, Function<T, String> value) {
+        TableColumn<T, String> column = new TableColumn<>(title);
+        column.setPrefWidth(width);
+        column.setCellValueFactory(cell -> new SimpleStringProperty(shown(value.apply(cell.getValue()))));
+        table.getColumns().add(column);
+    }
+
+    void addActionColumn(String title, String buttonText, Consumer<T> action) {
+        TableColumn<T, T> column = new TableColumn<>(title);
+        column.setSortable(false);
+        column.setPrefWidth(150);
+        column.setCellValueFactory(cell -> new javafx.beans.property.ReadOnlyObjectWrapper<>(cell.getValue()));
+        column.setCellFactory(ignored -> new TableCell<>() {
+            private final Button button = actionButton(buttonText);
+            {
+                button.setOnAction(event -> {
+                    T item = getItem();
+                    if (item != null) {
+                        action.accept(item);
+                    }
+                });
+            }
+
+            @Override
+            protected void updateItem(T item, boolean empty) {
+                super.updateItem(item, empty);
+                setGraphic(empty || item == null ? null : button);
+            }
+        });
+        table.getColumns().add(column);
+    }
+
+    void apply(List<T> values) {
+        source = values == null ? List.of() : List.copyOf(values);
+        refilter();
+    }
+
+    void setQuery(String nextQuery) {
+        query = nextQuery == null ? "" : nextQuery.trim().toLowerCase(Locale.ROOT);
+        refilter();
+    }
+
+    TableView<T> table() {
+        return table;
+    }
+
+    void setStatus(String message) {
+        status.setText(message == null ? "" : message);
+    }
+
+    private void refilter() {
+        List<T> filtered = query.isBlank()
+                ? source
+                : source.stream()
+                        .filter(value -> shown(searchableText.apply(value)).toLowerCase(Locale.ROOT).contains(query))
+                        .toList();
+        table.getItems().setAll(filtered);
+        count.setText(filtered.size() + " " + resultLabel + " gefunden");
+    }
+
+    private void openSelected() {
+        T selected = table.getSelectionModel().getSelectedItem();
+        if (selected != null) {
+            primaryAction.accept(selected);
+        }
+    }
+
+    private static Button actionButton(String text) {
+        Button button = new Button(text);
+        button.getStyleClass().addAll("accent", "compact");
+        return button;
+    }
+
+    private static String shown(String value) {
+        return value == null || value.isBlank() ? "–" : value;
+    }
+}

--- a/features/catalog/adapter/javafx/CatalogViewModel.java
+++ b/features/catalog/adapter/javafx/CatalogViewModel.java
@@ -10,17 +10,14 @@ import features.creatures.api.SelectCreatureDetailCommand;
 import features.encounter.api.EncounterApi;
 import features.encounter.api.ApplyEncounterStateCommand;
 import features.encounter.api.EncounterBuilderInputs;
-import features.encounter.api.UpdateEncounterBuilderInputsCommand;
+import features.encounter.api.EncounterPoolFilters;
+import features.encounter.api.UpdateEncounterPoolFiltersCommand;
 import features.encountertable.api.EncounterTableApi;
 import features.encountertable.api.RefreshEncounterTableCatalogCommand;
 
 final class CatalogViewModel {
 
     private static final long NO_CREATURE_ID = 0L;
-    private static final int MIN_DIFFICULTY_LEVEL = 1;
-    private static final int DEFAULT_DIFFICULTY_LEVEL = 2;
-    private static final int NEUTRAL_DIFFICULTY_LEVEL = 3;
-    private static final int MAX_DIFFICULTY_LEVEL = 4;
 
     private final CatalogMainContentModel mainContentModel = new CatalogMainContentModel();
     private final CatalogControlsContentModel controlsContentModel = new CatalogControlsContentModel();
@@ -66,7 +63,6 @@ final class CatalogViewModel {
         CatalogControlsContentModel.InteractionState interactionState = controlsContentModel.interactionState();
         CatalogControlsContentModel.LocalFilterState previousLocalFilters = interactionState.localFilters();
         CatalogControlsContentModel.ControlsState previousDraftControls = interactionState.draftControls();
-        CatalogControlsContentModel.ControlsState authoritativeControls = interactionState.domainControls();
 
         controlsContentModel.applyControlsDraft(new CatalogControlsContentModel.ControlsDraft(
                 new CatalogControlsContentModel.LocalFilterState(
@@ -112,23 +108,22 @@ final class CatalogViewModel {
         }
 
         CatalogControlsContentModel.ControlsState currentDraftControls = currentState.draftControls();
-        if (!previousDraftControls.equals(currentDraftControls) && !currentDraftControls.equals(authoritativeControls)) {
-            encounters.updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(
-                    new EncounterBuilderInputs(
-                            currentDraftControls.creatureTypes(),
-                            currentDraftControls.creatureSubtypes(),
-                            currentDraftControls.biomes(),
-                            currentDraftControls.difficulty().auto(),
-                            toDifficultyLevel(currentDraftControls.difficulty().value()),
-                            currentDraftControls.balance().auto(),
-                            roundedLevel(currentDraftControls.balance().value()),
-                            currentDraftControls.amount().auto(),
-                            currentDraftControls.amount().value(),
-                            currentDraftControls.diversity().auto(),
-                            roundedLevel(currentDraftControls.diversity().value()),
-                            currentDraftControls.encounterTableIds(),
-                            currentDraftControls.worldFactionIds(),
-                            currentDraftControls.worldLocationId())));
+        boolean poolFiltersChanged = !previousLocalFilters.equals(currentState.localFilters())
+                || !previousDraftControls.equals(currentDraftControls);
+        if (poolFiltersChanged) {
+            CatalogControlsContentModel.LocalFilterState filters = currentState.localFilters();
+            encounters.updatePoolFilters(new UpdateEncounterPoolFiltersCommand(new EncounterPoolFilters(
+                    filters.nameQuery(),
+                    filters.challengeRatingMin(),
+                    filters.challengeRatingMax(),
+                    filters.sizes(),
+                    currentDraftControls.creatureTypes(),
+                    currentDraftControls.creatureSubtypes(),
+                    currentDraftControls.biomes(),
+                    filters.alignments(),
+                    currentDraftControls.encounterTableIds(),
+                    currentDraftControls.worldFactionIds(),
+                    currentDraftControls.worldLocationId())));
         }
     }
 
@@ -181,21 +176,4 @@ final class CatalogViewModel {
                 mainContentModel.currentPageOffset()));
     }
 
-    private static int toDifficultyLevel(double value) {
-        int rounded = roundedLevel(value);
-        if (rounded <= MIN_DIFFICULTY_LEVEL) {
-            return MIN_DIFFICULTY_LEVEL;
-        }
-        if (rounded == NEUTRAL_DIFFICULTY_LEVEL) {
-            return NEUTRAL_DIFFICULTY_LEVEL;
-        }
-        if (rounded >= MAX_DIFFICULTY_LEVEL) {
-            return MAX_DIFFICULTY_LEVEL;
-        }
-        return DEFAULT_DIFFICULTY_LEVEL;
-    }
-
-    private static int roundedLevel(double value) {
-        return (int) Math.round(value);
-    }
 }

--- a/features/catalog/adapter/javafx/CatalogViewModel.java
+++ b/features/catalog/adapter/javafx/CatalogViewModel.java
@@ -25,15 +25,26 @@ final class CatalogViewModel {
     private final CreaturesApi creatures;
     private final EncounterTableApi encounterTables;
     private final EncounterApi encounters;
+    private final java.util.function.LongConsumer addCreatureToScene;
 
     CatalogViewModel(
             CreaturesApi creatures,
             EncounterTableApi encounterTables,
             EncounterApi encounters
     ) {
+        this(creatures, encounterTables, encounters, ignored -> { });
+    }
+
+    CatalogViewModel(
+            CreaturesApi creatures,
+            EncounterTableApi encounterTables,
+            EncounterApi encounters,
+            java.util.function.LongConsumer addCreatureToScene
+    ) {
         this.creatures = Objects.requireNonNull(creatures, "creatures");
         this.encounterTables = Objects.requireNonNull(encounterTables, "encounterTables");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
+        this.addCreatureToScene = Objects.requireNonNull(addCreatureToScene, "addCreatureToScene");
         creatures.refreshFilterOptions(new RefreshCreatureFilterOptionsCommand());
         encounterTables.refreshCatalog(new RefreshEncounterTableCatalogCommand());
         refreshCatalog();
@@ -150,6 +161,10 @@ final class CatalogViewModel {
         }
         if (event.actionCreatureId() > NO_CREATURE_ID) {
             encounters.applyState(ApplyEncounterStateCommand.addCreature(event.actionCreatureId()));
+            return;
+        }
+        if (event.sceneCreatureId() > NO_CREATURE_ID) {
+            addCreatureToScene.accept(event.sceneCreatureId());
         }
     }
 

--- a/features/catalog/adapter/javafx/CatalogWorkspaceView.java
+++ b/features/catalog/adapter/javafx/CatalogWorkspaceView.java
@@ -14,6 +14,9 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TableColumn;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
@@ -27,6 +30,10 @@ import features.encounter.api.EncounterApi;
 import features.encounter.api.OpenSavedEncounterPlanCommand;
 import features.encounter.api.OpenSavedEncounterPlanResult;
 import features.encounter.api.SavedEncounterPlanListModel;
+import features.encounter.api.EncounterBuilderInputsModel;
+import features.encounter.api.EncounterPoolFilters;
+import features.encounter.api.UpdateEncounterPoolFiltersCommand;
+import features.encounter.api.ApplyEncounterStateCommand;
 import features.encounter.api.SavedEncounterPlanListResult;
 import features.encounter.api.SavedEncounterPlanSummary;
 import features.encountertable.api.EncounterTableCatalogModel;
@@ -38,6 +45,8 @@ import features.worldplanner.api.WorldLocationSummary;
 import features.worldplanner.api.WorldNpcSummary;
 import features.worldplanner.api.WorldPlannerSnapshot;
 import features.worldplanner.api.WorldPlannerSnapshotModel;
+import features.creatures.api.CreatureCatalogModel;
+import features.creatures.api.CreatureQueryStatus;
 
 /** One reference workspace; provider features keep all domain truth. */
 final class CatalogWorkspaceView extends BorderPane {
@@ -50,13 +59,19 @@ final class CatalogWorkspaceView extends BorderPane {
     private final ReferenceListPane<WorldFactionSummary> factions;
     private final ReferenceListPane<WorldLocationSummary> locations;
     private final ReferenceListPane<EncounterTableSummary> encounterTables;
+    private final java.util.Map<Long, String> creatureNames = new java.util.HashMap<>();
+    private final java.util.Map<Long, String> factionNames = new java.util.HashMap<>();
+    private final java.util.Map<Long, String> tableNames = new java.util.HashMap<>();
+    private WorldPlannerSnapshot currentWorld;
 
     CatalogWorkspaceView(
             CatalogMainView monsters,
-            CatalogControlsView monsterControls,
+            CatalogControlsHost controls,
             ItemsCatalogApi itemsApi,
             EncounterApi encounterApi,
             SavedEncounterPlanListModel savedPlans,
+            EncounterBuilderInputsModel builderInputs,
+            CreatureCatalogModel creatureCatalog,
             EncounterTableCatalogModel encounterTableCatalog,
             WorldPlannerSnapshotModel worldPlanner,
             InspectorSink inspector,
@@ -65,19 +80,43 @@ final class CatalogWorkspaceView extends BorderPane {
             java.util.function.LongConsumer openLocationInspector,
             Runnable createNpc,
             Runnable createFaction,
-            Runnable createLocation
+            Runnable createLocation,
+            java.util.function.LongConsumer addNpcToScene,
+            java.util.function.LongConsumer setSceneLocation
     ) {
         this.monsters = monsters;
         items = new ItemsPane(itemsApi, inspector);
         encounters = new SavedEncounterPane(encounterApi);
-        npcs = new ReferenceListPane<>("Keine NPCs verfügbar.", WorldNpcSummary::displayName,
+        npcs = new ReferenceListPane<>("NPCs", "Keine NPCs verfügbar.", WorldNpcSummary::displayName,
+                value -> reference(creatureNames, value.creatureStatblockId(), "Statblock") + " · "
+                        + reference(factionNames, value.factionId(), "Keine Fraktion")
+                        + " · " + value.disposition() + " · " + value.status(),
                 value -> openNpcInspector.accept(value.npcId()), "NPC anlegen", createNpc);
-        factions = new ReferenceListPane<>("Keine Fraktionen verfügbar.", WorldFactionSummary::displayName,
+        factions = new ReferenceListPane<>("Fraktionen", "Keine Fraktionen verfügbar.", WorldFactionSummary::displayName,
+                value -> reference(tableNames, value.primaryEncounterTableId(), "Tabelle")
+                        + " · Haltung " + value.disposition()
+                        + " · " + value.npcIds().size() + " NPCs",
                 value -> openFactionInspector.accept(value.factionId()), "Fraktion anlegen", createFaction);
-        locations = new ReferenceListPane<>("Keine Orte verfügbar.", WorldLocationSummary::displayName,
+        locations = new ReferenceListPane<>("Orte", "Keine Orte verfügbar.", WorldLocationSummary::displayName,
+                value -> joinedReferences(factionNames, value.factionIds(), "Fraktionen") + " · "
+                        + joinedReferences(tableNames, value.encounterTableIds(), "Tabellen"),
                 value -> openLocationInspector.accept(value.locationId()), "Ort anlegen", createLocation);
-        encounterTables = new ReferenceListPane<>("Keine Encounter-Tabellen verfügbar.", EncounterTableSummary::name,
-                ignored -> { }, "", () -> { });
+        encounterTables = new ReferenceListPane<>("Tabellen", "Keine Encounter-Tabellen verfügbar.",
+                EncounterTableSummary::name,
+                value -> "#" + value.tableId(), ignored -> { }, "", () -> { });
+        npcs.addAction("Encounter", "Zum Encounter", value -> encounterApi.applyState(
+                ApplyEncounterStateCommand.addWorldNpcCreature(value.creatureStatblockId(), value.npcId())));
+        npcs.addAction("Scene", "Zur Scene", value -> addNpcToScene.accept(value.npcId()));
+        factions.addAction("Encounter", "Als Quelle", value -> encounterApi.updatePoolFilters(
+                new UpdateEncounterPoolFiltersCommand(withFaction(builderInputs.current().poolFilters(),
+                        value.factionId()))));
+        locations.addAction("Encounter", "Als Quelle", value -> encounterApi.updatePoolFilters(
+                new UpdateEncounterPoolFiltersCommand(withLocation(builderInputs.current().poolFilters(),
+                        value.locationId()))));
+        locations.addAction("Scene", "Als Ort", value -> setSceneLocation.accept(value.locationId()));
+        encounterTables.addAction("Encounter", "Als Quelle", value -> encounterApi.updatePoolFilters(
+                new UpdateEncounterPoolFiltersCommand(withTable(builderInputs.current().poolFilters(),
+                        value.tableId()))));
 
         Tab monsterTab = tab("Monster", monsters);
         tabs.getTabs().setAll(
@@ -88,10 +127,25 @@ final class CatalogWorkspaceView extends BorderPane {
                 tab("Fraktionen", factions),
                 tab("Orte", locations),
                 tab("Encounter-Tabellen", encounterTables));
+        tabs.getStyleClass().add("catalog-category-tabs");
         tabs.getSelectionModel().selectedItemProperty().addListener((ignored, before, after) -> {
-            boolean monsterSelected = after == monsterTab;
-            monsterControls.setVisible(monsterSelected);
-            monsterControls.setManaged(monsterSelected);
+            if (after == monsterTab) {
+                controls.showMonster();
+            } else if (after != null && "Items".equals(after.getText())) {
+                controls.showSection("Items", "Items filtern …", items::setQuickQuery, "", () -> { });
+            } else if (after != null && "Encounter".equals(after.getText())) {
+                controls.showSection("Encounter", "Gespeicherte Encounter suchen …", encounters::setQuery, "", () -> { });
+            } else if (after != null && "NPCs".equals(after.getText())) {
+                controls.showSection("NPCs", "NPCs suchen …", npcs::setQuery, "NPC anlegen", createNpc);
+            } else if (after != null && "Fraktionen".equals(after.getText())) {
+                controls.showSection("Fraktionen", "Fraktionen suchen …", factions::setQuery,
+                        "Fraktion anlegen", createFaction);
+            } else if (after != null && "Orte".equals(after.getText())) {
+                controls.showSection("Orte", "Orte suchen …", locations::setQuery, "Ort anlegen", createLocation);
+            } else {
+                controls.showSection("Encounter-Tabellen", "Tabellen suchen …", encounterTables::setQuery,
+                        "", () -> { });
+            }
         });
         setCenter(tabs);
 
@@ -99,6 +153,8 @@ final class CatalogWorkspaceView extends BorderPane {
         encounters.apply(savedPlans.current());
         encounterTableCatalog.subscribe(this::applyEncounterTables);
         applyEncounterTables(encounterTableCatalog.current());
+        creatureCatalog.subscribe(this::applyCreatures);
+        applyCreatures(creatureCatalog.current());
         if (worldPlanner != null) {
             worldPlanner.subscribe(this::applyWorld);
             applyWorld(worldPlanner.current());
@@ -119,13 +175,31 @@ final class CatalogWorkspaceView extends BorderPane {
     }
 
     private void applyEncounterTables(EncounterTableCatalogResult result) {
-        encounterTables.apply(result == null ? List.of() : result.tables());
+        List<EncounterTableSummary> values = result == null ? List.of() : result.tables();
+        tableNames.clear();
+        values.forEach(value -> tableNames.put(value.tableId(), value.name()));
+        encounterTables.apply(values);
+        if (currentWorld != null) {
+            applyWorld(currentWorld);
+        }
+    }
+
+    private void applyCreatures(features.creatures.api.CreatureCatalogPageResult result) {
+        if (result != null && result.status() == CreatureQueryStatus.SUCCESS && result.page() != null) {
+            result.page().rows().forEach(value -> creatureNames.put(value.id(), value.name()));
+            if (currentWorld != null) {
+                applyWorld(currentWorld);
+            }
+        }
     }
 
     private void applyWorld(WorldPlannerSnapshot snapshot) {
         if (snapshot == null) {
             return;
         }
+        currentWorld = snapshot;
+        factionNames.clear();
+        snapshot.factions().forEach(value -> factionNames.put(value.factionId(), value.displayName()));
         npcs.apply(snapshot.npcs());
         factions.apply(snapshot.factions());
         locations.apply(snapshot.locations());
@@ -137,21 +211,42 @@ final class CatalogWorkspaceView extends BorderPane {
         return tab;
     }
 
+    private static String reference(java.util.Map<Long, String> labels, long id, String fallback) {
+        if (id <= 0L) {
+            return fallback;
+        }
+        String label = labels.get(id);
+        return label == null || label.isBlank() ? fallback + " #" + id : label + " (#" + id + ")";
+    }
+
+    private static String joinedReferences(
+            java.util.Map<Long, String> labels,
+            List<Long> ids,
+            String empty
+    ) {
+        if (ids == null || ids.isEmpty()) {
+            return "Keine " + empty;
+        }
+        return ids.stream().map(id -> reference(labels, id, empty)).collect(java.util.stream.Collectors.joining(", "));
+    }
+
     private static final class SavedEncounterPane extends BorderPane {
 
         private final EncounterApi encounters;
-        private final ListView<SavedEncounterPlanSummary> plans = new ListView<>();
+        private final TableView<SavedEncounterPlanSummary> plans = new TableView<>();
         private final Label status = new Label();
+        private List<SavedEncounterPlanSummary> source = List.of();
+        private String query = "";
 
         private SavedEncounterPane(EncounterApi encounters) {
             this.encounters = encounters;
-            plans.setCellFactory(ignored -> new ListCell<>() {
-                @Override
-                protected void updateItem(SavedEncounterPlanSummary item, boolean empty) {
-                    super.updateItem(item, empty);
-                    setText(empty || item == null ? "" : item.name() + " · " + item.summaryText());
-                }
-            });
+            plans.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+            TableColumn<SavedEncounterPlanSummary, String> name =
+                    textColumn("Name", SavedEncounterPlanSummary::name);
+            TableColumn<SavedEncounterPlanSummary, String> summary =
+                    textColumn("Zusammenfassung", SavedEncounterPlanSummary::summaryText);
+            plans.getColumns().setAll(name, summary);
+            plans.setPlaceholder(new Label("Keine gespeicherten Encounter."));
             plans.setOnMouseClicked(event -> {
                 if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
                     open(false);
@@ -166,8 +261,21 @@ final class CatalogWorkspaceView extends BorderPane {
         }
 
         private void apply(SavedEncounterPlanListResult result) {
-            plans.getItems().setAll(result == null ? List.of() : result.plans());
+            source = result == null ? List.of() : result.plans();
+            refilter();
             status.setText(result == null ? "" : result.message());
+        }
+
+        private void setQuery(String value) {
+            query = value == null ? "" : value.trim().toLowerCase(java.util.Locale.ROOT);
+            refilter();
+        }
+
+        private void refilter() {
+            plans.getItems().setAll(query.isBlank() ? source : source.stream()
+                    .filter(plan -> (plan.name() + " " + plan.summaryText())
+                            .toLowerCase(java.util.Locale.ROOT).contains(query))
+                    .toList());
         }
 
         private void open(boolean confirmed) {
@@ -221,7 +329,7 @@ final class CatalogWorkspaceView extends BorderPane {
         private final TextField maximumCost = textField("Item-Maximalkosten", "Max. CP");
         private final ComboBox<ItemsCatalogApi.SortField> sort = sortBox();
         private final ComboBox<SortDirection> direction = directionBox();
-        private final ListView<ItemsCatalogApi.ItemRow> rows = new ListView<>();
+        private final TableView<ItemsCatalogApi.ItemRow> rows = new TableView<>();
         private final Label status = new Label();
         private final Label page = new Label("Seite –");
         private final Button previous = new Button("Zurück");
@@ -270,13 +378,17 @@ final class CatalogWorkspaceView extends BorderPane {
         private void configureRows() {
             rows.setAccessibleText("Item-Ergebnisse");
             rows.setPlaceholder(new Label("Keine Items gefunden."));
-            rows.setCellFactory(ignored -> new ListCell<>() {
-                @Override
-                protected void updateItem(ItemsCatalogApi.ItemRow item, boolean empty) {
-                    super.updateItem(item, empty);
-                    setText(empty || item == null ? "" : rowText(item));
-                }
-            });
+            rows.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+            TableColumn<ItemsCatalogApi.ItemRow, String> name = textColumn("Name", ItemsCatalogApi.ItemRow::name);
+            TableColumn<ItemsCatalogApi.ItemRow, String> category =
+                    textColumn("Kategorie", item -> joined(item.category(), item.subcategory()));
+            TableColumn<ItemsCatalogApi.ItemRow, String> rarity =
+                    textColumn("Seltenheit", item -> shown(item.rarity()));
+            TableColumn<ItemsCatalogApi.ItemRow, String> magic =
+                    textColumn("Magie", item -> yesNo(item.magic()));
+            TableColumn<ItemsCatalogApi.ItemRow, String> cost =
+                    textColumn("Kosten", item -> shown(item.costDisplay()));
+            rows.getColumns().setAll(name, category, rarity, magic, cost);
             rows.setOnMouseClicked(event -> {
                 if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
                     openDetail();
@@ -312,6 +424,11 @@ final class CatalogWorkspaceView extends BorderPane {
 
         void refresh() {
             loadFilterOptions();
+            searchFirstPage();
+        }
+
+        void setQuickQuery(String value) {
+            search.setText(value == null ? "" : value);
             searchFirstPage();
         }
 
@@ -640,49 +757,60 @@ final class CatalogWorkspaceView extends BorderPane {
 
     private static final class ReferenceListPane<T> extends BorderPane {
 
-        private final ListView<T> values = new ListView<>();
+        private final CatalogSectionFrame<T> frame;
 
         private ReferenceListPane(
+                String resultLabel,
                 String emptyText,
                 java.util.function.Function<T, String> label,
+                java.util.function.Function<T, String> detail,
                 java.util.function.Consumer<T> open,
                 String createLabel,
                 Runnable create
         ) {
-            values.setPlaceholder(new Label(emptyText));
-            values.setCellFactory(ignored -> new ListCell<>() {
-                @Override
-                protected void updateItem(T item, boolean empty) {
-                    super.updateItem(item, empty);
-                    setText(empty || item == null ? "" : label.apply(item));
-                }
-            });
-            values.setOnMouseClicked(event -> {
-                T selected = values.getSelectionModel().getSelectedItem();
-                if (selected != null && event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
-                    open.accept(selected);
-                }
-            });
-            values.setOnKeyPressed(event -> {
-                T selected = values.getSelectionModel().getSelectedItem();
-                if (selected != null && event.getCode() == KeyCode.ENTER) {
-                    open.accept(selected);
-                    event.consume();
-                }
-            });
-            setCenter(values);
-            if (!createLabel.isBlank()) {
-                Button createButton = new Button(createLabel);
-                createButton.setOnAction(ignored -> create.run());
-                HBox actions = new HBox(createButton);
-                actions.setPadding(new Insets(8));
-                setTop(actions);
-            }
+            frame = new CatalogSectionFrame<>(resultLabel, emptyText,
+                    value -> label.apply(value) + " " + detail.apply(value), open,
+                    createLabel, create);
+            frame.addTextColumn("Name", 260, label);
+            frame.addTextColumn("Details", 520, detail);
+            frame.addActionColumn("Aktion", "Details", open);
+            setCenter(frame);
         }
 
         private void apply(List<T> next) {
-            values.getItems().setAll(next == null ? List.of() : next);
+            frame.apply(next);
         }
+
+        private void setQuery(String query) {
+            frame.setQuery(query);
+        }
+
+        private void addAction(String title, String label, java.util.function.Consumer<T> action) {
+            frame.addActionColumn(title, label, action);
+        }
+    }
+
+    private static EncounterPoolFilters withFaction(EncounterPoolFilters source, long factionId) {
+        EncounterPoolFilters safe = source == null ? EncounterPoolFilters.empty() : source;
+        return new EncounterPoolFilters(safe.nameQuery(), safe.challengeRatingMin(), safe.challengeRatingMax(),
+                safe.sizes(), safe.creatureTypes(), safe.creatureSubtypes(), safe.biomes(), safe.alignments(),
+                safe.encounterTableIds(), List.of(factionId), safe.worldLocationId());
+    }
+
+    private static EncounterPoolFilters withLocation(EncounterPoolFilters source, long locationId) {
+        EncounterPoolFilters safe = source == null ? EncounterPoolFilters.empty() : source;
+        return new EncounterPoolFilters(safe.nameQuery(), safe.challengeRatingMin(), safe.challengeRatingMax(),
+                safe.sizes(), safe.creatureTypes(), safe.creatureSubtypes(), safe.biomes(), safe.alignments(),
+                safe.encounterTableIds(), safe.worldFactionIds(), locationId);
+    }
+
+    private static EncounterPoolFilters withTable(EncounterPoolFilters source, long tableId) {
+        EncounterPoolFilters safe = source == null ? EncounterPoolFilters.empty() : source;
+        java.util.LinkedHashSet<Long> ids = new java.util.LinkedHashSet<>(safe.encounterTableIds());
+        ids.add(tableId);
+        return new EncounterPoolFilters(safe.nameQuery(), safe.challengeRatingMin(), safe.challengeRatingMax(),
+                safe.sizes(), safe.creatureTypes(), safe.creatureSubtypes(), safe.biomes(), safe.alignments(),
+                List.copyOf(ids), safe.worldFactionIds(), safe.worldLocationId());
     }
 
     private static void runOnFx(Runnable action) {
@@ -691,5 +819,14 @@ final class CatalogWorkspaceView extends BorderPane {
         } else {
             Platform.runLater(action);
         }
+    }
+
+    private static <T> TableColumn<T, String> textColumn(
+            String title,
+            java.util.function.Function<T, String> value
+    ) {
+        TableColumn<T, String> column = new TableColumn<>(title);
+        column.setCellValueFactory(cell -> new SimpleStringProperty(value.apply(cell.getValue())));
+        return column;
     }
 }

--- a/features/creatures/adapter/sqlite/gateway/local/CreatureFilterTempTables.java
+++ b/features/creatures/adapter/sqlite/gateway/local/CreatureFilterTempTables.java
@@ -36,7 +36,9 @@ final class CreatureFilterTempTables {
         CreatureFilterTempTableSchema.createTempTables(connection);
         clearFilters(connection);
         try {
+            CreatureFilterTempTableValues.insertSizes(connection, spec.sizes());
             CreatureFilterTempTableValues.insertTypes(connection, spec.types());
+            CreatureFilterTempTableValues.insertAlignments(connection, spec.alignments());
             CreatureFilterTempTableValues.insertSubtypes(connection, spec.subtypes());
             CreatureFilterTempTableValues.insertBiomes(connection, spec.biomes());
         } catch (SQLException exception) {

--- a/features/creatures/adapter/sqlite/gateway/local/EncounterCandidateSqliteStore.java
+++ b/features/creatures/adapter/sqlite/gateway/local/EncounterCandidateSqliteStore.java
@@ -19,6 +19,10 @@ final class EncounterCandidateSqliteStore {
                     + CreaturesPersistenceSchema.CREATURES.name()
                     + " "
                     + "WHERE xp >= ? AND xp <= ? "
+                    + "AND (? = '' OR LOWER(name) LIKE '%' || LOWER(?) || '%') "
+                    + "AND ((SELECT COUNT(*) FROM " + CreaturesPersistenceSchema.TEMP_FILTER_SIZES_TABLE + ") = 0 "
+                    + "OR LOWER(size) IN (SELECT value FROM "
+                    + CreaturesPersistenceSchema.TEMP_FILTER_SIZES_TABLE + ")) "
                     + "AND ((SELECT COUNT(*) FROM " + CreaturesPersistenceSchema.TEMP_FILTER_TYPES_TABLE + ") = 0 "
                     + "OR LOWER(creature_type) IN (SELECT value FROM "
                     + CreaturesPersistenceSchema.TEMP_FILTER_TYPES_TABLE + ")) "
@@ -30,6 +34,9 @@ final class EncounterCandidateSqliteStore {
                     + "OR id IN (SELECT creature_id FROM " + CreaturesPersistenceSchema.CREATURE_BIOMES.name()
                     + " WHERE LOWER(biome) IN (SELECT value FROM "
                     + CreaturesPersistenceSchema.TEMP_FILTER_BIOMES_TABLE + "))) "
+                    + "AND ((SELECT COUNT(*) FROM " + CreaturesPersistenceSchema.TEMP_FILTER_ALIGNMENTS_TABLE + ") = 0 "
+                    + "OR LOWER(alignment) IN (SELECT value FROM "
+                    + CreaturesPersistenceSchema.TEMP_FILTER_ALIGNMENTS_TABLE + ")) "
                     + "ORDER BY xp ASC, name ASC LIMIT ?";
 
     List<EncounterCandidateRecord> loadEncounterCandidates(
@@ -40,7 +47,9 @@ final class EncounterCandidateSqliteStore {
         try (PreparedStatement statement = connection.prepareStatement(LOAD_ENCOUNTER_CANDIDATES_SQL)) {
             statement.setInt(1, spec.minimumXp());
             statement.setInt(2, spec.maximumXp());
-            statement.setInt(3, spec.limit());
+            statement.setString(3, spec.nameQuery());
+            statement.setString(4, spec.nameQuery());
+            statement.setInt(5, spec.limit());
             return readEncounterCandidates(statement);
         } finally {
             CreatureFilterTempTables.clearFilters(connection);

--- a/features/creatures/adapter/sqlite/mapper/CreatureCatalogQueryMappingFacade.java
+++ b/features/creatures/adapter/sqlite/mapper/CreatureCatalogQueryMappingFacade.java
@@ -51,9 +51,12 @@ public final class CreatureCatalogQueryMappingFacade {
             CreatureCatalogData.EncounterCandidateSpec spec
     ) {
         return new EncounterCandidateCriteriaRecord(
+                spec.nameQuery(),
                 spec.types(),
                 spec.subtypes(),
                 spec.biomes(),
+                spec.sizes(),
+                spec.alignments(),
                 spec.minimumXp(),
                 spec.maximumXp(),
                 spec.limit());

--- a/features/creatures/adapter/sqlite/model/EncounterCandidateCriteriaRecord.java
+++ b/features/creatures/adapter/sqlite/model/EncounterCandidateCriteriaRecord.java
@@ -3,17 +3,34 @@ package features.creatures.adapter.sqlite.model;
 import java.util.List;
 
 public record EncounterCandidateCriteriaRecord(
+        String nameQuery,
         List<String> types,
         List<String> subtypes,
         List<String> biomes,
+        List<String> sizes,
+        List<String> alignments,
         int minimumXp,
         int maximumXp,
         int limit
 ) {
+    public EncounterCandidateCriteriaRecord(
+            List<String> types,
+            List<String> subtypes,
+            List<String> biomes,
+            int minimumXp,
+            int maximumXp,
+            int limit
+    ) {
+        this("", types, subtypes, biomes, List.of(), List.of(), minimumXp, maximumXp, limit);
+    }
+
     public EncounterCandidateCriteriaRecord {
+        nameQuery = nameQuery == null ? "" : nameQuery.trim();
         types = copyStrings(types);
         subtypes = copyStrings(subtypes);
         biomes = copyStrings(biomes);
+        sizes = copyStrings(sizes);
+        alignments = copyStrings(alignments);
     }
 
     @Override
@@ -29,6 +46,16 @@ public record EncounterCandidateCriteriaRecord(
     @Override
     public List<String> biomes() {
         return copyStrings(biomes);
+    }
+
+    @Override
+    public List<String> sizes() {
+        return copyStrings(sizes);
+    }
+
+    @Override
+    public List<String> alignments() {
+        return copyStrings(alignments);
     }
 
     private static List<String> copyStrings(List<String> values) {

--- a/features/creatures/api/RefreshCreatureEncounterCandidatesCommand.java
+++ b/features/creatures/api/RefreshCreatureEncounterCandidatesCommand.java
@@ -7,15 +7,37 @@ public record RefreshCreatureEncounterCandidatesCommand(
         List<String> creatureTypes,
         List<String> creatureSubtypes,
         List<String> biomes,
+        String nameQuery,
+        String challengeRatingMin,
+        String challengeRatingMax,
+        List<String> sizes,
+        List<String> alignments,
         int minimumXp,
         int maximumXp,
         int limit
 ) {
 
+    public RefreshCreatureEncounterCandidatesCommand(
+            List<String> creatureTypes,
+            List<String> creatureSubtypes,
+            List<String> biomes,
+            int minimumXp,
+            int maximumXp,
+            int limit
+    ) {
+        this(creatureTypes, creatureSubtypes, biomes, "", "", "", List.of(), List.of(),
+                minimumXp, maximumXp, limit);
+    }
+
     public RefreshCreatureEncounterCandidatesCommand {
         creatureTypes = copyStrings(creatureTypes);
         creatureSubtypes = copyStrings(creatureSubtypes);
         biomes = copyStrings(biomes);
+        nameQuery = nameQuery == null ? "" : nameQuery.trim();
+        challengeRatingMin = challengeRatingMin == null ? "" : challengeRatingMin.trim();
+        challengeRatingMax = challengeRatingMax == null ? "" : challengeRatingMax.trim();
+        sizes = copyStrings(sizes);
+        alignments = copyStrings(alignments);
     }
 
     @Override

--- a/features/creatures/application/CreaturesApplicationService.java
+++ b/features/creatures/application/CreaturesApplicationService.java
@@ -259,10 +259,10 @@ public final class CreaturesApplicationService implements features.creatures.api
             if (command == null) {
                 return empty();
             }
-            String minimumChallengeRating = trimmedOrNull(command.challengeRatingMin());
-            String maximumChallengeRating = trimmedOrNull(command.challengeRatingMax());
+            String minimumChallengeRating = CatalogRequest.trimmedOrNull(command.challengeRatingMin());
+            String maximumChallengeRating = CatalogRequest.trimmedOrNull(command.challengeRatingMax());
             return new CatalogRequest(
-                    trimmedOrNull(command.nameQuery()),
+                    CatalogRequest.trimmedOrNull(command.nameQuery()),
                     minimumChallengeRating,
                     maximumChallengeRating,
                     xpForChallengeRating(minimumChallengeRating),
@@ -364,9 +364,12 @@ public final class CreaturesApplicationService implements features.creatures.api
     }
 
     private record EncounterCandidateRequest(
+            @Nullable String nameQuery,
             List<String> creatureTypes,
             List<String> creatureSubtypes,
             List<String> biomes,
+            List<String> sizes,
+            List<String> alignments,
             int minimumXp,
             int maximumXp,
             int limit
@@ -375,6 +378,9 @@ public final class CreaturesApplicationService implements features.creatures.api
         static EncounterCandidateRequest from(@Nullable RefreshCreatureEncounterCandidatesCommand command) {
             if (command == null) {
                 return new EncounterCandidateRequest(
+                        null,
+                        List.of(),
+                        List.of(),
                         List.of(),
                         List.of(),
                         List.of(),
@@ -382,20 +388,35 @@ public final class CreaturesApplicationService implements features.creatures.api
                         Integer.MAX_VALUE,
                         DEFAULT_ENCOUNTER_CANDIDATE_LIMIT);
             }
+            String minimumChallengeRating = CatalogRequest.trimmedOrNull(command.challengeRatingMin());
+            String maximumChallengeRating = CatalogRequest.trimmedOrNull(command.challengeRatingMax());
+            Integer challengeMinimumXp = CatalogRequest.xpForChallengeRating(minimumChallengeRating);
+            Integer challengeMaximumXp = CatalogRequest.xpForChallengeRating(maximumChallengeRating);
             return new EncounterCandidateRequest(
+                    CatalogRequest.trimmedOrNull(command.nameQuery()),
                     CatalogRequest.normalizeValues(command.creatureTypes()),
                     CatalogRequest.normalizeValues(command.creatureSubtypes()),
                     CatalogRequest.normalizeValues(command.biomes()),
-                    Math.max(0, command.minimumXp()),
-                    command.maximumXp() <= 0 ? Integer.MAX_VALUE : command.maximumXp(),
+                    CatalogRequest.normalizeValues(command.sizes()),
+                    CatalogRequest.normalizeValues(command.alignments()),
+                    challengeMinimumXp == null
+                            ? Math.max(0, command.minimumXp())
+                            : Math.max(Math.max(0, command.minimumXp()), challengeMinimumXp.intValue()),
+                    challengeMaximumXp == null
+                            ? (command.maximumXp() <= 0 ? Integer.MAX_VALUE : command.maximumXp())
+                            : Math.min(command.maximumXp() <= 0 ? Integer.MAX_VALUE : command.maximumXp(),
+                                    challengeMaximumXp.intValue()),
                     normalizeLimit(command.limit()));
         }
 
         CreatureCatalogData.EncounterCandidateSpec spec() {
             return new CreatureCatalogData.EncounterCandidateSpec(
+                    nameQuery,
                     creatureTypes,
                     creatureSubtypes,
                     biomes,
+                    sizes,
+                    alignments,
                     minimumXp,
                     maximumXp,
                     limit);

--- a/features/creatures/domain/catalog/CreatureCatalogData.java
+++ b/features/creatures/domain/catalog/CreatureCatalogData.java
@@ -127,17 +127,33 @@ public final class CreatureCatalogData {
     }
 
     public record EncounterCandidateSpec(
+            @Nullable String nameQuery,
             List<String> types,
             List<String> subtypes,
             List<String> biomes,
+            List<String> sizes,
+            List<String> alignments,
             int minimumXp,
             int maximumXp,
             int limit
     ) {
+        public EncounterCandidateSpec(
+                List<String> types,
+                List<String> subtypes,
+                List<String> biomes,
+                int minimumXp,
+                int maximumXp,
+                int limit
+        ) {
+            this(null, types, subtypes, biomes, List.of(), List.of(), minimumXp, maximumXp, limit);
+        }
+
         public EncounterCandidateSpec {
             types = copyStrings(types);
             subtypes = copyStrings(subtypes);
             biomes = copyStrings(biomes);
+            sizes = copyStrings(sizes);
+            alignments = copyStrings(alignments);
         }
 
         @Override
@@ -153,6 +169,16 @@ public final class CreatureCatalogData {
         @Override
         public List<String> biomes() {
             return copyStrings(biomes);
+        }
+
+        @Override
+        public List<String> sizes() {
+            return copyStrings(sizes);
+        }
+
+        @Override
+        public List<String> alignments() {
+            return copyStrings(alignments);
         }
     }
 

--- a/features/encounter/EncounterServiceAssembly.java
+++ b/features/encounter/EncounterServiceAssembly.java
@@ -200,6 +200,7 @@ public final class EncounterServiceAssembly {
                     creatures,
                     state,
                     application,
+                    builderInputs,
                     worldPlanner,
                     openCreatureInspector);
         }

--- a/features/encounter/adapter/javafx/state/EncounterStateContribution.java
+++ b/features/encounter/adapter/javafx/state/EncounterStateContribution.java
@@ -10,6 +10,7 @@ import shell.api.ShellStateTabSpec;
 import features.creatures.api.CreaturesApi;
 import features.encounter.api.EncounterApi;
 import features.encounter.api.EncounterStateModel;
+import features.encounter.api.EncounterBuilderInputsModel;
 import features.worldplanner.api.WorldPlannerApi;
 
 public final class EncounterStateContribution implements ShellContribution {
@@ -17,6 +18,7 @@ public final class EncounterStateContribution implements ShellContribution {
     private final CreaturesApi creatures;
     private final EncounterStateModel stateModel;
     private final EncounterApi encounters;
+    private final EncounterBuilderInputsModel builderInputs;
     private final @Nullable WorldPlannerApi worldPlanner;
     private final java.util.function.LongConsumer openCreatureInspector;
 
@@ -27,9 +29,23 @@ public final class EncounterStateContribution implements ShellContribution {
             @Nullable WorldPlannerApi worldPlanner,
             java.util.function.LongConsumer openCreatureInspector
     ) {
+        this(creatures, stateModel, encounters,
+                new EncounterBuilderInputsModel(features.encounter.api.EncounterBuilderInputs::empty, null),
+                worldPlanner, openCreatureInspector);
+    }
+
+    public EncounterStateContribution(
+            CreaturesApi creatures,
+            EncounterStateModel stateModel,
+            EncounterApi encounters,
+            EncounterBuilderInputsModel builderInputs,
+            @Nullable WorldPlannerApi worldPlanner,
+            java.util.function.LongConsumer openCreatureInspector
+    ) {
         this.creatures = Objects.requireNonNull(creatures, "creatures");
         this.stateModel = Objects.requireNonNull(stateModel, "stateModel");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
+        this.builderInputs = Objects.requireNonNull(builderInputs, "builderInputs");
         this.worldPlanner = worldPlanner;
         this.openCreatureInspector = Objects.requireNonNull(openCreatureInspector, "openCreatureInspector");
     }
@@ -50,7 +66,8 @@ public final class EncounterStateContribution implements ShellContribution {
         EncounterInitiativeStateView initiativeView = new EncounterInitiativeStateView();
         EncounterCombatStateView combatView = new EncounterCombatStateView();
         EncounterResultsStateView resultsView = new EncounterResultsStateView();
-        EncounterStateView state = new EncounterStateView(builderView, initiativeView, combatView, resultsView);
+        EncounterTuningPane tuning = new EncounterTuningPane(encounters, builderInputs);
+        EncounterStateView state = new EncounterStateView(tuning, builderView, initiativeView, combatView, resultsView);
         state.bind(viewModel.activeModeProperty());
         builderView.bind(viewModel.builderPanelProperty());
         initiativeView.bind(viewModel.initiativePanelProperty());

--- a/features/encounter/adapter/javafx/state/EncounterStateView.java
+++ b/features/encounter/adapter/javafx/state/EncounterStateView.java
@@ -10,6 +10,7 @@ import features.encounter.api.EncounterStateSnapshot;
 public final class EncounterStateView extends VBox {
 
     private final StackPane contentArea = new EncounterContentStack();
+    private final Node tuning;
 
     public EncounterStateView(
             Node builderContent,
@@ -17,11 +18,26 @@ public final class EncounterStateView extends VBox {
             Node combatContent,
             Node resultsContent
     ) {
+        this(null, builderContent, initiativeContent, combatContent, resultsContent);
+    }
+
+    public EncounterStateView(
+            Node tuning,
+            Node builderContent,
+            Node initiativeContent,
+            Node combatContent,
+            Node resultsContent
+    ) {
+        this.tuning = tuning;
         ((EncounterContentStack) contentArea).setContent(builderContent, initiativeContent, combatContent, resultsContent);
         getStyleClass().add("surface-root");
         setFillWidth(true);
         setVgrow(contentArea, Priority.ALWAYS);
-        getChildren().add(contentArea);
+        if (tuning == null) {
+            getChildren().add(contentArea);
+        } else {
+            getChildren().addAll(tuning, contentArea);
+        }
     }
 
     public void bind(ReadOnlyObjectProperty<EncounterStateSnapshot.Mode> activeMode) {
@@ -33,6 +49,11 @@ public final class EncounterStateView extends VBox {
     }
 
     private void show(EncounterStateSnapshot.Mode activeContent) {
+        if (tuning != null) {
+            boolean builder = activeContent == EncounterStateSnapshot.Mode.BUILDER;
+            tuning.setVisible(builder);
+            tuning.setManaged(builder);
+        }
         showContent(EncounterStateVocabulary.contentIndex(activeContent));
     }
 

--- a/features/encounter/adapter/javafx/state/EncounterTuningPane.java
+++ b/features/encounter/adapter/javafx/state/EncounterTuningPane.java
@@ -1,0 +1,128 @@
+package features.encounter.adapter.javafx.state;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.Slider;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import features.encounter.api.EncounterApi;
+import features.encounter.api.EncounterBuilderInputs;
+import features.encounter.api.EncounterBuilderInputsModel;
+import features.encounter.api.EncounterTuningSettings;
+import features.encounter.api.UpdateEncounterTuningCommand;
+
+/** Encounter-owned, collapsible composition controls. */
+final class EncounterTuningPane extends TitledPane {
+
+    private final EncounterApi encounters;
+    private final CheckBox difficultyAuto = auto();
+    private final CheckBox balanceAuto = auto();
+    private final CheckBox amountAuto = auto();
+    private final CheckBox diversityAuto = auto();
+    private final Slider difficulty = slider(1, 4, 2);
+    private final Slider balance = slider(1, 5, 3);
+    private final Slider amount = slider(1, 5, 3);
+    private final Slider diversity = slider(1, 4, 3);
+    private final Label difficultyValue = new Label();
+    private final Label balanceValue = new Label();
+    private final Label amountValue = new Label();
+    private final Label diversityValue = new Label();
+    private boolean applying;
+
+    EncounterTuningPane(
+            EncounterApi encounters,
+            EncounterBuilderInputsModel inputsModel
+    ) {
+        super("Encounter abstimmen", new GridPane());
+        this.encounters = encounters;
+        setExpanded(false);
+        setAnimated(false);
+        getStyleClass().add("encounter-tuning-pane");
+        GridPane grid = (GridPane) getContent();
+        grid.setHgap(8);
+        grid.setVgap(6);
+        grid.setPadding(new Insets(8));
+        addRow(grid, 0, "Schwierigkeit", difficultyAuto, difficulty, difficultyValue);
+        addRow(grid, 1, "Balance", balanceAuto, balance, balanceValue);
+        addRow(grid, 2, "Menge", amountAuto, amount, amountValue);
+        addRow(grid, 3, "Diversität", diversityAuto, diversity, diversityValue);
+        configurePublishing();
+        inputsModel.subscribe(this::apply);
+        apply(inputsModel.current());
+    }
+
+    private void configurePublishing() {
+        difficultyAuto.setOnAction(ignored -> publish());
+        balanceAuto.setOnAction(ignored -> publish());
+        amountAuto.setOnAction(ignored -> publish());
+        diversityAuto.setOnAction(ignored -> publish());
+        difficulty.valueProperty().addListener((ignored, before, after) -> publish());
+        balance.valueProperty().addListener((ignored, before, after) -> publish());
+        amount.valueProperty().addListener((ignored, before, after) -> publish());
+        diversity.valueProperty().addListener((ignored, before, after) -> publish());
+    }
+
+    private void apply(EncounterBuilderInputs inputs) {
+        EncounterBuilderInputs safe = inputs == null ? EncounterBuilderInputs.empty() : inputs;
+        applying = true;
+        try {
+            difficultyAuto.setSelected(safe.autoDifficulty());
+            balanceAuto.setSelected(safe.autoBalance());
+            amountAuto.setSelected(safe.autoAmount());
+            diversityAuto.setSelected(safe.autoDiversity());
+            difficulty.setValue(safe.difficultyLevel());
+            balance.setValue(safe.balanceLevel());
+            amount.setValue(safe.amountValue());
+            diversity.setValue(safe.diversityLevel());
+            updateLabels();
+        } finally {
+            applying = false;
+        }
+    }
+
+    private void publish() {
+        updateLabels();
+        if (applying) {
+            return;
+        }
+        encounters.updateTuning(new UpdateEncounterTuningCommand(new EncounterTuningSettings(
+                difficultyAuto.isSelected(), rounded(difficulty),
+                balanceAuto.isSelected(), rounded(balance),
+                amountAuto.isSelected(), amount.getValue(),
+                diversityAuto.isSelected(), rounded(diversity))));
+    }
+
+    private void updateLabels() {
+        difficultyValue.setText(difficultyAuto.isSelected() ? "Auto" : Integer.toString(rounded(difficulty)));
+        balanceValue.setText(balanceAuto.isSelected() ? "Auto" : Integer.toString(rounded(balance)));
+        amountValue.setText(amountAuto.isSelected() ? "Auto" : String.format(java.util.Locale.ROOT, "%.1f", amount.getValue()));
+        diversityValue.setText(diversityAuto.isSelected() ? "Auto" : Integer.toString(rounded(diversity)));
+    }
+
+    private static void addRow(GridPane grid, int row, String label, CheckBox auto, Slider slider, Label value) {
+        grid.addRow(row, new Label(label), auto, slider, value);
+        GridPane.setHgrow(slider, Priority.ALWAYS);
+    }
+
+    private static CheckBox auto() {
+        CheckBox box = new CheckBox("Auto");
+        box.setSelected(true);
+        return box;
+    }
+
+    private static Slider slider(double minimum, double maximum, double initial) {
+        Slider slider = new Slider(minimum, maximum, initial);
+        slider.setBlockIncrement(1);
+        slider.setMajorTickUnit(1);
+        slider.setMinorTickCount(0);
+        slider.setSnapToTicks(true);
+        slider.setMaxWidth(Double.MAX_VALUE);
+        return slider;
+    }
+
+    private static int rounded(Slider slider) {
+        return (int) Math.round(slider.getValue());
+    }
+}

--- a/features/encounter/adapter/sqlite/gateway/local/SqliteEncounterRuntimeContextRepository.java
+++ b/features/encounter/adapter/sqlite/gateway/local/SqliteEncounterRuntimeContextRepository.java
@@ -214,6 +214,11 @@ public final class SqliteEncounterRuntimeContextRepository implements EncounterR
                 integers(values, "encounter-table"),
                 integers(values, "world-faction"),
                 root.getLong("builder_world_location_id"),
+                firstText(values, "name-query"),
+                firstText(values, "challenge-rating-min"),
+                firstText(values, "challenge-rating-max"),
+                texts(values, "size"),
+                texts(values, "alignment"),
                 caps);
     }
 
@@ -269,6 +274,11 @@ public final class SqliteEncounterRuntimeContextRepository implements EncounterR
         writeTextValues(connection, contextId, "creature-type", inputs.creatureTypes());
         writeTextValues(connection, contextId, "creature-subtype", inputs.creatureSubtypes());
         writeTextValues(connection, contextId, "biome", inputs.biomes());
+        writeTextValues(connection, contextId, "name-query", List.of(inputs.nameQuery()));
+        writeTextValues(connection, contextId, "challenge-rating-min", List.of(inputs.challengeRatingMin()));
+        writeTextValues(connection, contextId, "challenge-rating-max", List.of(inputs.challengeRatingMax()));
+        writeTextValues(connection, contextId, "size", inputs.sizes());
+        writeTextValues(connection, contextId, "alignment", inputs.alignments());
         writeIntegerValues(connection, contextId, "encounter-table", inputs.encounterTableIds());
         writeIntegerValues(connection, contextId, "world-faction", inputs.worldFactionIds());
         int order = 0;
@@ -295,6 +305,11 @@ public final class SqliteEncounterRuntimeContextRepository implements EncounterR
 
     private static List<String> texts(Map<String, List<ValueRow>> values, String kind) {
         return values.getOrDefault(kind, List.of()).stream().map(ValueRow::textValue).toList();
+    }
+
+    private static String firstText(Map<String, List<ValueRow>> values, String kind) {
+        List<ValueRow> rows = values.getOrDefault(kind, List.of());
+        return rows.isEmpty() ? "" : rows.getFirst().textValue();
     }
 
     private static List<Long> integers(Map<String, List<ValueRow>> values, String kind) {

--- a/features/encounter/api/EncounterApi.java
+++ b/features/encounter/api/EncounterApi.java
@@ -4,6 +4,11 @@ public interface EncounterApi {
 
     void applyState(ApplyEncounterStateCommand command);
 
+    void updatePoolFilters(UpdateEncounterPoolFiltersCommand command);
+
+    void updateTuning(UpdateEncounterTuningCommand command);
+
+    /** Compatibility entry point for consumers that still submit one complete snapshot. */
     void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command);
 
     void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command);

--- a/features/encounter/api/EncounterBuilderInputs.java
+++ b/features/encounter/api/EncounterBuilderInputs.java
@@ -2,72 +2,116 @@ package features.encounter.api;
 
 import java.util.List;
 
-public record EncounterBuilderInputs(
-        List<String> creatureTypes,
-        List<String> creatureSubtypes,
-        List<String> biomes,
-        boolean autoDifficulty,
-        int difficultyLevel,
-        boolean autoBalance,
-        int balanceLevel,
-        boolean autoAmount,
-        double amountValue,
-        boolean autoDiversity,
-        int diversityLevel,
-        List<Long> encounterTableIds,
-        List<Long> worldFactionIds,
-        long worldLocationId
-) {
-
-    private static final int DEFAULT_DIFFICULTY_LEVEL = 2;
-    private static final int DEFAULT_BALANCE_LEVEL = 3;
-    private static final double DEFAULT_AMOUNT_VALUE = 3.0;
-    private static final int DEFAULT_DIVERSITY_LEVEL = 3;
+public record EncounterBuilderInputs(EncounterPoolFilters poolFilters, EncounterTuningSettings tuning) {
 
     public EncounterBuilderInputs {
-        creatureTypes = creatureTypes == null ? List.of() : List.copyOf(creatureTypes);
-        creatureSubtypes = creatureSubtypes == null ? List.of() : List.copyOf(creatureSubtypes);
-        biomes = biomes == null ? List.of() : List.copyOf(biomes);
-        difficultyLevel = normalizeDifficulty(difficultyLevel);
-        balanceLevel = normalizeBalance(balanceLevel);
-        amountValue = normalizeAmount(amountValue);
-        diversityLevel = normalizeDiversity(diversityLevel);
-        encounterTableIds = encounterTableIds == null ? List.of() : List.copyOf(encounterTableIds);
-        worldFactionIds = worldFactionIds == null ? List.of() : List.copyOf(worldFactionIds);
-        worldLocationId = Math.max(0L, worldLocationId);
+        poolFilters = poolFilters == null ? EncounterPoolFilters.empty() : poolFilters;
+        tuning = tuning == null ? EncounterTuningSettings.defaults() : tuning;
+    }
+
+    public EncounterBuilderInputs(
+            List<String> creatureTypes,
+            List<String> creatureSubtypes,
+            List<String> biomes,
+            boolean autoDifficulty,
+            int difficultyLevel,
+            boolean autoBalance,
+            int balanceLevel,
+            boolean autoAmount,
+            double amountValue,
+            boolean autoDiversity,
+            int diversityLevel,
+            List<Long> encounterTableIds,
+            List<Long> worldFactionIds,
+            long worldLocationId
+    ) {
+        this(new EncounterPoolFilters(
+                        "", "", "", List.of(), creatureTypes, creatureSubtypes, biomes, List.of(),
+                        encounterTableIds, worldFactionIds, worldLocationId),
+                new EncounterTuningSettings(
+                        autoDifficulty, difficultyLevel,
+                        autoBalance, balanceLevel,
+                        autoAmount, amountValue,
+                        autoDiversity, diversityLevel));
     }
 
     public static EncounterBuilderInputs empty() {
-        return new EncounterBuilderInputs(
-                List.of(),
-                List.of(),
-                List.of(),
-                true,
-                DEFAULT_DIFFICULTY_LEVEL,
-                true,
-                DEFAULT_BALANCE_LEVEL,
-                true,
-                DEFAULT_AMOUNT_VALUE,
-                true,
-                DEFAULT_DIVERSITY_LEVEL,
-                List.of(),
-                List.of(),
-                0L);
+        return new EncounterBuilderInputs(EncounterPoolFilters.empty(), EncounterTuningSettings.defaults());
     }
 
-    private static int normalizeDifficulty(int value) {
-        return value < 1 || value > 4 ? DEFAULT_DIFFICULTY_LEVEL : value;
+    public String nameQuery() {
+        return poolFilters.nameQuery();
     }
 
-    private static int normalizeBalance(int value) {
-        return value < 1 || value > 5 ? DEFAULT_BALANCE_LEVEL : value;
+    public String challengeRatingMin() {
+        return poolFilters.challengeRatingMin();
     }
 
-    private static double normalizeAmount(double value) {
-        return !Double.isFinite(value) || value < 1.0 || value > 5.0 ? DEFAULT_AMOUNT_VALUE : value;
+    public String challengeRatingMax() {
+        return poolFilters.challengeRatingMax();
     }
 
-    private static int normalizeDiversity(int value) {
-        return value < 1 || value > 4 ? DEFAULT_DIVERSITY_LEVEL : value;
+    public List<String> sizes() {
+        return poolFilters.sizes();
+    }
+
+    public List<String> creatureTypes() {
+        return poolFilters.creatureTypes();
+    }
+
+    public List<String> creatureSubtypes() {
+        return poolFilters.creatureSubtypes();
+    }
+
+    public List<String> biomes() {
+        return poolFilters.biomes();
+    }
+
+    public List<String> alignments() {
+        return poolFilters.alignments();
+    }
+
+    public List<Long> encounterTableIds() {
+        return poolFilters.encounterTableIds();
+    }
+
+    public List<Long> worldFactionIds() {
+        return poolFilters.worldFactionIds();
+    }
+
+    public long worldLocationId() {
+        return poolFilters.worldLocationId();
+    }
+
+    public boolean autoDifficulty() {
+        return tuning.autoDifficulty();
+    }
+
+    public int difficultyLevel() {
+        return tuning.difficultyLevel();
+    }
+
+    public boolean autoBalance() {
+        return tuning.autoBalance();
+    }
+
+    public int balanceLevel() {
+        return tuning.balanceLevel();
+    }
+
+    public boolean autoAmount() {
+        return tuning.autoAmount();
+    }
+
+    public double amountValue() {
+        return tuning.amountValue();
+    }
+
+    public boolean autoDiversity() {
+        return tuning.autoDiversity();
+    }
+
+    public int diversityLevel() {
+        return tuning.diversityLevel();
     }
 }

--- a/features/encounter/api/EncounterPoolFilters.java
+++ b/features/encounter/api/EncounterPoolFilters.java
@@ -1,0 +1,47 @@
+package features.encounter.api;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/** Catalog-owned creature and source constraints used by Encounter generation. */
+public record EncounterPoolFilters(
+        String nameQuery,
+        String challengeRatingMin,
+        String challengeRatingMax,
+        List<String> sizes,
+        List<String> creatureTypes,
+        List<String> creatureSubtypes,
+        List<String> biomes,
+        List<String> alignments,
+        List<Long> encounterTableIds,
+        List<Long> worldFactionIds,
+        long worldLocationId
+) {
+
+    public EncounterPoolFilters {
+        nameQuery = normalized(nameQuery);
+        challengeRatingMin = normalized(challengeRatingMin);
+        challengeRatingMax = normalized(challengeRatingMax);
+        sizes = copy(sizes);
+        creatureTypes = copy(creatureTypes);
+        creatureSubtypes = copy(creatureSubtypes);
+        biomes = copy(biomes);
+        alignments = copy(alignments);
+        encounterTableIds = copy(encounterTableIds);
+        worldFactionIds = copy(worldFactionIds);
+        worldLocationId = Math.max(0L, worldLocationId);
+    }
+
+    public static EncounterPoolFilters empty() {
+        return new EncounterPoolFilters("", "", "", List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(), List.of(), 0L);
+    }
+
+    private static String normalized(@Nullable String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static <T> List<T> copy(@Nullable List<T> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+}

--- a/features/encounter/api/EncounterTuningSettings.java
+++ b/features/encounter/api/EncounterTuningSettings.java
@@ -1,0 +1,38 @@
+package features.encounter.api;
+
+/** Encounter-state-owned generation difficulty and composition tuning. */
+public record EncounterTuningSettings(
+        boolean autoDifficulty,
+        int difficultyLevel,
+        boolean autoBalance,
+        int balanceLevel,
+        boolean autoAmount,
+        double amountValue,
+        boolean autoDiversity,
+        int diversityLevel
+) {
+
+    private static final int DEFAULT_DIFFICULTY_LEVEL = 2;
+    private static final int DEFAULT_BALANCE_LEVEL = 3;
+    private static final double DEFAULT_AMOUNT_VALUE = 3.0;
+    private static final int DEFAULT_DIVERSITY_LEVEL = 3;
+
+    public EncounterTuningSettings {
+        difficultyLevel = difficultyLevel < 1 || difficultyLevel > 4
+                ? DEFAULT_DIFFICULTY_LEVEL : difficultyLevel;
+        balanceLevel = balanceLevel < 1 || balanceLevel > 5
+                ? DEFAULT_BALANCE_LEVEL : balanceLevel;
+        amountValue = !Double.isFinite(amountValue) || amountValue < 1.0 || amountValue > 5.0
+                ? DEFAULT_AMOUNT_VALUE : amountValue;
+        diversityLevel = diversityLevel < 1 || diversityLevel > 4
+                ? DEFAULT_DIVERSITY_LEVEL : diversityLevel;
+    }
+
+    public static EncounterTuningSettings defaults() {
+        return new EncounterTuningSettings(
+                true, DEFAULT_DIFFICULTY_LEVEL,
+                true, DEFAULT_BALANCE_LEVEL,
+                true, DEFAULT_AMOUNT_VALUE,
+                true, DEFAULT_DIVERSITY_LEVEL);
+    }
+}

--- a/features/encounter/api/UpdateEncounterBuilderInputsCommand.java
+++ b/features/encounter/api/UpdateEncounterBuilderInputsCommand.java
@@ -20,6 +20,26 @@ public record UpdateEncounterBuilderInputsCommand(EncounterBuilderInputs inputs)
         return inputs.biomes();
     }
 
+    public String nameQuery() {
+        return inputs.nameQuery();
+    }
+
+    public String challengeRatingMin() {
+        return inputs.challengeRatingMin();
+    }
+
+    public String challengeRatingMax() {
+        return inputs.challengeRatingMax();
+    }
+
+    public List<String> sizes() {
+        return inputs.sizes();
+    }
+
+    public List<String> alignments() {
+        return inputs.alignments();
+    }
+
     public boolean autoDifficulty() {
         return inputs.autoDifficulty();
     }

--- a/features/encounter/api/UpdateEncounterPoolFiltersCommand.java
+++ b/features/encounter/api/UpdateEncounterPoolFiltersCommand.java
@@ -1,0 +1,8 @@
+package features.encounter.api;
+
+public record UpdateEncounterPoolFiltersCommand(EncounterPoolFilters filters) {
+
+    public UpdateEncounterPoolFiltersCommand {
+        filters = filters == null ? EncounterPoolFilters.empty() : filters;
+    }
+}

--- a/features/encounter/api/UpdateEncounterTuningCommand.java
+++ b/features/encounter/api/UpdateEncounterTuningCommand.java
@@ -1,0 +1,8 @@
+package features.encounter.api;
+
+public record UpdateEncounterTuningCommand(EncounterTuningSettings settings) {
+
+    public UpdateEncounterTuningCommand {
+        settings = settings == null ? EncounterTuningSettings.defaults() : settings;
+    }
+}

--- a/features/encounter/application/EncounterApplicationService.java
+++ b/features/encounter/application/EncounterApplicationService.java
@@ -20,8 +20,12 @@ import features.encounter.domain.session.EncounterSessionCommand;
 import features.encounter.domain.session.Mode;
 import features.encounter.api.ApplyEncounterStateCommand;
 import features.encounter.api.EncounterBuilderInputs;
+import features.encounter.api.EncounterPoolFilters;
+import features.encounter.api.EncounterTuningSettings;
 import features.encounter.api.RefreshEncounterPlanBudgetCommand;
 import features.encounter.api.UpdateEncounterBuilderInputsCommand;
+import features.encounter.api.UpdateEncounterPoolFiltersCommand;
+import features.encounter.api.UpdateEncounterTuningCommand;
 import features.encounter.api.EncounterRuntimeContextApi;
 import features.encounter.api.EncounterRuntimeContextId;
 import features.encounter.api.EncounterRuntimeContextSpec;
@@ -118,6 +122,16 @@ public final class EncounterApplicationService implements features.encounter.api
         executionLane.execute(() -> commands.updateBuilderInputs(command));
     }
 
+    @Override
+    public void updatePoolFilters(UpdateEncounterPoolFiltersCommand command) {
+        executionLane.execute(() -> commands.updatePoolFilters(command));
+    }
+
+    @Override
+    public void updateTuning(UpdateEncounterTuningCommand command) {
+        executionLane.execute(() -> commands.updateTuning(command));
+    }
+
     public void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command) {
         executionLane.execute(() -> commands.refreshPlanBudget(command));
     }
@@ -212,6 +226,11 @@ public final class EncounterApplicationService implements features.encounter.api
                 effective.encounterTableIds(),
                 effective.worldFactionIds(),
                 effective.worldLocationId(),
+                effective.nameQuery(),
+                effective.challengeRatingMin(),
+                effective.challengeRatingMax(),
+                effective.sizes(),
+                effective.alignments(),
                 Map.of());
     }
 
@@ -227,6 +246,18 @@ public final class EncounterApplicationService implements features.encounter.api
         void applyState(ApplyEncounterStateCommand command);
 
         void updateBuilderInputs(UpdateEncounterBuilderInputsCommand command);
+
+        default void updatePoolFilters(UpdateEncounterPoolFiltersCommand command) {
+            EncounterPoolFilters filters = command == null ? EncounterPoolFilters.empty() : command.filters();
+            updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(
+                    new EncounterBuilderInputs(filters, EncounterTuningSettings.defaults())));
+        }
+
+        default void updateTuning(UpdateEncounterTuningCommand command) {
+            EncounterTuningSettings tuning = command == null ? EncounterTuningSettings.defaults() : command.settings();
+            updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(
+                    new EncounterBuilderInputs(EncounterPoolFilters.empty(), tuning)));
+        }
 
         void refreshPlanBudget(RefreshEncounterPlanBudgetCommand command);
     }
@@ -319,6 +350,24 @@ public final class EncounterApplicationService implements features.encounter.api
                     focused().access());
             persist();
             publishCurrentSession();
+        }
+
+        @Override
+        public void updatePoolFilters(UpdateEncounterPoolFiltersCommand command) {
+            EncounterPoolFilters filters = command == null ? EncounterPoolFilters.empty() : command.filters();
+            EncounterGenerationInputs current = focused().session().builderInputs();
+            updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(new EncounterBuilderInputs(
+                    filters,
+                    EncounterProjection.builderInputs(current).tuning())));
+        }
+
+        @Override
+        public void updateTuning(UpdateEncounterTuningCommand command) {
+            EncounterTuningSettings tuning = command == null ? EncounterTuningSettings.defaults() : command.settings();
+            EncounterGenerationInputs current = focused().session().builderInputs();
+            updateBuilderInputs(new UpdateEncounterBuilderInputsCommand(new EncounterBuilderInputs(
+                    EncounterProjection.builderInputs(current).poolFilters(),
+                    tuning)));
         }
 
         @Override
@@ -618,6 +667,11 @@ public final class EncounterApplicationService implements features.encounter.api
                     original.encounterTableIds(),
                     original.worldFactionIds(),
                     specification.locationId(),
+                    original.nameQuery(),
+                    original.challengeRatingMin(),
+                    original.challengeRatingMax(),
+                    original.sizes(),
+                    original.alignments(),
                     original.finiteCreatureStockCaps());
             return new EncounterGenerationRequest(
                     scoped,

--- a/features/encounter/application/EncounterForeignFacts.java
+++ b/features/encounter/application/EncounterForeignFacts.java
@@ -162,6 +162,11 @@ public final class EncounterForeignFacts implements EncounterGenerator.ForeignFa
                 source.effectiveEncounterTableIds(original.encounterTableIds()),
                 original.worldFactionIds(),
                 original.worldLocationId(),
+                original.nameQuery(),
+                original.challengeRatingMin(),
+                original.challengeRatingMax(),
+                original.sizes(),
+                original.alignments(),
                 source.invalid() ? Map.of() : source.finiteStockCaps());
         return new EncounterGenerationRequest(
                 resolvedInputs,
@@ -215,6 +220,11 @@ public final class EncounterForeignFacts implements EncounterGenerator.ForeignFa
                     safeCriteria.creatureTypes(),
                     safeCriteria.creatureSubtypes(),
                     safeCriteria.biomes(),
+                    safeCriteria.nameQuery(),
+                    safeCriteria.challengeRatingMin(),
+                    safeCriteria.challengeRatingMax(),
+                    safeCriteria.sizes(),
+                    safeCriteria.alignments(),
                     minimumXp,
                     maximumXp,
                     normalizeLimit(safeCriteria.limit())));

--- a/features/encounter/application/EncounterProjection.java
+++ b/features/encounter/application/EncounterProjection.java
@@ -72,20 +72,27 @@ final class EncounterProjection {
                 difficulty == null ? EncounterRequestedDifficulty.autoDifficulty() : difficulty;
         EncounterTuningIntent safeTuning = tuning == null ? EncounterTuningIntent.defaultIntent() : tuning;
         return new EncounterBuilderInputs(
-                safeInputs.creatureTypes(),
-                safeInputs.creatureSubtypes(),
-                safeInputs.biomes(),
-                difficulty == null || difficulty.isAuto(),
-                safeDifficulty.publishedDifficultyLevel(),
-                tuning == null || tuning.isBalanceAuto(),
-                safeTuning.publishedBalanceLevel(),
-                tuning == null || tuning.isAmountAuto(),
-                safeTuning.publishedAmountValue(),
-                tuning == null || tuning.isDiversityAuto(),
-                safeTuning.publishedDiversityLevel(),
-                safeInputs.encounterTableIds(),
-                safeInputs.worldFactionIds(),
-                safeInputs.worldLocationId());
+                new features.encounter.api.EncounterPoolFilters(
+                        safeInputs.nameQuery(),
+                        safeInputs.challengeRatingMin(),
+                        safeInputs.challengeRatingMax(),
+                        safeInputs.sizes(),
+                        safeInputs.creatureTypes(),
+                        safeInputs.creatureSubtypes(),
+                        safeInputs.biomes(),
+                        safeInputs.alignments(),
+                        safeInputs.encounterTableIds(),
+                        safeInputs.worldFactionIds(),
+                        safeInputs.worldLocationId()),
+                new features.encounter.api.EncounterTuningSettings(
+                        difficulty == null || difficulty.isAuto(),
+                        safeDifficulty.publishedDifficultyLevel(),
+                        tuning == null || tuning.isBalanceAuto(),
+                        safeTuning.publishedBalanceLevel(),
+                        tuning == null || tuning.isAmountAuto(),
+                        safeTuning.publishedAmountValue(),
+                        tuning == null || tuning.isDiversityAuto(),
+                        safeTuning.publishedDiversityLevel()));
     }
 
     static EncounterTuningPreviewResult tuningPreview(EncounterTuningPreviewData data) {

--- a/features/encounter/domain/generation/EncounterGenerationInputs.java
+++ b/features/encounter/domain/generation/EncounterGenerationInputs.java
@@ -12,8 +12,29 @@ public record EncounterGenerationInputs(
         List<Long> encounterTableIds,
         List<Long> worldFactionIds,
         long worldLocationId,
+        String nameQuery,
+        String challengeRatingMin,
+        String challengeRatingMax,
+        List<String> sizes,
+        List<String> alignments,
         Map<Long, Integer> finiteCreatureStockCaps
 ) {
+
+    public EncounterGenerationInputs(
+            List<String> creatureTypes,
+            List<String> creatureSubtypes,
+            List<String> biomes,
+            EncounterRequestedDifficulty targetDifficulty,
+            EncounterTuningIntent tuning,
+            List<Long> encounterTableIds,
+            List<Long> worldFactionIds,
+            long worldLocationId,
+            Map<Long, Integer> finiteCreatureStockCaps
+    ) {
+        this(creatureTypes, creatureSubtypes, biomes, targetDifficulty, tuning,
+                encounterTableIds, worldFactionIds, worldLocationId,
+                "", "", "", List.of(), List.of(), finiteCreatureStockCaps);
+    }
 
     public EncounterGenerationInputs {
         creatureTypes = creatureTypes == null ? List.of() : List.copyOf(creatureTypes);
@@ -26,6 +47,11 @@ public record EncounterGenerationInputs(
         encounterTableIds = encounterTableIds == null ? List.of() : List.copyOf(encounterTableIds);
         worldFactionIds = worldFactionIds == null ? List.of() : List.copyOf(worldFactionIds);
         worldLocationId = Math.max(0L, worldLocationId);
+        nameQuery = nameQuery == null ? "" : nameQuery.trim();
+        challengeRatingMin = challengeRatingMin == null ? "" : challengeRatingMin.trim();
+        challengeRatingMax = challengeRatingMax == null ? "" : challengeRatingMax.trim();
+        sizes = sizes == null ? List.of() : List.copyOf(sizes);
+        alignments = alignments == null ? List.of() : List.copyOf(alignments);
         finiteCreatureStockCaps = finiteCreatureStockCaps == null ? Map.of() : Map.copyOf(finiteCreatureStockCaps);
     }
 
@@ -39,6 +65,11 @@ public record EncounterGenerationInputs(
                 List.of(),
                 List.of(),
                 0L,
+                "",
+                "",
+                "",
+                List.of(),
+                List.of(),
                 Map.of());
     }
 }

--- a/features/encounter/domain/generation/EncounterGenerationRequest.java
+++ b/features/encounter/domain/generation/EncounterGenerationRequest.java
@@ -35,6 +35,26 @@ public record EncounterGenerationRequest(
         return inputs.biomes();
     }
 
+    public String nameQuery() {
+        return inputs.nameQuery();
+    }
+
+    public String challengeRatingMin() {
+        return inputs.challengeRatingMin();
+    }
+
+    public String challengeRatingMax() {
+        return inputs.challengeRatingMax();
+    }
+
+    public List<String> sizes() {
+        return inputs.sizes();
+    }
+
+    public List<String> alignments() {
+        return inputs.alignments();
+    }
+
     public EncounterRequestedDifficulty requestedDifficulty() {
         return inputs.targetDifficulty();
     }

--- a/features/encounter/domain/generation/EncounterGenerator.java
+++ b/features/encounter/domain/generation/EncounterGenerator.java
@@ -143,13 +143,34 @@ public final class EncounterGenerator {
     ) {
         Set<Long> excludedCreatureIds = new LinkedHashSet<>(request.excludedCreatureIds());
         excludedCreatureIds.removeAll(lockedCreatureIds);
-        List<EncounterCandidateProfile> profiles = request.encounterTableIds().isEmpty()
-                ? creatureProfiles(request, thresholds, excludedCreatureIds, lockedCreatureIds, searchLimit)
-                : tableProfiles(request, thresholds, excludedCreatureIds, lockedCreatureIds);
+        List<EncounterCandidateProfile> profiles;
+        if (request.encounterTableIds().isEmpty()) {
+            profiles = creatureProfiles(request, thresholds, excludedCreatureIds, lockedCreatureIds, searchLimit);
+        } else {
+            profiles = tableProfiles(request, thresholds, excludedCreatureIds, lockedCreatureIds);
+            if (profiles != null && hasCreaturePoolConstraint(request)) {
+                java.util.Set<Long> eligibleIds = creatureProfiles(
+                        request, thresholds, excludedCreatureIds, lockedCreatureIds, searchLimit).stream()
+                        .map(EncounterCandidateProfile::id)
+                        .collect(java.util.stream.Collectors.toSet());
+                profiles = profiles.stream().filter(profile -> eligibleIds.contains(profile.id())).toList();
+            }
+        }
         if (profiles == null) {
             return CandidateLoad.failure("Encounter tables are not available.");
         }
         return CandidateLoad.success(profiles);
+    }
+
+    private static boolean hasCreaturePoolConstraint(EncounterGenerationRequest request) {
+        return !request.nameQuery().isBlank()
+                || !request.challengeRatingMin().isBlank()
+                || !request.challengeRatingMax().isBlank()
+                || !request.sizes().isEmpty()
+                || !request.creatureTypes().isEmpty()
+                || !request.creatureSubtypes().isEmpty()
+                || !request.biomes().isEmpty()
+                || !request.alignments().isEmpty();
     }
 
     private List<EncounterCandidateProfile> creatureProfiles(
@@ -163,6 +184,11 @@ public final class EncounterGenerator {
                 request.creatureTypes(),
                 request.creatureSubtypes(),
                 request.biomes(),
+                request.nameQuery(),
+                request.challengeRatingMin(),
+                request.challengeRatingMax(),
+                request.sizes(),
+                request.alignments(),
                 0,
                 EncounterDifficultyTargetHelper.candidateMaxXp(thresholds),
                 searchLimit);

--- a/features/encounter/domain/reference/EncounterCreatureCandidateCriteria.java
+++ b/features/encounter/domain/reference/EncounterCreatureCandidateCriteria.java
@@ -6,14 +6,36 @@ public record EncounterCreatureCandidateCriteria(
         List<String> creatureTypes,
         List<String> creatureSubtypes,
         List<String> biomes,
+        String nameQuery,
+        String challengeRatingMin,
+        String challengeRatingMax,
+        List<String> sizes,
+        List<String> alignments,
         int minimumXp,
         int maximumXp,
         int limit
 ) {
 
+    public EncounterCreatureCandidateCriteria(
+            List<String> creatureTypes,
+            List<String> creatureSubtypes,
+            List<String> biomes,
+            int minimumXp,
+            int maximumXp,
+            int limit
+    ) {
+        this(creatureTypes, creatureSubtypes, biomes, "", "", "", List.of(), List.of(),
+                minimumXp, maximumXp, limit);
+    }
+
     public EncounterCreatureCandidateCriteria {
         creatureTypes = creatureTypes == null ? List.of() : List.copyOf(creatureTypes);
         creatureSubtypes = creatureSubtypes == null ? List.of() : List.copyOf(creatureSubtypes);
         biomes = biomes == null ? List.of() : List.copyOf(biomes);
+        nameQuery = nameQuery == null ? "" : nameQuery.trim();
+        challengeRatingMin = challengeRatingMin == null ? "" : challengeRatingMin.trim();
+        challengeRatingMax = challengeRatingMax == null ? "" : challengeRatingMax.trim();
+        sizes = sizes == null ? List.of() : List.copyOf(sizes);
+        alignments = alignments == null ? List.of() : List.copyOf(alignments);
     }
 }

--- a/features/worldplanner/adapter/javafx/WorldPlannerBinder.java
+++ b/features/worldplanner/adapter/javafx/WorldPlannerBinder.java
@@ -26,6 +26,15 @@ import features.worldplanner.api.SetWorldFactionDispositionCommand;
 import features.worldplanner.api.SetWorldNpcLifecycleStatusCommand;
 import features.worldplanner.api.SetWorldNpcDispositionModifierCommand;
 import features.worldplanner.api.UpdateWorldNpcNotesCommand;
+import features.worldplanner.api.UpdateWorldNpcCommand;
+import features.worldplanner.api.DeleteWorldNpcCommand;
+import features.worldplanner.api.UpdateWorldFactionCommand;
+import features.worldplanner.api.RemoveWorldFactionNpcCommand;
+import features.worldplanner.api.DeleteWorldFactionCommand;
+import features.worldplanner.api.UpdateWorldLocationCommand;
+import features.worldplanner.api.RemoveWorldLocationFactionCommand;
+import features.worldplanner.api.RemoveWorldLocationEncounterTableCommand;
+import features.worldplanner.api.DeleteWorldLocationCommand;
 import features.worldplanner.api.WorldPlannerSnapshotModel;
 import features.worldplanner.api.WorldPlannerEncounterSink;
 import platform.ui.searchfilter.SearchFilterControlsView;
@@ -236,6 +245,14 @@ final class WorldPlannerBinder {
                     snapshot.behaviorNotes(),
                     snapshot.historyNotes(),
                     snapshot.generalNotes()));
+        } else if (actions.saveEntityRequested()) {
+            worldPlanner.updateNpc(new UpdateWorldNpcCommand(
+                    viewModel.selectedNpcId(),
+                    snapshot.displayName(),
+                    viewModel.npcStatblockChoiceId(snapshot.statblockChoiceIndex()),
+                    snapshot.appearanceNotes(), snapshot.behaviorNotes(), snapshot.historyNotes(), snapshot.generalNotes()));
+        } else if (actions.deleteRequested()) {
+            worldPlanner.deleteNpc(new DeleteWorldNpcCommand(viewModel.selectedNpcId()));
         } else if (actions.saveNotesRequested()) {
             worldPlanner.updateNpcNotes(new UpdateWorldNpcNotesCommand(
                     viewModel.selectedNpcId(),
@@ -267,12 +284,21 @@ final class WorldPlannerBinder {
         if (actions.createRequested()) {
             worldPlanner.createFaction(new CreateWorldFactionCommand(
                     snapshot.displayName(),
-                    "",
+                    snapshot.notes(),
                     viewModel.factionPrimaryTableChoiceId(snapshot.primaryEncounterTableChoiceIndex())));
+        } else if (actions.saveEntityRequested()) {
+            worldPlanner.updateFaction(new UpdateWorldFactionCommand(
+                    viewModel.selectedFactionId(), snapshot.displayName(), snapshot.notes(),
+                    viewModel.factionPrimaryTableChoiceId(snapshot.primaryEncounterTableChoiceIndex())));
+        } else if (actions.deleteRequested()) {
+            worldPlanner.deleteFaction(new DeleteWorldFactionCommand(viewModel.selectedFactionId()));
         } else if (actions.addNpcRequested()) {
             worldPlanner.addFactionNpc(new AddWorldFactionNpcCommand(
                     viewModel.selectedFactionId(),
                     viewModel.factionNpcChoiceId(snapshot.npcChoiceIndex())));
+        } else if (actions.removeNpcRequested()) {
+            worldPlanner.removeFactionNpc(new RemoveWorldFactionNpcCommand(
+                    viewModel.selectedFactionId(), viewModel.factionNpcChoiceId(snapshot.npcChoiceIndex())));
         } else if (actions.setInventoryLimitRequested()) {
             worldPlanner.setFactionInventoryLimit(new SetWorldFactionInventoryLimitCommand(
                     viewModel.selectedFactionId(),
@@ -293,15 +319,26 @@ final class WorldPlannerBinder {
             ActionSnapshot actions
     ) {
         if (actions.createRequested()) {
-            worldPlanner.createLocation(new CreateWorldLocationCommand(snapshot.displayName(), ""));
+            worldPlanner.createLocation(new CreateWorldLocationCommand(snapshot.displayName(), snapshot.notes()));
+        } else if (actions.saveEntityRequested()) {
+            worldPlanner.updateLocation(new UpdateWorldLocationCommand(
+                    viewModel.selectedLocationId(), snapshot.displayName(), snapshot.notes()));
+        } else if (actions.deleteRequested()) {
+            worldPlanner.deleteLocation(new DeleteWorldLocationCommand(viewModel.selectedLocationId()));
         } else if (actions.linkFactionRequested()) {
             worldPlanner.addLocationFaction(new AddWorldLocationFactionCommand(
                     viewModel.selectedLocationId(),
                     viewModel.locationFactionChoiceId(snapshot.factionChoiceIndex())));
+        } else if (actions.removeFactionRequested()) {
+            worldPlanner.removeLocationFaction(new RemoveWorldLocationFactionCommand(
+                    viewModel.selectedLocationId(), viewModel.locationFactionChoiceId(snapshot.factionChoiceIndex())));
         } else if (actions.linkTableRequested()) {
             worldPlanner.addLocationEncounterTable(new AddWorldLocationEncounterTableCommand(
                     viewModel.selectedLocationId(),
                     viewModel.locationTableChoiceId(snapshot.encounterTableChoiceIndex())));
+        } else if (actions.removeTableRequested()) {
+            worldPlanner.removeLocationEncounterTable(new RemoveWorldLocationEncounterTableCommand(
+                    viewModel.selectedLocationId(), viewModel.locationTableChoiceId(snapshot.encounterTableChoiceIndex())));
         }
     }
 
@@ -430,7 +467,12 @@ final class WorldPlannerBinder {
                 || actions.linkFactionRequested()
                 || actions.linkTableRequested()
                 || actions.setNpcDispositionRequested()
-                || actions.setFactionDispositionRequested();
+                || actions.setFactionDispositionRequested()
+                || actions.saveEntityRequested()
+                || actions.deleteRequested()
+                || actions.removeNpcRequested()
+                || actions.removeFactionRequested()
+                || actions.removeTableRequested();
     }
 
     private static Map<String, List<String>> selectedFiltersByGroup(SearchFilterControlsViewInputEvent event) {

--- a/features/worldplanner/adapter/javafx/WorldPlannerStateView.java
+++ b/features/worldplanner/adapter/javafx/WorldPlannerStateView.java
@@ -34,6 +34,7 @@ public final class WorldPlannerStateView extends VBox {
     private final TextArea generalNotes = notesArea();
     private final TextField npcDisposition = new TextField("0");
     private final TextField factionName = new TextField();
+    private final TextArea factionNotes = notesArea();
     private final ComboBox<String> primaryEncounterTableChoice = new ComboBox<>();
     private final ComboBox<String> npcChoice = new ComboBox<>();
     private final ComboBox<String> inventoryStatblockChoice = new ComboBox<>();
@@ -41,6 +42,7 @@ public final class WorldPlannerStateView extends VBox {
     private final TextField inventoryQuantity = new TextField();
     private final TextField factionDisposition = new TextField("0");
     private final TextField locationName = new TextField();
+    private final TextArea locationNotes = notesArea();
     private final ComboBox<String> factionChoice = new ComboBox<>();
     private final ComboBox<String> locationTableChoice = new ComboBox<>();
     private final VBox npcEditor = new VBox(8);
@@ -117,6 +119,7 @@ public final class WorldPlannerStateView extends VBox {
 
     private void renderFaction(FactionEditor faction) {
         factionName.setText(faction.displayName());
+        factionNotes.setText(faction.notes());
         renderChoices(primaryEncounterTableChoice, faction.encounterTableLabels(), faction.selectedPrimaryTableLabel());
         renderChoices(npcChoice, faction.npcReferenceLabels(), "");
         renderChoices(inventoryStatblockChoice, faction.statblockLabels(), "");
@@ -125,6 +128,7 @@ public final class WorldPlannerStateView extends VBox {
 
     private void renderLocation(LocationEditor location) {
         locationName.setText(location.displayName());
+        locationNotes.setText(location.notes());
         renderChoices(factionChoice, location.factionReferenceLabels(), "");
         renderChoices(locationTableChoice, location.encounterTableLabels(), "");
     }
@@ -141,17 +145,19 @@ public final class WorldPlannerStateView extends VBox {
     private Node factionFields() {
         GridPane fields = grid();
         fields.addRow(0, factionName, primaryEncounterTableChoice);
-        fields.addRow(1, npcChoice, inventoryStatblockChoice);
-        fields.addRow(2, finiteInventory, inventoryQuantity);
-        fields.addRow(3, labelled("Haltung zu den PCs", factionDisposition));
+        fields.addRow(1, labelled("Notizen", factionNotes));
+        fields.addRow(2, npcChoice, inventoryStatblockChoice);
+        fields.addRow(3, finiteInventory, inventoryQuantity);
+        fields.addRow(4, labelled("Haltung zu den PCs", factionDisposition));
         return fields;
     }
 
     private Node locationFields() {
         GridPane fields = grid();
         fields.addRow(0, locationName);
-        fields.addRow(1, factionChoice);
-        fields.addRow(2, locationTableChoice);
+        fields.addRow(1, labelled("Notizen", locationNotes));
+        fields.addRow(2, factionChoice);
+        fields.addRow(3, locationTableChoice);
         return fields;
     }
 
@@ -159,13 +165,15 @@ public final class WorldPlannerStateView extends VBox {
         Button create = action(NPCS, "NPC anlegen", actions(true, false, false, false, false, false, false, false, false));
         Button updateNotes = action(NPCS, "Notizen speichern",
                 actions(false, true, false, false, false, false, false, false, false));
+        Button save = action(NPCS, "NPC speichern", requested(ActionKind.SAVE));
+        Button delete = destructive(NPCS, "NPC löschen", requested(ActionKind.DELETE));
         Button defeat = action(NPCS, "Besiegt", actions(false, false, true, false, false, false, false, false, false));
         Button reactivate = action(NPCS, "Aktiv", actions(false, false, false, true, false, false, false, false, false));
         Button addToEncounter = action(NPCS, "Zum Encounter",
                 actions(false, false, false, false, true, false, false, false, false));
         Button disposition = action(NPCS, "Haltung setzen",
-                new ActionSnapshot(false, false, false, false, false, false, false, false, false, true, false));
-        return new HBox(8, create, updateNotes, disposition, defeat, reactivate, addToEncounter);
+                requested(ActionKind.NPC_DISPOSITION));
+        return new HBox(8, create, save, updateNotes, disposition, defeat, reactivate, addToEncounter, delete);
     }
 
     private Node factionActions() {
@@ -173,11 +181,14 @@ public final class WorldPlannerStateView extends VBox {
                 actions(true, false, false, false, false, false, false, false, false));
         Button addNpc = action(FACTIONS, "NPC hinzufuegen",
                 actions(false, false, false, false, false, true, false, false, false));
+        Button removeNpc = action(FACTIONS, "NPC entfernen", requested(ActionKind.REMOVE_NPC));
+        Button save = action(FACTIONS, "Fraktion speichern", requested(ActionKind.SAVE));
+        Button delete = destructive(FACTIONS, "Fraktion löschen", requested(ActionKind.DELETE));
         Button limit = action(FACTIONS, "Bestand setzen",
                 actions(false, false, false, false, false, false, true, false, false));
         Button disposition = action(FACTIONS, "Haltung setzen",
-                new ActionSnapshot(false, false, false, false, false, false, false, false, false, false, true));
-        return new HBox(8, create, addNpc, disposition, limit);
+                requested(ActionKind.FACTION_DISPOSITION));
+        return new HBox(8, create, save, addNpc, removeNpc, disposition, limit, delete);
     }
 
     private Node locationActions() {
@@ -187,12 +198,32 @@ public final class WorldPlannerStateView extends VBox {
                 actions(false, false, false, false, false, false, false, true, false));
         Button linkTable = action(LOCATIONS, "Tabelle linken",
                 actions(false, false, false, false, false, false, false, false, true));
-        return new HBox(8, create, linkFaction, linkTable);
+        Button unlinkFaction = action(LOCATIONS, "Fraktion entfernen", requested(ActionKind.REMOVE_FACTION));
+        Button unlinkTable = action(LOCATIONS, "Tabelle entfernen", requested(ActionKind.REMOVE_TABLE));
+        Button save = action(LOCATIONS, "Ort speichern", requested(ActionKind.SAVE));
+        Button delete = destructive(LOCATIONS, "Ort löschen", requested(ActionKind.DELETE));
+        return new HBox(8, create, save, linkFaction, unlinkFaction, linkTable, unlinkTable, delete);
     }
 
     private Button action(int moduleIndex, String label, ActionSnapshot actions) {
         Button button = new Button(label);
         button.setOnAction(event -> eventSink.accept(snapshot(moduleIndex, actions)));
+        return button;
+    }
+
+    private Button destructive(int moduleIndex, String label, ActionSnapshot actions) {
+        Button button = new Button(label);
+        button.getStyleClass().add("danger");
+        button.setOnAction(event -> {
+            javafx.scene.control.Alert alert = new javafx.scene.control.Alert(
+                    javafx.scene.control.Alert.AlertType.CONFIRMATION,
+                    label + "?",
+                    javafx.scene.control.ButtonType.CANCEL,
+                    javafx.scene.control.ButtonType.OK);
+            alert.setHeaderText("Diese Änderung kann nicht rückgängig gemacht werden.");
+            alert.showAndWait().filter(javafx.scene.control.ButtonType.OK::equals)
+                    .ifPresent(ignored -> eventSink.accept(snapshot(moduleIndex, actions)));
+        });
         return button;
     }
 
@@ -212,6 +243,7 @@ public final class WorldPlannerStateView extends VBox {
                         npcDisposition.getText()),
                 new FactionSnapshot(
                         factionName.getText(),
+                        factionNotes.getText(),
                         primaryEncounterTableChoice.getSelectionModel().getSelectedIndex(),
                         npcChoice.getSelectionModel().getSelectedIndex(),
                         inventoryStatblockChoice.getSelectionModel().getSelectedIndex(),
@@ -220,6 +252,7 @@ public final class WorldPlannerStateView extends VBox {
                         factionDisposition.getText()),
                 new LocationSnapshot(
                         locationName.getText(),
+                        locationNotes.getText(),
                         factionChoice.getSelectionModel().getSelectedIndex(),
                         locationTableChoice.getSelectionModel().getSelectedIndex()),
                 actions);
@@ -246,6 +279,22 @@ public final class WorldPlannerStateView extends VBox {
                 setInventoryLimit,
                 linkFaction,
                 linkTable);
+    }
+
+    private static ActionSnapshot requested(ActionKind kind) {
+        return new ActionSnapshot(
+                false, false, false, false, false, false, false, false, false,
+                kind == ActionKind.NPC_DISPOSITION,
+                kind == ActionKind.FACTION_DISPOSITION,
+                kind == ActionKind.SAVE,
+                kind == ActionKind.DELETE,
+                kind == ActionKind.REMOVE_NPC,
+                kind == ActionKind.REMOVE_FACTION,
+                kind == ActionKind.REMOVE_TABLE);
+    }
+
+    private enum ActionKind {
+        SAVE, DELETE, REMOVE_NPC, REMOVE_FACTION, REMOVE_TABLE, NPC_DISPOSITION, FACTION_DISPOSITION
     }
 
     private static void renderChoices(ComboBox<String> comboBox, List<String> rows, String selected) {

--- a/features/worldplanner/adapter/javafx/WorldPlannerViewModel.java
+++ b/features/worldplanner/adapter/javafx/WorldPlannerViewModel.java
@@ -442,10 +442,10 @@ record StateInput(
     StateInput {
         activeModuleIndex = Math.max(0, activeModuleIndex);
         npc = npc == null ? new NpcSnapshot("", -1, "", "", "", "", "0") : npc;
-        faction = faction == null ? new FactionSnapshot("", -1, -1, -1, false, "", "0") : faction;
-        location = location == null ? new LocationSnapshot("", -1, -1) : location;
+        faction = faction == null ? new FactionSnapshot("", "", -1, -1, -1, false, "", "0") : faction;
+        location = location == null ? new LocationSnapshot("", "", -1, -1) : location;
         actions = actions == null
-                ? new ActionSnapshot(false, false, false, false, false, false, false, false, false, false, false)
+                ? ActionSnapshot.none()
                 : actions;
     }
 }
@@ -476,6 +476,7 @@ record NpcSnapshot(
 
 record FactionSnapshot(
         String displayName,
+        String notes,
         int primaryEncounterTableChoiceIndex,
         int npcChoiceIndex,
         int inventoryStatblockChoiceIndex,
@@ -485,11 +486,12 @@ record FactionSnapshot(
 ) {
     FactionSnapshot(String displayName, int primaryEncounterTableChoiceIndex, int npcChoiceIndex,
             int inventoryStatblockChoiceIndex, boolean finiteInventory, String inventoryQuantityText) {
-        this(displayName, primaryEncounterTableChoiceIndex, npcChoiceIndex, inventoryStatblockChoiceIndex,
+        this(displayName, "", primaryEncounterTableChoiceIndex, npcChoiceIndex, inventoryStatblockChoiceIndex,
                 finiteInventory, inventoryQuantityText, "0");
     }
     FactionSnapshot {
         displayName = WorldPlannerVocabulary.text(displayName);
+        notes = WorldPlannerVocabulary.text(notes);
         primaryEncounterTableChoiceIndex = Math.max(-1, primaryEncounterTableChoiceIndex);
         npcChoiceIndex = Math.max(-1, npcChoiceIndex);
         inventoryStatblockChoiceIndex = Math.max(-1, inventoryStatblockChoiceIndex);
@@ -500,11 +502,13 @@ record FactionSnapshot(
 
 record LocationSnapshot(
         String displayName,
+        String notes,
         int factionChoiceIndex,
         int encounterTableChoiceIndex
 ) {
     LocationSnapshot {
         displayName = WorldPlannerVocabulary.text(displayName);
+        notes = WorldPlannerVocabulary.text(notes);
         factionChoiceIndex = Math.max(-1, factionChoiceIndex);
         encounterTableChoiceIndex = Math.max(-1, encounterTableChoiceIndex);
     }
@@ -521,13 +525,24 @@ record ActionSnapshot(
         boolean linkFactionRequested,
         boolean linkTableRequested,
         boolean setNpcDispositionRequested,
-        boolean setFactionDispositionRequested
+        boolean setFactionDispositionRequested,
+        boolean saveEntityRequested,
+        boolean deleteRequested,
+        boolean removeNpcRequested,
+        boolean removeFactionRequested,
+        boolean removeTableRequested
 ) {
     ActionSnapshot(boolean createRequested, boolean saveNotesRequested, boolean defeatRequested,
             boolean reactivateRequested, boolean addToEncounterRequested, boolean addNpcRequested,
             boolean setInventoryLimitRequested, boolean linkFactionRequested, boolean linkTableRequested) {
         this(createRequested, saveNotesRequested, defeatRequested, reactivateRequested, addToEncounterRequested,
-                addNpcRequested, setInventoryLimitRequested, linkFactionRequested, linkTableRequested, false, false);
+                addNpcRequested, setInventoryLimitRequested, linkFactionRequested, linkTableRequested,
+                false, false, false, false, false, false, false);
+    }
+
+    static ActionSnapshot none() {
+        return new ActionSnapshot(false, false, false, false, false, false, false, false, false,
+                false, false, false, false, false, false, false);
     }
 }
 
@@ -574,6 +589,7 @@ record FactionProjection(
         List<String> statblockLabels,
         int selectedFactionIndex,
         String selectedFactionName,
+        String selectedNotes,
         String selectedPrimaryTableLabel,
         int selectedDisposition,
         String emptyText
@@ -585,12 +601,13 @@ record FactionProjection(
         npcReferenceLabels = WorldPlannerViewModel.copiedStrings(npcReferenceLabels);
         statblockLabels = WorldPlannerViewModel.copiedStrings(statblockLabels);
         selectedFactionName = WorldPlannerVocabulary.text(selectedFactionName);
+        selectedNotes = WorldPlannerVocabulary.text(selectedNotes);
         selectedPrimaryTableLabel = WorldPlannerVocabulary.text(selectedPrimaryTableLabel);
         emptyText = WorldPlannerVocabulary.text(emptyText);
     }
 
     static FactionProjection empty() {
-        return new FactionProjection(false, List.of(), List.of(), List.of(), List.of(), List.of(), -1, "", "", 0,
+        return new FactionProjection(false, List.of(), List.of(), List.of(), List.of(), List.of(), -1, "", "", "", 0,
                 "Noch keine Fraktionen.");
     }
 }
@@ -603,6 +620,7 @@ record LocationProjection(
         List<String> encounterTableLabels,
         int selectedLocationIndex,
         String selectedLocationName,
+        String selectedNotes,
         String emptyText
 ) {
     LocationProjection {
@@ -611,11 +629,12 @@ record LocationProjection(
         factionReferenceLabels = WorldPlannerViewModel.copiedStrings(factionReferenceLabels);
         encounterTableLabels = WorldPlannerViewModel.copiedStrings(encounterTableLabels);
         selectedLocationName = WorldPlannerVocabulary.text(selectedLocationName);
+        selectedNotes = WorldPlannerVocabulary.text(selectedNotes);
         emptyText = WorldPlannerVocabulary.text(emptyText);
     }
 
     static LocationProjection empty() {
-        return new LocationProjection(false, List.of(), List.of(), List.of(), List.of(), -1, "",
+        return new LocationProjection(false, List.of(), List.of(), List.of(), List.of(), -1, "", "",
                 "Noch keine Locations.");
     }
 }
@@ -709,6 +728,7 @@ record NpcEditor(
 
 record FactionEditor(
         String displayName,
+        String notes,
         List<String> encounterTableLabels,
         String selectedPrimaryTableLabel,
         List<String> npcReferenceLabels,
@@ -717,6 +737,7 @@ record FactionEditor(
 ) {
     FactionEditor {
         displayName = WorldPlannerVocabulary.text(displayName);
+        notes = WorldPlannerVocabulary.text(notes);
         encounterTableLabels = WorldPlannerViewModel.copiedStrings(encounterTableLabels);
         selectedPrimaryTableLabel = WorldPlannerVocabulary.text(selectedPrimaryTableLabel);
         npcReferenceLabels = WorldPlannerViewModel.copiedStrings(npcReferenceLabels);
@@ -725,23 +746,25 @@ record FactionEditor(
     }
 
     static FactionEditor empty() {
-        return new FactionEditor("", List.of(), "", List.of(), List.of(), "0");
+        return new FactionEditor("", "", List.of(), "", List.of(), List.of(), "0");
     }
 }
 
 record LocationEditor(
         String displayName,
+        String notes,
         List<String> factionReferenceLabels,
         List<String> encounterTableLabels
 ) {
     LocationEditor {
         displayName = WorldPlannerVocabulary.text(displayName);
+        notes = WorldPlannerVocabulary.text(notes);
         factionReferenceLabels = WorldPlannerViewModel.copiedStrings(factionReferenceLabels);
         encounterTableLabels = WorldPlannerViewModel.copiedStrings(encounterTableLabels);
     }
 
     static LocationEditor empty() {
-        return new LocationEditor("", List.of(), List.of());
+        return new LocationEditor("", "", List.of(), List.of());
     }
 }
 
@@ -1108,6 +1131,7 @@ final class WorldPlannerStateProjectionBuilder {
                 NpcEditor.empty(),
                 new FactionEditor(
                         projection.selectedFactionName(),
+                        projection.selectedNotes(),
                         projection.encounterTableLabels(),
                         projection.selectedPrimaryTableLabel(),
                         projection.npcReferenceLabels(),
@@ -1130,6 +1154,7 @@ final class WorldPlannerStateProjectionBuilder {
                 FactionEditor.empty(),
                 new LocationEditor(
                         projection.selectedLocationName(),
+                        projection.selectedNotes(),
                         projection.factionReferenceLabels(),
                         projection.encounterTableLabels()),
                 "");
@@ -1434,6 +1459,7 @@ final class WorldPlannerProjectionBuilder {
                 WorldPlannerProjectionLabels.labels(input.options().statblockOptions()),
                 WorldPlannerVocabulary.indexOf(ids, input.selection().selectedFactionId()),
                 selected == null ? "" : selected.displayName(),
+                selected == null ? "" : selected.notes(),
                 WorldPlannerProjectionLabels.tableLabel(input.options().encounterTableOptions(), selected),
                 selected == null ? 0 : selected.disposition(),
                 ids.isEmpty() ? "Noch keine Fraktionen." : "");
@@ -1459,6 +1485,7 @@ final class WorldPlannerProjectionBuilder {
                 WorldPlannerProjectionLabels.labels(input.options().encounterTableOptions()),
                 WorldPlannerVocabulary.indexOf(ids, input.selection().selectedLocationId()),
                 selected == null ? "" : selected.displayName(),
+                selected == null ? "" : selected.notes(),
                 ids.isEmpty() ? "Noch keine Locations." : "");
     }
 

--- a/features/worldplanner/api/DeleteWorldFactionCommand.java
+++ b/features/worldplanner/api/DeleteWorldFactionCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record DeleteWorldFactionCommand(long factionId) {
+}

--- a/features/worldplanner/api/DeleteWorldLocationCommand.java
+++ b/features/worldplanner/api/DeleteWorldLocationCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record DeleteWorldLocationCommand(long locationId) {
+}

--- a/features/worldplanner/api/DeleteWorldNpcCommand.java
+++ b/features/worldplanner/api/DeleteWorldNpcCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record DeleteWorldNpcCommand(long npcId) {
+}

--- a/features/worldplanner/api/RemoveWorldFactionNpcCommand.java
+++ b/features/worldplanner/api/RemoveWorldFactionNpcCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record RemoveWorldFactionNpcCommand(long factionId, long npcId) {
+}

--- a/features/worldplanner/api/RemoveWorldLocationEncounterTableCommand.java
+++ b/features/worldplanner/api/RemoveWorldLocationEncounterTableCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record RemoveWorldLocationEncounterTableCommand(long locationId, long encounterTableId) {
+}

--- a/features/worldplanner/api/RemoveWorldLocationFactionCommand.java
+++ b/features/worldplanner/api/RemoveWorldLocationFactionCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record RemoveWorldLocationFactionCommand(long locationId, long factionId) {
+}

--- a/features/worldplanner/api/UpdateWorldFactionCommand.java
+++ b/features/worldplanner/api/UpdateWorldFactionCommand.java
@@ -1,0 +1,9 @@
+package features.worldplanner.api;
+
+public record UpdateWorldFactionCommand(
+        long factionId,
+        String displayName,
+        String notes,
+        long primaryEncounterTableId
+) {
+}

--- a/features/worldplanner/api/UpdateWorldLocationCommand.java
+++ b/features/worldplanner/api/UpdateWorldLocationCommand.java
@@ -1,0 +1,4 @@
+package features.worldplanner.api;
+
+public record UpdateWorldLocationCommand(long locationId, String displayName, String notes) {
+}

--- a/features/worldplanner/api/UpdateWorldNpcCommand.java
+++ b/features/worldplanner/api/UpdateWorldNpcCommand.java
@@ -1,0 +1,12 @@
+package features.worldplanner.api;
+
+public record UpdateWorldNpcCommand(
+        long npcId,
+        String displayName,
+        long creatureStatblockId,
+        String appearanceNotes,
+        String behaviorNotes,
+        String historyNotes,
+        String generalNotes
+) {
+}

--- a/features/worldplanner/api/WorldPlannerApi.java
+++ b/features/worldplanner/api/WorldPlannerApi.java
@@ -8,11 +8,21 @@ public interface WorldPlannerApi {
 
     void updateNpcNotes(UpdateWorldNpcNotesCommand command);
 
+    void updateNpc(UpdateWorldNpcCommand command);
+
+    void deleteNpc(DeleteWorldNpcCommand command);
+
     void setNpcLifecycleStatus(SetWorldNpcLifecycleStatusCommand command);
 
     void createFaction(CreateWorldFactionCommand command);
 
     void addFactionNpc(AddWorldFactionNpcCommand command);
+
+    void removeFactionNpc(RemoveWorldFactionNpcCommand command);
+
+    void updateFaction(UpdateWorldFactionCommand command);
+
+    void deleteFaction(DeleteWorldFactionCommand command);
 
     void setFactionDisposition(SetWorldFactionDispositionCommand command);
 
@@ -24,5 +34,13 @@ public interface WorldPlannerApi {
 
     void addLocationFaction(AddWorldLocationFactionCommand command);
 
+    void removeLocationFaction(RemoveWorldLocationFactionCommand command);
+
     void addLocationEncounterTable(AddWorldLocationEncounterTableCommand command);
+
+    void removeLocationEncounterTable(RemoveWorldLocationEncounterTableCommand command);
+
+    void updateLocation(UpdateWorldLocationCommand command);
+
+    void deleteLocation(DeleteWorldLocationCommand command);
 }

--- a/features/worldplanner/application/WorldPlannerApplicationService.java
+++ b/features/worldplanner/application/WorldPlannerApplicationService.java
@@ -30,6 +30,15 @@ import features.worldplanner.api.SetWorldFactionInventoryLimitCommand;
 import features.worldplanner.api.SetWorldNpcDispositionModifierCommand;
 import features.worldplanner.api.SetWorldNpcLifecycleStatusCommand;
 import features.worldplanner.api.UpdateWorldNpcNotesCommand;
+import features.worldplanner.api.UpdateWorldNpcCommand;
+import features.worldplanner.api.DeleteWorldNpcCommand;
+import features.worldplanner.api.UpdateWorldFactionCommand;
+import features.worldplanner.api.RemoveWorldFactionNpcCommand;
+import features.worldplanner.api.DeleteWorldFactionCommand;
+import features.worldplanner.api.UpdateWorldLocationCommand;
+import features.worldplanner.api.RemoveWorldLocationFactionCommand;
+import features.worldplanner.api.RemoveWorldLocationEncounterTableCommand;
+import features.worldplanner.api.DeleteWorldLocationCommand;
 
 public final class WorldPlannerApplicationService implements features.worldplanner.api.WorldPlannerApi {
 
@@ -132,6 +141,47 @@ public final class WorldPlannerApplicationService implements features.worldplann
         });
     }
 
+    @Override
+    public void updateNpc(UpdateWorldNpcCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldNpc npc = state.npc(command.npcId());
+            long statblockId = command.creatureStatblockId();
+            if (npc == null || !WorldPlannerIds.isPositive(statblockId)
+                    || !referenceExists(() -> referenceValidator.creatureStatblockExists(statblockId))) {
+                save(state.withStatus("NPC oder Creature Statblock nicht gefunden."));
+                return;
+            }
+            WorldNpc.Notes notes = new WorldNpc.Notes(
+                    command.appearanceNotes(), command.behaviorNotes(), command.historyNotes(), command.generalNotes());
+            save(replaceNpc(state, npc.updateDetails(command.displayName(), statblockId, notes),
+                    "NPC aktualisiert."));
+        });
+    }
+
+    @Override
+    public void deleteNpc(DeleteWorldNpcCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            if (state.npc(command.npcId()) == null) {
+                save(state.withStatus("NPC nicht gefunden."));
+                return;
+            }
+            List<WorldFaction> factions = state.factions().stream()
+                    .map(faction -> faction.npcIds().contains(command.npcId())
+                            ? faction.removeNpc(command.npcId()) : faction)
+                    .toList();
+            save(new WorldPlannerState(
+                    state.npcs().stream().filter(npc -> npc.npcId() != command.npcId()).toList(),
+                    factions,
+                    state.locations(),
+                    state.nextNpcId(), state.nextFactionId(), state.nextLocationId(),
+                    "NPC gelöscht."));
+        });
+    }
+
     public void setNpcLifecycleStatus(SetWorldNpcLifecycleStatusCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
         execute(() -> {
@@ -224,6 +274,60 @@ public final class WorldPlannerApplicationService implements features.worldplann
         });
     }
 
+    @Override
+    public void removeFactionNpc(RemoveWorldFactionNpcCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldFaction faction = state.faction(command.factionId());
+            if (faction == null || !faction.npcIds().contains(command.npcId())) {
+                save(state.withStatus("Fraktion oder verknüpfter NPC nicht gefunden."));
+                return;
+            }
+            save(replaceFaction(state, faction.removeNpc(command.npcId()), "NPC aus Fraktion entfernt."));
+        });
+    }
+
+    @Override
+    public void updateFaction(UpdateWorldFactionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldFaction faction = state.faction(command.factionId());
+            long tableId = command.primaryEncounterTableId();
+            if (faction == null || !WorldPlannerIds.isPositive(tableId)
+                    || !referenceExists(() -> referenceValidator.encounterTableExists(tableId))) {
+                save(state.withStatus("Fraktion oder Encounter Table nicht gefunden."));
+                return;
+            }
+            save(replaceFaction(state,
+                    faction.updateDetails(command.displayName(), command.notes(), tableId),
+                    "Fraktion aktualisiert."));
+        });
+    }
+
+    @Override
+    public void deleteFaction(DeleteWorldFactionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            if (state.faction(command.factionId()) == null) {
+                save(state.withStatus("Fraktion nicht gefunden."));
+                return;
+            }
+            List<WorldLocation> locations = state.locations().stream()
+                    .map(location -> location.factionIds().contains(command.factionId())
+                            ? location.removeFaction(command.factionId()) : location)
+                    .toList();
+            save(new WorldPlannerState(
+                    state.npcs(),
+                    state.factions().stream().filter(faction -> faction.factionId() != command.factionId()).toList(),
+                    locations,
+                    state.nextNpcId(), state.nextFactionId(), state.nextLocationId(),
+                    "Fraktion gelöscht."));
+        });
+    }
+
     public void setFactionDisposition(SetWorldFactionDispositionCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
         execute(() -> {
@@ -312,6 +416,21 @@ public final class WorldPlannerApplicationService implements features.worldplann
         });
     }
 
+    @Override
+    public void removeLocationFaction(RemoveWorldLocationFactionCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldLocation location = state.location(command.locationId());
+            if (location == null || !location.factionIds().contains(command.factionId())) {
+                save(state.withStatus("Location oder verknüpfte Fraktion nicht gefunden."));
+                return;
+            }
+            save(replaceLocation(state, location.removeFaction(command.factionId()),
+                    "Fraktion aus Location entfernt."));
+        });
+    }
+
     public void addLocationEncounterTable(AddWorldLocationEncounterTableCommand command) {
         Objects.requireNonNull(command, COMMAND_PARAMETER);
         execute(() -> {
@@ -329,6 +448,53 @@ public final class WorldPlannerApplicationService implements features.worldplann
                 return;
             }
             save(replaceLocation(state, location.addEncounterTable(tableId), "Encounter Table zur Location hinzugefuegt."));
+        });
+    }
+
+    @Override
+    public void removeLocationEncounterTable(RemoveWorldLocationEncounterTableCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldLocation location = state.location(command.locationId());
+            if (location == null || !location.encounterTableIds().contains(command.encounterTableId())) {
+                save(state.withStatus("Location oder verknüpfte Encounter Table nicht gefunden."));
+                return;
+            }
+            save(replaceLocation(state, location.removeEncounterTable(command.encounterTableId()),
+                    "Encounter Table aus Location entfernt."));
+        });
+    }
+
+    @Override
+    public void updateLocation(UpdateWorldLocationCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            WorldLocation location = state.location(command.locationId());
+            if (location == null) {
+                save(state.withStatus("Location nicht gefunden."));
+                return;
+            }
+            save(replaceLocation(state, location.updateDetails(command.displayName(), command.notes()),
+                    "Location aktualisiert."));
+        });
+    }
+
+    @Override
+    public void deleteLocation(DeleteWorldLocationCommand command) {
+        Objects.requireNonNull(command, COMMAND_PARAMETER);
+        execute(() -> {
+            WorldPlannerState state = load();
+            if (state.location(command.locationId()) == null) {
+                save(state.withStatus("Location nicht gefunden."));
+                return;
+            }
+            save(new WorldPlannerState(
+                    state.npcs(), state.factions(),
+                    state.locations().stream().filter(location -> location.locationId() != command.locationId()).toList(),
+                    state.nextNpcId(), state.nextFactionId(), state.nextLocationId(),
+                    "Location gelöscht."));
         });
     }
 

--- a/features/worldplanner/domain/world/WorldFaction.java
+++ b/features/worldplanner/domain/world/WorldFaction.java
@@ -71,6 +71,17 @@ public record WorldFaction(
                 npcIds.stream().filter(id -> id != npcId).toList(), inventoryLimits);
     }
 
+    public WorldFaction updateDetails(String nextDisplayName, String nextNotes, long nextPrimaryEncounterTableId) {
+        return new WorldFaction(
+                factionId,
+                nextDisplayName,
+                nextNotes,
+                nextPrimaryEncounterTableId,
+                disposition,
+                npcIds,
+                inventoryLimits);
+    }
+
     public WorldFaction withDisposition(int value) {
         return new WorldFaction(
                 factionId, displayName, notes, primaryEncounterTableId, value, npcIds, inventoryLimits);

--- a/features/worldplanner/domain/world/WorldLocation.java
+++ b/features/worldplanner/domain/world/WorldLocation.java
@@ -46,4 +46,26 @@ public record WorldLocation(
                 factionIds,
                 WorldPlannerIds.addUnique(encounterTableIds, encounterTableId));
     }
+
+    public WorldLocation removeFaction(long factionId) {
+        return new WorldLocation(
+                locationId,
+                displayName,
+                notes,
+                factionIds.stream().filter(id -> id.longValue() != factionId).toList(),
+                encounterTableIds);
+    }
+
+    public WorldLocation removeEncounterTable(long encounterTableId) {
+        return new WorldLocation(
+                locationId,
+                displayName,
+                notes,
+                factionIds,
+                encounterTableIds.stream().filter(id -> id.longValue() != encounterTableId).toList());
+    }
+
+    public WorldLocation updateDetails(String nextDisplayName, String nextNotes) {
+        return new WorldLocation(locationId, nextDisplayName, nextNotes, factionIds, encounterTableIds);
+    }
 }

--- a/features/worldplanner/domain/world/WorldNpc.java
+++ b/features/worldplanner/domain/world/WorldNpc.java
@@ -57,6 +57,20 @@ public record WorldNpc(
                 status);
     }
 
+    public WorldNpc updateDetails(String nextDisplayName, long nextCreatureStatblockId, Notes notes) {
+        Notes safeNotes = notes == null ? Notes.empty() : notes;
+        return new WorldNpc(
+                npcId,
+                nextDisplayName,
+                nextCreatureStatblockId,
+                safeNotes.appearanceNotes(),
+                safeNotes.behaviorNotes(),
+                safeNotes.historyNotes(),
+                safeNotes.generalNotes(),
+                dispositionModifier,
+                status);
+    }
+
     public WorldNpc withDispositionModifier(int modifier) {
         return new WorldNpc(
                 npcId, displayName, creatureStatblockId, appearanceNotes, behaviorNotes,

--- a/resources/salt-marcher.css
+++ b/resources/salt-marcher.css
@@ -252,6 +252,31 @@
     -fx-spacing: 8;
     -fx-padding: 8 0 0 0;
 }
+.catalog-category-tabs > .tab-header-area > .headers-region > .tab {
+    -fx-background-color: -sm-bg-panel;
+    -fx-border-color: transparent transparent -sm-border-subtle transparent;
+    -fx-padding: 7 12 7 12;
+}
+.catalog-category-tabs > .tab-header-area > .headers-region > .tab:selected {
+    -fx-background-color: -sm-bg-darkest;
+    -fx-border-color: transparent transparent -sm-accent transparent;
+    -fx-border-width: 0 0 2 0;
+}
+.catalog-category-tabs > .tab-header-area {
+    -fx-background-color: -sm-bg-panel;
+    -fx-padding: 0;
+}
+.filter-surface {
+    -fx-background-color: -sm-bg-card;
+    -fx-border-color: -sm-border-subtle;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+    -fx-padding: 8;
+}
+.encounter-tuning-pane {
+    -fx-background-color: -sm-bg-panel;
+    -fx-border-color: transparent transparent -sm-border-subtle transparent;
+}
 .party-header {
     -fx-background-color: -sm-bg-elevated;
     -fx-padding: 8 12 8 12;

--- a/test/features/catalog/adapter/javafx/CatalogControlsRawInputTest.java
+++ b/test/features/catalog/adapter/javafx/CatalogControlsRawInputTest.java
@@ -128,8 +128,8 @@ public final class CatalogControlsRawInputTest {
     void CATALOG_CONTROLS_RAW_INPUT_007() throws Exception {
         runOnFxThread(() -> {
             start();
-            toggleDifficultyAutoAndSlide();
-            assertDifficultyTuningPublishesRawInput();
+            assertTrue(descendants(view()).stream().noneMatch(Slider.class::isInstance),
+                    "Encounter tuning belongs to the Encounter state tab, not Catalog controls");
         });
     }
 

--- a/test/features/catalog/adapter/javafx/CatalogInitialLoadTest.java
+++ b/test/features/catalog/adapter/javafx/CatalogInitialLoadTest.java
@@ -18,7 +18,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TableView;
 import javafx.scene.input.KeyCode;
@@ -118,8 +117,8 @@ public final class CatalogInitialLoadTest {
             Button create = button((Parent) tabs.getSelectionModel().getSelectedItem().getContent(), "NPC anlegen");
             create.fire();
 
-            ListView<?> npcs = descendant(
-                    (Parent) tabs.getSelectionModel().getSelectedItem().getContent(), ListView.class);
+            TableView<?> npcs = descendant(
+                    (Parent) tabs.getSelectionModel().getSelectedItem().getContent(), TableView.class);
             npcs.getSelectionModel().selectFirst();
             npcs.fireEvent(new KeyEvent(
                     KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER,

--- a/test/features/catalog/adapter/javafx/CatalogInitialLoadTest.java
+++ b/test/features/catalog/adapter/javafx/CatalogInitialLoadTest.java
@@ -129,6 +129,26 @@ public final class CatalogInitialLoadTest {
         });
     }
 
+    @Test
+    void CATALOG_SCENE_ROUTE_001() throws Exception {
+        seedCreatureCatalog();
+        AtomicLong addedCreature = new AtomicLong();
+        runOnFxThread(() -> {
+            CatalogTestRuntime runtime = services();
+            ShellBinding binding = runtime.contribution(
+                    EmptyInspectorSink.INSTANCE, ignored -> { }, () -> { }, addedCreature::set).bind();
+            CatalogWorkspaceView workspace = slot(binding, ShellSlot.COCKPIT_MAIN, CatalogWorkspaceView.class);
+            Stage stage = new Stage();
+            stage.setScene(new Scene(workspace, 1_100.0, 700.0));
+            stage.show();
+            workspace.applyCss();
+            workspace.layout();
+
+            button(workspace.monsterView(), "+ Scene").fire();
+            assertTrue(addedCreature.get() > 0L, "Monster + Scene did not publish the selected creature id.");
+        });
+    }
+
     private static CatalogFixture setupCatalog() {
         CatalogTestRuntime runtime = services();
         ShellBinding binding = runtime.contribution(EmptyInspectorSink.INSTANCE).bind();

--- a/test/features/catalog/adapter/javafx/CatalogTestRuntime.java
+++ b/test/features/catalog/adapter/javafx/CatalogTestRuntime.java
@@ -55,12 +55,21 @@ final class CatalogTestRuntime {
             java.util.function.LongConsumer openNpc,
             Runnable createNpc
     ) {
+        return contribution(inspector, openNpc, createNpc, ignored -> { });
+    }
+
+    CatalogContribution contribution(
+            InspectorSink inspector,
+            java.util.function.LongConsumer openNpc,
+            Runnable createNpc,
+            java.util.function.LongConsumer addCreatureToScene
+    ) {
         return new CatalogContribution(
                 creatures.application(), tables.application(), encounter.application(),
                 encounter.builderInputs(), creatures.filterOptions(), creatures.catalog(),
                 tables.catalog(), encounter.tuningPreview(), encounter.savedPlans(), unavailableItems(),
                 worldPlanner, inspector, ignored -> { }, openNpc, ignored -> { }, ignored -> { },
-                createNpc, () -> { }, () -> { });
+                createNpc, () -> { }, () -> { }, ignored -> { }, ignored -> { }, addCreatureToScene);
     }
 
     private static features.items.api.ItemsCatalogApi unavailableItems() {

--- a/test/features/catalog/adapter/javafx/ItemsCatalogUiTest.java
+++ b/test/features/catalog/adapter/javafx/ItemsCatalogUiTest.java
@@ -20,7 +20,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
+import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -134,7 +134,7 @@ public final class ItemsCatalogUiTest {
             RecordingInspector inspector = new RecordingInspector();
             CatalogWorkspaceView.ItemsPane pane = show(api, inspector);
             pane.refresh();
-            ListView<?> results = list(pane, "Item-Ergebnisse");
+            TableView<?> results = table(pane, "Item-Ergebnisse");
             results.getSelectionModel().selectFirst();
 
             Button open = button(pane, "Ausgewähltes Item im Inspector öffnen");
@@ -211,8 +211,8 @@ public final class ItemsCatalogUiTest {
         return node(root, Label.class, accessibleText);
     }
 
-    private static ListView<?> list(Parent root, String accessibleText) {
-        return node(root, ListView.class, accessibleText);
+    private static TableView<?> table(Parent root, String accessibleText) {
+        return node(root, TableView.class, accessibleText);
     }
 
     private static <T extends Node> T node(Parent root, Class<T> type, String accessibleText) {

--- a/test/features/creatures/application/CreatureCatalogTest.java
+++ b/test/features/creatures/application/CreatureCatalogTest.java
@@ -96,6 +96,11 @@ public final class CreatureCatalogTest {
                 List.of(" Fiend ", "Fiend", ""),
                 List.of("Devil"),
                 List.of("Cavern"),
+                "Cinder",
+                "1/2",
+                "1/2",
+                List.of("Tiny"),
+                List.of("LE"),
                 0,
                 1_000,
                 0));
@@ -327,6 +332,11 @@ public final class CreatureCatalogTest {
     ) {
         assertEquals(CreatureQueryStatus.SUCCESS, result.status(), "CREATURE-CATALOG-007 candidate status");
         assertEquals(List.of("Fiend"), lastEncounterSpec.types(), "CREATURE-CATALOG-007 normalized candidate type");
+        assertEquals("Cinder", lastEncounterSpec.nameQuery(), "CREATURE-CATALOG-007 candidate name filter");
+        assertEquals(List.of("Tiny"), lastEncounterSpec.sizes(), "CREATURE-CATALOG-007 candidate size filter");
+        assertEquals(List.of("LE"), lastEncounterSpec.alignments(), "CREATURE-CATALOG-007 candidate alignment filter");
+        assertEquals(100, lastEncounterSpec.minimumXp(), "CREATURE-CATALOG-007 CR minimum");
+        assertEquals(100, lastEncounterSpec.maximumXp(), "CREATURE-CATALOG-007 CR maximum");
         assertEquals(250, lastEncounterSpec.limit(), "CREATURE-CATALOG-007 default candidate limit");
         assertEquals(1, result.candidates().size(), "CREATURE-CATALOG-007 candidate count");
         CreatureEncounterCandidate candidate = result.candidates().getFirst();
@@ -548,10 +558,13 @@ public final class CreatureCatalogTest {
         }
 
         private static boolean matchesEncounter(EncounterCandidateSpec spec, CreatureProfile profile) {
-            return withinXp(profile, spec.minimumXp(), spec.maximumXp())
+            return containsName(profile, spec.nameQuery())
+                    && withinXp(profile, spec.minimumXp(), spec.maximumXp())
+                    && matchesAny(spec.sizes(), List.of(profile.size()))
                     && matchesAny(spec.types(), List.of(profile.creatureType()))
                     && matchesAny(spec.subtypes(), profile.subtypes())
-                    && matchesAny(spec.biomes(), profile.biomes());
+                    && matchesAny(spec.biomes(), profile.biomes())
+                    && matchesAny(spec.alignments(), List.of(profile.alignment()));
         }
 
         private static boolean containsName(CreatureProfile profile, String query) {

--- a/test/features/encounter/adapter/javafx/state/EncounterStateTabTest.java
+++ b/test/features/encounter/adapter/javafx/state/EncounterStateTabTest.java
@@ -35,6 +35,10 @@ import features.encounter.domain.plan.repository.EncounterPlanRepository;
 import features.encounter.api.ApplyEncounterStateCommand;
 import features.encounter.api.OpenSavedEncounterPlanCommand;
 import features.encounter.api.OpenSavedEncounterPlanResult;
+import features.encounter.api.EncounterPoolFilters;
+import features.encounter.api.EncounterTuningSettings;
+import features.encounter.api.UpdateEncounterPoolFiltersCommand;
+import features.encounter.api.UpdateEncounterTuningCommand;
 import features.encountertable.domain.catalog.EncounterTableCandidateData;
 import features.encountertable.domain.catalog.EncounterTableSummaryData;
 import features.encountertable.domain.catalog.port.EncounterTableCatalogPort;
@@ -80,6 +84,14 @@ public final class EncounterStateTabTest {
     }
 
     @Test
+    void ENCOUNTER_STATE_TAB_003_hostsCollapsibleTuning() throws Exception {
+        runOnFxThread(() -> {
+            EncounterStateView view = encounterStateView(TestRuntime.create().contribution().bind());
+            assertTextPresent(view, "Encounter abstimmen", "Encounter tuning title");
+        });
+    }
+
+    @Test
     void savedCatalogOpenRequiresDiscardConfirmationForUnsavedRoster() {
         TestRuntime runtime = TestRuntime.create();
         runtime.encounter.application().applyState(ApplyEncounterStateCommand.addCreature(GOBLIN_ID));
@@ -117,6 +129,22 @@ public final class EncounterStateTabTest {
         org.junit.jupiter.api.Assertions.assertEquals(
                 OpenSavedEncounterPlanResult.Status.CONFIRMATION_REQUIRED,
                 guarded.status());
+    }
+
+    @Test
+    void poolAndTuningUpdatesMergeWithoutOverwritingEachOther() {
+        TestRuntime runtime = TestRuntime.create();
+        runtime.encounter.application().updatePoolFilters(new UpdateEncounterPoolFiltersCommand(
+                new EncounterPoolFilters("goblin", "1/4", "2", List.of("Small"), List.of("Humanoid"),
+                        List.of(), List.of("Forest"), List.of("Neutral Evil"), List.of(), List.of(), 0L)));
+        runtime.encounter.application().updateTuning(new UpdateEncounterTuningCommand(
+                new EncounterTuningSettings(false, 4, false, 5, false, 2.5, false, 2)));
+
+        var inputs = runtime.encounter.builderInputs().current();
+        org.junit.jupiter.api.Assertions.assertEquals("goblin", inputs.nameQuery());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("Small"), inputs.sizes());
+        org.junit.jupiter.api.Assertions.assertEquals(4, inputs.difficultyLevel());
+        org.junit.jupiter.api.Assertions.assertEquals(2.5, inputs.amountValue());
     }
 
     private static void assertEncounterStateTabOpensThroughShellBinding() {
@@ -268,7 +296,7 @@ public final class EncounterStateTabTest {
         EncounterStateContribution contribution() {
             return new EncounterStateContribution(
                     creatures.application(), encounter.state(), encounter.application(),
-                    null, ignored -> { });
+                    encounter.builderInputs(), null, ignored -> { });
         }
 
         private static void seedParty(PartyApi party) {

--- a/test/features/worldplanner/adapter/javafx/WorldPlannerInspectorRefreshTest.java
+++ b/test/features/worldplanner/adapter/javafx/WorldPlannerInspectorRefreshTest.java
@@ -337,6 +337,14 @@ public final class WorldPlannerInspectorRefreshTest {
         }
 
         @Override
+        public void updateNpc(features.worldplanner.api.UpdateWorldNpcCommand command) {
+        }
+
+        @Override
+        public void deleteNpc(features.worldplanner.api.DeleteWorldNpcCommand command) {
+        }
+
+        @Override
         public void setNpcLifecycleStatus(SetWorldNpcLifecycleStatusCommand command) {
             WorldPlannerSnapshot current = snapshots.current();
             List<WorldNpcSummary> npcs = current.npcs().stream()
@@ -370,6 +378,18 @@ public final class WorldPlannerInspectorRefreshTest {
                             : npc)
                     .toList();
             snapshots.publish(copy(current, npcs, factions, current.locations()));
+        }
+
+        @Override
+        public void removeFactionNpc(features.worldplanner.api.RemoveWorldFactionNpcCommand command) {
+        }
+
+        @Override
+        public void updateFaction(features.worldplanner.api.UpdateWorldFactionCommand command) {
+        }
+
+        @Override
+        public void deleteFaction(features.worldplanner.api.DeleteWorldFactionCommand command) {
         }
 
         @Override
@@ -420,7 +440,25 @@ public final class WorldPlannerInspectorRefreshTest {
         }
 
         @Override
+        public void removeLocationFaction(features.worldplanner.api.RemoveWorldLocationFactionCommand command) {
+        }
+
+        @Override
         public void addLocationEncounterTable(AddWorldLocationEncounterTableCommand command) {
+        }
+
+        @Override
+        public void removeLocationEncounterTable(
+                features.worldplanner.api.RemoveWorldLocationEncounterTableCommand command
+        ) {
+        }
+
+        @Override
+        public void updateLocation(features.worldplanner.api.UpdateWorldLocationCommand command) {
+        }
+
+        @Override
+        public void deleteLocation(features.worldplanner.api.DeleteWorldLocationCommand command) {
         }
 
         private static WorldNpcSummary npc(

--- a/test/features/worldplanner/application/WorldPlannerBackendTest.java
+++ b/test/features/worldplanner/application/WorldPlannerBackendTest.java
@@ -41,6 +41,15 @@ import features.worldplanner.api.SetWorldNpcLifecycleStatusCommand;
 import features.worldplanner.api.SetWorldNpcDispositionModifierCommand;
 import features.worldplanner.api.WorldDispositionKind;
 import features.worldplanner.api.UpdateWorldNpcNotesCommand;
+import features.worldplanner.api.UpdateWorldNpcCommand;
+import features.worldplanner.api.DeleteWorldNpcCommand;
+import features.worldplanner.api.UpdateWorldFactionCommand;
+import features.worldplanner.api.RemoveWorldFactionNpcCommand;
+import features.worldplanner.api.DeleteWorldFactionCommand;
+import features.worldplanner.api.UpdateWorldLocationCommand;
+import features.worldplanner.api.RemoveWorldLocationFactionCommand;
+import features.worldplanner.api.RemoveWorldLocationEncounterTableCommand;
+import features.worldplanner.api.DeleteWorldLocationCommand;
 import features.worldplanner.api.WorldNpcLifecycleStatus;
 import features.worldplanner.api.WorldPlannerReadStatus;
 import features.worldplanner.api.WorldPlannerSnapshot;
@@ -87,6 +96,22 @@ public final class WorldPlannerBackendTest {
         service.createLocation(new CreateWorldLocationCommand("Old Gate", "wind-cut ruins"));
         service.addLocationFaction(new AddWorldLocationFactionCommand(1L, 1L));
         service.addLocationEncounterTable(new AddWorldLocationEncounterTableCommand(1L, 201L));
+        service.updateNpc(new UpdateWorldNpcCommand(
+                1L, "Captain Vale Updated", 101L, "scarred", "watchful", "former scout", "knows the pass"));
+        service.updateFaction(new UpdateWorldFactionCommand(1L, "Ash Guard Updated", "border patrol", 201L));
+        service.updateLocation(new UpdateWorldLocationCommand(1L, "Old Gate Updated", "wind-cut ruins"));
+        service.removeFactionNpc(new RemoveWorldFactionNpcCommand(1L, 1L));
+        service.addFactionNpc(new AddWorldFactionNpcCommand(1L, 1L));
+        service.removeLocationFaction(new RemoveWorldLocationFactionCommand(1L, 1L));
+        service.addLocationFaction(new AddWorldLocationFactionCommand(1L, 1L));
+        service.removeLocationEncounterTable(new RemoveWorldLocationEncounterTableCommand(1L, 201L));
+        service.addLocationEncounterTable(new AddWorldLocationEncounterTableCommand(1L, 201L));
+        service.createNpc(new CreateWorldNpcCommand("Temporary NPC", 101L, "", "", "", ""));
+        service.deleteNpc(new DeleteWorldNpcCommand(2L));
+        service.createFaction(new CreateWorldFactionCommand("Temporary Faction", "", 201L));
+        service.deleteFaction(new DeleteWorldFactionCommand(2L));
+        service.createLocation(new CreateWorldLocationCommand("Temporary Location", ""));
+        service.deleteLocation(new DeleteWorldLocationCommand(2L));
         service.createNpc(new CreateWorldNpcCommand("Invalid", -1L, "", "", "", ""));
         service.addFactionNpc(new AddWorldFactionNpcCommand(1L, 1L));
         service.addLocationFaction(new AddWorldLocationFactionCommand(1L, 1L));
@@ -98,7 +123,7 @@ public final class WorldPlannerBackendTest {
 
         WorldPlannerSnapshot current = model.current();
         assertEquals(1, current.npcs().size(), "npc count");
-        assertEquals("Captain Vale", current.npcs().get(0).displayName(), "npc name");
+        assertEquals("Captain Vale Updated", current.npcs().get(0).displayName(), "npc name");
         assertEquals(WorldNpcLifecycleStatus.ACTIVE, current.npcs().get(0).status(), "npc lifecycle");
         assertEquals("NPC Status nicht gefunden.", current.statusText(), "transient null lifecycle status");
         assertEquals(1, current.factions().size(), "faction count");
@@ -119,7 +144,9 @@ public final class WorldPlannerBackendTest {
         assertEquals(201L, current.locations().get(0).encounterTableIds().get(0), "location table link");
 
         WorldPlannerSnapshot reloaded = reloadedSnapshot();
-        assertEquals("Captain Vale", reloaded.npcs().get(0).displayName(), "persisted npc name");
+        assertEquals("Captain Vale Updated", reloaded.npcs().get(0).displayName(), "persisted npc name");
+        assertEquals("Ash Guard Updated", reloaded.factions().get(0).displayName(), "persisted faction rename");
+        assertEquals("Old Gate Updated", reloaded.locations().get(0).displayName(), "persisted location rename");
         assertEquals(WorldNpcLifecycleStatus.ACTIVE, reloaded.npcs().get(0).status(), "persisted lifecycle");
         assertEquals(201L, reloaded.factions().get(0).primaryEncounterTableId(), "persisted faction table");
         assertEquals(-20, reloaded.factions().getFirst().disposition(), "persisted faction disposition");


### PR DESCRIPTION
## Outcome
- turns Katalog into the single seven-section reference workspace with consistent tables and contextual controls
- moves difficulty, balance, amount, and diversity into a collapsible Encounter state section
- makes every visible monster filter constrain generation, including table intersections
- completes World Planner edit, rename, delete, and relationship-removal commands with persisted cleanup
- adds explicit Encounter and focused-Scene actions for compatible catalog rows

## Proof
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain

Addresses #434, #435, #436, and #450. The broad stories remain open because this PR does not claim their still-open acceptance scope.