### PR TITLE
feat: typisiere Dungeon-Editor-Werkzeuggrenze

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,15 +97,16 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 is complete, and M1 slices 1 through 3 are complete on
-  `main` through PRs #489 through #492.
-- This slice: M1 slice 4 makes `DungeonEditorState` the internal atomic
-  publication, removes compatibility readbacks and prepared render frames, and
-  installs the permanent API-only Dungeon JavaFX architecture rule.
-- Next step after this slice merges: M2 canonicalizes Editor language and adds
-  typed command outcomes.
-- Remaining M1 boundary: none; M1 is complete when this slice merges with a
-  green `check`.
+- Current foundation: M0 and M1 are complete on `main` through PR #493.
+- This slice: M2.1 replaces the public Editor create/delete tool variants and
+  string option keys with typed `ToolFamily`, `ToolOptions`, and
+  `PointerGesture` values, and moves the JavaFX consumer to that boundary.
+- Temporary boundary in this slice: one application-owned adapter maps the new
+  API language to the legacy runtime tool enum. No API or JavaFX caller may use
+  that enum.
+- Next step after this slice merges: M2.2 makes the typed family and gesture
+  language canonical inside the runtime and deletes that adapter, the old tool
+  enum, and tool-name translation.
 
 ## M0: Target Lock And Baseline
 
@@ -228,6 +229,22 @@ Make the model and interaction language express product concepts once.
   treating an unchanged map as the only rejection signal
 - make corridor routing an injected domain policy so a richer route finder can
   replace the initial orthogonal policy without changing editor commands
+
+### Migration Slices
+
+1. Publish typed tool families, family-specific options, and pointer gestures;
+   move the JavaFX consumer and retain only one application adapter to the old
+   runtime language.
+2. Make family and gesture semantics canonical in the runtime; delete the old
+   create/delete tool enum, registry, and tool-name translation.
+3. Publish typed accepted or rejected outcomes and map stable rejection reasons
+   to specific status messages.
+4. Establish `RoomRegion` and `RoomCluster` ownership and collapse same-layer
+   room and cluster wrapper/core pairs.
+5. Remove the remaining duplicate primitives and enum-name round trips within
+   the milestone boundary.
+6. Inject corridor routing, move feature-marker semantic edits to the typed
+   command path, and close the M2 architecture and behavior gates.
 
 ### Exit Gate
 

--- a/features/dungeon/adapter/javafx/DungeonEditorToolPresentation.java
+++ b/features/dungeon/adapter/javafx/DungeonEditorToolPresentation.java
@@ -1,0 +1,76 @@
+package features.dungeon.adapter.javafx;
+
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolOptions;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
+
+/** JavaFX-owned labels for typed Dungeon Editor tool language. */
+public final class DungeonEditorToolPresentation {
+    private DungeonEditorToolPresentation() {
+    }
+
+    public static String label(DungeonEditorToolSelection selection) {
+        DungeonEditorToolSelection safeSelection = safe(selection);
+        return switch (safeSelection.family()) {
+            case SELECT -> "Auswahl";
+            case ROOM -> "Raum malen";
+            case WALL -> "Wand setzen";
+            case DOOR -> "Tür setzen";
+            case CORRIDOR -> "Korridor erstellen";
+            case STAIR -> "Treppe erstellen";
+            case TRANSITION -> "Übergang erstellen";
+            case FEATURE -> featureLabel(safeSelection.options());
+        };
+    }
+
+    public static String familyLabel(DungeonEditorToolFamily family) {
+        DungeonEditorToolFamily safeFamily = family == null ? DungeonEditorToolFamily.SELECT : family;
+        return switch (safeFamily) {
+            case SELECT -> "Auswahl";
+            case ROOM -> "Raum";
+            case WALL -> "Wand";
+            case DOOR -> "Tür";
+            case CORRIDOR -> "Korridor";
+            case FEATURE -> "Feature";
+            case STAIR -> "Treppe";
+            case TRANSITION -> "Übergang";
+        };
+    }
+
+    public static String optionLabel(DungeonEditorToolSelection selection) {
+        DungeonEditorToolOptions options = safe(selection).options();
+        if (options instanceof DungeonEditorToolOptions.Wall wall) {
+            return wall.mode() == DungeonEditorToolOptions.Wall.Mode.SINGLE ? "Einzeln" : "Pfad";
+        }
+        if (options instanceof DungeonEditorToolOptions.Stair stair) {
+            return switch (stair.shape()) {
+                case STRAIGHT -> "Gerade";
+                case SQUARE -> "Eckspirale";
+                case CIRCULAR -> "Rundspirale";
+            };
+        }
+        if (options instanceof DungeonEditorToolOptions.Feature feature) {
+            return switch (feature.kind()) {
+                case POINT_OF_INTEREST -> "POI";
+                case OBJECT -> "Objekt";
+                case ENCOUNTER -> "Encounter";
+            };
+        }
+        return familyLabel(safe(selection).family());
+    }
+
+    private static String featureLabel(DungeonEditorToolOptions options) {
+        if (!(options instanceof DungeonEditorToolOptions.Feature feature)) {
+            return "POI erstellen";
+        }
+        return switch (feature.kind()) {
+            case POINT_OF_INTEREST -> "POI erstellen";
+            case OBJECT -> "Objekt erstellen";
+            case ENCOUNTER -> "Encounter erstellen";
+        };
+    }
+
+    private static DungeonEditorToolSelection safe(DungeonEditorToolSelection selection) {
+        return selection == null ? DungeonEditorToolSelection.select() : selection;
+    }
+}

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorControlsInput.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorControlsInput.java
@@ -1,7 +1,7 @@
 package features.dungeon.adapter.javafx.editor;
 
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 record DungeonEditorControlsInput(
         MapInput map,
@@ -49,18 +49,11 @@ record DungeonEditorControlsInput(
     }
 
     record ToolInput(
-            String requestedFamilyKey,
-            DungeonEditorTool selectedTool,
-            String selectedOptionKey,
+            DungeonEditorToolSelection selection,
             boolean dismissControlActivated
     ) {
-        ToolInput {
-            requestedFamilyKey = requestedFamilyKey == null ? "" : requestedFamilyKey.strip();
-            selectedOptionKey = selectedOptionKey == null ? "" : selectedOptionKey.strip();
-        }
-
         static ToolInput none() {
-            return new ToolInput("", null, "", false);
+            return new ToolInput(null, false);
         }
     }
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorControlsPanelModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorControlsPanelModel.java
@@ -8,7 +8,10 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.api.DungeonOverlaySettings;
-import features.dungeon.api.DungeonEditorTool;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolOptions;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.adapter.javafx.DungeonEditorToolPresentation;
 import features.dungeon.adapter.javafx.editor.DungeonEditorControlsInput.OverlayMode;
 
 final class DungeonEditorControlsPanelModel {
@@ -39,7 +42,7 @@ final class DungeonEditorControlsPanelModel {
             String viewMode,
             DungeonOverlaySettings overlaySettings,
             int projectionLevel,
-            String selectedTool
+            DungeonEditorToolSelection toolSelection
     ) {
         MapProjection nextMapProjection = mapCatalog.showMapCatalog(maps, selectedKey, busy, statusText);
         boolean hasMap = !nextMapProjection.selectedKey().isBlank();
@@ -50,7 +53,7 @@ final class DungeonEditorControlsPanelModel {
                 overlaySettings,
                 projectionLevel,
                 viewMode);
-        toolPalette.showSelectedTool(selectedTool);
+        toolPalette.showSelectedTool(toolSelection);
     }
 
     List<OverlayModeOption> overlayModeOptions() {
@@ -61,12 +64,8 @@ final class DungeonEditorControlsPanelModel {
         return toolPalette.toolControls();
     }
 
-    void rememberToolSelection(
-            String requestedFamilyKey,
-            DungeonEditorTool selectedTool,
-            String selectedOptionKey
-    ) {
-        toolPalette.rememberToolSelection(requestedFamilyKey, selectedTool, selectedOptionKey);
+    void rememberToolSelection(DungeonEditorToolSelection selection) {
+        toolPalette.rememberToolSelection(selection);
     }
 
     MapEditorUiState currentMapEditorUiState() {
@@ -308,11 +307,9 @@ final class DungeonEditorControlsPanelModel {
         }
     }
 
-    record ToolProjection(String selectedTool, ToolControls toolControls) {
+    record ToolProjection(DungeonEditorToolSelection selection, ToolControls toolControls) {
         ToolProjection {
-            selectedTool = selectedTool == null || selectedTool.isBlank()
-                    ? defaultToolLabel()
-                    : selectedTool;
+            selection = selection == null ? DungeonEditorToolSelection.select() : selection;
             toolControls = toolControls == null
                     ? ToolPalettePanel.defaultToolControls()
                     : toolControls;
@@ -320,7 +317,7 @@ final class DungeonEditorControlsPanelModel {
 
         static ToolProjection initial() {
             return new ToolProjection(
-                    defaultToolLabel(),
+                    DungeonEditorToolSelection.select(),
                     ToolPalettePanel.defaultToolControls());
         }
     }
@@ -341,51 +338,46 @@ final class DungeonEditorControlsPanelModel {
     }
 
     record ToolFamilyButton(
-            String familyKey,
+            DungeonEditorToolFamily family,
             String label,
-            String selectedOptionKey,
+            DungeonEditorToolSelection selectedOption,
             List<ToolButton> options
     ) {
         ToolFamilyButton {
-            familyKey = familyKey == null ? "" : familyKey;
+            family = family == null ? DungeonEditorToolFamily.SELECT : family;
             label = label == null ? "" : label;
-            selectedOptionKey = selectedOptionKey == null ? "" : selectedOptionKey;
+            selectedOption = selectedOption == null ? DungeonEditorToolSelection.family(family) : selectedOption;
             options = options == null ? List.of() : List.copyOf(options);
         }
 
-        ToolButton selectedOption() {
+        ToolButton selectedButton() {
             for (ToolButton option : options) {
-                if (option.key().equals(selectedOptionKey)) {
+                if (option.selection().equals(selectedOption)) {
                     return option;
                 }
             }
-            return options.isEmpty() ? new ToolButton(label, label, selectedOptionKey) : options.getFirst();
+            return options.isEmpty() ? new ToolButton(label, label, selectedOption, true) : options.getFirst();
         }
 
         boolean hasSecondaryOptions() {
             return options.size() > 1;
         }
 
-        boolean selectedByLabel(String selectedToolLabel) {
-            for (ToolButton option : options) {
-                if (option.selectedLabel().equals(selectedToolLabel)) {
-                    return true;
-                }
-            }
-            return false;
+        boolean selectedBy(DungeonEditorToolSelection selection) {
+            return selection != null && family == selection.family();
         }
     }
 
-    record ToolButton(String label, String selectedLabel, String key, DungeonEditorTool tool, boolean enabled) {
+    record ToolButton(
+            String label,
+            String selectedLabel,
+            DungeonEditorToolSelection selection,
+            boolean enabled
+    ) {
         ToolButton {
             label = label == null ? "" : label;
             selectedLabel = selectedLabel == null ? "" : selectedLabel;
-            key = key == null ? "" : key;
-            tool = tool == null ? DungeonEditorTool.SELECT : tool;
-        }
-
-        ToolButton(String label, String selectedLabel, String key) {
-            this(label, selectedLabel, key, DungeonEditorTool.SELECT, true);
+            selection = selection == null ? DungeonEditorToolSelection.select() : selection;
         }
 
     }
@@ -402,12 +394,8 @@ final class DungeonEditorControlsPanelModel {
         return ToolPalettePanel.graphViewLabel();
     }
 
-    static String labelOf(@Nullable DungeonEditorTool tool) {
-        return ToolPalettePanel.labelOf(tool);
-    }
-
-    boolean wallSingleClickModeSelected() {
-        return toolPalette.wallSingleClickModeSelected();
+    static String labelOf(DungeonEditorToolSelection selection) {
+        return ToolPalettePanel.labelOf(selection);
     }
 
     static String normalizeViewModeKey(@Nullable String viewModeKey) {
@@ -620,291 +608,137 @@ final class DungeonEditorControlsPanelModel {
     }
 
     private static final class ToolPalettePanel {
-    private static final DungeonEditorTool SELECT_TOOL = DungeonEditorTool.SELECT;
-    private static final DungeonEditorTool ROOM_PAINT_TOOL = DungeonEditorTool.ROOM_PAINT;
-    private static final DungeonEditorTool WALL_CREATE_TOOL = DungeonEditorTool.WALL_CREATE;
-    private static final DungeonEditorTool DOOR_CREATE_TOOL = DungeonEditorTool.DOOR_CREATE;
-    private static final DungeonEditorTool CORRIDOR_CREATE_TOOL = DungeonEditorTool.CORRIDOR_CREATE;
-    private static final DungeonEditorTool STAIR_CREATE_TOOL = DungeonEditorTool.STAIR_CREATE;
-    private static final DungeonEditorTool STAIR_CREATE_SQUARE_TOOL = DungeonEditorTool.STAIR_CREATE_SQUARE;
-    private static final DungeonEditorTool STAIR_CREATE_CIRCULAR_TOOL = DungeonEditorTool.STAIR_CREATE_CIRCULAR;
-    private static final DungeonEditorTool TRANSITION_CREATE_TOOL = DungeonEditorTool.TRANSITION_CREATE;
-    private static final DungeonEditorTool FEATURE_POI_CREATE_TOOL = DungeonEditorTool.FEATURE_POI_CREATE;
-    private static final DungeonEditorTool FEATURE_OBJECT_CREATE_TOOL = DungeonEditorTool.FEATURE_OBJECT_CREATE;
-    private static final DungeonEditorTool FEATURE_ENCOUNTER_CREATE_TOOL = DungeonEditorTool.FEATURE_ENCOUNTER_CREATE;
-    private static final String WALL_PATH_MODE_OPTION_KEY = "WALL_PATH";
-    private static final String WALL_SINGLE_CLICK_MODE_OPTION_KEY = "WALL_SINGLE_CLICK";
-    private static final String GRID_VIEW_LABEL = "Grid";
-    private static final String GRAPH_VIEW_LABEL = "Graph";
+        private static final String GRID_VIEW_LABEL = "Grid";
+        private static final String GRAPH_VIEW_LABEL = "Graph";
 
-    private final ReadOnlyObjectWrapper<DungeonEditorControlsPanelModel.ToolProjection> toolProjection =
-            new ReadOnlyObjectWrapper<>(DungeonEditorControlsPanelModel.ToolProjection.initial());
-    private final Map<ToolFamily, String> selectedFamilyOptionKeys = new EnumMap<>(ToolFamily.class);
+        private final ReadOnlyObjectWrapper<DungeonEditorControlsPanelModel.ToolProjection> toolProjection =
+                new ReadOnlyObjectWrapper<>(DungeonEditorControlsPanelModel.ToolProjection.initial());
+        private final Map<DungeonEditorToolFamily, DungeonEditorToolOptions> selectedFamilyOptions =
+                new EnumMap<>(DungeonEditorToolFamily.class);
 
-    ReadOnlyObjectProperty<DungeonEditorControlsPanelModel.ToolProjection> toolProjectionProperty() {
-        return toolProjection.getReadOnlyProperty();
-    }
-
-    DungeonEditorControlsPanelModel.ToolControls toolControls() {
-        return currentToolControls(selectedFamilyOptionKeys);
-    }
-
-    void showSelectedTool(String selectedTool) {
-        if (defaultToolLabel().equals(selectedTool)) {
-            selectedFamilyOptionKeys.clear();
+        ReadOnlyObjectProperty<DungeonEditorControlsPanelModel.ToolProjection> toolProjectionProperty() {
+            return toolProjection.getReadOnlyProperty();
         }
-        toolProjection.set(new DungeonEditorControlsPanelModel.ToolProjection(selectedTool, toolControls()));
-    }
 
-    void rememberToolSelection(
-            String requestedFamilyKey,
-            DungeonEditorTool selectedTool,
-            String selectedOptionKey
-    ) {
-        ToolFamily requestedFamily = ToolFamily.fromKey(requestedFamilyKey);
-        DungeonEditorTool safeSelectedTool = selectedTool == null ? SELECT_TOOL : selectedTool;
-        ToolFamily selectedFamily = ToolFamily.fromTool(safeSelectedTool);
-        ToolFamily family = selectedFamily == null ? requestedFamily : selectedFamily;
-        String optionKey = selectedOptionKey == null || selectedOptionKey.isBlank()
-                ? safeSelectedTool.name()
-                : selectedOptionKey;
-        if (family != null && family.containsOptionKey(optionKey)) {
-            selectedFamilyOptionKeys.put(family, optionKey);
+        DungeonEditorControlsPanelModel.ToolControls toolControls() {
+            return currentToolControls(selectedFamilyOptions);
+        }
+
+        void showSelectedTool(DungeonEditorToolSelection selection) {
+            DungeonEditorToolSelection safeSelection = selection == null
+                    ? DungeonEditorToolSelection.select()
+                    : selection;
+            if (safeSelection.family() == DungeonEditorToolFamily.SELECT) {
+                selectedFamilyOptions.clear();
+            } else {
+                selectedFamilyOptions.put(safeSelection.family(), safeSelection.options());
+            }
+            toolProjection.set(new DungeonEditorControlsPanelModel.ToolProjection(safeSelection, toolControls()));
+        }
+
+        void rememberToolSelection(DungeonEditorToolSelection selection) {
+            if (selection == null || selection.family() == DungeonEditorToolFamily.SELECT) {
+                return;
+            }
+            selectedFamilyOptions.put(selection.family(), selection.options());
             toolProjection.set(new DungeonEditorControlsPanelModel.ToolProjection(
-                    toolProjection.get().selectedTool(),
+                    toolProjection.get().selection(),
                     toolControls()));
         }
-    }
 
-    boolean wallSingleClickModeSelected() {
-        return wallSingleClickModeOptionKey().equals(selectedFamilyOptionKeys.get(ToolFamily.WALL));
-    }
-
-    static DungeonEditorControlsPanelModel.ToolControls defaultToolControls() {
-        return currentToolControls(Map.of());
-    }
-
-    static String defaultToolLabel() {
-        return labelOf(SELECT_TOOL);
-    }
-
-    static String gridViewLabel() {
-        return GRID_VIEW_LABEL;
-    }
-
-    static String graphViewLabel() {
-        return GRAPH_VIEW_LABEL;
-    }
-
-    static String wallPathModeOptionKey() {
-        return WALL_PATH_MODE_OPTION_KEY;
-    }
-
-    static String wallSingleClickModeOptionKey() {
-        return WALL_SINGLE_CLICK_MODE_OPTION_KEY;
-    }
-
-    static String labelOf(@Nullable DungeonEditorTool tool) {
-        return ToolPresentation.labelOf(tool);
-    }
-
-    static String normalizeViewModeKey(@Nullable String viewModeKey) {
-        return ToolPresentation.normalizeViewModeKey(viewModeKey);
-    }
-
-    private static DungeonEditorControlsPanelModel.ToolControls currentToolControls(
-            Map<ToolFamily, String> selectedFamilyOptionKeys
-    ) {
-        return new DungeonEditorControlsPanelModel.ToolControls(
-                defaultToolLabel(),
-                gridViewLabel(),
-                graphViewLabel(),
-                new DungeonEditorControlsPanelModel.ToolButton(
-                        defaultToolLabel(),
-                        defaultToolLabel(),
-                        SELECT_TOOL.name(),
-                        SELECT_TOOL,
-                        true),
-                ToolFamily.ROOM.toButton(selectedFamilyOptionKeys),
-                ToolFamily.WALL.toButton(selectedFamilyOptionKeys),
-                ToolFamily.DOOR.toButton(selectedFamilyOptionKeys),
-                ToolFamily.CORRIDOR.toButton(selectedFamilyOptionKeys),
-                ToolFamily.FEATURE.toButton(selectedFamilyOptionKeys),
-                ToolFamily.STAIR.toButton(selectedFamilyOptionKeys),
-                ToolFamily.TRANSITION.toButton(selectedFamilyOptionKeys));
-    }
-
-    private enum ToolFamily {
-        ROOM("ROOM", "Raum", ROOM_PAINT_TOOL),
-        WALL(
-                "WALL",
-                "Wand",
-                WALL_CREATE_TOOL,
-                new ToolOptionSpec(
-                        wallPathModeOptionKey(),
-                        "Pfad",
-                        WALL_CREATE_TOOL,
-                        true),
-                new ToolOptionSpec(
-                        wallSingleClickModeOptionKey(),
-                        "Einzeln",
-                        WALL_CREATE_TOOL,
-                        true)),
-        DOOR("DOOR", "Tür", DOOR_CREATE_TOOL),
-        CORRIDOR("CORRIDOR", "Korridor", CORRIDOR_CREATE_TOOL),
-        FEATURE(
-                "FEATURE",
-                "Feature",
-                FEATURE_POI_CREATE_TOOL,
-                new ToolOptionSpec(
-                        "FEATURE_POI",
-                        "POI",
-                        FEATURE_POI_CREATE_TOOL,
-                        true),
-                new ToolOptionSpec(
-                        "FEATURE_OBJECT",
-                        "Objekt",
-                        FEATURE_OBJECT_CREATE_TOOL,
-                        true),
-                new ToolOptionSpec(
-                        "FEATURE_ENCOUNTER",
-                        "Encounter",
-                        FEATURE_ENCOUNTER_CREATE_TOOL,
-                        true)),
-        STAIR(
-                "STAIR",
-                "Treppe",
-                STAIR_CREATE_TOOL,
-                new ToolOptionSpec(
-                        "STAIR_STRAIGHT",
-                        "Gerade",
-                        STAIR_CREATE_TOOL,
-                        true),
-                new ToolOptionSpec(
-                        "STAIR_ANGULAR_SPIRAL",
-                        "Eckspirale",
-                        STAIR_CREATE_SQUARE_TOOL,
-                        true),
-                new ToolOptionSpec(
-                        "STAIR_ROUND_SPIRAL",
-                        "Rundspirale",
-                        STAIR_CREATE_CIRCULAR_TOOL,
-                        true)),
-        TRANSITION("TRANSITION", "Übergang", TRANSITION_CREATE_TOOL);
-
-        private final String key;
-        private final String label;
-        private final DungeonEditorTool primaryTool;
-        private final List<ToolOptionSpec> optionSpecs;
-
-        ToolFamily(String key, String label, DungeonEditorTool primaryTool, ToolOptionSpec... optionSpecs) {
-            this.key = key;
-            this.label = label;
-            this.primaryTool = primaryTool;
-            this.optionSpecs = List.copyOf(List.of(optionSpecs));
+        static DungeonEditorControlsPanelModel.ToolControls defaultToolControls() {
+            return currentToolControls(Map.of());
         }
 
-        private DungeonEditorControlsPanelModel.ToolFamilyButton toButton(
-                Map<ToolFamily, String> selectedFamilyOptionKeys
-        ) {
-            return new DungeonEditorControlsPanelModel.ToolFamilyButton(
-                    key,
-                    label,
-                    selectedOptionKey(selectedFamilyOptionKeys),
-                    toolOptions());
+        static String defaultToolLabel() {
+            return labelOf(DungeonEditorToolSelection.select());
         }
 
-        private String selectedOptionKey(Map<ToolFamily, String> selectedFamilyOptionKeys) {
-            String rememberedKey = selectedFamilyOptionKeys.get(this);
-            return containsOptionKey(rememberedKey) ? rememberedKey : toolOptions().getFirst().key();
+        static String gridViewLabel() {
+            return GRID_VIEW_LABEL;
         }
 
-        private boolean containsTool(@Nullable DungeonEditorTool tool) {
-            if (primaryTool == tool) {
-                return true;
-            }
-            for (DungeonEditorControlsPanelModel.ToolButton option : toolOptions()) {
-                if (option.tool() == tool) {
-                    return true;
-                }
-            }
-            return false;
+        static String graphViewLabel() {
+            return GRAPH_VIEW_LABEL;
         }
 
-        private boolean containsOptionKey(@Nullable String optionKey) {
-            if (optionKey == null || optionKey.isBlank()) {
-                return false;
-            }
-            for (DungeonEditorControlsPanelModel.ToolButton option : toolOptions()) {
-                if (option.enabled() && option.key().equals(optionKey)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private List<DungeonEditorControlsPanelModel.ToolButton> toolOptions() {
-            if (optionSpecs.isEmpty()) {
-                return List.of(toToolButton(primaryTool));
-            }
-            return optionSpecs.stream()
-                    .map(option -> new DungeonEditorControlsPanelModel.ToolButton(
-                            option.label(),
-                            labelOf(option.tool()),
-                            option.key(),
-                            option.tool(),
-                            option.enabled()))
-                    .toList();
-        }
-
-        private static DungeonEditorControlsPanelModel.ToolButton toToolButton(DungeonEditorTool tool) {
-            String label = labelOf(tool);
-            return new DungeonEditorControlsPanelModel.ToolButton(label, label, tool.name(), tool, true);
-        }
-
-        private static @Nullable ToolFamily fromKey(@Nullable String familyKey) {
-            if (familyKey == null || familyKey.isBlank()) {
-                return null;
-            }
-            for (ToolFamily family : values()) {
-                if (family.key.equalsIgnoreCase(familyKey.strip())) {
-                    return family;
-                }
-            }
-            return null;
-        }
-
-        private static @Nullable ToolFamily fromTool(@Nullable DungeonEditorTool selectedTool) {
-            if (selectedTool == null) {
-                return null;
-            }
-            for (ToolFamily family : values()) {
-                if (family.containsTool(selectedTool)) {
-                    return family;
-                }
-            }
-            return null;
-        }
-    }
-
-    private record ToolOptionSpec(String key, String label, DungeonEditorTool tool, boolean enabled) {
-        ToolOptionSpec {
-            key = key == null ? "" : key;
-            label = label == null ? "" : label;
-            tool = tool == null ? SELECT_TOOL : tool;
-        }
-    }
-
-    private interface ToolPresentation {
-
-        static String labelOf(@Nullable DungeonEditorTool tool) {
-            return DungeonEditorTool.labelFor(tool);
+        static String labelOf(DungeonEditorToolSelection selection) {
+            return DungeonEditorToolPresentation.label(selection);
         }
 
         static String normalizeViewModeKey(@Nullable String viewModeKey) {
             return graphViewLabel().equals(viewModeKey) ? graphViewLabel() : gridViewLabel();
         }
-    }
+
+        private static DungeonEditorControlsPanelModel.ToolControls currentToolControls(
+                Map<DungeonEditorToolFamily, DungeonEditorToolOptions> selectedFamilyOptions
+        ) {
+            return new DungeonEditorControlsPanelModel.ToolControls(
+                    defaultToolLabel(),
+                    gridViewLabel(),
+                    graphViewLabel(),
+                    toolButton(DungeonEditorToolSelection.select()),
+                    familyButton(DungeonEditorToolFamily.ROOM, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.WALL, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.DOOR, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.CORRIDOR, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.FEATURE, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.STAIR, selectedFamilyOptions),
+                    familyButton(DungeonEditorToolFamily.TRANSITION, selectedFamilyOptions));
+        }
+
+        private static DungeonEditorControlsPanelModel.ToolFamilyButton familyButton(
+                DungeonEditorToolFamily family,
+                Map<DungeonEditorToolFamily, DungeonEditorToolOptions> selectedFamilyOptions
+        ) {
+            List<DungeonEditorToolSelection> selections = selections(family);
+            DungeonEditorToolSelection selected = new DungeonEditorToolSelection(
+                    family,
+                    selectedFamilyOptions.get(family));
+            if (!selections.contains(selected)) {
+                selected = selections.getFirst();
+            }
+            return new DungeonEditorControlsPanelModel.ToolFamilyButton(
+                    family,
+                    DungeonEditorToolPresentation.familyLabel(family),
+                    selected,
+                    selections.stream().map(ToolPalettePanel::toolButton).toList());
+        }
+
+        private static DungeonEditorControlsPanelModel.ToolButton toolButton(
+                DungeonEditorToolSelection selection
+        ) {
+            return new DungeonEditorControlsPanelModel.ToolButton(
+                    DungeonEditorToolPresentation.optionLabel(selection),
+                    labelOf(selection),
+                    selection,
+                    true);
+        }
+
+        private static List<DungeonEditorToolSelection> selections(DungeonEditorToolFamily family) {
+            return switch (family) {
+                case WALL -> List.of(
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Wall(
+                                DungeonEditorToolOptions.Wall.Mode.PATH)),
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Wall(
+                                DungeonEditorToolOptions.Wall.Mode.SINGLE)));
+                case STAIR -> List.of(
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Stair(
+                                DungeonEditorToolOptions.Stair.Shape.STRAIGHT)),
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Stair(
+                                DungeonEditorToolOptions.Stair.Shape.SQUARE)),
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Stair(
+                                DungeonEditorToolOptions.Stair.Shape.CIRCULAR)));
+                case FEATURE -> List.of(
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Feature(
+                                DungeonEditorToolOptions.Feature.Kind.POINT_OF_INTEREST)),
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Feature(
+                                DungeonEditorToolOptions.Feature.Kind.OBJECT)),
+                        new DungeonEditorToolSelection(family, new DungeonEditorToolOptions.Feature(
+                                DungeonEditorToolOptions.Feature.Kind.ENCOUNTER)));
+                default -> List.of(DungeonEditorToolSelection.family(family));
+            };
+        }
     }
 
 }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorControlsView.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorControlsView.java
@@ -26,8 +26,8 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import org.jspecify.annotations.Nullable;
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.adapter.javafx.editor.DungeonEditorControlsInput.OverlayMode;
 
 public final class DungeonEditorControlsView extends VBox {
@@ -339,13 +339,13 @@ public final class DungeonEditorControlsView extends VBox {
             selectButton.setToggleGroup(toolGroup);
             selectButton.setSelected(true);
             selectButton.setAccessibleText("Auswahlwerkzeug aktivieren");
-            selectButton.setOnAction(event -> emitToolSelection("", toolControls.select().tool()));
+            selectButton.setOnAction(event -> emitToolSelection(toolControls.select().selection()));
         }
 
         private void configureFamilyButton(
                 Button button,
                 DungeonEditorControlsPanelModel.ToolFamilyButton family,
-                DungeonEditorTool selectTool
+                DungeonEditorToolSelection selectTool
         ) {
             button.setAccessibleText(family.label() + "werkzeug wählen");
             button.setOnAction(event -> activateFamily(button, family, selectTool));
@@ -354,13 +354,12 @@ public final class DungeonEditorControlsView extends VBox {
         private void activateFamily(
                 Button anchor,
                 DungeonEditorControlsPanelModel.ToolFamilyButton family,
-                DungeonEditorTool selectTool
+                DungeonEditorToolSelection selectTool
         ) {
-            DungeonEditorControlsPanelModel.ToolButton selectedOption = family.selectedOption();
-            String selectedOptionKey = selectedOption.key();
-            emitToolSelection(family.familyKey(), selectedOption.tool(), selectedOptionKey);
+            DungeonEditorControlsPanelModel.ToolButton selectedOption = family.selectedButton();
+            emitToolSelection(selectedOption.selection());
             if (family.hasSecondaryOptions()) {
-                showFamilyOptions(anchor, family, selectedOptionKey, selectTool);
+                showFamilyOptions(anchor, family, selectedOption.selection(), selectTool);
             } else {
                 optionMenu.hide();
             }
@@ -369,18 +368,18 @@ public final class DungeonEditorControlsView extends VBox {
         private void showFamilyOptions(
                 Button anchor,
                 DungeonEditorControlsPanelModel.ToolFamilyButton family,
-                String selectedOptionKey,
-                DungeonEditorTool selectTool
+                DungeonEditorToolSelection selectedOption,
+                DungeonEditorToolSelection selectTool
         ) {
             HBox options = row();
             for (DungeonEditorControlsPanelModel.ToolButton option : family.options()) {
-                options.getChildren().add(optionButton(family.familyKey(), option, selectedOptionKey));
+                options.getChildren().add(optionButton(option, selectedOption));
             }
             options.getStyleClass().addAll("dropdown-window", "dropdown-form", "dungeon-editor-popup");
             options.setOnMouseExited(event -> optionMenu.hide());
             options.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
                 if (event.getCode() == KeyCode.ESCAPE) {
-                    emitToolSelection("", selectTool);
+                    emitToolSelection(selectTool);
                     optionMenu.hide();
                     event.consume();
                 }
@@ -388,30 +387,29 @@ public final class DungeonEditorControlsView extends VBox {
             CustomMenuItem item = new CustomMenuItem(options, false);
             optionMenu.getItems().setAll(item);
             optionMenu.show(anchor, Side.BOTTOM, 0.0, 2.0);
-            requestOptionFocus(options, selectedOptionKey);
+            requestOptionFocus(options);
         }
 
         private Button optionButton(
-                String familyKey,
                 DungeonEditorControlsPanelModel.ToolButton option,
-                String selectedOptionKey
+                DungeonEditorToolSelection selectedOption
         ) {
             Button button = toolButton(option.label());
-            boolean selected = option.key().equals(selectedOptionKey);
+            boolean selected = option.selection().equals(selectedOption);
             setStyleClassPresence(button, SELECTED_STYLE_CLASS, selected);
             button.setDisable(!option.enabled());
             button.setAccessibleText(option.label()
                     + (option.enabled() ? (selected ? " aktiv" : " wählen") : " noch nicht verfügbar"));
             if (option.enabled()) {
                 button.setOnAction(event -> {
-                    emitToolSelection(familyKey, option.tool(), option.key());
+                    emitToolSelection(option.selection());
                     optionMenu.hide();
                 });
             }
             return button;
         }
 
-        private void requestOptionFocus(HBox options, String selectedOptionKey) {
+        private void requestOptionFocus(HBox options) {
             Node fallbackOption = null;
             for (Node node : options.getChildren()) {
                 if (fallbackOption == null) {
@@ -431,32 +429,33 @@ public final class DungeonEditorControlsView extends VBox {
                 DungeonEditorControlsPanelModel.ToolProjection projection,
                 DungeonEditorControlsPanelModel.ToolControls toolControls
         ) {
-            String defaultToolLabel = toolControls.defaultTool();
-            String selectedTool = projection == null ? defaultToolLabel : projection.selectedTool();
+            DungeonEditorToolSelection selection = projection == null
+                    ? DungeonEditorToolSelection.select()
+                    : projection.selection();
             DungeonEditorControlsPanelModel.ToolControls currentToolControls =
                     projection == null ? toolControls : projection.toolControls();
-            selectButton.setSelected(defaultToolLabel.equals(selectedTool));
-            if (defaultToolLabel.equals(selectedTool)) {
+            selectButton.setSelected(selection.equals(DungeonEditorToolSelection.select()));
+            if (selection.equals(DungeonEditorToolSelection.select())) {
                 optionMenu.hide();
             }
-            DungeonEditorTool selectTool = currentToolControls.select().tool();
-            bindFamilyButton(roomButton, selectedTool, currentToolControls.room(), selectTool);
-            bindFamilyButton(wallButton, selectedTool, currentToolControls.wall(), selectTool);
-            bindFamilyButton(doorButton, selectedTool, currentToolControls.door(), selectTool);
-            bindFamilyButton(corridorButton, selectedTool, currentToolControls.corridor(), selectTool);
-            bindFamilyButton(featureButton, selectedTool, currentToolControls.feature(), selectTool);
-            bindFamilyButton(stairButton, selectedTool, currentToolControls.stair(), selectTool);
-            bindFamilyButton(transitionButton, selectedTool, currentToolControls.transition(), selectTool);
+            DungeonEditorToolSelection selectTool = currentToolControls.select().selection();
+            bindFamilyButton(roomButton, selection, currentToolControls.room(), selectTool);
+            bindFamilyButton(wallButton, selection, currentToolControls.wall(), selectTool);
+            bindFamilyButton(doorButton, selection, currentToolControls.door(), selectTool);
+            bindFamilyButton(corridorButton, selection, currentToolControls.corridor(), selectTool);
+            bindFamilyButton(featureButton, selection, currentToolControls.feature(), selectTool);
+            bindFamilyButton(stairButton, selection, currentToolControls.stair(), selectTool);
+            bindFamilyButton(transitionButton, selection, currentToolControls.transition(), selectTool);
         }
 
         private void bindFamilyButton(
                 Button button,
-                String selectedTool,
+                DungeonEditorToolSelection selection,
                 DungeonEditorControlsPanelModel.ToolFamilyButton family,
-                DungeonEditorTool selectTool
+                DungeonEditorToolSelection selectTool
         ) {
             configureFamilyButton(button, family, selectTool);
-            markSelectedFamily(button, selectedTool, family, family.selectedOptionKey());
+            markSelectedFamily(button, selection, family);
         }
     }
 
@@ -500,25 +499,10 @@ public final class DungeonEditorControlsView extends VBox {
                 DungeonEditorControlsInput.OverlayInput.none()));
     }
 
-    private void emitToolSelection(String requestedFamilyKey, DungeonEditorTool selectedTool) {
-        emitToolSelection(
-                requestedFamilyKey,
-                selectedTool,
-                selectedTool == null ? "" : selectedTool.name());
-    }
-
-    private void emitToolSelection(
-            String requestedFamilyKey,
-            DungeonEditorTool selectedTool,
-            String selectedOptionKey
-    ) {
+    private void emitToolSelection(DungeonEditorToolSelection selection) {
         controlsInputHandler.accept(new DungeonEditorControlsInput(
                 DungeonEditorControlsInput.MapInput.none(),
-                new DungeonEditorControlsInput.ToolInput(
-                        requestedFamilyKey,
-                        selectedTool,
-                        selectedOptionKey,
-                        false),
+                new DungeonEditorControlsInput.ToolInput(selection, false),
                 DungeonEditorControlsInput.ProjectionInput.none(),
                 DungeonEditorControlsInput.OverlayInput.none()));
     }
@@ -533,7 +517,7 @@ public final class DungeonEditorControlsView extends VBox {
     private void emitToolDismiss() {
         controlsInputHandler.accept(new DungeonEditorControlsInput(
                 DungeonEditorControlsInput.MapInput.none(),
-                new DungeonEditorControlsInput.ToolInput("", null, "", true),
+                new DungeonEditorControlsInput.ToolInput(null, true),
                 DungeonEditorControlsInput.ProjectionInput.none(),
                 DungeonEditorControlsInput.OverlayInput.none()));
     }
@@ -631,27 +615,14 @@ public final class DungeonEditorControlsView extends VBox {
 
     private static void markSelectedFamily(
             Button button,
-            String selectedTool,
-            DungeonEditorControlsPanelModel.ToolFamilyButton family,
-            String selectedOptionKey
+            DungeonEditorToolSelection selection,
+            DungeonEditorControlsPanelModel.ToolFamilyButton family
     ) {
-        boolean selected = family.selectedByLabel(selectedTool);
-        DungeonEditorControlsPanelModel.ToolButton option = toolOption(family, selectedOptionKey);
+        boolean selected = family.selectedBy(selection);
+        DungeonEditorControlsPanelModel.ToolButton option = family.selectedButton();
         setStyleClassPresence(button, SELECTED_STYLE_CLASS, selected);
         button.setAccessibleText(family.label() + "werkzeug"
                 + (selected ? " aktiv, Option " + option.label() : ", letzte Option " + option.label()));
-    }
-
-    private static DungeonEditorControlsPanelModel.ToolButton toolOption(
-            DungeonEditorControlsPanelModel.ToolFamilyButton family,
-            String selectedOptionKey
-    ) {
-        for (DungeonEditorControlsPanelModel.ToolButton option : family.options()) {
-            if (option.key().equals(selectedOptionKey)) {
-                return option;
-            }
-        }
-        return family.selectedOption();
     }
 
     private static void setNodeVisibility(Node node, boolean visible) {

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
@@ -11,6 +11,7 @@ import features.dungeon.api.DungeonTopologyElementRef;
 import features.dungeon.api.DungeonInspectorSnapshot;
 import features.dungeon.api.editor.DungeonEditorDraftState;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
 
 final class DungeonEditorStatePanelModel {
     private final ReadOnlyObjectWrapper<StateProjection> stateProjection =
@@ -465,7 +466,7 @@ final class DungeonEditorStatePanelModel {
 
     String stateTextFor(DungeonEditorState state) {
         DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
-        return "Werkzeug: " + DungeonEditorControlsPanelModel.labelOf(safeState.selectedTool())
+        return "Werkzeug: " + DungeonEditorControlsPanelModel.labelOf(safeState.toolSelection())
                 + "\nAnsicht: " + normalizeViewModeKey(safeState.viewMode().name())
                 + "\nEbene: z=" + safeState.projectionLevel()
                 + "\nOverlay: " + safeState.overlaySettings().modeKey()
@@ -651,7 +652,6 @@ final class DungeonEditorStatePanelModel {
     private static final class TransitionPanel {
     private static final long NO_TRANSITION_ID = 0L;
     private static final long NO_SELECTED_MAP_ID = 0L;
-    private static final String TRANSITION_CREATE_TOOL = "TRANSITION_CREATE";
     private static final String DESTINATION_DUNGEON_MAP = "DUNGEON_MAP";
     private static final String DESTINATION_OVERWORLD_TILE = "OVERWORLD_TILE";
     private static final String DESTINATION_UNLINKED_ENTRANCE = "UNLINKED_ENTRANCE";
@@ -695,7 +695,7 @@ final class DungeonEditorStatePanelModel {
         }
         DungeonTopologyElementRef topologyRef = safeTopologyRef(safeState.selection().topologyRef());
         long selectedTransitionId = selectedTransitionId(topologyRef);
-        if (!TRANSITION_CREATE_TOOL.equals(safeState.selectedTool().name())
+        if (safeState.toolSelection().family() != DungeonEditorToolFamily.TRANSITION
                 && selectedTransitionId <= NO_TRANSITION_ID) {
             return null;
         }

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -9,8 +9,12 @@ import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.api.DungeonMapId;
 import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorPointerGesture;
 import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolOptions;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 import platform.ui.catalogcrud.CatalogCrudControlsContentModel;
 import platform.ui.catalogcrud.CatalogCrudControlsViewInputEvent;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel;
@@ -111,7 +115,7 @@ final class DungeonEditorViewModel {
                 safeProjection.viewModeLabel(),
                 safeProjection.overlaySettings(),
                 safeProjection.projectionLevel(),
-                safeProjection.selectedToolLabel());
+                safeProjection.toolSelection());
     }
 
     private static void applyMapCatalogProjection(
@@ -579,7 +583,7 @@ final class DungeonEditorViewModel {
     }
 
     private void consumePointerToolInput(DungeonMapViewInputEvent event) {
-        String selectedTool = currentInteractionState().currentSelectedToolKey();
+        DungeonEditorToolSelection toolSelection = currentInteractionState().currentToolSelection();
         DungeonEditorPointerInput.Action action = pointerAction(event.input());
         double sceneX = sceneX(event);
         double sceneY = sceneY(event);
@@ -590,16 +594,14 @@ final class DungeonEditorViewModel {
         editorApi.dispatch(new DungeonEditorIntent.Pointer(new DungeonEditorPointerInput(
                 latestEditorState.publicationRevision(),
                 action,
-                selectedTool,
+                toolSelection,
                 pointerWorkflowGesture(event),
                 sceneX,
                 sceneY,
-                event.buttons().primaryButtonDown(),
-                event.buttons().secondaryButtonDown(),
                 targets.stream().map(DungeonEditorViewModel::apiPointerTarget).toList(),
                 currentInteractionState().currentProjectionLevel(),
                 transitionDestination())));
-        updateHoverTarget(event, hoverTarget(selectedTool, event, targets, sceneX, sceneY));
+        updateHoverTarget(event, hoverTarget(toolSelection, event, targets, sceneX, sceneY));
     }
 
     private void updateHoverTarget(
@@ -649,40 +651,42 @@ final class DungeonEditorViewModel {
     }
 
     private PointerTarget hoverTarget(
-            String selectedTool,
+            DungeonEditorToolSelection toolSelection,
             DungeonMapViewInputEvent event,
             List<PointerTarget> targets,
             double sceneX,
             double sceneY
     ) {
         PointerTarget primary = primaryTarget(targets, sceneX, sceneY);
-        String tool = effectiveHoverTool(selectedTool, event);
-        if (tool.isBlank()) {
+        DungeonEditorToolFamily family = toolSelection == null
+                ? DungeonEditorToolFamily.SELECT
+                : toolSelection.family();
+        if (event.buttons().secondaryButtonDown() && event.modifiers().shiftDown()
+                && family != DungeonEditorToolFamily.WALL) {
             return PointerTarget.empty();
         }
-        if ("SELECT".equals(tool)) {
+        if (family == DungeonEditorToolFamily.SELECT) {
             return primary.selectableBySelectTool() ? primary : PointerTarget.empty();
         }
-        if (tool.startsWith("ROOM_")) {
+        if (family == DungeonEditorToolFamily.ROOM) {
             return mapContentModel.syntheticHoverTarget(
-                    tool, false, sceneX, sceneY, currentInteractionState().currentProjectionLevel());
+                    toolSelection, false, sceneX, sceneY, currentInteractionState().currentProjectionLevel());
         }
-        if ("WALL_CREATE".equals(tool)) {
+        if (family == DungeonEditorToolFamily.WALL) {
             boolean singleClick = event.modifiers().controlDown()
-                    || controlsPanelModel.wallSingleClickModeSelected();
+                    || toolSelection.options() instanceof DungeonEditorToolOptions.Wall wall
+                    && wall.mode() == DungeonEditorToolOptions.Wall.Mode.SINGLE;
             if (singleClick && primary.isBoundaryTarget()) {
                 return primary;
             }
             return mapContentModel.syntheticHoverTarget(
-                    tool, singleClick, sceneX, sceneY, currentInteractionState().currentProjectionLevel());
+                    toolSelection, singleClick, sceneX, sceneY, currentInteractionState().currentProjectionLevel());
         }
-        if ("WALL_DELETE".equals(tool)
-                || "DOOR_CREATE".equals(tool)
-                || "DOOR_DELETE".equals(tool)) {
+        if (family == DungeonEditorToolFamily.DOOR) {
             PointerTarget boundary = boundaryPreferredTarget(targets, sceneX, sceneY);
             return boundary.isBoundaryTarget() ? boundary : PointerTarget.empty();
         }
-        if (tool.startsWith("CORRIDOR_")) {
+        if (family == DungeonEditorToolFamily.CORRIDOR) {
             PointerTarget boundaryPreferred = boundaryPreferredTarget(targets, sceneX, sceneY);
             return boundaryPreferred.isWallOrDoorBoundaryTarget() || boundaryPreferred.isCorridorCellTarget()
                     ? boundaryPreferred
@@ -739,28 +743,6 @@ final class DungeonEditorViewModel {
             }
         }
         return bestTarget;
-    }
-
-    private static String effectiveHoverTool(String selectedTool, DungeonMapViewInputEvent event) {
-        String tool = selectedTool == null ? "" : selectedTool;
-        if (event.buttons().secondaryButtonDown() && event.modifiers().shiftDown()) {
-            return "WALL_CREATE".equals(tool) ? tool : "";
-        }
-        if (event.buttons().secondaryButtonDown()
-                && !event.buttons().primaryButtonDown()
-                && !event.buttons().middleButtonDown()) {
-            return switch (tool) {
-                case "ROOM_PAINT" -> "ROOM_DELETE";
-                case "WALL_CREATE" -> "WALL_CREATE";
-                case "DOOR_CREATE" -> "DOOR_DELETE";
-                case "CORRIDOR_CREATE" -> "CORRIDOR_DELETE";
-                case "FEATURE_CREATE" -> "FEATURE_DELETE";
-                case "STAIR_CREATE" -> "STAIR_DELETE";
-                case "TRANSITION_CREATE" -> "TRANSITION_DELETE";
-                default -> tool;
-            };
-        }
-        return tool;
     }
 
     private static int pointerTargetPriority(PointerTarget target) {
@@ -932,14 +914,18 @@ final class DungeonEditorViewModel {
         return currentInteractionState().currentTransitionDestination();
     }
 
-    private DungeonEditorPointerInput.Gesture pointerWorkflowGesture(DungeonMapViewInputEvent event) {
-        return new DungeonEditorPointerInput.Gesture(
-                event.buttons().primaryButtonDown(),
-                event.buttons().secondaryButtonDown(),
-                event.buttons().middleButtonDown(),
+    private static DungeonEditorPointerGesture pointerWorkflowGesture(DungeonMapViewInputEvent event) {
+        DungeonEditorPointerGesture.Button button = event.buttons().primaryButtonDown()
+                ? DungeonEditorPointerGesture.Button.PRIMARY
+                : event.buttons().secondaryButtonDown()
+                ? DungeonEditorPointerGesture.Button.SECONDARY
+                : event.buttons().middleButtonDown()
+                ? DungeonEditorPointerGesture.Button.MIDDLE
+                : DungeonEditorPointerGesture.Button.NONE;
+        return new DungeonEditorPointerGesture(
+                button,
                 event.modifiers().shiftDown(),
-                event.modifiers().controlDown(),
-                controlsPanelModel.wallSingleClickModeSelected());
+                event.modifiers().controlDown());
     }
 
     private static int normalizeLevelDelta(double scrollDeltaY) {
@@ -1109,18 +1095,15 @@ final class DungeonEditorViewModel {
             editorApi.dispatch(DungeonEditorIntent.CancelPreview.INSTANCE);
             return;
         }
-        if (tool.selectedTool() == null) {
+        if (tool.selection() == null) {
             return;
         }
         InteractionState interactionState = currentInteractionState();
-        String selectedToolControlKey = tool.selectedTool().name();
-        controlsPanelModel.rememberToolSelection(
-                tool.requestedFamilyKey(),
-                tool.selectedTool(),
-                tool.selectedOptionKey());
-        if (!selectedToolControlKey.equals(interactionState.currentSelectedToolKey())) {
+        DungeonEditorToolSelection selection = tool.selection();
+        controlsPanelModel.rememberToolSelection(selection);
+        if (!selection.equals(interactionState.currentToolSelection())) {
             mapContentModel.clearHoverTarget();
-            editorApi.dispatch(new DungeonEditorIntent.SetTool(tool.selectedTool()));
+            editorApi.dispatch(new DungeonEditorIntent.SetTool(selection));
         }
     }
 
@@ -1157,9 +1140,7 @@ final class DungeonEditorViewModel {
     }
 
     private static boolean hasToolInput(DungeonEditorControlsInput.ToolInput tool) {
-        return !tool.requestedFamilyKey().isBlank()
-                || tool.selectedTool() != null
-                || tool.dismissControlActivated();
+        return tool.selection() != null || tool.dismissControlActivated();
     }
 
     private static Optional<List<Integer>> parseLevels(@Nullable String raw) {
@@ -1270,7 +1251,7 @@ final class DungeonEditorViewModel {
             String viewModeLabel,
             DungeonOverlaySettings overlaySettings,
             int projectionLevel,
-            String selectedToolLabel
+            DungeonEditorToolSelection toolSelection
     ) {
         ControlsProjection {
             mapEntries = mapEntries == null ? List.of() : List.copyOf(mapEntries);
@@ -1279,9 +1260,7 @@ final class DungeonEditorViewModel {
             statusText = statusText == null ? "" : statusText;
             viewModeLabel = DungeonEditorControlsPanelModel.normalizeViewModeKey(viewModeLabel);
             overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
-            selectedToolLabel = selectedToolLabel == null
-                    ? DungeonEditorControlsPanelModel.defaultToolLabel()
-                    : selectedToolLabel;
+            toolSelection = toolSelection == null ? DungeonEditorToolSelection.select() : toolSelection;
         }
 
         static ControlsProjection initial() {
@@ -1294,7 +1273,7 @@ final class DungeonEditorViewModel {
                     DungeonEditorControlsPanelModel.gridViewLabel(),
                     DungeonOverlaySettings.defaults(),
                     0,
-                    DungeonEditorControlsPanelModel.defaultToolLabel());
+                    DungeonEditorToolSelection.select());
         }
 
         static ControlsProjection from(DungeonEditorState state) {
@@ -1318,15 +1297,14 @@ final class DungeonEditorViewModel {
                             : DungeonEditorControlsPanelModel.gridViewLabel(),
                     safeState.overlaySettings(),
                     safeState.projectionLevel(),
-                    DungeonEditorControlsPanelModel.labelOf(safeState.selectedTool()));
+                    safeState.toolSelection());
         }
     }
 
     record InteractionState(
             long currentSelectedMapIdValue,
             String currentViewModeKey,
-            String currentSelectedToolLabel,
-            String currentSelectedToolKey,
+            DungeonEditorToolSelection currentToolSelection,
             int currentProjectionLevel,
             DungeonOverlaySettings currentOverlayProjection,
             long currentSelectedTransitionId,
@@ -1335,12 +1313,9 @@ final class DungeonEditorViewModel {
         InteractionState {
             currentSelectedMapIdValue = Math.max(0L, currentSelectedMapIdValue);
             currentViewModeKey = DungeonEditorControlsPanelModel.normalizeViewModeKey(currentViewModeKey);
-            currentSelectedToolLabel = currentSelectedToolLabel == null
-                    ? DungeonEditorControlsPanelModel.defaultToolLabel()
-                    : currentSelectedToolLabel;
-            currentSelectedToolKey = currentSelectedToolKey == null || currentSelectedToolKey.isBlank()
-                    ? "SELECT"
-                    : currentSelectedToolKey;
+            currentToolSelection = currentToolSelection == null
+                    ? DungeonEditorToolSelection.select()
+                    : currentToolSelection;
             currentOverlayProjection = currentOverlayProjection == null
                     ? DungeonOverlaySettings.defaults()
                     : currentOverlayProjection;
@@ -1354,8 +1329,7 @@ final class DungeonEditorViewModel {
             return new InteractionState(
                     0L,
                     DungeonEditorControlsPanelModel.gridViewLabel(),
-                    DungeonEditorControlsPanelModel.defaultToolLabel(),
-                    "SELECT",
+                    DungeonEditorToolSelection.select(),
                     0,
                     DungeonOverlaySettings.defaults(),
                     0L,
@@ -1375,8 +1349,7 @@ final class DungeonEditorViewModel {
                     safeState.viewMode() == features.dungeon.api.DungeonEditorViewMode.GRAPH
                             ? DungeonEditorControlsPanelModel.graphViewLabel()
                             : DungeonEditorControlsPanelModel.gridViewLabel(),
-                    DungeonEditorControlsPanelModel.labelOf(safeState.selectedTool()),
-                    safeState.selectedTool().name(),
+                    safeState.toolSelection(),
                     safeState.projectionLevel(),
                     safeState.overlaySettings(),
                     transitionId,

--- a/features/dungeon/adapter/javafx/map/DungeonMapContentModel.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapContentModel.java
@@ -11,11 +11,12 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.api.DungeonEditorHandleRef;
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.TravelDungeonSnapshot;
 import features.dungeon.api.editor.DungeonEditorDraftState;
 import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 public final class DungeonMapContentModel {
 
@@ -105,21 +106,23 @@ public final class DungeonMapContentModel {
     }
 
     public PointerTarget syntheticHoverTarget(
-            String selectedToolKey,
+            DungeonEditorToolSelection toolSelection,
             boolean wallSingleClick,
             double sceneX,
             double sceneY,
             int level
     ) {
-        String tool = selectedToolKey == null ? "" : selectedToolKey;
-        if (tool.startsWith("ROOM_")) {
+        DungeonEditorToolFamily family = toolSelection == null
+                ? DungeonEditorToolFamily.SELECT
+                : toolSelection.family();
+        if (family == DungeonEditorToolFamily.ROOM) {
             return PointerTarget.syntheticCell(PreparedElementKind.ROOM,
                     (int) Math.floor(sceneX), (int) Math.floor(sceneY), level);
         }
-        if (tool.startsWith("WALL_") && !wallSingleClick) {
+        if (family == DungeonEditorToolFamily.WALL && !wallSingleClick) {
             return PointerTarget.syntheticVertex((int) Math.round(sceneX), (int) Math.round(sceneY), level);
         }
-        if (tool.startsWith("WALL_") || tool.startsWith("DOOR_")) {
+        if (family == DungeonEditorToolFamily.WALL || family == DungeonEditorToolFamily.DOOR) {
             int q = (int) Math.floor(sceneX);
             int r = (int) Math.floor(sceneY);
             double localQ = sceneX - q;

--- a/features/dungeon/adapter/javafx/map/DungeonMapFrameProjector.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapFrameProjector.java
@@ -1,8 +1,8 @@
 package features.dungeon.adapter.javafx.map;
 
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.api.TravelDungeonSnapshot;
+import features.dungeon.adapter.javafx.DungeonEditorToolPresentation;
 import features.dungeon.api.editor.DungeonEditorState;
 
 final class DungeonMapFrameProjector {
@@ -29,7 +29,7 @@ final class DungeonMapFrameProjector {
                         DungeonMapRenderState.ViewMode.fromEditor(safeState.viewMode()))
                 .withOverlaySettings(toOverlaySettings(safeState.overlaySettings()))
                 .withProjectionLevel(safeState.projectionLevel())
-                .withSelectedTool(toolLabel(safeState.selectedTool()));
+                .withSelectedTool(DungeonEditorToolPresentation.label(safeState.toolSelection()));
     }
 
     DungeonMapRenderState mapTravel(
@@ -60,7 +60,4 @@ final class DungeonMapFrameProjector {
                 safeOverlay.selectedLevels());
     }
 
-    private static String toolLabel(DungeonEditorTool selectedTool) {
-        return DungeonEditorTool.labelFor(selectedTool);
-    }
 }

--- a/features/dungeon/adapter/javafx/map/DungeonMapRenderState.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapRenderState.java
@@ -7,10 +7,11 @@ import org.jspecify.annotations.Nullable;
 import features.dungeon.api.DungeonEdgeRef;
 import features.dungeon.api.DungeonEditorHandleKind;
 import features.dungeon.api.DungeonEditorHandleRef;
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonTopologyKind;
 import features.dungeon.api.DungeonTravelHeading;
+import features.dungeon.adapter.javafx.DungeonEditorToolPresentation;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 // Render-state values
 record DungeonMapRenderState(
@@ -561,7 +562,7 @@ private static String normalizeTool(String selectedTool) {
 }
 
 static String selectToolLabel() {
-    return DungeonEditorTool.SELECT.displayLabel();
+    return DungeonEditorToolPresentation.label(DungeonEditorToolSelection.select());
 }
 
 private static String normalizeEmptyMessage(String emptyMessage, boolean projectionAvailable) {

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -1,6 +1,5 @@
 package features.dungeon.api.editor;
 
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonMapId;
 import features.dungeon.api.DungeonOverlaySettings;
@@ -46,9 +45,9 @@ public sealed interface DungeonEditorIntent {
         }
     }
 
-    record SetTool(DungeonEditorTool tool) implements DungeonEditorIntent {
+    record SetTool(DungeonEditorToolSelection selection) implements DungeonEditorIntent {
         public SetTool {
-            tool = tool == null ? DungeonEditorTool.SELECT : tool;
+            selection = selection == null ? DungeonEditorToolSelection.select() : selection;
         }
     }
 

--- a/features/dungeon/api/editor/DungeonEditorPointerGesture.java
+++ b/features/dungeon/api/editor/DungeonEditorPointerGesture.java
@@ -1,0 +1,35 @@
+package features.dungeon.api.editor;
+
+/** Semantic pointer intent independent of JavaFX button events. */
+public record DungeonEditorPointerGesture(
+        Button button,
+        boolean shiftDown,
+        boolean controlDown
+) {
+    public DungeonEditorPointerGesture {
+        button = button == null ? Button.NONE : button;
+    }
+
+    public static DungeonEditorPointerGesture none() {
+        return new DungeonEditorPointerGesture(Button.NONE, false, false);
+    }
+
+    public boolean primary() {
+        return button == Button.PRIMARY;
+    }
+
+    public boolean secondary() {
+        return button == Button.SECONDARY;
+    }
+
+    public boolean middle() {
+        return button == Button.MIDDLE;
+    }
+
+    public enum Button {
+        NONE,
+        PRIMARY,
+        SECONDARY,
+        MIDDLE
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorPointerInput.java
+++ b/features/dungeon/api/editor/DungeonEditorPointerInput.java
@@ -7,12 +7,10 @@ import java.util.List;
 public record DungeonEditorPointerInput(
         long sourceRevision,
         Action action,
-        String selectedToolKey,
-        Gesture gesture,
+        DungeonEditorToolSelection toolSelection,
+        DungeonEditorPointerGesture gesture,
         double sceneX,
         double sceneY,
-        boolean primaryButtonDown,
-        boolean secondaryButtonDown,
         List<Target> targets,
         int projectionLevel,
         DungeonEditorIntent.TransitionDestinationInput transitionDestination
@@ -20,8 +18,8 @@ public record DungeonEditorPointerInput(
     public DungeonEditorPointerInput {
         sourceRevision = Math.max(0L, sourceRevision);
         action = action == null ? Action.MOVED : action;
-        selectedToolKey = selectedToolKey == null ? "" : selectedToolKey;
-        gesture = gesture == null ? Gesture.empty() : gesture;
+        toolSelection = toolSelection == null ? DungeonEditorToolSelection.select() : toolSelection;
+        gesture = gesture == null ? DungeonEditorPointerGesture.none() : gesture;
         sceneX = Double.isFinite(sceneX) ? sceneX : 0.0;
         sceneY = Double.isFinite(sceneY) ? sceneY : 0.0;
         targets = targets == null ? List.of() : List.copyOf(targets);
@@ -35,19 +33,6 @@ public record DungeonEditorPointerInput(
         DRAGGED,
         RELEASED,
         MOVED
-    }
-
-    public record Gesture(
-            boolean primaryButtonDown,
-            boolean secondaryButtonDown,
-            boolean middleButtonDown,
-            boolean shiftDown,
-            boolean controlDown,
-            boolean wallSingleClickModeSelected
-    ) {
-        public static Gesture empty() {
-            return new Gesture(false, false, false, false, false, false);
-        }
     }
 
     public record Target(

--- a/features/dungeon/api/editor/DungeonEditorState.java
+++ b/features/dungeon/api/editor/DungeonEditorState.java
@@ -3,7 +3,6 @@ package features.dungeon.api.editor;
 import features.dungeon.api.DungeonEditorPreview;
 import features.dungeon.api.DungeonEditorStateSnapshot;
 import features.dungeon.api.DungeonEditorSurface;
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonInspectorSnapshot;
 import features.dungeon.api.DungeonMapId;
@@ -20,7 +19,6 @@ public record DungeonEditorState(
         @Nullable DungeonMapId selectedMapId,
         @Nullable DungeonEditorSurface selectedWindow,
         DungeonEditorViewMode viewMode,
-        DungeonEditorTool selectedTool,
         DungeonEditorToolSelection toolSelection,
         DungeonOverlaySettings overlaySettings,
         int projectionLevel,
@@ -36,7 +34,6 @@ public record DungeonEditorState(
         requestGeneration = Math.max(0L, requestGeneration);
         catalog = catalog == null ? List.of() : List.copyOf(catalog);
         viewMode = viewMode == null ? DungeonEditorViewMode.GRID : viewMode;
-        selectedTool = selectedTool == null ? DungeonEditorTool.SELECT : selectedTool;
         toolSelection = toolSelection == null ? DungeonEditorToolSelection.select() : toolSelection;
         overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
         reachableLevels = reachableLevels == null ? List.of(0) : List.copyOf(reachableLevels);
@@ -54,7 +51,6 @@ public record DungeonEditorState(
                 null,
                 null,
                 DungeonEditorViewMode.GRID,
-                DungeonEditorTool.SELECT,
                 DungeonEditorToolSelection.select(),
                 DungeonOverlaySettings.defaults(),
                 0,

--- a/features/dungeon/api/editor/DungeonEditorToolOptions.java
+++ b/features/dungeon/api/editor/DungeonEditorToolOptions.java
@@ -1,0 +1,51 @@
+package features.dungeon.api.editor;
+
+/** Typed family-specific Dungeon Editor tool parameters. */
+public sealed interface DungeonEditorToolOptions
+        permits DungeonEditorToolOptions.None,
+                DungeonEditorToolOptions.Wall,
+                DungeonEditorToolOptions.Stair,
+                DungeonEditorToolOptions.Feature {
+
+    record None() implements DungeonEditorToolOptions {
+    }
+
+    record Wall(Mode mode) implements DungeonEditorToolOptions {
+        public Wall {
+            mode = mode == null ? Mode.PATH : mode;
+        }
+
+        public enum Mode {
+            PATH,
+            SINGLE
+        }
+    }
+
+    record Stair(Shape shape) implements DungeonEditorToolOptions {
+        public Stair {
+            shape = shape == null ? Shape.STRAIGHT : shape;
+        }
+
+        public enum Shape {
+            STRAIGHT,
+            SQUARE,
+            CIRCULAR
+        }
+    }
+
+    record Feature(Kind kind) implements DungeonEditorToolOptions {
+        public Feature {
+            kind = kind == null ? Kind.POINT_OF_INTEREST : kind;
+        }
+
+        public enum Kind {
+            POINT_OF_INTEREST,
+            OBJECT,
+            ENCOUNTER
+        }
+    }
+
+    static None none() {
+        return new None();
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorToolSelection.java
+++ b/features/dungeon/api/editor/DungeonEditorToolSelection.java
@@ -3,14 +3,48 @@ package features.dungeon.api.editor;
 /** Active tool family and its currently selected option. */
 public record DungeonEditorToolSelection(
         DungeonEditorToolFamily family,
-        String optionKey
+        DungeonEditorToolOptions options
 ) {
     public DungeonEditorToolSelection {
         family = family == null ? DungeonEditorToolFamily.SELECT : family;
-        optionKey = optionKey == null || optionKey.isBlank() ? "SELECT" : optionKey.strip();
+        options = compatibleOptions(family, options);
     }
 
     public static DungeonEditorToolSelection select() {
-        return new DungeonEditorToolSelection(DungeonEditorToolFamily.SELECT, "SELECT");
+        return family(DungeonEditorToolFamily.SELECT);
+    }
+
+    public static DungeonEditorToolSelection family(DungeonEditorToolFamily family) {
+        DungeonEditorToolFamily safeFamily = family == null ? DungeonEditorToolFamily.SELECT : family;
+        return new DungeonEditorToolSelection(safeFamily, defaultOptions(safeFamily));
+    }
+
+    private static DungeonEditorToolOptions compatibleOptions(
+            DungeonEditorToolFamily family,
+            DungeonEditorToolOptions options
+    ) {
+        if (family == DungeonEditorToolFamily.WALL && options instanceof DungeonEditorToolOptions.Wall
+                || family == DungeonEditorToolFamily.STAIR && options instanceof DungeonEditorToolOptions.Stair
+                || family == DungeonEditorToolFamily.FEATURE && options instanceof DungeonEditorToolOptions.Feature
+                || noOptionsFamily(family) && options instanceof DungeonEditorToolOptions.None) {
+            return options;
+        }
+        return defaultOptions(family);
+    }
+
+    private static boolean noOptionsFamily(DungeonEditorToolFamily family) {
+        return family != DungeonEditorToolFamily.WALL
+                && family != DungeonEditorToolFamily.STAIR
+                && family != DungeonEditorToolFamily.FEATURE;
+    }
+
+    private static DungeonEditorToolOptions defaultOptions(DungeonEditorToolFamily family) {
+        return switch (family) {
+            case WALL -> new DungeonEditorToolOptions.Wall(DungeonEditorToolOptions.Wall.Mode.PATH);
+            case STAIR -> new DungeonEditorToolOptions.Stair(DungeonEditorToolOptions.Stair.Shape.STRAIGHT);
+            case FEATURE -> new DungeonEditorToolOptions.Feature(
+                    DungeonEditorToolOptions.Feature.Kind.POINT_OF_INTEREST);
+            default -> DungeonEditorToolOptions.none();
+        };
     }
 }

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -56,7 +56,7 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
         } else if (safeIntent instanceof DungeonEditorIntent.SetViewMode setViewMode) {
             runtimeRoot.setViewMode(setViewMode.viewMode());
         } else if (safeIntent instanceof DungeonEditorIntent.SetTool setTool) {
-            runtimeRoot.setTool(setTool.tool());
+            runtimeRoot.setTool(setTool.selection());
         } else if (safeIntent instanceof DungeonEditorIntent.ShiftProjectionLevel shiftLevel) {
             runtimeRoot.shiftProjectionLevel(shiftLevel.levelShift());
         } else if (safeIntent instanceof DungeonEditorIntent.SetOverlay setOverlay) {
@@ -111,21 +111,21 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                 .map(DungeonEditorApiFacade::runtimeTargetFrom)
                 .toList();
         PointerWorkflowGesture gesture = new PointerWorkflowGesture(
-                input.gesture().primaryButtonDown(),
-                input.gesture().secondaryButtonDown(),
-                input.gesture().middleButtonDown(),
+                input.gesture().primary(),
+                input.gesture().secondary(),
+                input.gesture().middle(),
                 input.gesture().shiftDown(),
                 input.gesture().controlDown(),
-                input.gesture().wallSingleClickModeSelected());
+                DungeonEditorLegacyToolAdapter.wallSingleClick(input.toolSelection()));
         runtimeRoot.applyPointerInteraction(new PointerInteractionRequest(
                 enumValue(PointerAction.class, input.action().name(), PointerAction.MOVED),
-                input.selectedToolKey(),
+                DungeonEditorLegacyToolAdapter.tool(input.toolSelection()).name(),
                 gesture,
                 PointerInteractionTargets.fromRuntimeTargets(
                         input.sceneX(),
                         input.sceneY(),
-                        input.primaryButtonDown(),
-                        input.secondaryButtonDown(),
+                        input.gesture().primary(),
+                        input.gesture().secondary(),
                         targets,
                         input.projectionLevel()),
                 input.projectionLevel(),

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 public final class DungeonEditorFeatureRuntimeRoot
         implements DungeonEditorMapCatalogOperations,
@@ -125,6 +126,10 @@ public final class DungeonEditorFeatureRuntimeRoot
     @Override
     public void setTool(DungeonEditorTool tool) {
         commands.setTool(tool);
+    }
+
+    void setTool(DungeonEditorToolSelection selection) {
+        commands.setTool(selection);
     }
 
     @Override

--- a/features/dungeon/application/editor/DungeonEditorLegacyToolAdapter.java
+++ b/features/dungeon/application/editor/DungeonEditorLegacyToolAdapter.java
@@ -1,0 +1,93 @@
+package features.dungeon.application.editor;
+
+import features.dungeon.api.DungeonEditorTool;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolOptions;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
+
+/** M2-only adapter between the typed Editor API and the legacy runtime tool enum. */
+final class DungeonEditorLegacyToolAdapter {
+    private DungeonEditorLegacyToolAdapter() {
+    }
+
+    static DungeonEditorToolSelection selection(DungeonEditorTool tool) {
+        DungeonEditorTool safeTool = tool == null ? DungeonEditorTool.SELECT : tool;
+        return switch (safeTool) {
+            case SELECT -> DungeonEditorToolSelection.select();
+            case ROOM_PAINT, ROOM_DELETE -> DungeonEditorToolSelection.family(DungeonEditorToolFamily.ROOM);
+            case WALL_CREATE -> new DungeonEditorToolSelection(
+                    DungeonEditorToolFamily.WALL,
+                    new DungeonEditorToolOptions.Wall(DungeonEditorToolOptions.Wall.Mode.PATH));
+            case WALL_DELETE -> DungeonEditorToolSelection.family(DungeonEditorToolFamily.WALL);
+            case DOOR_CREATE, DOOR_DELETE -> DungeonEditorToolSelection.family(DungeonEditorToolFamily.DOOR);
+            case CORRIDOR_CREATE, CORRIDOR_DELETE ->
+                    DungeonEditorToolSelection.family(DungeonEditorToolFamily.CORRIDOR);
+            case STAIR_CREATE -> stair(DungeonEditorToolOptions.Stair.Shape.STRAIGHT);
+            case STAIR_CREATE_SQUARE -> stair(DungeonEditorToolOptions.Stair.Shape.SQUARE);
+            case STAIR_CREATE_CIRCULAR -> stair(DungeonEditorToolOptions.Stair.Shape.CIRCULAR);
+            case STAIR_DELETE -> DungeonEditorToolSelection.family(DungeonEditorToolFamily.STAIR);
+            case TRANSITION_CREATE, TRANSITION_DELETE ->
+                    DungeonEditorToolSelection.family(DungeonEditorToolFamily.TRANSITION);
+            case FEATURE_POI_CREATE -> feature(DungeonEditorToolOptions.Feature.Kind.POINT_OF_INTEREST);
+            case FEATURE_OBJECT_CREATE -> feature(DungeonEditorToolOptions.Feature.Kind.OBJECT);
+            case FEATURE_ENCOUNTER_CREATE -> feature(DungeonEditorToolOptions.Feature.Kind.ENCOUNTER);
+            case FEATURE_DELETE -> DungeonEditorToolSelection.family(DungeonEditorToolFamily.FEATURE);
+        };
+    }
+
+    static DungeonEditorTool tool(DungeonEditorToolSelection selection) {
+        DungeonEditorToolSelection safeSelection = selection == null
+                ? DungeonEditorToolSelection.select()
+                : selection;
+        return switch (safeSelection.family()) {
+            case SELECT -> DungeonEditorTool.SELECT;
+            case ROOM -> DungeonEditorTool.ROOM_PAINT;
+            case WALL -> DungeonEditorTool.WALL_CREATE;
+            case DOOR -> DungeonEditorTool.DOOR_CREATE;
+            case CORRIDOR -> DungeonEditorTool.CORRIDOR_CREATE;
+            case STAIR -> stairTool(safeSelection.options());
+            case TRANSITION -> DungeonEditorTool.TRANSITION_CREATE;
+            case FEATURE -> featureTool(safeSelection.options());
+        };
+    }
+
+    static boolean wallSingleClick(DungeonEditorToolSelection selection) {
+        return selection != null
+                && selection.options() instanceof DungeonEditorToolOptions.Wall wall
+                && wall.mode() == DungeonEditorToolOptions.Wall.Mode.SINGLE;
+    }
+
+    private static DungeonEditorTool stairTool(DungeonEditorToolOptions options) {
+        if (!(options instanceof DungeonEditorToolOptions.Stair stair)) {
+            return DungeonEditorTool.STAIR_CREATE;
+        }
+        return switch (stair.shape()) {
+            case STRAIGHT -> DungeonEditorTool.STAIR_CREATE;
+            case SQUARE -> DungeonEditorTool.STAIR_CREATE_SQUARE;
+            case CIRCULAR -> DungeonEditorTool.STAIR_CREATE_CIRCULAR;
+        };
+    }
+
+    private static DungeonEditorTool featureTool(DungeonEditorToolOptions options) {
+        if (!(options instanceof DungeonEditorToolOptions.Feature feature)) {
+            return DungeonEditorTool.FEATURE_POI_CREATE;
+        }
+        return switch (feature.kind()) {
+            case POINT_OF_INTEREST -> DungeonEditorTool.FEATURE_POI_CREATE;
+            case OBJECT -> DungeonEditorTool.FEATURE_OBJECT_CREATE;
+            case ENCOUNTER -> DungeonEditorTool.FEATURE_ENCOUNTER_CREATE;
+        };
+    }
+
+    private static DungeonEditorToolSelection stair(DungeonEditorToolOptions.Stair.Shape shape) {
+        return new DungeonEditorToolSelection(
+                DungeonEditorToolFamily.STAIR,
+                new DungeonEditorToolOptions.Stair(shape));
+    }
+
+    private static DungeonEditorToolSelection feature(DungeonEditorToolOptions.Feature.Kind kind) {
+        return new DungeonEditorToolSelection(
+                DungeonEditorToolFamily.FEATURE,
+                new DungeonEditorToolOptions.Feature(kind));
+    }
+}

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -11,6 +11,7 @@ import features.dungeon.api.DungeonEditorStateModel;
 import features.dungeon.api.DungeonEditorStateSnapshot;
 import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 final class DungeonEditorRuntimeCommands
         implements DungeonEditorMapCatalogOperations,
@@ -119,9 +120,18 @@ final class DungeonEditorRuntimeCommands
 
     @Override
     public void setTool(DungeonEditorTool tool) {
+        setTool(DungeonEditorLegacyToolAdapter.selection(tool));
+    }
+
+    void setTool(DungeonEditorToolSelection selection) {
+        DungeonEditorToolSelection safeSelection = selection == null
+                ? DungeonEditorToolSelection.select()
+                : selection;
+        DungeonEditorTool tool = DungeonEditorLegacyToolAdapter.tool(safeSelection);
         execute(() -> {
             clearActiveInteraction();
             stairDraftOperation.clear();
+            statePublisher.selectTool(safeSelection);
             if (activePublishedMapInteraction()) {
                 applyInExecutionLane(() -> context.setToolAndPublishSnapshot(tool));
                 return;
@@ -135,6 +145,7 @@ final class DungeonEditorRuntimeCommands
         execute(() -> {
             clearActiveInteraction();
             stairDraftOperation.clear();
+            statePublisher.selectTool(DungeonEditorToolSelection.select());
             if (!activePublishedMapInteraction()) {
                 applyInExecutionLane(() -> context.setTool(DungeonEditorTool.SELECT));
                 return;
@@ -366,7 +377,7 @@ final class DungeonEditorRuntimeCommands
         boolean ownerReadbackChanged = !Objects.equals(controlsBefore, controlsModel.current())
                 || !Objects.equals(mapSurfaceBefore, mapSurfaceModel.current())
                 || !Objects.equals(stateBefore, stateModel.current());
-        if (operationResult.shouldPublish(ownerReadbackChanged)) {
+        if (operationResult.shouldPublish(ownerReadbackChanged) || statePublisher.publicationPending()) {
             beforePublish.accept(operationResult);
             statePublisher.publishCurrentToSubscribers();
         }

--- a/features/dungeon/application/editor/DungeonEditorStateAssembler.java
+++ b/features/dungeon/application/editor/DungeonEditorStateAssembler.java
@@ -3,10 +3,8 @@ package features.dungeon.application.editor;
 import features.dungeon.api.DungeonEditorControlsSnapshot;
 import features.dungeon.api.DungeonEditorMapSurfaceSnapshot;
 import features.dungeon.api.DungeonEditorStateSnapshot;
-import features.dungeon.api.DungeonEditorTool;
 import features.dungeon.api.editor.DungeonEditorDraftState;
 import features.dungeon.api.editor.DungeonEditorState;
-import features.dungeon.api.editor.DungeonEditorToolFamily;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 /** Assembles the single public editor publication directly from owner readbacks. */
@@ -17,7 +15,8 @@ final class DungeonEditorStateAssembler {
             DungeonEditorControlsSnapshot controls,
             DungeonEditorMapSurfaceSnapshot mapSurface,
             DungeonEditorStateSnapshot state,
-            DungeonEditorRuntimeDraftFrame drafts
+            DungeonEditorRuntimeDraftFrame drafts,
+            DungeonEditorToolSelection toolSelection
     ) {
         DungeonEditorControlsSnapshot safeControls = controls == null
                 ? DungeonEditorControlsSnapshot.empty("")
@@ -38,8 +37,7 @@ final class DungeonEditorStateAssembler {
                 safeControls.selectedMapId(),
                 safeMapSurface.surface(),
                 safeControls.viewMode(),
-                safeControls.selectedTool(),
-                toolSelectionFrom(safeControls.selectedTool()),
+                toolSelection,
                 safeControls.overlaySettings(),
                 safeControls.projectionLevel(),
                 safeControls.reachableLevels(),
@@ -61,30 +59,6 @@ final class DungeonEditorStateAssembler {
             return "Kein Dungeon ausgewählt.";
         }
         return controls.statusText();
-    }
-
-    private static DungeonEditorToolSelection toolSelectionFrom(DungeonEditorTool tool) {
-        DungeonEditorTool safeTool = tool == null ? DungeonEditorTool.SELECT : tool;
-        String key = safeTool.name();
-        DungeonEditorToolFamily family;
-        if (key.startsWith("ROOM_")) {
-            family = DungeonEditorToolFamily.ROOM;
-        } else if (key.startsWith("WALL_")) {
-            family = DungeonEditorToolFamily.WALL;
-        } else if (key.startsWith("DOOR_")) {
-            family = DungeonEditorToolFamily.DOOR;
-        } else if (key.startsWith("CORRIDOR_")) {
-            family = DungeonEditorToolFamily.CORRIDOR;
-        } else if (key.startsWith("FEATURE_")) {
-            family = DungeonEditorToolFamily.FEATURE;
-        } else if (key.startsWith("STAIR_")) {
-            family = DungeonEditorToolFamily.STAIR;
-        } else if (key.startsWith("TRANSITION_")) {
-            family = DungeonEditorToolFamily.TRANSITION;
-        } else {
-            family = DungeonEditorToolFamily.SELECT;
-        }
-        return new DungeonEditorToolSelection(family, key);
     }
 
     private static DungeonEditorDraftState draftFrom(DungeonEditorRuntimeDraftFrame drafts) {

--- a/features/dungeon/application/editor/DungeonEditorStatePublisher.java
+++ b/features/dungeon/application/editor/DungeonEditorStatePublisher.java
@@ -4,6 +4,7 @@ import features.dungeon.api.DungeonEditorControlsModel;
 import features.dungeon.api.DungeonEditorMapSurfaceModel;
 import features.dungeon.api.DungeonEditorStateModel;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -22,6 +23,8 @@ final class DungeonEditorStatePublisher {
     private final DungeonEditorStateAssembler assembler = new DungeonEditorStateAssembler();
     private final List<Consumer<DungeonEditorState>> subscribers = new ArrayList<>();
     private volatile DungeonEditorState latestState;
+    private DungeonEditorToolSelection toolSelection;
+    private boolean publicationPending;
     private long publicationRevision;
 
     DungeonEditorStatePublisher(
@@ -36,6 +39,7 @@ final class DungeonEditorStatePublisher {
         this.stateModel = Objects.requireNonNull(stateModel, "stateModel");
         this.draftSession = Objects.requireNonNull(draftSession, "draftSession");
         this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        toolSelection = DungeonEditorLegacyToolAdapter.selection(controlsModel.current().selectedTool());
         latestState = assembleCurrentState();
     }
 
@@ -61,6 +65,7 @@ final class DungeonEditorStatePublisher {
     void publishCurrentToSubscribers() {
         publicationRevision++;
         latestState = assembleCurrentState();
+        publicationPending = false;
         for (Consumer<DungeonEditorState> subscriber : List.copyOf(subscribers)) {
             subscriber.accept(latestState);
         }
@@ -72,6 +77,20 @@ final class DungeonEditorStatePublisher {
 
     void markDraftSessionChanged() {
         // Draft mutation is assembled into the next atomic state publication.
+    }
+
+    void selectTool(DungeonEditorToolSelection selection) {
+        DungeonEditorToolSelection safeSelection = selection == null
+                ? DungeonEditorToolSelection.select()
+                : selection;
+        if (!safeSelection.equals(toolSelection)) {
+            toolSelection = safeSelection;
+            publicationPending = true;
+        }
+    }
+
+    boolean publicationPending() {
+        return publicationPending;
     }
 
     DungeonEditorState currentState() {
@@ -86,7 +105,8 @@ final class DungeonEditorStatePublisher {
                 readback.controls(),
                 readback.mapSurface(),
                 readback.state(),
-                draftSession.draftFrame(readback.controls(), readback.state()));
+                draftSession.draftFrame(readback.controls(), readback.state()),
+                toolSelection);
     }
 
     private void executeIfOpen(Runnable work) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorSelectionScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorSelectionScenarios.java
@@ -973,7 +973,6 @@ final class DungeonEditorSelectionScenarios {
                 null,
                 safeSnapshot.surface(),
                 safeSnapshot.viewMode(),
-                safeSnapshot.selectedTool(),
                 DungeonEditorToolSelection.select(),
                 safeSnapshot.overlaySettings(),
                 safeSnapshot.projectionLevel(),

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -25,11 +25,34 @@ import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.editor.DungeonEditorIntent;
 import features.dungeon.api.editor.DungeonEditorState;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolOptions;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.party.PartyServiceAssembly;
 import features.party.domain.roster.PartyRoster;
 import features.party.domain.roster.repository.PartyRosterRepository;
 
 final class DungeonEditorRuntimeThreadOwnershipTest {
+
+    @Test
+    void editorApiPublishesTheTypedToolOptionSelectedByItsConsumer() {
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+        DungeonEditorFeatureRuntimeRoot runtime = createRuntimeDirect(repository);
+        DungeonEditorApi api = new DungeonEditorApiFacade(runtime, DirectUiDispatcher.INSTANCE);
+        DungeonEditorToolSelection pathSelection = DungeonEditorToolSelection.family(
+                DungeonEditorToolFamily.WALL);
+        DungeonEditorToolSelection singleSelection = new DungeonEditorToolSelection(
+                DungeonEditorToolFamily.WALL,
+                new DungeonEditorToolOptions.Wall(DungeonEditorToolOptions.Wall.Mode.SINGLE));
+
+        api.dispatch(new DungeonEditorIntent.SetTool(pathSelection));
+        long pathRevision = api.current().publicationRevision();
+        api.dispatch(new DungeonEditorIntent.SetTool(singleSelection));
+
+        assertEquals(singleSelection, api.current().toolSelection());
+        assertTrue(api.current().publicationRevision() > pathRevision,
+                "an option-only change must publish even when its legacy tool value stays equal");
+    }
 
     @Test
     void editorApiPublishesOneAtomicStateAndDispatchesThroughTheRuntimeOwner() {
@@ -63,7 +86,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         assertEquals(current.inspector(), published.inspector());
         assertEquals(current.commandStatus(), published.commandStatus());
         assertEquals(DungeonEditorToolFamily.SELECT, published.toolSelection().family());
-        assertEquals("SELECT", published.toolSelection().optionKey());
+        assertEquals(DungeonEditorToolOptions.none(), published.toolSelection().options());
     }
 
     @Test


### PR DESCRIPTION
## Ergebnis

- ersetzt öffentliche Werkzeug- und Optionsstrings durch typisierte Familien, Optionen und Pointer-Gesten
- migriert den JavaFX-Produktionskonsumenten auf die neue Editor-API
- hält genau einen M2-temporären Adapter zum Legacy-Runtimepfad vor
- aktualisiert die Greenfield-Roadmap mit den M2-Slices

## Beleg

- ./gradlew test --tests features.dungeon.application.editor.DungeonEditorRuntimeThreadOwnershipTest --console=plain
- ./gradlew check --console=plain

Beide Läufe: BUILD SUCCESSFUL.