### PR TITLE
Complete Dungeon M2 canonical language migration

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -1,6 +1,6 @@
 Status: Temporary Migration
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-17
+Last Reviewed: 2026-07-18
 Source of Truth: Ordered delivery milestones, dependencies, exit gates, and
 legacy-deletion boundaries for the Dungeon greenfield migration.
 
@@ -97,18 +97,18 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2.4 are complete on `main` through PR #497.
-- This slice: M2.5 makes the API handle, view, and overlay values and the domain
-  `Cell`, `Edge`, `Direction`, boundary kind, corridor binding, wall-delete,
-  and boundary-stretch values canonical within Dungeon.
-- The parallel Editor handle kinds, session view and overlay values, workspace
-  geometry values, corridor binding state adapters, wall-delete copy, and
-  boundary-stretch selection copy are deleted. Dungeon-layer enum publication
-  now uses typed values or explicit boundary mappings instead of enum-name
-  round trips.
-- Next step after this slice merges: M2.6 injects corridor routing, moves
-  feature-marker semantic edits to the typed command path, and closes the M2
-  architecture and behavior gates.
+- Current foundation: M0 through M2.5 are complete on `main` through PR #498.
+- This slice: M2.6 moves deterministic orthogonal route selection behind one
+  injected domain policy shared by Editor preview and authored corridor
+  commands. `CorridorRoute` remains only the immutable route value.
+- Feature-marker label and description edits now travel from the JavaFX state
+  panel through a typed Editor intent to the aggregate and persistence boundary.
+  The direct-SQL description shortcut in production-route proof is deleted;
+  accepted and rejected edits prove revision, selection, persistence, reload,
+  and typed outcome behavior.
+- Next step after this slice merges: M3.1 introduces the canonical typed command,
+  patch, inverse, touched-chunk, and result-fact vocabulary without changing the
+  now-closed M2 Editor command language.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -22,6 +22,8 @@ import features.dungeon.application.editor.DungeonEditorApiFacade;
 import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
 import features.dungeon.application.editor.DungeonEditorRuntimeApplicationService;
 import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 import features.dungeon.application.travel.DungeonTravelNavigator;
 import features.dungeon.application.travel.DungeonTravelPartyGateway;
 import features.dungeon.application.travel.DungeonTravelPublishedState;
@@ -65,6 +67,7 @@ public final class DungeonFeature {
         DungeonEditorRuntimeDependencies editorDependencies = new DungeonEditorRuntimeDependencies(
                 runtime.editorControls(), runtime.editorMapSurface(), runtime.editorState(),
                 runtime.editor(),
+                runtime.corridorRoutingPolicy(),
                 lane,
                 dispatcher);
         DungeonEditorFeatureRuntimeRoot editorRuntimeRoot =
@@ -93,8 +96,9 @@ public final class DungeonFeature {
         Objects.requireNonNull(diagnostics, "diagnostics");
         DungeonEditorPublishedState editorPublishedState = new DungeonEditorPublishedState(dispatcher);
         DungeonAuthoredPublishedState authoredPublishedState = new DungeonAuthoredPublishedState(dispatcher);
+        CorridorRoutingPolicy corridorRoutingPolicy = new OrthogonalCorridorRoutingPolicy();
         DungeonAuthoredApplicationService authoredMaps = new DungeonAuthoredApplicationService(
-                Objects.requireNonNull(repository, "repository"), authoredPublishedState);
+                Objects.requireNonNull(repository, "repository"), authoredPublishedState, corridorRoutingPolicy);
         DungeonEditorRuntimeApplicationService editor =
                 new DungeonEditorRuntimeApplicationService(authoredMaps, editorPublishedState);
         DungeonTravelPartyGateway partyGateway = new DungeonTravelPartyGateway(
@@ -103,6 +107,7 @@ public final class DungeonFeature {
         DungeonTravelNavigator navigator = new DungeonTravelNavigator(authoredMaps, partyGateway, surfaceLoader);
         DungeonTravelPublishedState publishedState = new DungeonTravelPublishedState(dispatcher);
         return new Runtime(
+                corridorRoutingPolicy,
                 authoredMaps,
                 editor,
                 new DungeonTravelRuntimeApplicationService(surfaceLoader, navigator, publishedState, lane),
@@ -132,6 +137,7 @@ public final class DungeonFeature {
     }
 
     record Runtime(
+            CorridorRoutingPolicy corridorRoutingPolicy,
             DungeonAuthoredApplicationService authored,
             DungeonEditorRuntimeApplicationService editor,
             DungeonTravelRuntimeApplicationService travel,

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorStateInput.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorStateInput.java
@@ -9,7 +9,8 @@ record DungeonEditorStateInput(
         CorridorPointInput corridorPoint,
         TransitionDestinationInput transitionDestination,
         TransitionDescriptionInput transitionDescription,
-        StairGeometryInput stairGeometry
+        StairGeometryInput stairGeometry,
+        FeatureMarkerSemanticsInput featureMarkerSemantics
 ) {
 
     DungeonEditorStateInput {
@@ -23,6 +24,9 @@ record DungeonEditorStateInput(
                 ? TransitionDescriptionInput.none()
                 : transitionDescription;
         stairGeometry = stairGeometry == null ? StairGeometryInput.none() : stairGeometry;
+        featureMarkerSemantics = featureMarkerSemantics == null
+                ? FeatureMarkerSemanticsInput.none()
+                : featureMarkerSemantics;
     }
 
     static DungeonEditorStateInput narration(
@@ -37,7 +41,8 @@ record DungeonEditorStateInput(
                 CorridorPointInput.none(),
                 TransitionDestinationInput.none(),
                 TransitionDescriptionInput.none(),
-                StairGeometryInput.none());
+                StairGeometryInput.none(),
+                FeatureMarkerSemanticsInput.none());
     }
 
     static DungeonEditorStateInput labelName(
@@ -51,7 +56,8 @@ record DungeonEditorStateInput(
                 CorridorPointInput.none(),
                 TransitionDestinationInput.none(),
                 TransitionDescriptionInput.none(),
-                StairGeometryInput.none());
+                StairGeometryInput.none(),
+                FeatureMarkerSemanticsInput.none());
     }
 
     static DungeonEditorStateInput corridorPoint(
@@ -65,7 +71,8 @@ record DungeonEditorStateInput(
                 new CorridorPointInput(q, r, true, submitRequested),
                 TransitionDestinationInput.none(),
                 TransitionDescriptionInput.none(),
-                StairGeometryInput.none());
+                StairGeometryInput.none(),
+                FeatureMarkerSemanticsInput.none());
     }
 
     static DungeonEditorStateInput transitionDescription(
@@ -79,7 +86,8 @@ record DungeonEditorStateInput(
                 CorridorPointInput.none(),
                 TransitionDestinationInput.none(),
                 new TransitionDescriptionInput(transitionId, description, true, saveRequested),
-                StairGeometryInput.none());
+                StairGeometryInput.none(),
+                FeatureMarkerSemanticsInput.none());
     }
 
     static DungeonEditorStateInput transitionDestination(
@@ -103,7 +111,8 @@ record DungeonEditorStateInput(
                         true,
                         saveRequested),
                 TransitionDescriptionInput.none(),
-                StairGeometryInput.none());
+                StairGeometryInput.none(),
+                FeatureMarkerSemanticsInput.none());
     }
 
     static DungeonEditorStateInput stairGeometry(
@@ -127,7 +136,35 @@ record DungeonEditorStateInput(
                         dimension1,
                         dimension2,
                         true,
-                        saveRequested));
+                        saveRequested),
+                FeatureMarkerSemanticsInput.none());
+    }
+
+    static DungeonEditorStateInput featureMarkerSemantics(
+            long markerId,
+            String label,
+            String description
+    ) {
+        return new DungeonEditorStateInput(
+                NarrationInput.none(),
+                LabelNameInput.none(),
+                CorridorPointInput.none(),
+                TransitionDestinationInput.none(),
+                TransitionDescriptionInput.none(),
+                StairGeometryInput.none(),
+                new FeatureMarkerSemanticsInput(markerId, label, description));
+    }
+
+    record FeatureMarkerSemanticsInput(long markerId, String label, String description) {
+        FeatureMarkerSemanticsInput {
+            markerId = Math.max(0L, markerId);
+            label = safeText(label);
+            description = safeText(description);
+        }
+
+        static FeatureMarkerSemanticsInput none() {
+            return new FeatureMarkerSemanticsInput(0L, "", "");
+        }
     }
 
     record NarrationInput(

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorStatePanelModel.java
@@ -46,6 +46,7 @@ final class DungeonEditorStatePanelModel {
                 narrationCards,
                 nameProjection(safeState),
                 corridorPointProjection(safeState),
+                featureMarkerProjection(safeState),
                 transitionContent.transitionDestinationProjection(safeState),
                 transitionContent.transitionDescriptionProjection(safeState),
                 stairGeometryContent.stairGeometryProjection(safeState)));
@@ -85,6 +86,22 @@ final class DungeonEditorStatePanelModel {
                 draft);
     }
 
+    private static @Nullable FeatureMarkerProjection featureMarkerProjection(DungeonEditorState state) {
+        DungeonEditorState safeState = state == null ? DungeonEditorState.empty() : state;
+        DungeonTopologyElementRef topologyRef = safeState.selection().topologyRef();
+        DungeonInspectorSnapshot inspector = safeState.inspector();
+        if (topologyRef == null
+                || topologyRef.kind() != features.dungeon.api.DungeonTopologyElementKind.FEATURE_MARKER
+                || topologyRef.id() <= 0L
+                || inspector == null) {
+            return null;
+        }
+        return new FeatureMarkerProjection(
+                topologyRef.id(),
+                inspector.title(),
+                inspector.summary());
+    }
+
     private static LabelNameTarget labelNameTarget(DungeonEditorDraftState.LabelNameDraft target) {
         if (target == null || target.targetId() <= 0L) {
             return LabelNameTarget.empty();
@@ -119,6 +136,7 @@ final class DungeonEditorStatePanelModel {
             List<RoomNarrationCardProjection> narrationCards,
             @Nullable NameProjection name,
             @Nullable CorridorPointProjection corridorPoint,
+            @Nullable FeatureMarkerProjection featureMarker,
             @Nullable TransitionDestinationProjection transitionDestination,
             @Nullable TransitionDescriptionProjection transitionDescription,
             @Nullable StairGeometryProjection stairGeometry
@@ -131,7 +149,15 @@ final class DungeonEditorStatePanelModel {
         }
 
         static StateProjection initial() {
-            return new StateProjection("", "", false, "", List.of(), null, null, null, null, null);
+            return new StateProjection("", "", false, "", List.of(), null, null, null, null, null, null);
+        }
+    }
+
+    record FeatureMarkerProjection(long markerId, String label, String description) {
+        FeatureMarkerProjection {
+            markerId = Math.max(0L, markerId);
+            label = label == null ? "" : label;
+            description = description == null ? "" : description;
         }
     }
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorStateView.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorStateView.java
@@ -22,6 +22,8 @@ public final class DungeonEditorStateView extends VBox {
     private static final String CORRIDOR_POINT_Q_ACCESSIBLE = "Korridorpunkt q";
     private static final String CORRIDOR_POINT_R_ACCESSIBLE = "Korridorpunkt r";
     private static final String TRANSITION_DESCRIPTION_ACCESSIBLE = "Übergang Beschreibung";
+    private static final String FEATURE_MARKER_LABEL_ACCESSIBLE = "Feature-Marker Name";
+    private static final String FEATURE_MARKER_DESCRIPTION_ACCESSIBLE = "Feature-Marker Beschreibung";
     private static final String STAIR_SHAPE_ACCESSIBLE = "Treppe Form";
     private static final String STAIR_DIRECTION_ACCESSIBLE = "Treppe Richtung";
     private static final String STAIR_DIMENSION_1_ACCESSIBLE = "Treppe Laenge";
@@ -39,6 +41,7 @@ public final class DungeonEditorStateView extends VBox {
     private final VBox corridorPointCards = new VBox();
     private final VBox transitionDestinationCards = new VBox();
     private final VBox transitionCards = new VBox();
+    private final VBox featureMarkerCards = new VBox();
     private final VBox stairGeometryCards = new VBox();
     private final VBox narrationCards = new VBox();
     private final VBox nameCards = new VBox();
@@ -54,6 +57,7 @@ public final class DungeonEditorStateView extends VBox {
         corridorPointCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
         transitionDestinationCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
         transitionCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
+        featureMarkerCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
         stairGeometryCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
         narrationCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
         nameCards.getStyleClass().add(STATE_CARD_STACK_STYLE);
@@ -61,6 +65,7 @@ public final class DungeonEditorStateView extends VBox {
                 new StateCard(body),
                 nameCards,
                 corridorPointCards,
+                featureMarkerCards,
                 transitionDestinationCards,
                 transitionCards,
                 stairGeometryCards,
@@ -108,6 +113,7 @@ public final class DungeonEditorStateView extends VBox {
     private void showProjection(DungeonEditorStatePanelModel.StateProjection projection) {
         body.setText(projection.stateText());
         showCorridorPoint(projection.corridorPoint(), projection.busy());
+        showFeatureMarker(projection.featureMarker(), projection.busy(), projection.statusText());
         showTransitionDestination(projection.transitionDestination(), projection.busy(), projection.statusText());
         showTransitionDescription(projection.transitionDescription(), projection.busy(), projection.statusText());
         showStairGeometry(projection.stairGeometry(), projection.busy(), projection.statusText());
@@ -117,6 +123,17 @@ public final class DungeonEditorStateView extends VBox {
                 projection.statusText(),
                 projection.narrationRenderStructureKey());
         showName(projection.name(), projection.busy());
+    }
+
+    private void showFeatureMarker(
+            DungeonEditorStatePanelModel.FeatureMarkerProjection featureMarker,
+            boolean busy,
+            String statusText
+    ) {
+        featureMarkerCards.getChildren().clear();
+        if (featureMarker != null) {
+            featureMarkerCards.getChildren().add(new FeatureMarkerCard(featureMarker, busy, statusText));
+        }
     }
 
     private void showCorridorPoint(
@@ -869,6 +886,44 @@ public final class DungeonEditorStateView extends VBox {
             updateDisabled.run();
             save.setOnAction(event -> emitNameInput(nameField, true));
             getChildren().addAll(new PanelTitle(name.label()), fieldLabel, nameField, save);
+            getStyleClass().addAll(CARD_SURFACE_STYLE, CONTENT_CARD_STYLE);
+        }
+
+        private Label labeled(String text, Node field) {
+            Label label = muted(text);
+            label.setLabelFor(field);
+            return label;
+        }
+    }
+
+    private final class FeatureMarkerCard extends VBox {
+
+        private FeatureMarkerCard(
+                DungeonEditorStatePanelModel.FeatureMarkerProjection marker,
+                boolean busy,
+                String statusText
+        ) {
+            TextField labelField = textField(marker.label());
+            labelField.setAccessibleText(FEATURE_MARKER_LABEL_ACCESSIBLE);
+            TextArea descriptionArea = textArea(marker.description());
+            descriptionArea.setAccessibleText(FEATURE_MARKER_DESCRIPTION_ACCESSIBLE);
+            Label status = stableStatusLabel(statusText);
+            Button save = new ToolbarActionButton("Speichern");
+            save.setAccessibleText("Feature-Marker speichern");
+            Runnable updateDisabled = () -> save.setDisable(busy || labelField.getText().isBlank());
+            labelField.textProperty().addListener((ignored, before, after) -> updateDisabled.run());
+            updateDisabled.run();
+            save.setOnAction(event -> stateInputHandler.accept(
+                    DungeonEditorStateInput.featureMarkerSemantics(
+                            marker.markerId(), labelField.getText(), descriptionArea.getText())));
+            getChildren().addAll(
+                    new PanelTitle("Feature-Marker"),
+                    labeled("Name", labelField),
+                    labelField,
+                    labeled("Beschreibung", descriptionArea),
+                    descriptionArea,
+                    status,
+                    save);
             getStyleClass().addAll(CARD_SURFACE_STYLE, CONTENT_CARD_STYLE);
         }
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -300,6 +300,7 @@ final class DungeonEditorViewModel {
         consumeTransitionDestinationWhenPresent(event.transitionDestination());
         consumeTransitionDescriptionWhenPresent(event.transitionDescription());
         consumeStairGeometryWhenPresent(event.stairGeometry());
+        consumeFeatureMarkerSemanticsWhenPresent(event.featureMarkerSemantics());
     }
 
     private void consumeNarrationWhenPresent(DungeonEditorStateInput.NarrationInput input) {
@@ -348,6 +349,16 @@ final class DungeonEditorViewModel {
         if (input.inputObserved() || input.saveRequested()) {
             consumeStairGeometryInput(input);
         }
+    }
+
+    private void consumeFeatureMarkerSemanticsWhenPresent(
+            DungeonEditorStateInput.FeatureMarkerSemanticsInput input
+    ) {
+        if (input.markerId() <= 0L || input.label().isBlank()) {
+            return;
+        }
+        editorApi.dispatch(new DungeonEditorIntent.CommitFeatureMarkerSemantics(
+                input.markerId(), input.label(), input.description()));
     }
 
     private void consumeNarrationInput(DungeonEditorStateInput.NarrationInput input) {

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -137,6 +137,18 @@ public sealed interface DungeonEditorIntent {
         }
     }
 
+    record CommitFeatureMarkerSemantics(
+            long markerId,
+            String label,
+            String description
+    ) implements DungeonEditorIntent {
+        public CommitFeatureMarkerSemantics {
+            markerId = Math.max(0L, markerId);
+            label = safeText(label);
+            description = safeText(description);
+        }
+    }
+
     record UpdateTransitionDestination(TransitionDestinationInput destination) implements DungeonEditorIntent {
         public UpdateTransitionDestination {
             destination = destination == null ? TransitionDestinationInput.empty() : destination;

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -28,6 +28,8 @@ import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.DungeonMapOperationFeedbackRules;
 import features.dungeon.domain.core.structure.corridor.CorridorDeletionTarget;
 import features.dungeon.domain.core.structure.corridor.CorridorMapAuthoring;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerKind;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
@@ -74,7 +76,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private static final DungeonMapOperationFeedbackRules OPERATION_FEEDBACK_POLICY =
             new DungeonMapOperationFeedbackRules();
     private static final DungeonEditorHandleMutation HANDLE_MUTATION = new DungeonEditorHandleMutation();
-    private static final CorridorMapAuthoring CORRIDOR_AUTHORING = new CorridorMapAuthoring();
     private static final long PREVIEW_STAIR_ID = Long.MAX_VALUE;
     private static final long ABSENT_ID = 0L;
     private static final long MIN_CLUSTER_ID = 0L;
@@ -85,6 +86,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
     private final DungeonMapRepository repository;
     private final DungeonAuthoredPublishedState publishedState;
+    private final CorridorRoutingPolicy corridorRoutingPolicy;
+    private final CorridorMapAuthoring corridorAuthoring;
     /* Pointer previews operate on this immutable authored workset. */
     private final ConcurrentMap<Long, DungeonMap> authoredWorkset = new ConcurrentHashMap<>();
     private final DungeonEditHistory editHistory = new DungeonEditHistory();
@@ -112,8 +115,18 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             DungeonMapRepository repository,
             DungeonAuthoredPublishedState publishedState
     ) {
+        this(repository, publishedState, new OrthogonalCorridorRoutingPolicy());
+    }
+
+    public DungeonAuthoredApplicationService(
+            DungeonMapRepository repository,
+            DungeonAuthoredPublishedState publishedState,
+            CorridorRoutingPolicy corridorRoutingPolicy
+    ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
+        this.corridorRoutingPolicy = Objects.requireNonNull(corridorRoutingPolicy, "corridorRoutingPolicy");
+        corridorAuthoring = new CorridorMapAuthoring(this.corridorRoutingPolicy);
     }
 
     public Session openSession(DungeonEditorDungeonState dungeonState) {
@@ -523,6 +536,14 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
     }
 
+    public record FeatureMarkerSemanticsInput(long markerId, String label, String description) {
+        public FeatureMarkerSemanticsInput {
+            markerId = Math.max(0L, markerId);
+            label = label == null ? "" : label;
+            description = description == null ? "" : description;
+        }
+    }
+
     public record StairGeometryInput(
             long stairId,
             String shapeName,
@@ -712,6 +733,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             OperationResultData result = mutationPipeline.executeOperation(
                     domainMapId(mapId),
                     current -> current.createCorridor(
+                            corridorRoutingPolicy,
                             stairIdForCorridor(current, startEndpoint, endEndpoint, true),
                             startEndpoint,
                             endEndpoint),
@@ -722,7 +744,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         private void deleteCorridor(MapId mapId, CorridorDeletionTarget target, Session session) {
             OperationResultData result = mutationPipeline.executeOperation(
                     domainMapId(mapId),
-                    current -> CORRIDOR_AUTHORING.deleteCorridor(current, target),
+                    current -> corridorAuthoring.deleteCorridor(current, target),
                     DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
@@ -1324,6 +1346,23 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             publicationOperations.publishMutation(result, state);
         }
 
+        private void saveAuthoredFeatureMarkerSemantics(
+                MapId mapId,
+                long markerId,
+                String label,
+                String description,
+                DungeonEditorDungeonState state
+        ) {
+            if (mapId == null || markerId <= 0L || label == null || label.isBlank()) {
+                return;
+            }
+            OperationResultData result = mutationPipeline.executeOperation(
+                    domainMapId(mapId),
+                    current -> current.updateFeatureMarkerSemantics(markerId, label, description),
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+            publicationOperations.publishMutation(result, state);
+        }
+
         private boolean saveAuthoredTransitionLink(
                 MapId sourceMapId,
                 long sourceTransitionId,
@@ -1501,6 +1540,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 return mutationPipeline.previewOperation(
                         domainMapId,
                         current -> current.createCorridor(
+                                corridorRoutingPolicy,
                                 stairIdForCorridor(current, startEndpoint, endEndpoint, false),
                                 startEndpoint,
                                 endEndpoint));
@@ -1508,7 +1548,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (preview instanceof DungeonEditorSessionValues.DeleteCorridorPreview corridor) {
                 return mutationPipeline.previewOperation(
                         domainMapId,
-                        current -> CORRIDOR_AUTHORING.deleteCorridor(current, corridor.target()));
+                        current -> corridorAuthoring.deleteCorridor(current, corridor.target()));
             }
             return null;
         }
@@ -1612,6 +1652,16 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
         public void saveAuthoredTransitionDescription(MapId mapId, long transitionId, String description) {
             detailSaveOperations.saveAuthoredTransitionDescription(mapId, transitionId, description, dungeonState);
+        }
+
+        public void saveAuthoredFeatureMarkerSemantics(
+                MapId mapId,
+                long markerId,
+                String label,
+                String description
+        ) {
+            detailSaveOperations.saveAuthoredFeatureMarkerSemantics(
+                    mapId, markerId, label, description, dungeonState);
         }
 
         public boolean saveAuthoredTransitionLink(

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -87,6 +87,9 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                     update.transitionId(), update.description());
         } else if (safeIntent instanceof DungeonEditorIntent.CommitTransitionDescription commit) {
             runtimeRoot.saveTransitionDescription(commit.transitionId(), commit.description());
+        } else if (safeIntent instanceof DungeonEditorIntent.CommitFeatureMarkerSemantics commit) {
+            runtimeRoot.saveFeatureMarkerSemantics(
+                    commit.markerId(), commit.label(), commit.description());
         } else if (safeIntent instanceof DungeonEditorIntent.UpdateTransitionDestination update) {
             runtimeRoot.updateStatePanelTransitionDestinationDraft(destinationFrom(update.destination()));
         } else if (safeIntent instanceof DungeonEditorIntent.CommitTransitionDestination commit) {
@@ -113,7 +116,7 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                 .map(DungeonEditorApiFacade::runtimeTargetFrom)
                 .toList();
         runtimeRoot.applyPointerInteraction(new PointerInteractionRequest(
-                enumValue(PointerAction.class, input.action().name(), PointerAction.MOVED),
+                pointerActionFrom(input.action()),
                 input.toolSelection(),
                 input.gesture(),
                 PointerInteractionTargets.fromRuntimeTargets(
@@ -133,25 +136,19 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                 : target;
         DungeonEditorPointerInput.BoundaryTarget boundary = safeTarget.boundary();
         return new DungeonEditorRuntimePointerTarget(
-                enumValue(DungeonEditorRuntimePointerTarget.TargetKind.class,
-                        safeTarget.targetKind(), DungeonEditorRuntimePointerTarget.TargetKind.EMPTY),
-                enumValue(DungeonEditorRuntimePointerTarget.LabelKind.class,
-                        safeTarget.labelKind(), DungeonEditorRuntimePointerTarget.LabelKind.EMPTY),
-                enumValue(DungeonEditorRuntimePointerTarget.ElementKind.class,
-                        safeTarget.elementKind(), DungeonEditorRuntimePointerTarget.ElementKind.EMPTY),
+                targetKindFrom(safeTarget.targetKind()),
+                labelKindFrom(safeTarget.labelKind()),
+                elementKindFrom(safeTarget.elementKind()),
                 safeTarget.ownerId(),
                 safeTarget.clusterId(),
-                enumValue(DungeonEditorRuntimePointerTarget.TopologyKind.class,
-                        safeTarget.topologyKind(), DungeonEditorRuntimePointerTarget.TopologyKind.EMPTY),
+                topologyKindFrom(safeTarget.topologyKind()),
                 safeTarget.topologyId(),
                 safeTarget.handleRef(),
                 new DungeonEditorRuntimePointerTarget.BoundaryTarget(
-                        enumValue(DungeonEditorRuntimePointerTarget.BoundaryKind.class,
-                                boundary.boundaryKind(), DungeonEditorRuntimePointerTarget.BoundaryKind.WALL),
+                        boundaryKindFrom(boundary.boundaryKind()),
                         boundary.key(),
                         boundary.ownerId(),
-                        enumValue(DungeonEditorRuntimePointerTarget.TopologyKind.class,
-                                boundary.topologyKind(), DungeonEditorRuntimePointerTarget.TopologyKind.EMPTY),
+                        topologyKindFrom(boundary.topologyKind()),
                         boundary.topologyId(),
                         boundary.startQ(),
                         boundary.startR(),
@@ -159,8 +156,7 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                         boundary.endQ(),
                         boundary.endR(),
                         boundary.endLevel()),
-                enumValue(DungeonEditorRuntimePointerTarget.SyntheticHoverKind.class,
-                        safeTarget.syntheticHoverKind(), DungeonEditorRuntimePointerTarget.SyntheticHoverKind.NONE),
+                syntheticHoverKindFrom(safeTarget.syntheticHoverKind()),
                 new DungeonEditorRuntimePointerTarget.CellTarget(
                         safeTarget.cell().exact(),
                         safeTarget.cell().q(),
@@ -173,12 +169,82 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
                         safeTarget.vertex().level()));
     }
 
-    private static <E extends Enum<E>> E enumValue(Class<E> type, String name, E fallback) {
-        try {
-            return Enum.valueOf(type, name == null ? "" : name);
-        } catch (IllegalArgumentException ignored) {
-            return fallback;
-        }
+    private static PointerAction pointerActionFrom(DungeonEditorPointerInput.Action action) {
+        return switch (action == null ? DungeonEditorPointerInput.Action.MOVED : action) {
+            case PRESSED -> PointerAction.PRESSED;
+            case DRAGGED -> PointerAction.DRAGGED;
+            case RELEASED -> PointerAction.RELEASED;
+            case MOVED -> PointerAction.MOVED;
+        };
+    }
+
+    private static DungeonEditorRuntimePointerTarget.TargetKind targetKindFrom(String value) {
+        return switch (value == null ? "" : value) {
+            case "CELL" -> DungeonEditorRuntimePointerTarget.TargetKind.CELL;
+            case "LABEL" -> DungeonEditorRuntimePointerTarget.TargetKind.LABEL;
+            case "MARKER" -> DungeonEditorRuntimePointerTarget.TargetKind.MARKER;
+            case "GRAPH_NODE" -> DungeonEditorRuntimePointerTarget.TargetKind.GRAPH_NODE;
+            case "HANDLE" -> DungeonEditorRuntimePointerTarget.TargetKind.HANDLE;
+            case "BOUNDARY" -> DungeonEditorRuntimePointerTarget.TargetKind.BOUNDARY;
+            case "VERTEX" -> DungeonEditorRuntimePointerTarget.TargetKind.VERTEX;
+            default -> DungeonEditorRuntimePointerTarget.TargetKind.EMPTY;
+        };
+    }
+
+    private static DungeonEditorRuntimePointerTarget.LabelKind labelKindFrom(String value) {
+        return switch (value == null ? "" : value) {
+            case "ROOM_LABEL" -> DungeonEditorRuntimePointerTarget.LabelKind.ROOM_LABEL;
+            case "CLUSTER_LABEL" -> DungeonEditorRuntimePointerTarget.LabelKind.CLUSTER_LABEL;
+            case "FEATURE_LABEL" -> DungeonEditorRuntimePointerTarget.LabelKind.FEATURE_LABEL;
+            default -> DungeonEditorRuntimePointerTarget.LabelKind.EMPTY;
+        };
+    }
+
+    private static DungeonEditorRuntimePointerTarget.ElementKind elementKindFrom(String value) {
+        return switch (value == null ? "" : value) {
+            case "ROOM" -> DungeonEditorRuntimePointerTarget.ElementKind.ROOM;
+            case "CORRIDOR" -> DungeonEditorRuntimePointerTarget.ElementKind.CORRIDOR;
+            case "CORRIDOR_ANCHOR" -> DungeonEditorRuntimePointerTarget.ElementKind.CORRIDOR_ANCHOR;
+            case "STAIR" -> DungeonEditorRuntimePointerTarget.ElementKind.STAIR;
+            case "TRANSITION" -> DungeonEditorRuntimePointerTarget.ElementKind.TRANSITION;
+            case "FEATURE_MARKER" -> DungeonEditorRuntimePointerTarget.ElementKind.FEATURE_MARKER;
+            case "FEATURE_OBJECT" -> DungeonEditorRuntimePointerTarget.ElementKind.FEATURE_OBJECT;
+            case "FEATURE_ENCOUNTER" -> DungeonEditorRuntimePointerTarget.ElementKind.FEATURE_ENCOUNTER;
+            case "FEATURE_POI" -> DungeonEditorRuntimePointerTarget.ElementKind.FEATURE_POI;
+            case "WALL" -> DungeonEditorRuntimePointerTarget.ElementKind.WALL;
+            case "DOOR" -> DungeonEditorRuntimePointerTarget.ElementKind.DOOR;
+            case "WALL_VERTEX" -> DungeonEditorRuntimePointerTarget.ElementKind.WALL_VERTEX;
+            default -> DungeonEditorRuntimePointerTarget.ElementKind.EMPTY;
+        };
+    }
+
+    private static DungeonEditorRuntimePointerTarget.TopologyKind topologyKindFrom(String value) {
+        return switch (value == null ? "" : value) {
+            case "ROOM" -> DungeonEditorRuntimePointerTarget.TopologyKind.ROOM;
+            case "CORRIDOR" -> DungeonEditorRuntimePointerTarget.TopologyKind.CORRIDOR;
+            case "CORRIDOR_ANCHOR" -> DungeonEditorRuntimePointerTarget.TopologyKind.CORRIDOR_ANCHOR;
+            case "DOOR" -> DungeonEditorRuntimePointerTarget.TopologyKind.DOOR;
+            case "WALL" -> DungeonEditorRuntimePointerTarget.TopologyKind.WALL;
+            case "STAIR" -> DungeonEditorRuntimePointerTarget.TopologyKind.STAIR;
+            case "TRANSITION" -> DungeonEditorRuntimePointerTarget.TopologyKind.TRANSITION;
+            case "FEATURE_MARKER" -> DungeonEditorRuntimePointerTarget.TopologyKind.FEATURE_MARKER;
+            default -> DungeonEditorRuntimePointerTarget.TopologyKind.EMPTY;
+        };
+    }
+
+    private static DungeonEditorRuntimePointerTarget.BoundaryKind boundaryKindFrom(String value) {
+        return "DOOR".equals(value)
+                ? DungeonEditorRuntimePointerTarget.BoundaryKind.DOOR
+                : DungeonEditorRuntimePointerTarget.BoundaryKind.WALL;
+    }
+
+    private static DungeonEditorRuntimePointerTarget.SyntheticHoverKind syntheticHoverKindFrom(String value) {
+        return switch (value == null ? "" : value) {
+            case "CELL" -> DungeonEditorRuntimePointerTarget.SyntheticHoverKind.CELL;
+            case "BOUNDARY" -> DungeonEditorRuntimePointerTarget.SyntheticHoverKind.BOUNDARY;
+            case "VERTEX" -> DungeonEditorRuntimePointerTarget.SyntheticHoverKind.VERTEX;
+            default -> DungeonEditorRuntimePointerTarget.SyntheticHoverKind.NONE;
+        };
     }
 
     private static RoomNarrationDraftInput roomNarrationDraftFrom(

--- a/features/dungeon/application/editor/DungeonEditorCorridorInteractionUseCase.java
+++ b/features/dungeon/application/editor/DungeonEditorCorridorInteractionUseCase.java
@@ -14,8 +14,13 @@ final class DungeonEditorCorridorInteractionUseCase {
     private final DungeonEditorCorridorTargetHelper targetService = new DungeonEditorCorridorTargetHelper();
     private final DungeonEditorCorridorFacingTargetHelper facingTargetHelper =
             new DungeonEditorCorridorFacingTargetHelper();
-    private final DungeonEditorCorridorRoutePreviewValidationHelper routeValidationHelper =
-            new DungeonEditorCorridorRoutePreviewValidationHelper();
+    private final DungeonEditorCorridorRoutePreviewValidationHelper routeValidationHelper;
+
+    DungeonEditorCorridorInteractionUseCase(
+            features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy routingPolicy
+    ) {
+        routeValidationHelper = new DungeonEditorCorridorRoutePreviewValidationHelper(routingPolicy);
+    }
 
     DungeonEditorMainViewInterpretation press(
             PointerState input,

--- a/features/dungeon/application/editor/DungeonEditorCorridorRoutePreviewValidationHelper.java
+++ b/features/dungeon/application/editor/DungeonEditorCorridorRoutePreviewValidationHelper.java
@@ -5,13 +5,18 @@ import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.geometry.Direction;
-import features.dungeon.domain.core.structure.corridor.CorridorRoute;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
 import features.dungeon.application.editor.DungeonEditorInteractionValues.CellKey;
 import features.dungeon.application.editor.DungeonEditorInteractionValues.TravelHeading;
 import features.dungeon.application.editor.DungeonEditorMainViewInteractionValues.PendingCorridorTarget;
 
 final class DungeonEditorCorridorRoutePreviewValidationHelper {
+    private final CorridorRoutingPolicy routingPolicy;
+
+    DungeonEditorCorridorRoutePreviewValidationHelper(CorridorRoutingPolicy routingPolicy) {
+        this.routingPolicy = java.util.Objects.requireNonNull(routingPolicy, "routingPolicy");
+    }
 
     boolean hasValidRoute(
             DungeonEditorWorkspaceValues.MapSnapshot snapshot,
@@ -23,8 +28,7 @@ final class DungeonEditorCorridorRoutePreviewValidationHelper {
         if (snapshot == null || startCell == null || endCell == null || startCell.level() != endCell.level()) {
             return true;
         }
-        Set<CellKey> roomCells = roomCells(snapshot);
-        return CorridorRoute.unblockedBetween(toCoreCell(startCell), toCoreCell(endCell), coreCells(roomCells)).present();
+        return routingPolicy.route(startCell, endCell, roomCells(snapshot)).present();
     }
 
     @Nullable Cell corridorCell(
@@ -38,28 +42,16 @@ final class DungeonEditorCorridorRoutePreviewValidationHelper {
         };
     }
 
-    private static Set<CellKey> roomCells(DungeonEditorWorkspaceValues.MapSnapshot snapshot) {
-        Set<CellKey> result = new LinkedHashSet<>();
+    private static Set<Cell> roomCells(DungeonEditorWorkspaceValues.MapSnapshot snapshot) {
+        Set<Cell> result = new LinkedHashSet<>();
         for (DungeonEditorWorkspaceValues.Area area : snapshot.areas()) {
             if (area.kind().isRoom()) {
                 for (features.dungeon.domain.core.geometry.Cell cell : area.cells()) {
-                    result.add(new CellKey(cell.q(), cell.r(), cell.level()));
+                    result.add(cell);
                 }
             }
         }
         return Set.copyOf(result);
-    }
-
-    private static Set<Cell> coreCells(Set<CellKey> cells) {
-        Set<Cell> result = new LinkedHashSet<>();
-        for (CellKey cell : cells == null ? Set.<CellKey>of() : cells) {
-            result.add(new Cell(cell.q(), cell.r(), cell.level()));
-        }
-        return Set.copyOf(result);
-    }
-
-    private static Cell toCoreCell(features.dungeon.domain.core.geometry.Cell cell) {
-        return new Cell(cell.q(), cell.r(), cell.level());
     }
 
     private static features.dungeon.domain.core.geometry.Cell neighbor(

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -248,6 +248,10 @@ public final class DungeonEditorFeatureRuntimeRoot
         commands.saveTransitionDescription(transitionId, description);
     }
 
+    public void saveFeatureMarkerSemantics(long markerId, String label, String description) {
+        commands.saveFeatureMarkerSemantics(markerId, label, description);
+    }
+
     @Override
     public void saveStairGeometry(StairGeometryDraftInput input) {
         commands.saveStairGeometry(input);

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -308,6 +308,26 @@ public final class DungeonEditorRuntimeApplicationService {
             return publishCurrent();
         }
 
+        public DungeonEditorSessionSnapshot.@Nullable SnapshotData saveFeatureMarkerSemantics(
+                DungeonAuthoredApplicationService.FeatureMarkerSemanticsInput input
+        ) {
+            DungeonAuthoredApplicationService.FeatureMarkerSemanticsInput safeInput = input == null
+                    ? new DungeonAuthoredApplicationService.FeatureMarkerSemanticsInput(0L, "", "")
+                    : input;
+            if (safeInput.markerId() <= 0L
+                    || safeInput.label().isBlank()
+                    || !workflow.session().hasSelectedMap()) {
+                return rejectInvalidTarget();
+            }
+            authored.saveAuthoredFeatureMarkerSemantics(
+                    workflow.session().selectedMapId(),
+                    safeInput.markerId(),
+                    safeInput.label(),
+                    safeInput.description());
+            workflow.clearPreviewWithCommandOutcome(currentFacts().commandOutcome());
+            return publishCurrent();
+        }
+
         public DungeonAuthoredApplicationService.OperationResult saveTransitionLink(
                 DungeonAuthoredApplicationService.TransitionLinkInput input
         ) {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -313,6 +313,11 @@ final class DungeonEditorRuntimeCommands
         });
     }
 
+    public void saveFeatureMarkerSemantics(long markerId, String label, String description) {
+        execute(() -> applyInExecutionLane(
+                () -> context.saveFeatureMarkerSemantics(markerId, label, description)));
+    }
+
     @Override
     public void saveStairGeometry(StairGeometryDraftInput input) {
         StairGeometryDraftInput safeInput = input == null ? StairGeometryDraftInput.empty() : input;

--- a/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
@@ -43,7 +43,9 @@ final class DungeonEditorRuntimeContext {
                 Objects.requireNonNull(interactionState, "interactionState");
         DungeonEditorDungeonState dungeonState = new DungeonEditorDungeonState();
         InterpretDungeonEditorMainViewInputUseCase interpreter =
-                new InterpretDungeonEditorMainViewInputUseCase(safeInteractionState);
+                new InterpretDungeonEditorMainViewInputUseCase(
+                        safeInteractionState,
+                        safeDependencies.corridorRoutingPolicy());
         return safeDependencies.editorRuntimeApplicationService().openSession(
                 dungeonState,
                 runtimeSession -> new DungeonEditorRuntimeContext(runtimeSession, interpreter));
@@ -192,6 +194,12 @@ final class DungeonEditorRuntimeContext {
                 new DungeonAuthoredApplicationService.TransitionDescriptionInput(
                         transitionId,
                         description)));
+    }
+
+    Result saveFeatureMarkerSemantics(long markerId, String label, String description) {
+        return fromSnapshot(session.saveFeatureMarkerSemantics(
+                new DungeonAuthoredApplicationService.FeatureMarkerSemanticsInput(
+                        markerId, label, description)));
     }
 
     Result saveStairGeometry(StairGeometryDraftInput input) {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeDependencies.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeDependencies.java
@@ -9,12 +9,15 @@ import features.dungeon.application.editor.DungeonEditorRuntimeApplicationServic
 import features.dungeon.api.DungeonEditorControlsModel;
 import features.dungeon.api.DungeonEditorMapSurfaceModel;
 import features.dungeon.api.DungeonEditorStateModel;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 
 public record DungeonEditorRuntimeDependencies(
         DungeonEditorControlsModel controlsModel,
         DungeonEditorMapSurfaceModel mapSurfaceModel,
         DungeonEditorStateModel stateModel,
         DungeonEditorRuntimeApplicationService editorRuntimeApplicationService,
+        CorridorRoutingPolicy corridorRoutingPolicy,
         ExecutionLane executionLane,
         UiDispatcher uiDispatcher
 ) {
@@ -25,7 +28,20 @@ public record DungeonEditorRuntimeDependencies(
             DungeonEditorRuntimeApplicationService editorRuntimeApplicationService
     ) {
         this(controlsModel, mapSurfaceModel, stateModel, editorRuntimeApplicationService,
+                new OrthogonalCorridorRoutingPolicy(),
                 DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE);
+    }
+
+    public DungeonEditorRuntimeDependencies(
+            DungeonEditorControlsModel controlsModel,
+            DungeonEditorMapSurfaceModel mapSurfaceModel,
+            DungeonEditorStateModel stateModel,
+            DungeonEditorRuntimeApplicationService editorRuntimeApplicationService,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher
+    ) {
+        this(controlsModel, mapSurfaceModel, stateModel, editorRuntimeApplicationService,
+                new OrthogonalCorridorRoutingPolicy(), executionLane, uiDispatcher);
     }
 
     public DungeonEditorRuntimeDependencies {
@@ -34,6 +50,7 @@ public record DungeonEditorRuntimeDependencies(
         stateModel = Objects.requireNonNull(stateModel, "stateModel");
         editorRuntimeApplicationService =
                 Objects.requireNonNull(editorRuntimeApplicationService, "editorRuntimeApplicationService");
+        corridorRoutingPolicy = Objects.requireNonNull(corridorRoutingPolicy, "corridorRoutingPolicy");
         executionLane = Objects.requireNonNull(executionLane, "executionLane");
         uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }

--- a/features/dungeon/application/editor/InterpretDungeonEditorMainViewHoverUseCase.java
+++ b/features/dungeon/application/editor/InterpretDungeonEditorMainViewHoverUseCase.java
@@ -7,7 +7,13 @@ import features.dungeon.application.editor.DungeonEditorMainViewInteractionValue
 
 final class InterpretDungeonEditorMainViewHoverUseCase {
     private final DungeonEditorBoundaryDraftUseCase boundaryDraft = new DungeonEditorBoundaryDraftUseCase();
-    private final DungeonEditorCorridorInteractionUseCase corridor = new DungeonEditorCorridorInteractionUseCase();
+    private final DungeonEditorCorridorInteractionUseCase corridor;
+
+    InterpretDungeonEditorMainViewHoverUseCase(
+            features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy routingPolicy
+    ) {
+        corridor = new DungeonEditorCorridorInteractionUseCase(routingPolicy);
+    }
 
     DungeonEditorSessionEffect interpretSelection(InteractionState state) {
         return DungeonEditorSessionEffect.clearPreviewIfNeeded(state.boundaryDraft().present() || state.corridorDraft().present());

--- a/features/dungeon/application/editor/InterpretDungeonEditorMainViewInputUseCase.java
+++ b/features/dungeon/application/editor/InterpretDungeonEditorMainViewInputUseCase.java
@@ -16,20 +16,23 @@ final class InterpretDungeonEditorMainViewInputUseCase {
 
     private final DungeonEditorMainViewInputBoundaryTranslationHelper inputTranslator =
             new DungeonEditorMainViewInputBoundaryTranslationHelper();
-    private final InterpretDungeonEditorMainViewPressUseCase pressUseCase =
-            new InterpretDungeonEditorMainViewPressUseCase();
+    private final InterpretDungeonEditorMainViewPressUseCase pressUseCase;
     private final InterpretDungeonEditorMainViewDragUseCase dragUseCase =
             new InterpretDungeonEditorMainViewDragUseCase();
     private final InterpretDungeonEditorMainViewReleaseUseCase releaseUseCase =
             new InterpretDungeonEditorMainViewReleaseUseCase();
-    private final InterpretDungeonEditorMainViewHoverUseCase hoverUseCase =
-            new InterpretDungeonEditorMainViewHoverUseCase();
+    private final InterpretDungeonEditorMainViewHoverUseCase hoverUseCase;
     private final InterpretDungeonEditorMainViewScrollUseCase scrollUseCase =
             new InterpretDungeonEditorMainViewScrollUseCase();
     private final DungeonEditorMainViewInteractionState state;
 
-    InterpretDungeonEditorMainViewInputUseCase(DungeonEditorMainViewInteractionState state) {
+    InterpretDungeonEditorMainViewInputUseCase(
+            DungeonEditorMainViewInteractionState state,
+            features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy routingPolicy
+    ) {
         this.state = java.util.Objects.requireNonNull(state, "state");
+        pressUseCase = new InterpretDungeonEditorMainViewPressUseCase(routingPolicy);
+        hoverUseCase = new InterpretDungeonEditorMainViewHoverUseCase(routingPolicy);
     }
 
     DungeonEditorSessionEffect selection(

--- a/features/dungeon/application/editor/InterpretDungeonEditorMainViewPressUseCase.java
+++ b/features/dungeon/application/editor/InterpretDungeonEditorMainViewPressUseCase.java
@@ -12,8 +12,14 @@ import features.dungeon.application.editor.DungeonEditorMainViewInteractionValue
 
 final class InterpretDungeonEditorMainViewPressUseCase {
     private final DungeonEditorBoundaryDraftUseCase boundaryDraft = new DungeonEditorBoundaryDraftUseCase();
-    private final DungeonEditorCorridorInteractionUseCase corridor = new DungeonEditorCorridorInteractionUseCase();
+    private final DungeonEditorCorridorInteractionUseCase corridor;
     private final DungeonEditorBoundaryStretchHelper boundaryStretch = new DungeonEditorBoundaryStretchHelper();
+
+    InterpretDungeonEditorMainViewPressUseCase(
+            features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy routingPolicy
+    ) {
+        corridor = new DungeonEditorCorridorInteractionUseCase(routingPolicy);
+    }
 
     DungeonEditorMainViewInterpretation interpretSelection(
             PointerState input,

--- a/features/dungeon/domain/core/projection/DungeonCorridorCellProjection.java
+++ b/features/dungeon/domain/core/projection/DungeonCorridorCellProjection.java
@@ -8,7 +8,8 @@ import java.util.Set;
 import features.dungeon.domain.core.component.CorridorWaypoint;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.corridor.Corridor;
-import features.dungeon.domain.core.structure.corridor.CorridorRoute;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.room.RoomCluster;
 
 /**
@@ -16,6 +17,7 @@ import features.dungeon.domain.core.structure.room.RoomCluster;
  * structure owners.
  */
 final class DungeonCorridorCellProjection {
+    private static final CorridorRoutingPolicy ROUTING_POLICY = new OrthogonalCorridorRoutingPolicy();
     private static final int SINGLE_ROUTE_TERMINUS_COUNT = 1;
     private static final int FULL_ROUTE_TERMINUS_COUNT = 2;
 
@@ -138,7 +140,7 @@ final class DungeonCorridorCellProjection {
             return List.of();
         }
         Set<Cell> blockedCells = roomCells == null ? Set.of() : roomCells;
-        return CorridorRoute.unblockedBetweenWithLevelTransition(start, end, blockedCells).cells();
+        return ROUTING_POLICY.routeWithLevelTransition(start, end, blockedCells).cells();
     }
 
     private static int compareCells(Cell left, Cell right) {

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -8,6 +8,7 @@ import features.dungeon.domain.core.geometry.Edge;
 import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import features.dungeon.domain.core.structure.corridor.Corridor;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
 import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
 import features.dungeon.domain.core.structure.room.RoomCatalog;
@@ -298,6 +299,10 @@ public record DungeonMap(
         return withFeatureMarkers(featureMarkers.withoutMarker(markerId));
     }
 
+    public DungeonMap updateFeatureMarkerSemantics(long markerId, String label, String description) {
+        return withFeatureMarkers(featureMarkers.withSemantics(markerId, label, description));
+    }
+
     public boolean canDeleteStair(long stairId) {
         return stairId > 0L && stairs.canDeleteUnboundStair(stairId);
     }
@@ -355,11 +360,12 @@ public record DungeonMap(
     }
 
     public DungeonMap createCorridor(
+            CorridorRoutingPolicy routingPolicy,
             long stairId,
             DungeonCorridorEndpoint start,
             DungeonCorridorEndpoint end
     ) {
-        return CONNECTION_AUTHORING.createCorridor(this, stairId, start, end);
+        return CONNECTION_AUTHORING.createCorridor(this, routingPolicy, stairId, start, end);
     }
 
     DungeonMap withStairs(StairCollection nextStairs) {

--- a/features/dungeon/domain/core/structure/DungeonMapConnectionAuthoring.java
+++ b/features/dungeon/domain/core/structure/DungeonMapConnectionAuthoring.java
@@ -5,13 +5,13 @@ import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import features.dungeon.domain.core.structure.corridor.CorridorBindingMovement;
 import features.dungeon.domain.core.structure.corridor.CorridorBindingMovement.DoorBindingMoveResult;
 import features.dungeon.domain.core.structure.corridor.CorridorMapAuthoring;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
 import features.dungeon.domain.core.structure.door.DoorBoundaryRelocation;
 import features.dungeon.domain.core.structure.door.DoorBoundaryRelocation.DoorBoundaryMovePlan;
 import features.dungeon.domain.core.structure.topology.SpatialTopology;
 
 final class DungeonMapConnectionAuthoring {
-    private final CorridorMapAuthoring corridorAuthoring = new CorridorMapAuthoring();
     private final CorridorBindingMovement corridorBindingMovement = new CorridorBindingMovement();
     private final DoorBoundaryRelocation doorBoundaryRelocation = new DoorBoundaryRelocation();
 
@@ -105,11 +105,12 @@ final class DungeonMapConnectionAuthoring {
 
     DungeonMap createCorridor(
             DungeonMap dungeonMap,
+            CorridorRoutingPolicy routingPolicy,
             long stairId,
             DungeonCorridorEndpoint start,
             DungeonCorridorEndpoint end
     ) {
-        return corridorAuthoring.createCorridor(dungeonMap, stairId, start, end);
+        return new CorridorMapAuthoring(routingPolicy).createCorridor(dungeonMap, stairId, start, end);
     }
 
     private DungeonMap withRelocatedDoorBoundary(

--- a/features/dungeon/domain/core/structure/corridor/CorridorAnchorDependencyUpdate.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorAnchorDependencyUpdate.java
@@ -13,7 +13,7 @@ import features.dungeon.domain.core.structure.DungeonMap;
 
 final class CorridorAnchorDependencyUpdate {
     private static final CorridorReplacementRouteValidation REPLACEMENT_ROUTE_VALIDATION =
-            new CorridorReplacementRouteValidation();
+            new CorridorReplacementRouteValidation(new OrthogonalCorridorRoutingPolicy());
 
     DependencyUpdateResult rerouteDependents(
             DungeonMap currentMap,

--- a/features/dungeon/domain/core/structure/corridor/CorridorDeletion.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorDeletion.java
@@ -22,8 +22,11 @@ final class CorridorDeletion {
             new CorridorConnectionNormalization();
     private static final CorridorTargetDeletion TARGET_DELETION =
             new CorridorTargetDeletion();
-    private static final CorridorReplacementRouteValidation REPLACEMENT_ROUTE_VALIDATION =
-            new CorridorReplacementRouteValidation();
+    private final CorridorReplacementRouteValidation replacementRouteValidation;
+
+    CorridorDeletion(CorridorRoutingPolicy routingPolicy) {
+        replacementRouteValidation = new CorridorReplacementRouteValidation(routingPolicy);
+    }
 
     DungeonMap deleteCorridor(
             DungeonMap dungeonMap,
@@ -71,7 +74,7 @@ final class CorridorDeletion {
         }
         Corridor updated = updatedCore;
         List<Corridor> candidateCorridors = withUpdatedCorridor(dungeonMap, updated);
-        if (!REPLACEMENT_ROUTE_VALIDATION.hasValidReplacementRoute(dungeonMap, updated, candidateCorridors)) {
+        if (!replacementRouteValidation.hasValidReplacementRoute(dungeonMap, updated, candidateCorridors)) {
             return dungeonMap;
         }
         return CONNECTION_NORMALIZATION.copyWithConnections(

--- a/features/dungeon/domain/core/structure/corridor/CorridorHostCellDerivation.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorHostCellDerivation.java
@@ -10,6 +10,7 @@ import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.room.RoomCluster;
 
 final class CorridorHostCellDerivation {
+    private static final CorridorRoutingPolicy ROUTING_POLICY = new OrthogonalCorridorRoutingPolicy();
     private static final int SINGLE_ROUTE_TERMINUS_COUNT = 1;
     private static final CorridorHostBackboneCells BACKBONE_CELLS = new CorridorHostBackboneCells();
     private static final int FULL_ROUTE_TERMINUS_COUNT = 2;
@@ -72,7 +73,7 @@ final class CorridorHostCellDerivation {
         Cell current = routeNodes.get(index);
         return previous == null || current == null
                 ? List.of()
-                : CorridorRoute.unblockedBetweenWithLevelTransition(previous, current, roomCells).cells();
+                : ROUTING_POLICY.routeWithLevelTransition(previous, current, roomCells).cells();
     }
 
     private static void addIfKept(

--- a/features/dungeon/domain/core/structure/corridor/CorridorMapAuthoring.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorMapAuthoring.java
@@ -18,14 +18,18 @@ public final class CorridorMapAuthoring {
             new CorridorEndpointMatching();
     private static final CorridorEndpointResolution ENDPOINT_RESOLUTION =
             new CorridorEndpointResolution();
-    private static final CorridorRouteValidation ROUTE_VALIDATION =
-            new CorridorRouteValidation();
     private static final CorridorRouteSplitting ROUTE_SPLITTING =
             new CorridorRouteSplitting();
     private static final CorridorCreationBinding CREATION_BINDING =
             new CorridorCreationBinding();
-    private static final CorridorDeletion DELETION =
-            new CorridorDeletion();
+    private final CorridorRouteValidation routeValidation;
+    private final CorridorDeletion deletion;
+
+    public CorridorMapAuthoring(CorridorRoutingPolicy routingPolicy) {
+        CorridorRoutingPolicy safePolicy = Objects.requireNonNull(routingPolicy, "routingPolicy");
+        routeValidation = new CorridorRouteValidation(safePolicy);
+        deletion = new CorridorDeletion(safePolicy);
+    }
 
     public DungeonMap createCorridor(
             DungeonMap dungeonMap,
@@ -38,7 +42,7 @@ public final class CorridorMapAuthoring {
             return dungeonMap;
         }
         CorridorHostCells initialHostCells = hostCells(dungeonMap, dungeonMap.corridors());
-        RouteValidation routeValidation = ROUTE_VALIDATION.validate(dungeonMap, start, end, initialHostCells);
+        RouteValidation routeValidation = this.routeValidation.validate(dungeonMap, start, end, initialHostCells);
         if (!routeValidation.hasValidRoute()) {
             return dungeonMap;
         }
@@ -87,7 +91,7 @@ public final class CorridorMapAuthoring {
             DungeonMap dungeonMap,
             CorridorDeletionTarget target
     ) {
-        return DELETION.deleteCorridor(dungeonMap, target);
+        return deletion.deleteCorridor(dungeonMap, target);
     }
 
     private static boolean validCreateEndpoints(DungeonCorridorEndpoint start, DungeonCorridorEndpoint end) {

--- a/features/dungeon/domain/core/structure/corridor/CorridorReplacementRouteValidation.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorReplacementRouteValidation.java
@@ -13,13 +13,18 @@ final class CorridorReplacementRouteValidation {
     private static final CorridorHostRoomCells ROOM_CELLS = new CorridorHostRoomCells();
     private static final CorridorHostEndpointQuery ENDPOINTS = new CorridorHostEndpointQuery();
     private static final CorridorHostBackboneCells BACKBONE_CELLS = new CorridorHostBackboneCells();
+    private final CorridorRoutingPolicy routingPolicy;
+
+    CorridorReplacementRouteValidation(CorridorRoutingPolicy routingPolicy) {
+        this.routingPolicy = java.util.Objects.requireNonNull(routingPolicy, "routingPolicy");
+    }
 
     boolean hasValidReplacementRoute(
             DungeonMap dungeonMap,
             Corridor corridor,
             List<Corridor> candidateCorridors
     ) {
-        return ValidationContext.from(dungeonMap, candidateCorridors)
+        return ValidationContext.from(dungeonMap, candidateCorridors, routingPolicy)
                 .hasValidReplacementRoute(corridor);
     }
 
@@ -27,15 +32,19 @@ final class CorridorReplacementRouteValidation {
             DungeonMap dungeonMap,
             List<Corridor> candidateCorridors
     ) {
-        return ValidationContext.from(dungeonMap, candidateCorridors);
+        return ValidationContext.from(dungeonMap, candidateCorridors, routingPolicy);
     }
 
-    private static boolean hasUnblockedBackbone(List<Cell> backbone, Set<Cell> roomCells) {
+    private static boolean hasUnblockedBackbone(
+            List<Cell> backbone,
+            Set<Cell> roomCells,
+            CorridorRoutingPolicy routingPolicy
+    ) {
         if (backbone == null || backbone.size() < 2) {
             return false;
         }
         for (int index = 1; index < backbone.size(); index++) {
-            CorridorRoute segment = CorridorRoute.unblockedBetween(backbone.get(index - 1), backbone.get(index), roomCells);
+            CorridorRoute segment = routingPolicy.route(backbone.get(index - 1), backbone.get(index), roomCells);
             if (!segment.present()) {
                 return false;
             }
@@ -49,14 +58,16 @@ final class CorridorReplacementRouteValidation {
             Map<Long, RoomRegion> roomsById,
             Map<Long, List<Cell>> roomCellsByRoom,
             Map<CorridorNetwork.AnchorKey, CorridorAnchor> anchorsByKey,
-            Set<Cell> allRoomCells
+            Set<Cell> allRoomCells,
+            CorridorRoutingPolicy routingPolicy
     ) {
         static ValidationContext from(
                 DungeonMap dungeonMap,
-                List<Corridor> candidateCorridors
+                List<Corridor> candidateCorridors,
+            CorridorRoutingPolicy routingPolicy
         ) {
             if (dungeonMap == null) {
-                return invalid();
+                return invalid(routingPolicy);
             }
             Map<Long, List<Cell>> roomCellsByRoom = ROOM_CELLS.roomCellsByRoom(dungeonMap);
             return new ValidationContext(
@@ -65,17 +76,19 @@ final class CorridorReplacementRouteValidation {
                     ROOM_CELLS.roomsById(dungeonMap),
                     roomCellsByRoom,
                     ENDPOINTS.anchorsByKey(candidateCorridors),
-                    ROOM_CELLS.allRoomCells(roomCellsByRoom));
+                    ROOM_CELLS.allRoomCells(roomCellsByRoom),
+                    routingPolicy);
         }
 
-        static ValidationContext invalid() {
+        static ValidationContext invalid(CorridorRoutingPolicy routingPolicy) {
             return new ValidationContext(
                     false,
                     Map.of(),
                     Map.of(),
                     Map.of(),
                     Map.of(),
-                    Set.of());
+                    Set.of(),
+                    routingPolicy);
         }
 
         boolean hasValidReplacementRoute(Corridor corridor) {
@@ -91,7 +104,7 @@ final class CorridorReplacementRouteValidation {
             List<Cell> backbone = corridor.bindings().waypoints().isEmpty()
                     ? BACKBONE_CELLS.endpointBackbone(endpoints)
                     : BACKBONE_CELLS.authoredBackbone(corridor.bindings().waypoints(), clustersById, endpoints);
-            return hasUnblockedBackbone(backbone, allRoomCells);
+            return hasUnblockedBackbone(backbone, allRoomCells, routingPolicy);
         }
     }
 }

--- a/features/dungeon/domain/core/structure/corridor/CorridorRoute.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorRoute.java
@@ -4,42 +4,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import features.dungeon.domain.core.geometry.Cell;
-import features.dungeon.domain.core.geometry.Route;
 
 public record CorridorRoute(List<Cell> cells) {
 
     public CorridorRoute {
         cells = cells == null ? List.of() : List.copyOf(cells);
-    }
-
-    public static CorridorRoute unblockedBetween(Cell start, Cell end, Set<Cell> blockedCells) {
-        return unblockedBetween(start, end, blockedCells, true);
-    }
-
-    public static CorridorRoute unblockedBetweenWithLevelTransition(Cell start, Cell end, Set<Cell> blockedCells) {
-        return unblockedBetween(start, end, blockedCells, false);
-    }
-
-    private static CorridorRoute unblockedBetween(
-            Cell start,
-            Cell end,
-            Set<Cell> blockedCells,
-            boolean keepStartLevel
-    ) {
-        if (start == null || end == null) {
-            return new CorridorRoute(List.of());
-        }
-        Set<Cell> blocked = blockedCells == null ? Set.of() : blockedCells;
-        CorridorRoute horizontalFirst = new CorridorRoute(keepStartLevel
-                ? Route.horizontalFirstOnStartLevel(start, end)
-                : Route.horizontalFirst(start, end));
-        if (!horizontalFirst.blockedBy(blocked)) {
-            return horizontalFirst;
-        }
-        CorridorRoute verticalFirst = new CorridorRoute(keepStartLevel
-                ? Route.verticalFirstOnStartLevel(start, end)
-                : Route.verticalFirst(start, end));
-        return verticalFirst.blockedBy(blocked) ? new CorridorRoute(List.of()) : verticalFirst;
     }
 
     @Override

--- a/features/dungeon/domain/core/structure/corridor/CorridorRouteValidation.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorRouteValidation.java
@@ -14,6 +14,11 @@ import features.dungeon.domain.core.structure.room.RoomCellCoverage;
 
 final class CorridorRouteValidation {
     private static final CorridorHostCellQuery HOST_CELL_QUERY = new CorridorHostCellQuery();
+    private final CorridorRoutingPolicy routingPolicy;
+
+    CorridorRouteValidation(CorridorRoutingPolicy routingPolicy) {
+        this.routingPolicy = java.util.Objects.requireNonNull(routingPolicy, "routingPolicy");
+    }
 
     RouteValidation validate(
             DungeonMap dungeonMap,
@@ -32,7 +37,7 @@ final class CorridorRouteValidation {
         return HOST_CELL_QUERY.cellsByCorridor(dungeonMap, corridors);
     }
 
-    private static CorridorRoute route(
+    private CorridorRoute route(
             DungeonMap dungeonMap,
             DungeonCorridorEndpoint start,
             DungeonCorridorEndpoint end,
@@ -47,7 +52,7 @@ final class CorridorRouteValidation {
         if (startCell == null || endCell == null) {
             return new CorridorRoute(List.of());
         }
-        return CorridorRoute.unblockedBetween(startCell, endCell, roomCells);
+        return routingPolicy.route(startCell, endCell, roomCells);
     }
 
     private static @Nullable Cell corridorCell(

--- a/features/dungeon/domain/core/structure/corridor/CorridorRoutingPolicy.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorRoutingPolicy.java
@@ -1,0 +1,12 @@
+package features.dungeon.domain.core.structure.corridor;
+
+import java.util.Set;
+import features.dungeon.domain.core.geometry.Cell;
+
+/** Selects an authored corridor route without coupling editor commands to an algorithm. */
+public interface CorridorRoutingPolicy {
+
+    CorridorRoute route(Cell start, Cell end, Set<Cell> blockedCells);
+
+    CorridorRoute routeWithLevelTransition(Cell start, Cell end, Set<Cell> blockedCells);
+}

--- a/features/dungeon/domain/core/structure/corridor/OrthogonalCorridorRoutingPolicy.java
+++ b/features/dungeon/domain/core/structure/corridor/OrthogonalCorridorRoutingPolicy.java
@@ -1,0 +1,42 @@
+package features.dungeon.domain.core.structure.corridor;
+
+import java.util.List;
+import java.util.Set;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Route;
+
+/** Deterministic horizontal-first, vertical-fallback routing used by the initial product. */
+public final class OrthogonalCorridorRoutingPolicy implements CorridorRoutingPolicy {
+
+    @Override
+    public CorridorRoute route(Cell start, Cell end, Set<Cell> blockedCells) {
+        return route(start, end, blockedCells, true);
+    }
+
+    @Override
+    public CorridorRoute routeWithLevelTransition(Cell start, Cell end, Set<Cell> blockedCells) {
+        return route(start, end, blockedCells, false);
+    }
+
+    private static CorridorRoute route(
+            Cell start,
+            Cell end,
+            Set<Cell> blockedCells,
+            boolean keepStartLevel
+    ) {
+        if (start == null || end == null) {
+            return new CorridorRoute(List.of());
+        }
+        Set<Cell> blocked = blockedCells == null ? Set.of() : blockedCells;
+        CorridorRoute horizontalFirst = new CorridorRoute(keepStartLevel
+                ? Route.horizontalFirstOnStartLevel(start, end)
+                : Route.horizontalFirst(start, end));
+        if (!horizontalFirst.blockedBy(blocked)) {
+            return horizontalFirst;
+        }
+        CorridorRoute verticalFirst = new CorridorRoute(keepStartLevel
+                ? Route.verticalFirstOnStartLevel(start, end)
+                : Route.verticalFirst(start, end));
+        return verticalFirst.blockedBy(blocked) ? new CorridorRoute(List.of()) : verticalFirst;
+    }
+}

--- a/features/dungeon/domain/core/structure/feature/FeatureMarker.java
+++ b/features/dungeon/domain/core/structure/feature/FeatureMarker.java
@@ -33,6 +33,10 @@ public record FeatureMarker(
         return new DungeonTopologyRef(DungeonTopologyElementKind.FEATURE_MARKER, markerId);
     }
 
+    public FeatureMarker withSemantics(String nextLabel, String nextDescription) {
+        return new FeatureMarker(markerId, mapId, kind, anchor, nextLabel, nextDescription);
+    }
+
     private static String defaultLabel(FeatureMarkerKind kind, long markerId) {
         return kind.name() + " " + markerId;
     }

--- a/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
+++ b/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
@@ -50,6 +50,19 @@ public record FeatureMarkerCatalog(
         return false;
     }
 
+    public FeatureMarkerCatalog withSemantics(long markerId, String label, String description) {
+        if (!canDelete(markerId)) {
+            return this;
+        }
+        List<FeatureMarker> nextMarkers = new ArrayList<>();
+        for (FeatureMarker marker : markers) {
+            nextMarkers.add(marker.markerId() == markerId
+                    ? marker.withSemantics(label, description)
+                    : marker);
+        }
+        return new FeatureMarkerCatalog(nextMarkers);
+    }
+
     public FeatureMarkerCatalog withoutMarker(long markerId) {
         if (!canDelete(markerId)) {
             return this;

--- a/test/features/dungeon/adapter/javafx/editor/DungeonCorridorInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonCorridorInvariantScenarios.java
@@ -25,6 +25,8 @@ import features.dungeon.domain.core.structure.corridor.CorridorResolvedEndpoint;
 import features.dungeon.domain.core.structure.corridor.CorridorRoomSet;
 import features.dungeon.domain.core.structure.corridor.CorridorRoute;
 import features.dungeon.domain.core.structure.corridor.CorridorRoutePlan;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.corridor.CorridorTargetDeletion;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorDeletionOwnerProbe;
 import features.dungeon.domain.core.structure.room.RoomCatalog;
@@ -35,6 +37,7 @@ import features.dungeon.application.editor.DungeonEditorRuntimeDraftOwnerProbe;
 import static features.dungeon.adapter.javafx.editor.DungeonEditorTestSupport.*;
 
 final class DungeonCorridorInvariantScenarios {
+    private static final CorridorRoutingPolicy ROUTING_POLICY = new OrthogonalCorridorRoutingPolicy();
 
 
     private DungeonCorridorInvariantScenarios() {
@@ -104,11 +107,11 @@ final class DungeonCorridorInvariantScenarios {
     }
 
     private static void assertRouteOwner() {
-        CorridorRoute straight = CorridorRoute.unblockedBetween(new Cell(0, 0, 0), new Cell(3, 0, 0), Set.of());
+        CorridorRoute straight = ROUTING_POLICY.route(new Cell(0, 0, 0), new Cell(3, 0, 0), Set.of());
         assertEquals(List.of(new Cell(0, 0, 0), new Cell(1, 0, 0), new Cell(2, 0, 0), new Cell(3, 0, 0)),
                 straight.cells(),
                 "corridor route owner derives deterministic straight route");
-        CorridorRoute turned = CorridorRoute.unblockedBetween(new Cell(0, 0, 0), new Cell(2, 2, 1), Set.of());
+        CorridorRoute turned = ROUTING_POLICY.route(new Cell(0, 0, 0), new Cell(2, 2, 1), Set.of());
         assertEquals(List.of(new Cell(0, 0, 0), new Cell(1, 0, 0), new Cell(2, 0, 0),
                         new Cell(2, 1, 0), new Cell(2, 2, 0)),
                 turned.cells(),
@@ -119,13 +122,13 @@ final class DungeonCorridorInvariantScenarios {
                 "corridor route owner ignores unrelated blocked cells");
         assertEquals(List.of(new Cell(0, 0, 0), new Cell(0, 1, 0), new Cell(0, 2, 0),
                         new Cell(1, 2, 0), new Cell(2, 2, 0)),
-                CorridorRoute.unblockedBetween(
+                ROUTING_POLICY.route(
                                 new Cell(0, 0, 0),
                                 new Cell(2, 2, 1),
                                 Set.of(new Cell(1, 0, 0)))
                         .cells(),
                 "corridor route owner uses vertical-first fallback when horizontal-first is blocked");
-        assertTrue(!CorridorRoute.unblockedBetween(
+        assertTrue(!ROUTING_POLICY.route(
                         new Cell(0, 0, 0),
                         new Cell(2, 2, 1),
                         Set.of(new Cell(1, 0, 0), new Cell(0, 1, 0)))
@@ -216,6 +219,7 @@ final class DungeonCorridorInvariantScenarios {
         assertEquals(List.of(10L), corridorIds(network.withoutCorridor(11L)),
                 "corridor network deletes the unreferenced branch corridor");
         DungeonCorridorDeletionOwnerProbe.assertInvalidReplacementRouteRejectedBeforeMutation();
+        DungeonCorridorDeletionOwnerProbe.assertInjectedRoutingPolicyOwnsReplacementValidation();
     }
 
     private static void assertNetworkMovementOwner() {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorFeatureMarkerScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorFeatureMarkerScenarios.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import javafx.geometry.Point2D;
 import javafx.scene.Parent;
 import javafx.scene.control.ButtonBase;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
 import javafx.scene.input.MouseButton;
 import features.dungeon.api.DungeonEditorMapSurfaceSnapshot;
 import features.dungeon.api.DungeonEditorMapSnapshot;
@@ -13,6 +15,8 @@ import features.dungeon.api.DungeonInspectorSnapshot;
 import features.dungeon.api.DungeonTopologyElementRef;
 import features.dungeon.api.editor.DungeonEditorToolOptions;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
 import features.dungeon.application.editor.DungeonEditorRuntimePointerTarget;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel;
 import features.dungeon.adapter.javafx.map.DungeonMapView;
@@ -124,8 +128,6 @@ final class DungeonEditorFeatureMarkerScenarios {
                 "DE-FEATURE-003 persists one dungeon_feature_markers row for the created POI");
         assertEquals(1L, runtime.database().countFeatureMarkerTopologyElementById(mapId, markerId),
                 "DE-FEATURE-003 persists one stable FEATURE_MARKER topology ref");
-        String authoredDescription = "Verborgener Altar am alten Pilgerweg.";
-        runtime.database().updateFeatureMarkerDescription(mapId, markerId, authoredDescription);
         List<String> stableRowsAfterCreate = runtime.database().featureMarkerStableState(mapId);
         assertTrue(stableRowsAfterCreate.stream().anyMatch(row -> row.startsWith(
                         "dungeon_feature_markers|feature_marker_id=" + markerId)
@@ -174,9 +176,43 @@ final class DungeonEditorFeatureMarkerScenarios {
         assertEquals(DungeonInspectorSnapshot.StatePanelFacts.empty(), selectedState.inspector().statePanelFacts(),
                 "DE-FEATURE-004 marker inspector publishes no unrelated stair or transition panel state");
 
+        String authoredLabel = "Verborgener Altar";
+        String authoredDescription = "Verborgener Altar am alten Pilgerweg.";
+        long revisionBeforeSemanticEdit = runtime.mapSurfaceModel().current().surface().revision();
+        TextField labelField = textField(binding.stateView(), "Feature-Marker Name");
+        TextArea descriptionArea = textArea(binding.stateView(), "Feature-Marker Beschreibung");
+        labelField.setText(authoredLabel);
+        descriptionArea.setText(authoredDescription);
+        click(buttonWithAccessibleText(binding.stateView(), "Feature-Marker speichern"));
+        DungeonEditorStateSnapshot editedState = runtime.stateModel().current();
+        assertEquals(revisionBeforeSemanticEdit + 1L,
+                runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-FEATURE-006 one typed marker semantic command advances revision exactly once");
+        assertEquals(markerRef, editedState.selection().topologyRef(),
+                "DE-FEATURE-006 marker semantic edit preserves selection identity");
+        assertEquals(authoredLabel, editedState.inspector().title(),
+                "DE-FEATURE-006 typed marker semantic edit publishes the authored label");
+        assertEquals(authoredDescription, editedState.inspector().summary(),
+                "DE-FEATURE-006 typed marker semantic edit publishes the authored description");
+        List<String> stableRowsAfterSemanticEdit = runtime.database().featureMarkerStableState(mapId);
+        assertTrue(stableRowsAfterSemanticEdit.stream().anyMatch(row -> row.contains("|label=" + authoredLabel)
+                        && row.contains("|description=" + authoredDescription)),
+                "DE-FEATURE-006 typed marker semantic edit persists label and description");
+        long revisionBeforeRejectedEdit = runtime.mapSurfaceModel().current().surface().revision();
+        runtime.editorApi().dispatch(new DungeonEditorIntent.CommitFeatureMarkerSemantics(
+                markerId + 10_000L, "Fehlt", "Ungültiges Ziel"));
+        assertEquals(revisionBeforeRejectedEdit, runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-FEATURE-006 rejected marker semantic edit preserves authored revision");
+        assertEquals(new DungeonEditorCommandOutcome.Rejected(
+                        DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET),
+                runtime.editorApi().current().commandStatus().outcome(),
+                "DE-FEATURE-006 rejected marker semantic edit publishes one typed reason");
+        assertEquals(stableRowsAfterSemanticEdit, runtime.database().featureMarkerStableState(mapId),
+                "DE-FEATURE-006 rejected marker semantic edit preserves persisted state");
+
         selectMap(controls, "Feature POI Reload Hop");
         selectMap(controls, "Feature POI Create Map");
-        assertEquals(stableRowsAfterCreate, runtime.database().featureMarkerStableState(mapId),
+        assertEquals(stableRowsAfterSemanticEdit, runtime.database().featureMarkerStableState(mapId),
                 "DE-FEATURE-006 reload keeps the POI feature-marker rows stable");
         assertFeatureMarkerCreatedInSnapshot(
                 runtime.mapSurfaceModel().current(),
@@ -200,6 +236,8 @@ final class DungeonEditorFeatureMarkerScenarios {
                 "DE-FEATURE-006 production selection publishes the typed marker topology ref");
         assertTrue(reloadedSelection.inspector() != null,
                 "DE-FEATURE-006 production selection publishes the marker inspector");
+        assertEquals(authoredLabel, reloadedSelection.inspector().title(),
+                "DE-FEATURE-006 reloaded inspector keeps the authored marker label");
         assertEquals(authoredDescription, reloadedSelection.inspector().summary(),
                 "DE-FEATURE-006 inspector summary is only the authored marker description");
         assertEquals(DungeonInspectorSnapshot.StatePanelFacts.empty(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
@@ -1191,20 +1191,6 @@ class DungeonEditorTestPersistence {
             }
         }
 
-        void updateFeatureMarkerDescription(long mapId, long markerId, String description) {
-            try (Connection connection = open();
-                 PreparedStatement statement = connection.prepareStatement(
-                         "UPDATE dungeon_feature_markers SET description=?"
-                                 + " WHERE dungeon_map_id=? AND feature_marker_id=?")) {
-                bind(statement, description, mapId, markerId);
-                if (statement.executeUpdate() != 1) {
-                    throw new SQLException("Expected exactly one feature marker description update.");
-                }
-            } catch (SQLException exception) {
-                throw new IllegalStateException("Failed to update feature marker description.", exception);
-            }
-        }
-
         long countFeatureMarkerById(long mapId, long markerId) {
             return count(
                     "SELECT COUNT(*) FROM dungeon_feature_markers"

--- a/test/features/dungeon/adapter/javafx/editor/DungeonPathInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonPathInvariantScenarios.java
@@ -13,6 +13,8 @@ import features.dungeon.domain.core.geometry.Route;
 import features.dungeon.domain.core.structure.corridor.CorridorBindings;
 import features.dungeon.domain.core.structure.corridor.CorridorRoute;
 import features.dungeon.domain.core.structure.corridor.CorridorRoutePlan;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryRow;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryStretchPlan;
@@ -24,6 +26,7 @@ import features.dungeon.domain.core.structure.stair.StairShape;
 import features.dungeon.application.editor.DungeonEditorRuntimeDraftOwnerProbe;
 
 final class DungeonPathInvariantScenarios {
+    private static final CorridorRoutingPolicy ROUTING_POLICY = new OrthogonalCorridorRoutingPolicy();
 
 
     private DungeonPathInvariantScenarios() {
@@ -64,7 +67,7 @@ final class DungeonPathInvariantScenarios {
     }
 
     private static void assertCorridorPathOwner() {
-        CorridorRoute route = CorridorRoute.unblockedBetween(new Cell(0, 0, 0), new Cell(2, 1, 1), Set.of());
+        CorridorRoute route = ROUTING_POLICY.route(new Cell(0, 0, 0), new Cell(2, 1, 1), Set.of());
         assertEquals(List.of(new Cell(0, 0, 0), new Cell(1, 0, 0), new Cell(2, 0, 0),
                         new Cell(2, 1, 0)),
                 route.cells(),
@@ -76,19 +79,19 @@ final class DungeonPathInvariantScenarios {
                 "corridor path owner keeps unrelated room cells from blocking route");
         assertEquals(List.of(new Cell(0, 0, 0), new Cell(0, 1, 0), new Cell(1, 1, 0),
                         new Cell(2, 1, 0)),
-                CorridorRoute.unblockedBetween(
+                ROUTING_POLICY.route(
                                 new Cell(0, 0, 0),
                                 new Cell(2, 1, 1),
                                 Set.of(new Cell(1, 0, 0)))
                         .cells(),
                 "corridor path owner falls back to vertical-first when horizontal-first is blocked");
-        assertFalse(CorridorRoute.unblockedBetween(
+        assertFalse(ROUTING_POLICY.route(
                         new Cell(0, 0, 0),
                         new Cell(2, 1, 1),
                         Set.of(new Cell(1, 0, 0), new Cell(0, 1, 0)))
                 .present(),
                 "corridor path owner rejects when both orthogonal candidates are blocked");
-        assertFalse(CorridorRoute.unblockedBetween(null, new Cell(1, 0, 0), Set.of()).present(),
+        assertFalse(ROUTING_POLICY.route(null, new Cell(1, 0, 0), Set.of()).present(),
                 "corridor path owner reports missing endpoint route as no-op");
 
         CorridorRoutePlan plan = new CorridorRoutePlan(

--- a/test/features/dungeon/adapter/javafx/editor/DungeonStairInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonStairInvariantScenarios.java
@@ -22,7 +22,8 @@ final class DungeonStairInvariantScenarios {
 
     private static final long CORRIDOR_ID = 20L;
     private static final long STAIR_ID = 9L;
-    private static final CorridorMapAuthoring CORRIDOR_AUTHORING = new CorridorMapAuthoring();
+    private static final CorridorMapAuthoring CORRIDOR_AUTHORING = new CorridorMapAuthoring(
+            new features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy());
 
     private DungeonStairInvariantScenarios() {
     }

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTopologyInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTopologyInvariantScenarios.java
@@ -116,6 +116,7 @@ final class DungeonTopologyInvariantScenarios {
         RoomRegion leftRoom = roomInCluster(map, leftDoor.clusterId());
         RoomRegion rightRoom = roomInCluster(map, rightDoor.clusterId());
         return map.createCorridor(
+                new features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy(),
                 0L,
                 DungeonCorridorEndpoint.door(
                         leftRoom.roomId(),

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeDraftOwnerProbe.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeDraftOwnerProbe.java
@@ -97,7 +97,8 @@ public final class DungeonEditorRuntimeDraftOwnerProbe {
     }
 
     public static void assertCorridorDraftSessionOwner() {
-        DungeonEditorCorridorInteractionUseCase useCase = new DungeonEditorCorridorInteractionUseCase();
+        DungeonEditorCorridorInteractionUseCase useCase = new DungeonEditorCorridorInteractionUseCase(
+                new features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy());
         PointerState firstClick = corridorDoorPress();
         DungeonEditorMainViewInterpretation started = useCase.press(
                 firstClick,

--- a/test/features/dungeon/domain/core/structure/corridor/DungeonCorridorDeletionOwnerProbe.java
+++ b/test/features/dungeon/domain/core/structure/corridor/DungeonCorridorDeletionOwnerProbe.java
@@ -1,6 +1,7 @@
 package features.dungeon.domain.core.structure.corridor;
 
 import java.util.List;
+import java.util.Set;
 import features.dungeon.domain.core.component.CorridorAnchor;
 import features.dungeon.domain.core.component.CorridorAnchorRef;
 import features.dungeon.domain.core.component.CorridorWaypoint;
@@ -13,7 +14,8 @@ import features.dungeon.domain.core.structure.room.RoomCluster;
 
 public final class DungeonCorridorDeletionOwnerProbe {
     private static final long CORRIDOR_ID = 20L;
-    private static final CorridorMapAuthoring CORRIDOR_AUTHORING = new CorridorMapAuthoring();
+    private static final CorridorMapAuthoring CORRIDOR_AUTHORING =
+            new CorridorMapAuthoring(new OrthogonalCorridorRoutingPolicy());
 
     private DungeonCorridorDeletionOwnerProbe() {
     }
@@ -44,6 +46,38 @@ public final class DungeonCorridorDeletionOwnerProbe {
 
         assertEquals(withCorridor, rejected,
                 "corridor deletion owner rejects invalid replacement route before mutation");
+    }
+
+    public static void assertInjectedRoutingPolicyOwnsReplacementValidation() {
+        DungeonMap base = DungeonMapAuthoring.empty(
+                new DungeonMapIdentity(81L),
+                "Injected Corridor Routing Policy");
+        base = base.paintRoomRectangle(new Cell(1, 0, 0), new Cell(1, 0, 0));
+        RoomCluster blocker = base.topology().roomClusters().getFirst();
+        Corridor corridor = replacementRouteFixture(blocker);
+        DungeonMap withCorridor = DungeonMapAuthoring.authored(
+                base.metadata().mapId(),
+                base.metadata().mapName(),
+                new AuthoredContent(
+                        base.topology(),
+                        base.topologyIndex(),
+                        base.rooms(),
+                        List.of(corridor),
+                        base.stairs(),
+                        base.transitionCatalog().transitions(),
+                        base.featureMarkers()),
+                base.revision());
+        RecordingRoutingPolicy policy = new RecordingRoutingPolicy();
+
+        DungeonMap updated = new CorridorMapAuthoring(policy).deleteCorridor(
+                withCorridor,
+                CorridorDeletionTarget.corridorWaypoint(CORRIDOR_ID, 0));
+
+        assertEquals(1, policy.routeCalls,
+                "injected corridor routing policy owns replacement validation");
+        if (updated.equals(withCorridor)) {
+            throw new IllegalStateException("injected corridor routing policy result must control authoring");
+        }
     }
 
     private static Corridor replacementRouteFixture(RoomCluster blocker) {
@@ -77,6 +111,21 @@ public final class DungeonCorridorDeletionOwnerProbe {
     private static void assertEquals(Object expected, Object actual, String message) {
         if (!java.util.Objects.equals(expected, actual)) {
             throw new IllegalStateException(message + " expected=" + expected + " actual=" + actual);
+        }
+    }
+
+    private static final class RecordingRoutingPolicy implements CorridorRoutingPolicy {
+        private int routeCalls;
+
+        @Override
+        public CorridorRoute route(Cell start, Cell end, Set<Cell> blockedCells) {
+            routeCalls++;
+            return new CorridorRoute(List.of(start, end));
+        }
+
+        @Override
+        public CorridorRoute routeWithLevelTransition(Cell start, Cell end, Set<Cell> blockedCells) {
+            return route(start, end, blockedCells);
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject one orthogonal corridor routing policy through composition, preview, creation, and replacement validation
- add typed feature-marker label and description editing through the Editor API, aggregate, persistence, and JavaFX state panel
- delete static route selection, the marker SQL test shortcut, and the remaining Dungeon Editor enum-name round trip
- advance the greenfield roadmap to M3.1

## Verification
- ./gradlew uiTest architectureTest --console=plain
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain