### PR TITLE
Migrate stair commands to exact patches

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,24 +97,28 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2, M3.1, and M3.2 are complete on `main`
-  through PR #501. Feature-marker create, semantic update, and delete use exact
-  patches and one shared patch executor; their former direct mutation routes
-  are deleted.
-- This slice: M3.3 moves room name, room narration, and room-cluster name to
-  exact stable-entity patches and the shared executor. Direct aggregate save
-  routes for those semantics are deleted.
+- Current foundation: M0 through M2 and M3.1 through M3.3 are complete on
+  `main` through PR #502. Feature-marker and room or cluster semantic commands
+  use exact patches and one shared patch executor; their former direct mutation
+  routes are deleted.
+- This slice: M3.4 moves editor-authored stair create, full geometry recompute,
+  and delete to exact stable-entity patches and the shared executor. The
+  history-free preview mutation is named explicitly; replaced commit mutation
+  routes are deleted.
 - Patch result facts now identify a stable authored entity and carry its
   topology ref only where that entity owns one. This preserves independent
   cluster identity without fabricating a room topology ref.
-- Deterministic proof covers exact room and cluster identity, chunk membership,
-  forward and inverse application, monotonic revision, encoded byte weight,
-  missing-target and no-effect rejection, and the Dungeon Editor production
-  route.
+- Deterministic proof covers exact stair identity and topology ref, generated
+  geometry, chunk membership, forward and inverse application, monotonic
+  revision, encoded byte weight, and typed rejection of invalid geometry, room
+  collisions, id collisions, no-effect updates, and corridor-bound deletion.
+- Direct stair-handle movement and corridor-owned stair segments remain owned
+  by later geometry and corridor patch slices; M3.4 does not create a second
+  route for either behavior.
 - `DungeonChangeSet` persistence and full-map session history remain temporary
   M3/M4 boundaries; no second persistence contract is introduced in this slice.
-- Next step after this slice merges: M3.4 moves the stair create, geometry
-  update, and delete command family to exact patches.
+- Next step after this slice merges: M3.5 introduces exact transition changes,
+  compound cross-map patches, and atomic transition-link history.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -24,11 +24,14 @@ import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.authored.port.DungeonChangeSet;
 import features.dungeon.application.authored.command.DungeonCommandResult;
 import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
+import features.dungeon.application.authored.command.CreateStairCommand;
 import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
+import features.dungeon.application.authored.command.DeleteStairCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
 import features.dungeon.application.authored.command.RoomClusterNameCommand;
 import features.dungeon.application.authored.command.RoomNameCommand;
 import features.dungeon.application.authored.command.RoomNarrationCommand;
+import features.dungeon.application.authored.command.UpdateStairGeometryCommand;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -117,6 +120,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final RoomNarrationCommand roomNarrationCommand = new RoomNarrationCommand();
     private final RoomNameCommand roomNameCommand = new RoomNameCommand();
     private final RoomClusterNameCommand roomClusterNameCommand = new RoomClusterNameCommand();
+    private final CreateStairCommand createStairCommand = new CreateStairCommand();
+    private final DeleteStairCommand deleteStairCommand = new DeleteStairCommand();
+    private final UpdateStairGeometryCommand updateStairGeometryCommand =
+            new UpdateStairGeometryCommand();
     private final PublicationOperations publicationOperations = new PublicationOperations();
     private final PreviewOperations previewOperations = new PreviewOperations();
     private final DetailSaveOperations detailSaveOperations = new DetailSaveOperations();
@@ -833,10 +840,9 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             Objects.requireNonNull(mapId, "mapId");
             Objects.requireNonNull(spec, "spec");
             long stairId = repository.nextStairId();
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.createStair(stairId, spec),
-                    DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
+                    current -> createStairCommand.plan(current, stairId, spec));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -848,17 +854,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || stairId <= 0L) {
                 return false;
             }
-            DungeonMapIdentity mapIdentity = domainMapId(mapId);
-            if (!loadMap(mapIdentity).canDeleteStair(stairId)) {
-                return false;
-            }
-            OperationResultData result =
-                    mutationPipeline.executeOperation(
-                            mapIdentity,
-                            current -> current.deleteStair(stairId),
-                            DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
+            OperationResultData result = mutationPipeline.executePatchCommand(
+                    domainMapId(mapId),
+                    current -> deleteStairCommand.plan(current, stairId));
             publicationOperations.publishMutation(result, session.dungeonState());
-            return true;
+            return result.changed();
         }
 
         private void createTransition(
@@ -1441,10 +1441,9 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || stairId <= 0L || spec == null) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.saveStairGeometry(stairId, spec),
-                    DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
+                    current -> updateStairGeometryCommand.plan(current, stairId, spec));
             publicationOperations.publishMutation(result, state);
         }
 
@@ -1646,7 +1645,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             return mutationPipeline.previewOperation(
                     domainMapId,
-                    current -> current.createStair(PREVIEW_STAIR_ID, spec));
+                    current -> current.previewStair(PREVIEW_STAIR_ID, spec));
         }
     }
 

--- a/features/dungeon/application/authored/command/CreateStairCommand.java
+++ b/features/dungeon/application/authored/command/CreateStairCommand.java
@@ -1,0 +1,38 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.stair.Stair;
+import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
+import java.util.List;
+
+/** Plans creation of one editor-authored stair. */
+public final class CreateStairCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long stairId,
+            StairGeometrySpec spec
+    ) {
+        if (current == null || stairId <= 0L || spec == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
+        }
+        if (current.stairs().stair(stairId) != null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (!current.canCreateStair(spec)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
+        }
+        Stair stair = Stair.authored(stairId, current.metadata().mapId().value(), spec);
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new StairChange(null, stair))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/DeleteStairCommand.java
+++ b/features/dungeon/application/authored/command/DeleteStairCommand.java
@@ -1,0 +1,33 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.stair.Stair;
+import java.util.List;
+
+/** Plans deletion of one unbound editor-authored stair. */
+public final class DeleteStairCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long stairId) {
+        if (current == null || stairId <= 0L) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        Stair stair = current.stairs().stair(stairId);
+        if (stair == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (!current.stairs().canDeleteUnboundStair(stairId)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new StairChange(stair, null))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatch.java
+++ b/features/dungeon/application/authored/command/DungeonPatch.java
@@ -92,6 +92,8 @@ public record DungeonPatch(
                         roomRegionChange.before(), roomRegionChange.after());
                 case RoomClusterChange roomClusterChange -> changed.withExactRoomClusterChange(
                         roomClusterChange.before(), roomClusterChange.after());
+                case StairChange stairChange -> changed.withExactStairChange(
+                        stairChange.before(), stairChange.after());
             };
         }
         if (changed.equals(safeCurrent)) {

--- a/features/dungeon/application/authored/command/DungeonPatchChange.java
+++ b/features/dungeon/application/authored/command/DungeonPatchChange.java
@@ -5,7 +5,8 @@ import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import java.util.Set;
 
 /** One stable-identity authored entity delta carried by a Dungeon patch. */
-public sealed interface DungeonPatchChange permits FeatureMarkerChange, RoomRegionChange, RoomClusterChange {
+public sealed interface DungeonPatchChange permits FeatureMarkerChange, RoomRegionChange, RoomClusterChange,
+        StairChange {
 
     DungeonMapIdentity mapId();
 

--- a/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
+++ b/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
@@ -18,6 +18,7 @@ public record DungeonPatchEntityRef(
         DungeonTopologyElementKind expectedTopologyKind = switch (kind) {
             case ROOM -> DungeonTopologyElementKind.ROOM;
             case FEATURE_MARKER -> DungeonTopologyElementKind.FEATURE_MARKER;
+            case STAIR -> DungeonTopologyElementKind.STAIR;
             case ROOM_CLUSTER -> null;
         };
         if (expectedTopologyKind == null && topologyRef != null) {
@@ -49,9 +50,17 @@ public record DungeonPatchEntityRef(
                 new DungeonTopologyRef(DungeonTopologyElementKind.FEATURE_MARKER, markerId));
     }
 
+    public static DungeonPatchEntityRef stair(long stairId) {
+        return new DungeonPatchEntityRef(
+                Kind.STAIR,
+                stairId,
+                new DungeonTopologyRef(DungeonTopologyElementKind.STAIR, stairId));
+    }
+
     public enum Kind {
         ROOM,
         ROOM_CLUSTER,
-        FEATURE_MARKER
+        FEATURE_MARKER,
+        STAIR
     }
 }

--- a/features/dungeon/application/authored/command/StairChange.java
+++ b/features/dungeon/application/authored/command/StairChange.java
@@ -1,0 +1,90 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.component.StairExit;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.stair.Stair;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Exact before/after delta for one stable authored stair. */
+public record StairChange(Stair before, Stair after) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 128L;
+    private static final long CELL_ENCODING_BYTES = 16L;
+    private static final long EXIT_ENCODING_BYTES = 32L;
+
+    public StairChange {
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a stair change requires before or after state");
+        }
+        if (before != null && after != null) {
+            if (before.equals(after)) {
+                throw new IllegalArgumentException("a stair change requires distinct before and after state");
+            }
+            if (before.stairId() != after.stairId() || before.mapId() != after.mapId()) {
+                throw new IllegalArgumentException("stair identity must remain stable");
+            }
+        }
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return new DungeonMapIdentity(state().mapId());
+    }
+
+    @Override
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.stair(state().stairId());
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addChunks(result, before);
+        addChunks(result, after);
+        return Set.copyOf(result);
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES + encodedBytes(before) + encodedBytes(after);
+    }
+
+    @Override
+    public StairChange inverse() {
+        return new StairChange(after, before);
+    }
+
+    private Stair state() {
+        return after == null ? before : after;
+    }
+
+    private static void addChunks(Set<DungeonChunkKey> result, Stair stair) {
+        if (stair == null) {
+            return;
+        }
+        for (Cell cell : stair.occupiedCells()) {
+            result.add(new DungeonChunkKey(
+                    stair.mapId(),
+                    cell.level(),
+                    Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                    Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+        }
+    }
+
+    private static long encodedBytes(Stair stair) {
+        if (stair == null) {
+            return 1L;
+        }
+        long result = stair.name().getBytes(StandardCharsets.UTF_8).length
+                + CELL_ENCODING_BYTES * stair.path().size();
+        for (StairExit exit : stair.exits()) {
+            result += EXIT_ENCODING_BYTES
+                    + Objects.requireNonNullElse(exit.label(), "").getBytes(StandardCharsets.UTF_8).length;
+        }
+        return result;
+    }
+}

--- a/features/dungeon/application/authored/command/UpdateStairGeometryCommand.java
+++ b/features/dungeon/application/authored/command/UpdateStairGeometryCommand.java
@@ -1,0 +1,42 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.stair.Stair;
+import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
+import java.util.List;
+
+/** Plans a full deterministic geometry recompute for one editor-authored stair. */
+public final class UpdateStairGeometryCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long stairId,
+            StairGeometrySpec spec
+    ) {
+        if (current == null || stairId <= 0L || spec == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        Stair before = current.stairs().stair(stairId);
+        if (before == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (!current.canSaveStairGeometry(stairId, spec)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY);
+        }
+        Stair after = before.withRecomputedGeometry(spec);
+        if (after.equals(before)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new StairChange(before, after))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -14,6 +14,7 @@ import features.dungeon.domain.core.structure.room.RoomCluster;
 import features.dungeon.domain.core.structure.room.RoomRegion;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
 import features.dungeon.domain.core.structure.stair.StairCollection;
+import features.dungeon.domain.core.structure.stair.Stair;
 import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
 import features.dungeon.domain.core.structure.topology.DungeonMapTopology;
 import features.dungeon.domain.core.structure.topology.SpatialTopology;
@@ -212,22 +213,11 @@ public record DungeonMap(
         return featureMarkers.nextMarkerId();
     }
 
-    public boolean canDeleteStair(long stairId) {
-        return stairId > 0L && stairs.canDeleteUnboundStair(stairId);
-    }
-
-    public DungeonMap deleteStair(long stairId) {
-        if (!canDeleteStair(stairId)) {
-            return this;
-        }
-        return withStairs(stairs.withoutUnboundStair(stairId));
-    }
-
-    public DungeonMap createStair(
+    public DungeonMap previewStair(
             long stairId,
             StairGeometrySpec spec
     ) {
-        return STAIR_AUTHORING.createStair(this, stairId, spec);
+        return STAIR_AUTHORING.previewStair(this, stairId, spec);
     }
 
     public boolean canCreateStair(StairGeometrySpec spec) {
@@ -239,16 +229,6 @@ public record DungeonMap(
             StairGeometrySpec spec
     ) {
         return STAIR_AUTHORING.canSaveStairGeometry(this, stairId, spec);
-    }
-
-    public DungeonMap saveStairGeometry(
-            long stairId,
-            StairGeometrySpec spec
-    ) {
-        if (!canSaveStairGeometry(stairId, spec)) {
-            return this;
-        }
-        return STAIR_AUTHORING.saveStairGeometry(this, stairId, spec);
     }
 
     public DungeonMap paintRoomRectangle(Cell start, Cell end) {
@@ -338,6 +318,23 @@ public record DungeonMap(
                 rooms,
                 corridors,
                 stairs,
+                transitionCatalog,
+                featureMarkers,
+                revision + 1L);
+    }
+
+    public DungeonMap withExactStairChange(
+            @Nullable Stair before,
+            @Nullable Stair after
+    ) {
+        StairCollection nextStairs = stairs.withExactChange(before, after);
+        return new DungeonMap(
+                metadata,
+                topology,
+                null,
+                rooms,
+                corridors,
+                nextStairs,
                 transitionCatalog,
                 featureMarkers,
                 revision + 1L);

--- a/features/dungeon/domain/core/structure/DungeonMapStairAuthoring.java
+++ b/features/dungeon/domain/core/structure/DungeonMapStairAuthoring.java
@@ -10,12 +10,12 @@ final class DungeonMapStairAuthoring {
         return stairAuthoring.moveAnchor(dungeonMap, stairId, handleIndex, deltaQ, deltaR, deltaLevel);
     }
 
-    DungeonMap createStair(
+    DungeonMap previewStair(
             DungeonMap dungeonMap,
             long stairId,
             StairGeometrySpec spec
     ) {
-        var nextStairs = stairAuthoring.withAuthoredStair(dungeonMap, stairId, spec);
+        var nextStairs = stairAuthoring.withPreviewAuthoredStair(dungeonMap, stairId, spec);
         return nextStairs.equals(dungeonMap.stairs()) ? dungeonMap : dungeonMap.withStairs(nextStairs);
     }
 
@@ -37,15 +37,4 @@ final class DungeonMapStairAuthoring {
                 spec);
     }
 
-    DungeonMap saveStairGeometry(
-            DungeonMap dungeonMap,
-            long stairId,
-            StairGeometrySpec spec
-    ) {
-        var nextStairs = stairAuthoring.withSavedStairGeometry(
-                dungeonMap,
-                stairId,
-                spec);
-        return nextStairs.equals(dungeonMap.stairs()) ? dungeonMap : dungeonMap.withStairs(nextStairs);
-    }
 }

--- a/features/dungeon/domain/core/structure/stair/StairCollection.java
+++ b/features/dungeon/domain/core/structure/stair/StairCollection.java
@@ -2,6 +2,7 @@ package features.dungeon.domain.core.structure.stair;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.component.StairExit;
@@ -21,21 +22,8 @@ public record StairCollection(List<Stair> stairs) {
     }
 
     public boolean canDeleteUnboundStair(long stairId) {
-        Stair stair = stairById(stairId);
+        Stair stair = stair(stairId);
         return stair != null && stair.corridorId() == null;
-    }
-
-    public StairCollection withoutUnboundStair(long stairId) {
-        if (!canDeleteUnboundStair(stairId)) {
-            return this;
-        }
-        List<Stair> result = new ArrayList<>();
-        for (Stair stair : stairs) {
-            if (stair.stairId() != stairId) {
-                result.add(stair);
-            }
-        }
-        return new StairCollection(result);
     }
 
     public StairCollection withoutCorridorBoundStairs(long corridorId) {
@@ -111,7 +99,7 @@ public record StairCollection(List<Stair> stairs) {
         return supportedAuthoredSpec(spec) && spec.avoidsRoomInteriors(roomCells);
     }
 
-    public StairCollection withAuthoredStair(
+    public StairCollection withPreviewAuthoredStair(
             long stairId,
             long mapId,
             @Nullable StairGeometrySpec spec,
@@ -132,7 +120,7 @@ public record StairCollection(List<Stair> stairs) {
     ) {
         return stairId > NO_STAIR_ID
                 && supportedAuthoredSpec(spec)
-                && canRecompute(stairById(stairId))
+                && canRecompute(stair(stairId))
                 && spec.avoidsRoomInteriors(roomCells);
     }
 
@@ -142,29 +130,6 @@ public record StairCollection(List<Stair> stairs) {
             @Nullable Set<Cell> roomCells
     ) {
         return canRecomputeStair(stairId, spec, roomCells);
-    }
-
-    public StairCollection withRecomputedStair(
-            long stairId,
-            @Nullable StairGeometrySpec spec,
-            @Nullable Set<Cell> roomCells
-    ) {
-        if (!canRecomputeStair(stairId, spec, roomCells)) {
-            return this;
-        }
-        List<Stair> result = new ArrayList<>();
-        for (Stair stair : stairs) {
-            result.add(stair.stairId() == stairId ? stair.withRecomputedGeometry(spec) : stair);
-        }
-        return new StairCollection(result);
-    }
-
-    public StairCollection withRecomputedAuthoredStair(
-            long stairId,
-            @Nullable StairGeometrySpec spec,
-            @Nullable Set<Cell> roomCells
-    ) {
-        return withRecomputedStair(stairId, spec, roomCells);
     }
 
     public StairCollection withMovedHandle(long stairId, int handleIndex, int deltaQ, int deltaR, int deltaLevel) {
@@ -186,10 +151,10 @@ public record StairCollection(List<Stair> stairs) {
     }
 
     public @Nullable Cell anchorOf(long stairId) {
-        return anchorOf(stairById(stairId));
+        return anchorOf(stair(stairId));
     }
 
-    private @Nullable Stair stairById(long stairId) {
+    public @Nullable Stair stair(long stairId) {
         if (stairId <= NO_STAIR_ID) {
             return null;
         }
@@ -199,6 +164,33 @@ public record StairCollection(List<Stair> stairs) {
             }
         }
         return null;
+    }
+
+    public StairCollection withExactChange(
+            @Nullable Stair before,
+            @Nullable Stair after
+    ) {
+        Stair identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("stair change requires identity");
+        }
+        if (!Objects.equals(stair(identity.stairId()), before)) {
+            throw new IllegalStateException("stair patch does not match current authored truth");
+        }
+        List<Stair> nextStairs = new ArrayList<>();
+        for (Stair stair : stairs) {
+            if (stair.stairId() == identity.stairId()) {
+                if (after != null) {
+                    nextStairs.add(after);
+                }
+            } else {
+                nextStairs.add(stair);
+            }
+        }
+        if (before == null && after != null) {
+            nextStairs.add(after);
+        }
+        return new StairCollection(nextStairs);
     }
 
     private static boolean supportedAuthoredSpec(@Nullable StairGeometrySpec spec) {

--- a/features/dungeon/domain/core/structure/stair/StairMapAuthoring.java
+++ b/features/dungeon/domain/core/structure/stair/StairMapAuthoring.java
@@ -35,12 +35,12 @@ public final class StairMapAuthoring {
                 : copyWithConnections(dungeonMap, dungeonMap.corridors(), nextStairs);
     }
 
-    public StairCollection withAuthoredStair(
+    public StairCollection withPreviewAuthoredStair(
             DungeonMap dungeonMap,
             long stairId,
             StairGeometrySpec spec
     ) {
-        return dungeonMap.stairs().withAuthoredStair(
+        return dungeonMap.stairs().withPreviewAuthoredStair(
                 stairId,
                 dungeonMap.metadata().mapId().value(),
                 spec,
@@ -62,17 +62,6 @@ public final class StairMapAuthoring {
             StairGeometrySpec spec
     ) {
         return dungeonMap.stairs().canRecomputeAuthoredStair(
-                stairId,
-                spec,
-                roomInteriorCells(dungeonMap));
-    }
-
-    public StairCollection withSavedStairGeometry(
-            DungeonMap dungeonMap,
-            long stairId,
-            StairGeometrySpec spec
-    ) {
-        return dungeonMap.stairs().withRecomputedAuthoredStair(
                 stairId,
                 spec,
                 roomInteriorCells(dungeonMap));

--- a/test/features/dungeon/adapter/javafx/editor/DungeonStairInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonStairInvariantScenarios.java
@@ -40,12 +40,6 @@ final class DungeonStairInvariantScenarios {
 
         assertFalse(map.stairs().canDeleteUnboundStair(STAIR_ID),
                 "stair binding owner rejects direct delete eligibility for corridor-bound stair");
-        assertEquals(map.stairs(), map.stairs().withoutUnboundStair(STAIR_ID),
-                "stair binding owner keeps corridor-bound stair on direct delete request");
-        assertFalse(map.canDeleteStair(STAIR_ID),
-                "DungeonMap aggregate rejects direct corridor-bound stair delete");
-        assertEquals(map, map.deleteStair(STAIR_ID),
-                "DungeonMap direct delete leaves corridor-bound stair map unchanged");
 
         DungeonMap corridorDeleted = CORRIDOR_AUTHORING.deleteCorridor(
                 map,

--- a/test/features/dungeon/application/authored/command/DungeonStairPatchCommandsTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonStairPatchCommandsTest.java
@@ -1,0 +1,169 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Direction;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring.AuthoredContent;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.stair.Stair;
+import features.dungeon.domain.core.structure.stair.StairCollection;
+import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
+import features.dungeon.domain.core.structure.stair.StairShape;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DungeonStairPatchCommandsTest {
+
+    private static final long MAP_ID = 95L;
+    private static final long STAIR_ID = 17L;
+
+    @Test
+    void stairCreateUpdateAndDeleteProduceExactInvertiblePatches() {
+        DungeonMap empty = emptyMap();
+        StairGeometrySpec initialSpec = new StairGeometrySpec(
+                StairShape.STRAIGHT,
+                new Cell(1, 1, 0),
+                Direction.NORTH,
+                1,
+                2);
+
+        DungeonCommandResult.Accepted createdResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new CreateStairCommand().plan(empty, STAIR_ID, initialSpec));
+        assertEquals(
+                DungeonPatchEntityRef.stair(STAIR_ID),
+                createdResult.patch().resultFacts().affectedEntities().getFirst());
+        assertEquals(Set.of(
+                new DungeonChunkKey(MAP_ID, 0, 0, 0),
+                new DungeonChunkKey(MAP_ID, 1, 0, 0),
+                new DungeonChunkKey(MAP_ID, 2, 0, 0)), createdResult.patch().touchedChunks());
+        DungeonMap created = createdResult.patch().applyTo(empty);
+        Stair initial = created.stairs().stair(STAIR_ID);
+        assertEquals(Stair.authored(STAIR_ID, MAP_ID, initialSpec), initial);
+        DungeonMap createUndone = createdResult.inverse().applyTo(created);
+        assertNull(createUndone.stairs().stair(STAIR_ID));
+        assertEquals(empty.revision() + 2L, createUndone.revision());
+
+        StairGeometrySpec updatedSpec = new StairGeometrySpec(
+                StairShape.SQUARE,
+                new Cell(4, 4, 0),
+                Direction.EAST,
+                3,
+                2);
+        DungeonCommandResult.Accepted updatedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new UpdateStairGeometryCommand().plan(created, STAIR_ID, updatedSpec));
+        DungeonMap updated = updatedResult.patch().applyTo(created);
+        Stair recomputed = updated.stairs().stair(STAIR_ID);
+        assertEquals(STAIR_ID, recomputed.stairId());
+        assertEquals(initial.name(), recomputed.name());
+        assertEquals(updatedSpec.generatedPath(), recomputed.path());
+        assertEquals(initial.exits().stream().map(exit -> exit.exitId()).toList(),
+                recomputed.exits().stream().map(exit -> exit.exitId()).toList());
+        DungeonMap updateUndone = updatedResult.inverse().applyTo(updated);
+        assertEquals(initial, updateUndone.stairs().stair(STAIR_ID));
+
+        DungeonCommandResult.Accepted deletedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new DeleteStairCommand().plan(updated, STAIR_ID));
+        DungeonMap deleted = deletedResult.patch().applyTo(updated);
+        assertNull(deleted.stairs().stair(STAIR_ID));
+        DungeonMap deleteUndone = deletedResult.inverse().applyTo(deleted);
+        assertEquals(recomputed, deleteUndone.stairs().stair(STAIR_ID));
+        assertThrows(IllegalArgumentException.class, () -> deletedResult.patch().applyTo(deleted));
+        assertTrue(deletedResult.patch().encodedBytes() > recomputed.path().size());
+    }
+
+    @Test
+    void invalidGeometryCollisionAndNoEffectRejectWithoutMutation() {
+        DungeonMap empty = emptyMap();
+        StairGeometrySpec valid = new StairGeometrySpec(
+                StairShape.STRAIGHT,
+                new Cell(1, 1, 0),
+                Direction.NORTH,
+                1,
+                2);
+        DungeonMap created = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new CreateStairCommand().plan(empty, STAIR_ID, valid)).patch().applyTo(empty);
+
+        DungeonCommandResult.Rejected collision = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new CreateStairCommand().plan(created, STAIR_ID, valid));
+        DungeonCommandResult.Rejected noEffect = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new UpdateStairGeometryCommand().plan(created, STAIR_ID, valid));
+        StairGeometrySpec unsupported = new StairGeometrySpec(
+                StairShape.LADDER,
+                new Cell(8, 8, 0),
+                Direction.NORTH,
+                3,
+                2);
+        DungeonCommandResult.Rejected invalid = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new CreateStairCommand().plan(empty, STAIR_ID + 1L, unsupported));
+
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, collision.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, noEffect.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY, invalid.reason());
+        assertEquals(1, created.stairs().stairs().size());
+    }
+
+    @Test
+    void roomInteriorAndCorridorBindingRejectAtomically() {
+        DungeonMap roomMap = emptyMap().paintRoomRectangle(new Cell(1, 1, 0), new Cell(5, 3, 0));
+        StairGeometrySpec crossing = new StairGeometrySpec(
+                StairShape.STRAIGHT,
+                new Cell(1, 1, 0),
+                Direction.EAST,
+                5,
+                1);
+        DungeonCommandResult.Rejected roomCollision = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new CreateStairCommand().plan(roomMap, STAIR_ID, crossing));
+        DungeonMap boundMap = corridorBoundStairMap();
+        DungeonCommandResult.Rejected boundDelete = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new DeleteStairCommand().plan(boundMap, STAIR_ID));
+
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_STAIR_GEOMETRY, roomCollision.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION, boundDelete.reason());
+        assertEquals(boundMap.stairs().stair(STAIR_ID), boundMap.stairs().stairs().getFirst());
+    }
+
+    private static DungeonMap emptyMap() {
+        return DungeonMapAuthoring.empty(new DungeonMapIdentity(MAP_ID), "Stair Patch Commands");
+    }
+
+    private static DungeonMap corridorBoundStairMap() {
+        DungeonMap base = emptyMap();
+        Stair bound = Stair.corridorBound(
+                STAIR_ID,
+                MAP_ID,
+                44L,
+                List.of(new Cell(0, 0, 0), new Cell(0, 1, 0)),
+                new Cell(0, 1, 1));
+        return DungeonMapAuthoring.authored(
+                base.metadata().mapId(),
+                base.metadata().mapName(),
+                new AuthoredContent(
+                        base.topology(),
+                        base.topologyIndex(),
+                        base.rooms(),
+                        base.corridors(),
+                        new StairCollection(List.of(bound)),
+                        base.transitionCatalog().transitions(),
+                        base.featureMarkers()),
+                base.revision());
+    }
+}


### PR DESCRIPTION
## Summary
- route editor-authored stair create, full geometry recompute, and delete through exact patches
- preserve stable stair identity, topology ref, generated geometry, and inverse patches
- reject invalid geometry, room collisions, id collisions, no-effect updates, and corridor-bound deletion with typed reasons
- delete replaced commit mutation routes while retaining one explicitly named history-free preview route
- advance the temporary roadmap to transition and compound patches

## Proof
- ./gradlew test --tests features.dungeon.application.authored.command.DungeonPatchVocabularyTest --tests features.dungeon.application.authored.command.DungeonRoomClusterPatchCommandsTest --tests features.dungeon.application.authored.command.DungeonStairPatchCommandsTest --console=plain
- ./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest --console=plain
- ./gradlew architectureTest --console=plain
- ./gradlew check --console=plain
- ./gradlew installDesktopApp --console=plain

All commands completed with BUILD SUCCESSFUL.