### PR TITLE
M2.3: Typisierte Dungeon-Befehlsergebnisse

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,14 +97,15 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0, M1, and M2.1 are complete on `main` through PR #494.
-- This slice: M2.2 makes typed tool selections and gesture-derived actions
-  canonical through the runtime and Session, and deletes the old tool enum,
-  registry, definition table, compatibility adapter, and name translation.
-- Contextual wall behavior remains explicit in its owner: secondary input
-  deletes from the base state but completes an already active create path.
-- Next step after this slice merges: M2.3 publishes typed accepted or rejected
-  command outcomes and maps stable rejection reasons to specific status.
+- Current foundation: M0 through M2.2 are complete on `main` through PR #495.
+- This slice: M2.3 publishes typed accepted or rejected command outcomes in the
+  atomic Editor state. Blocked route, protected exterior wall, referenced
+  connection, invalid stair geometry, stale revision, and missing transition
+  destination are stable reasons mapped to user-facing status in one place.
+- Rejected production routes preserve authored state and revision; outcome-only
+  feedback remains a controls publication and does not republish map geometry.
+- Next step after this slice merges: M2.4 establishes `RoomRegion` and
+  `RoomCluster` ownership and collapses same-layer room and cluster pairs.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/api/DungeonEditorControlsSnapshot.java
+++ b/features/dungeon/api/DungeonEditorControlsSnapshot.java
@@ -2,6 +2,7 @@ package features.dungeon.api;
 
 import java.util.List;
 import org.jspecify.annotations.Nullable;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 public record DungeonEditorControlsSnapshot(
@@ -13,7 +14,8 @@ public record DungeonEditorControlsSnapshot(
         DungeonOverlaySettings overlaySettings,
         List<Integer> reachableLevels,
         boolean surfaceLoaded,
-        String statusText
+        String statusText,
+        DungeonEditorCommandOutcome commandOutcome
 ) {
     public DungeonEditorControlsSnapshot {
         maps = maps == null ? List.of() : List.copyOf(maps);
@@ -22,6 +24,7 @@ public record DungeonEditorControlsSnapshot(
         overlaySettings = overlaySettings == null ? DungeonOverlaySettings.defaults() : overlaySettings;
         reachableLevels = reachableLevels == null ? List.of(0) : List.copyOf(reachableLevels);
         statusText = statusText == null ? "" : statusText;
+        commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
     }
 
     public static DungeonEditorControlsSnapshot empty(String statusText) {
@@ -34,6 +37,7 @@ public record DungeonEditorControlsSnapshot(
                 DungeonOverlaySettings.defaults(),
                 List.of(0),
                 false,
-                statusText);
+                statusText,
+                DungeonEditorCommandOutcome.idle());
     }
 }

--- a/features/dungeon/api/editor/DungeonEditorCommandOutcome.java
+++ b/features/dungeon/api/editor/DungeonEditorCommandOutcome.java
@@ -1,0 +1,44 @@
+package features.dungeon.api.editor;
+
+/** Stable result of the most recently completed authored Editor command. */
+public sealed interface DungeonEditorCommandOutcome {
+
+    static DungeonEditorCommandOutcome idle() {
+        return Idle.INSTANCE;
+    }
+
+    static DungeonEditorCommandOutcome accepted(long authoredRevision) {
+        return new Accepted(authoredRevision);
+    }
+
+    static DungeonEditorCommandOutcome rejected(RejectionReason reason) {
+        return new Rejected(reason);
+    }
+
+    enum Idle implements DungeonEditorCommandOutcome {
+        INSTANCE
+    }
+
+    record Accepted(long authoredRevision) implements DungeonEditorCommandOutcome {
+        public Accepted {
+            authoredRevision = Math.max(0L, authoredRevision);
+        }
+    }
+
+    record Rejected(RejectionReason reason) implements DungeonEditorCommandOutcome {
+        public Rejected {
+            reason = reason == null ? RejectionReason.INVALID_TARGET : reason;
+        }
+    }
+
+    enum RejectionReason {
+        BLOCKED_ROUTE,
+        PROTECTED_EXTERIOR_WALL,
+        REFERENCED_CONNECTION,
+        INVALID_STAIR_GEOMETRY,
+        STALE_REVISION,
+        MISSING_TRANSITION_DESTINATION,
+        INVALID_TARGET,
+        NO_EFFECT
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorState.java
+++ b/features/dungeon/api/editor/DungeonEditorState.java
@@ -62,13 +62,18 @@ public record DungeonEditorState(
                 CommandStatus.idle());
     }
 
-    public record CommandStatus(boolean busy, String message) {
+    public record CommandStatus(
+            boolean busy,
+            DungeonEditorCommandOutcome outcome,
+            String message
+    ) {
         public CommandStatus {
+            outcome = outcome == null ? DungeonEditorCommandOutcome.idle() : outcome;
             message = message == null ? "" : message;
         }
 
         public static CommandStatus idle() {
-            return new CommandStatus(false, "");
+            return new CommandStatus(false, DungeonEditorCommandOutcome.idle(), "");
         }
     }
 }

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -66,6 +66,7 @@ import features.dungeon.api.DungeonAuthoredMutationModel;
 import features.dungeon.api.DungeonAuthoredReadModel;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.authored.DungeonAuthoredApi;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.DungeonViewportRequest;
 import features.dungeon.api.DungeonViewportSnapshot;
 
@@ -211,9 +212,15 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
         List<Edge> safeEdges = List.copyOf(Objects.requireNonNull(edges, "edges"));
         BoundaryKind safeBoundaryKind = Objects.requireNonNull(boundaryKind, "boundaryKind");
+        DungeonEditorCommandOutcome.RejectionReason rejectionReason = !deleteMode
+                ? DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT
+                : safeBoundaryKind == BoundaryKind.WALL
+                        ? DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL
+                        : DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION;
         OperationResultData result = mutationPipeline.executeOperation(
                 domainMapId(mapId),
-                current -> current.editClusterBoundaries(clusterId, safeEdges, safeBoundaryKind, deleteMode));
+                current -> current.editClusterBoundaries(clusterId, safeEdges, safeBoundaryKind, deleteMode),
+                rejectionReason);
         publicationOperations.publishMutation(result, session.dungeonState());
     }
 
@@ -297,7 +304,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 mutationPipeline.snapshotData(saved, derive(saved)),
                 true,
                 List.of(),
-                List.of(undo ? "undo applied" : "redo applied"));
+                List.of(undo ? "undo applied" : "redo applied"),
+                DungeonEditorCommandOutcome.accepted(saved.revision()));
         publicationOperations.publishMutation(result, session.dungeonState());
     }
 
@@ -491,9 +499,20 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
     }
 
-    public record OperationResult(boolean present) {
+    public record OperationResult(DungeonEditorCommandOutcome commandOutcome) {
+        public OperationResult {
+            commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
+        }
+
         public static OperationResult fromNullable(Object result) {
-            return new OperationResult(result != null);
+            return new OperationResult(result == null
+                    ? DungeonEditorCommandOutcome.rejected(
+                            DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION)
+                    : DungeonEditorCommandOutcome.accepted(0L));
+        }
+
+        public boolean present() {
+            return commandOutcome instanceof DungeonEditorCommandOutcome.Accepted;
         }
     }
 
@@ -526,6 +545,14 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 @Nullable DungeonMapIdentity mapId,
                 @Nullable AuthoredMapMutation operation
         ) {
+            return executeOperation(mapId, operation, DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+
+        private OperationResultData executeOperation(
+                @Nullable DungeonMapIdentity mapId,
+                @Nullable AuthoredMapMutation operation,
+                DungeonEditorCommandOutcome.RejectionReason rejectionReason
+        ) {
             DungeonMap current = loadMap(mapId);
             DungeonMap operationResult = applyOperation(current, operation);
             boolean changed = !operationResult.equals(current);
@@ -542,7 +569,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (changed) {
                 editHistory.record(current, saved);
             }
-            return new OperationResultData(snapshotData(saved, derived), changed, validationMessages, reactionMessages);
+            DungeonEditorCommandOutcome outcome = changed
+                    ? DungeonEditorCommandOutcome.accepted(saved.revision())
+                    : DungeonEditorCommandOutcome.rejected(rejectionReason);
+            return new OperationResultData(
+                    snapshotData(saved, derived), changed, validationMessages, reactionMessages, outcome);
         }
 
         private OperationResultData previewOperation(
@@ -556,7 +587,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     snapshotData(mutated, derived),
                     !mutated.equals(current),
                     OPERATION_FEEDBACK_POLICY.validationMessages(current, mutated),
-                    OPERATION_FEEDBACK_POLICY.reactionMessages(current, mutated));
+                    OPERATION_FEEDBACK_POLICY.reactionMessages(current, mutated),
+                    DungeonEditorCommandOutcome.idle());
         }
 
         private LoadDungeonSnapshotUseCase.DungeonSnapshotData snapshotData(DungeonMap dungeonMap) {
@@ -610,7 +642,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     : snapshotPublication.stateFacts();
             state.replaceMutation(snapshot == null
                     ? null
-                    : new DungeonEditorDungeonState.MutationFacts(snapshot, mutationStatusText(mutation)));
+                    : new DungeonEditorDungeonState.MutationFacts(snapshot, mutation.commandOutcome()));
             if (mutation != null && snapshotPublication != null) {
                 publishedState.publishMutation(new DungeonAuthoredPublication.Mutation(
                         snapshotPublication.publishedSnapshot(),
@@ -632,21 +664,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     snapshot.revision());
         }
 
-        private String mutationStatusText(@Nullable OperationResultData mutation) {
-            if (mutation == null) {
-                return "";
-            }
-            if (!mutation.changed()) {
-                return "Keine Änderung angewendet.";
-            }
-            if (!mutation.reactionMessages().isEmpty()) {
-                return mutation.reactionMessages().getFirst();
-            }
-            if (!mutation.validationMessages().isEmpty()) {
-                return mutation.validationMessages().getFirst();
-            }
-            return "";
-        }
     }
 
     private final class LoadOperations {
@@ -697,14 +714,16 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     current -> current.createCorridor(
                             stairIdForCorridor(current, startEndpoint, endEndpoint, true),
                             startEndpoint,
-                            endEndpoint));
+                            endEndpoint),
+                    DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
         private void deleteCorridor(MapId mapId, CorridorDeletionTarget target, Session session) {
             OperationResultData result = mutationPipeline.executeOperation(
                     domainMapId(mapId),
-                    current -> CORRIDOR_AUTHORING.deleteCorridor(current, target));
+                    current -> CORRIDOR_AUTHORING.deleteCorridor(current, target),
+                    DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -755,7 +774,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             long stairId = repository.nextStairId();
             OperationResultData result = mutationPipeline.executeOperation(
                     domainMapId(mapId),
-                    current -> current.createStair(stairId, spec));
+                    current -> current.createStair(stairId, spec),
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -772,7 +792,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 return false;
             }
             OperationResultData result =
-                    mutationPipeline.executeOperation(mapIdentity, current -> current.deleteStair(stairId));
+                    mutationPipeline.executeOperation(
+                            mapIdentity,
+                            current -> current.deleteStair(stairId),
+                            DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
             publicationOperations.publishMutation(result, session.dungeonState());
             return true;
         }
@@ -793,7 +816,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                             transitionId,
                             current.metadata().mapId().value(),
                             anchor,
-                            destination)));
+                            destination)),
+                    DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -817,7 +841,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 return false;
             }
             OperationResultData result =
-                    mutationPipeline.executeOperation(mapIdentity, current -> current.deleteTransition(transitionId));
+                    mutationPipeline.executeOperation(
+                            mapIdentity,
+                            current -> current.deleteTransition(transitionId),
+                            DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
             publicationOperations.publishMutation(result, session.dungeonState());
             return true;
         }
@@ -1162,7 +1189,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     mutationPipeline.snapshotData(savedSourceMap, derived),
                     true,
                     List.of(),
-                    List.of("transition link saved"));
+                    List.of("transition link saved"),
+                    DungeonEditorCommandOutcome.accepted(savedSourceMap.revision()));
         }
 
         private @Nullable LoadedTransitionLink loadTransitionLink(
@@ -1331,7 +1359,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             OperationResultData result = mutationPipeline.executeOperation(
                     domainMapId(mapId),
-                    current -> current.saveStairGeometry(stairId, spec));
+                    current -> current.saveStairGeometry(stairId, spec),
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
             publicationOperations.publishMutation(result, state);
         }
 
@@ -1668,11 +1697,13 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             LoadDungeonSnapshotUseCase.DungeonSnapshotData snapshot,
             boolean changed,
             List<String> validationMessages,
-            List<String> reactionMessages
+            List<String> reactionMessages,
+            DungeonEditorCommandOutcome commandOutcome
     ) {
         OperationResultData {
             validationMessages = validationMessages == null ? List.of() : List.copyOf(validationMessages);
             reactionMessages = reactionMessages == null ? List.of() : List.copyOf(reactionMessages);
+            commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
         }
 
         @Override

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -5,6 +5,7 @@ import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.editor.DungeonEditorIntent;
 import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -105,6 +106,7 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
 
     private void dispatchPointer(DungeonEditorPointerInput input) {
         if (input.sourceRevision() != current().publicationRevision()) {
+            runtimeRoot.rejectCommand(DungeonEditorCommandOutcome.RejectionReason.STALE_REVISION);
             return;
         }
         List<DungeonEditorRuntimePointerTarget> targets = input.targets().stream()

--- a/features/dungeon/application/editor/DungeonEditorBoundaryDraftEffectHelper.java
+++ b/features/dungeon/application/editor/DungeonEditorBoundaryDraftEffectHelper.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import features.dungeon.application.editor.session.DungeonEditorSessionEffect;
 import features.dungeon.application.editor.session.DungeonEditorSessionValues;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.BoundaryDraft;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.EdgeKey;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.InteractionState;
@@ -76,7 +77,8 @@ final class DungeonEditorBoundaryDraftEffectHelper {
     DungeonEditorMainViewInterpretation rejectExteriorWallDelete(InteractionState state) {
         return new DungeonEditorMainViewInterpretation(
                 state.withBoundaryDraft(BoundaryDraft.none()),
-                DungeonEditorSessionEffect.clearPreviewWithStatus("Cluster-Aussenwand kann nicht gelöscht werden."));
+                DungeonEditorSessionEffect.rejected(
+                        DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL));
     }
 
     private static DungeonEditorSessionValues.ClusterBoundariesPreview boundaryPreview(

--- a/features/dungeon/application/editor/DungeonEditorCommandStatusMessages.java
+++ b/features/dungeon/application/editor/DungeonEditorCommandStatusMessages.java
@@ -1,0 +1,28 @@
+package features.dungeon.application.editor;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+
+/** Maps stable command meaning to presentation text without parsing domain feedback. */
+final class DungeonEditorCommandStatusMessages {
+    private DungeonEditorCommandStatusMessages() {
+    }
+
+    static String message(DungeonEditorCommandOutcome outcome) {
+        if (outcome instanceof DungeonEditorCommandOutcome.Accepted) {
+            return "Aenderung gespeichert.";
+        }
+        if (outcome instanceof DungeonEditorCommandOutcome.Rejected rejected) {
+            return switch (rejected.reason()) {
+                case BLOCKED_ROUTE -> "Korridorroute blockiert.";
+                case PROTECTED_EXTERIOR_WALL -> "Cluster-Aussenwand kann nicht geloescht werden.";
+                case REFERENCED_CONNECTION -> "Verknuepfte Verbindung kann nicht geloescht werden.";
+                case INVALID_STAIR_GEOMETRY -> "Treppengeometrie ungueltig.";
+                case STALE_REVISION -> "Eingabe verworfen: Editor-Stand ist veraltet.";
+                case MISSING_TRANSITION_DESTINATION -> "Uebergangsziel fehlt oder ist ungueltig.";
+                case INVALID_TARGET -> "Bearbeitungsziel ist ungueltig.";
+                case NO_EFFECT -> "Der Befehl hat keine Aenderung erzeugt.";
+            };
+        }
+        return "";
+    }
+}

--- a/features/dungeon/application/editor/DungeonEditorControlsProjectionServiceAssembly.java
+++ b/features/dungeon/application/editor/DungeonEditorControlsProjectionServiceAssembly.java
@@ -35,7 +35,8 @@ final class DungeonEditorControlsProjectionServiceAssembly {
                 DungeonEditorValueProjectionServiceAssembly.overlay(safeControls.overlaySettings()),
                 safeCurrent.reachableLevels(),
                 safeCurrent.surfaceLoaded(),
-                safeControls.statusText());
+                statusText(safeControls.statusText(), safeControls.commandOutcome()),
+                safeControls.commandOutcome());
     }
 
     private static features.dungeon.api.DungeonEditorControlsSnapshot snapshot(
@@ -52,7 +53,16 @@ final class DungeonEditorControlsProjectionServiceAssembly {
                 DungeonEditorValueProjectionServiceAssembly.overlay(snapshot.overlaySettings()),
                 reachableLevels,
                 surfacePresent,
-                snapshot.statusText());
+                statusText(snapshot.statusText(), snapshot.commandOutcome()),
+                snapshot.commandOutcome());
+    }
+
+    private static String statusText(
+            String fallback,
+            features.dungeon.api.editor.DungeonEditorCommandOutcome outcome
+    ) {
+        String outcomeText = DungeonEditorCommandStatusMessages.message(outcome);
+        return outcomeText.isBlank() ? fallback : outcomeText;
     }
 
     private static List<features.dungeon.api.DungeonMapSummary> publishedMapSummaries(

--- a/features/dungeon/application/editor/DungeonEditorCorridorInteractionUseCase.java
+++ b/features/dungeon/application/editor/DungeonEditorCorridorInteractionUseCase.java
@@ -8,6 +8,7 @@ import features.dungeon.application.editor.DungeonEditorMainViewInteractionValue
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.InteractionState;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.PendingCorridorTarget;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.PointerState;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 final class DungeonEditorCorridorInteractionUseCase {
     private final DungeonEditorCorridorTargetHelper targetService = new DungeonEditorCorridorTargetHelper();
@@ -63,7 +64,9 @@ final class DungeonEditorCorridorInteractionUseCase {
         if (!routeValidationHelper.hasValidRoute(snapshot, facingTargets.start(), facingTargets.target())) {
             return new DungeonEditorMainViewInterpretation(
                     nextState,
-                    DungeonEditorSessionEffect.select(facingTargets.target().selection(), "Korridorroute blockiert."));
+                    DungeonEditorSessionEffect.selectRejected(
+                            facingTargets.target().selection(),
+                            DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE));
         }
         return new DungeonEditorMainViewInterpretation(
                 nextState,

--- a/features/dungeon/application/editor/DungeonEditorFeatureMarkerRuntimeOperation.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureMarkerRuntimeOperation.java
@@ -10,7 +10,6 @@ import features.dungeon.application.editor.session.DungeonEditorSessionValues;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
 
 final class DungeonEditorFeatureMarkerRuntimeOperation {
-    private static final String INVALID_FEATURE_MARKER_STATUS = "Feature-Markierung ungueltig.";
     private static final long NO_MARKER_ID = 0L;
 
     private final DungeonEditorRuntimeContext context;
@@ -55,7 +54,7 @@ final class DungeonEditorFeatureMarkerRuntimeOperation {
                 context.selectedMapId(),
                 kind,
                 anchor)) {
-            context.clearPreviewWithStatus(INVALID_FEATURE_MARKER_STATUS);
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
             return context.publishCurrent();
         }
         long markerId = context.createFeatureMarker(
@@ -63,12 +62,11 @@ final class DungeonEditorFeatureMarkerRuntimeOperation {
                 kind,
                 anchor);
         if (markerId <= NO_MARKER_ID) {
-            context.clearPreviewWithStatus(INVALID_FEATURE_MARKER_STATUS);
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
             return context.publishCurrent();
         }
-        context.applySessionEffect(DungeonEditorSessionEffect.select(
-                markerSelection(markerId),
-                context.currentFacts().mutationStatusText()));
+        context.applySessionEffect(DungeonEditorSessionEffect.select(markerSelection(markerId)));
+        context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
         return context.publishCurrent();
     }
 
@@ -91,7 +89,9 @@ final class DungeonEditorFeatureMarkerRuntimeOperation {
         boolean deleted = context.deleteFeatureMarker(context.selectedMapId(), markerId);
         if (deleted) {
             context.applySessionEffect(DungeonEditorSessionEffect.clearedSelection());
-            context.clearPreviewWithStatus(context.currentFacts().mutationStatusText());
+            context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
+        } else {
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
         }
         return context.publishCurrent();
     }

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 public final class DungeonEditorFeatureRuntimeRoot
         implements DungeonEditorMapCatalogOperations,
@@ -165,6 +166,10 @@ public final class DungeonEditorFeatureRuntimeRoot
     @Override
     public void clearPointerSession() {
         pointerWorkflow.clearPointerSession();
+    }
+
+    public void rejectCommand(DungeonEditorCommandOutcome.RejectionReason reason) {
+        commands.rejectCommand(reason);
     }
 
     @Override

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -24,6 +24,7 @@ import features.dungeon.application.editor.session.DungeonEditorSessionValues;
 import features.dungeon.application.editor.session.DungeonEditorSessionWorkflow;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceCoreGeometry;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
@@ -32,8 +33,6 @@ import features.dungeon.application.editor.helper.DungeonEditorSessionPreviewHel
 import features.dungeon.application.editor.helper.DungeonEditorSnapshotStateProjectionHelper;
 
 public final class DungeonEditorRuntimeApplicationService {
-
-    private static final String INVALID_STAIR_GEOMETRY_STATUS = "Treppengeometrie ungueltig.";
 
     private final DungeonAuthoredApplicationService authoredService;
     private final DungeonEditorPublishedState editorPublishedState;
@@ -108,6 +107,10 @@ public final class DungeonEditorRuntimeApplicationService {
             workflow.clearPreviewWithStatus(statusText);
         }
 
+        public void clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome outcome) {
+            workflow.clearPreviewWithCommandOutcome(outcome);
+        }
+
         public @Nullable MapSnapshot loadCommittedSnapshot() {
             return snapshotBuilder.loadCommittedSnapshot(workflow.session().selectedMapId());
         }
@@ -180,6 +183,7 @@ public final class DungeonEditorRuntimeApplicationService {
             MapId mapId = workflow.session().selectedMapId();
             if (mapId != null) {
                 authoredService.undo(mapId, authored);
+                workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             }
             return refreshAuthoredSnapshot();
         }
@@ -188,6 +192,7 @@ public final class DungeonEditorRuntimeApplicationService {
             MapId mapId = workflow.session().selectedMapId();
             if (mapId != null) {
                 authoredService.redo(mapId, authored);
+                workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             }
             return refreshAuthoredSnapshot();
         }
@@ -255,12 +260,12 @@ public final class DungeonEditorRuntimeApplicationService {
                     input == null ? new DungeonAuthoredApplicationService.RoomNarrationInput(0L, "", List.of()) : input;
             DungeonEditorRoomNarrationInput roomNarration = roomNarration(safeInput);
             if (roomNarration == null || !DungeonEditorWorkspaceValues.hasId(roomNarration.roomId())) {
-                return null;
+                return rejectInvalidTarget();
             }
             if (workflow.session().selectedMapId() != null) {
                 authored.saveAuthoredRoomNarration(workflow.session().selectedMapId(), roomNarration);
             }
-            workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             return publishCurrent();
         }
 
@@ -280,7 +285,7 @@ public final class DungeonEditorRuntimeApplicationService {
                         safeInput.targetId(),
                         safeInput.name());
             }
-            workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             return publishCurrent();
         }
 
@@ -291,13 +296,13 @@ public final class DungeonEditorRuntimeApplicationService {
                     ? new DungeonAuthoredApplicationService.TransitionDescriptionInput(0L, "")
                     : input;
             if (safeInput.transitionId() <= 0L || !workflow.session().hasSelectedMap()) {
-                return null;
+                return rejectInvalidTarget();
             }
             authored.saveAuthoredTransitionDescription(
                     workflow.session().selectedMapId(),
                     safeInput.transitionId(),
                     safeInput.description());
-            workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             return publishCurrent();
         }
 
@@ -305,7 +310,7 @@ public final class DungeonEditorRuntimeApplicationService {
                 DungeonAuthoredApplicationService.TransitionLinkInput input
         ) {
             if (!workflow.session().hasSelectedMap()) {
-                return DungeonAuthoredApplicationService.OperationResult.fromNullable(null);
+                return rejectTransitionLink();
             }
             return saveTransitionLink(workflow.session().selectedMapId(), input);
         }
@@ -318,7 +323,7 @@ public final class DungeonEditorRuntimeApplicationService {
                     ? new DungeonAuthoredApplicationService.TransitionLinkInput(0L, 0L, 0L, false)
                     : input;
             if (sourceMapId == null) {
-                return DungeonAuthoredApplicationService.OperationResult.fromNullable(null);
+                return rejectTransitionLink();
             }
             boolean result = authored.saveAuthoredTransitionLink(
                     sourceMapId,
@@ -327,11 +332,24 @@ public final class DungeonEditorRuntimeApplicationService {
                     safeInput.targetTransitionId(),
                     safeInput.bidirectional());
             if (!result) {
-                return DungeonAuthoredApplicationService.OperationResult.fromNullable(null);
+                return rejectTransitionLink();
             }
-            workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             publishCurrent();
             return DungeonAuthoredApplicationService.OperationResult.fromNullable(Boolean.TRUE);
+        }
+
+        private DungeonAuthoredApplicationService.OperationResult rejectTransitionLink() {
+            workflow.clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome.rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION));
+            publishCurrent();
+            return DungeonAuthoredApplicationService.OperationResult.fromNullable(null);
+        }
+
+        private DungeonEditorSessionSnapshot.@Nullable SnapshotData rejectInvalidTarget() {
+            workflow.clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome.rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET));
+            return publishCurrent();
         }
 
         public DungeonEditorSessionSnapshot.@Nullable SnapshotData saveStairGeometry(
@@ -358,14 +376,15 @@ public final class DungeonEditorRuntimeApplicationService {
                             workflow.session().selectedMapId(),
                             safeInput.stairId(),
                             spec)) {
-                workflow.clearPreviewWithStatus(INVALID_STAIR_GEOMETRY_STATUS);
+                workflow.clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome.rejected(
+                        DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY));
                 return publishCurrent();
             }
             authored.saveAuthoredStairGeometry(
                     workflow.session().selectedMapId(),
                     safeInput.stairId(),
                     spec);
-            workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
             return publishCurrent();
         }
 
@@ -617,7 +636,7 @@ public final class DungeonEditorRuntimeApplicationService {
                 if (mapId != null && authoredCommit != null) {
                     authoredCommit.apply(mapId);
                 }
-                workflow.clearPreviewWithStatus(currentFacts().mutationStatusText());
+                workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
                 if (DungeonEditorSessionPreviewHelper.clearsSelectionAfterApply(applyPreview)) {
                     workflow.applyEffect(DungeonEditorSessionEffect.clearedSelection());
                 }
@@ -627,8 +646,13 @@ public final class DungeonEditorRuntimeApplicationService {
                     DungeonEditorSession previousSession,
                     DungeonEditorSession currentSession
             ) {
-                return !Objects.equals(previousSession.statusText(), currentSession.statusText())
-                        && previousSession.withStatusText(currentSession.statusText()).equals(currentSession);
+                boolean commandStatusChanged =
+                        !Objects.equals(previousSession.statusText(), currentSession.statusText())
+                                || !Objects.equals(previousSession.commandOutcome(), currentSession.commandOutcome());
+                return commandStatusChanged
+                        && previousSession.withCommandStatus(
+                                currentSession.statusText(),
+                                currentSession.commandOutcome()).equals(currentSession);
             }
 
             private enum PublicationOutcome {
@@ -808,7 +832,8 @@ public final class DungeonEditorRuntimeApplicationService {
                     safeState.selection(),
                     surface,
                     safeState.preview(),
-                    nextStatus);
+                    nextStatus,
+                    safeState.commandOutcome());
         }
 
         private void refreshAuthoredSurface(

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -3,6 +3,7 @@ package features.dungeon.application.editor;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import platform.execution.ExecutionLane;
 import features.dungeon.api.DungeonEditorControlsModel;
 import features.dungeon.api.DungeonEditorMapSurfaceModel;
@@ -326,6 +327,13 @@ final class DungeonEditorRuntimeCommands
 
     void apply(Supplier<DungeonEditorRuntimeContext.Result> action) {
         apply(action, ignored -> { });
+    }
+
+    void rejectCommand(DungeonEditorCommandOutcome.RejectionReason reason) {
+        apply(() -> {
+            context.reject(reason);
+            return context.publishCurrent();
+        });
     }
 
     void apply(

--- a/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
@@ -18,6 +18,7 @@ import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 final class DungeonEditorRuntimeContext {
     private final DungeonEditorRuntimeApplicationService.RuntimeSession session;
@@ -69,6 +70,14 @@ final class DungeonEditorRuntimeContext {
 
     void clearPreviewWithStatus(String statusText) {
         session.clearPreviewWithStatus(statusText);
+    }
+
+    void clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome outcome) {
+        session.clearPreviewWithCommandOutcome(outcome);
+    }
+
+    void reject(DungeonEditorCommandOutcome.RejectionReason reason) {
+        clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome.rejected(reason));
     }
 
     DungeonEditorDungeonFacts currentFacts() {

--- a/features/dungeon/application/editor/DungeonEditorSelectedHandleRuntimeOperation.java
+++ b/features/dungeon/application/editor/DungeonEditorSelectedHandleRuntimeOperation.java
@@ -73,7 +73,7 @@ final class DungeonEditorSelectedHandleRuntimeOperation {
             return DungeonEditorRuntimeContext.Result.none();
         }
         context.moveCorridorHandle(selectedMapId, preview);
-        context.clearPreviewWithStatus(context.currentFacts().mutationStatusText());
+        context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
         return context.publishCurrent();
     }
 

--- a/features/dungeon/application/editor/DungeonEditorStairDeleteRuntimeOperation.java
+++ b/features/dungeon/application/editor/DungeonEditorStairDeleteRuntimeOperation.java
@@ -41,7 +41,9 @@ final class DungeonEditorStairDeleteRuntimeOperation {
         boolean deleted = context.deleteStair(context.selectedMapId(), stairId);
         if (deleted) {
             context.applySessionEffect(DungeonEditorSessionEffect.clearedSelection());
-            context.clearPreviewWithStatus(context.currentFacts().mutationStatusText());
+            context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
+        } else {
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
         }
         return context.publishCurrent();
     }

--- a/features/dungeon/application/editor/DungeonEditorStateAssembler.java
+++ b/features/dungeon/application/editor/DungeonEditorStateAssembler.java
@@ -43,7 +43,10 @@ final class DungeonEditorStateAssembler {
                 draftFrom(safeDrafts),
                 safeMapSurface.preview(),
                 safeState.inspector(),
-                new DungeonEditorState.CommandStatus(false, statusText(safeControls)));
+                new DungeonEditorState.CommandStatus(
+                        false,
+                        safeControls.commandOutcome(),
+                        statusText(safeControls)));
     }
 
     private static String statusText(DungeonEditorControlsSnapshot controls) {

--- a/features/dungeon/application/editor/DungeonEditorTransitionRuntimeOperation.java
+++ b/features/dungeon/application/editor/DungeonEditorTransitionRuntimeOperation.java
@@ -11,7 +11,6 @@ import features.dungeon.application.editor.session.DungeonEditorSessionEffect;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
 
 final class DungeonEditorTransitionRuntimeOperation {
-    private static final String INVALID_TRANSITION_DESTINATION_STATUS = "Uebergangsziel ungueltig.";
     private static final long NO_TRANSITION_ID = 0L;
 
     private final DungeonEditorRuntimeContext context;
@@ -62,7 +61,9 @@ final class DungeonEditorTransitionRuntimeOperation {
         boolean deleted = context.deleteTransition(context.selectedMapId(), transitionId);
         if (deleted) {
             context.applySessionEffect(DungeonEditorSessionEffect.clearedSelection());
-            context.clearPreviewWithStatus(context.currentFacts().mutationStatusText());
+            context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
+        } else {
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
         }
         return context.publishCurrent();
     }
@@ -86,11 +87,11 @@ final class DungeonEditorTransitionRuntimeOperation {
                 context.selectedMapId(),
                 anchor,
                 destination)) {
-            context.clearPreviewWithStatus(INVALID_TRANSITION_DESTINATION_STATUS);
+            context.reject(features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION);
             return context.publishCurrent();
         }
         context.createTransition(context.selectedMapId(), anchor, destination);
-        context.clearPreviewWithStatus(context.currentFacts().mutationStatusText());
+        context.clearPreviewWithCommandOutcome(context.currentFacts().commandOutcome());
         return context.publishCurrent();
     }
 

--- a/features/dungeon/application/editor/session/DungeonEditorDungeonFacts.java
+++ b/features/dungeon/application/editor/session/DungeonEditorDungeonFacts.java
@@ -5,19 +5,20 @@ import org.jspecify.annotations.Nullable;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSummary;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 public record DungeonEditorDungeonFacts(
         List<MapSummary> maps,
         @Nullable MapId mutationMapId,
         @Nullable MapSnapshot committedSnapshot,
         DungeonEditorSessionSnapshot.@Nullable SurfaceData surface,
-        String mutationStatusText,
+        DungeonEditorCommandOutcome commandOutcome,
         String previewStatusText
 ) {
 
     public DungeonEditorDungeonFacts {
         maps = maps == null ? List.of() : List.copyOf(maps);
-        mutationStatusText = mutationStatusText == null ? "" : mutationStatusText;
+        commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
         previewStatusText = previewStatusText == null ? "" : previewStatusText;
     }
 

--- a/features/dungeon/application/editor/session/DungeonEditorDungeonState.java
+++ b/features/dungeon/application/editor/session/DungeonEditorDungeonState.java
@@ -6,6 +6,7 @@ import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSummary;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 public final class DungeonEditorDungeonState {
 
@@ -63,12 +64,12 @@ public final class DungeonEditorDungeonState {
         }
     }
 
-    public record MutationFacts(SnapshotFacts snapshot, String statusText) {
+    public record MutationFacts(SnapshotFacts snapshot, DungeonEditorCommandOutcome commandOutcome) {
         public MutationFacts {
             snapshot = snapshot == null
                     ? new SnapshotFacts("Dungeon Map", 0, DungeonEditorWorkspaceValues.MapSnapshot.empty())
                     : snapshot;
-            statusText = statusText == null ? "" : statusText;
+            commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
         }
     }
 

--- a/features/dungeon/application/editor/session/DungeonEditorDungeonStateStore.java
+++ b/features/dungeon/application/editor/session/DungeonEditorDungeonStateStore.java
@@ -7,6 +7,7 @@ import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSummary;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 
 final class DungeonEditorDungeonStateStore {
     private List<MapSummary> catalog = List.of();
@@ -50,7 +51,7 @@ final class DungeonEditorDungeonStateStore {
                 mutationMapId,
                 snapshot == null ? null : snapshot.map(),
                 currentSurface(mapId, selection, preview),
-                mutation == null ? "" : mutation.statusText(),
+                mutation == null ? DungeonEditorCommandOutcome.idle() : mutation.commandOutcome(),
                 preview == DungeonEditorSessionValues.Preview.none() || this.preview == null
                         ? ""
                         : this.preview.statusText());

--- a/features/dungeon/application/editor/session/DungeonEditorSession.java
+++ b/features/dungeon/application/editor/session/DungeonEditorSession.java
@@ -2,6 +2,7 @@ package features.dungeon.application.editor.session;
 
 import org.jspecify.annotations.Nullable;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 public record DungeonEditorSession(
@@ -12,7 +13,8 @@ public record DungeonEditorSession(
         DungeonEditorSessionValues.OverlaySettings overlaySettings,
         DungeonEditorSessionValues.Selection selection,
         DungeonEditorSessionValues.Preview preview,
-        String statusText
+        String statusText,
+        DungeonEditorCommandOutcome commandOutcome
 ) {
 
     public DungeonEditorSession {
@@ -22,6 +24,7 @@ public record DungeonEditorSession(
         selection = selection == null ? DungeonEditorSessionValues.Selection.empty() : selection;
         preview = preview == null ? DungeonEditorSessionValues.Preview.none() : preview;
         statusText = statusText == null ? "" : statusText;
+        commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
     }
 
     public static DungeonEditorSession empty() {
@@ -33,7 +36,8 @@ public record DungeonEditorSession(
                 DungeonEditorSessionValues.OverlaySettings.defaults(),
                 DungeonEditorSessionValues.Selection.empty(),
                 DungeonEditorSessionValues.Preview.none(),
-                "");
+                "",
+                DungeonEditorCommandOutcome.idle());
     }
 
     public boolean hasSelectedMap() {
@@ -41,51 +45,23 @@ public record DungeonEditorSession(
     }
 
     public DungeonEditorSession withSelectedMap(@Nullable MapId nextSelectedMapId) {
-        return new DungeonEditorSession(
-                nextSelectedMapId,
-                viewMode,
-                toolSelection,
-                projectionLevel,
-                overlaySettings,
-                selection,
-                preview,
-                statusText);
+        return copy(nextSelectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession withViewMode(DungeonEditorSessionValues.ViewMode nextViewMode) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                nextViewMode,
-                toolSelection,
-                projectionLevel,
-                overlaySettings,
-                selection,
-                preview,
-                statusText);
+        return copy(selectedMapId, nextViewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession withToolSelection(DungeonEditorToolSelection nextSelection) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                nextSelection,
-                projectionLevel,
-                overlaySettings,
-                selection,
-                preview,
-                statusText);
+        return copy(selectedMapId, viewMode, nextSelection, projectionLevel, overlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession withProjectionLevel(int nextProjectionLevel) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                toolSelection,
-                nextProjectionLevel,
-                overlaySettings,
-                selection,
-                preview,
-                statusText);
+        return copy(selectedMapId, viewMode, toolSelection, nextProjectionLevel, overlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession shiftProjectionLevel(int delta) {
@@ -93,27 +69,13 @@ public record DungeonEditorSession(
     }
 
     public DungeonEditorSession withOverlaySettings(DungeonEditorSessionValues.OverlaySettings nextOverlaySettings) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                toolSelection,
-                projectionLevel,
-                nextOverlaySettings,
-                selection,
-                preview,
-                statusText);
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, nextOverlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession withSelection(DungeonEditorSessionValues.Selection nextSelection) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                toolSelection,
-                projectionLevel,
-                overlaySettings,
-                nextSelection,
-                preview,
-                statusText);
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                nextSelection, preview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession clearSelection() {
@@ -121,15 +83,8 @@ public record DungeonEditorSession(
     }
 
     public DungeonEditorSession withPreview(DungeonEditorSessionValues.Preview nextPreview) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                toolSelection,
-                projectionLevel,
-                overlaySettings,
-                selection,
-                nextPreview,
-                statusText);
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, nextPreview, statusText, commandOutcome);
     }
 
     public DungeonEditorSession clearPreview() {
@@ -137,18 +92,44 @@ public record DungeonEditorSession(
     }
 
     public DungeonEditorSession withStatusText(String nextStatusText) {
-        return new DungeonEditorSession(
-                selectedMapId,
-                viewMode,
-                toolSelection,
-                projectionLevel,
-                overlaySettings,
-                selection,
-                preview,
-                nextStatusText);
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, nextStatusText, DungeonEditorCommandOutcome.idle());
+    }
+
+    public DungeonEditorSession withCommandOutcome(DungeonEditorCommandOutcome nextOutcome) {
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, "", nextOutcome);
+    }
+
+    public DungeonEditorSession withCommandStatus(
+            String nextStatusText,
+            DungeonEditorCommandOutcome nextOutcome
+    ) {
+        return copy(selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, nextStatusText, nextOutcome);
     }
 
     public DungeonEditorSession clearTransientState(String nextStatusText) {
         return clearPreview().withStatusText(nextStatusText);
+    }
+
+    public DungeonEditorSession clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome nextOutcome) {
+        return clearPreview().withCommandOutcome(nextOutcome);
+    }
+
+    private static DungeonEditorSession copy(
+            @Nullable MapId selectedMapId,
+            DungeonEditorSessionValues.ViewMode viewMode,
+            DungeonEditorToolSelection toolSelection,
+            int projectionLevel,
+            DungeonEditorSessionValues.OverlaySettings overlaySettings,
+            DungeonEditorSessionValues.Selection selection,
+            DungeonEditorSessionValues.Preview preview,
+            String statusText,
+            DungeonEditorCommandOutcome commandOutcome
+    ) {
+        return new DungeonEditorSession(
+                selectedMapId, viewMode, toolSelection, projectionLevel, overlaySettings,
+                selection, preview, statusText, commandOutcome);
     }
 }

--- a/features/dungeon/application/editor/session/DungeonEditorSessionEffect.java
+++ b/features/dungeon/application/editor/session/DungeonEditorSessionEffect.java
@@ -1,5 +1,6 @@
 package features.dungeon.application.editor.session;
 
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import org.jspecify.annotations.Nullable;
 
 public final class DungeonEditorSessionEffect {
@@ -10,6 +11,7 @@ public final class DungeonEditorSessionEffect {
     private final DungeonEditorSessionValues.@Nullable Preview applyPreview;
     private final int projectionLevelDelta;
     private final @Nullable String statusText;
+    private final DungeonEditorCommandOutcome.@Nullable Rejected rejection;
 
     private DungeonEditorSessionEffect(
             DungeonEditorSessionValues.@Nullable Selection selection,
@@ -18,7 +20,8 @@ public final class DungeonEditorSessionEffect {
             boolean clearPreview,
             DungeonEditorSessionValues.@Nullable Preview applyPreview,
             int projectionLevelDelta,
-            @Nullable String statusText
+            @Nullable String statusText,
+            DungeonEditorCommandOutcome.@Nullable Rejected rejection
     ) {
         this.selection = selection;
         this.clearSelection = clearSelection;
@@ -27,49 +30,65 @@ public final class DungeonEditorSessionEffect {
         this.applyPreview = applyPreview;
         this.projectionLevelDelta = projectionLevelDelta;
         this.statusText = statusText;
+        this.rejection = rejection;
     }
 
     public static DungeonEditorSessionEffect none() {
-        return new DungeonEditorSessionEffect(null, false, null, false, null, 0, null);
+        return new DungeonEditorSessionEffect(null, false, null, false, null, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect preview(DungeonEditorSessionValues.Preview preview) {
-        return new DungeonEditorSessionEffect(null, false, preview, false, null, 0, null);
+        return new DungeonEditorSessionEffect(null, false, preview, false, null, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect apply(DungeonEditorSessionValues.Preview applyPreview) {
-        return new DungeonEditorSessionEffect(null, false, null, true, applyPreview, 0, null);
+        return new DungeonEditorSessionEffect(null, false, null, true, applyPreview, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect applyWithStatus(
             DungeonEditorSessionValues.Preview applyPreview,
             String statusText
     ) {
-        return new DungeonEditorSessionEffect(null, false, null, true, applyPreview, 0, statusText);
+        return new DungeonEditorSessionEffect(null, false, null, true, applyPreview, 0, statusText, null);
     }
 
     public static DungeonEditorSessionEffect select(DungeonEditorSessionValues.Selection selection) {
-        return new DungeonEditorSessionEffect(selection, false, null, true, null, 0, null);
+        return new DungeonEditorSessionEffect(selection, false, null, true, null, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect select(DungeonEditorSessionValues.Selection selection, String statusText) {
-        return new DungeonEditorSessionEffect(selection, false, null, true, null, 0, statusText);
+        return new DungeonEditorSessionEffect(selection, false, null, true, null, 0, statusText, null);
+    }
+
+    public static DungeonEditorSessionEffect selectRejected(
+            DungeonEditorSessionValues.Selection selection,
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonEditorSessionEffect(
+                selection, false, null, true, null, 0, null,
+                new DungeonEditorCommandOutcome.Rejected(reason));
     }
 
     public static DungeonEditorSessionEffect clearedSelection() {
-        return new DungeonEditorSessionEffect(null, true, null, true, null, 0, null);
+        return new DungeonEditorSessionEffect(null, true, null, true, null, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect projectionLevel(int delta) {
-        return new DungeonEditorSessionEffect(null, false, null, false, null, delta, null);
+        return new DungeonEditorSessionEffect(null, false, null, false, null, delta, null, null);
     }
 
     public static DungeonEditorSessionEffect clearPreviewIfNeeded(boolean clearPreview) {
-        return new DungeonEditorSessionEffect(null, false, null, clearPreview, null, 0, null);
+        return new DungeonEditorSessionEffect(null, false, null, clearPreview, null, 0, null, null);
     }
 
     public static DungeonEditorSessionEffect clearPreviewWithStatus(String statusText) {
-        return new DungeonEditorSessionEffect(null, false, null, true, null, 0, statusText);
+        return new DungeonEditorSessionEffect(null, false, null, true, null, 0, statusText, null);
+    }
+
+    public static DungeonEditorSessionEffect rejected(DungeonEditorCommandOutcome.RejectionReason reason) {
+        return new DungeonEditorSessionEffect(
+                null, false, null, true, null, 0, null,
+                new DungeonEditorCommandOutcome.Rejected(reason));
     }
 
     public DungeonEditorSessionValues.@Nullable Selection getSelection() {
@@ -100,8 +119,12 @@ public final class DungeonEditorSessionEffect {
         return statusText;
     }
 
+    public DungeonEditorCommandOutcome.@Nullable Rejected getRejection() {
+        return rejection;
+    }
+
     public boolean isNoop() {
         return !clearSelection && selection == null && preview == null && !clearPreview
-                && applyPreview == null && projectionLevelDelta == 0 && statusText == null;
+                && applyPreview == null && projectionLevelDelta == 0 && statusText == null && rejection == null;
     }
 }

--- a/features/dungeon/application/editor/session/DungeonEditorSessionSnapshot.java
+++ b/features/dungeon/application/editor/session/DungeonEditorSessionSnapshot.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.Nullable;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.Inspector;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 
 public final class DungeonEditorSessionSnapshot {
@@ -23,7 +24,8 @@ public final class DungeonEditorSessionSnapshot {
                 DungeonEditorSessionValues.Selection.empty(),
                 null,
                 DungeonEditorSessionValues.Preview.none(),
-                statusText);
+                statusText,
+                DungeonEditorCommandOutcome.idle());
     }
 
     public record SnapshotData(
@@ -36,7 +38,8 @@ public final class DungeonEditorSessionSnapshot {
             DungeonEditorSessionValues.Selection selection,
             @Nullable SurfaceData surface,
             DungeonEditorSessionValues.Preview preview,
-            String statusText
+            String statusText,
+            DungeonEditorCommandOutcome commandOutcome
     ) {
         public SnapshotData {
             maps = maps == null ? List.of() : List.copyOf(maps);
@@ -46,6 +49,7 @@ public final class DungeonEditorSessionSnapshot {
             selection = selection == null ? DungeonEditorSessionValues.Selection.empty() : selection;
             preview = preview == null ? DungeonEditorSessionValues.Preview.none() : preview;
             statusText = statusText == null ? "" : statusText;
+            commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
         }
 
     }
@@ -71,7 +75,8 @@ public final class DungeonEditorSessionSnapshot {
                 safeSession.toolSelection(),
                 safeSession.projectionLevel(),
                 safeSession.overlaySettings(),
-                safeSession.statusText());
+                safeSession.statusText(),
+                safeSession.commandOutcome());
     }
 
     public static SessionFrameData sessionFrameData(@Nullable DungeonEditorSession session) {
@@ -88,13 +93,15 @@ public final class DungeonEditorSessionSnapshot {
             DungeonEditorToolSelection toolSelection,
             int projectionLevel,
             DungeonEditorSessionValues.OverlaySettings overlaySettings,
-            String statusText
+            String statusText,
+            DungeonEditorCommandOutcome commandOutcome
     ) {
         public ControlsData {
             viewMode = viewMode == null ? DungeonEditorSessionValues.ViewMode.defaultMode() : viewMode;
             toolSelection = toolSelection == null ? DungeonEditorToolSelection.select() : toolSelection;
             overlaySettings = overlaySettings == null ? DungeonEditorSessionValues.OverlaySettings.defaults() : overlaySettings;
             statusText = statusText == null ? "" : statusText;
+            commandOutcome = commandOutcome == null ? DungeonEditorCommandOutcome.idle() : commandOutcome;
         }
 
     }

--- a/features/dungeon/application/editor/session/DungeonEditorSessionWorkflow.java
+++ b/features/dungeon/application/editor/session/DungeonEditorSessionWorkflow.java
@@ -1,6 +1,7 @@
 package features.dungeon.application.editor.session;
 
 import org.jspecify.annotations.Nullable;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 
@@ -80,6 +81,9 @@ public final class DungeonEditorSessionWorkflow {
         if (effect.getStatusText() != null) {
             session.replace(session.current().withStatusText(effect.getStatusText()));
         }
+        if (effect.getRejection() != null) {
+            session.replace(session.current().withCommandOutcome(effect.getRejection()));
+        }
         if (effect.isClearSelection()) {
             session.replace(session.current().clearSelection().clearPreview());
         } else if (effect.getSelection() != null) {
@@ -96,6 +100,10 @@ public final class DungeonEditorSessionWorkflow {
 
     public void clearPreviewWithStatus(String statusText) {
         session.replace(session.current().clearPreview().withStatusText(statusText));
+    }
+
+    public void clearPreviewWithCommandOutcome(DungeonEditorCommandOutcome outcome) {
+        session.replace(session.current().clearPreviewWithCommandOutcome(outcome));
     }
 
     public DungeonEditorSessionSnapshot.SnapshotData reconcileSnapshot(

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorCorridorScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorCorridorScenarios.java
@@ -1051,6 +1051,11 @@ final class DungeonEditorCorridorScenarios {
                 "DE-COR-008 invalid route clears published preview state");
         assertTrue(runtime.controlsModel().current().statusText().contains("blockiert"),
                 "DE-COR-008 status reports route rejection");
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                "DE-COR-008 publishes typed blocked-route rejection");
         assertEquals(0L, runtime.mapSurfaceModel().current().surface().map().areas().stream()
                         .filter(area -> "CORRIDOR".equalsIgnoreCase(area.kind()))
                         .count(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorRoomWallDoorScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorRoomWallDoorScenarios.java
@@ -2665,6 +2665,11 @@ final class DungeonEditorRoomWallDoorScenarios {
                 "DE-WALL-014 exterior delete rejection leaves rendered geometry unchanged");
         assertTrue(runtime.controlsModel().current().statusText().contains("Aussenwand"),
                 "DE-WALL-014 exterior delete rejection publishes a concrete status");
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                "DE-WALL-014 publishes typed exterior-wall rejection");
         assertEquals(0L, rejectionMapSurfacePublications.get(),
                 "DE-WALL-014 exterior delete rejection does not publish map surface");
         assertEquals(0L, rejectionStatePublications.get(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
@@ -416,6 +416,14 @@ final class DungeonEditorStairScenarios {
                 "DE-STATE-003 published feature exposes generated circular top exit");
         assertTrue(renderSurfaceCellOriginsWithZ(binding.mapContentModel()).containsAll(expectedCircularPath),
                 "DE-STATE-003 render state exposes circular active-level path");
+        assertTrue(runtime.controlsModel().current().commandOutcome()
+                        instanceof features.dungeon.api.editor.DungeonEditorCommandOutcome.Accepted,
+                "DE-STATE-003 publishes typed accepted stair edit outcome");
+        assertEquals(
+                runtime.mapSurfaceModel().current().surface().revision(),
+                (int) ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Accepted)
+                        runtime.controlsModel().current().commandOutcome()).authoredRevision(),
+                "DE-STATE-003 accepted outcome identifies committed authored revision");
         click(button(controls, "+"));
         assertTrue(renderSurfaceCellOriginsWithZ(binding.mapContentModel()).contains("4,2,1"),
                 "DE-STATE-003 render state exposes circular top crossed-floor exit");
@@ -443,6 +451,11 @@ final class DungeonEditorStairScenarios {
                 "DE-STAIR-007 zero-level span");
         assertEquals("Treppengeometrie ungueltig.", runtime.controlsModel().current().statusText(),
                 "DE-STAIR-007 zero-level span publishes rejection status");
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                "DE-STAIR-007 publishes typed invalid-geometry rejection");
 
         invalidBaselineSurface = runtime.mapSurfaceModel().current();
         invalidBaselineRenderCells = renderSurfaceCellOriginsWithZ(binding.mapContentModel());

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTransitionScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTransitionScenarios.java
@@ -201,6 +201,11 @@ final class DungeonEditorTransitionScenarios {
                 "DE-TRN-003 invalid entrance-link target map leaves target transitions unchanged");
         assertEquals(sourceRef, runtime.mapSurfaceModel().current().selection().topologyRef(),
                 "DE-TRN-003 invalid entrance-link target map keeps source selected");
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                "DE-TRN-003 invalid target map publishes typed missing-destination rejection");
         assertTransitionEntranceLinkDraft(
                 stateView,
                 targetMapId + 1000L,
@@ -1144,6 +1149,11 @@ final class DungeonEditorTransitionScenarios {
                 scenario + " keeps projection level stable");
         assertEquals(DungeonEditorPreview.none(), runtime.mapSurfaceModel().current().preview(),
                 scenario + " keeps preview empty");
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                scenario + " publishes typed referenced-connection rejection");
         assertTrue(renderHasGlyphAt(binding.mapContentModel(), transitionRef, transitionCenter.getX(), transitionCenter.getY(), false),
                 scenario + " keeps rendered transition marker");
     }

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -22,7 +22,10 @@ import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.api.editor.DungeonEditorApi;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorPointerGesture;
+import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.api.editor.DungeonEditorState;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
 import features.dungeon.api.editor.DungeonEditorToolOptions;
@@ -32,6 +35,39 @@ import features.party.domain.roster.PartyRoster;
 import features.party.domain.roster.repository.PartyRosterRepository;
 
 final class DungeonEditorRuntimeThreadOwnershipTest {
+
+    @Test
+    void stalePointerInputPublishesTypedRejectionWithoutChangingAuthoredState() {
+        InMemoryDungeonRepository repository = new InMemoryDungeonRepository();
+        repository.seed(1L, "Only");
+        DungeonEditorApi api = new DungeonEditorApiFacade(
+                createRuntimeDirect(repository),
+                DirectUiDispatcher.INSTANCE);
+        DungeonEditorState before = api.current();
+
+        api.dispatch(new DungeonEditorIntent.Pointer(new DungeonEditorPointerInput(
+                0L,
+                DungeonEditorPointerInput.Action.PRESSED,
+                DungeonEditorToolSelection.select(),
+                new DungeonEditorPointerGesture(
+                        DungeonEditorPointerGesture.Button.PRIMARY,
+                        false,
+                        false),
+                0.0,
+                0.0,
+                List.of(DungeonEditorPointerInput.Target.empty()),
+                0,
+                DungeonEditorIntent.TransitionDestinationInput.empty())));
+
+        DungeonEditorState after = api.current();
+        DungeonEditorCommandOutcome.Rejected rejected =
+                (DungeonEditorCommandOutcome.Rejected) after.commandStatus().outcome();
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.STALE_REVISION, rejected.reason());
+        assertEquals(before.selectedWindow(), after.selectedWindow(),
+                "stale pointer input leaves authored state and revision unchanged");
+        assertTrue(after.publicationRevision() > before.publicationRevision(),
+                "stale pointer rejection publishes one new atomic editor state");
+    }
 
     @Test
     void editorApiPublishesTheTypedToolOptionSelectedByItsConsumer() {


### PR DESCRIPTION
## Ergebnis
- publiziert Accepted/Rejected atomar im DungeonEditorState
- führt stabile Gründe für blockierte Route, geschützte Außenwand, referenzierte Verbindung, ungültige Treppengeometrie, stale Revision und fehlendes Übergangsziel ein
- bildet Outcome-Typen zentral auf UI-Status ab und bewahrt controls-only Rejection-Publikation
- aktualisiert die Greenfield-Roadmap auf M2.4

## Proof
- ./gradlew test --tests features.dungeon.application.editor.DungeonEditorRuntimeThreadOwnershipTest --console=plain
- fokussierte Corridor-, Stair- und Transition-Produktionstests
- vollständige DungeonEditorBehaviorSuiteTest
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain — BUILD SUCCESSFUL in 3m 28s
- git diff --check