### PR TITLE
Add atomic Dungeon Editor API

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -95,6 +95,20 @@ M0 Target Lock And Baseline
 M5 and M6 may proceed in parallel only after M4 provides the shared window-read
 and commit boundaries. M7 starts only after both are complete.
 
+## Current Migration State
+
+- Current foundation: M0 is complete on `main` through PR #489.
+- This slice: M1 slice 1 publishes `DungeonEditorApi.current/subscribe/dispatch`,
+  exposes it from `DungeonFeature.Component`, and adapts the existing runtime
+  into one immutable editor-state publication without creating a second
+  runtime owner.
+- Next step after this slice merges: M1 slice 2 moves controls and state-pane
+  consumers from direct application operations and compatibility readbacks to
+  the Editor API.
+- Remaining M1 boundary: map scene, hit translation, and pointer dispatch stay
+  on their current route until slice 3; the JavaFX-to-Application debt ledger
+  must not grow meanwhile.
+
 ## M0: Target Lock And Baseline
 
 ### Goal

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -12,11 +12,14 @@ import features.dungeon.api.DungeonEditorStateModel;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.TravelDungeonModel;
 import features.dungeon.api.authored.DungeonAuthoredApi;
+import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
 import features.dungeon.application.authored.DungeonAuthoredPublishedState;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.editor.DungeonEditorPublishedState;
+import features.dungeon.application.editor.DungeonEditorApiFacade;
+import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
 import features.dungeon.application.editor.DungeonEditorRuntimeApplicationService;
 import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
 import features.dungeon.application.travel.DungeonTravelNavigator;
@@ -65,10 +68,14 @@ public final class DungeonFeature {
                 runtime.editor(),
                 lane,
                 dispatcher);
+        DungeonEditorFeatureRuntimeRoot editorRuntimeRoot =
+                DungeonEditorFeatureRuntimeRoot.create(editorDependencies);
+        DungeonEditorApi editorApi = new DungeonEditorApiFacade(editorRuntimeRoot, dispatcher);
         return new Component(
-                new DungeonEditorContribution(editorDependencies),
+                new DungeonEditorContribution(editorRuntimeRoot, dispatcher),
                 new DungeonTravelContribution(runtime.travel(), runtime.mapCatalog(), runtime.travelModel()),
                 runtime.authored(),
+                editorApi,
                 runtime.travel());
     }
 
@@ -113,12 +120,14 @@ public final class DungeonFeature {
             ShellContribution editorContribution,
             ShellContribution travelContribution,
             DungeonAuthoredApi authoredApi,
+            DungeonEditorApi editorApi,
             DungeonTravelApi travelApi
     ) {
         public Component {
             editorContribution = Objects.requireNonNull(editorContribution, "editorContribution");
             travelContribution = Objects.requireNonNull(travelContribution, "travelContribution");
             authoredApi = Objects.requireNonNull(authoredApi, "authoredApi");
+            editorApi = Objects.requireNonNull(editorApi, "editorApi");
             travelApi = Objects.requireNonNull(travelApi, "travelApi");
         }
     }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
@@ -6,6 +6,7 @@ import javafx.scene.Node;
 import shell.api.ShellBinding;
 import shell.api.ShellControls;
 import shell.api.ShellSlot;
+import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
 import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
 import features.dungeon.adapter.javafx.editor.DungeonEditorFeatureShellBinding;
 import platform.ui.catalogcrud.CatalogCrudControlsContentModel;
@@ -15,14 +16,26 @@ import features.dungeon.adapter.javafx.map.DungeonMapView;
 
 final class DungeonEditorBinder {
 
-    private final DungeonEditorRuntimeDependencies dependencies;
+    private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final platform.ui.UiDispatcher uiDispatcher;
 
     DungeonEditorBinder(DungeonEditorRuntimeDependencies dependencies) {
-        this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+        DungeonEditorRuntimeDependencies safeDependencies = Objects.requireNonNull(dependencies, "dependencies");
+        this.runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
+        this.uiDispatcher = safeDependencies.uiDispatcher();
+    }
+
+    DungeonEditorBinder(
+            DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            platform.ui.UiDispatcher uiDispatcher
+    ) {
+        this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
     ShellBinding bind() {
-        DungeonEditorFeatureShellBinding featureShell = new DungeonEditorFeatureShellBinding(dependencies);
+        DungeonEditorFeatureShellBinding featureShell =
+                new DungeonEditorFeatureShellBinding(runtimeRoot, uiDispatcher);
         DungeonEditorControlsPanelModel controlsPanelModel = new DungeonEditorControlsPanelModel();
         CatalogCrudControlsContentModel mapCatalogContentModel = new CatalogCrudControlsContentModel();
         DungeonEditorStatePanelModel statePanelModel = new DungeonEditorStatePanelModel();

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorContribution.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorContribution.java
@@ -9,14 +9,27 @@ import shell.api.ShellContribution;
 import shell.api.ShellContributionSpec;
 import shell.api.ShellLeftBarTabMode;
 import shell.api.ShellLeftBarTabSpec;
+import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
 import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
+import platform.ui.UiDispatcher;
 
 public final class DungeonEditorContribution implements ShellContribution {
 
-    private final DungeonEditorRuntimeDependencies dependencies;
+    private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final UiDispatcher uiDispatcher;
 
     public DungeonEditorContribution(DungeonEditorRuntimeDependencies dependencies) {
-        this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+        DungeonEditorRuntimeDependencies safeDependencies = Objects.requireNonNull(dependencies, "dependencies");
+        this.runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
+        this.uiDispatcher = safeDependencies.uiDispatcher();
+    }
+
+    public DungeonEditorContribution(
+            DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            UiDispatcher uiDispatcher
+    ) {
+        this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
     @Override
@@ -32,6 +45,6 @@ public final class DungeonEditorContribution implements ShellContribution {
 
     @Override
     public ShellBinding bind() {
-        return new DungeonEditorBinder(dependencies).bind();
+        return new DungeonEditorBinder(runtimeRoot, uiDispatcher).bind();
     }
 }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorFeatureShellBinding.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorFeatureShellBinding.java
@@ -16,8 +16,16 @@ public final class DungeonEditorFeatureShellBinding {
     public DungeonEditorFeatureShellBinding(DungeonEditorRuntimeDependencies dependencies) {
         DungeonEditorRuntimeDependencies safeDependencies =
                 Objects.requireNonNull(dependencies, "dependencies");
-        runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
-        uiDispatcher = safeDependencies.uiDispatcher();
+        this.runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
+        this.uiDispatcher = safeDependencies.uiDispatcher();
+    }
+
+    public DungeonEditorFeatureShellBinding(
+            DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            UiDispatcher uiDispatcher
+    ) {
+        this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
     public DungeonEditorRuntimeOperations operations() {

--- a/features/dungeon/api/editor/DungeonEditorApi.java
+++ b/features/dungeon/api/editor/DungeonEditorApi.java
@@ -1,0 +1,13 @@
+package features.dungeon.api.editor;
+
+import java.util.function.Consumer;
+
+/** Atomic editor-session capability consumed outside the Dungeon application layer. */
+public interface DungeonEditorApi {
+
+    DungeonEditorState current();
+
+    Runnable subscribe(Consumer<DungeonEditorState> subscriber);
+
+    void dispatch(DungeonEditorIntent intent);
+}

--- a/features/dungeon/api/editor/DungeonEditorDraftState.java
+++ b/features/dungeon/api/editor/DungeonEditorDraftState.java
@@ -1,0 +1,196 @@
+package features.dungeon.api.editor;
+
+import java.util.List;
+
+/** Immutable drafts that belong to one editor-state publication. */
+public record DungeonEditorDraftState(
+        List<RoomNarrationDraft> roomNarrations,
+        LabelNameDraft labelName,
+        CorridorPointDraft corridorPoint,
+        TransitionDescriptionDraft transitionDescription,
+        TransitionDestinationDraft transitionDestination,
+        StairGeometryDraft stairGeometry,
+        InlineLabelDraft inlineLabel
+) {
+    public DungeonEditorDraftState {
+        roomNarrations = roomNarrations == null ? List.of() : List.copyOf(roomNarrations);
+        labelName = labelName == null ? LabelNameDraft.empty() : labelName;
+        corridorPoint = corridorPoint == null ? CorridorPointDraft.empty() : corridorPoint;
+        transitionDescription = transitionDescription == null
+                ? TransitionDescriptionDraft.empty()
+                : transitionDescription;
+        transitionDestination = transitionDestination == null
+                ? TransitionDestinationDraft.empty()
+                : transitionDestination;
+        stairGeometry = stairGeometry == null ? StairGeometryDraft.empty() : stairGeometry;
+        inlineLabel = inlineLabel == null ? InlineLabelDraft.empty() : inlineLabel;
+    }
+
+    public static DungeonEditorDraftState empty() {
+        return new DungeonEditorDraftState(
+                List.of(), null, null, null, null, null, null);
+    }
+
+    public record RoomNarrationDraft(
+            long roomId,
+            boolean visualPresent,
+            String visualDescription,
+            List<ExitNarrationDraft> exits
+    ) {
+        public RoomNarrationDraft {
+            roomId = Math.max(0L, roomId);
+            visualDescription = safeText(visualDescription);
+            exits = exits == null ? List.of() : List.copyOf(exits);
+        }
+    }
+
+    public record ExitNarrationDraft(
+            String label,
+            int q,
+            int r,
+            int level,
+            String direction,
+            String description,
+            boolean present
+    ) {
+        public ExitNarrationDraft {
+            label = safeText(label);
+            direction = safeText(direction);
+            description = safeText(description);
+        }
+    }
+
+    public record LabelNameDraft(
+            String targetKind,
+            long targetId,
+            String label,
+            String fallbackName,
+            String name,
+            boolean present
+    ) {
+        public LabelNameDraft {
+            targetKind = safeText(targetKind);
+            targetId = Math.max(0L, targetId);
+            label = safeText(label);
+            fallbackName = safeText(fallbackName);
+            name = safeText(name);
+            present = present && targetId > 0L;
+        }
+
+        public static LabelNameDraft empty() {
+            return new LabelNameDraft("", 0L, "", "", "", false);
+        }
+    }
+
+    public record CorridorPointDraft(
+            boolean targetPresent,
+            boolean present,
+            String label,
+            String q,
+            String r,
+            String level
+    ) {
+        public CorridorPointDraft {
+            label = safeText(label);
+            q = safeText(q);
+            r = safeText(r);
+            level = safeText(level);
+            present = present && targetPresent;
+        }
+
+        public static CorridorPointDraft empty() {
+            return new CorridorPointDraft(false, false, "", "", "", "");
+        }
+    }
+
+    public record TransitionDescriptionDraft(long transitionId, String description, boolean present) {
+        public TransitionDescriptionDraft {
+            transitionId = Math.max(0L, transitionId);
+            description = safeText(description);
+            present = present && transitionId > 0L;
+        }
+
+        public static TransitionDescriptionDraft empty() {
+            return new TransitionDescriptionDraft(0L, "", false);
+        }
+    }
+
+    public record TransitionDestinationDraft(
+            boolean targetPresent,
+            long sourceTransitionId,
+            String destinationType,
+            String mapId,
+            String tileId,
+            String transitionId,
+            boolean bidirectional,
+            boolean present
+    ) {
+        public TransitionDestinationDraft {
+            sourceTransitionId = Math.max(0L, sourceTransitionId);
+            destinationType = safeText(destinationType);
+            mapId = safeText(mapId);
+            tileId = safeText(tileId);
+            transitionId = safeText(transitionId);
+            present = present && targetPresent;
+        }
+
+        public static TransitionDestinationDraft empty() {
+            return new TransitionDestinationDraft(false, 0L, "", "", "", "", true, false);
+        }
+    }
+
+    public record StairGeometryDraft(
+            boolean targetPresent,
+            long stairId,
+            String shape,
+            String direction,
+            String dimension1,
+            String dimension2,
+            boolean present
+    ) {
+        public StairGeometryDraft {
+            stairId = Math.max(0L, stairId);
+            shape = safeText(shape);
+            direction = safeText(direction);
+            dimension1 = safeText(dimension1);
+            dimension2 = safeText(dimension2);
+            present = present && targetPresent && stairId > 0L;
+        }
+
+        public static StairGeometryDraft empty() {
+            return new StairGeometryDraft(false, 0L, "", "", "", "", false);
+        }
+    }
+
+    public record InlineLabelDraft(
+            boolean active,
+            String targetKind,
+            long targetId,
+            String labelKind,
+            long ownerId,
+            long clusterId,
+            String topologyKind,
+            long topologyId,
+            String text
+    ) {
+        public InlineLabelDraft {
+            targetKind = safeText(targetKind);
+            targetId = Math.max(0L, targetId);
+            labelKind = safeText(labelKind);
+            ownerId = Math.max(0L, ownerId);
+            clusterId = Math.max(0L, clusterId);
+            topologyKind = safeText(topologyKind);
+            topologyId = Math.max(0L, topologyId);
+            text = safeText(text);
+            active = active && targetId > 0L;
+        }
+
+        public static InlineLabelDraft empty() {
+            return new InlineLabelDraft(false, "", 0L, "", 0L, 0L, "", 0L, "");
+        }
+    }
+
+    private static String safeText(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -1,0 +1,84 @@
+package features.dungeon.api.editor;
+
+import features.dungeon.api.DungeonEditorTool;
+import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.DungeonOverlaySettings;
+
+/** Typed editor inputs introduced ahead of the JavaFX consumer migration. */
+public sealed interface DungeonEditorIntent {
+
+    record SelectMap(DungeonMapId mapId) implements DungeonEditorIntent {
+        public SelectMap {
+            if (mapId == null) {
+                throw new IllegalArgumentException("mapId is required");
+            }
+        }
+    }
+
+    record CreateMap(String mapName) implements DungeonEditorIntent {
+        public CreateMap {
+            mapName = cleanName(mapName);
+        }
+    }
+
+    record RenameMap(DungeonMapId mapId, String mapName) implements DungeonEditorIntent {
+        public RenameMap {
+            if (mapId == null) {
+                throw new IllegalArgumentException("mapId is required");
+            }
+            mapName = cleanName(mapName);
+        }
+    }
+
+    record DeleteMap(DungeonMapId mapId) implements DungeonEditorIntent {
+        public DeleteMap {
+            if (mapId == null) {
+                throw new IllegalArgumentException("mapId is required");
+            }
+        }
+    }
+
+    record SetViewMode(DungeonEditorViewMode viewMode) implements DungeonEditorIntent {
+        public SetViewMode {
+            viewMode = viewMode == null ? DungeonEditorViewMode.GRID : viewMode;
+        }
+    }
+
+    record SetTool(DungeonEditorTool tool) implements DungeonEditorIntent {
+        public SetTool {
+            tool = tool == null ? DungeonEditorTool.SELECT : tool;
+        }
+    }
+
+    record ShiftProjectionLevel(int levelShift) implements DungeonEditorIntent {
+    }
+
+    record SetOverlay(DungeonOverlaySettings overlaySettings) implements DungeonEditorIntent {
+        public SetOverlay {
+            overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
+        }
+    }
+
+    record ScrollSelection(int levelDelta) implements DungeonEditorIntent {
+    }
+
+    enum CancelPreview implements DungeonEditorIntent {
+        INSTANCE
+    }
+
+    enum Undo implements DungeonEditorIntent {
+        INSTANCE
+    }
+
+    enum Redo implements DungeonEditorIntent {
+        INSTANCE
+    }
+
+    private static String cleanName(String mapName) {
+        if (mapName == null || mapName.isBlank()) {
+            throw new IllegalArgumentException("mapName is required");
+        }
+        return mapName.strip();
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorState.java
+++ b/features/dungeon/api/editor/DungeonEditorState.java
@@ -1,0 +1,75 @@
+package features.dungeon.api.editor;
+
+import features.dungeon.api.DungeonEditorPreview;
+import features.dungeon.api.DungeonEditorStateSnapshot;
+import features.dungeon.api.DungeonEditorSurface;
+import features.dungeon.api.DungeonEditorTool;
+import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.DungeonInspectorSnapshot;
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.DungeonMapSummary;
+import features.dungeon.api.DungeonOverlaySettings;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/** One immutable publication supplying every current Dungeon Editor consumer. */
+public record DungeonEditorState(
+        long publicationRevision,
+        long requestGeneration,
+        List<DungeonMapSummary> catalog,
+        @Nullable DungeonMapId selectedMapId,
+        @Nullable DungeonEditorSurface selectedWindow,
+        DungeonEditorViewMode viewMode,
+        DungeonEditorTool selectedTool,
+        DungeonOverlaySettings overlaySettings,
+        int projectionLevel,
+        List<Integer> reachableLevels,
+        DungeonEditorStateSnapshot.Selection selection,
+        DungeonEditorDraftState draft,
+        DungeonEditorPreview preview,
+        @Nullable DungeonInspectorSnapshot inspector,
+        CommandStatus commandStatus
+) {
+    public DungeonEditorState {
+        publicationRevision = Math.max(0L, publicationRevision);
+        requestGeneration = Math.max(0L, requestGeneration);
+        catalog = catalog == null ? List.of() : List.copyOf(catalog);
+        viewMode = viewMode == null ? DungeonEditorViewMode.GRID : viewMode;
+        selectedTool = selectedTool == null ? DungeonEditorTool.SELECT : selectedTool;
+        overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
+        reachableLevels = reachableLevels == null ? List.of(0) : List.copyOf(reachableLevels);
+        selection = selection == null ? DungeonEditorStateSnapshot.Selection.empty() : selection;
+        draft = draft == null ? DungeonEditorDraftState.empty() : draft;
+        preview = preview == null ? DungeonEditorPreview.none() : preview;
+        commandStatus = commandStatus == null ? CommandStatus.idle() : commandStatus;
+    }
+
+    public static DungeonEditorState empty() {
+        return new DungeonEditorState(
+                0L,
+                0L,
+                List.of(),
+                null,
+                null,
+                DungeonEditorViewMode.GRID,
+                DungeonEditorTool.SELECT,
+                DungeonOverlaySettings.defaults(),
+                0,
+                List.of(0),
+                DungeonEditorStateSnapshot.Selection.empty(),
+                DungeonEditorDraftState.empty(),
+                DungeonEditorPreview.none(),
+                null,
+                CommandStatus.idle());
+    }
+
+    public record CommandStatus(boolean busy, String message) {
+        public CommandStatus {
+            message = message == null ? "" : message;
+        }
+
+        public static CommandStatus idle() {
+            return new CommandStatus(false, "");
+        }
+    }
+}

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -1,0 +1,234 @@
+package features.dungeon.application.editor;
+
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.DungeonMapSummary;
+import features.dungeon.api.editor.DungeonEditorApi;
+import features.dungeon.api.editor.DungeonEditorDraftState;
+import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorState;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import platform.ui.UiDispatcher;
+
+/** Bridges the existing runtime into the atomic public Editor capability during M1. */
+public final class DungeonEditorApiFacade implements DungeonEditorApi {
+    private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final UiDispatcher uiDispatcher;
+
+    public DungeonEditorApiFacade(
+            DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            UiDispatcher uiDispatcher
+    ) {
+        this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+    }
+
+    @Override
+    public DungeonEditorState current() {
+        return stateFrom(runtimeRoot.currentFrame());
+    }
+
+    @Override
+    public Runnable subscribe(Consumer<DungeonEditorState> subscriber) {
+        StateDelivery delivery = new StateDelivery(
+                Objects.requireNonNull(subscriber, "subscriber"),
+                uiDispatcher);
+        Runnable unsubscribeRuntime = runtimeRoot.subscribe(delivery::deliver);
+        return () -> {
+            delivery.close();
+            unsubscribeRuntime.run();
+        };
+    }
+
+    @Override
+    public void dispatch(DungeonEditorIntent intent) {
+        DungeonEditorIntent safeIntent = Objects.requireNonNull(intent, "intent");
+        if (safeIntent instanceof DungeonEditorIntent.SelectMap selectMap) {
+            runtimeRoot.selectMap(selectMap.mapId().value());
+        } else if (safeIntent instanceof DungeonEditorIntent.CreateMap createMap) {
+            runtimeRoot.createMap(createMap.mapName());
+        } else if (safeIntent instanceof DungeonEditorIntent.RenameMap renameMap) {
+            runtimeRoot.renameMap(renameMap.mapId().value(), renameMap.mapName());
+        } else if (safeIntent instanceof DungeonEditorIntent.DeleteMap deleteMap) {
+            runtimeRoot.deleteMap(deleteMap.mapId().value());
+        } else if (safeIntent instanceof DungeonEditorIntent.SetViewMode setViewMode) {
+            runtimeRoot.setViewMode(setViewMode.viewMode());
+        } else if (safeIntent instanceof DungeonEditorIntent.SetTool setTool) {
+            runtimeRoot.setTool(setTool.tool());
+        } else if (safeIntent instanceof DungeonEditorIntent.ShiftProjectionLevel shiftLevel) {
+            runtimeRoot.shiftProjectionLevel(shiftLevel.levelShift());
+        } else if (safeIntent instanceof DungeonEditorIntent.SetOverlay setOverlay) {
+            runtimeRoot.setOverlay(overlayFrom(setOverlay));
+        } else if (safeIntent instanceof DungeonEditorIntent.ScrollSelection scrollSelection) {
+            runtimeRoot.scrollSelection(scrollSelection.levelDelta());
+        } else if (safeIntent == DungeonEditorIntent.CancelPreview.INSTANCE) {
+            runtimeRoot.cancelActivePreviewSession();
+        } else if (safeIntent == DungeonEditorIntent.Undo.INSTANCE) {
+            runtimeRoot.undo();
+        } else if (safeIntent == DungeonEditorIntent.Redo.INSTANCE) {
+            runtimeRoot.redo();
+        } else {
+            throw new IllegalArgumentException("Unsupported Dungeon Editor intent: " + safeIntent.getClass());
+        }
+    }
+
+    private static DungeonEditorOverlaySettings overlayFrom(DungeonEditorIntent.SetOverlay intent) {
+        var settings = intent.overlaySettings();
+        DungeonEditorOverlaySettings.Mode mode;
+        try {
+            mode = DungeonEditorOverlaySettings.Mode.valueOf(settings.modeKey());
+        } catch (IllegalArgumentException ignored) {
+            mode = DungeonEditorOverlaySettings.Mode.OFF;
+        }
+        return new DungeonEditorOverlaySettings(
+                mode,
+                settings.levelRange(),
+                settings.opacity(),
+                settings.selectedLevels());
+    }
+
+    private static DungeonEditorState stateFrom(DungeonEditorRenderFrame frame) {
+        DungeonEditorRenderFrame safeFrame = frame == null ? DungeonEditorRenderFrame.empty() : frame;
+        DungeonEditorPreparedFrameFacts facts = safeFrame.preparedFacts();
+        DungeonEditorPreparedFrameFacts.MapSurfaceFrame mapSurface = facts.mapSurfaceFrame();
+        DungeonEditorPreparedFrameFacts.StatePanelFrame statePanel = facts.statePanelFrame();
+        DungeonMapId selectedMapId = facts.selectedMapIdValue() > 0L
+                ? new DungeonMapId(facts.selectedMapIdValue())
+                : null;
+        List<DungeonMapSummary> catalog = facts.mapEntries().stream()
+                .filter(entry -> entry.mapIdValue() > 0L)
+                .map(entry -> new DungeonMapSummary(
+                        new DungeonMapId(entry.mapIdValue()),
+                        entry.mapName(),
+                        entry.revision()))
+                .toList();
+        return new DungeonEditorState(
+                safeFrame.measurement().runtimeFramePublicationCount(),
+                0L,
+                catalog,
+                selectedMapId,
+                mapSurface.surface(),
+                mapSurface.viewMode(),
+                mapSurface.selectedTool(),
+                mapSurface.overlaySettings(),
+                mapSurface.projectionLevel(),
+                facts.reachableLevels(),
+                mapSurface.selection(),
+                draftFrom(statePanel, safeFrame.inlineLabelEditSession()),
+                mapSurface.preview(),
+                statePanel.inspector(),
+                new DungeonEditorState.CommandStatus(facts.busy(), facts.statusText()));
+    }
+
+    private static DungeonEditorDraftState draftFrom(
+            DungeonEditorPreparedFrameFacts.StatePanelFrame statePanel,
+            DungeonEditorInlineLabelEditSession inlineLabel
+    ) {
+        DungeonEditorPreparedFrameFacts.StatePanelFrame safeStatePanel = statePanel == null
+                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
+                : statePanel;
+        DungeonEditorInlineLabelEditSession safeInlineLabel = inlineLabel == null
+                ? DungeonEditorInlineLabelEditSession.inactive()
+                : inlineLabel;
+        var label = safeStatePanel.labelNameDraft();
+        var labelTarget = label.target();
+        var corridor = safeStatePanel.corridorPointDraft();
+        var transitionDescription = safeStatePanel.transitionDescriptionDraft();
+        var transitionDestination = safeStatePanel.transitionDestinationDraft();
+        var stair = safeStatePanel.stairGeometryDraft();
+        return new DungeonEditorDraftState(
+                safeStatePanel.roomNarrationDrafts().rooms().stream()
+                        .map(room -> new DungeonEditorDraftState.RoomNarrationDraft(
+                                room.roomId(),
+                                room.visualPresent(),
+                                room.visualDescription(),
+                                room.exits().stream()
+                                        .map(exit -> new DungeonEditorDraftState.ExitNarrationDraft(
+                                                exit.label(),
+                                                exit.q(),
+                                                exit.r(),
+                                                exit.level(),
+                                                exit.direction(),
+                                                exit.description(),
+                                                exit.present()))
+                                        .toList()))
+                        .toList(),
+                new DungeonEditorDraftState.LabelNameDraft(
+                        labelTarget.kind().name(),
+                        labelTarget.targetId(),
+                        label.label(),
+                        label.fallbackName(),
+                        label.name(),
+                        label.present()),
+                new DungeonEditorDraftState.CorridorPointDraft(
+                        corridor.targetPresent(),
+                        corridor.present(),
+                        corridor.label(),
+                        corridor.q(),
+                        corridor.r(),
+                        corridor.level()),
+                new DungeonEditorDraftState.TransitionDescriptionDraft(
+                        transitionDescription.transitionId(),
+                        transitionDescription.description(),
+                        transitionDescription.present()),
+                new DungeonEditorDraftState.TransitionDestinationDraft(
+                        transitionDestination.targetPresent(),
+                        transitionDestination.sourceTransitionId(),
+                        transitionDestination.destinationTypeKey(),
+                        transitionDestination.mapId(),
+                        transitionDestination.tileId(),
+                        transitionDestination.transitionId(),
+                        transitionDestination.bidirectional(),
+                        transitionDestination.present()),
+                new DungeonEditorDraftState.StairGeometryDraft(
+                        stair.targetPresent(),
+                        stair.stairId(),
+                        stair.shapeName(),
+                        stair.directionName(),
+                        stair.dimension1(),
+                        stair.dimension2(),
+                        stair.present()),
+                new DungeonEditorDraftState.InlineLabelDraft(
+                        safeInlineLabel.active(),
+                        safeInlineLabel.target().kind().name(),
+                        safeInlineLabel.target().targetId(),
+                        safeInlineLabel.labelKind(),
+                        safeInlineLabel.ownerId(),
+                        safeInlineLabel.clusterId(),
+                        safeInlineLabel.topologyKind(),
+                        safeInlineLabel.topologyId(),
+                        safeInlineLabel.draftText()));
+    }
+
+    private static final class StateDelivery {
+        private final Consumer<DungeonEditorState> subscriber;
+        private final UiDispatcher uiDispatcher;
+        private final AtomicBoolean open = new AtomicBoolean(true);
+        private final AtomicLong deliveryRevision = new AtomicLong();
+
+        private StateDelivery(Consumer<DungeonEditorState> subscriber, UiDispatcher uiDispatcher) {
+            this.subscriber = subscriber;
+            this.uiDispatcher = uiDispatcher;
+        }
+
+        private void deliver(DungeonEditorRenderFrame frame) {
+            long revision = deliveryRevision.incrementAndGet();
+            DungeonEditorState state = stateFrom(frame);
+            uiDispatcher.dispatch(() -> applyIfCurrent(revision, state));
+        }
+
+        private void applyIfCurrent(long revision, DungeonEditorState state) {
+            if (open.get() && revision == deliveryRevision.get()) {
+                subscriber.accept(state);
+            }
+        }
+
+        private void close() {
+            open.set(false);
+            deliveryRevision.incrementAndGet();
+        }
+    }
+}

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -21,11 +21,47 @@ import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.api.editor.DungeonEditorApi;
+import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorState;
 import features.party.PartyServiceAssembly;
 import features.party.domain.roster.PartyRoster;
 import features.party.domain.roster.repository.PartyRosterRepository;
 
 final class DungeonEditorRuntimeThreadOwnershipTest {
+
+    @Test
+    void editorApiPublishesOneAtomicStateAndDispatchesThroughTheRuntimeOwner() {
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntimeDirect(repository);
+        QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
+        DungeonEditorApi api = new DungeonEditorApiFacade(runtime, dispatcher);
+        List<DungeonEditorState> delivered = new ArrayList<>();
+        api.subscribe(delivered::add);
+
+        api.dispatch(new DungeonEditorIntent.CreateMap("Second"));
+
+        DungeonEditorState current = api.current();
+        assertEquals(2, repository.size());
+        assertEquals(2, current.catalog().size());
+        assertEquals("Second", current.selectedWindow().mapName());
+        assertTrue(current.publicationRevision() > 0L);
+        assertTrue(delivered.isEmpty(), "API publications must cross the supplied UI dispatcher");
+
+        dispatcher.runAll();
+
+        assertEquals(1, delivered.size());
+        DungeonEditorState published = delivered.getFirst();
+        assertEquals(current.publicationRevision(), published.publicationRevision());
+        assertEquals(current.catalog(), published.catalog());
+        assertEquals(current.selectedMapId(), published.selectedMapId());
+        assertEquals(current.selectedWindow(), published.selectedWindow());
+        assertEquals(current.selection(), published.selection());
+        assertEquals(current.preview(), published.preview());
+        assertEquals(current.inspector(), published.inspector());
+        assertEquals(current.commandStatus(), published.commandStatus());
+    }
 
     @Test
     void constructionDefersInitialReadbackAndDeliversTheCompletedOwnerFrame() {
@@ -285,6 +321,10 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         void seed(long mapId, String name) {
             DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), name);
             maps.put(mapId, map);
+        }
+
+        int size() {
+            return maps.size();
         }
 
         @Override


### PR DESCRIPTION
## Summary
- publish DungeonEditorApi current/subscribe/dispatch and expose it from DungeonFeature.Component
- adapt the existing editor runtime into one immutable revisioned state without creating a second runtime owner
- add typed catalog and control intents plus UI-dispatch proof
- record M1.2 as the next roadmap slice

## Verification
- ./gradlew test --tests features.dungeon.application.editor.DungeonEditorRuntimeThreadOwnershipTest --console=plain
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain
- git diff --cached --check