### PR TITLE
Migrate room and cluster semantics to exact patches

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,21 +97,24 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 are complete on `main` through
-  PR #500. M3.1 established `DungeonCommandResult`, revision-checked
-  `DungeonPatch`, stable-entity changes, touched chunks, result facts, exact
-  encoded-weight bounds, and generated inverse patches.
-- This slice: M3.2 moves feature-marker create, semantic update, and delete to
-  exact patches and one shared patch executor. The former direct aggregate and
-  catalog create/delete mutation routes are deleted.
-- Deterministic command proof covers create, update, delete, exact forward and
-  inverse application, collision and missing-target rejection, stale revision,
-  negative chunk identity, result facts, and encoded byte weight. The Dungeon
-  Editor behavior suite remains the production-route proof.
+- Current foundation: M0 through M2, M3.1, and M3.2 are complete on `main`
+  through PR #501. Feature-marker create, semantic update, and delete use exact
+  patches and one shared patch executor; their former direct mutation routes
+  are deleted.
+- This slice: M3.3 moves room name, room narration, and room-cluster name to
+  exact stable-entity patches and the shared executor. Direct aggregate save
+  routes for those semantics are deleted.
+- Patch result facts now identify a stable authored entity and carry its
+  topology ref only where that entity owns one. This preserves independent
+  cluster identity without fabricating a room topology ref.
+- Deterministic proof covers exact room and cluster identity, chunk membership,
+  forward and inverse application, monotonic revision, encoded byte weight,
+  missing-target and no-effect rejection, and the Dungeon Editor production
+  route.
 - `DungeonChangeSet` persistence and full-map session history remain temporary
   M3/M4 boundaries; no second persistence contract is introduced in this slice.
-- Next step after this slice merges: M3.3 moves room and cluster semantic
-  commands to exact stable-entity patches and the shared patch executor.
+- Next step after this slice merges: M3.4 moves the stair create, geometry
+  update, and delete command family to exact patches.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -26,6 +26,9 @@ import features.dungeon.application.authored.command.DungeonCommandResult;
 import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
 import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
+import features.dungeon.application.authored.command.RoomClusterNameCommand;
+import features.dungeon.application.authored.command.RoomNameCommand;
+import features.dungeon.application.authored.command.RoomNarrationCommand;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -111,6 +114,9 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             new CreateFeatureMarkerCommand();
     private final DeleteFeatureMarkerCommand deleteFeatureMarkerCommand =
             new DeleteFeatureMarkerCommand();
+    private final RoomNarrationCommand roomNarrationCommand = new RoomNarrationCommand();
+    private final RoomNameCommand roomNameCommand = new RoomNameCommand();
+    private final RoomClusterNameCommand roomClusterNameCommand = new RoomClusterNameCommand();
     private final PublicationOperations publicationOperations = new PublicationOperations();
     private final PreviewOperations previewOperations = new PreviewOperations();
     private final DetailSaveOperations detailSaveOperations = new DetailSaveOperations();
@@ -1334,9 +1340,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (roomNarration == null || !DungeonEditorWorkspaceValues.hasId(roomNarration.roomId())) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.saveRoomNarration(
+                    current -> roomNarrationCommand.plan(
+                            current,
                             roomNarration.roomId(),
                             DungeonEditorAuthoredOperationHelper.roomNarration(roomNarration)));
             publicationOperations.publishMutation(result, state);
@@ -1354,13 +1361,18 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             LabelTargetKind safeTargetType = targetType == null ? LabelTargetKind.EMPTY : targetType;
             String trimmedName = name.trim();
-            OperationResultData result = mutationPipeline.executeOperation(
-                    domainMapId(mapId),
-                    current -> switch (safeTargetType) {
-                        case CLUSTER -> current.saveClusterName(targetId, trimmedName);
-                        case ROOM -> current.saveRoomName(targetId, trimmedName);
-                        case EMPTY -> current;
-                    });
+            OperationResultData result = switch (safeTargetType) {
+                case CLUSTER -> mutationPipeline.executePatchCommand(
+                        domainMapId(mapId),
+                        current -> roomClusterNameCommand.plan(current, targetId, trimmedName));
+                case ROOM -> mutationPipeline.executePatchCommand(
+                        domainMapId(mapId),
+                        current -> roomNameCommand.plan(current, targetId, trimmedName));
+                case EMPTY -> null;
+            };
+            if (result == null) {
+                return;
+            }
             publicationOperations.publishMutation(result, state);
         }
 

--- a/features/dungeon/application/authored/command/DungeonPatch.java
+++ b/features/dungeon/application/authored/command/DungeonPatch.java
@@ -4,7 +4,6 @@ import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
-import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -84,13 +83,17 @@ public record DungeonPatch(
         if (!mapId.equals(safeCurrent.metadata().mapId()) || safeCurrent.revision() != expectedRevision) {
             throw new IllegalArgumentException("patch map and expected revision must match current authored truth");
         }
-        FeatureMarkerCatalog featureMarkers = safeCurrent.featureMarkers();
+        DungeonMap changed = safeCurrent;
         for (DungeonPatchChange change : changes) {
-            featureMarkers = switch (change) {
-                case FeatureMarkerChange featureMarkerChange -> featureMarkerChange.applyTo(featureMarkers);
+            changed = switch (change) {
+                case FeatureMarkerChange featureMarkerChange -> changed.withFeatureMarkers(
+                        featureMarkerChange.applyTo(changed.featureMarkers()));
+                case RoomRegionChange roomRegionChange -> changed.withExactRoomRegionChange(
+                        roomRegionChange.before(), roomRegionChange.after());
+                case RoomClusterChange roomClusterChange -> changed.withExactRoomClusterChange(
+                        roomClusterChange.before(), roomClusterChange.after());
             };
         }
-        DungeonMap changed = safeCurrent.withFeatureMarkers(featureMarkers);
         if (changed.equals(safeCurrent)) {
             throw new IllegalStateException("accepted patch must change authored truth");
         }
@@ -120,7 +123,7 @@ public record DungeonPatch(
     private static DungeonPatchResultFacts derivedFacts(List<DungeonPatchChange> changes) {
         return new DungeonPatchResultFacts(changes.stream()
                 .filter(Objects::nonNull)
-                .map(DungeonPatchChange::topologyRef)
+                .map(DungeonPatchChange::entityRef)
                 .distinct()
                 .toList());
     }

--- a/features/dungeon/application/authored/command/DungeonPatchChange.java
+++ b/features/dungeon/application/authored/command/DungeonPatchChange.java
@@ -1,16 +1,15 @@
 package features.dungeon.application.authored.command;
 
 import features.dungeon.api.DungeonChunkKey;
-import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import java.util.Set;
 
 /** One stable-identity authored entity delta carried by a Dungeon patch. */
-public sealed interface DungeonPatchChange permits FeatureMarkerChange {
+public sealed interface DungeonPatchChange permits FeatureMarkerChange, RoomRegionChange, RoomClusterChange {
 
     DungeonMapIdentity mapId();
 
-    DungeonTopologyRef topologyRef();
+    DungeonPatchEntityRef entityRef();
 
     Set<DungeonChunkKey> touchedChunks();
 

--- a/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
+++ b/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
@@ -1,0 +1,57 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.domain.core.graph.DungeonTopologyElementKind;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import org.jspecify.annotations.Nullable;
+
+/** Stable authored entity identity carried by patch result facts. */
+public record DungeonPatchEntityRef(
+        Kind kind,
+        long id,
+        @Nullable DungeonTopologyRef topologyRef
+) {
+
+    public DungeonPatchEntityRef {
+        if (kind == null || id <= 0L) {
+            throw new IllegalArgumentException("patch entity identity must be present");
+        }
+        DungeonTopologyElementKind expectedTopologyKind = switch (kind) {
+            case ROOM -> DungeonTopologyElementKind.ROOM;
+            case FEATURE_MARKER -> DungeonTopologyElementKind.FEATURE_MARKER;
+            case ROOM_CLUSTER -> null;
+        };
+        if (expectedTopologyKind == null && topologyRef != null) {
+            throw new IllegalArgumentException("room cluster identity must not invent a topology ref");
+        }
+        if (expectedTopologyKind != null
+                && (topologyRef == null
+                        || topologyRef.kind() != expectedTopologyKind
+                        || topologyRef.id() != id)) {
+            throw new IllegalArgumentException("topology ref must identify the same patch entity");
+        }
+    }
+
+    public static DungeonPatchEntityRef room(long roomId) {
+        return new DungeonPatchEntityRef(
+                Kind.ROOM,
+                roomId,
+                new DungeonTopologyRef(DungeonTopologyElementKind.ROOM, roomId));
+    }
+
+    public static DungeonPatchEntityRef roomCluster(long clusterId) {
+        return new DungeonPatchEntityRef(Kind.ROOM_CLUSTER, clusterId, null);
+    }
+
+    public static DungeonPatchEntityRef featureMarker(long markerId) {
+        return new DungeonPatchEntityRef(
+                Kind.FEATURE_MARKER,
+                markerId,
+                new DungeonTopologyRef(DungeonTopologyElementKind.FEATURE_MARKER, markerId));
+    }
+
+    public enum Kind {
+        ROOM,
+        ROOM_CLUSTER,
+        FEATURE_MARKER
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatchResultFacts.java
+++ b/features/dungeon/application/authored/command/DungeonPatchResultFacts.java
@@ -1,19 +1,18 @@
 package features.dungeon.application.authored.command;
 
-import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import java.util.List;
 
 /** Stable authored facts needed by post-commit publication. */
-public record DungeonPatchResultFacts(List<DungeonTopologyRef> affectedTopologyRefs) {
+public record DungeonPatchResultFacts(List<DungeonPatchEntityRef> affectedEntities) {
 
     public DungeonPatchResultFacts {
-        affectedTopologyRefs = affectedTopologyRefs == null
+        affectedEntities = affectedEntities == null
                 ? List.of()
-                : List.copyOf(affectedTopologyRefs);
+                : List.copyOf(affectedEntities);
     }
 
     @Override
-    public List<DungeonTopologyRef> affectedTopologyRefs() {
-        return List.copyOf(affectedTopologyRefs);
+    public List<DungeonPatchEntityRef> affectedEntities() {
+        return List.copyOf(affectedEntities);
     }
 }

--- a/features/dungeon/application/authored/command/FeatureMarkerChange.java
+++ b/features/dungeon/application/authored/command/FeatureMarkerChange.java
@@ -2,7 +2,6 @@ package features.dungeon.application.authored.command;
 
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.geometry.Cell;
-import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import features.dungeon.domain.core.structure.feature.FeatureMarker;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -35,8 +34,8 @@ public record FeatureMarkerChange(FeatureMarker before, FeatureMarker after) imp
     }
 
     @Override
-    public DungeonTopologyRef topologyRef() {
-        return state().topologyRef();
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.featureMarker(state().markerId());
     }
 
     @Override

--- a/features/dungeon/application/authored/command/RoomClusterChange.java
+++ b/features/dungeon/application/authored/command/RoomClusterChange.java
@@ -1,0 +1,56 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+/** Exact before/after delta for one stable authored room cluster. */
+public record RoomClusterChange(
+        RoomCluster before,
+        RoomCluster after,
+        Set<DungeonChunkKey> touchedChunks
+) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 128L;
+    private static final long BOUNDARY_ENCODING_BYTES = 48L;
+
+    public RoomClusterChange {
+        if (before == null || after == null || before.equals(after)) {
+            throw new IllegalArgumentException("a cluster semantic change requires distinct before and after state");
+        }
+        if (before.clusterId() != after.clusterId() || before.mapId() != after.mapId()) {
+            throw new IllegalArgumentException("room cluster identity must remain stable");
+        }
+        touchedChunks = touchedChunks == null ? Set.of() : Set.copyOf(touchedChunks);
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return new DungeonMapIdentity(after.mapId());
+    }
+
+    @Override
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.roomCluster(after.clusterId());
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES
+                + before.name().getBytes(StandardCharsets.UTF_8).length
+                + after.name().getBytes(StandardCharsets.UTF_8).length
+                + BOUNDARY_ENCODING_BYTES * (before.orderedAuthoredBoundaries().size()
+                        + after.orderedAuthoredBoundaries().size());
+    }
+
+    @Override
+    public RoomClusterChange inverse() {
+        return new RoomClusterChange(after, before, touchedChunks);
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        return Set.copyOf(touchedChunks);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomClusterNameCommand.java
+++ b/features/dungeon/application/authored/command/RoomClusterNameCommand.java
@@ -1,0 +1,64 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.DungeonClusterBoundary;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Plans one exact authored room-cluster-name patch. */
+public final class RoomClusterNameCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long clusterId, String name) {
+        if (current == null || clusterId <= 0L || name == null || name.isBlank()) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomCluster before = current.topology().roomCluster(clusterId);
+        if (before == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomCluster after = before.withName(name);
+        if (after.equals(before)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new RoomClusterChange(before, after, touchedChunks(current, before)))));
+    }
+
+    private static Set<DungeonChunkKey> touchedChunks(DungeonMap current, RoomCluster cluster) {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        for (RoomRegion room : current.rooms().roomsInCluster(cluster.clusterId())) {
+            for (Cell cell : room.floorCells()) {
+                addChunk(result, current, cell);
+            }
+        }
+        for (DungeonClusterBoundary boundary : cluster.orderedAuthoredBoundaries()) {
+            addChunk(result, current, boundary.absoluteCell(cluster.center()));
+        }
+        if (result.isEmpty()) {
+            addChunk(result, current, cluster.center());
+        }
+        return Set.copyOf(result);
+    }
+
+    private static void addChunk(Set<DungeonChunkKey> result, DungeonMap current, Cell cell) {
+        result.add(new DungeonChunkKey(
+                current.metadata().mapId().value(),
+                cell.level(),
+                Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomNameCommand.java
+++ b/features/dungeon/application/authored/command/RoomNameCommand.java
@@ -1,0 +1,34 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.List;
+
+/** Plans one exact authored room-name patch. */
+public final class RoomNameCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long roomId, String name) {
+        if (current == null || roomId <= 0L || name == null || name.isBlank()) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomRegion before = current.rooms().findRoom(roomId).orElse(null);
+        if (before == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomRegion after = before.withName(name);
+        if (after.equals(before)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new RoomRegionChange(before, after))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomNarrationCommand.java
+++ b/features/dungeon/application/authored/command/RoomNarrationCommand.java
@@ -1,0 +1,39 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.List;
+
+/** Plans one exact authored room-narration patch. */
+public final class RoomNarrationCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long roomId,
+            DungeonRoomNarration narration
+    ) {
+        if (current == null || roomId <= 0L || narration == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomRegion before = current.rooms().findRoom(roomId).orElse(null);
+        if (before == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        RoomRegion after = before.withNarration(narration);
+        if (after.equals(before)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new RoomRegionChange(before, after))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomRegionChange.java
+++ b/features/dungeon/application/authored/command/RoomRegionChange.java
@@ -1,0 +1,85 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.room.DungeonRoomExitDescription;
+import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Exact before/after delta for one stable authored room. */
+public record RoomRegionChange(RoomRegion before, RoomRegion after) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 128L;
+    private static final long CELL_ENCODING_BYTES = 16L;
+
+    public RoomRegionChange {
+        if (before == null || after == null || before.equals(after)) {
+            throw new IllegalArgumentException("a room semantic change requires distinct before and after state");
+        }
+        if (before.roomId() != after.roomId()
+                || before.mapId() != after.mapId()
+                || before.clusterId() != after.clusterId()) {
+            throw new IllegalArgumentException("room identity and cluster membership must remain stable");
+        }
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return new DungeonMapIdentity(after.mapId());
+    }
+
+    @Override
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.room(after.roomId());
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addChunks(result, before);
+        addChunks(result, after);
+        return Set.copyOf(result);
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES + encodedBytes(before) + encodedBytes(after);
+    }
+
+    @Override
+    public RoomRegionChange inverse() {
+        return new RoomRegionChange(after, before);
+    }
+
+    private static void addChunks(Set<DungeonChunkKey> result, RoomRegion room) {
+        for (Cell cell : room.floorCells()) {
+            result.add(new DungeonChunkKey(
+                    room.mapId(),
+                    cell.level(),
+                    Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                    Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+        }
+    }
+
+    private static long encodedBytes(RoomRegion room) {
+        return CELL_ENCODING_BYTES * room.floorCells().size()
+                + textBytes(room.name())
+                + narrationBytes(room.narration());
+    }
+
+    private static long narrationBytes(DungeonRoomNarration narration) {
+        long result = textBytes(narration.visualDescription());
+        for (DungeonRoomExitDescription exit : narration.exitDescriptions()) {
+            result += CELL_ENCODING_BYTES + textBytes(exit.description());
+        }
+        return result;
+    }
+
+    private static long textBytes(String value) {
+        return Objects.requireNonNullElse(value, "").getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -1,6 +1,5 @@
 package features.dungeon.domain.core.structure;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.geometry.Cell;
@@ -10,8 +9,9 @@ import features.dungeon.domain.core.structure.corridor.Corridor;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
 import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
-import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
 import features.dungeon.domain.core.structure.room.RoomCatalog;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import features.dungeon.domain.core.structure.room.RoomRegion;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
 import features.dungeon.domain.core.structure.stair.StairCollection;
 import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
@@ -34,8 +34,6 @@ public record DungeonMap(
         long revision
 ) {
     private static final long NO_TRANSITION_ID = 0L;
-    private static final long NO_ROOM_ID = 0L;
-    private static final long NO_CLUSTER_ID = 0L;
 
     public DungeonMap(
             DungeonMapMetadata metadata,
@@ -189,80 +187,6 @@ public record DungeonMap(
         return ROOM_AUTHORING.moveBoundaryStretch(this, clusterId, sourceEdges, deltaQ, deltaR, deltaLevel);
     }
 
-    public DungeonMap saveRoomNarration(long roomId, DungeonRoomNarration narration) {
-        if (roomId <= 0L || narration == null) {
-            return this;
-        }
-        var nextRooms = new ArrayList<>(rooms.rooms());
-        boolean changed = false;
-        for (int index = 0; index < nextRooms.size(); index++) {
-            var room = nextRooms.get(index);
-            if (room.roomId() == roomId) {
-                nextRooms.set(index, room.withNarration(narration));
-                changed = true;
-            }
-        }
-        return changed
-                ? new DungeonMap(
-                        metadata,
-                        topology,
-                        topologyIndex,
-                        new RoomCatalog(nextRooms),
-                        corridors,
-                        stairs,
-                        transitionCatalog,
-                        featureMarkers,
-                        revision + 1L)
-                : this;
-    }
-
-    public DungeonMap saveRoomName(long roomId, String name) {
-        if (roomId <= NO_ROOM_ID) {
-            return this;
-        }
-        var nextRooms = new ArrayList<>(rooms.rooms());
-        boolean changed = false;
-        for (int index = 0; index < nextRooms.size(); index++) {
-            var room = nextRooms.get(index);
-            if (room.roomId() == roomId) {
-                var renamed = room.withName(name);
-                nextRooms.set(index, renamed);
-                changed = changed || !renamed.equals(room);
-            }
-        }
-        return changed
-                ? new DungeonMap(
-                        metadata,
-                        topology,
-                        topologyIndex,
-                        new RoomCatalog(nextRooms),
-                        corridors,
-                        stairs,
-                        transitionCatalog,
-                        featureMarkers,
-                        revision + 1L)
-                : this;
-    }
-
-    public DungeonMap saveClusterName(long clusterId, String name) {
-        if (clusterId <= NO_CLUSTER_ID) {
-            return this;
-        }
-        SpatialTopology renamedTopology = topology.withRoomClusterName(clusterId, name);
-        return !renamedTopology.equals(topology)
-                ? new DungeonMap(
-                        metadata,
-                        renamedTopology,
-                        topologyIndex,
-                        rooms,
-                        corridors,
-                        stairs,
-                        transitionCatalog,
-                        featureMarkers,
-                        revision + 1L)
-                : this;
-    }
-
     public DungeonMap saveTransitionDescription(long transitionId, String description) {
         if (transitionId <= NO_TRANSITION_ID) {
             return this;
@@ -382,6 +306,40 @@ public record DungeonMap(
                 stairs,
                 transitionCatalog,
                 resolvedFeatureMarkers,
+                revision + 1L);
+    }
+
+    public DungeonMap withExactRoomRegionChange(
+            @Nullable RoomRegion before,
+            @Nullable RoomRegion after
+    ) {
+        RoomCatalog nextRooms = rooms.withExactChange(before, after);
+        return new DungeonMap(
+                metadata,
+                topology,
+                null,
+                nextRooms,
+                corridors,
+                stairs,
+                transitionCatalog,
+                featureMarkers,
+                revision + 1L);
+    }
+
+    public DungeonMap withExactRoomClusterChange(
+            @Nullable RoomCluster before,
+            @Nullable RoomCluster after
+    ) {
+        SpatialTopology nextTopology = topology.withExactRoomClusterChange(before, after);
+        return new DungeonMap(
+                metadata,
+                nextTopology,
+                null,
+                rooms,
+                corridors,
+                stairs,
+                transitionCatalog,
+                featureMarkers,
                 revision + 1L);
     }
 

--- a/features/dungeon/domain/core/structure/room/RoomCatalog.java
+++ b/features/dungeon/domain/core/structure/room/RoomCatalog.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Authored rooms loaded from the dungeon write model.
@@ -28,6 +30,34 @@ public record RoomCatalog(
             }
         }
         return Optional.empty();
+    }
+
+    public RoomCatalog withExactChange(
+            @Nullable RoomRegion before,
+            @Nullable RoomRegion after
+    ) {
+        RoomRegion identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("room change requires identity");
+        }
+        RoomRegion current = findRoom(identity.roomId()).orElse(null);
+        if (!Objects.equals(current, before)) {
+            throw new IllegalStateException("room patch does not match current authored truth");
+        }
+        List<RoomRegion> nextRooms = new ArrayList<>();
+        for (RoomRegion room : rooms) {
+            if (room.roomId() == identity.roomId()) {
+                if (after != null) {
+                    nextRooms.add(after);
+                }
+            } else {
+                nextRooms.add(room);
+            }
+        }
+        if (before == null && after != null) {
+            nextRooms.add(after);
+        }
+        return new RoomCatalog(nextRooms);
     }
 
     public List<RoomRegion> roomsInCluster(long clusterId) {

--- a/features/dungeon/domain/core/structure/topology/SpatialTopology.java
+++ b/features/dungeon/domain/core/structure/topology/SpatialTopology.java
@@ -1,6 +1,8 @@
 package features.dungeon.domain.core.structure.topology;
 
 import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.geometry.DungeonTopology;
 import features.dungeon.domain.core.structure.room.RoomCluster;
 
@@ -19,8 +21,6 @@ public record SpatialTopology(
         int roomAnchorR,
         List<RoomCluster> roomClusters
 ) {
-    private static final long NO_CLUSTER_ID = 0L;
-
     public SpatialTopology(
             DungeonTopology topology,
             int width,
@@ -52,22 +52,40 @@ public record SpatialTopology(
         return new SpatialTopology(topology, width, height, roomAnchorQ, roomAnchorR, clusters);
     }
 
-    public SpatialTopology withRoomClusterName(long clusterId, String name) {
-        if (clusterId <= NO_CLUSTER_ID) {
-            return this;
-        }
-        List<RoomCluster> nextClusters = new java.util.ArrayList<>();
-        boolean changed = false;
+    public @Nullable RoomCluster roomCluster(long clusterId) {
         for (RoomCluster cluster : roomClusters) {
             if (cluster.clusterId() == clusterId) {
-                RoomCluster renamed = cluster.withName(name);
-                nextClusters.add(renamed);
-                changed = changed || !renamed.equals(cluster);
+                return cluster;
+            }
+        }
+        return null;
+    }
+
+    public SpatialTopology withExactRoomClusterChange(
+            @Nullable RoomCluster before,
+            @Nullable RoomCluster after
+    ) {
+        RoomCluster identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("room cluster change requires identity");
+        }
+        if (!Objects.equals(roomCluster(identity.clusterId()), before)) {
+            throw new IllegalStateException("room cluster patch does not match current authored truth");
+        }
+        List<RoomCluster> nextClusters = new java.util.ArrayList<>();
+        for (RoomCluster cluster : roomClusters) {
+            if (cluster.clusterId() == identity.clusterId()) {
+                if (after != null) {
+                    nextClusters.add(after);
+                }
             } else {
                 nextClusters.add(cluster);
             }
         }
-        return changed ? withRoomClusters(nextClusters) : this;
+        if (before == null && after != null) {
+            nextClusters.add(after);
+        }
+        return withRoomClusters(nextClusters);
     }
 
     public boolean hasAuthoredRooms() {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonClusterInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonClusterInvariantScenarios.java
@@ -179,10 +179,6 @@ final class DungeonClusterInvariantScenarios {
         assertEquals("North Hall", defaultCluster.withName("  North Hall  ").name(),
                 "DGI-CLUSTER-005 custom cluster name trims");
 
-        DungeonMap map = twoByTwoMap();
-        long clusterId = firstClusterId(map);
-        DungeonMap renamed = map.saveClusterName(clusterId, "  Gallery Cluster  ");
-        assertEquals("Gallery Cluster", firstClusterName(renamed), "DGI-CLUSTER-005 aggregate saves cluster name");
     }
 
     private static DungeonMap twoByTwoMap() {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonRoomInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonRoomInvariantScenarios.java
@@ -10,7 +10,6 @@ import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.room.RoomRegion;
 import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
-import features.dungeon.domain.core.structure.room.RoomRegion;
 import features.dungeon.domain.core.structure.room.RoomClusterGeometry;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
 import features.dungeon.domain.core.structure.room.RoomClusterRoomPartition;
@@ -35,7 +34,7 @@ final class DungeonRoomInvariantScenarios {
     private static void assertRoomIdentityAndNarrationSurviveClusterEdits() {
         DungeonMap map = twoByTwoMap();
         RoomRegion original = firstRoom(map).withNarration(new DungeonRoomNarration("Quiet room", List.of()));
-        DungeonMap narrated = map.saveRoomNarration(original.roomId(), original.narration());
+        DungeonMap narrated = withNarration(map, original.roomId(), original.narration());
         DungeonMap moved = narrated.moveCluster(original.clusterId(), 1, 0, 0);
         RoomRegion movedRoom = firstRoom(moved);
         assertEquals(original.roomId(), movedRoom.roomId(), "DGI-ROOM-001 room id survives cluster move");
@@ -62,9 +61,10 @@ final class DungeonRoomInvariantScenarios {
         RoomRegion right = roomByAnchor(partitioned, new Cell(2, 1, 0));
         DungeonRoomNarration leftNarration = new DungeonRoomNarration("Left identity", List.of());
         DungeonRoomNarration rightNarration = new DungeonRoomNarration("Right identity", List.of());
-        DungeonMap narratedTwoRooms = partitioned
-                .saveRoomNarration(left.roomId(), leftNarration)
-                .saveRoomNarration(right.roomId(), rightNarration);
+        DungeonMap narratedTwoRooms = withNarration(
+                withNarration(partitioned, left.roomId(), leftNarration),
+                right.roomId(),
+                rightNarration);
         DungeonMap expanded = narratedTwoRooms.paintRoomRectangle(new Cell(1, 1, 0), new Cell(1, 2, 0));
         assertEquals(leftNarration, roomById(expanded, left.roomId()).narration(),
                 "DGI-ROOM-001 partition-preserving paint keeps left room narration");
@@ -121,10 +121,6 @@ final class DungeonRoomInvariantScenarios {
         RoomRegion defaultRoom = new RoomRegion(12L, 4L, 3L, "", Map.of(0, new Cell(1, 1, 0)), null);
         assertEquals("Raum 12", defaultRoom.name(), "DGI-ROOM-003 default room name");
         assertEquals("Library", defaultRoom.withName("  Library  ").name(), "DGI-ROOM-003 custom room name trims");
-        DungeonMap map = twoByTwoMap();
-        long roomId = firstRoom(map).roomId();
-        DungeonMap renamed = map.saveRoomName(roomId, "  Blue Room  ");
-        assertEquals("Blue Room", firstRoom(renamed).name(), "DGI-ROOM-003 aggregate saves room name");
     }
 
     private static void assertRoomLabelFloorAndAnchorFacts() {
@@ -143,6 +139,15 @@ final class DungeonRoomInvariantScenarios {
     private static DungeonMap twoByTwoMap() {
         return DungeonMapAuthoring.empty(new DungeonMapIdentity(10L), "Room Test")
                 .paintRoomRectangle(new Cell(1, 1, 0), new Cell(2, 2, 0));
+    }
+
+    private static DungeonMap withNarration(
+            DungeonMap map,
+            long roomId,
+            DungeonRoomNarration narration
+    ) {
+        RoomRegion before = map.rooms().findRoom(roomId).orElseThrow();
+        return map.withExactRoomRegionChange(before, before.withNarration(narration));
     }
 
     private static RoomRegion firstRoom(DungeonMap map) {

--- a/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonPatchVocabularyTest.java
@@ -35,7 +35,9 @@ final class DungeonPatchVocabularyTest {
         assertEquals(current.revision() + 1L, patch.committedRevision());
         assertEquals(1, patch.changes().size());
         assertEquals(Set.of(new DungeonChunkKey(91L, -2, -1, 1)), patch.touchedChunks());
-        assertEquals(before.topologyRef(), patch.resultFacts().affectedTopologyRefs().getFirst());
+        assertEquals(
+                DungeonPatchEntityRef.featureMarker(before.markerId()),
+                patch.resultFacts().affectedEntities().getFirst());
         long changedTextBytes = "Neuer NameNeue Beschreibung"
                 .getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
         assertTrue(patch.encodedBytes() >= changedTextBytes);

--- a/test/features/dungeon/application/authored/command/DungeonRoomClusterPatchCommandsTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonRoomClusterPatchCommandsTest.java
@@ -1,0 +1,126 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Direction;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.room.DungeonRoomExitDescription;
+import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DungeonRoomClusterPatchCommandsTest {
+
+    @Test
+    void roomNamePatchPreservesIdentityAndAppliesExactInverse() {
+        DungeonMap current = mapWithRoom();
+        RoomRegion before = current.rooms().rooms().getFirst();
+
+        DungeonCommandResult.Accepted accepted = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new RoomNameCommand().plan(current, before.roomId(), "  Blaue Kammer  "));
+
+        assertEquals(
+                DungeonPatchEntityRef.room(before.roomId()),
+                accepted.patch().resultFacts().affectedEntities().getFirst());
+        assertEquals(Set.of(new DungeonChunkKey(93L, 0, 0, 0)), accepted.patch().touchedChunks());
+        DungeonMap renamed = accepted.patch().applyTo(current);
+        RoomRegion after = renamed.rooms().findRoom(before.roomId()).orElseThrow();
+        assertEquals("Blaue Kammer", after.name());
+        assertEquals(before.clusterId(), after.clusterId());
+        assertEquals(before.floorCells(), after.floorCells());
+        assertEquals(current.revision() + 1L, renamed.revision());
+
+        DungeonMap restored = accepted.inverse().applyTo(renamed);
+        assertEquals(before, restored.rooms().findRoom(before.roomId()).orElseThrow());
+        assertEquals(current.revision() + 2L, restored.revision());
+        assertThrows(IllegalArgumentException.class, () -> accepted.patch().applyTo(renamed));
+    }
+
+    @Test
+    void roomNarrationPatchCarriesFullSemanticStateAndInverse() {
+        DungeonMap current = mapWithRoom();
+        RoomRegion before = current.rooms().rooms().getFirst();
+        DungeonRoomNarration narration = new DungeonRoomNarration(
+                "Kühle Luft",
+                List.of(new DungeonRoomExitDescription(
+                        before.primaryAnchor(),
+                        Direction.NORTH,
+                        "Schwere Tür")));
+
+        DungeonCommandResult.Accepted accepted = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new RoomNarrationCommand().plan(current, before.roomId(), narration));
+        assertTrue(accepted.patch().encodedBytes() >= "Kühle LuftSchwere Tür".getBytes(
+                java.nio.charset.StandardCharsets.UTF_8).length);
+
+        DungeonMap narrated = accepted.patch().applyTo(current);
+        assertEquals(narration, narrated.rooms().findRoom(before.roomId()).orElseThrow().narration());
+        DungeonMap restored = accepted.inverse().applyTo(narrated);
+        assertEquals(before, restored.rooms().findRoom(before.roomId()).orElseThrow());
+    }
+
+    @Test
+    void clusterNamePatchUsesClusterIdentityWithoutInventingTopologyRef() {
+        DungeonMap current = mapWithRoom();
+        RoomCluster before = current.topology().roomClusters().getFirst();
+
+        DungeonCommandResult.Accepted accepted = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new RoomClusterNameCommand().plan(current, before.clusterId(), "  Nordflügel  "));
+        DungeonPatchEntityRef entityRef = accepted.patch().resultFacts().affectedEntities().getFirst();
+        assertEquals(DungeonPatchEntityRef.Kind.ROOM_CLUSTER, entityRef.kind());
+        assertEquals(before.clusterId(), entityRef.id());
+        assertNull(entityRef.topologyRef());
+        assertThrows(IllegalArgumentException.class, () -> new DungeonPatchEntityRef(
+                DungeonPatchEntityRef.Kind.ROOM_CLUSTER,
+                before.clusterId(),
+                DungeonPatchEntityRef.room(before.clusterId()).topologyRef()));
+        assertEquals(Set.of(new DungeonChunkKey(93L, 0, 0, 0)), accepted.patch().touchedChunks());
+
+        DungeonMap renamed = accepted.patch().applyTo(current);
+        assertEquals("Nordflügel", renamed.topology().roomCluster(before.clusterId()).name());
+        DungeonMap restored = accepted.inverse().applyTo(renamed);
+        assertEquals(before, restored.topology().roomCluster(before.clusterId()));
+    }
+
+    @Test
+    void missingAndNoEffectRoomClusterCommandsRejectWithoutMutation() {
+        DungeonMap current = mapWithRoom();
+        RoomRegion room = current.rooms().rooms().getFirst();
+        RoomCluster cluster = current.topology().roomClusters().getFirst();
+
+        DungeonCommandResult.Rejected missingRoom = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new RoomNameCommand().plan(current, 999L, "Fehlt"));
+        DungeonCommandResult.Rejected unchangedRoom = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new RoomNarrationCommand().plan(current, room.roomId(), room.narration()));
+        DungeonCommandResult.Rejected unchangedCluster = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new RoomClusterNameCommand().plan(current, cluster.clusterId(), cluster.name()));
+
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, missingRoom.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, unchangedRoom.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, unchangedCluster.reason());
+        assertEquals(room, current.rooms().findRoom(room.roomId()).orElseThrow());
+        assertEquals(cluster, current.topology().roomCluster(cluster.clusterId()));
+    }
+
+    private static DungeonMap mapWithRoom() {
+        return DungeonMapAuthoring.empty(new DungeonMapIdentity(93L), "Room Patch Commands")
+                .paintRoomRectangle(new Cell(1, 1, 0), new Cell(2, 2, 0));
+    }
+}


### PR DESCRIPTION
## Summary
- route room names, room narration, and cluster names through exact revision-checked patches
- identify patch results by stable authored entity with an optional real topology ref
- delete replaced direct aggregate semantic save paths
- prove exact chunk facts, inverses, rejection behavior, and production-route compatibility
- advance the temporary roadmap to the M3.4 stair command family

## Proof
- ./gradlew test --tests features.dungeon.application.authored.command.DungeonPatchVocabularyTest --tests features.dungeon.application.authored.command.DungeonRoomClusterPatchCommandsTest --console=plain
- ./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest --console=plain
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain

All commands completed with BUILD SUCCESSFUL.