### PR TITLE
Migrate feature marker commands to exact patches

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,19 +97,21 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 are complete on `main` through PR #499.
-- This slice: M3.1 introduces `DungeonCommandResult`, revision-checked
+- Current foundation: M0 through M2 and M3.1 are complete on `main` through
+  PR #500. M3.1 established `DungeonCommandResult`, revision-checked
   `DungeonPatch`, stable-entity changes, touched chunks, result facts, exact
   encoded-weight bounds, and generated inverse patches.
-- Feature-marker semantic edits are the first real production command moved to
-  that vocabulary. Their former direct aggregate-mutation route is deleted;
-  deterministic proof covers forward and inverse application, stale revision,
-  negative chunk identity, result facts, byte weight, and typed rejection.
+- This slice: M3.2 moves feature-marker create, semantic update, and delete to
+  exact patches and one shared patch executor. The former direct aggregate and
+  catalog create/delete mutation routes are deleted.
+- Deterministic command proof covers create, update, delete, exact forward and
+  inverse application, collision and missing-target rejection, stale revision,
+  negative chunk identity, result facts, and encoded byte weight. The Dungeon
+  Editor behavior suite remains the production-route proof.
 - `DungeonChangeSet` persistence and full-map session history remain temporary
   M3/M4 boundaries; no second persistence contract is introduced in this slice.
-- Next step after this slice merges: M3.2 moves the remaining ordinary
-  single-map authored commands to exact patches and removes unchanged-map
-  inference from their commit results.
+- Next step after this slice merges: M3.3 moves room and cluster semantic
+  commands to exact stable-entity patches and the shared patch executor.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -23,6 +23,8 @@ import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.authored.port.DungeonChangeSet;
 import features.dungeon.application.authored.command.DungeonCommandResult;
+import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
+import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
@@ -105,6 +107,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final MutationPipeline mutationPipeline = new MutationPipeline();
     private final FeatureMarkerSemanticsCommand featureMarkerSemanticsCommand =
             new FeatureMarkerSemanticsCommand();
+    private final CreateFeatureMarkerCommand createFeatureMarkerCommand =
+            new CreateFeatureMarkerCommand();
+    private final DeleteFeatureMarkerCommand deleteFeatureMarkerCommand =
+            new DeleteFeatureMarkerCommand();
     private final PublicationOperations publicationOperations = new PublicationOperations();
     private final PreviewOperations previewOperations = new PreviewOperations();
     private final DetailSaveOperations detailSaveOperations = new DetailSaveOperations();
@@ -573,15 +579,12 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             return executeOperation(mapId, operation, DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
         }
 
-        private OperationResultData executeFeatureMarkerSemantics(
+        private OperationResultData executePatchCommand(
                 DungeonMapIdentity mapId,
-                long markerId,
-                String label,
-                String description
+                AuthoredPatchCommand command
         ) {
             DungeonMap current = loadMap(mapId);
-            DungeonCommandResult commandResult = featureMarkerSemanticsCommand.plan(
-                    current, markerId, label, description);
+            DungeonCommandResult commandResult = command.plan(current);
             if (commandResult instanceof DungeonCommandResult.Rejected rejected) {
                 return new OperationResultData(
                         snapshotData(current, derive(current)),
@@ -789,17 +792,17 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             Objects.requireNonNull(anchor, "anchor");
             DungeonMap currentMap = loadMap(domainMapId(mapId));
             long markerId = currentMap.nextFeatureMarkerId();
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.withFeatureMarkers(current.featureMarkers().withCreated(
+                    current -> createFeatureMarkerCommand.plan(
+                            current,
                             markerId,
-                            current.metadata().mapId(),
                             kind,
                             anchor,
                             DEFAULT_LABEL,
-                            DEFAULT_DESCRIPTION)));
+                            DEFAULT_DESCRIPTION));
             publicationOperations.publishMutation(result, session.dungeonState());
-            return markerId;
+            return result.changed() ? markerId : 0L;
         }
 
         private boolean canCreateFeatureMarker(MapId mapId, FeatureMarkerKind kind, Cell anchor) {
@@ -810,15 +813,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || markerId <= 0L) {
                 return false;
             }
-            DungeonMapIdentity mapIdentity = domainMapId(mapId);
-            DungeonMap currentMap = loadMap(mapIdentity);
-            if (!currentMap.canDeleteFeatureMarker(markerId)) {
-                return false;
-            }
-            OperationResultData result =
-                    mutationPipeline.executeOperation(mapIdentity, current -> current.deleteFeatureMarker(markerId));
+            OperationResultData result = mutationPipeline.executePatchCommand(
+                    domainMapId(mapId),
+                    current -> deleteFeatureMarkerCommand.plan(current, markerId));
             publicationOperations.publishMutation(result, session.dungeonState());
-            return true;
+            return result.changed();
         }
     }
 
@@ -1390,8 +1389,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || markerId <= 0L || label == null || label.isBlank()) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeFeatureMarkerSemantics(
-                    domainMapId(mapId), markerId, label, description);
+            OperationResultData result = mutationPipeline.executePatchCommand(
+                    domainMapId(mapId),
+                    current -> featureMarkerSemanticsCommand.plan(
+                            current, markerId, label, description));
             publicationOperations.publishMutation(result, state);
         }
 
@@ -1802,6 +1803,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     @FunctionalInterface
     private interface AuthoredMapMutation {
         DungeonMap apply(DungeonMap current);
+    }
+
+    @FunctionalInterface
+    private interface AuthoredPatchCommand {
+        DungeonCommandResult plan(DungeonMap current);
     }
 
     private record SnapshotPublication(

--- a/features/dungeon/application/authored/command/CreateFeatureMarkerCommand.java
+++ b/features/dungeon/application/authored/command/CreateFeatureMarkerCommand.java
@@ -1,0 +1,38 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import features.dungeon.domain.core.structure.feature.FeatureMarkerKind;
+import java.util.List;
+
+/** Plans creation of one stable feature marker. */
+public final class CreateFeatureMarkerCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long markerId,
+            FeatureMarkerKind kind,
+            Cell anchor,
+            String label,
+            String description
+    ) {
+        if (current == null || markerId <= 0L || kind == null || anchor == null
+                || current.featureMarkers().marker(markerId) != null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        FeatureMarker marker = new FeatureMarker(
+                markerId,
+                current.metadata().mapId(),
+                kind,
+                anchor,
+                label,
+                description);
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new FeatureMarkerChange(null, marker))));
+    }
+}

--- a/features/dungeon/application/authored/command/DeleteFeatureMarkerCommand.java
+++ b/features/dungeon/application/authored/command/DeleteFeatureMarkerCommand.java
@@ -1,0 +1,26 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import java.util.List;
+
+/** Plans deletion of one existing stable feature marker. */
+public final class DeleteFeatureMarkerCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long markerId) {
+        if (current == null || markerId <= 0L) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        FeatureMarker marker = current.featureMarkers().marker(markerId);
+        if (marker == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new FeatureMarkerChange(marker, null))));
+    }
+}

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -288,17 +288,6 @@ public record DungeonMap(
         return featureMarkers.nextMarkerId();
     }
 
-    public boolean canDeleteFeatureMarker(long markerId) {
-        return featureMarkers.canDelete(markerId);
-    }
-
-    public DungeonMap deleteFeatureMarker(long markerId) {
-        if (!canDeleteFeatureMarker(markerId)) {
-            return this;
-        }
-        return withFeatureMarkers(featureMarkers.withoutMarker(markerId));
-    }
-
     public boolean canDeleteStair(long stairId) {
         return stairId > 0L && stairs.canDeleteUnboundStair(stairId);
     }

--- a/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
+++ b/features/dungeon/domain/core/structure/feature/FeatureMarkerCatalog.java
@@ -4,52 +4,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
-import features.dungeon.domain.core.geometry.Cell;
-import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.topology.DungeonMapTopology.DungeonTopologyBinding;
 
 public record FeatureMarkerCatalog(
         List<FeatureMarker> markers
 ) {
-    private static final long NO_MARKER_ID = 0L;
-
     public FeatureMarkerCatalog {
         markers = markers == null ? List.of() : List.copyOf(markers);
     }
 
     public static FeatureMarkerCatalog empty() {
         return new FeatureMarkerCatalog(List.of());
-    }
-
-    public FeatureMarkerCatalog withCreated(
-            long markerId,
-            DungeonMapIdentity mapId,
-            FeatureMarkerKind kind,
-            Cell anchor,
-            String label,
-            String description
-    ) {
-        List<FeatureMarker> nextMarkers = new ArrayList<>(markers);
-        nextMarkers.add(new FeatureMarker(
-                markerId,
-                mapId,
-                kind,
-                anchor,
-                label,
-                description));
-        return new FeatureMarkerCatalog(nextMarkers);
-    }
-
-    public boolean canDelete(long markerId) {
-        if (markerId <= NO_MARKER_ID) {
-            return false;
-        }
-        for (FeatureMarker marker : markers) {
-            if (marker.markerId() == markerId) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public @Nullable FeatureMarker marker(long markerId) {
@@ -85,19 +50,6 @@ public record FeatureMarkerCatalog(
         }
         if (before == null && after != null) {
             nextMarkers.add(after);
-        }
-        return new FeatureMarkerCatalog(nextMarkers);
-    }
-
-    public FeatureMarkerCatalog withoutMarker(long markerId) {
-        if (!canDelete(markerId)) {
-            return this;
-        }
-        List<FeatureMarker> nextMarkers = new ArrayList<>();
-        for (FeatureMarker marker : markers) {
-            if (marker.markerId() != markerId) {
-                nextMarkers.add(marker);
-            }
         }
         return new FeatureMarkerCatalog(nextMarkers);
     }

--- a/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
@@ -2,6 +2,7 @@ package features.dungeon.application.authored.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -73,14 +74,76 @@ final class DungeonPatchVocabularyTest {
         assertEquals(2L, current.revision());
     }
 
+    @Test
+    void featureMarkerCreateAndDeleteUseExactForwardAndInversePatches() {
+        DungeonMap empty = DungeonMapAuthoring.empty(new DungeonMapIdentity(91L), "Patch Vocabulary");
+        Cell anchor = new Cell(-1, 64, -2);
+        CreateFeatureMarkerCommand createCommand = new CreateFeatureMarkerCommand();
+
+        DungeonCommandResult.Accepted createdResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                createCommand.plan(empty, 7L, FeatureMarkerKind.POI, anchor, "Fundort", "Hinweis"));
+        DungeonPatch createPatch = createdResult.patch();
+        assertEquals(Set.of(new DungeonChunkKey(91L, -2, -1, 1)), createPatch.touchedChunks());
+
+        DungeonMap created = createPatch.applyTo(empty);
+        FeatureMarker createdMarker = created.featureMarkers().marker(7L);
+        assertEquals(new FeatureMarker(
+                7L,
+                empty.metadata().mapId(),
+                FeatureMarkerKind.POI,
+                anchor,
+                "Fundort",
+                "Hinweis"), createdMarker);
+        DungeonMap createUndone = createdResult.inverse().applyTo(created);
+        assertNull(createUndone.featureMarkers().marker(7L));
+        assertEquals(empty.revision() + 2L, createUndone.revision());
+
+        DeleteFeatureMarkerCommand deleteCommand = new DeleteFeatureMarkerCommand();
+        DungeonCommandResult.Accepted deletedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                deleteCommand.plan(created, 7L));
+        DungeonMap deleted = deletedResult.patch().applyTo(created);
+        assertNull(deleted.featureMarkers().marker(7L));
+        DungeonMap deleteUndone = deletedResult.inverse().applyTo(deleted);
+        assertEquals(createdMarker, deleteUndone.featureMarkers().marker(7L));
+        assertEquals(created.revision() + 2L, deleteUndone.revision());
+    }
+
+    @Test
+    void featureMarkerCreateCollisionAndMissingDeleteRejectWithoutMutation() {
+        DungeonMap current = mapWithMarker();
+        CreateFeatureMarkerCommand createCommand = new CreateFeatureMarkerCommand();
+        DeleteFeatureMarkerCommand deleteCommand = new DeleteFeatureMarkerCommand();
+
+        DungeonCommandResult.Rejected collision = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                createCommand.plan(
+                        current,
+                        7L,
+                        FeatureMarkerKind.OBJECT,
+                        new Cell(0, 0, 0),
+                        "Kollision",
+                        ""));
+        DungeonCommandResult.Rejected missing = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                deleteCommand.plan(current, 99L));
+
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, collision.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, missing.reason());
+        assertEquals(1, current.featureMarkers().markers().size());
+        assertEquals(2L, current.revision());
+    }
+
     private static DungeonMap mapWithMarker() {
         DungeonMap base = DungeonMapAuthoring.empty(new DungeonMapIdentity(91L), "Patch Vocabulary");
-        return base.withFeatureMarkers(base.featureMarkers().withCreated(
+        FeatureMarker marker = new FeatureMarker(
                 7L,
                 base.metadata().mapId(),
                 FeatureMarkerKind.POI,
                 new Cell(-1, 64, -2),
                 "Alter Name",
-                "Alte Beschreibung"));
+                "Alte Beschreibung");
+        return base.withFeatureMarkers(base.featureMarkers().withExactChange(null, marker));
     }
 }


### PR DESCRIPTION
## Summary
- route feature-marker create, semantic update, and delete through exact Dungeon patches
- share one patch executor for persistence and publication
- delete replaced aggregate and catalog mutation paths
- record M3.2 completion scope and M3.3 next action in the temporary roadmap

## Proof
- ./gradlew test --tests features.dungeon.application.authored.command.DungeonPatchVocabularyTest --console=plain
- ./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest --console=plain
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain

All commands completed with BUILD SUCCESSFUL.