### PR TITLE
Build dungeon greenfield foundation

### DIFF
--- a/docs/dungeon/README.md
+++ b/docs/dungeon/README.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-07
+Last Reviewed: 2026-07-17
 Source of Truth: Routing entrypoint for the dungeon gameplay and domain
 documentation bundle.
 
@@ -11,8 +11,8 @@ documentation bundle.
 The dungeon feature owns authored dungeon truth, dungeon travel runtime
 behavior, dungeon editor behavior, and dungeon persistence truth.
 
-Generic map-canvas behavior and dungeon map-surface adoption now live in
-`docs/maps/`.
+Generic passive map-canvas mechanisms live in `platform.ui.mapcanvas`; the
+Dungeon architecture owns how its API facts adopt those mechanisms.
 
 ## Document Set
 
@@ -46,9 +46,13 @@ Generic map-canvas behavior and dungeon map-surface adoption now live in
 
 - [Dungeon Domain Model](./domain/domain-dungeon.md)
 
-### Related Maps Docs
+### Temporary Delivery
 
-- [Maps Feature Overview](../maps/README.md) (line 1)
+- [Dungeon Greenfield Delivery](./delivery/delivery-dungeon-greenfield.md)
+
+### Related Map Canvas Docs
+
+- [Map Canvas Overview](../maps/README.md) (line 1)
 - [Dungeon Map Adoption Architecture](../maps/architecture/architecture-maps-dungeon-adoption.md) (line 1)
 - [Dungeon Map Surface Contract](../maps/contract/contract-maps-dungeon-surface.md) (line 1)
 - [Maps Canvas Requirements](../maps/requirements/requirements-maps-canvas.md) (line 1)

--- a/docs/dungeon/architecture/architecture-dungeon-domain.md
+++ b/docs/dungeon/architecture/architecture-dungeon-domain.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-17
 Source of Truth: Dungeon feature ownership, authored-core boundary, runtime
 capabilities, and target dependency direction.
 
@@ -58,21 +58,55 @@ graph queries and projections.
 - All published state is immutable and revisioned; persistence-backed calls are
   non-blocking and publish through the UI dispatcher.
 
+## Sparse Authored Worksets
+
+The authored aggregate remains the consistency owner, while editor and travel
+read only the spatial workset needed by their current viewport.
+
+- one chunk is `64 x 64` cells identified by
+  `(mapId, level, chunkQ, chunkR)`; negative coordinates use floor division
+- one viewport request loads visible chunks plus one surrounding ring
+- `DungeonViewportSnapshot` carries map revision, request generation, loaded
+  chunk identities, window facts, and optional authored bounds; fixed width and
+  height are not authored limits
+- the in-memory authored workset is the preview source after load; pointer
+  preview has no repository route
+- committed edits publish one immutable change result and advance the map
+  revision once; per-session undo/redo restores content as a new revision
+- viewport caches use bounded weighted eviction while visible and actively
+  edited chunks remain protected
+
+Late viewport results are rejected by request generation and map revision.
+Replaceable pointer-move work is coalesced on the owning serial lane; discrete
+gesture inputs invalidate older move samples.
+
+## Passive Map Canvas
+
+Generic camera, visible-window calculation, weighted viewport caching, layered
+JavaFX canvas hosting, and replaceable input scheduling live under
+`platform.ui.mapcanvas` and `platform.execution`. They are mechanisms, not a
+Maps business feature. Dungeon JavaFX code owns the translation between Dungeon
+API facts and canvas-native drawing or hit evidence.
+
 ## Adapters And Composition
 
 The SQLite adapter persists authored Dungeon truth and satisfies feature-owned
 ports. The JavaFX adapter renders, hit-tests, and translates input through the
 three Dungeon APIs without importing application, domain, or SQLite packages.
 
-`DungeonFeature` receives platform services, `PartyApi`, and the Maps canvas
-capability, constructs the three APIs and shell contributions, and exposes no
-internal repository or adapter.
+`DungeonFeature` receives platform services and `PartyApi`, constructs the
+three APIs and shell contributions, and exposes no internal repository or
+adapter. Its JavaFX adapter consumes the feature-neutral map-canvas mechanism;
+there is no `features.maps` dependency or composition lifecycle.
 
 ## Verification
 
 Target dependency direction is mechanically enforced by `architectureTest`.
 Domain-invariant, editor, travel, persistence, and JavaFX production routes own
 behavior proof.
+
+Temporary migration state and the remaining deletion boundary live only in
+[Dungeon Greenfield Delivery](../delivery/delivery-dungeon-greenfield.md).
 
 ## References
 

--- a/docs/dungeon/contract/contract-dungeon-persistence.md
+++ b/docs/dungeon/contract/contract-dungeon-persistence.md
@@ -1,6 +1,6 @@
-Status: Draft
+Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-08
+Last Reviewed: 2026-07-17
 Source of Truth: Dungeon persistence boundary, stored truth, adapter mapping
 rules, and schema ownership.
 
@@ -60,6 +60,37 @@ Persisted authored truth includes:
 - `dungeon_topology_elements` is authoritative for persisted topology identity
 - compatibility detail tables remain source-local storage and correlation
   detail, not alternate semantic owners
+
+`dungeon_maps.revision` stores the last committed authored revision. Adapters
+MUST read and write that value; they MUST NOT replace it with a constant
+readback revision.
+
+`dungeon_chunks` is a source-local spatial inventory keyed by
+`(dungeon_map_id, level_z, chunk_q, chunk_r)`. One chunk covers `64 x 64`
+cells, and negative coordinates use mathematical floor division. The row's
+`revision` identifies the authored map revision from which that inventory entry
+was derived. Chunk rows are indexing metadata, not authored semantic truth.
+
+## Window Reads And Incremental Writes
+
+- a viewport read MUST address explicit chunk keys and return the request
+  generation plus committed map revision needed to reject late results
+- a loaded viewport consists of visible chunks plus one surrounding ring
+- entities retain map-wide stable identities and MAY cross chunk boundaries;
+  an adapter MUST NOT clone identity merely to fit storage partitions
+- an authored commit MUST validate the expected map revision, write only
+  affected authored rows and chunk inventory, and advance the map revision once
+  in the same transaction
+- a failed validation or storage write MUST roll back authored rows, chunk
+  inventory, and map revision together
+- successful writes return the committed change result; the application MUST
+  NOT require an unconditional whole-map readback to discover what it wrote
+- preview, hover, camera movement, and undo/redo stacks MUST NOT write SQLite
+
+Ordinary single-map commands use the incremental before/after port. Initial map
+creation and the remaining multi-map transition-link write still use one
+whole-record compatibility route. Its owner and deletion milestone live in the
+temporary Dungeon delivery note; it is not an alternative target.
 
 ## Authored Name Storage Semantics
 
@@ -237,6 +268,9 @@ state, render state, or travel behavior.
   they are treated as supported authored maps
 - direct runtime token movement does not justify new authored-position tables;
   runtime party position remains owned outside dungeon persistence
+- revision, chunk inventory, and incremental chunk ownership may be introduced
+  through an automatic destructive schema migration; existing Dungeon rows are
+  disposable test data and have no compatibility or backup obligation
 
 ## Verification Notes
 
@@ -250,4 +284,4 @@ state, render state, or travel behavior.
 
 - [Dungeon Domain Model](../domain/domain-dungeon.md) (line 1)
 - [Dungeon Map Surface Contract](../../maps/contract/contract-maps-dungeon-surface.md) (line 1)
-- [Maps Feature Overview](../../maps/README.md) (line 1)
+- [Map Canvas Overview](../../maps/README.md) (line 1)

--- a/docs/dungeon/delivery/delivery-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/delivery-dungeon-greenfield.md
@@ -1,0 +1,85 @@
+Status: Temporary Migration
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-17
+Source of Truth: Temporary implementation sequence and remaining deletion
+boundary for the Dungeon greenfield migration.
+
+# Dungeon Greenfield Delivery
+
+## Why This Exists
+
+The durable target is owned by the Dungeon requirements, domain, architecture,
+and persistence contract. This file records only the temporary path from the
+shipped whole-map editor to that target and is deleted when the final legacy
+route is gone.
+
+## Current Foundation
+
+- passive camera math, negative unbounded scene coordinates, logical paint
+  phases on one bounded JavaFX backing surface, and weighted viewport caching live
+  in `platform.ui.mapcanvas`
+- Dungeon exposes typed Authored and Travel APIs; the travel JavaFX adapter no
+  longer imports the travel application service
+- pointer-move work is latest-wins and discrete gesture input invalidates stale
+  queued moves
+- authored preview reuses an immutable loaded workset and has executable proof
+  that repeated preview does not reread the repository
+- `64 x 64` chunk identity, negative floor-division, visible-plus-one-ring
+  loading sets, revision-scoped `256 MiB` viewport caching, off-window
+  continuation evidence, viewport snapshots, persisted map revision, and
+  SQLite chunk inventory exist
+- ordinary single-map authored commands use an incremental before/after write:
+  unchanged stable-identity rows are not rewritten, obsolete identities are
+  removed in the same transaction, and SQLite accepts only revision `n -> n+1`
+- per-session undo/redo is limited to `200` commands or `128 MiB`, is available
+  through standard shortcuts, and restores content as a new revision
+
+## Recommended Rollout
+
+1. Replace the editor's application-type dependency bundle with
+   `DungeonEditorApi.current/subscribe/dispatch` and move scene translation
+   wholly into the Dungeon JavaFX adapter.
+2. Replace the cold-load full-map repository adapter with chunk-content reads,
+   and migrate the remaining multi-map compatibility write to the incremental
+   change path.
+3. Drive viewport requests from camera and resize changes, protect visible and
+   edited chunks in the `256 MiB` cache, and expose off-window graph
+   continuations.
+4. Remove fixed map dimensions, unconditional whole-map readback, prepared
+   render frames in application code, and the legacy full-record repository
+   writer.
+5. Qualify performance budgets and parity for editor and travel, then delete
+   this delivery note.
+
+## Risks And Dependencies
+
+- cross-chunk corridors, stairs, transitions, and labels require map-wide
+  identity with multi-chunk membership, not duplicated entities
+- chunk-content reads must preserve one map-wide identity when an entity spans
+  several chunks
+- existing Dungeon rows are disposable test data, so schema replacement may be
+  destructive and automatic; no compatibility or backup phase is required
+- the editor JavaFX adapter still imports editor application types and still
+  consumes the compatibility full-map projection; the durable architecture
+  gate must not claim either boundary is complete before steps 1 through 3
+
+## Milestone Verification
+
+- every migration slice runs `./gradlew check`
+- visible behavior uses production-route JavaFX tests
+- chunk math, cache eviction, latest-wins scheduling, no-preview-I/O, revision
+  persistence, and history have deterministic JUnit proof
+- final qualification follows `docs/project/verification/quality-platforms.md`
+
+## Open Delivery Questions
+
+None. Product choices are fixed: seamless sparse coordinates, one Dungeon
+feature, platform-owned passive canvas mechanisms, and per-session history.
+
+## References
+
+- [Dungeon Architecture](../architecture/architecture-dungeon-domain.md)
+- [Dungeon Domain Model](../domain/domain-dungeon.md)
+- [Dungeon Editor Requirements](../requirements/requirements-dungeon-editor.md)
+- [Dungeon Persistence Contract](../contract/contract-dungeon-persistence.md)
+- [Quality Platforms](../../project/verification/quality-platforms.md)

--- a/docs/dungeon/domain/domain-dungeon.md
+++ b/docs/dungeon/domain/domain-dungeon.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-08
+Last Reviewed: 2026-07-17
 Source of Truth: Dungeon write model, ownership boundaries, and domain
 invariants.
 
@@ -65,6 +65,12 @@ Application-owned editor-session values/effects and travel-session state may
 exist outside the authored write model when they are not persisted as dungeon
 truth. Pointer interpretation, transient interaction state, and draft workflows
 are application concerns, not authored domain truth.
+
+Chunks are a spatial partition of authored facts, not a second write model.
+Chunk identity, viewport membership, cache residency, request generation, and
+authored bounds are derived indexing or application state. Stable entity and
+topology identities remain map-wide even when an entity touches several
+chunks.
 
 ## Aggregate Model
 
@@ -205,6 +211,9 @@ and travel capabilities without publishing repositories or adapters.
 - authored feature markers use `FEATURE_MARKER` topology refs and do not reuse
   stair or transition identity
 - preview state never mutates authored truth
+- one successful user command advances the authored map revision exactly once
+- per-session undo and redo restore aggregate-owned authored content as a new
+  revision; their stacks and memory estimates are not durable domain truth
 - room geometry authority comes from reusable floor-cell and boundary-segment
   component ownership; boundary-corner and wall-run handles derive through
   that component boundary, and persistence adapters translate its segments

--- a/docs/dungeon/requirements/requirements-dungeon-editor.md
+++ b/docs/dungeon/requirements/requirements-dungeon-editor.md
@@ -1,6 +1,6 @@
 Status: Draft
 Owner: SaltMarcher Team
-Last Reviewed: 2026-06-23
+Last Reviewed: 2026-07-17
 Source of Truth: Editor-facing dungeon behavior, visible states, and acceptance criteria.
 
 # Dungeon Editor Requirements
@@ -34,8 +34,8 @@ structure, authored dungeon invariants, or SQLite schema detail.
 - The sibling `salt-marcher` repo shows the fuller visible target-state editor
   experience for corridor creation or merge, stair parameter editing, and
   transition destination selection.
-- No current SaltMarcher editor surface evidence was found for dedicated
-  committed-history controls; future history behavior remains target-state.
+- The editor owns per-session committed history and exposes undo/redo through
+  the standard platform shortcuts. History is not persisted across restarts.
 
 ## Visible Structure
 
@@ -91,12 +91,58 @@ cards.
 - handle drag preview MUST be responsive and MUST avoid a full authored
   map reload during per-mouse-move preview when the typed preview can be
   rendered from the current editor session
+- after the visible chunk workset is loaded, pointer preview MUST NOT read from
+  or write to the repository
+- only the newest pending pointer-move preview may remain queued; press,
+  release, commit, cancel, and tool-switch inputs MUST invalidate older queued
+  move samples
 - apply MUST commit only on explicit gesture completion
 - corridor editing MUST support visible create and delete flows
 - stair editing MUST support visible create and delete flows plus stair shape, direction, and exit-level configuration
 - transition editing MUST support visible create and delete flows plus destination selection for dungeon, overworld, or an explicit unlinked entrance placeholder
 - cluster and room naming MUST support default and custom names through the
   state panel; only cluster labels may also use direct label editing
+
+## Sparse Map And Camera Behavior
+
+- authored coordinates MUST support positive and negative values without a
+  fixed map width or height acting as an editing boundary
+- the editor MUST load chunks intersecting the visible viewport plus one
+  surrounding chunk ring for the active level
+- chunks are `64 x 64` cells and use mathematical floor division for negative
+  coordinates
+- panning or zooming MUST remain passive presentation behavior and MUST NOT
+  mutate authored truth
+- coordinate jump, fit-selection, and fit-authored-content actions MUST remain
+  possible even when authored content is far from the current viewport
+- graph presentation MUST distinguish loaded relations from continuations into
+  unloaded chunks rather than presenting the loaded window as the whole map
+
+## Committed History
+
+- `Ctrl/Cmd+Z` MUST undo the latest committed authored command for the selected
+  map in the running editor session
+- `Ctrl/Cmd+Y` and `Ctrl/Cmd+Shift+Z` MUST redo the latest undone command
+- previews, rejected commands, camera changes, selection, and tool changes MUST
+  NOT create history entries
+- a new committed command after undo MUST discard that map's redo branch
+- history MUST preserve stable authored identities and restore content as a
+  new monotonically increasing map revision
+- one map session retains at most `200` committed commands or `128 MiB` of
+  estimated history, whichever limit is reached first
+- closing the editor session or restarting the application clears history;
+  history MUST NOT be stored as dungeon-authored truth
+
+## Responsiveness Qualification
+
+- camera-only and hover-only work MUST complete within a `16 ms` p95 budget in
+  the qualification scenario
+- preview over an already loaded workset MUST complete within a `50 ms` p95
+  budget
+- rendering and hit work MUST be proportional to visible primitives and
+  touched chunks rather than total authored map size
+- stable authored content and the dynamic interaction/actor layer MUST be
+  independently invalidatable so hover changes do not redraw authored content
 
 ## Supported Interaction States
 
@@ -338,6 +384,10 @@ Delete and corridor binding behavior:
   and recompute deterministically.
 - Advanced tool families stay directly visible even when specific authored
   mutations are still delivered incrementally.
+- Undo and redo are observable through the real map-view shortcut route,
+  persist the restored authored result, and keep revision monotonic.
+- Negative-coordinate chunk assignment, one-ring loading, preview workset
+  reuse, and latest-wins pointer scheduling are deterministic and executable.
 
 ## References
 

--- a/docs/hex/README.md
+++ b/docs/hex/README.md
@@ -33,7 +33,7 @@ Generic shared map-canvas behavior remains canonical in `docs/maps/`.
 
 ### Related Maps Docs
 
-- [Maps Feature Overview](../maps/README.md) (line 1)
+- [Map Canvas Overview](../maps/README.md) (line 1)
 - [Maps Canvas Requirements](../maps/requirements/requirements-maps-canvas.md) (line 1)
 - [Hex Map Adoption Architecture](../maps/architecture/architecture-maps-hex-adoption.md) (line 1)
 
@@ -50,4 +50,4 @@ Generic shared map-canvas behavior remains canonical in `docs/maps/`.
 
 ## References
 
-- [Maps Feature Overview](../maps/README.md) (line 1)
+- [Map Canvas Overview](../maps/README.md) (line 1)

--- a/docs/maps/README.md
+++ b/docs/maps/README.md
@@ -1,19 +1,18 @@
-Status: Draft
+Status: Active Target
 Owner: SaltMarcher Team
 Last Reviewed: 2026-04-24
-Source of Truth: Routing entrypoint for the generic maps feature bundle.
+Source of Truth: Routing entrypoint for the generic passive map-canvas bundle.
 
-# Maps Feature Docs
+# Map Canvas Docs
 
 ## Purpose
 
-The `maps` feature owns the generic map canvas that multiple adopting features
-can use. It defines the passive canvas surface, the shared canvas contract, and
-the adopter architecture for translating between canvas coordinates and each
-adopter's internal coordinate system.
+`platform.ui.mapcanvas` owns feature-neutral camera, viewport, layered-canvas,
+cache, and technical pointer mechanisms that multiple map surfaces can use.
+This bundle defines those passive mechanisms and adopter translation.
 
-It does not own adopter domain truth, adopter persistence truth, or adopter
-gameplay semantics.
+It is not a product feature, has no application lifecycle or feature API, and
+does not own adopter domain, persistence, or gameplay semantics.
 
 ## Document Set
 

--- a/docs/maps/architecture/architecture-maps-canvas.md
+++ b/docs/maps/architecture/architecture-maps-canvas.md
@@ -8,7 +8,7 @@ reusable passive map canvas.
 
 ## Purpose And Concerns
 
-This specification defines the reusable canvas owned by the Maps feature. It
+This specification defines reusable mechanisms owned by `platform.ui.mapcanvas`. It
 serves maintainers of map presentation and adopting features that translate
 their own map facts into canvas-native scenes.
 
@@ -25,20 +25,19 @@ domain invariants.
 ## Target Ownership
 
 ```text
-features/maps/
-  api/             immutable canvas scene, hit, pointer, and capability types
-  domain/          canvas-native camera and viewport invariants
-  application/     passive scene, camera, hit, and input orchestration
-  adapter/javafx/  rendering, viewport observation, and pointer capture
-  <feature root>   Maps composition entry point used by app
+platform/ui/mapcanvas/
+  camera and viewport values
+  bounded viewport caches
+  logical paint phases on one bounded JavaFX canvas host
+  technical scene, hit, and pointer values
 ```
 
-The Maps API is the only cross-feature boundary. Adopters may depend on
-`features.maps.api`; Maps must not import an adopter's API or implementation.
+The platform package is a feature-neutral mechanism boundary. JavaFX adapters
+may depend on it; it must not import any adopter API or implementation.
 
 ## Boundaries
 
-- All scene geometry and pointer coordinates crossing the Maps API are
+- All scene geometry and pointer coordinates crossing the mechanism boundary are
   canvas-native.
 - One immutable scene revision supplies both draw order and ordered hit evidence.
 - The JavaFX adapter renders the supplied scene and captures technical input. It
@@ -46,7 +45,7 @@ The Maps API is the only cross-feature boundary. Adopters may depend on
 - Camera, pan, zoom, viewport, resize, and reset behavior remain Maps-owned
   passive presentation behavior.
 - Each adopter owns one translation boundary in its `adapter/javafx` package
-  between its feature API and the Maps API.
+  between its feature API and canvas-native values.
 - Adopter domain and application packages never depend on JavaFX or Maps
   presentation types.
 - Maps owns no SQLite state under the current contract.
@@ -55,25 +54,27 @@ The Maps API is the only cross-feature boundary. Adopters may depend on
 
 ## Composition View
 
-`app` constructs the Maps feature explicitly, obtains its typed canvas
-capability, and passes that capability to each adopting feature entry point. An
-adopter entry point constructs its own API, application, adapters, and shell
-contribution. The shell receives already constructed contributions and does not
-discover or locate canvas or adopter services.
+`app` constructs adopter features. Their JavaFX adapters instantiate passive
+map-canvas mechanisms directly; the platform mechanism has no feature entry
+point, lifecycle, discovery, or service lookup.
 
 ## Capability Paths
 
 ### Surface Read
 
-`adopter API state -> adopter JavaFX adapter -> Maps API scene -> Maps application -> Maps JavaFX adapter`
+`adopter API state -> adopter JavaFX translation -> platform map canvas`
 
 ### Pointer Input
 
-`Maps JavaFX adapter -> Maps API pointer sample -> adopter JavaFX adapter -> adopter API command`
+`platform pointer sample -> adopter JavaFX translation -> adopter API command`
 
 ### Draw And Hit
 
-`one Maps API scene revision -> ordered draw primitives + ordered hit evidence -> Maps JavaFX adapter`
+`one canvas scene revision -> ordered draw primitives + ordered hit evidence -> bounded JavaFX canvas`
+
+Base, interaction, and actor paint remain separate invalidation phases. They
+share one backing surface so each open editor does not multiply a full-window
+pixel buffer; transient repaint replays the retained base phase first.
 
 The adopter translation boundary derives canvas-native geometry and stable hit
 references from adopter API state. It also translates a technical hit reference

--- a/docs/maps/architecture/architecture-maps-dungeon-adoption.md
+++ b/docs/maps/architecture/architecture-maps-dungeon-adoption.md
@@ -1,7 +1,7 @@
 Status: Active Target
 Owner: SaltMarcher Team
 Last Reviewed: 2026-07-15
-Source of Truth: Target Dungeon adoption of the Maps canvas through feature APIs
+Source of Truth: Target Dungeon adoption of platform map-canvas mechanisms through feature APIs
 and explicit application composition.
 
 # Dungeon Map Adoption Architecture
@@ -12,7 +12,7 @@ This specification defines how the Dungeon feature adopts the passive Maps
 canvas for editor and travel workspaces. It serves Dungeon, Maps, shell, and
 application-composition maintainers.
 
-It owns the structural translation between Dungeon API state and Maps API scene
+It owns the structural translation between Dungeon API state and canvas-native scene
 and pointer types. Dungeon requirements own observable editor and travel
 behavior; Dungeon domain and persistence documents own authored truth and stored
 truth.
@@ -30,15 +30,15 @@ features/dungeon/
 ```
 
 The Dungeon JavaFX adapter may depend on `features.dungeon.api`,
-`features.maps.api`, `shell.api`, and feature-neutral UI contracts. It must not
+`shell.api`, and `platform.ui.mapcanvas`. It must not
 reach into Dungeon domain, application, or SQLite packages. Maps must not depend
 on any Dungeon package.
 
 ## Composition And Dependencies
 
-`app` constructs platform persistence, the Maps entry point, and the Dungeon
-entry point explicitly. It supplies Dungeon with the Maps canvas capability and
-any foreign feature APIs required by travel composition. Dungeon exposes its
+`app` constructs platform persistence and the Dungeon entry point explicitly.
+Dungeon's JavaFX adapter instantiates the passive canvas mechanism and receives
+foreign feature APIs required by travel composition. Dungeon exposes its
 constructed shell contribution and public APIs back to `app`; internal
 repositories and adapters remain feature-private.
 
@@ -49,8 +49,8 @@ of the target route.
 
 The Dungeon JavaFX adapter is the single owner of both directions:
 
-- Dungeon API state to one canvas-native Maps API scene revision
-- Maps API pointer and hit samples to typed Dungeon API inputs
+- Dungeon API state to one canvas-native scene revision
+- platform pointer and hit samples to typed Dungeon API inputs
 
 Dungeon-grid coordinates, topology identity, preview meaning, editing tools,
 selection, and travel actions remain Dungeon-owned. Canvas coordinates, camera,
@@ -65,11 +65,11 @@ input.
 
 ### Authored And Editor Read
 
-`Dungeon API state -> Dungeon JavaFX translation -> Maps API scene -> Maps canvas`
+`Dungeon API state -> Dungeon JavaFX translation -> platform map canvas`
 
 ### Preview And Apply
 
-`Maps pointer sample -> Dungeon JavaFX translation -> Dungeon Editor API -> Dungeon application -> immutable Dungeon API state -> translated Maps scene`
+`platform pointer sample -> Dungeon JavaFX translation -> Dungeon Editor API -> Dungeon application -> immutable Dungeon API state -> translated canvas scene`
 
 Preview and apply reuse the same authored operation vocabulary. Preview does not
 persist; apply commits only after Dungeon validation succeeds.
@@ -93,7 +93,7 @@ API.
   authored catalog work belongs to `DungeonAuthoredApi`.
 - One JavaFX translation owner keeps dungeon-grid conversion and hit identity
   consistent across editor and travel surfaces.
-- Maps receives canvas-native presentation facts only; it never receives
+- The platform canvas receives canvas-native presentation facts only; it never receives
   Dungeon commands, aggregates, repositories, or persistence rows.
 - Render-ready state is derived in the JavaFX adapter from revisioned Dungeon API
   state and must not become a second Dungeon publication or persistence model.

--- a/docs/maps/architecture/architecture-maps-hex-adoption.md
+++ b/docs/maps/architecture/architecture-maps-hex-adoption.md
@@ -8,7 +8,7 @@ Source of Truth: Target boundary between the shipped Hex feature and the Maps ca
 ## Purpose
 
 Hex is a shipped feature. This specification owns how its editor and travel
-surfaces adopt the target Maps API without leaking canvas mechanisms into the
+surfaces adopt the platform map-canvas mechanism without leaking it into the
 Hex domain or duplicating coordinate and interaction truth.
 
 It does not own Hex gameplay, persistence, or the generic Maps contract.
@@ -21,7 +21,7 @@ It does not own Hex gameplay, persistence, or the generic Maps contract.
 - Maps exposes its reusable canvas capability through `features.maps.api`.
 - `app` explicitly composes that capability into the Hex feature. Runtime
   discovery, registries, and service locators are forbidden.
-- The Hex JavaFX adapter is the only Hex role allowed to consume the Maps API.
+- The Hex JavaFX adapter is the only Hex role allowed to consume the map-canvas mechanism.
   The Hex domain and application layers remain independent of JavaFX, canvas,
   camera, viewport, and pointer mechanisms.
 

--- a/docs/maps/contract/contract-maps-canvas.md
+++ b/docs/maps/contract/contract-maps-canvas.md
@@ -8,11 +8,11 @@ samples shared with adopting features.
 
 ## Purpose, Owners, And Consumers
 
-This feature-boundary contract defines the canvas-native values exchanged
-through `features/maps/api`.
+This technical contract defines canvas-native values exchanged through
+`platform.ui.mapcanvas`.
 
-- provider: Maps feature
-- consumers: adopting feature JavaFX adapters and application composition
+- provider: platform map-canvas mechanism
+- consumers: adopting feature JavaFX adapters
 - non-owners: adopter domain, application, persistence, and gameplay semantics
 
 The API owns technical scene, camera, hit, and pointer semantics. It does not own
@@ -88,7 +88,7 @@ adopter truth.
 
 ## Validation And Error Behavior
 
-- Non-finite coordinates or geometry are rejected at the Maps API boundary.
+- Non-finite coordinates or geometry are rejected at the map-canvas boundary.
 - A pointer sample without a hit still carries a valid canvas point and scene
   revision.
 - A hit whose revision is stale or unknown is returned as no-hit; Maps does not

--- a/docs/maps/contract/contract-maps-dungeon-surface.md
+++ b/docs/maps/contract/contract-maps-dungeon-surface.md
@@ -147,7 +147,7 @@ requests.
 - Missing optional result sections mean absence, not defaults invented by a
   consumer.
 - A stale asynchronous result must not overwrite a newer Dungeon API revision.
-- Translation into Maps API values must preserve Dungeon meaning but must not
+- Translation into canvas-native values must preserve Dungeon meaning but must not
   mutate Dungeon state.
 
 ## Compatibility, Migration, And Versioning

--- a/docs/maps/requirements/requirements-maps-canvas.md
+++ b/docs/maps/requirements/requirements-maps-canvas.md
@@ -8,8 +8,9 @@ canvas.
 
 ## Goal
 
-Provide one generic passive map canvas that Dungeon and Hex surfaces reuse for
-rendering, hit-testing, and passive pointer capture.
+Provide feature-neutral passive map-canvas mechanisms that Dungeon and Hex
+JavaFX surfaces reuse for rendering, hit-testing, camera behavior, viewport
+caching, and passive pointer capture.
 
 ## Non-Goals
 

--- a/docs/project/architecture/source-architecture.md
+++ b/docs/project/architecture/source-architecture.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-17
 Source of Truth: Target source shape, dependency direction, and
 architecture-significant quality constraints for the SaltMarcher desktop app.
 
@@ -53,6 +53,9 @@ feature and publishes separate Authored, Editor, and Travel APIs.
   `app`, `shell`, or feature code. Its capability packages are
   `platform.execution`, `platform.persistence`, `platform.diagnostics`,
   `platform.state`, and `platform.ui`; new catch-all packages are forbidden.
+  Passive map camera, viewport, layered-canvas, cache, and technical pointer
+  mechanisms live in `platform.ui.mapcanvas`; they do not form a Maps feature
+  or own adopter coordinates and behavior.
 - A feature MUST expose cross-feature capabilities only from its `api` package.
   Application, JavaFX adapter, and composition code may consume foreign APIs;
   no consumer may import another feature's domain, application, adapters, or

--- a/docs/project/verification/quality-platforms.md
+++ b/docs/project/verification/quality-platforms.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-17
 Source of Truth: SaltMarcher's required proof surface and verification principles.
 
 # Quality Platforms
@@ -28,6 +28,9 @@ the single test source set and requires no build registry entry.
   already covered by the compiler, tests, ArchUnit, or another retained tool.
 - Verification code does not test its own fixtures, registries, task topology,
   or implementation form as a substitute for product behavior.
+- Responsive interaction claims require deterministic work-bound evidence plus
+  a named production-route qualification scenario; timing assertions alone are
+  not accepted as stable CI proof.
 
 Branch protection requires exactly the `check` context. External analyzer and
 AI-review services are not part of verification.

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -11,6 +11,8 @@ import features.dungeon.api.DungeonEditorMapSurfaceModel;
 import features.dungeon.api.DungeonEditorStateModel;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.TravelDungeonModel;
+import features.dungeon.api.authored.DungeonAuthoredApi;
+import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
 import features.dungeon.application.authored.DungeonAuthoredPublishedState;
 import features.dungeon.application.authored.port.DungeonMapRepository;
@@ -65,7 +67,9 @@ public final class DungeonFeature {
                 dispatcher);
         return new Component(
                 new DungeonEditorContribution(editorDependencies),
-                new DungeonTravelContribution(runtime.travel(), runtime.mapCatalog(), runtime.travelModel()));
+                new DungeonTravelContribution(runtime.travel(), runtime.mapCatalog(), runtime.travelModel()),
+                runtime.authored(),
+                runtime.travel());
     }
 
     static Runtime createRuntime(
@@ -107,11 +111,15 @@ public final class DungeonFeature {
 
     public record Component(
             ShellContribution editorContribution,
-            ShellContribution travelContribution
+            ShellContribution travelContribution,
+            DungeonAuthoredApi authoredApi,
+            DungeonTravelApi travelApi
     ) {
         public Component {
             editorContribution = Objects.requireNonNull(editorContribution, "editorContribution");
             travelContribution = Objects.requireNonNull(travelContribution, "travelContribution");
+            authoredApi = Objects.requireNonNull(authoredApi, "authoredApi");
+            travelApi = Objects.requireNonNull(travelApi, "travelApi");
         }
     }
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -40,6 +40,8 @@ import features.dungeon.adapter.javafx.map.DungeonMapViewInputEvent;
 
 final class DungeonEditorViewModel {
     private static final long NO_TRANSITION_ID = 0L;
+    private static final String UNDO_COMMAND = "UNDO";
+    private static final String REDO_COMMAND = "REDO";
 
     private final ReadOnlyObjectWrapper<ControlsProjection> controlsProjection =
             new ReadOnlyObjectWrapper<>(ControlsProjection.initial());
@@ -470,12 +472,30 @@ final class DungeonEditorViewModel {
         if (event == null) {
             return;
         }
-        if (consumeInlineLabelEditEvent(event) || consumeInlineEditOutsidePressGesture(event)
+        if (consumeInlineLabelEditEvent(event) || consumeHistoryCommand(event)
+                || consumeInlineEditOutsidePressGesture(event)
                 || consumeActiveInlineEditBoundary(event)
                 || consumeLocalCameraInput(event) || consumeScrollInput(event) || consumeEscapeInput(event)) {
             return;
         }
         consumePointerToolInput(event);
+    }
+
+    private boolean consumeHistoryCommand(DungeonMapViewInputEvent event) {
+        if (!event.input().escapePressed()) {
+            return false;
+        }
+        if (UNDO_COMMAND.equals(event.textInput())) {
+            mapContentModel.clearHoverTarget();
+            controlOperations.undo();
+            return true;
+        }
+        if (REDO_COMMAND.equals(event.textInput())) {
+            mapContentModel.clearHoverTarget();
+            controlOperations.redo();
+            return true;
+        }
+        return false;
     }
 
     private boolean consumeInlineLabelEditEvent(DungeonMapViewInputEvent event) {

--- a/features/dungeon/adapter/javafx/map/DungeonMapView.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapView.java
@@ -3,6 +3,7 @@ package features.dungeon.adapter.javafx.map;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import javafx.beans.InvalidationListener;
 import javafx.beans.value.ChangeListener;
@@ -33,6 +34,10 @@ import features.dungeon.adapter.javafx.map.DungeonMapContentModel.PaintStyle;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.RelationPrimitive;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.RenderScene;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.Viewport;
+import platform.ui.mapcanvas.MapCanvasLayer;
+import platform.ui.mapcanvas.MapCanvasPane;
+import platform.ui.mapcanvas.MapCanvasViewport;
+import platform.ui.mapcanvas.MapCanvasWindow;
 
 public class DungeonMapView extends BorderPane {
 
@@ -58,6 +63,8 @@ public class DungeonMapView extends BorderPane {
     private static final DungeonMapViewInputEvent.CanvasInput LABEL_EDIT_TEXT_CHANGED_INPUT =
             rawLabelEditTextChangedInput();
     private static final Runnable NO_CANVAS_BINDING = () -> {};
+    private static final String UNDO_COMMAND = "UNDO";
+    private static final String REDO_COMMAND = "REDO";
     private static final int[] GRID_STEPS = {1, 5, 10, 25};
     private static final Map<DungeonMapContentModel.RenderColor, Color> FX_COLOR_CACHE = new HashMap<>();
     private static final Color BACKGROUND_COLOR = PaintPalette.color(0x12, 0x18, 0x1c, 1.0);
@@ -68,8 +75,9 @@ public class DungeonMapView extends BorderPane {
             PaintPalette.color(0xb1, 0xbc, 0xc5, 0.28)
     };
     private final StackPane host = ViewChrome.createHost();
-    private final Pane canvasLayer = ViewChrome.createCanvasLayer();
-    private final Canvas canvas = ViewChrome.createCanvas();
+    private final MapCanvasPane canvasLayer = ViewChrome.createCanvasLayer();
+    private final Canvas canvas = canvasLayer.canvas(MapCanvasLayer.BASE);
+    private final Canvas interactionCanvas = canvasLayer.canvas(MapCanvasLayer.INTERACTION);
     private final TextField inlineLabelEditor = ViewChrome.createInlineLabelEditor();
     private final Label overlayMessage = ViewChrome.createOverlayMessage();
     private final ChangeListener<String> inlineLabelEditorTextListener =
@@ -78,12 +86,15 @@ public class DungeonMapView extends BorderPane {
     private Runnable removeCanvasBinding = NO_CANVAS_BINDING;
     private double[] polygonXBuffer = new double[0];
     private double[] polygonYBuffer = new double[0];
+    private RenderScene lastRenderedScene;
+    private Viewport lastRenderedViewport;
+    private List<MapCanvasPolygonPrimitive> lastHoverSurfaces = List.of();
+    private List<BoundaryPrimitive> lastHoverBoundaries = List.of();
+    private List<GlyphPrimitive> lastHoverGlyphs = List.of();
+    private List<DungeonMapContentModel.TextPrimitive> lastHoverTexts = List.of();
 
     public DungeonMapView() {
         getStyleClass().addAll("surface-root", "dungeon-map-surface");
-        canvas.widthProperty().bind(canvasLayer.widthProperty());
-        canvas.heightProperty().bind(canvasLayer.heightProperty());
-        ViewChrome.installCanvas(canvasLayer, canvas);
         ViewChrome.installHost(host, canvasLayer, inlineLabelEditor, overlayMessage);
         InputEvents.installInlineLabelEditor(inlineLabelEditor, this);
         setCenter(host);
@@ -140,18 +151,57 @@ public class DungeonMapView extends BorderPane {
         }
         long startedNanos = System.nanoTime();
         try {
-            CanvasRenderer.render(
-                    this,
-                    CanvasSurface.graphicsContext(canvas),
-                    canvasState,
-                    CanvasSurface.renderWidth(canvas),
-                CanvasSurface.renderHeight(canvas));
+            redrawChangedLayers(canvasState);
         } finally {
             if (measurementSink != null) {
                 measurementSink.recordCanvasRedraw(System.nanoTime() - startedNanos);
             }
         }
         ViewChrome.showOverlay(overlayMessage, canvasState);
+    }
+
+    private void redrawChangedLayers(DungeonMapContentModel.CanvasState canvasState) {
+        RenderScene scene = canvasState.baseRenderScene();
+        Viewport viewport = canvasState.viewport();
+        double width = CanvasSurface.renderWidth(canvas);
+        double height = CanvasSurface.renderHeight(canvas);
+        boolean cameraOrBaseChanged = !Objects.equals(lastRenderedScene, scene)
+                || !Objects.equals(lastRenderedViewport, viewport);
+        if (cameraOrBaseChanged) {
+            CanvasRenderer.renderBase(this, CanvasSurface.graphicsContext(canvas), scene, viewport, width, height);
+            lastRenderedScene = scene;
+        }
+        boolean hoverChanged = cameraOrBaseChanged
+                || !Objects.equals(lastHoverSurfaces, canvasState.hoverSurfaces())
+                || !Objects.equals(lastHoverBoundaries, canvasState.hoverBoundaries())
+                || !Objects.equals(lastHoverGlyphs, canvasState.hoverGlyphs())
+                || !Objects.equals(lastHoverTexts, canvasState.hoverTexts());
+        if (hoverChanged) {
+            boolean sharedSurface = interactionCanvas == canvas;
+            if (sharedSurface && !cameraOrBaseChanged) {
+                CanvasRenderer.renderBase(
+                        this,
+                        CanvasSurface.graphicsContext(canvas),
+                        scene,
+                        viewport,
+                        width,
+                        height);
+            }
+            CanvasRenderer.renderDynamic(
+                    this,
+                    CanvasSurface.graphicsContext(interactionCanvas),
+                    canvasState,
+                    scene,
+                    viewport,
+                    width,
+                    height,
+                    !sharedSurface);
+            lastHoverSurfaces = canvasState.hoverSurfaces();
+            lastHoverBoundaries = canvasState.hoverBoundaries();
+            lastHoverGlyphs = canvasState.hoverGlyphs();
+            lastHoverTexts = canvasState.hoverTexts();
+        }
+        lastRenderedViewport = viewport;
     }
 
     private void removeCurrentCanvasListeners() {
@@ -341,6 +391,28 @@ public class DungeonMapView extends BorderPane {
                     canvas.getWidth(),
                     canvas.getHeight(),
                     0.0);
+            event.consume();
+            return;
+        }
+        if (event.isShortcutDown() && code == KeyCode.Z) {
+            InputSnapshots.emitKeyboardCommand(
+                    this,
+                    ESCAPE_PRESSED_INPUT,
+                    event,
+                    canvas.getWidth(),
+                    canvas.getHeight(),
+                    event.isShiftDown() ? REDO_COMMAND : UNDO_COMMAND);
+            event.consume();
+            return;
+        }
+        if (event.isShortcutDown() && code == KeyCode.Y) {
+            InputSnapshots.emitKeyboardCommand(
+                    this,
+                    ESCAPE_PRESSED_INPUT,
+                    event,
+                    canvas.getWidth(),
+                    canvas.getHeight(),
+                    REDO_COMMAND);
             event.consume();
         }
     }
@@ -536,6 +608,27 @@ public class DungeonMapView extends BorderPane {
                     text,
                     0));
         }
+
+        static void emitKeyboardCommand(
+                DungeonMapView view,
+                DungeonMapViewInputEvent.CanvasInput input,
+                KeyEvent event,
+                double canvasWidth,
+                double canvasHeight,
+                String command
+        ) {
+            view.emitInput(new DungeonMapViewInputEvent(
+                    input,
+                    new DungeonMapViewInputEvent.CanvasButtons(false, false, false),
+                    new DungeonMapViewInputEvent.CanvasModifiers(
+                            event.isControlDown(),
+                            event.isShiftDown(),
+                            event.isAltDown()),
+                    new DungeonMapViewInputEvent.CanvasPosition(canvasWidth / 2.0, canvasHeight / 2.0),
+                    0.0,
+                    command,
+                    0));
+        }
     }
 
     private interface ViewChrome {
@@ -547,8 +640,8 @@ public class DungeonMapView extends BorderPane {
             return newHost;
         }
 
-        static Pane createCanvasLayer() {
-            Pane newCanvasLayer = new Pane();
+        static MapCanvasPane createCanvasLayer() {
+            MapCanvasPane newCanvasLayer = new MapCanvasPane();
             newCanvasLayer.setMinSize(0.0, 0.0);
             newCanvasLayer.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
             newCanvasLayer.setFocusTraversable(true);
@@ -556,12 +649,6 @@ public class DungeonMapView extends BorderPane {
             newCanvasLayer.setAccessibleHelp(
                     "Arrow keys move the map focus. Enter or Space activates the current target.");
             return newCanvasLayer;
-        }
-
-        static Canvas createCanvas() {
-            Canvas newCanvas = new Canvas(960.0, 640.0);
-            newCanvas.getStyleClass().add("dungeon-map-canvas");
-            return newCanvas;
         }
 
         static Label createOverlayMessage() {
@@ -578,10 +665,6 @@ public class DungeonMapView extends BorderPane {
             editor.setAccessibleText("Dungeon map label editor");
             editor.getStyleClass().add(MAP_LABEL_STYLE_CLASS);
             return editor;
-        }
-
-        static void installCanvas(Pane canvasLayer, Canvas canvas) {
-            canvasLayer.getChildren().setAll(canvas);
         }
 
         static void installHost(
@@ -628,33 +711,53 @@ public class DungeonMapView extends BorderPane {
 
     private interface CanvasRenderer {
 
-        static void render(
+        static void renderBase(
                 DungeonMapView view,
                 GraphicsContext gc,
-                DungeonMapContentModel.CanvasState canvasState,
+                RenderScene renderScene,
+                Viewport viewport,
                 double width,
                 double height
         ) {
-            RenderScene renderScene = canvasState.baseRenderScene();
-            Viewport viewport = canvasState.viewport();
             clear(gc, width, height);
             drawGrid(gc, renderScene, viewport, width, height);
-            drawRelations(gc, renderScene.relations(), viewport);
-            drawSurfaces(view, gc, renderScene.baseSurfaces(), viewport);
-            drawBoundaries(gc, renderScene.baseBoundaries(), viewport);
-            drawGlyphs(view, gc, renderScene.baseGlyphs(), viewport);
-            drawTexts(gc, renderScene.baseTexts(), viewport);
-            drawSurfaces(view, gc, canvasState.hoverSurfaces(), viewport);
-            drawBoundaries(gc, canvasState.hoverBoundaries(), viewport);
-            drawGlyphs(view, gc, canvasState.hoverGlyphs(), viewport);
-            drawTexts(gc, canvasState.hoverTexts(), viewport);
-            drawSurfaces(view, gc, renderScene.actors(), viewport);
+            MapCanvasWindow visibleWindow = visibleWindow(viewport, width, height);
+            drawRelations(gc, renderScene.relations(), viewport, visibleWindow);
+            drawSurfaces(view, gc, renderScene.baseSurfaces(), viewport, visibleWindow);
+            drawBoundaries(gc, renderScene.baseBoundaries(), viewport, visibleWindow);
+            drawGlyphs(view, gc, renderScene.baseGlyphs(), viewport, visibleWindow);
+            drawTexts(gc, renderScene.baseTexts(), viewport, visibleWindow);
+        }
+
+        static void renderDynamic(
+                DungeonMapView view,
+                GraphicsContext gc,
+                DungeonMapContentModel.CanvasState canvasState,
+                RenderScene renderScene,
+                Viewport viewport,
+                double width,
+                double height,
+                boolean clearSurface
+        ) {
+            if (clearSurface) {
+                clearTransparent(gc, width, height);
+            }
+            MapCanvasWindow visibleWindow = visibleWindow(viewport, width, height);
+            drawSurfaces(view, gc, canvasState.hoverSurfaces(), viewport, visibleWindow);
+            drawBoundaries(gc, canvasState.hoverBoundaries(), viewport, visibleWindow);
+            drawGlyphs(view, gc, canvasState.hoverGlyphs(), viewport, visibleWindow);
+            drawTexts(gc, canvasState.hoverTexts(), viewport, visibleWindow);
+            drawSurfaces(view, gc, renderScene.actors(), viewport, visibleWindow);
         }
 
         static void clear(GraphicsContext gc, double width, double height) {
             gc.clearRect(0.0, 0.0, width, height);
             gc.setFill(BACKGROUND_COLOR);
             gc.fillRect(0.0, 0.0, width, height);
+        }
+
+        static void clearTransparent(GraphicsContext gc, double width, double height) {
+            gc.clearRect(0.0, 0.0, width, height);
         }
 
         static void drawGrid(
@@ -693,30 +796,39 @@ public class DungeonMapView extends BorderPane {
                 DungeonMapView view,
                 GraphicsContext gc,
                 List<MapCanvasPolygonPrimitive> surfaces,
-                Viewport viewport
+                Viewport viewport,
+                MapCanvasWindow visibleWindow
         ) {
             for (MapCanvasPolygonPrimitive surface : surfaces) {
-                PrimitivePainter.drawPolygon(view, gc, surface.polygon(), surface.style(), viewport);
+                if (PrimitivePainter.visible(surface.polygon(), visibleWindow)) {
+                    PrimitivePainter.drawPolygon(view, gc, surface.polygon(), surface.style(), viewport);
+                }
             }
         }
 
         static void drawBoundaries(
                 GraphicsContext gc,
                 List<BoundaryPrimitive> boundaries,
-                Viewport viewport
+                Viewport viewport,
+                MapCanvasWindow visibleWindow
         ) {
             for (BoundaryPrimitive boundary : boundaries) {
-                PrimitivePainter.drawPolyline(gc, boundary.polyline(), boundary.style(), viewport);
+                if (PrimitivePainter.visible(boundary.polyline(), visibleWindow)) {
+                    PrimitivePainter.drawPolyline(gc, boundary.polyline(), boundary.style(), viewport);
+                }
             }
         }
 
         static void drawRelations(
                 GraphicsContext gc,
                 List<RelationPrimitive> relations,
-                Viewport viewport
+                Viewport viewport,
+                MapCanvasWindow visibleWindow
         ) {
             for (RelationPrimitive relation : relations) {
-                PrimitivePainter.drawPolyline(gc, relation.polyline(), relation.style(), viewport);
+                if (PrimitivePainter.visible(relation.polyline(), visibleWindow)) {
+                    PrimitivePainter.drawPolyline(gc, relation.polyline(), relation.style(), viewport);
+                }
             }
         }
 
@@ -724,10 +836,14 @@ public class DungeonMapView extends BorderPane {
                 DungeonMapView view,
                 GraphicsContext gc,
                 List<GlyphPrimitive> glyphs,
-                Viewport viewport
+                Viewport viewport,
+                MapCanvasWindow visibleWindow
         ) {
             gc.setTextAlign(TextAlignment.CENTER);
             for (GlyphPrimitive glyph : glyphs) {
+                if (!PrimitivePainter.visible(glyph.polygon(), visibleWindow)) {
+                    continue;
+                }
                 PrimitivePainter.drawPolygon(view, gc, glyph.polygon(), glyph.style(), viewport);
                 String label = glyph.label();
                 if (!label.isBlank()) {
@@ -744,10 +860,20 @@ public class DungeonMapView extends BorderPane {
         static void drawTexts(
                 GraphicsContext gc,
                 List<DungeonMapContentModel.TextPrimitive> texts,
-                Viewport viewport
+                Viewport viewport,
+                MapCanvasWindow visibleWindow
         ) {
             gc.setTextAlign(TextAlignment.CENTER);
             for (DungeonMapContentModel.TextPrimitive text : texts) {
+                double halfWidth = Math.max(0.0, text.width()) / 2.0;
+                double halfHeight = Math.max(0.0, text.height()) / 2.0;
+                if (!visibleWindow.intersects(
+                        text.centerX() - halfWidth,
+                        text.centerY() - halfHeight,
+                        text.centerX() + halfWidth,
+                        text.centerY() + halfHeight)) {
+                    continue;
+                }
                 double width = text.width() * viewport.gridSize();
                 double height = text.height() * viewport.gridSize();
                 double centerX = viewport.sceneToScreenX(text.centerX());
@@ -773,6 +899,18 @@ public class DungeonMapView extends BorderPane {
                 gc.restore();
             }
             gc.setTextAlign(TextAlignment.LEFT);
+        }
+
+        private static MapCanvasWindow visibleWindow(Viewport viewport, double width, double height) {
+            return MapCanvasWindow.visible(
+                    new MapCanvasViewport(
+                            viewport.panX(),
+                            viewport.panY(),
+                            viewport.zoom(),
+                            DungeonMapViewportScale.baseGrid()),
+                    width,
+                    height,
+                    2.0);
         }
 
     }
@@ -829,6 +967,23 @@ public class DungeonMapView extends BorderPane {
 
         static boolean polylineDrawable(List<MapCanvasPoint> points) {
             return points.size() >= 2;
+        }
+
+        static boolean visible(List<MapCanvasPoint> points, MapCanvasWindow visibleWindow) {
+            if (points == null || points.isEmpty() || visibleWindow == null) {
+                return false;
+            }
+            double minimumX = Double.POSITIVE_INFINITY;
+            double minimumY = Double.POSITIVE_INFINITY;
+            double maximumX = Double.NEGATIVE_INFINITY;
+            double maximumY = Double.NEGATIVE_INFINITY;
+            for (MapCanvasPoint point : points) {
+                minimumX = Math.min(minimumX, point.x());
+                minimumY = Math.min(minimumY, point.y());
+                maximumX = Math.max(maximumX, point.x());
+                maximumY = Math.max(maximumY, point.y());
+            }
+            return visibleWindow.intersects(minimumX, minimumY, maximumX, maximumY);
         }
 
         static void drawLabelBox(

--- a/features/dungeon/adapter/javafx/map/DungeonMapViewportState.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapViewportState.java
@@ -3,9 +3,16 @@ package features.dungeon.adapter.javafx.map;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleWrapper;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.Viewport;
+import platform.ui.mapcanvas.MapCanvasCamera;
+import platform.ui.mapcanvas.MapCanvasViewport;
 
 final class DungeonMapViewportState {
-    private Viewport viewport = Viewport.initial();
+    private final MapCanvasCamera camera = new MapCanvasCamera(
+            DungeonMapViewportScale.baseGrid(),
+            DungeonMapViewportScale.defaultZoom(),
+            DungeonMapViewportScale.minimumZoom(),
+            DungeonMapViewportScale.maximumZoom());
+    private Viewport viewport = dungeonViewport(camera.viewport());
     private final ReadOnlyDoubleWrapper zoom = new ReadOnlyDoubleWrapper(viewport.zoom());
 
     ReadOnlyDoubleProperty zoomProperty() {
@@ -21,29 +28,25 @@ final class DungeonMapViewportState {
     }
 
     Viewport resetCamera() {
-        return setViewport(Viewport.initial());
+        return setViewport(dungeonViewport(camera.reset()));
     }
 
     Viewport panByPixels(double deltaX, double deltaY) {
-        return setViewport(new Viewport(
-                viewport.panX() + deltaX,
-                viewport.panY() + deltaY,
-                viewport.zoom()));
+        return setViewport(dungeonViewport(camera.panByPixels(deltaX, deltaY)));
     }
 
     Viewport zoomAround(double canvasX, double canvasY, double factor) {
-        double nextZoom = DungeonMapViewportScale.clampZoom(viewport.zoom() * factor);
-        double scale = nextZoom / viewport.zoom();
-        return setViewport(new Viewport(
-                canvasX - (canvasX - viewport.panX()) * scale,
-                canvasY - (canvasY - viewport.panY()) * scale,
-                nextZoom));
+        return setViewport(dungeonViewport(camera.zoomAround(canvasX, canvasY, factor)));
     }
 
     private Viewport setViewport(Viewport nextViewport) {
         viewport = nextViewport == null ? Viewport.initial() : nextViewport;
         zoom.set(viewport.zoom());
         return viewport;
+    }
+
+    private static Viewport dungeonViewport(MapCanvasViewport viewport) {
+        return new Viewport(viewport.panX(), viewport.panY(), viewport.zoom());
     }
 
 }

--- a/features/dungeon/adapter/javafx/travel/DungeonTravelBinder.java
+++ b/features/dungeon/adapter/javafx/travel/DungeonTravelBinder.java
@@ -6,7 +6,7 @@ import javafx.scene.Node;
 import shell.api.ShellBinding;
 import shell.api.ShellControls;
 import shell.api.ShellSlot;
-import features.dungeon.application.travel.DungeonTravelRuntimeApplicationService;
+import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.TravelDungeonModel;
 import features.dungeon.api.TravelDungeonSnapshot;
@@ -17,12 +17,12 @@ import features.dungeon.adapter.javafx.map.DungeonMapView;
 
 final class DungeonTravelBinder {
 
-    private final DungeonTravelRuntimeApplicationService travel;
+    private final DungeonTravelApi travel;
     private final DungeonMapCatalogModel mapCatalogModel;
     private final TravelDungeonModel travelModel;
 
     DungeonTravelBinder(
-            DungeonTravelRuntimeApplicationService travel,
+            DungeonTravelApi travel,
             DungeonMapCatalogModel mapCatalogModel,
             TravelDungeonModel travelModel
     ) {

--- a/features/dungeon/adapter/javafx/travel/DungeonTravelContribution.java
+++ b/features/dungeon/adapter/javafx/travel/DungeonTravelContribution.java
@@ -9,18 +9,18 @@ import shell.api.ShellContribution;
 import shell.api.ShellContributionSpec;
 import shell.api.ShellLeftBarTabMode;
 import shell.api.ShellLeftBarTabSpec;
-import features.dungeon.application.travel.DungeonTravelRuntimeApplicationService;
+import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.TravelDungeonModel;
 
 public final class DungeonTravelContribution implements ShellContribution {
 
-    private final DungeonTravelRuntimeApplicationService travel;
+    private final DungeonTravelApi travel;
     private final DungeonMapCatalogModel mapCatalogModel;
     private final TravelDungeonModel travelModel;
 
     public DungeonTravelContribution(
-            DungeonTravelRuntimeApplicationService travel,
+            DungeonTravelApi travel,
             DungeonMapCatalogModel mapCatalogModel,
             TravelDungeonModel travelModel
     ) {

--- a/features/dungeon/adapter/javafx/travel/DungeonTravelIntentHandler.java
+++ b/features/dungeon/adapter/javafx/travel/DungeonTravelIntentHandler.java
@@ -2,7 +2,7 @@ package features.dungeon.adapter.javafx.travel;
 
 import java.util.List;
 import java.util.Objects;
-import features.dungeon.application.travel.DungeonTravelRuntimeApplicationService;
+import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.api.DungeonOverlaySettings;
 import platform.ui.catalogcrud.CatalogCrudControlsContentModel;
 import platform.ui.catalogcrud.CatalogCrudControlsViewInputEvent;
@@ -15,7 +15,7 @@ final class DungeonTravelIntentHandler {
     private final DungeonTravelContributionModel presentationModel;
     private final CatalogCrudControlsContentModel catalogContentModel;
     private final DungeonMapContentModel mapContentModel;
-    private final DungeonTravelRuntimeApplicationService travel;
+    private final DungeonTravelApi travel;
     private double previousMiddleDragCanvasX;
     private double previousMiddleDragCanvasY;
     private boolean middleDragInProgress;
@@ -24,7 +24,7 @@ final class DungeonTravelIntentHandler {
             DungeonTravelContributionModel presentationModel,
             CatalogCrudControlsContentModel catalogContentModel,
             DungeonMapContentModel mapContentModel,
-            DungeonTravelRuntimeApplicationService travel
+            DungeonTravelApi travel
     ) {
         this.presentationModel = Objects.requireNonNull(presentationModel, "presentationModel");
         this.catalogContentModel = Objects.requireNonNull(catalogContentModel, "catalogContentModel");

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteChangedRecords.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteChangedRecords.java
@@ -1,0 +1,36 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.ToLongFunction;
+
+final class DungeonSqliteChangedRecords {
+    private DungeonSqliteChangedRecords() {
+    }
+
+    static <T> List<T> changed(List<T> before, List<T> after, ToLongFunction<T> identity) {
+        Map<Long, T> previous = new LinkedHashMap<>();
+        for (T value : before == null ? List.<T>of() : before) {
+            previous.put(identity.applyAsLong(value), value);
+        }
+        List<T> changed = new ArrayList<>();
+        for (T value : after == null ? List.<T>of() : after) {
+            if (!value.equals(previous.get(identity.applyAsLong(value)))) {
+                changed.add(value);
+            }
+        }
+        return List.copyOf(changed);
+    }
+
+    static <T> Set<Long> identities(List<T> values, ToLongFunction<T> identity) {
+        Set<Long> identities = new LinkedHashSet<>();
+        for (T value : values == null ? List.<T>of() : values) {
+            identities.add(identity.applyAsLong(value));
+        }
+        return Set.copyOf(identities);
+    }
+}

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteChunkWriter.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteChunkWriter.java
@@ -1,0 +1,157 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import features.dungeon.adapter.sqlite.model.DungeonClusterBoundaryRecord;
+import features.dungeon.adapter.sqlite.model.DungeonCorridorAnchorBindingRecord;
+import features.dungeon.adapter.sqlite.model.DungeonCorridorDoorBindingRecord;
+import features.dungeon.adapter.sqlite.model.DungeonCorridorRecord;
+import features.dungeon.adapter.sqlite.model.DungeonCorridorWaypointRecord;
+import features.dungeon.adapter.sqlite.model.DungeonFeatureMarkerRecord;
+import features.dungeon.adapter.sqlite.model.DungeonMapRecord;
+import features.dungeon.adapter.sqlite.model.DungeonPersistenceSchema;
+import features.dungeon.adapter.sqlite.model.DungeonRoomClusterFloorCellRecord;
+import features.dungeon.adapter.sqlite.model.DungeonRoomClusterRecord;
+import features.dungeon.adapter.sqlite.model.DungeonStairExitRecord;
+import features.dungeon.adapter.sqlite.model.DungeonStairPathNodeRecord;
+import features.dungeon.adapter.sqlite.model.DungeonStairRecord;
+import features.dungeon.adapter.sqlite.model.DungeonTransitionRecord;
+import features.dungeon.api.DungeonChunkKey;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+final class DungeonSqliteChunkWriter {
+    private DungeonSqliteChunkWriter() {
+    }
+
+    static void replaceChunkInventory(Connection connection, DungeonMapRecord map) throws SQLException {
+        try (PreparedStatement delete = connection.prepareStatement(
+                "DELETE FROM " + DungeonPersistenceSchema.CHUNKS_TABLE + " WHERE dungeon_map_id=?")) {
+            delete.setLong(1, map.mapId());
+            delete.executeUpdate();
+        }
+        Set<ChunkCoordinate> chunks = authoredChunks(map);
+        try (PreparedStatement insert = connection.prepareStatement(
+                "INSERT INTO " + DungeonPersistenceSchema.CHUNKS_TABLE
+                        + "(dungeon_map_id, level_z, chunk_q, chunk_r, revision) VALUES(?,?,?,?,?)")) {
+            for (ChunkCoordinate chunk : chunks) {
+                insert.setLong(1, map.mapId());
+                insert.setInt(2, chunk.level());
+                insert.setInt(3, chunk.q());
+                insert.setInt(4, chunk.r());
+                insert.setLong(5, map.revision());
+                insert.addBatch();
+            }
+            insert.executeBatch();
+        }
+    }
+
+    static void updateChunkInventory(
+            Connection connection,
+            DungeonMapRecord before,
+            DungeonMapRecord after
+    ) throws SQLException {
+        Set<ChunkCoordinate> previous = authoredChunks(before);
+        Set<ChunkCoordinate> current = authoredChunks(after);
+        Set<ChunkCoordinate> removed = new LinkedHashSet<>(previous);
+        removed.removeAll(current);
+        try (PreparedStatement delete = connection.prepareStatement(
+                "DELETE FROM " + DungeonPersistenceSchema.CHUNKS_TABLE
+                        + " WHERE dungeon_map_id=? AND level_z=? AND chunk_q=? AND chunk_r=?")) {
+            for (ChunkCoordinate chunk : removed) {
+                delete.setLong(1, after.mapId());
+                delete.setInt(2, chunk.level());
+                delete.setInt(3, chunk.q());
+                delete.setInt(4, chunk.r());
+                delete.addBatch();
+            }
+            delete.executeBatch();
+        }
+        Set<ChunkCoordinate> added = new LinkedHashSet<>(current);
+        added.removeAll(previous);
+        try (PreparedStatement insert = connection.prepareStatement(
+                "INSERT INTO " + DungeonPersistenceSchema.CHUNKS_TABLE
+                        + "(dungeon_map_id, level_z, chunk_q, chunk_r, revision) VALUES(?,?,?,?,?)")) {
+            for (ChunkCoordinate chunk : added) {
+                insert.setLong(1, after.mapId());
+                insert.setInt(2, chunk.level());
+                insert.setInt(3, chunk.q());
+                insert.setInt(4, chunk.r());
+                insert.setLong(5, after.revision());
+                insert.addBatch();
+            }
+            insert.executeBatch();
+        }
+    }
+
+    private static Set<ChunkCoordinate> authoredChunks(DungeonMapRecord map) {
+        Set<ChunkCoordinate> chunks = new LinkedHashSet<>();
+        for (DungeonRoomClusterRecord cluster : map.roomClusters()) {
+            for (DungeonRoomClusterFloorCellRecord cell : cluster.floorCells()) {
+                add(chunks, cell.levelZ(), cell.cellX(), cell.cellY());
+            }
+            for (DungeonClusterBoundaryRecord edge : cluster.boundaries()) {
+                add(chunks, edge.levelZ(), edge.cellX(), edge.cellY());
+            }
+        }
+        Map<Long, DungeonRoomClusterRecord> clustersById = new LinkedHashMap<>();
+        for (DungeonRoomClusterRecord cluster : map.roomClusters()) {
+            clustersById.put(cluster.clusterId(), cluster);
+        }
+        for (DungeonCorridorRecord corridor : map.corridors()) {
+            for (DungeonCorridorWaypointRecord waypoint : corridor.waypoints()) {
+                DungeonRoomClusterRecord cluster = clustersById.get(waypoint.clusterId());
+                if (cluster != null) {
+                    add(
+                            chunks,
+                            cluster.levelZ() + waypoint.relativeZ(),
+                            cluster.centerX() + waypoint.relativeX(),
+                            cluster.centerY() + waypoint.relativeY());
+                }
+            }
+            for (DungeonCorridorDoorBindingRecord door : corridor.doorBindings()) {
+                DungeonRoomClusterRecord cluster = clustersById.get(door.clusterId());
+                if (cluster != null) {
+                    add(
+                            chunks,
+                            cluster.levelZ(),
+                            cluster.centerX() + door.relativeCellX(),
+                            cluster.centerY() + door.relativeCellY());
+                }
+            }
+            for (DungeonCorridorAnchorBindingRecord anchor : corridor.anchorBindings()) {
+                add(chunks, anchor.cellZ(), anchor.cellX(), anchor.cellY());
+            }
+        }
+        for (DungeonFeatureMarkerRecord marker : map.featureMarkers()) {
+            add(chunks, marker.levelZ(), marker.cellX(), marker.cellY());
+        }
+        for (DungeonStairRecord stair : map.stairs()) {
+            for (DungeonStairPathNodeRecord node : stair.pathNodes()) {
+                add(chunks, node.cellZ(), node.cellX(), node.cellY());
+            }
+            for (DungeonStairExitRecord exit : stair.exits()) {
+                add(chunks, exit.cellZ(), exit.cellX(), exit.cellY());
+            }
+        }
+        for (DungeonTransitionRecord transition : map.transitions()) {
+            if (transition.cellX() != null && transition.cellY() != null && transition.levelZ() != null) {
+                add(chunks, transition.levelZ(), transition.cellX(), transition.cellY());
+            }
+        }
+        return Set.copyOf(chunks);
+    }
+
+    private static void add(Set<ChunkCoordinate> chunks, int level, int q, int r) {
+        chunks.add(new ChunkCoordinate(
+                level,
+                Math.floorDiv(q, DungeonChunkKey.CHUNK_SIZE),
+                Math.floorDiv(r, DungeonChunkKey.CHUNK_SIZE)));
+    }
+
+    private record ChunkCoordinate(int level, int q, int r) {
+    }
+}

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteConnectionPersistence.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteConnectionPersistence.java
@@ -16,4 +16,15 @@ final class DungeonSqliteConnectionPersistence {
         DungeonSqliteTransitionPersistence.persist(connection, record);
         DungeonSqliteFeatureMarkerPersistence.persist(connection, record);
     }
+
+    static void persistChange(
+            Connection connection,
+            DungeonMapRecord before,
+            DungeonMapRecord after
+    ) throws SQLException {
+        DungeonSqliteCorridorPersistence.persistChange(connection, before, after);
+        DungeonSqliteStairPersistence.persistChange(connection, before, after);
+        DungeonSqliteTransitionPersistence.persistChange(connection, before, after);
+        DungeonSqliteFeatureMarkerPersistence.persistChange(connection, before, after);
+    }
 }

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteConnectionSupport.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteConnectionSupport.java
@@ -12,7 +12,7 @@ import features.dungeon.adapter.sqlite.model.DungeonPersistenceSchema;
 
 final class DungeonSqliteConnectionSupport {
 
-    private static final String SELECT_MAP_COLUMNS = "SELECT dungeon_map_id, name";
+    private static final String SELECT_MAP_COLUMNS = "SELECT dungeon_map_id, name, revision";
     private static final String SQL_FROM = " FROM ";
     private static final String SQL_WHERE = " WHERE ";
     private static final String WHERE_DUNGEON_MAP_ID = SQL_WHERE + "dungeon_map_id=?";

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteCorridorPersistence.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteCorridorPersistence.java
@@ -35,6 +35,21 @@ final class DungeonSqliteCorridorPersistence {
         DungeonSqliteRetainedIdCleanup.deleteObsoleteCorridors(connection, record.mapId(), corridorIds);
     }
 
+    static void persistChange(Connection connection, DungeonMapRecord before, DungeonMapRecord after)
+            throws SQLException {
+        for (DungeonCorridorRecord corridor : DungeonSqliteChangedRecords.changed(
+                before.corridors(), after.corridors(), DungeonCorridorRecord::corridorId)) {
+            upsertCorridor(connection, corridor);
+            replaceCorridorMembers(connection, corridor);
+            replaceCorridorWaypoints(connection, corridor);
+            replaceCorridorBindings(connection, corridor);
+        }
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteCorridors(
+                connection,
+                after.mapId(),
+                DungeonSqliteChangedRecords.identities(after.corridors(), DungeonCorridorRecord::corridorId));
+    }
+
     private static void upsertCorridor(Connection connection, DungeonCorridorRecord corridor) throws SQLException {
         try (PreparedStatement update = connection.prepareStatement(
                 "UPDATE " + DungeonPersistenceSchema.CORRIDORS_TABLE

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteFeatureMarkerPersistence.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteFeatureMarkerPersistence.java
@@ -25,6 +25,19 @@ final class DungeonSqliteFeatureMarkerPersistence {
         DungeonSqliteRetainedIdCleanup.deleteObsoleteFeatureMarkers(connection, record.mapId(), markerIds);
     }
 
+    static void persistChange(Connection connection, DungeonMapRecord before, DungeonMapRecord after)
+            throws SQLException {
+        for (DungeonFeatureMarkerRecord marker : DungeonSqliteChangedRecords.changed(
+                before.featureMarkers(), after.featureMarkers(), DungeonFeatureMarkerRecord::markerId)) {
+            upsertFeatureMarker(connection, marker);
+        }
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteFeatureMarkers(
+                connection,
+                after.mapId(),
+                DungeonSqliteChangedRecords.identities(
+                        after.featureMarkers(), DungeonFeatureMarkerRecord::markerId));
+    }
+
     private static void upsertFeatureMarker(
             Connection connection,
             DungeonFeatureMarkerRecord marker

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteGateway.java
@@ -17,12 +17,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.DungeonViewportRequest;
 
 public final class DungeonSqliteGateway {
 
     private static final String INSERT_INTO = "INSERT INTO ";
     private static final String SQL_FROM = " FROM ";
-    private static final String SELECT_MAP_COLUMNS = "SELECT dungeon_map_id, name";
+    private static final String SELECT_MAP_COLUMNS = "SELECT dungeon_map_id, name, revision";
 
     private final DungeonSqliteConnectionSupport connectionSupport;
     private final DungeonSqliteMapBatchGateway batchGateway;
@@ -38,7 +42,8 @@ public final class DungeonSqliteGateway {
         DungeonSqliteSchemaManager schemaManager = new DungeonSqliteSchemaManager();
         SqliteConnectionSource connections = Objects.requireNonNull(database, "database").connections(
                 "dungeon",
-                new SqliteMigration(1, schemaManager::ensureSchema));
+                new SqliteMigration(1, schemaManager::ensureSchema),
+                new SqliteMigration(2, schemaManager::ensureSchema));
         connectionSupport = new DungeonSqliteConnectionSupport(connections);
         batchGateway = new DungeonSqliteMapBatchGateway(connections);
         identityReservation = new DungeonSqliteIdentityReservation(connections);
@@ -57,7 +62,7 @@ public final class DungeonSqliteGateway {
                     DungeonMapRecord record = new DungeonMapRecord(
                             resultSet.getLong("dungeon_map_id"),
                             resultSet.getString("name"),
-                            1L,
+                            resultSet.getLong("revision"),
                             null);
                     if (normalized.isBlank() || record.name().toLowerCase(Locale.ROOT).contains(normalized)) {
                         records.add(record);
@@ -107,11 +112,55 @@ public final class DungeonSqliteGateway {
         return batchGateway.saveMaps(records);
     }
 
+    public DungeonMapRecord saveChange(DungeonMapRecord before, DungeonMapRecord after) {
+        return batchGateway.saveChange(before, after);
+    }
+
     public void deleteMap(long mapId) {
         try (Connection connection = connectionSupport.openReadyConnection()) {
             DungeonSqliteMapRecordWriter.deleteMap(connection, mapId);
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to delete dungeon map from SQLite.", exception);
+        }
+    }
+
+    public Set<DungeonChunkKey> findAvailableChunks(DungeonViewportRequest request) {
+        if (request == null) {
+            return Set.of();
+        }
+        Set<DungeonChunkKey> requested = request.loadingChunks();
+        if (requested.isEmpty()) {
+            return Set.of();
+        }
+        int minimumChunkQ = requested.stream().mapToInt(DungeonChunkKey::chunkQ).min().orElse(0);
+        int maximumChunkQ = requested.stream().mapToInt(DungeonChunkKey::chunkQ).max().orElse(0);
+        int minimumChunkR = requested.stream().mapToInt(DungeonChunkKey::chunkR).min().orElse(0);
+        int maximumChunkR = requested.stream().mapToInt(DungeonChunkKey::chunkR).max().orElse(0);
+        try (Connection connection = connectionSupport.openReadyConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                     "SELECT level_z, chunk_q, chunk_r FROM " + DungeonPersistenceSchema.CHUNKS_TABLE
+                             + " WHERE dungeon_map_id=? AND level_z=?"
+                             + " AND chunk_q BETWEEN ? AND ? AND chunk_r BETWEEN ? AND ?"
+                             + " ORDER BY chunk_r, chunk_q")) {
+            statement.setLong(1, request.mapId());
+            statement.setInt(2, request.level());
+            statement.setInt(3, minimumChunkQ);
+            statement.setInt(4, maximumChunkQ);
+            statement.setInt(5, minimumChunkR);
+            statement.setInt(6, maximumChunkR);
+            Set<DungeonChunkKey> available = new LinkedHashSet<>();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    available.add(new DungeonChunkKey(
+                            request.mapId(),
+                            resultSet.getInt("level_z"),
+                            resultSet.getInt("chunk_q"),
+                            resultSet.getInt("chunk_r")));
+                }
+            }
+            return Set.copyOf(available);
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to load dungeon chunk inventory from SQLite.", exception);
         }
     }
 

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapBatchGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapBatchGateway.java
@@ -2,7 +2,6 @@ package features.dungeon.adapter.sqlite.gateway;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import platform.diagnostics.NoopDiagnostics;
@@ -27,7 +26,8 @@ public final class DungeonSqliteMapBatchGateway {
         this.connectionSupport = new DungeonSqliteConnectionSupport(
                 Objects.requireNonNull(database, "database").connections(
                         "dungeon",
-                        new SqliteMigration(1, schemaManager::ensureSchema)));
+                        new SqliteMigration(1, schemaManager::ensureSchema),
+                        new SqliteMigration(2, schemaManager::ensureSchema)));
     }
 
     DungeonSqliteMapBatchGateway(SqliteConnectionSource connections) {
@@ -47,6 +47,32 @@ public final class DungeonSqliteMapBatchGateway {
         }
     }
 
+    public DungeonMapRecord saveChange(DungeonMapRecord before, DungeonMapRecord after) {
+        DungeonMapRecord safeBefore = Objects.requireNonNull(before, "before");
+        DungeonMapRecord safeAfter = Objects.requireNonNull(after, "after");
+        if (safeBefore.mapId() != safeAfter.mapId()) {
+            throw new IllegalArgumentException("before and after must identify the same dungeon map");
+        }
+        try (Connection connection = connectionSupport.openReadyConnection()) {
+            boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                DungeonSqliteMapRecordWriter.persistChange(connection, safeBefore, safeAfter);
+                DungeonSqliteConnectionPersistence.persistChange(connection, safeBefore, safeAfter);
+                DungeonSqliteTopologyElementGateway.persistChange(connection, safeBefore, safeAfter);
+                connection.commit();
+                return safeAfter;
+            } catch (SQLException exception) {
+                rollbackQuietly(connection);
+                throw exception;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to save dungeon map change to SQLite.", exception);
+        }
+    }
+
     private List<DungeonMapRecord> saveInSingleTransaction(
             Connection connection,
             List<DungeonMapRecord> records
@@ -55,9 +81,8 @@ public final class DungeonSqliteMapBatchGateway {
         connection.setAutoCommit(false);
         try {
             persistRecords(connection, records);
-            List<DungeonMapRecord> savedRecords = loadSavedRecords(connection, records);
             connection.commit();
-            return List.copyOf(savedRecords);
+            return List.copyOf(records);
         } catch (SQLException exception) {
             rollbackQuietly(connection);
             throw exception;
@@ -87,17 +112,6 @@ public final class DungeonSqliteMapBatchGateway {
             DungeonSqliteConnectionPersistence.persist(connection, record);
             DungeonSqliteTopologyElementGateway.persist(connection, record);
         }
-    }
-
-    private static List<DungeonMapRecord> loadSavedRecords(
-            Connection connection,
-            List<DungeonMapRecord> records
-    ) throws SQLException {
-        List<DungeonMapRecord> savedRecords = new ArrayList<>();
-        for (DungeonMapRecord record : records) {
-            savedRecords.add(DungeonSqliteConnectionSupport.findMap(connection, record.mapId()).orElse(record));
-        }
-        return savedRecords;
     }
 
     private static void rollbackQuietly(Connection connection) {

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapRecordLoader.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapRecordLoader.java
@@ -45,7 +45,7 @@ final class DungeonSqliteMapRecordLoader {
         return new DungeonMapRecord(
                 mapId,
                 resultSet.getString("name"),
-                1L,
+                resultSet.getLong("revision"),
                 gridBounds(connection, mapId),
                 loadRoomClusters(connection, mapId),
                 loadRooms(connection, mapId),

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapRecordWriter.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteMapRecordWriter.java
@@ -11,6 +11,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 final class DungeonSqliteMapRecordWriter {
@@ -25,6 +27,17 @@ final class DungeonSqliteMapRecordWriter {
     static void persist(Connection connection, DungeonMapRecord record) throws SQLException {
         upsertMap(connection, record);
         persistAuthoredGeometry(connection, record);
+        DungeonSqliteChunkWriter.replaceChunkInventory(connection, record);
+    }
+
+    static void persistChange(
+            Connection connection,
+            DungeonMapRecord before,
+            DungeonMapRecord after
+    ) throws SQLException {
+        upsertMap(connection, after);
+        persistChangedAuthoredGeometry(connection, before, after);
+        DungeonSqliteChunkWriter.updateChunkInventory(connection, before, after);
     }
 
     static void deleteMap(Connection connection, long mapId) throws SQLException {
@@ -37,18 +50,40 @@ final class DungeonSqliteMapRecordWriter {
 
     private static void upsertMap(Connection connection, DungeonMapRecord record) throws SQLException {
         try (PreparedStatement update = connection.prepareStatement(
-                "UPDATE " + DungeonPersistenceSchema.MAPS_TABLE + " SET name=?" + SQL_WHERE + "dungeon_map_id=?")) {
+                "UPDATE " + DungeonPersistenceSchema.MAPS_TABLE
+                        + " SET name=?, revision=?" + SQL_WHERE
+                        + "dungeon_map_id=? AND revision=?")) {
             update.setString(1, record.name());
-            update.setLong(2, record.mapId());
+            update.setLong(2, record.revision());
+            update.setLong(3, record.mapId());
+            update.setLong(4, record.revision() - 1L);
             if (update.executeUpdate() > 0) {
                 return;
             }
         }
+        if (mapExists(connection, record.mapId())) {
+            throw new SQLException(
+                    "Dungeon map revision mismatch for map " + record.mapId()
+                            + "; expected " + (record.revision() - 1L));
+        }
         try (PreparedStatement insert = connection.prepareStatement(
-                INSERT_INTO + DungeonPersistenceSchema.MAPS_TABLE + "(dungeon_map_id, name) VALUES(?,?)")) {
+                INSERT_INTO + DungeonPersistenceSchema.MAPS_TABLE
+                        + "(dungeon_map_id, name, revision) VALUES(?,?,?)")) {
             insert.setLong(1, record.mapId());
             insert.setString(2, record.name());
+            insert.setLong(3, record.revision());
             insert.executeUpdate();
+        }
+    }
+
+    private static boolean mapExists(Connection connection, long mapId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT 1 FROM " + DungeonPersistenceSchema.MAPS_TABLE
+                        + SQL_WHERE + "dungeon_map_id=?")) {
+            statement.setLong(1, mapId);
+            try (var resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
         }
     }
 
@@ -67,6 +102,50 @@ final class DungeonSqliteMapRecordWriter {
         }
         DungeonSqliteRetainedIdCleanup.deleteObsoleteRooms(connection, record.mapId(), roomIds);
         DungeonSqliteRetainedIdCleanup.deleteObsoleteRoomClusters(connection, record.mapId(), clusterIds);
+    }
+
+    private static void persistChangedAuthoredGeometry(
+            Connection connection,
+            DungeonMapRecord before,
+            DungeonMapRecord after
+    ) throws SQLException {
+        Map<Long, DungeonRoomClusterRecord> previousClusters = clustersById(before);
+        Set<Long> retainedClusterIds = new LinkedHashSet<>();
+        for (DungeonRoomClusterRecord cluster : after.roomClusters()) {
+            retainedClusterIds.add(cluster.clusterId());
+            if (!cluster.equals(previousClusters.get(cluster.clusterId()))) {
+                DungeonSqliteClusterGeometryWriter.persist(connection, cluster);
+            }
+        }
+        Map<Long, DungeonRoomRecord> previousRooms = roomsById(before);
+        Set<Long> retainedRoomIds = new LinkedHashSet<>();
+        for (DungeonRoomRecord room : after.rooms()) {
+            retainedRoomIds.add(room.roomId());
+            if (!room.equals(previousRooms.get(room.roomId()))) {
+                upsertRoomPosition(connection, room);
+                replaceRoomFloors(connection, room);
+                replaceRoomExitDescriptions(connection, room);
+            }
+        }
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteRooms(connection, after.mapId(), retainedRoomIds);
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteRoomClusters(
+                connection, after.mapId(), retainedClusterIds);
+    }
+
+    private static Map<Long, DungeonRoomClusterRecord> clustersById(DungeonMapRecord record) {
+        Map<Long, DungeonRoomClusterRecord> result = new LinkedHashMap<>();
+        for (DungeonRoomClusterRecord cluster : record.roomClusters()) {
+            result.put(cluster.clusterId(), cluster);
+        }
+        return result;
+    }
+
+    private static Map<Long, DungeonRoomRecord> roomsById(DungeonMapRecord record) {
+        Map<Long, DungeonRoomRecord> result = new LinkedHashMap<>();
+        for (DungeonRoomRecord room : record.rooms()) {
+            result.put(room.roomId(), room);
+        }
+        return result;
     }
 
     private static void upsertRoomPosition(Connection connection, DungeonRoomRecord room) throws SQLException {

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteSchemaManager.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteSchemaManager.java
@@ -18,12 +18,17 @@ final class DungeonSqliteSchemaManager {
     private static final String ADD_TRANSITION_ANCHOR_EDGE_DIRECTION_COLUMN_SQL =
             "ALTER TABLE " + DungeonPersistenceSchema.TRANSITIONS_TABLE + " ADD COLUMN "
                     + TRANSITION_ANCHOR_EDGE_DIRECTION_COLUMN + " TEXT";
+    private static final String MAP_REVISION_COLUMN = "revision";
+    private static final String ADD_MAP_REVISION_COLUMN_SQL =
+            "ALTER TABLE " + DungeonPersistenceSchema.MAPS_TABLE
+                    + " ADD COLUMN " + MAP_REVISION_COLUMN + " INTEGER NOT NULL DEFAULT 1";
 
     void ensureSchema(Connection connection) throws SQLException {
         boolean topologyTableExisted = SqliteSchemaColumnSupport.hasTable(
                 connection,
                 DungeonPersistenceSchema.TOPOLOGY_ELEMENTS_TABLE);
         createTables(connection);
+        ensureMapRevisionColumn(connection);
         ensureTransitionAnchorColumns(connection);
         TOPOLOGY_BACKFILL.apply(connection, topologyTableExisted);
     }
@@ -31,6 +36,7 @@ final class DungeonSqliteSchemaManager {
     private static void createTables(Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_MAPS_TABLE_SQL);
+            statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_CHUNKS_TABLE_SQL);
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_ROOM_CLUSTERS_TABLE_SQL);
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_ROOMS_TABLE_SQL);
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_CORRIDORS_TABLE_SQL);
@@ -49,6 +55,21 @@ final class DungeonSqliteSchemaManager {
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_STAIR_EXITS_TABLE_SQL);
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_TRANSITIONS_TABLE_SQL);
             statement.execute(DungeonPersistenceSchema.CREATE_DUNGEON_FEATURE_MARKERS_TABLE_SQL);
+        }
+    }
+
+    private static void ensureMapRevisionColumn(Connection connection) throws SQLException {
+        if (!SqliteSchemaColumnSupport.hasColumn(
+                connection,
+                DungeonPersistenceSchema.MAPS_TABLE,
+                MAP_REVISION_COLUMN)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(ADD_MAP_REVISION_COLUMN_SQL);
+            }
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(
+                    "UPDATE " + DungeonPersistenceSchema.MAPS_TABLE + " SET revision=1 WHERE revision<1");
         }
     }
 

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteStairPersistence.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteStairPersistence.java
@@ -38,6 +38,20 @@ final class DungeonSqliteStairPersistence {
         DungeonSqliteRetainedIdCleanup.deleteObsoleteStairs(connection, record.mapId(), stairIds);
     }
 
+    static void persistChange(Connection connection, DungeonMapRecord before, DungeonMapRecord after)
+            throws SQLException {
+        for (DungeonStairRecord stair : DungeonSqliteChangedRecords.changed(
+                before.stairs(), after.stairs(), DungeonStairRecord::stairId)) {
+            upsertStair(connection, stair);
+            replaceStairPathNodes(connection, stair);
+            replaceStairExits(connection, stair);
+        }
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteStairs(
+                connection,
+                after.mapId(),
+                DungeonSqliteChangedRecords.identities(after.stairs(), DungeonStairRecord::stairId));
+    }
+
     private static void upsertStair(Connection connection, DungeonStairRecord stair) throws SQLException {
         try (PreparedStatement update = connection.prepareStatement(
                 "UPDATE " + DungeonPersistenceSchema.STAIRS_TABLE

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteTopologyElementGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteTopologyElementGateway.java
@@ -83,6 +83,16 @@ final class DungeonSqliteTopologyElementGateway {
         }
     }
 
+    static void persistChange(Connection connection, DungeonMapRecord before, DungeonMapRecord after)
+            throws SQLException {
+        if (before.topologyElements().equals(after.topologyElements())
+                && before.roomClusters().equals(after.roomClusters())
+                && before.corridors().equals(after.corridors())) {
+            return;
+        }
+        persist(connection, after);
+    }
+
     private static Set<TopologyElementKey> openOnlyBoundaryKeys(List<DungeonRoomClusterRecord> clusters) {
         Set<TopologyElementKey> openKeys = new LinkedHashSet<>();
         Set<TopologyElementKey> renderableKeys = new LinkedHashSet<>();

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteTransitionPersistence.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteTransitionPersistence.java
@@ -26,6 +26,19 @@ final class DungeonSqliteTransitionPersistence {
         DungeonSqliteRetainedIdCleanup.deleteObsoleteTransitions(connection, record.mapId(), transitionIds);
     }
 
+    static void persistChange(Connection connection, DungeonMapRecord before, DungeonMapRecord after)
+            throws SQLException {
+        for (DungeonTransitionRecord transition : DungeonSqliteChangedRecords.changed(
+                before.transitions(), after.transitions(), DungeonTransitionRecord::transitionId)) {
+            upsertTransition(connection, transition);
+        }
+        DungeonSqliteRetainedIdCleanup.deleteObsoleteTransitions(
+                connection,
+                after.mapId(),
+                DungeonSqliteChangedRecords.identities(
+                        after.transitions(), DungeonTransitionRecord::transitionId));
+    }
+
     private static void upsertTransition(Connection connection, DungeonTransitionRecord transition) throws SQLException {
         try (PreparedStatement update = connection.prepareStatement(
                 "UPDATE " + DungeonPersistenceSchema.TRANSITIONS_TABLE

--- a/features/dungeon/adapter/sqlite/model/DungeonPersistenceSchema.java
+++ b/features/dungeon/adapter/sqlite/model/DungeonPersistenceSchema.java
@@ -24,11 +24,23 @@ public final class DungeonPersistenceSchema {
     public static final String STAIR_EXITS_TABLE = "dungeon_stair_exits";
     public static final String TRANSITIONS_TABLE = "dungeon_transitions";
     public static final String FEATURE_MARKERS_TABLE = "dungeon_feature_markers";
+    public static final String CHUNKS_TABLE = "dungeon_chunks";
 
     public static final String CREATE_DUNGEON_MAPS_TABLE_SQL =
             "CREATE TABLE IF NOT EXISTS dungeon_maps ("
                     + "dungeon_map_id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                    + "name           TEXT NOT NULL"
+                    + "name           TEXT NOT NULL,"
+                    + "revision       INTEGER NOT NULL DEFAULT 1"
+                    + ")";
+
+    public static final String CREATE_DUNGEON_CHUNKS_TABLE_SQL =
+            "CREATE TABLE IF NOT EXISTS dungeon_chunks ("
+                    + "dungeon_map_id INTEGER NOT NULL REFERENCES dungeon_maps(dungeon_map_id) ON DELETE CASCADE,"
+                    + "level_z        INTEGER NOT NULL,"
+                    + "chunk_q        INTEGER NOT NULL,"
+                    + "chunk_r        INTEGER NOT NULL,"
+                    + "revision       INTEGER NOT NULL DEFAULT 0,"
+                    + "PRIMARY KEY (dungeon_map_id, level_z, chunk_q, chunk_r)"
                     + ")";
 
     public static final String CREATE_DUNGEON_ROOM_CLUSTERS_TABLE_SQL =
@@ -232,6 +244,7 @@ public final class DungeonPersistenceSchema {
 
     public static final List<String> CREATE_TABLE_SQL = List.of(
             CREATE_DUNGEON_MAPS_TABLE_SQL,
+            CREATE_DUNGEON_CHUNKS_TABLE_SQL,
             CREATE_DUNGEON_ROOM_CLUSTERS_TABLE_SQL,
             CREATE_DUNGEON_ROOMS_TABLE_SQL,
             CREATE_DUNGEON_CORRIDORS_TABLE_SQL,

--- a/features/dungeon/adapter/sqlite/repository/SqliteDungeonMapRepository.java
+++ b/features/dungeon/adapter/sqlite/repository/SqliteDungeonMapRepository.java
@@ -5,11 +5,15 @@ import features.dungeon.adapter.sqlite.gateway.DungeonSqliteGateway;
 import features.dungeon.adapter.sqlite.mapper.DungeonMapRecordMapper;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonChangeSet;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.DungeonViewportRequest;
 
 public final class SqliteDungeonMapRepository implements DungeonMapRepository {
 
@@ -68,6 +72,14 @@ public final class SqliteDungeonMapRepository implements DungeonMapRepository {
     }
 
     @Override
+    public DungeonMap saveChange(DungeonChangeSet changeSet) {
+        DungeonChangeSet safeChangeSet = Objects.requireNonNull(changeSet, "changeSet");
+        return DungeonMapRecordMapper.toDomain(gateway.saveChange(
+                DungeonMapRecordMapper.toRecord(safeChangeSet.before()),
+                DungeonMapRecordMapper.toRecord(safeChangeSet.after())));
+    }
+
+    @Override
     public List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps) {
         if (dungeonMaps == null || dungeonMaps.isEmpty()) {
             return List.of();
@@ -85,5 +97,10 @@ public final class SqliteDungeonMapRepository implements DungeonMapRepository {
         if (mapId != null) {
             gateway.deleteMap(mapId.value());
         }
+    }
+
+    @Override
+    public Set<DungeonChunkKey> findAvailableChunks(DungeonViewportRequest request) {
+        return gateway.findAvailableChunks(request);
     }
 }

--- a/features/dungeon/api/DungeonChunkKey.java
+++ b/features/dungeon/api/DungeonChunkKey.java
@@ -1,0 +1,37 @@
+package features.dungeon.api;
+
+/** Stable sparse-map chunk identity. Negative coordinates use floor division. */
+public record DungeonChunkKey(long mapId, int level, int chunkQ, int chunkR) {
+    public static final int CHUNK_SIZE = 64;
+
+    public DungeonChunkKey {
+        if (mapId <= 0L) {
+            throw new IllegalArgumentException("mapId must be positive");
+        }
+    }
+
+    public static DungeonChunkKey containing(long mapId, DungeonCellRef cell) {
+        DungeonCellRef safeCell = cell == null ? new DungeonCellRef(0, 0, 0) : cell;
+        return new DungeonChunkKey(
+                mapId,
+                safeCell.level(),
+                Math.floorDiv(safeCell.q(), CHUNK_SIZE),
+                Math.floorDiv(safeCell.r(), CHUNK_SIZE));
+    }
+
+    public int minimumQ() {
+        return chunkQ * CHUNK_SIZE;
+    }
+
+    public int minimumR() {
+        return chunkR * CHUNK_SIZE;
+    }
+
+    public int maximumQ() {
+        return minimumQ() + CHUNK_SIZE - 1;
+    }
+
+    public int maximumR() {
+        return minimumR() + CHUNK_SIZE - 1;
+    }
+}

--- a/features/dungeon/api/DungeonViewportContinuation.java
+++ b/features/dungeon/api/DungeonViewportContinuation.java
@@ -1,0 +1,18 @@
+package features.dungeon.api;
+
+/** Stable identity evidence that authored topology continues beyond the loaded workset. */
+public record DungeonViewportContinuation(
+        String ownerKind,
+        long ownerId,
+        DungeonTopologyElementRef topologyRef,
+        DungeonChunkKey offWindowChunk
+) {
+    public DungeonViewportContinuation {
+        ownerKind = ownerKind == null || ownerKind.isBlank() ? "ELEMENT" : ownerKind.trim();
+        ownerId = Math.max(1L, ownerId);
+        topologyRef = topologyRef == null ? DungeonTopologyElementRef.empty() : topologyRef;
+        if (offWindowChunk == null) {
+            throw new IllegalArgumentException("offWindowChunk must not be null");
+        }
+    }
+}

--- a/features/dungeon/api/DungeonViewportRequest.java
+++ b/features/dungeon/api/DungeonViewportRequest.java
@@ -1,0 +1,55 @@
+package features.dungeon.api;
+
+import java.util.LinkedHashSet;
+import java.util.Collections;
+import java.util.Set;
+
+/** One sparse authored-map window plus its prefetch ring. */
+public record DungeonViewportRequest(
+        long mapId,
+        long requestGeneration,
+        int level,
+        int minimumQ,
+        int minimumR,
+        int maximumQ,
+        int maximumR
+) {
+    public DungeonViewportRequest {
+        if (mapId <= 0L) {
+            throw new IllegalArgumentException("mapId must be positive");
+        }
+        requestGeneration = Math.max(0L, requestGeneration);
+        if (maximumQ < minimumQ || maximumR < minimumR) {
+            throw new IllegalArgumentException("viewport bounds must be ordered");
+        }
+    }
+
+    public Set<DungeonChunkKey> visibleChunks() {
+        return chunks(0);
+    }
+
+    public Set<DungeonChunkKey> loadingChunks() {
+        return chunks(1);
+    }
+
+    public boolean contains(DungeonCellRef cell) {
+        return cell != null
+                && cell.level() == level
+                && cell.q() >= minimumQ && cell.q() <= maximumQ
+                && cell.r() >= minimumR && cell.r() <= maximumR;
+    }
+
+    private Set<DungeonChunkKey> chunks(int ring) {
+        int minimumChunkQ = Math.floorDiv(minimumQ, DungeonChunkKey.CHUNK_SIZE) - ring;
+        int minimumChunkR = Math.floorDiv(minimumR, DungeonChunkKey.CHUNK_SIZE) - ring;
+        int maximumChunkQ = Math.floorDiv(maximumQ, DungeonChunkKey.CHUNK_SIZE) + ring;
+        int maximumChunkR = Math.floorDiv(maximumR, DungeonChunkKey.CHUNK_SIZE) + ring;
+        Set<DungeonChunkKey> chunks = new LinkedHashSet<>();
+        for (int chunkR = minimumChunkR; chunkR <= maximumChunkR; chunkR++) {
+            for (int chunkQ = minimumChunkQ; chunkQ <= maximumChunkQ; chunkQ++) {
+                chunks.add(new DungeonChunkKey(mapId, level, chunkQ, chunkR));
+            }
+        }
+        return Collections.unmodifiableSet(chunks);
+    }
+}

--- a/features/dungeon/api/DungeonViewportSnapshot.java
+++ b/features/dungeon/api/DungeonViewportSnapshot.java
@@ -1,0 +1,50 @@
+package features.dungeon.api;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Immutable authored facts for the currently loaded sparse-map workset. */
+public record DungeonViewportSnapshot(
+        long mapId,
+        long mapRevision,
+        long requestGeneration,
+        int level,
+        DungeonTopologyKind topology,
+        Set<DungeonChunkKey> loadedChunks,
+        List<DungeonAreaSnapshot> areas,
+        List<DungeonBoundarySnapshot> boundaries,
+        List<DungeonFeatureSnapshot> features,
+        List<DungeonEditorHandleSnapshot> editorHandles,
+        List<DungeonViewportContinuation> continuations,
+        AuthoredBounds authoredBounds
+) {
+    public DungeonViewportSnapshot {
+        if (mapId <= 0L) {
+            throw new IllegalArgumentException("mapId must be positive");
+        }
+        mapRevision = Math.max(0L, mapRevision);
+        requestGeneration = Math.max(0L, requestGeneration);
+        topology = topology == null ? DungeonTopologyKind.SQUARE : topology;
+        loadedChunks = loadedChunks == null
+                ? Set.of()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(loadedChunks));
+        areas = areas == null ? List.of() : List.copyOf(areas);
+        boundaries = boundaries == null ? List.of() : List.copyOf(boundaries);
+        features = features == null ? List.of() : List.copyOf(features);
+        editorHandles = editorHandles == null ? List.of() : List.copyOf(editorHandles);
+        continuations = continuations == null ? List.of() : List.copyOf(continuations);
+        authoredBounds = authoredBounds == null ? AuthoredBounds.empty() : authoredBounds;
+    }
+
+    public record AuthoredBounds(boolean present, int minimumQ, int minimumR, int maximumQ, int maximumR) {
+        public AuthoredBounds {
+            present = present && maximumQ >= minimumQ && maximumR >= minimumR;
+        }
+
+        public static AuthoredBounds empty() {
+            return new AuthoredBounds(false, 0, 0, 0, 0);
+        }
+    }
+}

--- a/features/dungeon/api/authored/DungeonAuthoredApi.java
+++ b/features/dungeon/api/authored/DungeonAuthoredApi.java
@@ -1,0 +1,19 @@
+package features.dungeon.api.authored;
+
+import features.dungeon.api.DungeonAuthoredMutationModel;
+import features.dungeon.api.DungeonAuthoredReadModel;
+import features.dungeon.api.DungeonMapCatalogModel;
+import features.dungeon.api.DungeonViewportRequest;
+import features.dungeon.api.DungeonViewportSnapshot;
+
+/** Public authored-map capability; repositories and aggregates remain internal. */
+public interface DungeonAuthoredApi {
+    DungeonAuthoredReadModel authoredMaps();
+
+    DungeonAuthoredMutationModel authoredMutations();
+
+    DungeonMapCatalogModel mapCatalog();
+
+    /** Returns the visible authored workset plus one prefetch ring. */
+    DungeonViewportSnapshot viewport(DungeonViewportRequest request);
+}

--- a/features/dungeon/api/travel/DungeonTravelApi.java
+++ b/features/dungeon/api/travel/DungeonTravelApi.java
@@ -1,0 +1,16 @@
+package features.dungeon.api.travel;
+
+import features.dungeon.api.DungeonOverlaySettings;
+
+/** Typed travel capability consumed by presentation and foreign features. */
+public interface DungeonTravelApi {
+    void refresh();
+
+    void performAction(int selectedActionRowIndex);
+
+    void selectMap(long mapId);
+
+    void shiftProjectionLevel(int projectionLevelShift);
+
+    void setOverlay(DungeonOverlaySettings overlaySettings);
+}

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.geometry.Direction;
@@ -19,6 +21,7 @@ import features.dungeon.domain.core.projection.DungeonDerivedState;
 import features.dungeon.domain.core.projection.DungeonDerivedStateProjection;
 import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonChangeSet;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -59,8 +62,14 @@ import features.dungeon.application.editor.usecase.InspectDungeonSelectionUseCas
 import features.dungeon.application.editor.usecase.LoadDungeonSnapshotUseCase;
 import features.dungeon.application.editor.usecase.PreviewDungeonEditorSurfaceMoveUseCase;
 import features.dungeon.application.editor.usecase.PublishDungeonEditorHandlesUseCase;
+import features.dungeon.api.DungeonAuthoredMutationModel;
+import features.dungeon.api.DungeonAuthoredReadModel;
+import features.dungeon.api.DungeonMapCatalogModel;
+import features.dungeon.api.authored.DungeonAuthoredApi;
+import features.dungeon.api.DungeonViewportRequest;
+import features.dungeon.api.DungeonViewportSnapshot;
 
-public final class DungeonAuthoredApplicationService {
+public final class DungeonAuthoredApplicationService implements DungeonAuthoredApi {
     private static final DungeonMapOperationFeedbackRules OPERATION_FEEDBACK_POLICY =
             new DungeonMapOperationFeedbackRules();
     private static final DungeonEditorHandleMutation HANDLE_MUTATION = new DungeonEditorHandleMutation();
@@ -75,6 +84,10 @@ public final class DungeonAuthoredApplicationService {
 
     private final DungeonMapRepository repository;
     private final DungeonAuthoredPublishedState publishedState;
+    /* Pointer previews operate on this immutable authored workset. */
+    private final ConcurrentMap<Long, DungeonMap> authoredWorkset = new ConcurrentHashMap<>();
+    private final DungeonEditHistory editHistory = new DungeonEditHistory();
+    private final DungeonViewportProjection viewportProjection = new DungeonViewportProjection();
     private final DungeonDerivedStateProjection derivedStateProjection = new DungeonDerivedStateProjection();
     private final PublishDungeonEditorHandlesUseCase publishDungeonEditorHandles =
             new PublishDungeonEditorHandlesUseCase();
@@ -111,18 +124,64 @@ public final class DungeonAuthoredApplicationService {
                 Objects.requireNonNull(dungeonState, "dungeonState"));
     }
 
+    @Override
+    public DungeonAuthoredReadModel authoredMaps() {
+        return publishedState.authoredReadModel();
+    }
+
+    @Override
+    public DungeonAuthoredMutationModel authoredMutations() {
+        return publishedState.authoredMutationModel();
+    }
+
+    @Override
+    public DungeonMapCatalogModel mapCatalog() {
+        return publishedState.mapCatalogModel();
+    }
+
+    @Override
+    public DungeonViewportSnapshot viewport(DungeonViewportRequest request) {
+        DungeonViewportRequest safeRequest = Objects.requireNonNull(request, "request");
+        DungeonMap map = loadMap(new DungeonMapIdentity(safeRequest.mapId()));
+        DungeonDerivedState derived = derive(map);
+        return viewportProjection.project(
+                safeRequest,
+                map.revision(),
+                DungeonPublishedMapProjectionServiceAssembly.mapSnapshot(
+                        derived.map(),
+                        publishDungeonEditorHandles.execute(map)));
+    }
+
     public DungeonMap loadMap(@Nullable DungeonMapIdentity mapId) {
         if (mapId != null) {
+            DungeonMap cached = authoredWorkset.get(mapId.value());
+            if (cached != null) {
+                return cached;
+            }
             Optional<DungeonMap> map = repository.findById(mapId);
             if (map.isPresent()) {
-                return map.get();
+                DungeonMap loaded = map.get();
+                authoredWorkset.put(mapId.value(), loaded);
+                return loaded;
             }
         }
-        return repository.firstMap().orElse(emptyFallbackMap());
+        DungeonMap fallback = repository.firstMap().orElse(emptyFallbackMap());
+        authoredWorkset.putIfAbsent(fallback.metadata().mapId().value(), fallback);
+        return fallback;
     }
 
     public Optional<DungeonMap> findMap(DungeonMapIdentity mapId) {
         return repository.findById(mapId);
+    }
+
+    private DungeonMap reloadMap(@Nullable DungeonMapIdentity mapId) {
+        DungeonMap loaded = mapId == null
+                ? repository.firstMap().orElse(emptyFallbackMap())
+                : repository.findById(mapId)
+                        .or(repository::firstMap)
+                        .orElseGet(DungeonAuthoredApplicationService::emptyFallbackMap);
+        authoredWorkset.put(loaded.metadata().mapId().value(), loaded);
+        return loaded;
     }
 
     public DungeonDerivedState derive(DungeonMap dungeonMap) {
@@ -194,6 +253,52 @@ public final class DungeonAuthoredApplicationService {
         if (preview instanceof DungeonEditorSessionValues.MoveHandlePreview move) {
             moveStairHandle(mapId, move, session);
         }
+    }
+
+    public boolean canUndo(MapId mapId) {
+        return mapId != null && editHistory.canUndo(domainMapId(mapId));
+    }
+
+    public boolean canRedo(MapId mapId) {
+        return mapId != null && editHistory.canRedo(domainMapId(mapId));
+    }
+
+    public void undo(MapId mapId, Session session) {
+        applyHistoryStep(mapId, session, true);
+    }
+
+    public void redo(MapId mapId, Session session) {
+        applyHistoryStep(mapId, session, false);
+    }
+
+    private void applyHistoryStep(MapId mapId, Session session, boolean undo) {
+        if (mapId == null || session == null) {
+            return;
+        }
+        DungeonMap current = loadMap(domainMapId(mapId));
+        DungeonMap snapshot = undo ? editHistory.undo(current) : editHistory.redo(current);
+        if (snapshot.equals(current)) {
+            return;
+        }
+        DungeonMap restored = DungeonMapAuthoring.restoreContent(snapshot, current.revision() + 1L);
+        DungeonMap saved;
+        try {
+            saved = repository.saveChange(new DungeonChangeSet(current, restored));
+        } catch (RuntimeException failure) {
+            if (undo) {
+                editHistory.redo(current);
+            } else {
+                editHistory.undo(current);
+            }
+            throw failure;
+        }
+        authoredWorkset.put(saved.metadata().mapId().value(), saved);
+        OperationResultData result = new OperationResultData(
+                mutationPipeline.snapshotData(saved, derive(saved)),
+                true,
+                List.of(),
+                List.of(undo ? "undo applied" : "redo applied"));
+        publicationOperations.publishMutation(result, session.dungeonState());
     }
 
     public void createCorridor(
@@ -422,12 +527,21 @@ public final class DungeonAuthoredApplicationService {
                 @Nullable AuthoredMapMutation operation
         ) {
             DungeonMap current = loadMap(mapId);
-            DungeonMap mutated = applyOperation(current, operation);
-            boolean changed = !mutated.equals(current);
+            DungeonMap operationResult = applyOperation(current, operation);
+            boolean changed = !operationResult.equals(current);
+            DungeonMap mutated = changed
+                    ? DungeonMapAuthoring.committedContent(operationResult, current.revision() + 1L)
+                    : current;
             List<String> validationMessages = OPERATION_FEEDBACK_POLICY.validationMessages(current, mutated);
             List<String> reactionMessages = OPERATION_FEEDBACK_POLICY.reactionMessages(current, mutated);
             DungeonDerivedState derived = derive(mutated);
-            DungeonMap saved = changed ? repository.save(mutated) : current;
+            DungeonMap saved = changed
+                    ? repository.saveChange(new DungeonChangeSet(current, mutated))
+                    : current;
+            authoredWorkset.put(saved.metadata().mapId().value(), saved);
+            if (changed) {
+                editHistory.record(current, saved);
+            }
             return new OperationResultData(snapshotData(saved, derived), changed, validationMessages, reactionMessages);
         }
 
@@ -542,7 +656,7 @@ public final class DungeonAuthoredApplicationService {
                 DungeonEditorDungeonState state
         ) {
             LoadDungeonSnapshotUseCase.DungeonSnapshotData snapshot =
-                    mutationPipeline.snapshotData(loadMap(domainMapId(mapId)));
+                    mutationPipeline.snapshotData(reloadMap(domainMapId(mapId)));
             publicationOperations.publishSnapshot(snapshot, state);
             return snapshot;
         }
@@ -554,7 +668,7 @@ public final class DungeonAuthoredApplicationService {
                 boolean clusterSelection,
                 DungeonEditorDungeonState state
         ) {
-            DungeonMap dungeonMap = loadMap(domainMapId(mapId));
+            DungeonMap dungeonMap = reloadMap(domainMapId(mapId));
             LoadDungeonSnapshotUseCase.DungeonSnapshotData snapshot = mutationPipeline.snapshotData(dungeonMap);
             LoadDungeonSnapshotUseCase.InspectorSnapshotData inspector = inspectDungeonSelection.execute(
                     dungeonMap,
@@ -919,23 +1033,29 @@ public final class DungeonAuthoredApplicationService {
                     : requestedMapName;
             DungeonMap dungeonMap = DungeonMapAuthoring.empty(mapIdentity, mapName);
             DungeonMap saved = repository.save(dungeonMap);
+            authoredWorkset.put(saved.metadata().mapId().value(), saved);
             return saved.metadata().mapId();
         }
 
         private DungeonMapIdentity renameMap(DungeonMapIdentity mapIdentity, String requestedMapName) {
-            Optional<DungeonMap> foundMap = repository.findById(mapIdentity);
-            if (foundMap.isEmpty()) {
+            DungeonMap foundMap = loadMap(mapIdentity);
+            if (!foundMap.metadata().mapId().equals(mapIdentity)) {
                 throw new IllegalArgumentException("Unknown dungeon map: " + mapIdentity.value());
             }
             String mapName = requestedMapName == null || requestedMapName.isBlank()
                     ? DEFAULT_MAP_NAME
                     : requestedMapName;
-            DungeonMap renamed = repository.save(DungeonMapAuthoring.rename(foundMap.orElseThrow(), mapName));
+            DungeonMap renamed = repository.saveChange(new DungeonChangeSet(
+                    foundMap,
+                    DungeonMapAuthoring.rename(foundMap, mapName)));
+            authoredWorkset.put(renamed.metadata().mapId().value(), renamed);
             return renamed.metadata().mapId();
         }
 
         private DungeonMapIdentity deleteMap(DungeonMapIdentity mapIdentity) {
             repository.delete(mapIdentity);
+            authoredWorkset.remove(mapIdentity.value());
+            editHistory.remove(mapIdentity);
             return mapIdentity;
         }
 
@@ -1033,6 +1153,9 @@ public final class DungeonAuthoredApplicationService {
             }
             applyCatalogUpdates(pendingMaps, rewrite);
             List<DungeonMap> savedMaps = repository.saveAll(List.copyOf(pendingMaps.values()));
+            for (DungeonMap savedMap : savedMaps) {
+                authoredWorkset.put(savedMap.metadata().mapId().value(), savedMap);
+            }
             DungeonMap savedSourceMap = savedSourceMap(savedMaps, loaded.sourceIdentity().value());
             DungeonDerivedState derived = derive(savedSourceMap);
             return new OperationResultData(

--- a/features/dungeon/application/authored/DungeonEditHistory.java
+++ b/features/dungeon/application/authored/DungeonEditHistory.java
@@ -1,0 +1,105 @@
+package features.dungeon.application.authored;
+
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Per-running-editor-session authored undo/redo history. */
+final class DungeonEditHistory {
+    static final int MAXIMUM_COMMANDS = 200;
+    static final long MAXIMUM_ESTIMATED_BYTES = 128L * 1024L * 1024L;
+
+    private final Map<Long, MapHistory> histories = new HashMap<>();
+
+    void record(DungeonMap before, DungeonMap after) {
+        if (before == null || after == null || before.equals(after)) {
+            return;
+        }
+        long mapId = after.metadata().mapId().value();
+        MapHistory history = histories.computeIfAbsent(mapId, ignored -> new MapHistory());
+        history.redo.clear();
+        history.undo.addLast(new Change(before, after, estimatedBytes(before, after)));
+        history.recalculateBytes();
+        history.trim();
+    }
+
+    DungeonMap undo(DungeonMap current) {
+        MapHistory history = history(current);
+        if (history == null || history.undo.isEmpty()) {
+            return current;
+        }
+        Change change = history.undo.removeLast();
+        history.redo.addLast(change);
+        history.recalculateBytes();
+        return change.before();
+    }
+
+    DungeonMap redo(DungeonMap current) {
+        MapHistory history = history(current);
+        if (history == null || history.redo.isEmpty()) {
+            return current;
+        }
+        Change change = history.redo.removeLast();
+        history.undo.addLast(change);
+        history.recalculateBytes();
+        return change.after();
+    }
+
+    boolean canUndo(DungeonMapIdentity mapId) {
+        MapHistory history = mapId == null ? null : histories.get(mapId.value());
+        return history != null && !history.undo.isEmpty();
+    }
+
+    boolean canRedo(DungeonMapIdentity mapId) {
+        MapHistory history = mapId == null ? null : histories.get(mapId.value());
+        return history != null && !history.redo.isEmpty();
+    }
+
+    void remove(DungeonMapIdentity mapId) {
+        if (mapId != null) {
+            histories.remove(mapId.value());
+        }
+    }
+
+    private MapHistory history(DungeonMap current) {
+        return current == null ? null : histories.get(current.metadata().mapId().value());
+    }
+
+    private static long estimatedBytes(DungeonMap before, DungeonMap after) {
+        return estimateMap(before) + estimateMap(after);
+    }
+
+    private static long estimateMap(DungeonMap map) {
+        long structuralObjects = 1L
+                + map.rooms().rooms().size()
+                + map.corridors().size()
+                + map.stairs().stairs().size()
+                + map.transitionCatalog().transitions().size()
+                + map.featureMarkers().markers().size();
+        return Math.max(4_096L, structuralObjects * 512L);
+    }
+
+    private record Change(DungeonMap before, DungeonMap after, long estimatedBytes) {
+    }
+
+    private static final class MapHistory {
+        private final Deque<Change> undo = new ArrayDeque<>();
+        private final Deque<Change> redo = new ArrayDeque<>();
+        private long estimatedBytes;
+
+        private void recalculateBytes() {
+            estimatedBytes = undo.stream().mapToLong(Change::estimatedBytes).sum()
+                    + redo.stream().mapToLong(Change::estimatedBytes).sum();
+        }
+
+        private void trim() {
+            while (undo.size() > MAXIMUM_COMMANDS || estimatedBytes > MAXIMUM_ESTIMATED_BYTES) {
+                Change removed = undo.removeFirst();
+                estimatedBytes -= removed.estimatedBytes();
+            }
+        }
+    }
+}

--- a/features/dungeon/application/authored/DungeonViewportProjection.java
+++ b/features/dungeon/application/authored/DungeonViewportProjection.java
@@ -1,0 +1,313 @@
+package features.dungeon.application.authored;
+
+import features.dungeon.api.DungeonAreaSnapshot;
+import features.dungeon.api.DungeonBoundarySnapshot;
+import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.DungeonEditorHandleSnapshot;
+import features.dungeon.api.DungeonEdgeRef;
+import features.dungeon.api.DungeonFeatureSnapshot;
+import features.dungeon.api.DungeonMapSnapshot;
+import features.dungeon.api.DungeonViewportRequest;
+import features.dungeon.api.DungeonViewportSnapshot;
+import features.dungeon.api.DungeonViewportContinuation;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import platform.ui.mapcanvas.WeightedViewportCache;
+
+/** Partitions immutable authored projections into revision-scoped sparse chunks. */
+final class DungeonViewportProjection {
+    private static final long MAXIMUM_CACHE_WEIGHT = 256L * 1024L * 1024L;
+    private final WeightedViewportCache<ChunkRevisionKey, ChunkProjection> cache =
+            new WeightedViewportCache<>(MAXIMUM_CACHE_WEIGHT, ChunkProjection::estimatedBytes);
+
+    DungeonViewportSnapshot project(
+            DungeonViewportRequest request,
+            long mapRevision,
+            DungeonMapSnapshot map
+    ) {
+        DungeonViewportRequest safeRequest = Objects.requireNonNull(request, "request");
+        DungeonMapSnapshot safeMap = map == null ? DungeonMapSnapshot.empty() : map;
+        Set<DungeonChunkKey> requestedChunks = safeRequest.loadingChunks();
+        Set<ChunkRevisionKey> protectedKeys = requestedChunks.stream()
+                .map(chunk -> new ChunkRevisionKey(chunk, mapRevision))
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        List<ChunkProjection> chunks = new ArrayList<>();
+        for (DungeonChunkKey chunk : requestedChunks) {
+            ChunkRevisionKey cacheKey = new ChunkRevisionKey(chunk, mapRevision);
+            ChunkProjection projection = cache.get(cacheKey);
+            if (projection == null) {
+                projection = ChunkProjection.from(safeMap, chunk);
+                cache.put(cacheKey, projection, protectedKeys);
+            }
+            if (!projection.empty()) {
+                chunks.add(projection);
+            }
+        }
+        return merge(safeRequest, mapRevision, safeMap, chunks);
+    }
+
+    private static DungeonViewportSnapshot merge(
+            DungeonViewportRequest request,
+            long mapRevision,
+            DungeonMapSnapshot map,
+            List<ChunkProjection> chunks
+    ) {
+        Set<DungeonChunkKey> loadedChunks = new LinkedHashSet<>();
+        Map<AreaKey, DungeonAreaSnapshot> areas = new LinkedHashMap<>();
+        Set<DungeonBoundarySnapshot> boundaries = new LinkedHashSet<>();
+        Map<FeatureKey, DungeonFeatureSnapshot> features = new LinkedHashMap<>();
+        Set<DungeonEditorHandleSnapshot> handles = new LinkedHashSet<>();
+        for (ChunkProjection chunk : chunks) {
+            loadedChunks.add(chunk.key());
+            for (DungeonAreaSnapshot area : chunk.areas()) {
+                areas.merge(new AreaKey(area.kind().name(), area.id()), area, DungeonViewportProjection::mergeArea);
+            }
+            boundaries.addAll(chunk.boundaries());
+            for (DungeonFeatureSnapshot feature : chunk.features()) {
+                features.merge(
+                        new FeatureKey(feature.kind().name(), feature.id()),
+                        feature,
+                        DungeonViewportProjection::mergeFeature);
+            }
+            handles.addAll(chunk.handles());
+        }
+        return new DungeonViewportSnapshot(
+                request.mapId(),
+                mapRevision,
+                request.requestGeneration(),
+                request.level(),
+                map.topology(),
+                loadedChunks,
+                List.copyOf(areas.values()),
+                List.copyOf(boundaries),
+                List.copyOf(features.values()),
+                List.copyOf(handles),
+                continuations(map, request, loadedChunks),
+                authoredBounds(map, request.level()));
+    }
+
+    private static List<DungeonViewportContinuation> continuations(
+            DungeonMapSnapshot map,
+            DungeonViewportRequest request,
+            Set<DungeonChunkKey> loadedChunks
+    ) {
+        Set<DungeonViewportContinuation> result = new LinkedHashSet<>();
+        for (DungeonAreaSnapshot area : map.areas()) {
+            addContinuations(
+                    result,
+                    area.kind().name(),
+                    area.id(),
+                    area.topologyRef(),
+                    area.cells(),
+                    request,
+                    loadedChunks);
+        }
+        for (DungeonFeatureSnapshot feature : map.features()) {
+            addContinuations(
+                    result,
+                    feature.kind().name(),
+                    feature.id(),
+                    feature.topologyRef(),
+                    feature.cells(),
+                    request,
+                    loadedChunks);
+        }
+        for (DungeonBoundarySnapshot boundary : map.boundaries()) {
+            DungeonEdgeRef edge = boundary.edge();
+            if (edge != null) {
+                List<DungeonCellRef> edgeCells = new ArrayList<>();
+                if (edge.from() != null) {
+                    edgeCells.add(edge.from());
+                }
+                if (edge.to() != null) {
+                    edgeCells.add(edge.to());
+                }
+                addContinuations(
+                        result,
+                        boundary.kind(),
+                        boundary.id(),
+                        boundary.topologyRef(),
+                        edgeCells,
+                        request,
+                        loadedChunks);
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static void addContinuations(
+            Set<DungeonViewportContinuation> result,
+            String kind,
+            long id,
+            features.dungeon.api.DungeonTopologyElementRef topologyRef,
+            List<DungeonCellRef> cells,
+            DungeonViewportRequest request,
+            Set<DungeonChunkKey> loadedChunks
+    ) {
+        Set<DungeonChunkKey> elementChunks = new LinkedHashSet<>();
+        for (DungeonCellRef cell : cells) {
+            if (cell != null && cell.level() == request.level()) {
+                elementChunks.add(DungeonChunkKey.containing(request.mapId(), cell));
+            }
+        }
+        boolean intersectsLoaded = elementChunks.stream().anyMatch(loadedChunks::contains);
+        if (!intersectsLoaded) {
+            return;
+        }
+        for (DungeonChunkKey chunk : elementChunks) {
+            if (!request.loadingChunks().contains(chunk)) {
+                result.add(new DungeonViewportContinuation(kind, id, topologyRef, chunk));
+            }
+        }
+    }
+
+    private static DungeonAreaSnapshot mergeArea(DungeonAreaSnapshot first, DungeonAreaSnapshot second) {
+        Set<DungeonCellRef> cells = new LinkedHashSet<>(first.cells());
+        cells.addAll(second.cells());
+        return new DungeonAreaSnapshot(
+                first.kind(), first.id(), first.clusterId(), first.label(), List.copyOf(cells), first.topologyRef());
+    }
+
+    private static DungeonFeatureSnapshot mergeFeature(
+            DungeonFeatureSnapshot first,
+            DungeonFeatureSnapshot second
+    ) {
+        Set<DungeonCellRef> cells = new LinkedHashSet<>(first.cells());
+        cells.addAll(second.cells());
+        return new DungeonFeatureSnapshot(
+                first.kind(),
+                first.id(),
+                first.label(),
+                List.copyOf(cells),
+                first.description(),
+                first.destinationLabel(),
+                first.topologyRef(),
+                first.anchorEdge() == null ? second.anchorEdge() : first.anchorEdge());
+    }
+
+    private static DungeonViewportSnapshot.AuthoredBounds authoredBounds(DungeonMapSnapshot map, int level) {
+        BoundsAccumulator bounds = new BoundsAccumulator();
+        map.areas().forEach(area -> area.cells().forEach(cell -> bounds.include(cell, level)));
+        map.boundaries().forEach(boundary -> bounds.include(boundary.edge(), level));
+        map.features().forEach(feature -> {
+            feature.cells().forEach(cell -> bounds.include(cell, level));
+            bounds.include(feature.anchorEdge(), level);
+        });
+        map.editorHandles().forEach(handle -> bounds.include(handle.cell(), level));
+        return bounds.snapshot();
+    }
+
+    private record ChunkRevisionKey(DungeonChunkKey chunk, long revision) {
+    }
+
+    private record AreaKey(String kind, long id) {
+    }
+
+    private record FeatureKey(String kind, long id) {
+    }
+
+    private record ChunkProjection(
+            DungeonChunkKey key,
+            List<DungeonAreaSnapshot> areas,
+            List<DungeonBoundarySnapshot> boundaries,
+            List<DungeonFeatureSnapshot> features,
+            List<DungeonEditorHandleSnapshot> handles
+    ) {
+        static ChunkProjection from(DungeonMapSnapshot map, DungeonChunkKey key) {
+            return new ChunkProjection(
+                    key,
+                    map.areas().stream().map(area -> areaInChunk(area, key)).filter(Objects::nonNull).toList(),
+                    map.boundaries().stream().filter(boundary -> edgeTouchesChunk(boundary.edge(), key)).toList(),
+                    map.features().stream().map(feature -> featureInChunk(feature, key)).filter(Objects::nonNull).toList(),
+                    map.editorHandles().stream().filter(handle -> inChunk(handle.cell(), key)).toList());
+        }
+
+        boolean empty() {
+            return areas.isEmpty() && boundaries.isEmpty() && features.isEmpty() && handles.isEmpty();
+        }
+
+        long estimatedBytes() {
+            long cellCount = areas.stream().mapToLong(area -> area.cells().size()).sum()
+                    + features.stream().mapToLong(feature -> feature.cells().size()).sum();
+            return 256L + cellCount * 48L + boundaries.size() * 192L
+                    + handles.size() * 256L + features.size() * 192L + areas.size() * 160L;
+        }
+
+        private static DungeonAreaSnapshot areaInChunk(DungeonAreaSnapshot area, DungeonChunkKey key) {
+            List<DungeonCellRef> cells = area.cells().stream().filter(cell -> inChunk(cell, key)).toList();
+            return cells.isEmpty() ? null : new DungeonAreaSnapshot(
+                    area.kind(), area.id(), area.clusterId(), area.label(), cells, area.topologyRef());
+        }
+
+        private static DungeonFeatureSnapshot featureInChunk(DungeonFeatureSnapshot feature, DungeonChunkKey key) {
+            List<DungeonCellRef> cells = feature.cells().stream().filter(cell -> inChunk(cell, key)).toList();
+            if (cells.isEmpty() && !edgeTouchesChunk(feature.anchorEdge(), key)) {
+                return null;
+            }
+            return new DungeonFeatureSnapshot(
+                    feature.kind(),
+                    feature.id(),
+                    feature.label(),
+                    cells,
+                    feature.description(),
+                    feature.destinationLabel(),
+                    feature.topologyRef(),
+                    feature.anchorEdge());
+        }
+    }
+
+    private static boolean edgeTouchesChunk(DungeonEdgeRef edge, DungeonChunkKey key) {
+        return edge != null && (inChunk(edge.from(), key) || inChunk(edge.to(), key));
+    }
+
+    private static boolean inChunk(DungeonCellRef cell, DungeonChunkKey key) {
+        return cell != null
+                && cell.level() == key.level()
+                && cell.q() >= key.minimumQ() && cell.q() <= key.maximumQ()
+                && cell.r() >= key.minimumR() && cell.r() <= key.maximumR();
+    }
+
+    private static final class BoundsAccumulator {
+        private boolean present;
+        private int minimumQ;
+        private int minimumR;
+        private int maximumQ;
+        private int maximumR;
+
+        void include(DungeonEdgeRef edge, int level) {
+            if (edge != null) {
+                include(edge.from(), level);
+                include(edge.to(), level);
+            }
+        }
+
+        void include(DungeonCellRef cell, int level) {
+            if (cell == null || cell.level() != level) {
+                return;
+            }
+            if (!present) {
+                present = true;
+                minimumQ = maximumQ = cell.q();
+                minimumR = maximumR = cell.r();
+                return;
+            }
+            minimumQ = Math.min(minimumQ, cell.q());
+            minimumR = Math.min(minimumR, cell.r());
+            maximumQ = Math.max(maximumQ, cell.q());
+            maximumR = Math.max(maximumR, cell.r());
+        }
+
+        DungeonViewportSnapshot.AuthoredBounds snapshot() {
+            return present
+                    ? new DungeonViewportSnapshot.AuthoredBounds(
+                            true, minimumQ, minimumR, maximumQ, maximumR)
+                    : DungeonViewportSnapshot.AuthoredBounds.empty();
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonChangeSet.java
+++ b/features/dungeon/application/authored/port/DungeonChangeSet.java
@@ -1,0 +1,26 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.domain.core.structure.DungeonMap;
+import java.util.Objects;
+
+/** One authored command crossing the persistence boundary. */
+public record DungeonChangeSet(DungeonMap before, DungeonMap after) {
+    public DungeonChangeSet {
+        before = Objects.requireNonNull(before, "before");
+        after = Objects.requireNonNull(after, "after");
+        if (!before.metadata().mapId().equals(after.metadata().mapId())) {
+            throw new IllegalArgumentException("before and after must identify the same dungeon map");
+        }
+        if (after.revision() != before.revision() + 1L) {
+            throw new IllegalArgumentException("one change set must advance the map revision exactly once");
+        }
+    }
+
+    public long expectedRevision() {
+        return before.revision();
+    }
+
+    public long committedRevision() {
+        return after.revision();
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonMapRepository.java
+++ b/features/dungeon/application/authored/port/DungeonMapRepository.java
@@ -5,6 +5,9 @@ import features.dungeon.domain.core.structure.DungeonMap;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.DungeonViewportRequest;
 
 /**
  * Repository contract for authored dungeon maps.
@@ -25,6 +28,11 @@ public interface DungeonMapRepository {
 
     DungeonMap save(DungeonMap dungeonMap);
 
+    /** Persists one revision-checked authored delta without requiring readback. */
+    default DungeonMap saveChange(DungeonChangeSet changeSet) {
+        return save(changeSet.after());
+    }
+
     /**
      * Persists the supplied authored maps as one all-or-none multi-map boundary
      * and returns the saved readback for each committed map.
@@ -32,4 +40,8 @@ public interface DungeonMapRepository {
     List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps);
 
     void delete(DungeonMapIdentity mapId);
+
+    default Set<DungeonChunkKey> findAvailableChunks(DungeonViewportRequest request) {
+        return Set.of();
+    }
 }

--- a/features/dungeon/application/editor/DungeonEditorControlOperations.java
+++ b/features/dungeon/application/editor/DungeonEditorControlOperations.java
@@ -15,4 +15,8 @@ public interface DungeonEditorControlOperations {
     void setOverlay(DungeonEditorOverlaySettings overlaySettings);
 
     void scrollSelection(int levelDelta);
+
+    void undo();
+
+    void redo();
 }

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -86,7 +86,8 @@ public final class DungeonEditorFeatureRuntimeRoot
                         new DungeonEditorTransitionRuntimeOperation(safeContext),
                         new DungeonEditorFeatureMarkerRuntimeOperation(safeContext),
                         selectedHandleOperation),
-                commands);
+                commands,
+                safeExecutionLane);
         commands.bindPointerOperations(pointerWorkflow);
         commands.apply(safeContext::publishCurrent);
     }
@@ -166,6 +167,16 @@ public final class DungeonEditorFeatureRuntimeRoot
     @Override
     public void cancelActivePreviewSession() {
         commands.cancelActivePreviewSession();
+    }
+
+    @Override
+    public void undo() {
+        commands.undo();
+    }
+
+    @Override
+    public void redo() {
+        commands.redo();
     }
 
     @Override

--- a/features/dungeon/application/editor/DungeonEditorPointerWorkflow.java
+++ b/features/dungeon/application/editor/DungeonEditorPointerWorkflow.java
@@ -1,6 +1,9 @@
 package features.dungeon.application.editor;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import platform.execution.ExecutionLane;
+import platform.execution.LatestWinsTaskQueue;
 import features.dungeon.application.editor.session.DungeonEditorSessionValues;
 import features.dungeon.api.DungeonEditorTool;
 
@@ -8,13 +11,17 @@ final class DungeonEditorPointerWorkflow implements DungeonEditorPointerInteract
     private final RuntimeFamilies runtimeFamilies;
     private final DungeonEditorRuntimeCommands commandPublisher;
     private final DungeonEditorPointerSession pointerSession = new DungeonEditorPointerSession();
+    private final LatestWinsTaskQueue hoverQueue;
+    private final AtomicLong interactionGeneration = new AtomicLong();
 
     DungeonEditorPointerWorkflow(
             RuntimeFamilies runtimeFamilies,
-            DungeonEditorRuntimeCommands commandPublisher
+            DungeonEditorRuntimeCommands commandPublisher,
+            ExecutionLane executionLane
     ) {
         this.runtimeFamilies = Objects.requireNonNull(runtimeFamilies, "runtimeFamilies");
         this.commandPublisher = Objects.requireNonNull(commandPublisher, "commandPublisher");
+        hoverQueue = new LatestWinsTaskQueue(Objects.requireNonNull(executionLane, "executionLane"));
     }
 
     @Override
@@ -47,12 +54,31 @@ final class DungeonEditorPointerWorkflow implements DungeonEditorPointerInteract
                 hoverTarget,
                 safeRequest.projectionLevel());
         PointerSample sample = DungeonEditorPointerSamplePolicy.pointerSample(targets, sampleTarget, intent);
-        commandPublisher.execute(() -> applyPointerInExecutionLane(safeRequest, intent, sample));
+        enqueuePointerSample(safeRequest, intent, sample);
         return new PointerInteractionResult(true, hoverTarget);
+    }
+
+    private void enqueuePointerSample(
+            PointerInteractionRequest request,
+            PointerWorkflowIntent intent,
+            PointerSample sample
+    ) {
+        if (PointerAction.isMoved(request.action())) {
+            long generation = interactionGeneration.get();
+            hoverQueue.submit(() -> {
+                if (generation == interactionGeneration.get()) {
+                    applyPointerInExecutionLane(request, intent, sample);
+                }
+            });
+            return;
+        }
+        interactionGeneration.incrementAndGet();
+        commandPublisher.execute(() -> applyPointerInExecutionLane(request, intent, sample));
     }
 
     @Override
     public void clearPointerSession() {
+        interactionGeneration.incrementAndGet();
         commandPublisher.execute(pointerSession::clear);
     }
 

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -175,6 +175,30 @@ public final class DungeonEditorRuntimeApplicationService {
             return refreshAuthoredSnapshot();
         }
 
+        public DungeonEditorSessionSnapshot.SnapshotData undo() {
+            MapId mapId = workflow.session().selectedMapId();
+            if (mapId != null) {
+                authoredService.undo(mapId, authored);
+            }
+            return refreshAuthoredSnapshot();
+        }
+
+        public DungeonEditorSessionSnapshot.SnapshotData redo() {
+            MapId mapId = workflow.session().selectedMapId();
+            if (mapId != null) {
+                authoredService.redo(mapId, authored);
+            }
+            return refreshAuthoredSnapshot();
+        }
+
+        public boolean canUndo() {
+            return authoredService.canUndo(workflow.session().selectedMapId());
+        }
+
+        public boolean canRedo() {
+            return authoredService.canRedo(workflow.session().selectedMapId());
+        }
+
         public DungeonEditorSessionSnapshot.SessionFrameData setViewMode(
                 DungeonEditorSessionValues.ViewMode viewMode
         ) {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -93,6 +93,22 @@ final class DungeonEditorRuntimeCommands
     }
 
     @Override
+    public void undo() {
+        execute(() -> {
+            clearActiveInteraction();
+            applyInExecutionLane(context::undo);
+        });
+    }
+
+    @Override
+    public void redo() {
+        execute(() -> {
+            clearActiveInteraction();
+            applyInExecutionLane(context::redo);
+        });
+    }
+
+    @Override
     public void setViewMode(DungeonEditorViewMode viewMode) {
         execute(() -> {
             clearActiveInteraction();

--- a/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
@@ -117,6 +117,14 @@ final class DungeonEditorRuntimeContext {
         return fromSnapshot(session.deleteMap(mapIdValue));
     }
 
+    Result undo() {
+        return fromSnapshot(session.undo());
+    }
+
+    Result redo() {
+        return fromSnapshot(session.redo());
+    }
+
     Result setViewMode(DungeonEditorViewMode viewMode) {
         return fromSessionFrame(session.setViewMode(DungeonEditorRuntimeInputTranslator.viewMode(viewMode)));
     }

--- a/features/dungeon/application/travel/DungeonTravelRuntimeApplicationService.java
+++ b/features/dungeon/application/travel/DungeonTravelRuntimeApplicationService.java
@@ -8,11 +8,12 @@ import features.dungeon.application.travel.projection.TravelActionFacts.Selected
 import features.dungeon.application.travel.session.TravelDungeonSession;
 import features.dungeon.application.travel.session.TravelDungeonSessionSurface.OverlayMode;
 import features.dungeon.api.DungeonOverlaySettings;
+import features.dungeon.api.travel.DungeonTravelApi;
 
 /**
  * Public backend facade for runtime travel composition.
  */
-public final class DungeonTravelRuntimeApplicationService {
+public final class DungeonTravelRuntimeApplicationService implements DungeonTravelApi {
     private static final long NO_MAP_ID = 0L;
 
     private final TravelDungeonSession session = new TravelDungeonSession();

--- a/features/dungeon/domain/core/structure/DungeonMapAuthoring.java
+++ b/features/dungeon/domain/core/structure/DungeonMapAuthoring.java
@@ -101,4 +101,38 @@ public final class DungeonMapAuthoring {
                 dungeonMap.featureMarkers(),
                 dungeonMap.revision() + 1L);
     }
+
+    /** Restores previously committed authored content while keeping revision monotonic. */
+    public static DungeonMap restoreContent(DungeonMap snapshot, long revision) {
+        if (snapshot == null) {
+            throw new IllegalArgumentException("snapshot must not be null");
+        }
+        return new DungeonMap(
+                snapshot.metadata(),
+                snapshot.topology(),
+                snapshot.topologyIndex(),
+                snapshot.rooms(),
+                snapshot.corridors(),
+                snapshot.stairs(),
+                snapshot.transitionCatalog(),
+                snapshot.featureMarkers(),
+                Math.max(snapshot.revision(), revision));
+    }
+
+    /** Seals one user command as exactly one committed map revision. */
+    public static DungeonMap committedContent(DungeonMap content, long revision) {
+        if (content == null) {
+            throw new IllegalArgumentException("content must not be null");
+        }
+        return new DungeonMap(
+                content.metadata(),
+                content.topology(),
+                content.topologyIndex(),
+                content.rooms(),
+                content.corridors(),
+                content.stairs(),
+                content.transitionCatalog(),
+                content.featureMarkers(),
+                Math.max(1L, revision));
+    }
 }

--- a/platform/execution/LatestWinsTaskQueue.java
+++ b/platform/execution/LatestWinsTaskQueue.java
@@ -1,0 +1,47 @@
+package platform.execution;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Coalesces replaceable work onto an owning execution lane.
+ *
+ * <p>At most one drain is pending. Samples submitted while the drain is
+ * waiting replace the previous sample; samples submitted while work runs are
+ * picked up by the same drain before it releases the lane.</p>
+ */
+public final class LatestWinsTaskQueue {
+    private final ExecutionLane executionLane;
+    private final AtomicReference<Runnable> latest = new AtomicReference<>();
+    private final AtomicBoolean drainScheduled = new AtomicBoolean();
+
+    public LatestWinsTaskQueue(ExecutionLane executionLane) {
+        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+    }
+
+    public void submit(Runnable work) {
+        latest.set(Objects.requireNonNull(work, "work"));
+        if (drainScheduled.compareAndSet(false, true)) {
+            executionLane.execute(this::drain);
+        }
+    }
+
+    public boolean pending() {
+        return drainScheduled.get();
+    }
+
+    private void drain() {
+        try {
+            Runnable work;
+            while ((work = latest.getAndSet(null)) != null) {
+                work.run();
+            }
+        } finally {
+            drainScheduled.set(false);
+            if (latest.get() != null && drainScheduled.compareAndSet(false, true)) {
+                executionLane.execute(this::drain);
+            }
+        }
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasCamera.java
+++ b/platform/ui/mapcanvas/MapCanvasCamera.java
@@ -1,0 +1,71 @@
+package platform.ui.mapcanvas;
+
+/** Passive pan/zoom owner reusable by square and hex map adapters. */
+public final class MapCanvasCamera {
+    private final double sceneUnitPixels;
+    private final double defaultZoom;
+    private final double minimumZoom;
+    private final double maximumZoom;
+    private MapCanvasViewport viewport;
+
+    public MapCanvasCamera(double sceneUnitPixels, double defaultZoom, double minimumZoom, double maximumZoom) {
+        if (!Double.isFinite(sceneUnitPixels) || sceneUnitPixels <= 0.0) {
+            throw new IllegalArgumentException("sceneUnitPixels must be positive and finite");
+        }
+        if (!Double.isFinite(minimumZoom) || minimumZoom <= 0.0
+                || !Double.isFinite(maximumZoom) || maximumZoom < minimumZoom) {
+            throw new IllegalArgumentException("zoom range must be positive and ordered");
+        }
+        this.sceneUnitPixels = sceneUnitPixels;
+        this.minimumZoom = minimumZoom;
+        this.maximumZoom = maximumZoom;
+        this.defaultZoom = clamp(defaultZoom);
+        viewport = new MapCanvasViewport(0.0, 0.0, this.defaultZoom, sceneUnitPixels);
+    }
+
+    public MapCanvasViewport viewport() {
+        return viewport;
+    }
+
+    public MapCanvasViewport reset() {
+        viewport = new MapCanvasViewport(0.0, 0.0, defaultZoom, sceneUnitPixels);
+        return viewport;
+    }
+
+    public MapCanvasViewport panByPixels(double deltaX, double deltaY) {
+        viewport = new MapCanvasViewport(
+                viewport.panX() + finiteOrZero(deltaX),
+                viewport.panY() + finiteOrZero(deltaY),
+                viewport.zoom(),
+                sceneUnitPixels);
+        return viewport;
+    }
+
+    public MapCanvasViewport zoomAround(double screenX, double screenY, double factor) {
+        double nextZoom = clamp(viewport.zoom() * positiveFactor(factor));
+        double scale = nextZoom / viewport.zoom();
+        viewport = new MapCanvasViewport(
+                finiteOrZero(screenX) - (finiteOrZero(screenX) - viewport.panX()) * scale,
+                finiteOrZero(screenY) - (finiteOrZero(screenY) - viewport.panY()) * scale,
+                nextZoom,
+                sceneUnitPixels);
+        return viewport;
+    }
+
+    private double clamp(double value) {
+        double finite = Double.isFinite(value) ? value : defaultZoomFallback();
+        return Math.max(minimumZoom, Math.min(maximumZoom, finite));
+    }
+
+    private double defaultZoomFallback() {
+        return minimumZoom;
+    }
+
+    private static double positiveFactor(double value) {
+        return Double.isFinite(value) && value > 0.0 ? value : 1.0;
+    }
+
+    private static double finiteOrZero(double value) {
+        return Double.isFinite(value) ? value : 0.0;
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasLayer.java
+++ b/platform/ui/mapcanvas/MapCanvasLayer.java
@@ -1,0 +1,8 @@
+package platform.ui.mapcanvas;
+
+/** Stable paint layers; interaction changes do not invalidate authored content. */
+public enum MapCanvasLayer {
+    BASE,
+    INTERACTION,
+    ACTOR
+}

--- a/platform/ui/mapcanvas/MapCanvasPane.java
+++ b/platform/ui/mapcanvas/MapCanvasPane.java
@@ -1,0 +1,34 @@
+package platform.ui.mapcanvas;
+
+import java.util.EnumMap;
+import java.util.Map;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.layout.Pane;
+
+/** JavaFX host for logical map paint layers on one bounded backing surface. */
+public final class MapCanvasPane extends Pane {
+    private final Map<MapCanvasLayer, Canvas> canvases = new EnumMap<>(MapCanvasLayer.class);
+
+    public MapCanvasPane() {
+        setFocusTraversable(true);
+        setMinSize(0.0, 0.0);
+        Canvas base = createCanvas(false);
+        canvases.put(MapCanvasLayer.BASE, base);
+        canvases.put(MapCanvasLayer.INTERACTION, base);
+        canvases.put(MapCanvasLayer.ACTOR, base);
+        getChildren().add(base);
+    }
+
+    public Canvas canvas(MapCanvasLayer layer) {
+        MapCanvasLayer safeLayer = layer == null ? MapCanvasLayer.BASE : layer;
+        return canvases.get(safeLayer);
+    }
+
+    private Canvas createCanvas(boolean mouseTransparent) {
+        Canvas canvas = new Canvas();
+        canvas.setMouseTransparent(mouseTransparent);
+        canvas.widthProperty().bind(widthProperty());
+        canvas.heightProperty().bind(heightProperty());
+        return canvas;
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasViewport.java
+++ b/platform/ui/mapcanvas/MapCanvasViewport.java
@@ -1,0 +1,45 @@
+package platform.ui.mapcanvas;
+
+/** Feature-neutral camera state expressed in canvas scene units. */
+public record MapCanvasViewport(double panX, double panY, double zoom, double sceneUnitPixels) {
+    public MapCanvasViewport {
+        panX = finiteOrZero(panX);
+        panY = finiteOrZero(panY);
+        zoom = positiveFinite(zoom, 1.0);
+        sceneUnitPixels = positiveFinite(sceneUnitPixels, 1.0);
+    }
+
+    public double scaledSceneUnit() {
+        return sceneUnitPixels * zoom;
+    }
+
+    public double sceneToScreenX(double sceneX) {
+        return panX + sceneX * scaledSceneUnit();
+    }
+
+    public double sceneToScreenY(double sceneY) {
+        return panY + sceneY * scaledSceneUnit();
+    }
+
+    public double screenToSceneX(double screenX) {
+        return (screenX - panX) / scaledSceneUnit();
+    }
+
+    public double screenToSceneY(double screenY) {
+        return (screenY - panY) / scaledSceneUnit();
+    }
+
+    public double normalizedOffset(double spacing, boolean horizontal) {
+        double safeSpacing = positiveFinite(spacing, scaledSceneUnit());
+        double offset = (horizontal ? panX : panY) % safeSpacing;
+        return offset < 0.0 ? offset + safeSpacing : offset;
+    }
+
+    private static double finiteOrZero(double value) {
+        return Double.isFinite(value) ? value : 0.0;
+    }
+
+    private static double positiveFinite(double value, double fallback) {
+        return Double.isFinite(value) && value > 0.0 ? value : fallback;
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasWindow.java
+++ b/platform/ui/mapcanvas/MapCanvasWindow.java
@@ -1,0 +1,45 @@
+package platform.ui.mapcanvas;
+
+/** Visible scene-unit window, independent of an adopter coordinate system. */
+public record MapCanvasWindow(double minX, double minY, double maxX, double maxY) {
+    public MapCanvasWindow {
+        if (!Double.isFinite(minX) || !Double.isFinite(minY)
+                || !Double.isFinite(maxX) || !Double.isFinite(maxY)
+                || maxX < minX || maxY < minY) {
+            throw new IllegalArgumentException("map canvas window must be finite and ordered");
+        }
+    }
+
+    public static MapCanvasWindow visible(
+            MapCanvasViewport viewport,
+            double screenWidth,
+            double screenHeight,
+            double scenePadding
+    ) {
+        MapCanvasViewport safeViewport = viewport == null
+                ? new MapCanvasViewport(0.0, 0.0, 1.0, 1.0)
+                : viewport;
+        double width = finiteNonNegative(screenWidth);
+        double height = finiteNonNegative(screenHeight);
+        double padding = finiteNonNegative(scenePadding);
+        return new MapCanvasWindow(
+                safeViewport.screenToSceneX(0.0) - padding,
+                safeViewport.screenToSceneY(0.0) - padding,
+                safeViewport.screenToSceneX(width) + padding,
+                safeViewport.screenToSceneY(height) + padding);
+    }
+
+    public boolean intersects(double otherMinX, double otherMinY, double otherMaxX, double otherMaxY) {
+        if (!Double.isFinite(otherMinX) || !Double.isFinite(otherMinY)
+                || !Double.isFinite(otherMaxX) || !Double.isFinite(otherMaxY)
+                || otherMaxX < otherMinX || otherMaxY < otherMinY) {
+            return false;
+        }
+        return otherMaxX >= minX && otherMinX <= maxX
+                && otherMaxY >= minY && otherMinY <= maxY;
+    }
+
+    private static double finiteNonNegative(double value) {
+        return Double.isFinite(value) ? Math.max(0.0, value) : 0.0;
+    }
+}

--- a/platform/ui/mapcanvas/WeightedViewportCache.java
+++ b/platform/ui/mapcanvas/WeightedViewportCache.java
@@ -1,0 +1,71 @@
+package platform.ui.mapcanvas;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.ToLongFunction;
+
+/** Access-ordered viewport cache that never evicts currently protected keys. */
+public final class WeightedViewportCache<K, V> {
+    private final long maximumWeight;
+    private final ToLongFunction<V> weightOf;
+    private final Map<K, Entry<V>> entries = new LinkedHashMap<>(16, 0.75f, true);
+    private long weight;
+
+    public WeightedViewportCache(long maximumWeight, ToLongFunction<V> weightOf) {
+        if (maximumWeight <= 0L) {
+            throw new IllegalArgumentException("maximumWeight must be positive");
+        }
+        this.maximumWeight = maximumWeight;
+        this.weightOf = Objects.requireNonNull(weightOf, "weightOf");
+    }
+
+    public synchronized V get(K key) {
+        Entry<V> entry = entries.get(key);
+        return entry == null ? null : entry.value();
+    }
+
+    public synchronized void put(K key, V value, Set<K> protectedKeys) {
+        K safeKey = Objects.requireNonNull(key, "key");
+        V safeValue = Objects.requireNonNull(value, "value");
+        Entry<V> previous = entries.remove(safeKey);
+        if (previous != null) {
+            weight -= previous.weight();
+        }
+        long entryWeight = Math.max(1L, weightOf.applyAsLong(safeValue));
+        entries.put(safeKey, new Entry<>(safeValue, entryWeight));
+        weight += entryWeight;
+        evict(protectedKeys == null ? Set.of() : Set.copyOf(protectedKeys));
+    }
+
+    public synchronized int size() {
+        return entries.size();
+    }
+
+    public synchronized long weight() {
+        return weight;
+    }
+
+    private void evict(Set<K> protectedKeys) {
+        boolean removed;
+        do {
+            removed = false;
+            Iterator<Map.Entry<K, Entry<V>>> iterator = entries.entrySet().iterator();
+            while (weight > maximumWeight && iterator.hasNext()) {
+                Map.Entry<K, Entry<V>> candidate = iterator.next();
+                if (protectedKeys.contains(candidate.getKey())) {
+                    continue;
+                }
+                weight -= candidate.getValue().weight();
+                iterator.remove();
+                removed = true;
+                break;
+            }
+        } while (weight > maximumWeight && removed);
+    }
+
+    private record Entry<V>(V value, long weight) {
+    }
+}

--- a/test/app/persistence/SqliteDungeonHexPlannerAdaptersTest.java
+++ b/test/app/persistence/SqliteDungeonHexPlannerAdaptersTest.java
@@ -30,7 +30,7 @@ final class SqliteDungeonHexPlannerAdaptersTest {
             SqliteSessionPlanRepository sessions = new SqliteSessionPlanRepository(database);
             SqliteWorldPlannerRepository world = new SqliteWorldPlannerRepository(database);
             Map<String, Integer> expectedVersions = Map.of(
-                    "dungeon", 1,
+                    "dungeon", 2,
                     "hex", 1,
                     "session-planner", 2,
                     "world-planner", 2);

--- a/test/architecture/system/TargetDependencyArchitectureTest.java
+++ b/test/architecture/system/TargetDependencyArchitectureTest.java
@@ -153,6 +153,12 @@ public final class TargetDependencyArchitectureTest {
                     case API, DOMAIN, SQLITE_ADAPTER, RESOURCE_ADAPTER, HTTP_ADAPTER, INVALID, NONE -> true;
                 };
             }
+            if (featureArea == FeatureArea.JAVAFX_ADAPTER
+                    && "dungeon".equals(feature)
+                    && inPackage(packageName, "features.dungeon.adapter.javafx.travel")) {
+                return target.featureArea != FeatureArea.API
+                        && target.featureArea != FeatureArea.JAVAFX_ADAPTER;
+            }
             return switch (featureArea) {
                 case API -> target.featureArea != FeatureArea.API;
                 case DOMAIN -> target.featureArea != FeatureArea.DOMAIN;

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
@@ -53,6 +53,46 @@ final class DungeonEditorMapControlsScenarios {
         route(() -> verifyToolFamilyRowThroughControlsView());
         route(() -> verifySecondaryToolDropdownThroughControlsView());
         route(() -> verifyEscapeResetsToolThroughMapView());
+        route(() -> verifySessionUndoRedoThroughMapView());
+    }
+
+    private static void verifySessionUndoRedoThroughMapView() {
+        TestRuntime runtime = TestRuntime.create();
+        TestBinding binding = bindTest(runtime);
+        DungeonEditorControlsView controls = binding.controls();
+        DungeonMapView mapView = binding.mapView();
+        long mapId = createMapThroughControls(controls, runtime, "Undo Redo Map");
+        click(button(controls, "Raum"));
+        DungeonMapContentModel.Viewport viewport = binding.mapContentModel().currentViewport();
+        double startX = viewport.sceneToScreenX(1.5);
+        double startY = viewport.sceneToScreenY(1.5);
+        double endX = viewport.sceneToScreenX(3.5);
+        double endY = viewport.sceneToScreenY(3.5);
+        fireMapMouse(mapView, MouseEvent.MOUSE_PRESSED, MouseButton.PRIMARY, startX, startY, false);
+        fireMapMouse(mapView, MouseEvent.MOUSE_DRAGGED, MouseButton.PRIMARY, endX, endY, false);
+        fireMapMouse(mapView, MouseEvent.MOUSE_RELEASED, MouseButton.PRIMARY, endX, endY, false);
+        assertEquals(1L, runtime.database().countRoomsForMap(mapId),
+                "DE-HISTORY-001 room exists after committed edit");
+        assertEquals(2L, runtime.database().mapRevision(mapId),
+                "DE-HISTORY-001 committed edit persists the aggregate revision");
+        assertEquals(1L, runtime.database().countChunksForMap(mapId),
+                "DE-HISTORY-001 committed edit persists the affected chunk inventory");
+
+        fireMapShortcut(mapView, KeyCode.Z, true, false);
+        assertEquals(0L, runtime.database().countRoomsForMap(mapId),
+                "DE-HISTORY-001 shortcut undo restores the prior authored map");
+        assertEquals(3L, runtime.database().mapRevision(mapId),
+                "DE-HISTORY-001 undo restores content as a new revision");
+        assertEquals(0L, runtime.database().countChunksForMap(mapId),
+                "DE-HISTORY-001 undo removes obsolete chunk inventory");
+
+        fireMapShortcut(mapView, KeyCode.Y, true, false);
+        assertEquals(1L, runtime.database().countRoomsForMap(mapId),
+                "DE-HISTORY-002 shortcut redo reapplies the authored edit");
+        assertEquals(4L, runtime.database().mapRevision(mapId),
+                "DE-HISTORY-002 redo restores content as a new revision");
+        assertEquals(1L, runtime.database().countChunksForMap(mapId),
+                "DE-HISTORY-002 redo restores chunk inventory");
     }
 
     private static void route(

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
@@ -194,6 +194,14 @@ class DungeonEditorTestPersistence {
             return count("SELECT COUNT(*) FROM dungeon_rooms WHERE dungeon_map_id=?", mapId);
         }
 
+        long mapRevision(long mapId) {
+            return count("SELECT revision FROM dungeon_maps WHERE dungeon_map_id=?", mapId);
+        }
+
+        long countChunksForMap(long mapId) {
+            return count("SELECT COUNT(*) FROM dungeon_chunks WHERE dungeon_map_id=?", mapId);
+        }
+
         long countRoomClustersForMap(long mapId) {
             return count("SELECT COUNT(*) FROM dungeon_room_clusters WHERE dungeon_map_id=?", mapId);
         }

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestSupport.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestSupport.java
@@ -284,14 +284,18 @@ final class DungeonEditorTestSupport extends DungeonEditorTestRuntime {
     }
 
     static void fireMapShortcut(DungeonMapView view, KeyCode keyCode) {
+        fireMapShortcut(view, keyCode, false, false);
+    }
+
+    static void fireMapShortcut(DungeonMapView view, KeyCode keyCode, boolean controlDown, boolean shiftDown) {
         Pane canvasLayer = mapCanvasLayer(view);
         canvasLayer.fireEvent(new KeyEvent(
                 KeyEvent.KEY_PRESSED,
                 keyCode.getChar(),
                 keyCode.getName(),
                 keyCode,
-                false,
-                false,
+                shiftDown,
+                controlDown,
                 false,
                 false));
     }

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonSqliteOptimisticRevisionTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonSqliteOptimisticRevisionTest.java
@@ -1,0 +1,91 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import features.dungeon.adapter.sqlite.model.DungeonGridBoundsRecord;
+import features.dungeon.adapter.sqlite.model.DungeonFeatureMarkerRecord;
+import features.dungeon.adapter.sqlite.model.DungeonMapRecord;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.persistence.SqliteDatabase;
+
+class DungeonSqliteOptimisticRevisionTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void rejectsSkippedOrStaleRevisionsWithoutChangingTheStoredMap() {
+        try (SqliteDatabase database = new SqliteDatabase(
+                temporaryDirectory.resolve("dungeon.sqlite"),
+                NoopDiagnostics.INSTANCE)) {
+            DungeonSqliteGateway gateway = new DungeonSqliteGateway(database);
+            gateway.saveMap(map(41L, "first", 1L));
+
+            assertThrows(IllegalStateException.class, () -> gateway.saveMap(map(41L, "skipped", 3L)));
+
+            DungeonMapRecord stored = gateway.findMap(41L).orElseThrow();
+            assertEquals(1L, stored.revision());
+            assertEquals("first", stored.name());
+
+            assertEquals(2L, gateway.saveMap(map(41L, "second", 2L)).revision());
+        }
+    }
+
+    @Test
+    void incrementalSaveDoesNotRewriteUnchangedStableIdentityRows() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("incremental.sqlite");
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            DungeonSqliteGateway gateway = new DungeonSqliteGateway(database);
+            DungeonMapRecord first = mapWithMarker(51L, "first", 1L, "Marker");
+            gateway.saveMap(first);
+            try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+                 var statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE marker_update_count(value INTEGER NOT NULL)");
+                statement.execute("INSERT INTO marker_update_count(value) VALUES(0)");
+                statement.execute("CREATE TRIGGER count_marker_updates AFTER UPDATE ON dungeon_feature_markers "
+                        + "BEGIN UPDATE marker_update_count SET value=value+1; END");
+            }
+
+            DungeonMapRecord renamed = mapWithMarker(51L, "renamed", 2L, "Marker");
+            gateway.saveChange(first, renamed);
+            assertEquals(0L, scalar(databasePath, "SELECT value FROM marker_update_count"));
+
+            DungeonMapRecord changed = mapWithMarker(51L, "renamed", 3L, "Changed");
+            gateway.saveChange(renamed, changed);
+            assertEquals(1L, scalar(databasePath, "SELECT value FROM marker_update_count"));
+        }
+    }
+
+    private static DungeonMapRecord map(long id, String name, long revision) {
+        return new DungeonMapRecord(id, name, revision, DungeonGridBoundsRecord.defaultGrid());
+    }
+
+    private static DungeonMapRecord mapWithMarker(long id, String name, long revision, String label) {
+        return new DungeonMapRecord(
+                id,
+                name,
+                revision,
+                DungeonGridBoundsRecord.defaultGrid(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new DungeonFeatureMarkerRecord(71L, id, "POI", 4, 5, 0, label, "")));
+    }
+
+    private static long scalar(Path databasePath, String sql) throws Exception {
+        try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+             var statement = connection.createStatement();
+             var resultSet = statement.executeQuery(sql)) {
+            return resultSet.getLong(1);
+        }
+    }
+}

--- a/test/features/dungeon/api/DungeonViewportRequestTest.java
+++ b/test/features/dungeon/api/DungeonViewportRequestTest.java
@@ -1,0 +1,26 @@
+package features.dungeon.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+final class DungeonViewportRequestTest {
+    @Test
+    void negativeCellsBelongToTheExpectedFloorDividedChunk() {
+        assertEquals(new DungeonChunkKey(7L, 2, -1, -1),
+                DungeonChunkKey.containing(7L, new DungeonCellRef(-1, -64, 2)));
+        assertEquals(new DungeonChunkKey(7L, 2, -2, -2),
+                DungeonChunkKey.containing(7L, new DungeonCellRef(-65, -65, 2)));
+    }
+
+    @Test
+    void loadingWindowIncludesExactlyOneChunkRing() {
+        DungeonViewportRequest request = new DungeonViewportRequest(7L, 4L, 0, 0, 0, 63, 63);
+
+        assertEquals(1, request.visibleChunks().size());
+        assertEquals(9, request.loadingChunks().size());
+        assertTrue(request.loadingChunks().contains(new DungeonChunkKey(7L, 0, -1, -1)));
+        assertTrue(request.loadingChunks().contains(new DungeonChunkKey(7L, 0, 1, 1)));
+    }
+}

--- a/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
+++ b/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
@@ -1,0 +1,86 @@
+package features.dungeon.application.authored;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.editor.session.DungeonEditorDungeonState;
+import features.dungeon.application.editor.session.DungeonEditorSessionValues;
+import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import platform.ui.DirectUiDispatcher;
+
+final class DungeonAuthoredPreviewWorksetTest {
+    @Test
+    void repeatedPointerPreviewsUseTheLoadedWorksetWithoutRepositoryReads() {
+        CountingRepository repository = new CountingRepository();
+        DungeonAuthoredApplicationService service = new DungeonAuthoredApplicationService(
+                repository,
+                new DungeonAuthoredPublishedState(DirectUiDispatcher.INSTANCE));
+        DungeonAuthoredApplicationService.Session session = service.openSession(new DungeonEditorDungeonState());
+        DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
+        DungeonEditorSessionValues.RoomRectanglePreview preview = new DungeonEditorSessionValues.RoomRectanglePreview(
+                new DungeonEditorWorkspaceValues.Cell(0, 0, 0),
+                new DungeonEditorWorkspaceValues.Cell(2, 2, 0),
+                false);
+
+        session.executePreview(mapId, preview);
+        session.executePreview(mapId, preview);
+
+        assertEquals(1, repository.findByIdCalls);
+    }
+
+    private static final class CountingRepository implements DungeonMapRepository {
+        private final DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(1L), "Map");
+        private int findByIdCalls;
+
+        @Override
+        public DungeonMapIdentity nextMapId() {
+            return new DungeonMapIdentity(2L);
+        }
+
+        @Override
+        public long nextStairId() {
+            return 1L;
+        }
+
+        @Override
+        public long nextTransitionId() {
+            return 1L;
+        }
+
+        @Override
+        public Optional<DungeonMap> findById(DungeonMapIdentity mapId) {
+            findByIdCalls++;
+            return Optional.of(map);
+        }
+
+        @Override
+        public List<DungeonMap> searchByName(String query) {
+            return List.of(map);
+        }
+
+        @Override
+        public Optional<DungeonMap> firstMap() {
+            return Optional.of(map);
+        }
+
+        @Override
+        public DungeonMap save(DungeonMap dungeonMap) {
+            return dungeonMap;
+        }
+
+        @Override
+        public List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps) {
+            return List.copyOf(dungeonMaps);
+        }
+
+        @Override
+        public void delete(DungeonMapIdentity mapId) {
+        }
+    }
+}

--- a/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
+++ b/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
@@ -1,0 +1,44 @@
+package features.dungeon.application.authored;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import org.junit.jupiter.api.Test;
+
+final class DungeonEditHistoryTest {
+    @Test
+    void undoAndRedoRemainLocalToOneRunningSessionAndMap() {
+        DungeonMapIdentity mapId = new DungeonMapIdentity(1L);
+        DungeonMap before = DungeonMapAuthoring.empty(mapId, "Before");
+        DungeonMap after = DungeonMapAuthoring.rename(before, "After");
+        DungeonEditHistory history = new DungeonEditHistory();
+
+        history.record(before, after);
+
+        assertTrue(history.canUndo(mapId));
+        assertEquals(before, history.undo(after));
+        assertFalse(history.canUndo(mapId));
+        assertTrue(history.canRedo(mapId));
+        assertEquals(after, history.redo(before));
+    }
+
+    @Test
+    void newCommitClearsTheRedoBranch() {
+        DungeonMapIdentity mapId = new DungeonMapIdentity(1L);
+        DungeonMap first = DungeonMapAuthoring.empty(mapId, "First");
+        DungeonMap second = DungeonMapAuthoring.rename(first, "Second");
+        DungeonMap replacement = DungeonMapAuthoring.rename(first, "Replacement");
+        DungeonEditHistory history = new DungeonEditHistory();
+        history.record(first, second);
+        history.undo(second);
+
+        history.record(first, replacement);
+
+        assertFalse(history.canRedo(mapId));
+        assertEquals(first, history.undo(replacement));
+    }
+}

--- a/test/features/dungeon/application/authored/DungeonViewportProjectionTest.java
+++ b/test/features/dungeon/application/authored/DungeonViewportProjectionTest.java
@@ -1,0 +1,52 @@
+package features.dungeon.application.authored;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonAreaKind;
+import features.dungeon.api.DungeonAreaSnapshot;
+import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonMapSnapshot;
+import features.dungeon.api.DungeonTopologyElementRef;
+import features.dungeon.api.DungeonTopologyKind;
+import features.dungeon.api.DungeonViewportRequest;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DungeonViewportProjectionTest {
+
+    @Test
+    void returnsOnlyTheVisibleWorksetAndItsPrefetchRingAcrossNegativeChunks() {
+        DungeonMapSnapshot map = new DungeonMapSnapshot(
+                DungeonTopologyKind.SQUARE,
+                1,
+                1,
+                List.of(new DungeonAreaSnapshot(
+                        DungeonAreaKind.ROOM,
+                        7L,
+                        3L,
+                        "Room",
+                        List.of(
+                                new DungeonCellRef(-65, 0, 2),
+                                new DungeonCellRef(0, 0, 2),
+                                new DungeonCellRef(130, 0, 2)),
+                        DungeonTopologyElementRef.empty())),
+                List.of(),
+                List.of());
+        DungeonViewportRequest request = new DungeonViewportRequest(9L, 4L, 2, -2, -2, 2, 2);
+
+        var result = new DungeonViewportProjection().project(request, 12L, map);
+
+        assertEquals(12L, result.mapRevision());
+        assertEquals(4L, result.requestGeneration());
+        assertEquals(Set.of(new DungeonCellRef(-65, 0, 2), new DungeonCellRef(0, 0, 2)),
+                Set.copyOf(result.areas().getFirst().cells()));
+        assertEquals(2, result.loadedChunks().size());
+        assertEquals(1, result.continuations().size());
+        assertEquals(2, result.continuations().getFirst().offWindowChunk().chunkQ());
+        assertTrue(result.authoredBounds().present());
+        assertEquals(-65, result.authoredBounds().minimumQ());
+        assertEquals(130, result.authoredBounds().maximumQ());
+    }
+}

--- a/test/features/dungeon/application/authored/port/DungeonChangeSetTest.java
+++ b/test/features/dungeon/application/authored/port/DungeonChangeSetTest.java
@@ -1,0 +1,30 @@
+package features.dungeon.application.authored.port;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import org.junit.jupiter.api.Test;
+
+class DungeonChangeSetTest {
+
+    @Test
+    void acceptsExactlyOneRevisionForTheSameMap() {
+        var before = DungeonMapAuthoring.empty(new DungeonMapIdentity(3L), "Map");
+        var after = DungeonMapAuthoring.rename(before, "Renamed");
+
+        DungeonChangeSet changeSet = new DungeonChangeSet(before, after);
+
+        assertEquals(1L, changeSet.expectedRevision());
+        assertEquals(2L, changeSet.committedRevision());
+    }
+
+    @Test
+    void rejectsSkippedRevisions() {
+        var before = DungeonMapAuthoring.empty(new DungeonMapIdentity(3L), "Map");
+        var after = DungeonMapAuthoring.committedContent(before, 3L);
+
+        assertThrows(IllegalArgumentException.class, () -> new DungeonChangeSet(before, after));
+    }
+}

--- a/test/platform/execution/LatestWinsTaskQueueTest.java
+++ b/test/platform/execution/LatestWinsTaskQueueTest.java
@@ -1,0 +1,67 @@
+package platform.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class LatestWinsTaskQueueTest {
+
+    @Test
+    void retainsOnlyLatestSampleWhileDrainIsWaiting() {
+        ManualExecutionLane lane = new ManualExecutionLane();
+        LatestWinsTaskQueue queue = new LatestWinsTaskQueue(lane);
+        List<Integer> observed = new ArrayList<>();
+
+        queue.submit(() -> observed.add(1));
+        queue.submit(() -> observed.add(2));
+        queue.submit(() -> observed.add(3));
+
+        assertTrue(queue.pending());
+        assertEquals(1, lane.queuedWork());
+        lane.runNext();
+
+        assertEquals(List.of(3), observed);
+        assertFalse(queue.pending());
+    }
+
+    @Test
+    void acceptsTheNextLatestSampleAfterACompletedDrain() {
+        ManualExecutionLane lane = new ManualExecutionLane();
+        LatestWinsTaskQueue queue = new LatestWinsTaskQueue(lane);
+        List<Integer> observed = new ArrayList<>();
+
+        queue.submit(() -> observed.add(1));
+        lane.runNext();
+        queue.submit(() -> observed.add(2));
+        lane.runNext();
+
+        assertEquals(List.of(1, 2), observed);
+    }
+
+    private static final class ManualExecutionLane implements ExecutionLane {
+        private final ArrayDeque<Runnable> work = new ArrayDeque<>();
+
+        @Override
+        public void execute(Runnable task) {
+            work.add(task);
+        }
+
+        int queuedWork() {
+            return work.size();
+        }
+
+        void runNext() {
+            work.remove().run();
+        }
+
+        @Override
+        public void close() {
+            work.clear();
+        }
+    }
+}

--- a/test/platform/ui/mapcanvas/MapCanvasCameraTest.java
+++ b/test/platform/ui/mapcanvas/MapCanvasCameraTest.java
@@ -1,0 +1,32 @@
+package platform.ui.mapcanvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+final class MapCanvasCameraTest {
+    @Test
+    void zoomKeepsTheScenePointUnderThePointerStable() {
+        MapCanvasCamera camera = new MapCanvasCamera(32.0, 1.0, 0.1, 4.0);
+        double sceneX = camera.viewport().screenToSceneX(320.0);
+        double sceneY = camera.viewport().screenToSceneY(160.0);
+
+        MapCanvasViewport zoomed = camera.zoomAround(320.0, 160.0, 2.0);
+
+        assertEquals(sceneX, zoomed.screenToSceneX(320.0), 0.000_001);
+        assertEquals(sceneY, zoomed.screenToSceneY(160.0), 0.000_001);
+    }
+
+    @Test
+    void visibleWindowSupportsNegativeUnboundedSceneCoordinates() {
+        MapCanvasCamera camera = new MapCanvasCamera(32.0, 1.0, 0.1, 4.0);
+        camera.panByPixels(640.0, 320.0);
+
+        MapCanvasWindow window = MapCanvasWindow.visible(camera.viewport(), 960.0, 640.0, 64.0);
+
+        assertTrue(window.minX() < 0.0);
+        assertTrue(window.minY() < 0.0);
+        assertTrue(window.maxX() > window.minX());
+    }
+}

--- a/test/platform/ui/mapcanvas/MapCanvasWindowTest.java
+++ b/test/platform/ui/mapcanvas/MapCanvasWindowTest.java
@@ -1,0 +1,18 @@
+package platform.ui.mapcanvas;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MapCanvasWindowTest {
+
+    @Test
+    void reportsWhetherSceneBoundsIntersectTheVisibleWindow() {
+        MapCanvasWindow window = new MapCanvasWindow(-2.0, -1.0, 5.0, 7.0);
+
+        assertTrue(window.intersects(4.0, 6.0, 8.0, 9.0));
+        assertFalse(window.intersects(6.0, 6.0, 8.0, 9.0));
+        assertFalse(window.intersects(Double.NaN, 0.0, 1.0, 1.0));
+    }
+}

--- a/test/platform/ui/mapcanvas/WeightedViewportCacheTest.java
+++ b/test/platform/ui/mapcanvas/WeightedViewportCacheTest.java
@@ -1,0 +1,21 @@
+package platform.ui.mapcanvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class WeightedViewportCacheTest {
+    @Test
+    void evictsLeastRecentlyUsedUnprotectedEntry() {
+        WeightedViewportCache<String, String> cache = new WeightedViewportCache<>(6L, String::length);
+        cache.put("visible", "1234", Set.of("visible"));
+        cache.put("old", "12", Set.of("visible"));
+        cache.put("new", "12", Set.of("visible"));
+
+        assertEquals("1234", cache.get("visible"));
+        assertNull(cache.get("old"));
+        assertEquals("12", cache.get("new"));
+    }
+}


### PR DESCRIPTION
## Summary
- define the sparse Dungeon target and disposable-test-data migration boundary
- add map-canvas camera/window/cache mechanisms, latest-wins pointer work, viewport snapshots, chunk inventory, and off-window continuation evidence
- add revision-checked incremental single-map persistence plus bounded session undo/redo and typed Authored/Travel APIs
- keep the remaining Editor API, cold chunk-content read, and multi-map compatibility deletion explicit in the temporary delivery owner

## Verification
- ./gradlew cleanTest check --console=plain (BUILD SUCCESSFUL in 3m 16s)
- ./gradlew installDesktopApp --console=plain (BUILD SUCCESSFUL in 14s)
- DungeonEditorBehaviorSuiteTest plus viewport and optimistic-revision tests (BUILD SUCCESSFUL in 1m 21s)