### PR TITLE
Introduce Dungeon M3 patch command vocabulary

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,18 +97,19 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2.5 are complete on `main` through PR #498.
-- This slice: M2.6 moves deterministic orthogonal route selection behind one
-  injected domain policy shared by Editor preview and authored corridor
-  commands. `CorridorRoute` remains only the immutable route value.
-- Feature-marker label and description edits now travel from the JavaFX state
-  panel through a typed Editor intent to the aggregate and persistence boundary.
-  The direct-SQL description shortcut in production-route proof is deleted;
-  accepted and rejected edits prove revision, selection, persistence, reload,
-  and typed outcome behavior.
-- Next step after this slice merges: M3.1 introduces the canonical typed command,
-  patch, inverse, touched-chunk, and result-fact vocabulary without changing the
-  now-closed M2 Editor command language.
+- Current foundation: M0 through M2 are complete on `main` through PR #499.
+- This slice: M3.1 introduces `DungeonCommandResult`, revision-checked
+  `DungeonPatch`, stable-entity changes, touched chunks, result facts, exact
+  encoded-weight bounds, and generated inverse patches.
+- Feature-marker semantic edits are the first real production command moved to
+  that vocabulary. Their former direct aggregate-mutation route is deleted;
+  deterministic proof covers forward and inverse application, stale revision,
+  negative chunk identity, result facts, byte weight, and typed rejection.
+- `DungeonChangeSet` persistence and full-map session history remain temporary
+  M3/M4 boundaries; no second persistence contract is introduced in this slice.
+- Next step after this slice merges: M3.2 moves the remaining ordinary
+  single-map authored commands to exact patches and removes unchanged-map
+  inference from their commit results.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -22,6 +22,8 @@ import features.dungeon.domain.core.projection.DungeonDerivedStateProjection;
 import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.authored.port.DungeonChangeSet;
+import features.dungeon.application.authored.command.DungeonCommandResult;
+import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -101,6 +103,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final PreviewDungeonEditorSurfaceMoveUseCase surfaceMovePreviewUseCase =
             new PreviewDungeonEditorSurfaceMoveUseCase();
     private final MutationPipeline mutationPipeline = new MutationPipeline();
+    private final FeatureMarkerSemanticsCommand featureMarkerSemanticsCommand =
+            new FeatureMarkerSemanticsCommand();
     private final PublicationOperations publicationOperations = new PublicationOperations();
     private final PreviewOperations previewOperations = new PreviewOperations();
     private final DetailSaveOperations detailSaveOperations = new DetailSaveOperations();
@@ -567,6 +571,36 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 @Nullable AuthoredMapMutation operation
         ) {
             return executeOperation(mapId, operation, DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+
+        private OperationResultData executeFeatureMarkerSemantics(
+                DungeonMapIdentity mapId,
+                long markerId,
+                String label,
+                String description
+        ) {
+            DungeonMap current = loadMap(mapId);
+            DungeonCommandResult commandResult = featureMarkerSemanticsCommand.plan(
+                    current, markerId, label, description);
+            if (commandResult instanceof DungeonCommandResult.Rejected rejected) {
+                return new OperationResultData(
+                        snapshotData(current, derive(current)),
+                        false,
+                        List.of(),
+                        List.of(),
+                        DungeonEditorCommandOutcome.rejected(rejected.reason()));
+            }
+            DungeonCommandResult.Accepted accepted = (DungeonCommandResult.Accepted) commandResult;
+            DungeonMap patched = accepted.patch().applyTo(current);
+            DungeonMap saved = repository.saveChange(new DungeonChangeSet(current, patched));
+            authoredWorkset.put(saved.metadata().mapId().value(), saved);
+            editHistory.record(current, saved);
+            return new OperationResultData(
+                    snapshotData(saved, derive(saved)),
+                    true,
+                    OPERATION_FEEDBACK_POLICY.validationMessages(current, saved),
+                    OPERATION_FEEDBACK_POLICY.reactionMessages(current, saved),
+                    DungeonEditorCommandOutcome.accepted(saved.revision()));
         }
 
         private OperationResultData executeOperation(
@@ -1356,10 +1390,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || markerId <= 0L || label == null || label.isBlank()) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeOperation(
-                    domainMapId(mapId),
-                    current -> current.updateFeatureMarkerSemantics(markerId, label, description),
-                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+            OperationResultData result = mutationPipeline.executeFeatureMarkerSemantics(
+                    domainMapId(mapId), markerId, label, description);
             publicationOperations.publishMutation(result, state);
         }
 

--- a/features/dungeon/application/authored/command/DungeonCommandResult.java
+++ b/features/dungeon/application/authored/command/DungeonCommandResult.java
@@ -1,0 +1,33 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import java.util.Objects;
+
+/** Typed authored-command result before persistence and publication. */
+public sealed interface DungeonCommandResult {
+
+    record Rejected(DungeonEditorCommandOutcome.RejectionReason reason) implements DungeonCommandResult {
+        public Rejected {
+            reason = reason == null ? DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET : reason;
+        }
+    }
+
+    record Accepted(DungeonPatch patch, DungeonPatch inverse) implements DungeonCommandResult {
+        public Accepted {
+            patch = Objects.requireNonNull(patch, "patch");
+            inverse = Objects.requireNonNull(inverse, "inverse");
+            if (!patch.mapId().equals(inverse.mapId())
+                    || inverse.expectedRevision() != patch.committedRevision()) {
+                throw new IllegalArgumentException("inverse patch must follow the accepted forward patch");
+            }
+            if (!inverse.equals(patch.inverse())) {
+                throw new IllegalArgumentException("accepted command must carry the exact inverse patch");
+            }
+        }
+
+        public static Accepted from(DungeonPatch patch) {
+            DungeonPatch safePatch = Objects.requireNonNull(patch, "patch");
+            return new Accepted(safePatch, safePatch.inverse());
+        }
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatch.java
+++ b/features/dungeon/application/authored/command/DungeonPatch.java
@@ -1,0 +1,134 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Revision-checked stable-entity delta for one authored Dungeon map. */
+public record DungeonPatch(
+        DungeonMapIdentity mapId,
+        long expectedRevision,
+        List<DungeonPatchChange> changes,
+        Set<DungeonChunkKey> touchedChunks,
+        DungeonPatchResultFacts resultFacts,
+        long encodedBytes
+) {
+
+    public DungeonPatch {
+        mapId = Objects.requireNonNull(mapId, "mapId");
+        expectedRevision = Math.max(0L, expectedRevision);
+        changes = changes == null ? List.of() : List.copyOf(changes);
+        if (changes.isEmpty() || changes.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("a Dungeon patch requires at least one change");
+        }
+        for (DungeonPatchChange change : changes) {
+            if (!mapId.equals(change.mapId())) {
+                throw new IllegalArgumentException("every patch change must belong to the patch map");
+            }
+        }
+        Set<DungeonChunkKey> derivedChunks = derivedChunks(changes);
+        touchedChunks = touchedChunks == null ? derivedChunks : Set.copyOf(touchedChunks);
+        if (!touchedChunks.equals(derivedChunks)) {
+            throw new IllegalArgumentException("touched chunks must match the encoded changes");
+        }
+        DungeonPatchResultFacts derivedFacts = derivedFacts(changes);
+        resultFacts = resultFacts == null ? derivedFacts : resultFacts;
+        if (!resultFacts.equals(derivedFacts)) {
+            throw new IllegalArgumentException("result facts must match the encoded changes");
+        }
+        long derivedBytes = derivedBytes(changes);
+        encodedBytes = encodedBytes <= 0L ? derivedBytes : encodedBytes;
+        if (encodedBytes != derivedBytes) {
+            throw new IllegalArgumentException("encoded byte weight must match the encoded changes");
+        }
+    }
+
+    public static DungeonPatch of(
+            DungeonMapIdentity mapId,
+            long expectedRevision,
+            List<DungeonPatchChange> changes
+    ) {
+        List<DungeonPatchChange> safeChanges = changes == null ? List.of() : List.copyOf(changes);
+        return new DungeonPatch(
+                mapId,
+                expectedRevision,
+                safeChanges,
+                derivedChunks(safeChanges),
+                derivedFacts(safeChanges),
+                derivedBytes(safeChanges));
+    }
+
+    public long committedRevision() {
+        return expectedRevision + 1L;
+    }
+
+    public DungeonPatch inverse() {
+        return DungeonPatch.of(
+                mapId,
+                committedRevision(),
+                changes.reversed().stream().map(DungeonPatchChange::inverse).toList());
+    }
+
+    public DungeonPatch rebased(long nextExpectedRevision) {
+        return DungeonPatch.of(mapId, nextExpectedRevision, changes);
+    }
+
+    public DungeonMap applyTo(DungeonMap current) {
+        DungeonMap safeCurrent = Objects.requireNonNull(current, "current");
+        if (!mapId.equals(safeCurrent.metadata().mapId()) || safeCurrent.revision() != expectedRevision) {
+            throw new IllegalArgumentException("patch map and expected revision must match current authored truth");
+        }
+        FeatureMarkerCatalog featureMarkers = safeCurrent.featureMarkers();
+        for (DungeonPatchChange change : changes) {
+            featureMarkers = switch (change) {
+                case FeatureMarkerChange featureMarkerChange -> featureMarkerChange.applyTo(featureMarkers);
+            };
+        }
+        DungeonMap changed = safeCurrent.withFeatureMarkers(featureMarkers);
+        if (changed.equals(safeCurrent)) {
+            throw new IllegalStateException("accepted patch must change authored truth");
+        }
+        return DungeonMapAuthoring.committedContent(changed, committedRevision());
+    }
+
+    @Override
+    public List<DungeonPatchChange> changes() {
+        return List.copyOf(changes);
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        return Set.copyOf(touchedChunks);
+    }
+
+    private static Set<DungeonChunkKey> derivedChunks(List<DungeonPatchChange> changes) {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        for (DungeonPatchChange change : changes) {
+            if (change != null) {
+                result.addAll(change.touchedChunks());
+            }
+        }
+        return Set.copyOf(result);
+    }
+
+    private static DungeonPatchResultFacts derivedFacts(List<DungeonPatchChange> changes) {
+        return new DungeonPatchResultFacts(changes.stream()
+                .filter(Objects::nonNull)
+                .map(DungeonPatchChange::topologyRef)
+                .distinct()
+                .toList());
+    }
+
+    private static long derivedBytes(List<DungeonPatchChange> changes) {
+        return Math.max(1L, changes.stream()
+                .filter(Objects::nonNull)
+                .mapToLong(DungeonPatchChange::encodedBytes)
+                .sum());
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatchChange.java
+++ b/features/dungeon/application/authored/command/DungeonPatchChange.java
@@ -1,0 +1,21 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.Set;
+
+/** One stable-identity authored entity delta carried by a Dungeon patch. */
+public sealed interface DungeonPatchChange permits FeatureMarkerChange {
+
+    DungeonMapIdentity mapId();
+
+    DungeonTopologyRef topologyRef();
+
+    Set<DungeonChunkKey> touchedChunks();
+
+    /** Deterministic upper bound for the encoded change payload. */
+    long encodedBytes();
+
+    DungeonPatchChange inverse();
+}

--- a/features/dungeon/application/authored/command/DungeonPatchResultFacts.java
+++ b/features/dungeon/application/authored/command/DungeonPatchResultFacts.java
@@ -1,0 +1,19 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import java.util.List;
+
+/** Stable authored facts needed by post-commit publication. */
+public record DungeonPatchResultFacts(List<DungeonTopologyRef> affectedTopologyRefs) {
+
+    public DungeonPatchResultFacts {
+        affectedTopologyRefs = affectedTopologyRefs == null
+                ? List.of()
+                : List.copyOf(affectedTopologyRefs);
+    }
+
+    @Override
+    public List<DungeonTopologyRef> affectedTopologyRefs() {
+        return List.copyOf(affectedTopologyRefs);
+    }
+}

--- a/features/dungeon/application/authored/command/FeatureMarkerChange.java
+++ b/features/dungeon/application/authored/command/FeatureMarkerChange.java
@@ -1,0 +1,88 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Exact before/after delta for one authored feature marker. */
+public record FeatureMarkerChange(FeatureMarker before, FeatureMarker after) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 96L;
+
+    public FeatureMarkerChange {
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a feature marker change requires before or after state");
+        }
+        if (before != null && after != null) {
+            if (before.markerId() != after.markerId()) {
+                throw new IllegalArgumentException("feature marker identity must remain stable");
+            }
+            if (!Objects.equals(before.mapId(), after.mapId())) {
+                throw new IllegalArgumentException("feature marker map identity must remain stable");
+            }
+        }
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return state().mapId();
+    }
+
+    @Override
+    public DungeonTopologyRef topologyRef() {
+        return state().topologyRef();
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addChunk(result, before);
+        addChunk(result, after);
+        return Set.copyOf(result);
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES + encodedTextBytes(before) + encodedTextBytes(after);
+    }
+
+    @Override
+    public FeatureMarkerChange inverse() {
+        return new FeatureMarkerChange(after, before);
+    }
+
+    public FeatureMarkerCatalog applyTo(FeatureMarkerCatalog catalog) {
+        FeatureMarkerCatalog safeCatalog = Objects.requireNonNull(catalog, "catalog");
+        return safeCatalog.withExactChange(before, after);
+    }
+
+    private FeatureMarker state() {
+        return after == null ? before : after;
+    }
+
+    private static void addChunk(Set<DungeonChunkKey> result, FeatureMarker marker) {
+        if (marker == null) {
+            return;
+        }
+        Cell anchor = marker.anchor();
+        result.add(new DungeonChunkKey(
+                marker.mapId().value(),
+                anchor.level(),
+                Math.floorDiv(anchor.q(), DungeonChunkKey.CHUNK_SIZE),
+                Math.floorDiv(anchor.r(), DungeonChunkKey.CHUNK_SIZE)));
+    }
+
+    private static long encodedTextBytes(FeatureMarker marker) {
+        if (marker == null) {
+            return 1L;
+        }
+        return marker.label().getBytes(StandardCharsets.UTF_8).length
+                + marker.description().getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/features/dungeon/application/authored/command/FeatureMarkerSemanticsCommand.java
+++ b/features/dungeon/application/authored/command/FeatureMarkerSemanticsCommand.java
@@ -1,0 +1,37 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import java.util.List;
+
+/** Plans one exact feature-marker semantic patch from current authored truth. */
+public final class FeatureMarkerSemanticsCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long markerId,
+            String label,
+            String description
+    ) {
+        if (current == null || markerId <= 0L || label == null || label.isBlank()) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        FeatureMarker before = current.featureMarkers().marker(markerId);
+        if (before == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        FeatureMarker after = before.withSemantics(label, description);
+        if (after.equals(before)) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        DungeonPatch patch = DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new FeatureMarkerChange(before, after)));
+        return DungeonCommandResult.Accepted.from(patch);
+    }
+}

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -299,10 +299,6 @@ public record DungeonMap(
         return withFeatureMarkers(featureMarkers.withoutMarker(markerId));
     }
 
-    public DungeonMap updateFeatureMarkerSemantics(long markerId, String label, String description) {
-        return withFeatureMarkers(featureMarkers.withSemantics(markerId, label, description));
-    }
-
     public boolean canDeleteStair(long stairId) {
         return stairId > 0L && stairs.canDeleteUnboundStair(stairId);
     }

--- a/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
+++ b/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
@@ -2,6 +2,8 @@ package features.dungeon.domain.core.structure.feature;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.topology.DungeonMapTopology.DungeonTopologyBinding;
@@ -50,15 +52,39 @@ public record FeatureMarkerCatalog(
         return false;
     }
 
-    public FeatureMarkerCatalog withSemantics(long markerId, String label, String description) {
-        if (!canDelete(markerId)) {
-            return this;
+    public @Nullable FeatureMarker marker(long markerId) {
+        for (FeatureMarker marker : markers) {
+            if (marker.markerId() == markerId) {
+                return marker;
+            }
+        }
+        return null;
+    }
+
+    public FeatureMarkerCatalog withExactChange(
+            @Nullable FeatureMarker before,
+            @Nullable FeatureMarker after
+    ) {
+        FeatureMarker identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("feature marker change requires identity");
+        }
+        FeatureMarker current = marker(identity.markerId());
+        if (!Objects.equals(current, before)) {
+            throw new IllegalStateException("feature marker patch does not match current authored truth");
         }
         List<FeatureMarker> nextMarkers = new ArrayList<>();
         for (FeatureMarker marker : markers) {
-            nextMarkers.add(marker.markerId() == markerId
-                    ? marker.withSemantics(label, description)
-                    : marker);
+            if (marker.markerId() == identity.markerId()) {
+                if (after != null) {
+                    nextMarkers.add(after);
+                }
+            } else {
+                nextMarkers.add(marker);
+            }
+        }
+        if (before == null && after != null) {
+            nextMarkers.add(after);
         }
         return new FeatureMarkerCatalog(nextMarkers);
     }

--- a/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
@@ -1,0 +1,86 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import features.dungeon.domain.core.structure.feature.FeatureMarkerKind;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DungeonPatchVocabularyTest {
+
+    @Test
+    void featureMarkerCommandProducesExactApplicableAndInvertiblePatch() {
+        DungeonMap current = mapWithMarker();
+        FeatureMarker before = current.featureMarkers().marker(7L);
+        FeatureMarkerSemanticsCommand command = new FeatureMarkerSemanticsCommand();
+
+        DungeonCommandResult.Accepted accepted = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                command.plan(current, 7L, "Neuer Name", "Neue Beschreibung"));
+
+        DungeonPatch patch = accepted.patch();
+        assertEquals(current.metadata().mapId(), patch.mapId());
+        assertEquals(current.revision(), patch.expectedRevision());
+        assertEquals(current.revision() + 1L, patch.committedRevision());
+        assertEquals(1, patch.changes().size());
+        assertEquals(Set.of(new DungeonChunkKey(91L, -2, -1, 1)), patch.touchedChunks());
+        assertEquals(before.topologyRef(), patch.resultFacts().affectedTopologyRefs().getFirst());
+        long changedTextBytes = "Neuer NameNeue Beschreibung"
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        assertTrue(patch.encodedBytes() >= changedTextBytes);
+        assertThrows(IllegalArgumentException.class, () -> DungeonPatch.of(
+                new DungeonMapIdentity(92L),
+                current.revision(),
+                patch.changes()));
+
+        DungeonMap changed = patch.applyTo(current);
+        assertEquals("Neuer Name", changed.featureMarkers().marker(7L).label());
+        assertEquals("Neue Beschreibung", changed.featureMarkers().marker(7L).description());
+        assertEquals(current.revision() + 1L, changed.revision());
+
+        DungeonMap restored = accepted.inverse().applyTo(changed);
+        assertEquals(before, restored.featureMarkers().marker(7L));
+        assertEquals(current.revision() + 2L, restored.revision());
+        assertThrows(IllegalArgumentException.class, () -> patch.applyTo(changed));
+    }
+
+    @Test
+    void invalidAndNoEffectCommandsRejectWithoutChangingAuthoredTruth() {
+        DungeonMap current = mapWithMarker();
+        FeatureMarker marker = current.featureMarkers().marker(7L);
+        FeatureMarkerSemanticsCommand command = new FeatureMarkerSemanticsCommand();
+
+        DungeonCommandResult.Rejected missing = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                command.plan(current, 99L, "Fehlt", ""));
+        DungeonCommandResult.Rejected noEffect = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                command.plan(current, 7L, marker.label(), marker.description()));
+
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, missing.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, noEffect.reason());
+        assertEquals(marker, current.featureMarkers().marker(7L));
+        assertEquals(2L, current.revision());
+    }
+
+    private static DungeonMap mapWithMarker() {
+        DungeonMap base = DungeonMapAuthoring.empty(new DungeonMapIdentity(91L), "Patch Vocabulary");
+        return base.withFeatureMarkers(base.featureMarkers().withCreated(
+                7L,
+                base.metadata().mapId(),
+                FeatureMarkerKind.POI,
+                new Cell(-1, 64, -2),
+                "Alter Name",
+                "Alte Beschreibung"));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce typed rejected/accepted authored command results with forward and exact inverse Dungeon patches
- encode stable-entity marker changes, expected revision, touched chunks, result facts, and deterministic byte-weight bounds
- move feature-marker semantic edits to the patch planning and application path
- delete their former direct aggregate mutation route and advance the roadmap to M3.2

## Verification
- ./gradlew test --tests features.dungeon.application.authored.command.DungeonPatchVocabularyTest --console=plain
- ./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest --console=plain
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain