### PR TITLE
Move Dungeon Editor controls to API

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,17 +97,17 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 is complete on `main` through PR #489.
-- This slice: M1 slice 1 publishes `DungeonEditorApi.current/subscribe/dispatch`,
-  exposes it from `DungeonFeature.Component`, and adapts the existing runtime
-  into one immutable editor-state publication without creating a second
-  runtime owner.
-- Next step after this slice merges: M1 slice 2 moves controls and state-pane
-  consumers from direct application operations and compatibility readbacks to
-  the Editor API.
-- Remaining M1 boundary: map scene, hit translation, and pointer dispatch stay
-  on their current route until slice 3; the JavaFX-to-Application debt ledger
-  must not grow meanwhile.
+- Current foundation: M0 and M1 slice 1 are complete on `main` through PRs #489
+  and #490.
+- This slice: M1 slice 2 moves controls and state-pane publication and commands
+  to `DungeonEditorApi`, including typed narration, label, corridor,
+  transition, and stair draft or commit inputs.
+- Next step after this slice merges: M1 slice 3 moves map scene construction,
+  hit translation, pointer dispatch, and inline-label interaction state to the
+  Editor API and JavaFX-local mechanisms.
+- Remaining M1 boundary: the map alone still consumes the prepared render frame
+  and JavaFX pointer-operation bundle until slice 3; atomic internal publication
+  and permanent enforcement remain owned by slice 4.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -72,7 +72,7 @@ public final class DungeonFeature {
                 DungeonEditorFeatureRuntimeRoot.create(editorDependencies);
         DungeonEditorApi editorApi = new DungeonEditorApiFacade(editorRuntimeRoot, dispatcher);
         return new Component(
-                new DungeonEditorContribution(editorRuntimeRoot, dispatcher),
+                new DungeonEditorContribution(editorRuntimeRoot, editorApi, dispatcher),
                 new DungeonTravelContribution(runtime.travel(), runtime.mapCatalog(), runtime.travelModel()),
                 runtime.authored(),
                 editorApi,

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
@@ -7,8 +7,8 @@ import shell.api.ShellBinding;
 import shell.api.ShellControls;
 import shell.api.ShellSlot;
 import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
-import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
 import features.dungeon.adapter.javafx.editor.DungeonEditorFeatureShellBinding;
+import features.dungeon.api.editor.DungeonEditorApi;
 import platform.ui.catalogcrud.CatalogCrudControlsContentModel;
 import platform.ui.catalogcrud.CatalogCrudControlsView;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel;
@@ -17,19 +17,16 @@ import features.dungeon.adapter.javafx.map.DungeonMapView;
 final class DungeonEditorBinder {
 
     private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final DungeonEditorApi editorApi;
     private final platform.ui.UiDispatcher uiDispatcher;
-
-    DungeonEditorBinder(DungeonEditorRuntimeDependencies dependencies) {
-        DungeonEditorRuntimeDependencies safeDependencies = Objects.requireNonNull(dependencies, "dependencies");
-        this.runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
-        this.uiDispatcher = safeDependencies.uiDispatcher();
-    }
 
     DungeonEditorBinder(
             DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            DungeonEditorApi editorApi,
             platform.ui.UiDispatcher uiDispatcher
     ) {
         this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.editorApi = Objects.requireNonNull(editorApi, "editorApi");
         this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
@@ -45,6 +42,7 @@ final class DungeonEditorBinder {
                 statePanelModel,
                 mapCatalogContentModel,
                 mapContentModel,
+                editorApi,
                 featureShell.operations());
         DungeonEditorControlsView controls = new DungeonEditorControlsView();
         CatalogCrudControlsView mapCatalog = new CatalogCrudControlsView();
@@ -63,6 +61,8 @@ final class DungeonEditorBinder {
         DungeonEditorFeatureShellBinding.PublicationSink frameSink = viewModel::applyFrame;
         featureShell.subscribe(frameSink);
         featureShell.publishCurrent(frameSink);
+        editorApi.subscribe(viewModel::applyState);
+        viewModel.applyState(editorApi.current());
         return new Binding(ShellControls.stack(mapCatalog, controls), main, state, mapContentModel);
     }
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorContribution.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorContribution.java
@@ -10,26 +10,40 @@ import shell.api.ShellContributionSpec;
 import shell.api.ShellLeftBarTabMode;
 import shell.api.ShellLeftBarTabSpec;
 import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
+import features.dungeon.application.editor.DungeonEditorApiFacade;
 import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
+import features.dungeon.api.editor.DungeonEditorApi;
 import platform.ui.UiDispatcher;
 
 public final class DungeonEditorContribution implements ShellContribution {
 
     private final DungeonEditorFeatureRuntimeRoot runtimeRoot;
+    private final DungeonEditorApi editorApi;
     private final UiDispatcher uiDispatcher;
 
     public DungeonEditorContribution(DungeonEditorRuntimeDependencies dependencies) {
-        DungeonEditorRuntimeDependencies safeDependencies = Objects.requireNonNull(dependencies, "dependencies");
-        this.runtimeRoot = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
-        this.uiDispatcher = safeDependencies.uiDispatcher();
+        this(assembly(dependencies));
+    }
+
+    private DungeonEditorContribution(Assembly assembly) {
+        this(assembly.runtimeRoot(), assembly.editorApi(), assembly.uiDispatcher());
     }
 
     public DungeonEditorContribution(
             DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            DungeonEditorApi editorApi,
             UiDispatcher uiDispatcher
     ) {
         this.runtimeRoot = Objects.requireNonNull(runtimeRoot, "runtimeRoot");
+        this.editorApi = Objects.requireNonNull(editorApi, "editorApi");
         this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+    }
+
+    private static Assembly assembly(DungeonEditorRuntimeDependencies dependencies) {
+        DungeonEditorRuntimeDependencies safeDependencies = Objects.requireNonNull(dependencies, "dependencies");
+        DungeonEditorFeatureRuntimeRoot root = DungeonEditorFeatureRuntimeRoot.create(safeDependencies);
+        return new Assembly(root, new DungeonEditorApiFacade(root, safeDependencies.uiDispatcher()),
+                safeDependencies.uiDispatcher());
     }
 
     @Override
@@ -45,6 +59,13 @@ public final class DungeonEditorContribution implements ShellContribution {
 
     @Override
     public ShellBinding bind() {
-        return new DungeonEditorBinder(runtimeRoot, uiDispatcher).bind();
+        return new DungeonEditorBinder(runtimeRoot, editorApi, uiDispatcher).bind();
+    }
+
+    private record Assembly(
+            DungeonEditorFeatureRuntimeRoot runtimeRoot,
+            DungeonEditorApi editorApi,
+            UiDispatcher uiDispatcher
+    ) {
     }
 }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorControlsPanelModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorControlsPanelModel.java
@@ -402,6 +402,10 @@ final class DungeonEditorControlsPanelModel {
         return ToolPalettePanel.graphViewLabel();
     }
 
+    static String labelOf(@Nullable DungeonEditorTool tool) {
+        return ToolPalettePanel.labelOf(tool);
+    }
+
     boolean wallSingleClickModeSelected() {
         return toolPalette.wallSingleClickModeSelected();
     }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
@@ -9,13 +9,8 @@ import org.jspecify.annotations.Nullable;
 import features.dungeon.api.DungeonEditorPreview;
 import features.dungeon.api.DungeonTopologyElementRef;
 import features.dungeon.api.DungeonInspectorSnapshot;
-import features.dungeon.application.editor.DungeonEditorPreparedFrameFacts;
-import features.dungeon.application.editor.DungeonEditorStatePanelCorridorPointDrafts;
-import features.dungeon.application.editor.DungeonEditorStatePanelLabelNameDrafts;
-import features.dungeon.application.editor.DungeonEditorStatePanelRoomNarrationDrafts;
-import features.dungeon.application.editor.DungeonEditorStatePanelStairGeometryDrafts;
-import features.dungeon.application.editor.DungeonEditorStatePanelTransitionDescriptionDrafts;
-import features.dungeon.application.editor.DungeonEditorStatePanelTransitionDestinationDrafts;
+import features.dungeon.api.editor.DungeonEditorDraftState;
+import features.dungeon.api.editor.DungeonEditorState;
 
 final class DungeonEditorStatePanelModel {
     private final ReadOnlyObjectWrapper<StateProjection> stateProjection =
@@ -33,27 +28,26 @@ final class DungeonEditorStatePanelModel {
         return stateProjection.getReadOnlyProperty();
     }
 
-    void apply(DungeonEditorPreparedFrameFacts.StatePanelFrame frame) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = frame == null
-                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
-                : frame;
+    void apply(DungeonEditorState state) {
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        DungeonEditorDraftState draft = safeState.draft();
         List<RoomNarrationCardProjection> narrationCards = narrationContent.narrationCards(
-                safeFrame.inspector(),
-                safeFrame.roomNarrationDrafts());
+                safeState.inspector(),
+                draft.roomNarrations());
         stateProjection.set(new StateProjection(
-                selectionPreviewContent.stateTextFor(safeFrame),
-                safeFrame.statusText(),
-                safeFrame.busy(),
+                selectionPreviewContent.stateTextFor(safeState),
+                safeState.commandStatus().message(),
+                safeState.commandStatus().busy(),
                 narrationContent.renderStructureKey(
                         narrationCards,
-                        safeFrame.busy(),
-                        safeFrame.statusText()),
+                        safeState.commandStatus().busy(),
+                        safeState.commandStatus().message()),
                 narrationCards,
-                nameProjection(safeFrame),
-                corridorPointProjection(safeFrame),
-                transitionContent.transitionDestinationProjection(safeFrame),
-                transitionContent.transitionDescriptionProjection(safeFrame),
-                stairGeometryContent.stairGeometryProjection(safeFrame)));
+                nameProjection(safeState),
+                corridorPointProjection(safeState),
+                transitionContent.transitionDestinationProjection(safeState),
+                transitionContent.transitionDescriptionProjection(safeState),
+                stairGeometryContent.stairGeometryProjection(safeState)));
     }
 
     @Nullable RoomNarrationCardProjection currentNarrationCard(long roomId) {
@@ -72,15 +66,13 @@ final class DungeonEditorStatePanelModel {
         return TransitionPanel.transitionDestinationTypeKey(optionIndex);
     }
 
-    private static @Nullable NameProjection nameProjection(DungeonEditorPreparedFrameFacts.StatePanelFrame frame) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = frame == null
-                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
-                : frame;
-        DungeonEditorStatePanelLabelNameDrafts.Draft target = safeFrame.labelNameDraft();
-        if (!target.targetPresent()) {
+    private static @Nullable NameProjection nameProjection(DungeonEditorState state) {
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        DungeonEditorDraftState.LabelNameDraft target = safeState.draft().labelName();
+        if (!target.present() && target.targetId() <= 0L) {
             return null;
         }
-        DungeonInspectorSnapshot inspector = safeFrame.inspector();
+        DungeonInspectorSnapshot inspector = safeState.inspector();
         String fallbackName = target.fallbackName();
         String currentName = inspector == null || inspector.title().isBlank() ? fallbackName : inspector.title();
         String draft = target.present()
@@ -92,26 +84,22 @@ final class DungeonEditorStatePanelModel {
                 draft);
     }
 
-    private static LabelNameTarget labelNameTarget(
-            DungeonEditorStatePanelLabelNameDrafts.Draft target
-    ) {
-        if (target == null || !target.targetPresent()) {
+    private static LabelNameTarget labelNameTarget(DungeonEditorDraftState.LabelNameDraft target) {
+        if (target == null || target.targetId() <= 0L) {
             return LabelNameTarget.empty();
         }
-        return switch (target.target().kind()) {
-            case ROOM -> LabelNameTarget.room(target.target().id());
-            case CLUSTER -> LabelNameTarget.cluster(target.target().id());
-            case EMPTY -> LabelNameTarget.empty();
+        return switch (target.targetKind()) {
+            case "ROOM" -> LabelNameTarget.room(target.targetId());
+            case "CLUSTER" -> LabelNameTarget.cluster(target.targetId());
+            default -> LabelNameTarget.empty();
         };
     }
 
     private static @Nullable CorridorPointProjection corridorPointProjection(
-            DungeonEditorPreparedFrameFacts.StatePanelFrame frame
+            DungeonEditorState state
     ) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = frame == null
-                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
-                : frame;
-        DungeonEditorStatePanelCorridorPointDrafts.Draft draft = safeFrame.corridorPointDraft();
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        DungeonEditorDraftState.CorridorPointDraft draft = safeState.draft().corridorPoint();
         if (!draft.targetPresent()) {
             return null;
         }
@@ -339,14 +327,14 @@ final class DungeonEditorStatePanelModel {
 
     List<DungeonEditorStatePanelModel.RoomNarrationCardProjection> narrationCards(
             @Nullable DungeonInspectorSnapshot inspector,
-            DungeonEditorStatePanelRoomNarrationDrafts.VisibleDrafts narrationDrafts
+            List<DungeonEditorDraftState.RoomNarrationDraft> narrationDrafts
     ) {
-        DungeonEditorStatePanelRoomNarrationDrafts.VisibleDrafts safeDrafts = narrationDrafts == null
-                ? DungeonEditorStatePanelRoomNarrationDrafts.VisibleDrafts.empty()
-                : narrationDrafts;
-        Map<Long, DungeonEditorStatePanelRoomNarrationDrafts.RoomDraft> roomDrafts = safeDrafts.rooms().stream()
+        List<DungeonEditorDraftState.RoomNarrationDraft> safeDrafts = narrationDrafts == null
+                ? List.of()
+                : List.copyOf(narrationDrafts);
+        Map<Long, DungeonEditorDraftState.RoomNarrationDraft> roomDrafts = safeDrafts.stream()
                 .collect(java.util.stream.Collectors.toMap(
-                        DungeonEditorStatePanelRoomNarrationDrafts.RoomDraft::roomId,
+                        DungeonEditorDraftState.RoomNarrationDraft::roomId,
                         draft -> draft,
                         (first, second) -> second));
         if (inspector == null) {
@@ -400,9 +388,9 @@ final class DungeonEditorStatePanelModel {
 
     private static DungeonEditorStatePanelModel.RoomNarrationCardProjection narrationCard(
             DungeonInspectorSnapshot.RoomNarrationCard card,
-            DungeonEditorStatePanelRoomNarrationDrafts.RoomDraft roomDraft
+            DungeonEditorDraftState.RoomNarrationDraft roomDraft
     ) {
-        Map<RoomExitKey, DungeonEditorStatePanelRoomNarrationDrafts.ExitDraft> exitDrafts = roomDraft == null
+        Map<RoomExitKey, DungeonEditorDraftState.ExitNarrationDraft> exitDrafts = roomDraft == null
                 ? Map.of()
                 : roomDraft.exits().stream()
                 .collect(java.util.stream.Collectors.toMap(
@@ -422,7 +410,7 @@ final class DungeonEditorStatePanelModel {
 
     private static DungeonEditorStatePanelModel.RoomExitNarrationProjection narrationExit(
             DungeonInspectorSnapshot.RoomExitNarration exit,
-            DungeonEditorStatePanelRoomNarrationDrafts.ExitDraft exitDraft
+            DungeonEditorDraftState.ExitNarrationDraft exitDraft
     ) {
         return new DungeonEditorStatePanelModel.RoomExitNarrationProjection(
                 exit.label(),
@@ -459,9 +447,9 @@ final class DungeonEditorStatePanelModel {
                     exit.direction());
         }
 
-        static RoomExitKey from(DungeonEditorStatePanelRoomNarrationDrafts.ExitDraft exit) {
-            DungeonEditorStatePanelRoomNarrationDrafts.ExitDraft safeExit = exit == null
-                    ? new DungeonEditorStatePanelRoomNarrationDrafts.ExitDraft("", 0, 0, 0, "", "", false)
+        static RoomExitKey from(DungeonEditorDraftState.ExitNarrationDraft exit) {
+            DungeonEditorDraftState.ExitNarrationDraft safeExit = exit == null
+                    ? new DungeonEditorDraftState.ExitNarrationDraft("", 0, 0, 0, "", "", false)
                     : exit;
             return new RoomExitKey(
                     safeExit.label(),
@@ -475,16 +463,15 @@ final class DungeonEditorStatePanelModel {
 
     private static final class SelectionPreviewPanel {
 
-    String stateTextFor(DungeonEditorPreparedFrameFacts.StatePanelFrame frame) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = frame == null
-                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
-                : frame;
-        return "Werkzeug: " + safeFrame.selectedToolLabel()
-                + "\nAnsicht: " + normalizeViewModeKey(safeFrame.viewModeLabel())
-                + "\nEbene: z=" + safeFrame.projectionLevel()
-                + "\n" + safeFrame.overlayLabel()
-                + "\n" + selectionTextFor(SelectionData.from(safeFrame.selectionTopologyRef()), safeFrame.inspector())
-                + "\n" + previewTextFor(safeFrame.preview());
+    String stateTextFor(DungeonEditorState state) {
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        return "Werkzeug: " + DungeonEditorControlsPanelModel.labelOf(safeState.selectedTool())
+                + "\nAnsicht: " + normalizeViewModeKey(safeState.viewMode().name())
+                + "\nEbene: z=" + safeState.projectionLevel()
+                + "\nOverlay: " + safeState.overlaySettings().modeKey()
+                + "\n" + selectionTextFor(
+                        SelectionData.from(safeState.selection().topologyRef()), safeState.inspector())
+                + "\n" + previewTextFor(safeState.preview());
     }
 
     private static String selectionTextFor(
@@ -572,15 +559,13 @@ final class DungeonEditorStatePanelModel {
 
     private static final class StairGeometryPanel {
     DungeonEditorStatePanelModel.@Nullable StairGeometryProjection stairGeometryProjection(
-            DungeonEditorPreparedFrameFacts.StatePanelFrame frame
+            DungeonEditorState state
     ) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = frame == null
-                ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty()
-                : frame;
-        DungeonTopologyElementRef topologyRef = safeFrame.selectionTopologyRef() == null
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        DungeonTopologyElementRef topologyRef = safeState.selection().topologyRef() == null
                 ? DungeonTopologyElementRef.empty()
-                : safeFrame.selectionTopologyRef();
-        DungeonInspectorSnapshot inspector = safeFrame.inspector();
+                : safeState.selection().topologyRef();
+        DungeonInspectorSnapshot inspector = safeState.inspector();
         long stairId = selectedStairId(topologyRef);
         if (stairId <= 0L || inspector == null) {
             return null;
@@ -589,7 +574,7 @@ final class DungeonEditorStatePanelModel {
         if (facts == null) {
             return null;
         }
-        StairGeometryFacts draft = currentStairGeometryFacts(safeFrame.stairGeometryDraft(), stairId, facts);
+        StairGeometryFacts draft = currentStairGeometryFacts(safeState.draft().stairGeometry(), stairId, facts);
         String label = inspector.title().isBlank() ? "Treppe " + stairId : inspector.title();
         return new DungeonEditorStatePanelModel.StairGeometryProjection(
                 stairId,
@@ -610,25 +595,25 @@ final class DungeonEditorStatePanelModel {
     }
 
     private static StairGeometryFacts currentStairGeometryFacts(
-            DungeonEditorStatePanelStairGeometryDrafts.Draft runtimeDraft,
+            DungeonEditorDraftState.StairGeometryDraft runtimeDraft,
             long stairId,
             StairGeometryFacts fallback
     ) {
-        DungeonEditorStatePanelStairGeometryDrafts.Draft safeDraft = runtimeDraft == null
-                ? DungeonEditorStatePanelStairGeometryDrafts.Draft.empty()
+        DungeonEditorDraftState.StairGeometryDraft safeDraft = runtimeDraft == null
+                ? DungeonEditorDraftState.StairGeometryDraft.empty()
                 : runtimeDraft;
         if (!runtimeStairDraftMatches(safeDraft, stairId)) {
             return fallback;
         }
         return new StairGeometryFacts(
-                safeDraft.shapeName(),
-                safeDraft.directionName(),
+                safeDraft.shape(),
+                safeDraft.direction(),
                 safeDraft.dimension1(),
                 safeDraft.dimension2());
     }
 
     private static boolean runtimeStairDraftMatches(
-            DungeonEditorStatePanelStairGeometryDrafts.Draft runtimeDraft,
+            DungeonEditorDraftState.StairGeometryDraft runtimeDraft,
             long stairId
     ) {
         return runtimeDraft.present() && runtimeDraft.targetPresent() && runtimeDraft.stairId() == stairId;
@@ -676,14 +661,14 @@ final class DungeonEditorStatePanelModel {
             new DestinationTypeOption(DESTINATION_DUNGEON_MAP, "Dungeon-Eingang"));
 
     DungeonEditorStatePanelModel.@Nullable TransitionDescriptionProjection transitionDescriptionProjection(
-            DungeonEditorPreparedFrameFacts.StatePanelFrame frame
+            DungeonEditorState state
     ) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = safeFrame(frame);
-        DungeonTopologyElementRef topologyRef = safeTopologyRef(safeFrame.selectionTopologyRef());
-        DungeonInspectorSnapshot inspector = safeFrame.inspector();
-        DungeonEditorStatePanelTransitionDescriptionDrafts.Draft runtimeDraft =
-                safeTransitionDescriptionDraft(safeFrame.transitionDescriptionDraft());
-        if (!runtimeDraft.targetPresent()
+        DungeonEditorState safeState = safeState(state);
+        DungeonTopologyElementRef topologyRef = safeTopologyRef(safeState.selection().topologyRef());
+        DungeonInspectorSnapshot inspector = safeState.inspector();
+        DungeonEditorDraftState.TransitionDescriptionDraft runtimeDraft =
+                safeTransitionDescriptionDraft(safeState.draft().transitionDescription());
+        if (runtimeDraft.transitionId() <= NO_TRANSITION_ID
                 || topologyRef.kind() != features.dungeon.api.DungeonTopologyElementKind.TRANSITION
                 || topologyRef.id() != runtimeDraft.transitionId()) {
             return null;
@@ -702,23 +687,24 @@ final class DungeonEditorStatePanelModel {
     }
 
     DungeonEditorStatePanelModel.@Nullable TransitionDestinationProjection transitionDestinationProjection(
-            DungeonEditorPreparedFrameFacts.StatePanelFrame frame
+            DungeonEditorState state
     ) {
-        DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame = safeFrame(frame);
-        if (safeFrame.selectedMapIdValue() <= NO_SELECTED_MAP_ID) {
+        DungeonEditorState safeState = safeState(state);
+        if (safeState.selectedMapId() == null || safeState.selectedMapId().value() <= NO_SELECTED_MAP_ID) {
             return null;
         }
-        DungeonTopologyElementRef topologyRef = safeTopologyRef(safeFrame.selectionTopologyRef());
+        DungeonTopologyElementRef topologyRef = safeTopologyRef(safeState.selection().topologyRef());
         long selectedTransitionId = selectedTransitionId(topologyRef);
-        if (!TRANSITION_CREATE_TOOL.equals(safeFrame.selectedToolKey()) && selectedTransitionId <= NO_TRANSITION_ID) {
+        if (!TRANSITION_CREATE_TOOL.equals(safeState.selectedTool().name())
+                && selectedTransitionId <= NO_TRANSITION_ID) {
             return null;
         }
-        DungeonEditorStatePanelTransitionDestinationDrafts.Draft runtimeDraft =
-                safeTransitionDestinationDraft(safeFrame.transitionDestinationDraft());
+        DungeonEditorDraftState.TransitionDestinationDraft runtimeDraft =
+                safeTransitionDestinationDraft(safeState.draft().transitionDestination());
         if (!runtimeDraft.targetPresent()) {
             return null;
         }
-        TransitionDestinationDraft baseline = TransitionDestinationDraft.fromTypedInspector(safeFrame.inspector());
+        TransitionDestinationDraft baseline = TransitionDestinationDraft.fromTypedInspector(safeState.inspector());
         TransitionDestinationDraft draft = runtimeDraft.present()
                 ? TransitionDestinationDraft.fromRuntimeDraft(runtimeDraft)
                 : baseline;
@@ -732,7 +718,7 @@ final class DungeonEditorStatePanelModel {
                 draft.tileId(),
                 draft.transitionId(),
                 draft.bidirectional(),
-                safeFrame.busy());
+                safeState.commandStatus().busy());
     }
 
     static String transitionDestinationTypeKey(int optionIndex) {
@@ -801,26 +787,24 @@ final class DungeonEditorStatePanelModel {
                 saveDisabled(safeProjection.busy(), linkMode, dungeonMapDestination, targetFieldsComplete));
     }
 
-    private static DungeonEditorPreparedFrameFacts.StatePanelFrame safeFrame(
-            DungeonEditorPreparedFrameFacts.StatePanelFrame frame
-    ) {
-        return frame == null ? DungeonEditorPreparedFrameFacts.StatePanelFrame.empty() : frame;
+    private static DungeonEditorState safeState(DungeonEditorState state) {
+        return state == null ? DungeonEditorState.empty() : state;
     }
 
     private static DungeonTopologyElementRef safeTopologyRef(DungeonTopologyElementRef topologyRef) {
         return topologyRef == null ? DungeonTopologyElementRef.empty() : topologyRef;
     }
 
-    private static DungeonEditorStatePanelTransitionDescriptionDrafts.Draft safeTransitionDescriptionDraft(
-            DungeonEditorStatePanelTransitionDescriptionDrafts.Draft draft
+    private static DungeonEditorDraftState.TransitionDescriptionDraft safeTransitionDescriptionDraft(
+            DungeonEditorDraftState.TransitionDescriptionDraft draft
     ) {
-        return draft == null ? DungeonEditorStatePanelTransitionDescriptionDrafts.Draft.empty() : draft;
+        return draft == null ? DungeonEditorDraftState.TransitionDescriptionDraft.empty() : draft;
     }
 
-    private static DungeonEditorStatePanelTransitionDestinationDrafts.Draft safeTransitionDestinationDraft(
-            DungeonEditorStatePanelTransitionDestinationDrafts.Draft draft
+    private static DungeonEditorDraftState.TransitionDestinationDraft safeTransitionDestinationDraft(
+            DungeonEditorDraftState.TransitionDestinationDraft draft
     ) {
-        return draft == null ? DungeonEditorStatePanelTransitionDestinationDrafts.Draft.empty() : draft;
+        return draft == null ? DungeonEditorDraftState.TransitionDestinationDraft.empty() : draft;
     }
 
     private static long selectedTransitionId(DungeonTopologyElementRef topologyRef) {
@@ -937,12 +921,12 @@ final class DungeonEditorStatePanelModel {
         }
 
         static TransitionDestinationDraft fromRuntimeDraft(
-                DungeonEditorStatePanelTransitionDestinationDrafts.Draft draft
+                DungeonEditorDraftState.TransitionDestinationDraft draft
         ) {
-            DungeonEditorStatePanelTransitionDestinationDrafts.Draft safeDraft =
-                    draft == null ? DungeonEditorStatePanelTransitionDestinationDrafts.Draft.empty() : draft;
+            DungeonEditorDraftState.TransitionDestinationDraft safeDraft =
+                    draft == null ? DungeonEditorDraftState.TransitionDestinationDraft.empty() : draft;
             return new TransitionDestinationDraft(
-                    safeDraft.destinationTypeKey(),
+                    safeDraft.destinationType(),
                     safeDraft.mapId(),
                     safeDraft.tileId(),
                     safeDraft.transitionId(),

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -5,32 +5,25 @@ import java.util.Objects;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
-import features.dungeon.application.editor.DungeonEditorControlOperations;
 import features.dungeon.application.editor.DungeonEditorInlineLabelEditSession;
 import features.dungeon.application.editor.DungeonEditorInlineLabelOperations;
-import features.dungeon.application.editor.DungeonEditorMapCatalogOperations;
 import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.application.editor.DungeonEditorOverlaySettings;
 import features.dungeon.application.editor.DungeonEditorPreparedFrameFacts;
 import features.dungeon.application.editor.DungeonEditorRenderFrame;
 import features.dungeon.application.editor.DungeonEditorPointerInteractionOperations;
-import features.dungeon.application.editor.DungeonEditorRuntimeLabelTarget;
 import features.dungeon.application.editor.DungeonEditorRuntimeOperations;
 import features.dungeon.application.editor.DungeonEditorRuntimePointerTarget;
-import features.dungeon.application.editor.DungeonEditorStatePanelDraftOperations;
-import features.dungeon.application.editor.DungeonEditorTransitionStairOperations;
-import features.dungeon.application.editor.ExitNarration;
-import features.dungeon.application.editor.ExitNarrationDraftInput;
 import features.dungeon.application.editor.PointerAction;
 import features.dungeon.application.editor.PointerInteractionRequest;
 import features.dungeon.application.editor.PointerInteractionResult;
 import features.dungeon.application.editor.PointerInteractionTargets;
 import features.dungeon.application.editor.PointerWorkflowGesture;
-import features.dungeon.application.editor.RoomNarration;
-import features.dungeon.application.editor.RoomNarrationDraftInput;
-import features.dungeon.application.editor.StairGeometryDraftInput;
 import features.dungeon.application.editor.TransitionDestination;
-import features.dungeon.application.editor.TransitionDestinationDraftInput;
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.editor.DungeonEditorApi;
+import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorState;
 import platform.ui.catalogcrud.CatalogCrudControlsContentModel;
 import platform.ui.catalogcrud.CatalogCrudControlsViewInputEvent;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel;
@@ -49,12 +42,9 @@ final class DungeonEditorViewModel {
     private final CatalogCrudControlsContentModel catalogContentModel;
     private final DungeonEditorStatePanelModel statePanelModel;
     private final DungeonMapContentModel mapContentModel;
-    private final DungeonEditorMapCatalogOperations catalogOperations;
-    private final DungeonEditorControlOperations controlOperations;
+    private final DungeonEditorApi editorApi;
     private final DungeonEditorPointerInteractionOperations pointerOperations;
-    private final DungeonEditorStatePanelDraftOperations statePanelDraftOperations;
     private final DungeonEditorInlineLabelOperations inlineLabelOperations;
-    private final DungeonEditorTransitionStairOperations transitionStairOperations;
     private double lastCameraDragCanvasX;
     private double lastCameraDragCanvasY;
     private boolean cameraDragActive;
@@ -66,19 +56,17 @@ final class DungeonEditorViewModel {
             DungeonEditorStatePanelModel statePanelModel,
             CatalogCrudControlsContentModel catalogContentModel,
             DungeonMapContentModel mapContentModel,
+            DungeonEditorApi editorApi,
             DungeonEditorRuntimeOperations operations
     ) {
         this.controlsPanelModel = Objects.requireNonNull(controlsPanelModel, "controlsPanelModel");
         this.catalogContentModel = Objects.requireNonNull(catalogContentModel, "catalogContentModel");
         this.statePanelModel = Objects.requireNonNull(statePanelModel, "statePanelModel");
         this.mapContentModel = Objects.requireNonNull(mapContentModel, "mapContentModel");
+        this.editorApi = Objects.requireNonNull(editorApi, "editorApi");
         DungeonEditorRuntimeOperations safeOperations = Objects.requireNonNull(operations, "operations");
-        this.catalogOperations = safeOperations.catalog();
-        this.controlOperations = safeOperations.controls();
         this.pointerOperations = safeOperations.pointer();
-        this.statePanelDraftOperations = safeOperations.statePanelDrafts();
         this.inlineLabelOperations = safeOperations.inlineLabels();
-        this.transitionStairOperations = safeOperations.transitionStairs();
     }
 
 
@@ -101,9 +89,13 @@ final class DungeonEditorViewModel {
         DungeonEditorRenderFrame safeFrame = frame == null ? DungeonEditorRenderFrame.empty() : frame;
         DungeonEditorPreparedFrameFacts facts = safeFrame.preparedFacts();
         interactionState = InteractionState.from(facts);
-        controlsProjection.set(ControlsProjection.from(facts));
-        statePanelModel.apply(facts.statePanelFrame());
         mapContentModel.applyEditorRenderFrame(frame);
+    }
+
+    void applyState(DungeonEditorState state) {
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        controlsProjection.set(ControlsProjection.from(safeState));
+        statePanelModel.apply(safeState);
     }
 
     private InteractionState currentInteractionState() {
@@ -226,7 +218,7 @@ final class DungeonEditorViewModel {
         int levelShift = projection.levelShift();
         if (levelShift != 0) {
             mapContentModel.clearHoverTarget();
-            controlOperations.shiftProjectionLevel(levelShift);
+            editorApi.dispatch(new DungeonEditorIntent.ShiftProjectionLevel(levelShift));
             return;
         }
         if (overlay.mode() != null) {
@@ -345,20 +337,20 @@ final class DungeonEditorViewModel {
 
     private void consumeTransitionDestinationWhenPresent(DungeonEditorStateInput.TransitionDestinationInput input) {
         if (input.inputObserved()) {
-            TransitionDestinationDraftInput draftInput = transitionDestinationDraftInput(input);
-            statePanelDraftOperations.updateStatePanelTransitionDestinationDraft(draftInput);
+            DungeonEditorIntent.TransitionDestinationInput draftInput = transitionDestinationDraftInput(input);
+            editorApi.dispatch(new DungeonEditorIntent.UpdateTransitionDestination(draftInput));
             if (input.saveRequested()) {
                 consumeTransitionLinkSave(draftInput);
             }
         }
     }
 
-    private void consumeTransitionLinkSave(TransitionDestinationDraftInput input) {
+    private void consumeTransitionLinkSave(DungeonEditorIntent.TransitionDestinationInput input) {
         long sourceTransitionId = selectedTransitionId();
         if (sourceTransitionId <= NO_TRANSITION_ID) {
             return;
         }
-        transitionStairOperations.saveTransitionLink(sourceTransitionId, input);
+        editorApi.dispatch(new DungeonEditorIntent.CommitTransitionDestination(sourceTransitionId, input));
     }
 
     private void consumeStairGeometryWhenPresent(DungeonEditorStateInput.StairGeometryInput input) {
@@ -368,49 +360,47 @@ final class DungeonEditorViewModel {
     }
 
     private void consumeNarrationInput(DungeonEditorStateInput.NarrationInput input) {
-        RoomNarrationDraftInput draftInput = toRoomNarrationDraftInput(input);
+        DungeonEditorIntent.RoomNarrationInput draftInput = toRoomNarrationInput(input);
         if (draftInput != null) {
-            statePanelDraftOperations.updateStatePanelRoomNarrationDraft(draftInput);
+            editorApi.dispatch(new DungeonEditorIntent.UpdateRoomNarration(draftInput));
         }
         if (!input.saveRequested()) {
             return;
         }
-        RoomNarration narration = toRoomNarration(input);
+        DungeonEditorIntent.RoomNarrationInput narration = toRoomNarrationInput(input);
         if (narration != null) {
-            transitionStairOperations.saveRoomNarration(narration);
+            editorApi.dispatch(new DungeonEditorIntent.CommitRoomNarration(narration));
         }
     }
 
     private void consumeLabelNameInput(DungeonEditorStateInput.LabelNameInput input) {
-        DungeonEditorRuntimeLabelTarget target = runtimeLabelTarget(statePanelModel.currentLabelNameTarget());
-        statePanelDraftOperations.updateStatePanelLabelNameDraft(
-                target,
-                input.name());
-        if (!input.saveRequested() || !target.present() || input.name().isBlank()) {
+        DungeonEditorIntent.LabelTarget target = apiLabelTarget(statePanelModel.currentLabelNameTarget());
+        editorApi.dispatch(new DungeonEditorIntent.UpdateLabelName(target, input.name()));
+        if (!input.saveRequested()
+                || target.kind() == DungeonEditorIntent.LabelTargetKind.EMPTY
+                || input.name().isBlank()) {
             return;
         }
-        transitionStairOperations.saveLabelName(
-                target,
-                input.name());
+        editorApi.dispatch(new DungeonEditorIntent.CommitLabelName(target, input.name()));
     }
 
-    private static DungeonEditorRuntimeLabelTarget runtimeLabelTarget(
+    private static DungeonEditorIntent.LabelTarget apiLabelTarget(
             DungeonEditorStatePanelModel.LabelNameTarget target
     ) {
         DungeonEditorStatePanelModel.LabelNameTarget safeTarget = target == null
                 ? DungeonEditorStatePanelModel.LabelNameTarget.empty()
                 : target;
         return switch (safeTarget.kind()) {
-            case ROOM -> DungeonEditorRuntimeLabelTarget.room(safeTarget.id());
-            case CLUSTER -> DungeonEditorRuntimeLabelTarget.cluster(safeTarget.id());
-            case EMPTY -> DungeonEditorRuntimeLabelTarget.empty();
+            case ROOM -> new DungeonEditorIntent.LabelTarget(
+                    DungeonEditorIntent.LabelTargetKind.ROOM, safeTarget.id());
+            case CLUSTER -> new DungeonEditorIntent.LabelTarget(
+                    DungeonEditorIntent.LabelTargetKind.CLUSTER, safeTarget.id());
+            case EMPTY -> DungeonEditorIntent.LabelTarget.empty();
         };
     }
 
     private void consumeCorridorPointInput(DungeonEditorStateInput.CorridorPointInput input) {
-        statePanelDraftOperations.updateStatePanelCorridorPointDraft(
-                input.q(),
-                input.r());
+        editorApi.dispatch(new DungeonEditorIntent.UpdateCorridorPoint(input.q(), input.r()));
         if (input.submitRequested()) {
             submitCorridorPointMove(input);
         }
@@ -419,53 +409,57 @@ final class DungeonEditorViewModel {
     private void consumeTransitionDescriptionInput(
             DungeonEditorStateInput.TransitionDescriptionInput input
     ) {
-        statePanelDraftOperations.updateStatePanelTransitionDescriptionDraft(
-                input.transitionId(),
-                input.description());
+        editorApi.dispatch(new DungeonEditorIntent.UpdateTransitionDescription(
+                input.transitionId(), input.description()));
         if (!input.saveRequested()) {
             return;
         }
         if (input.transitionId() > NO_TRANSITION_ID) {
-            transitionStairOperations.saveTransitionDescription(
-                    input.transitionId(),
-                    input.description());
+            editorApi.dispatch(new DungeonEditorIntent.CommitTransitionDescription(
+                    input.transitionId(), input.description()));
         }
     }
 
     private void consumeStairGeometryInput(
             DungeonEditorStateInput.StairGeometryInput input
     ) {
-        StairGeometryDraftInput draftInput = stairGeometryDraftInput(input);
-        statePanelDraftOperations.updateStatePanelStairGeometryDraft(draftInput);
+        DungeonEditorIntent.StairGeometryInput draftInput = stairGeometryInput(input);
+        editorApi.dispatch(new DungeonEditorIntent.UpdateStairGeometry(draftInput));
         if (!input.saveRequested()) {
             return;
         }
-        if (!draftInput.completeForSave()) {
+        if (!completeForSave(draftInput)) {
             return;
         }
-        transitionStairOperations.saveStairGeometry(draftInput);
+        editorApi.dispatch(new DungeonEditorIntent.CommitStairGeometry(draftInput));
     }
 
-    private static TransitionDestinationDraftInput transitionDestinationDraftInput(
+    private static DungeonEditorIntent.TransitionDestinationInput transitionDestinationDraftInput(
             DungeonEditorStateInput.TransitionDestinationInput input
     ) {
-        return TransitionDestinationDraftInput.fromExternalName(
-                new TransitionDestinationDraftInput.ExternalFields(
-                        DungeonEditorStatePanelModel.transitionDestinationTypeKey(
-                                input.destination().optionIndex()),
-                        input.mapId(),
-                        input.tileId(),
-                        input.transitionId(),
-                        input.bidirectional()));
+        return new DungeonEditorIntent.TransitionDestinationInput(
+                DungeonEditorStatePanelModel.transitionDestinationTypeKey(input.destination().optionIndex()),
+                input.mapId(),
+                input.tileId(),
+                input.transitionId(),
+                input.bidirectional());
     }
 
-    private static StairGeometryDraftInput stairGeometryDraftInput(DungeonEditorStateInput.StairGeometryInput input) {
-        return new StairGeometryDraftInput(
+    private static DungeonEditorIntent.StairGeometryInput stairGeometryInput(
+            DungeonEditorStateInput.StairGeometryInput input
+    ) {
+        return new DungeonEditorIntent.StairGeometryInput(
                 input.stairId(),
                 input.shape().externalName(),
                 input.direction().externalName(),
                 input.dimension1(),
                 input.dimension2());
+    }
+
+    private static boolean completeForSave(DungeonEditorIntent.StairGeometryInput input) {
+        return input.stairId() > 0L
+                && parseInteger(input.dimension1()).isPresent()
+                && parseInteger(input.dimension2()).isPresent();
     }
 
     private void consumeMapCanvas(DungeonMapViewInputEvent event) {
@@ -487,12 +481,12 @@ final class DungeonEditorViewModel {
         }
         if (UNDO_COMMAND.equals(event.textInput())) {
             mapContentModel.clearHoverTarget();
-            controlOperations.undo();
+            editorApi.dispatch(DungeonEditorIntent.Undo.INSTANCE);
             return true;
         }
         if (REDO_COMMAND.equals(event.textInput())) {
             mapContentModel.clearHoverTarget();
-            controlOperations.redo();
+            editorApi.dispatch(DungeonEditorIntent.Redo.INSTANCE);
             return true;
         }
         return false;
@@ -592,7 +586,7 @@ final class DungeonEditorViewModel {
         if (!event.input().escapePressed()) {
             return false;
         }
-        controlOperations.cancelActivePreviewSession();
+        editorApi.dispatch(DungeonEditorIntent.CancelPreview.INSTANCE);
         mapContentModel.clearHoverTarget();
         return true;
     }
@@ -764,7 +758,7 @@ final class DungeonEditorViewModel {
         }
         int levelDelta = normalizeLevelDelta(event.scrollDeltaY());
         if (levelDelta != 0) {
-            controlOperations.scrollSelection(levelDelta);
+            editorApi.dispatch(new DungeonEditorIntent.ScrollSelection(levelDelta));
         }
     }
 
@@ -823,7 +817,7 @@ final class DungeonEditorViewModel {
         if (selectedMapIdValue > noSelectedMapId
             && selectedMapIdValue != interactionState.currentSelectedMapIdValue()) {
             mapContentModel.clearHoverTarget();
-            catalogOperations.selectMap(selectedMapIdValue);
+            editorApi.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(selectedMapIdValue)));
         }
     }
 
@@ -831,7 +825,7 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (selectedMapIdValue > noSelectedMapId) {
             mapContentModel.clearHoverTarget();
-            catalogOperations.selectMap(selectedMapIdValue);
+            editorApi.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(selectedMapIdValue)));
         }
     }
 
@@ -877,7 +871,7 @@ final class DungeonEditorViewModel {
         }
         if (mapEditorUiState.isCreateMode()) {
             controlsPanelModel.closeMapEditor();
-            catalogOperations.createMap(draftName);
+            editorApi.dispatch(new DungeonEditorIntent.CreateMap(draftName));
             return;
         }
         if (mapEditorUiState.isRenameMode()) {
@@ -892,7 +886,7 @@ final class DungeonEditorViewModel {
             return;
         }
         controlsPanelModel.closeMapEditor();
-        catalogOperations.createMap(safeDraftName);
+        editorApi.dispatch(new DungeonEditorIntent.CreateMap(safeDraftName));
     }
 
     private void renameMap(long mapIdValue, String draftName) {
@@ -904,7 +898,8 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (mapIdValue > noSelectedMapId) {
             controlsPanelModel.closeMapEditor();
-            catalogOperations.renameMap(mapIdValue, safeDraftName);
+            editorApi.dispatch(new DungeonEditorIntent.RenameMap(
+                    new DungeonMapId(mapIdValue), safeDraftName));
         }
     }
 
@@ -912,7 +907,7 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (mapIdValue > noSelectedMapId) {
             controlsPanelModel.closeMapEditor();
-            catalogOperations.deleteMap(mapIdValue);
+            editorApi.dispatch(new DungeonEditorIntent.DeleteMap(new DungeonMapId(mapIdValue)));
         }
     }
 
@@ -921,7 +916,8 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (mapIdValue > noSelectedMapId) {
             controlsPanelModel.closeMapEditor();
-            catalogOperations.renameMap(mapIdValue, draftName);
+            editorApi.dispatch(new DungeonEditorIntent.RenameMap(
+                    new DungeonMapId(mapIdValue), draftName));
         }
     }
 
@@ -935,7 +931,7 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (mapIdValue > noSelectedMapId) {
             controlsPanelModel.closeMapEditor();
-            catalogOperations.deleteMap(mapIdValue);
+            editorApi.dispatch(new DungeonEditorIntent.DeleteMap(new DungeonMapId(mapIdValue)));
         }
     }
 
@@ -948,19 +944,19 @@ final class DungeonEditorViewModel {
         if (DungeonEditorControlsPanelModel.graphViewLabel().equals(normalizedViewModeKey)) {
             if (!normalizedViewModeKey.equals(selectedViewMode)) {
                 mapContentModel.clearHoverTarget();
-                controlOperations.setViewMode(projection.viewMode());
+                editorApi.dispatch(new DungeonEditorIntent.SetViewMode(projection.viewMode()));
             }
             return;
         }
         if (!normalizedViewModeKey.equals(selectedViewMode)) {
             mapContentModel.clearHoverTarget();
-            controlOperations.setViewMode(projection.viewMode());
+            editorApi.dispatch(new DungeonEditorIntent.SetViewMode(projection.viewMode()));
         }
     }
 
     private void handleToolInput(DungeonEditorControlsInput.ToolInput tool) {
         if (tool.dismissControlActivated()) {
-            controlOperations.cancelActivePreviewSession();
+            editorApi.dispatch(DungeonEditorIntent.CancelPreview.INSTANCE);
             return;
         }
         if (tool.selectedTool() == null) {
@@ -974,7 +970,7 @@ final class DungeonEditorViewModel {
                 tool.selectedOptionKey());
         if (!selectedToolControlKey.equals(interactionState.currentSelectedToolKey())) {
             mapContentModel.clearHoverTarget();
-            controlOperations.setTool(tool.selectedTool());
+            editorApi.dispatch(new DungeonEditorIntent.SetTool(tool.selectedTool()));
         }
     }
 
@@ -996,11 +992,8 @@ final class DungeonEditorViewModel {
                 && currentSelectedLevels.equals(selectedLevels)) {
             return;
         }
-        controlOperations.setOverlay(new DungeonEditorOverlaySettings(
-                overlay.mode(),
-                overlay.levelRange(),
-                overlay.opacity(),
-                selectedLevels));
+        editorApi.dispatch(new DungeonEditorIntent.SetOverlay(new DungeonOverlaySettings(
+                overlay.mode().name(), overlay.levelRange(), overlay.opacity(), selectedLevels)));
     }
 
     private static boolean hasMapEditorInput(DungeonEditorControlsInput.MapInput map) {
@@ -1042,7 +1035,8 @@ final class DungeonEditorViewModel {
         if (q.isEmpty() || r.isEmpty()) {
             return;
         }
-        statePanelDraftOperations.moveStatePanelCorridorPoint(q.orElseThrow(), r.orElseThrow());
+        editorApi.dispatch(new DungeonEditorIntent.CommitCorridorPoint(
+                q.orElseThrow(), r.orElseThrow()));
     }
 
     private static Optional<Integer> parseInteger(@Nullable String raw) {
@@ -1071,7 +1065,7 @@ final class DungeonEditorViewModel {
         }
     }
 
-    private @Nullable RoomNarration toRoomNarration(
+    private DungeonEditorIntent.@Nullable RoomNarrationInput toRoomNarrationInput(
             DungeonEditorStateInput.NarrationInput input
     ) {
         DungeonEditorStatePanelModel.RoomNarrationCardProjection card =
@@ -1079,27 +1073,11 @@ final class DungeonEditorViewModel {
         if (card == null) {
             return null;
         }
-        return new RoomNarration(
+        return new DungeonEditorIntent.RoomNarrationInput(
                 card.roomId(),
                 input.visualDescription(),
                 narrationExits(card, input.exitDescriptions()).stream()
-                        .map(DungeonEditorViewModel::toExitNarration)
-                        .toList());
-    }
-
-    private @Nullable RoomNarrationDraftInput toRoomNarrationDraftInput(
-            DungeonEditorStateInput.NarrationInput input
-    ) {
-        DungeonEditorStatePanelModel.RoomNarrationCardProjection card =
-                statePanelModel.currentNarrationCard(input.roomId());
-        if (card == null) {
-            return null;
-        }
-        return new RoomNarrationDraftInput(
-                card.roomId(),
-                input.visualDescription(),
-                narrationExits(card, input.exitDescriptions()).stream()
-                        .map(DungeonEditorViewModel::toExitNarrationDraftInput)
+                        .map(DungeonEditorViewModel::toExitNarrationInput)
                         .toList());
     }
 
@@ -1120,20 +1098,10 @@ final class DungeonEditorViewModel {
                 .toList();
     }
 
-    private static ExitNarration toExitNarration(DungeonEditorStatePanelModel.RoomExitNarrationProjection exit) {
-        return new ExitNarration(
-                exit.label(),
-                exit.q(),
-                exit.r(),
-                exit.level(),
-                exit.direction(),
-                exit.description());
-    }
-
-    private static ExitNarrationDraftInput toExitNarrationDraftInput(
+    private static DungeonEditorIntent.ExitNarrationInput toExitNarrationInput(
             DungeonEditorStatePanelModel.RoomExitNarrationProjection exit
     ) {
-        return new ExitNarrationDraftInput(
+        return new DungeonEditorIntent.ExitNarrationInput(
                 exit.label(),
                 exit.q(),
                 exit.r(),
@@ -1179,25 +1147,28 @@ final class DungeonEditorViewModel {
                     DungeonEditorControlsPanelModel.defaultToolLabel());
         }
 
-        static ControlsProjection from(DungeonEditorPreparedFrameFacts facts) {
-            DungeonEditorPreparedFrameFacts safeFacts =
-                    facts == null ? DungeonEditorPreparedFrameFacts.empty() : facts;
+        static ControlsProjection from(DungeonEditorState state) {
+            DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
             return new ControlsProjection(
-                    safeFacts.mapEntries().stream()
+                    safeState.catalog().stream()
                             .map(entry -> new MapListEntry(
-                                    entry.key(),
-                                    entry.mapIdValue(),
+                                    Long.toString(entry.mapId().value()),
+                                    entry.mapId().value(),
                                     entry.mapName(),
                                     entry.revision()))
                             .toList(),
-                    safeFacts.selectedMapKey(),
-                    safeFacts.reachableLevels(),
-                    safeFacts.busy(),
-                    safeFacts.statusText(),
-                    safeFacts.viewModeLabel(),
-                    safeFacts.overlaySettings(),
-                    safeFacts.projectionLevel(),
-                    safeFacts.selectedToolLabel());
+                    safeState.selectedMapId() == null
+                            ? ""
+                            : Long.toString(safeState.selectedMapId().value()),
+                    safeState.reachableLevels(),
+                    safeState.commandStatus().busy(),
+                    safeState.commandStatus().message(),
+                    safeState.viewMode() == features.dungeon.api.DungeonEditorViewMode.GRAPH
+                            ? DungeonEditorControlsPanelModel.graphViewLabel()
+                            : DungeonEditorControlsPanelModel.gridViewLabel(),
+                    safeState.overlaySettings(),
+                    safeState.projectionLevel(),
+                    DungeonEditorControlsPanelModel.labelOf(safeState.selectedTool()));
         }
     }
 

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -4,6 +4,7 @@ import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonMapId;
 import features.dungeon.api.DungeonOverlaySettings;
+import java.util.List;
 
 /** Typed editor inputs introduced ahead of the JavaFX consumer migration. */
 public sealed interface DungeonEditorIntent {
@@ -75,10 +76,179 @@ public sealed interface DungeonEditorIntent {
         INSTANCE
     }
 
+    record UpdateRoomNarration(RoomNarrationInput narration) implements DungeonEditorIntent {
+        public UpdateRoomNarration {
+            narration = narration == null ? RoomNarrationInput.empty() : narration;
+        }
+    }
+
+    record CommitRoomNarration(RoomNarrationInput narration) implements DungeonEditorIntent {
+        public CommitRoomNarration {
+            narration = narration == null ? RoomNarrationInput.empty() : narration;
+        }
+    }
+
+    record UpdateLabelName(LabelTarget target, String name) implements DungeonEditorIntent {
+        public UpdateLabelName {
+            target = target == null ? LabelTarget.empty() : target;
+            name = safeText(name);
+        }
+    }
+
+    record CommitLabelName(LabelTarget target, String name) implements DungeonEditorIntent {
+        public CommitLabelName {
+            target = target == null ? LabelTarget.empty() : target;
+            name = safeText(name);
+        }
+    }
+
+    record UpdateCorridorPoint(String q, String r) implements DungeonEditorIntent {
+        public UpdateCorridorPoint {
+            q = safeText(q);
+            r = safeText(r);
+        }
+    }
+
+    record CommitCorridorPoint(int q, int r) implements DungeonEditorIntent {
+    }
+
+    record UpdateTransitionDescription(long transitionId, String description) implements DungeonEditorIntent {
+        public UpdateTransitionDescription {
+            transitionId = Math.max(0L, transitionId);
+            description = safeText(description);
+        }
+    }
+
+    record CommitTransitionDescription(long transitionId, String description) implements DungeonEditorIntent {
+        public CommitTransitionDescription {
+            transitionId = Math.max(0L, transitionId);
+            description = safeText(description);
+        }
+    }
+
+    record UpdateTransitionDestination(TransitionDestinationInput destination) implements DungeonEditorIntent {
+        public UpdateTransitionDestination {
+            destination = destination == null ? TransitionDestinationInput.empty() : destination;
+        }
+    }
+
+    record CommitTransitionDestination(
+            long sourceTransitionId,
+            TransitionDestinationInput destination
+    ) implements DungeonEditorIntent {
+        public CommitTransitionDestination {
+            sourceTransitionId = Math.max(0L, sourceTransitionId);
+            destination = destination == null ? TransitionDestinationInput.empty() : destination;
+        }
+    }
+
+    record UpdateStairGeometry(StairGeometryInput geometry) implements DungeonEditorIntent {
+        public UpdateStairGeometry {
+            geometry = geometry == null ? StairGeometryInput.empty() : geometry;
+        }
+    }
+
+    record CommitStairGeometry(StairGeometryInput geometry) implements DungeonEditorIntent {
+        public CommitStairGeometry {
+            geometry = geometry == null ? StairGeometryInput.empty() : geometry;
+        }
+    }
+
+    record RoomNarrationInput(long roomId, String visualDescription, List<ExitNarrationInput> exits) {
+        public RoomNarrationInput {
+            roomId = Math.max(0L, roomId);
+            visualDescription = safeText(visualDescription);
+            exits = exits == null ? List.of() : List.copyOf(exits);
+        }
+
+        public static RoomNarrationInput empty() {
+            return new RoomNarrationInput(0L, "", List.of());
+        }
+    }
+
+    record ExitNarrationInput(
+            String label,
+            int q,
+            int r,
+            int level,
+            String direction,
+            String description
+    ) {
+        public ExitNarrationInput {
+            label = safeText(label);
+            direction = safeText(direction);
+            description = safeText(description);
+        }
+    }
+
+    record LabelTarget(LabelTargetKind kind, long id) {
+        public LabelTarget {
+            kind = kind == null ? LabelTargetKind.EMPTY : kind;
+            id = Math.max(0L, id);
+            if (kind == LabelTargetKind.EMPTY || id == 0L) {
+                kind = LabelTargetKind.EMPTY;
+                id = 0L;
+            }
+        }
+
+        public static LabelTarget empty() {
+            return new LabelTarget(LabelTargetKind.EMPTY, 0L);
+        }
+    }
+
+    enum LabelTargetKind {
+        EMPTY,
+        ROOM,
+        CLUSTER
+    }
+
+    record TransitionDestinationInput(
+            String destinationTypeKey,
+            String mapId,
+            String tileId,
+            String transitionId,
+            boolean bidirectional
+    ) {
+        public TransitionDestinationInput {
+            destinationTypeKey = safeText(destinationTypeKey);
+            mapId = safeText(mapId);
+            tileId = safeText(tileId);
+            transitionId = safeText(transitionId);
+        }
+
+        public static TransitionDestinationInput empty() {
+            return new TransitionDestinationInput("UNLINKED_ENTRANCE", "", "", "", true);
+        }
+    }
+
+    record StairGeometryInput(
+            long stairId,
+            String shapeName,
+            String directionName,
+            String dimension1,
+            String dimension2
+    ) {
+        public StairGeometryInput {
+            stairId = Math.max(0L, stairId);
+            shapeName = safeText(shapeName);
+            directionName = safeText(directionName);
+            dimension1 = safeText(dimension1);
+            dimension2 = safeText(dimension2);
+        }
+
+        public static StairGeometryInput empty() {
+            return new StairGeometryInput(0L, "", "", "", "");
+        }
+    }
+
     private static String cleanName(String mapName) {
         if (mapName == null || mapName.isBlank()) {
             throw new IllegalArgumentException("mapName is required");
         }
         return mapName.strip();
+    }
+
+    private static String safeText(String value) {
+        return value == null ? "" : value;
     }
 }

--- a/features/dungeon/api/editor/DungeonEditorState.java
+++ b/features/dungeon/api/editor/DungeonEditorState.java
@@ -21,6 +21,7 @@ public record DungeonEditorState(
         @Nullable DungeonEditorSurface selectedWindow,
         DungeonEditorViewMode viewMode,
         DungeonEditorTool selectedTool,
+        DungeonEditorToolSelection toolSelection,
         DungeonOverlaySettings overlaySettings,
         int projectionLevel,
         List<Integer> reachableLevels,
@@ -36,6 +37,7 @@ public record DungeonEditorState(
         catalog = catalog == null ? List.of() : List.copyOf(catalog);
         viewMode = viewMode == null ? DungeonEditorViewMode.GRID : viewMode;
         selectedTool = selectedTool == null ? DungeonEditorTool.SELECT : selectedTool;
+        toolSelection = toolSelection == null ? DungeonEditorToolSelection.select() : toolSelection;
         overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
         reachableLevels = reachableLevels == null ? List.of(0) : List.copyOf(reachableLevels);
         selection = selection == null ? DungeonEditorStateSnapshot.Selection.empty() : selection;
@@ -53,6 +55,7 @@ public record DungeonEditorState(
                 null,
                 DungeonEditorViewMode.GRID,
                 DungeonEditorTool.SELECT,
+                DungeonEditorToolSelection.select(),
                 DungeonOverlaySettings.defaults(),
                 0,
                 List.of(0),

--- a/features/dungeon/api/editor/DungeonEditorToolFamily.java
+++ b/features/dungeon/api/editor/DungeonEditorToolFamily.java
@@ -1,0 +1,13 @@
+package features.dungeon.api.editor;
+
+/** User-facing Dungeon Editor tool families published by the Editor API. */
+public enum DungeonEditorToolFamily {
+    SELECT,
+    ROOM,
+    WALL,
+    DOOR,
+    CORRIDOR,
+    FEATURE,
+    STAIR,
+    TRANSITION
+}

--- a/features/dungeon/api/editor/DungeonEditorToolSelection.java
+++ b/features/dungeon/api/editor/DungeonEditorToolSelection.java
@@ -1,0 +1,16 @@
+package features.dungeon.api.editor;
+
+/** Active tool family and its currently selected option. */
+public record DungeonEditorToolSelection(
+        DungeonEditorToolFamily family,
+        String optionKey
+) {
+    public DungeonEditorToolSelection {
+        family = family == null ? DungeonEditorToolFamily.SELECT : family;
+        optionKey = optionKey == null || optionKey.isBlank() ? "SELECT" : optionKey.strip();
+    }
+
+    public static DungeonEditorToolSelection select() {
+        return new DungeonEditorToolSelection(DungeonEditorToolFamily.SELECT, "SELECT");
+    }
+}

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -6,6 +6,8 @@ import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.editor.DungeonEditorDraftState;
 import features.dungeon.api.editor.DungeonEditorIntent;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,9 +72,87 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
             runtimeRoot.undo();
         } else if (safeIntent == DungeonEditorIntent.Redo.INSTANCE) {
             runtimeRoot.redo();
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateRoomNarration update) {
+            runtimeRoot.updateStatePanelRoomNarrationDraft(roomNarrationDraftFrom(update.narration()));
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitRoomNarration commit) {
+            runtimeRoot.saveRoomNarration(roomNarrationFrom(commit.narration()));
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateLabelName update) {
+            runtimeRoot.updateStatePanelLabelNameDraft(labelTargetFrom(update.target()), update.name());
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitLabelName commit) {
+            runtimeRoot.saveLabelName(labelTargetFrom(commit.target()), commit.name());
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateCorridorPoint update) {
+            runtimeRoot.updateStatePanelCorridorPointDraft(update.q(), update.r());
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitCorridorPoint commit) {
+            runtimeRoot.moveStatePanelCorridorPoint(commit.q(), commit.r());
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateTransitionDescription update) {
+            runtimeRoot.updateStatePanelTransitionDescriptionDraft(
+                    update.transitionId(), update.description());
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitTransitionDescription commit) {
+            runtimeRoot.saveTransitionDescription(commit.transitionId(), commit.description());
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateTransitionDestination update) {
+            runtimeRoot.updateStatePanelTransitionDestinationDraft(destinationFrom(update.destination()));
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitTransitionDestination commit) {
+            runtimeRoot.saveTransitionLink(commit.sourceTransitionId(), destinationFrom(commit.destination()));
+        } else if (safeIntent instanceof DungeonEditorIntent.UpdateStairGeometry update) {
+            runtimeRoot.updateStatePanelStairGeometryDraft(stairFrom(update.geometry()));
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitStairGeometry commit) {
+            runtimeRoot.saveStairGeometry(stairFrom(commit.geometry()));
         } else {
             throw new IllegalArgumentException("Unsupported Dungeon Editor intent: " + safeIntent.getClass());
         }
+    }
+
+    private static RoomNarrationDraftInput roomNarrationDraftFrom(
+            DungeonEditorIntent.RoomNarrationInput input
+    ) {
+        return new RoomNarrationDraftInput(
+                input.roomId(),
+                input.visualDescription(),
+                input.exits().stream()
+                        .map(exit -> new ExitNarrationDraftInput(
+                                exit.label(), exit.q(), exit.r(), exit.level(),
+                                exit.direction(), exit.description()))
+                        .toList());
+    }
+
+    private static RoomNarration roomNarrationFrom(DungeonEditorIntent.RoomNarrationInput input) {
+        return new RoomNarration(
+                input.roomId(),
+                input.visualDescription(),
+                input.exits().stream()
+                        .map(exit -> new ExitNarration(
+                                exit.label(), exit.q(), exit.r(), exit.level(),
+                                exit.direction(), exit.description()))
+                        .toList());
+    }
+
+    private static DungeonEditorRuntimeLabelTarget labelTargetFrom(DungeonEditorIntent.LabelTarget target) {
+        return switch (target.kind()) {
+            case ROOM -> DungeonEditorRuntimeLabelTarget.room(target.id());
+            case CLUSTER -> DungeonEditorRuntimeLabelTarget.cluster(target.id());
+            case EMPTY -> DungeonEditorRuntimeLabelTarget.empty();
+        };
+    }
+
+    private static TransitionDestinationDraftInput destinationFrom(
+            DungeonEditorIntent.TransitionDestinationInput input
+    ) {
+        return TransitionDestinationDraftInput.fromExternalName(
+                new TransitionDestinationDraftInput.ExternalFields(
+                        input.destinationTypeKey(),
+                        input.mapId(),
+                        input.tileId(),
+                        input.transitionId(),
+                        input.bidirectional()));
+    }
+
+    private static StairGeometryDraftInput stairFrom(DungeonEditorIntent.StairGeometryInput input) {
+        return new StairGeometryDraftInput(
+                input.stairId(),
+                input.shapeName(),
+                input.directionName(),
+                input.dimension1(),
+                input.dimension2());
     }
 
     private static DungeonEditorOverlaySettings overlayFrom(DungeonEditorIntent.SetOverlay intent) {
@@ -113,6 +193,7 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                 mapSurface.surface(),
                 mapSurface.viewMode(),
                 mapSurface.selectedTool(),
+                toolSelectionFrom(mapSurface.selectedTool()),
                 mapSurface.overlaySettings(),
                 mapSurface.projectionLevel(),
                 facts.reachableLevels(),
@@ -121,6 +202,32 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                 mapSurface.preview(),
                 statePanel.inspector(),
                 new DungeonEditorState.CommandStatus(facts.busy(), facts.statusText()));
+    }
+
+    private static DungeonEditorToolSelection toolSelectionFrom(features.dungeon.api.DungeonEditorTool tool) {
+        features.dungeon.api.DungeonEditorTool safeTool = tool == null
+                ? features.dungeon.api.DungeonEditorTool.SELECT
+                : tool;
+        String key = safeTool.name();
+        DungeonEditorToolFamily family;
+        if (key.startsWith("ROOM_")) {
+            family = DungeonEditorToolFamily.ROOM;
+        } else if (key.startsWith("WALL_")) {
+            family = DungeonEditorToolFamily.WALL;
+        } else if (key.startsWith("DOOR_")) {
+            family = DungeonEditorToolFamily.DOOR;
+        } else if (key.startsWith("CORRIDOR_")) {
+            family = DungeonEditorToolFamily.CORRIDOR;
+        } else if (key.startsWith("FEATURE_")) {
+            family = DungeonEditorToolFamily.FEATURE;
+        } else if (key.startsWith("STAIR_")) {
+            family = DungeonEditorToolFamily.STAIR;
+        } else if (key.startsWith("TRANSITION_")) {
+            family = DungeonEditorToolFamily.TRANSITION;
+        } else {
+            family = DungeonEditorToolFamily.SELECT;
+        }
+        return new DungeonEditorToolSelection(family, key);
     }
 
     private static DungeonEditorDraftState draftFrom(

--- a/test/architecture/system/DungeonEditorMigrationBoundaryTest.java
+++ b/test/architecture/system/DungeonEditorMigrationBoundaryTest.java
@@ -24,7 +24,6 @@ public final class DungeonEditorMigrationBoundaryTest {
             "features.dungeon.adapter.javafx.editor.DungeonEditorControlsPanelModel",
             "features.dungeon.adapter.javafx.editor.DungeonEditorControlsView",
             "features.dungeon.adapter.javafx.editor.DungeonEditorFeatureShellBinding",
-            "features.dungeon.adapter.javafx.editor.DungeonEditorStatePanelModel",
             "features.dungeon.adapter.javafx.editor.DungeonEditorViewModel",
             "features.dungeon.adapter.javafx.map.DungeonMapContentModel",
             "features.dungeon.adapter.javafx.map.DungeonMapEditorHandleProjector",

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -24,6 +24,7 @@ import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.editor.DungeonEditorIntent;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
 import features.party.PartyServiceAssembly;
 import features.party.domain.roster.PartyRoster;
 import features.party.domain.roster.repository.PartyRosterRepository;
@@ -61,6 +62,8 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         assertEquals(current.preview(), published.preview());
         assertEquals(current.inspector(), published.inspector());
         assertEquals(current.commandStatus(), published.commandStatus());
+        assertEquals(DungeonEditorToolFamily.SELECT, published.toolSelection().family());
+        assertEquals("SELECT", published.toolSelection().optionKey());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- route Dungeon Editor controls and state pane through the atomic Editor API
- add typed state-pane intents and published tool-family selection
- shrink the temporary JavaFX-to-Application debt ledger

## Proof
- ./gradlew test --tests 'features.dungeon.application.editor.DungeonEditorRuntimeThreadOwnershipTest' --console=plain
- ./gradlew uiTest --tests 'features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest' --console=plain
- ./gradlew architectureTest --tests 'architecture.system.DungeonEditorMigrationBoundaryTest' --console=plain
- ./gradlew check --console=plain