### PR TITLE
Migrate transition links to compound patches

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,28 +97,30 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.3 are complete on
-  `main` through PR #502. Feature-marker and room or cluster semantic commands
-  use exact patches and one shared patch executor; their former direct mutation
-  routes are deleted.
-- This slice: M3.4 moves editor-authored stair create, full geometry recompute,
-  and delete to exact stable-entity patches and the shared executor. The
-  history-free preview mutation is named explicitly; replaced commit mutation
-  routes are deleted.
-- Patch result facts now identify a stable authored entity and carry its
-  topology ref only where that entity owns one. This preserves independent
-  cluster identity without fabricating a room topology ref.
-- Deterministic proof covers exact stair identity and topology ref, generated
-  geometry, chunk membership, forward and inverse application, monotonic
-  revision, encoded byte weight, and typed rejection of invalid geometry, room
-  collisions, id collisions, no-effect updates, and corridor-bound deletion.
-- Direct stair-handle movement and corridor-owned stair segments remain owned
-  by later geometry and corridor patch slices; M3.4 does not create a second
-  route for either behavior.
-- `DungeonChangeSet` persistence and full-map session history remain temporary
-  M3/M4 boundaries; no second persistence contract is introduced in this slice.
-- Next step after this slice merges: M3.5 introduces exact transition changes,
-  compound cross-map patches, and atomic transition-link history.
+- Current foundation: M0 through M2 and M3.1 through M3.4 are complete on
+  `main` through PR #503. Feature markers, room or cluster semantics, and stair
+  create, geometry update, and delete use exact patches and the shared patch
+  executor; their replaced direct commit routes are deleted.
+- This slice: M3.5 moves transition create, description, delete, and authored
+  link save to exact transition changes. A transition link now yields one
+  `DungeonCompoundPatch` covering every affected map and persists the resulting
+  map set atomically through the existing multi-map repository boundary.
+- Per-session history stores forward and inverse patches for the M3.1 through
+  M3.5 command families. One compound transition entry is shared by every
+  affected map, and undo or redo applies and persists the full map set before
+  moving any history stack.
+- Deterministic proof covers transition identity and topology ref, touched
+  chunks, exact forward and inverse application, closure loading, missing
+  previous-map fallback, atomic multi-map history, later-edit ordering, encoded
+  patch weight, monotonic revisions, and typed rejection of invalid, referenced,
+  missing, and no-effect transition operations.
+- Ordinary commands that still use `executeOperation` retain the temporary
+  full-map `DungeonChangeSet` and snapshot-history path until their remaining
+  M3 geometry and corridor slices migrate. M3.5 introduces no second
+  persistence contract.
+- Next step after this slice merges: M3.6 moves room paint or delete,
+  cluster-boundary edits, and cluster geometry-handle commits to exact room and
+  cluster patches, then deletes their direct commit routes.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -3,12 +3,13 @@ package features.dungeon.application.authored;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.jspecify.annotations.Nullable;
@@ -23,15 +24,21 @@ import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.authored.port.DungeonChangeSet;
 import features.dungeon.application.authored.command.DungeonCommandResult;
+import features.dungeon.application.authored.command.DungeonCompoundCommandResult;
+import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
 import features.dungeon.application.authored.command.CreateStairCommand;
+import features.dungeon.application.authored.command.CreateTransitionCommand;
 import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
 import features.dungeon.application.authored.command.DeleteStairCommand;
+import features.dungeon.application.authored.command.DeleteTransitionCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
 import features.dungeon.application.authored.command.RoomClusterNameCommand;
 import features.dungeon.application.authored.command.RoomNameCommand;
 import features.dungeon.application.authored.command.RoomNarrationCommand;
 import features.dungeon.application.authored.command.UpdateStairGeometryCommand;
+import features.dungeon.application.authored.command.TransitionDescriptionCommand;
+import features.dungeon.application.authored.command.TransitionLinkCommand;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -48,8 +55,6 @@ import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
 import features.dungeon.domain.core.structure.stair.StairShape;
 import features.dungeon.domain.core.structure.transition.TransitionAnchor;
 import features.dungeon.domain.core.structure.transition.TransitionCatalog;
-import features.dungeon.domain.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkMap;
-import features.dungeon.domain.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkRewrite;
 import features.dungeon.domain.core.structure.transition.TransitionDestination;
 import features.dungeon.application.editor.interaction.DungeonEditorHandleMutation;
 import features.dungeon.application.editor.interaction.DungeonEditorHandleProjection;
@@ -124,6 +129,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final DeleteStairCommand deleteStairCommand = new DeleteStairCommand();
     private final UpdateStairGeometryCommand updateStairGeometryCommand =
             new UpdateStairGeometryCommand();
+    private final CreateTransitionCommand createTransitionCommand = new CreateTransitionCommand();
+    private final DeleteTransitionCommand deleteTransitionCommand = new DeleteTransitionCommand();
+    private final TransitionDescriptionCommand transitionDescriptionCommand =
+            new TransitionDescriptionCommand();
+    private final TransitionLinkCommand transitionLinkCommand = new TransitionLinkCommand();
     private final PublicationOperations publicationOperations = new PublicationOperations();
     private final PreviewOperations previewOperations = new PreviewOperations();
     private final DetailSaveOperations detailSaveOperations = new DetailSaveOperations();
@@ -318,24 +328,35 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         if (mapId == null || session == null) {
             return;
         }
-        DungeonMap current = loadMap(domainMapId(mapId));
-        DungeonMap snapshot = undo ? editHistory.undo(current) : editHistory.redo(current);
-        if (snapshot.equals(current)) {
+        DungeonMapIdentity selectedMapId = domainMapId(mapId);
+        DungeonEditHistory.Step step = undo
+                ? editHistory.peekUndo(selectedMapId)
+                : editHistory.peekRedo(selectedMapId);
+        if (!step.present()) {
             return;
         }
-        DungeonMap restored = DungeonMapAuthoring.restoreContent(snapshot, current.revision() + 1L);
-        DungeonMap saved;
-        try {
-            saved = repository.saveChange(new DungeonChangeSet(current, restored));
-        } catch (RuntimeException failure) {
-            if (undo) {
-                editHistory.redo(current);
-            } else {
-                editHistory.undo(current);
+        Map<Long, DungeonMap> currentMaps = new LinkedHashMap<>();
+        for (long affectedMapId : step.mapIds()) {
+            DungeonMap current = repository.findById(new DungeonMapIdentity(affectedMapId)).orElse(null);
+            if (current == null) {
+                return;
             }
-            throw failure;
+            currentMaps.put(affectedMapId, current);
         }
-        authoredWorkset.put(saved.metadata().mapId().value(), saved);
+        Map<Long, DungeonMap> changedMaps = step.applyTo(currentMaps);
+        List<DungeonMap> savedMaps = changedMaps.size() == 1
+                ? List.of(repository.saveChange(new DungeonChangeSet(
+                        currentMaps.values().iterator().next(),
+                        changedMaps.values().iterator().next())))
+                : repository.saveAll(List.copyOf(changedMaps.values()));
+        editHistory.complete(step);
+        for (DungeonMap savedMap : savedMaps) {
+            authoredWorkset.put(savedMap.metadata().mapId().value(), savedMap);
+        }
+        DungeonMap saved = savedMaps.stream()
+                .filter(candidate -> candidate.metadata().mapId().equals(selectedMapId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("history save omitted the selected map"));
         OperationResultData result = new OperationResultData(
                 mutationPipeline.snapshotData(saved, derive(saved)),
                 true,
@@ -610,7 +631,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             DungeonMap patched = accepted.patch().applyTo(current);
             DungeonMap saved = repository.saveChange(new DungeonChangeSet(current, patched));
             authoredWorkset.put(saved.metadata().mapId().value(), saved);
-            editHistory.record(current, saved);
+            editHistory.recordPatch(accepted.patch());
             return new OperationResultData(
                     snapshotData(saved, derive(saved)),
                     true,
@@ -871,14 +892,13 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             Objects.requireNonNull(anchor, "anchor");
             Objects.requireNonNull(destination, "destination");
             long transitionId = repository.nextTransitionId();
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.withTransitionCatalog(current.transitionCatalog().withCreated(
+                    current -> createTransitionCommand.plan(
+                            current,
                             transitionId,
-                            current.metadata().mapId().value(),
                             anchor,
-                            destination)),
-                    DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION);
+                            destination));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -897,17 +917,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || transitionId <= 0L) {
                 return false;
             }
-            DungeonMapIdentity mapIdentity = domainMapId(mapId);
-            if (!loadMap(mapIdentity).canDeleteTransition(transitionId)) {
-                return false;
-            }
-            OperationResultData result =
-                    mutationPipeline.executeOperation(
-                            mapIdentity,
-                            current -> current.deleteTransition(transitionId),
-                            DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
+            OperationResultData result = mutationPipeline.executePatchCommand(
+                    domainMapId(mapId),
+                    current -> deleteTransitionCommand.plan(current, transitionId));
             publicationOperations.publishMutation(result, session.dungeonState());
-            return true;
+            return result.changed();
         }
     }
 
@@ -1212,35 +1226,43 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 return null;
             }
             Map<Long, DungeonMap> pendingMaps = loadedMaps(loaded.sourceMap(), loaded.targetMap());
-            AuthoredTransitionLinkRewrite rewrite = transitionLinkRewrite(
-                    pendingMaps,
+            Set<Long> knownMissingMapIds = new LinkedHashSet<>();
+            DungeonCompoundCommandResult commandResult = transitionLinkCommand.plan(
+                    pendingMaps.values(),
                     loaded.sourceIdentity().value(),
                     sourceTransitionId,
                     loaded.targetIdentity().value(),
                     targetTransitionId,
-                    bidirectional);
-            OptionalLong requestedMapId = rewrite.requestedMapId();
-            if (requestedMapId.isPresent()) {
-                long mapId = requestedMapId.orElseThrow();
+                    bidirectional,
+                    knownMissingMapIds);
+            if (commandResult instanceof DungeonCompoundCommandResult.RequiresMap requiresMap) {
+                long mapId = requiresMap.mapId();
                 Optional<DungeonMap> requiredMap = repository.findById(new DungeonMapIdentity(mapId));
                 if (requiredMap.isPresent()) {
                     pendingMaps.put(mapId, requiredMap.orElseThrow());
-                    rewrite = transitionLinkRewrite(
-                            pendingMaps,
-                            loaded.sourceIdentity().value(),
-                            sourceTransitionId,
-                            loaded.targetIdentity().value(),
-                            targetTransitionId,
-                            bidirectional);
                 } else {
-                    rewrite = rewrite.acceptMissingRequestedMap();
+                    knownMissingMapIds.add(mapId);
                 }
+                commandResult = transitionLinkCommand.plan(
+                        pendingMaps.values(),
+                        loaded.sourceIdentity().value(),
+                        sourceTransitionId,
+                        loaded.targetIdentity().value(),
+                        targetTransitionId,
+                        bidirectional,
+                        knownMissingMapIds);
             }
-            if (!rewrite.accepted()) {
+            if (!(commandResult instanceof DungeonCompoundCommandResult.Accepted accepted)) {
                 return null;
             }
-            applyCatalogUpdates(pendingMaps, rewrite);
-            List<DungeonMap> savedMaps = repository.saveAll(List.copyOf(pendingMaps.values()));
+            DungeonCompoundPatch patch = accepted.patch();
+            Map<Long, DungeonMap> patchedMaps = patch.applyTo(pendingMaps);
+            List<DungeonMap> savedMaps = patchedMaps.size() == 1
+                    ? List.of(repository.saveChange(new DungeonChangeSet(
+                            pendingMaps.get(patchedMaps.keySet().iterator().next()),
+                            patchedMaps.values().iterator().next())))
+                    : repository.saveAll(List.copyOf(patchedMaps.values()));
+            editHistory.recordCompoundPatch(patch);
             for (DungeonMap savedMap : savedMaps) {
                 authoredWorkset.put(savedMap.metadata().mapId().value(), savedMap);
             }
@@ -1276,40 +1298,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             pendingMaps.put(sourceMap.metadata().mapId().value(), sourceMap);
             pendingMaps.put(targetMap.metadata().mapId().value(), targetMap);
             return pendingMaps;
-        }
-
-        private AuthoredTransitionLinkRewrite transitionLinkRewrite(
-                Map<Long, DungeonMap> pendingMaps,
-                long sourceMapId,
-                long sourceTransitionId,
-                long targetMapId,
-                long targetTransitionId,
-                boolean bidirectional
-        ) {
-            List<AuthoredTransitionLinkMap> loadedCatalogs = new ArrayList<>();
-            for (DungeonMap map : pendingMaps.values()) {
-                loadedCatalogs.add(new AuthoredTransitionLinkMap(
-                        map.metadata().mapId().value(),
-                        map.transitionCatalog()));
-            }
-            return TransitionCatalog.authoredTransitionLinkRewrite(
-                    loadedCatalogs,
-                    sourceMapId,
-                    sourceTransitionId,
-                    targetMapId,
-                    targetTransitionId,
-                    bidirectional);
-        }
-
-        private void applyCatalogUpdates(
-                Map<Long, DungeonMap> pendingMaps,
-                AuthoredTransitionLinkRewrite rewrite
-        ) {
-            for (Map.Entry<Long, DungeonMap> entry : pendingMaps.entrySet()) {
-                DungeonMap map = entry.getValue();
-                TransitionCatalog nextCatalog = rewrite.catalogFor(entry.getKey(), map.transitionCatalog());
-                entry.setValue(map.withTransitionCatalog(nextCatalog));
-            }
         }
 
         private DungeonMap savedSourceMap(List<DungeonMap> savedMaps, long sourceMapId) {
@@ -1385,9 +1373,9 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (mapId == null || transitionId <= 0L) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.saveTransitionDescription(transitionId, description));
+                    current -> transitionDescriptionCommand.plan(current, transitionId, description));
             publicationOperations.publishMutation(result, state);
         }
 

--- a/features/dungeon/application/authored/DungeonEditHistory.java
+++ b/features/dungeon/application/authored/DungeonEditHistory.java
@@ -1,11 +1,18 @@
 package features.dungeon.application.authored;
 
+import features.dungeon.application.authored.command.DungeonCompoundPatch;
+import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /** Per-running-editor-session authored undo/redo history. */
 final class DungeonEditHistory {
@@ -15,57 +22,153 @@ final class DungeonEditHistory {
     private final Map<Long, MapHistory> histories = new HashMap<>();
 
     void record(DungeonMap before, DungeonMap after) {
-        if (before == null || after == null || before.equals(after)) {
-            return;
+        if (before != null && after != null && !before.equals(after)) {
+            recordEntry(new SnapshotEntry(before, after, estimatedBytes(before, after)));
         }
-        long mapId = after.metadata().mapId().value();
-        MapHistory history = histories.computeIfAbsent(mapId, ignored -> new MapHistory());
-        history.redo.clear();
-        history.undo.addLast(new Change(before, after, estimatedBytes(before, after)));
-        history.recalculateBytes();
-        history.trim();
     }
 
-    DungeonMap undo(DungeonMap current) {
-        MapHistory history = history(current);
-        if (history == null || history.undo.isEmpty()) {
-            return current;
+    void recordPatch(DungeonPatch patch) {
+        if (patch != null) {
+            recordEntry(new PatchEntry(patch, patch.inverse()));
         }
-        Change change = history.undo.removeLast();
-        history.redo.addLast(change);
-        history.recalculateBytes();
-        return change.before();
     }
 
-    DungeonMap redo(DungeonMap current) {
-        MapHistory history = history(current);
-        if (history == null || history.redo.isEmpty()) {
-            return current;
+    void recordCompoundPatch(DungeonCompoundPatch patch) {
+        if (patch != null) {
+            recordEntry(new CompoundPatchEntry(patch, patch.inverse()));
         }
-        Change change = history.redo.removeLast();
-        history.undo.addLast(change);
-        history.recalculateBytes();
-        return change.after();
+    }
+
+    Step peekUndo(DungeonMapIdentity mapId) {
+        return peek(mapId, true);
+    }
+
+    Step peekRedo(DungeonMapIdentity mapId) {
+        return peek(mapId, false);
     }
 
     boolean canUndo(DungeonMapIdentity mapId) {
-        MapHistory history = mapId == null ? null : histories.get(mapId.value());
-        return history != null && !history.undo.isEmpty();
+        return peekUndo(mapId).present();
     }
 
     boolean canRedo(DungeonMapIdentity mapId) {
-        MapHistory history = mapId == null ? null : histories.get(mapId.value());
-        return history != null && !history.redo.isEmpty();
+        return peekRedo(mapId).present();
+    }
+
+    void complete(Step step) {
+        if (step == null || !step.present()) {
+            return;
+        }
+        HistoryEntry entry = step.entry();
+        for (long mapId : entry.mapIds()) {
+            MapHistory history = histories.get(mapId);
+            Deque<HistoryEntry> source = step.undo() ? history.undo : history.redo;
+            Deque<HistoryEntry> target = step.undo() ? history.redo : history.undo;
+            if (source.peekLast() != entry) {
+                throw new IllegalStateException("history entry is no longer current for every affected map");
+            }
+            source.removeLast();
+            target.addLast(entry);
+        }
+        recalculateAll();
     }
 
     void remove(DungeonMapIdentity mapId) {
-        if (mapId != null) {
-            histories.remove(mapId.value());
+        if (mapId == null) {
+            return;
+        }
+        MapHistory history = histories.get(mapId.value());
+        if (history == null) {
+            return;
+        }
+        for (HistoryEntry entry : Set.copyOf(history.undo)) {
+            removeFromAll(entry, true);
+        }
+        for (HistoryEntry entry : Set.copyOf(history.redo)) {
+            removeFromAll(entry, false);
+        }
+        histories.remove(mapId.value());
+        recalculateAll();
+    }
+
+    private Step peek(DungeonMapIdentity mapId, boolean undo) {
+        if (mapId == null) {
+            return Step.empty();
+        }
+        MapHistory history = histories.get(mapId.value());
+        Deque<HistoryEntry> stack = history == null ? null : undo ? history.undo : history.redo;
+        HistoryEntry entry = stack == null ? null : stack.peekLast();
+        return entry != null && currentForEveryAffectedMap(entry, undo)
+                ? new Step(entry, undo)
+                : Step.empty();
+    }
+
+    private boolean currentForEveryAffectedMap(HistoryEntry entry, boolean undo) {
+        for (long mapId : entry.mapIds()) {
+            MapHistory history = histories.get(mapId);
+            Deque<HistoryEntry> stack = history == null ? null : undo ? history.undo : history.redo;
+            if (stack == null || stack.peekLast() != entry) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void recordEntry(HistoryEntry entry) {
+        for (long mapId : entry.mapIds()) {
+            clearRedoForMap(mapId);
+        }
+        for (long mapId : entry.mapIds()) {
+            MapHistory history = histories.computeIfAbsent(mapId, ignored -> new MapHistory());
+            history.undo.addLast(entry);
+        }
+        recalculateAll();
+        trimAll();
+    }
+
+    private void clearRedoForMap(long mapId) {
+        MapHistory history = histories.get(mapId);
+        if (history == null) {
+            return;
+        }
+        for (HistoryEntry entry : Set.copyOf(history.redo)) {
+            removeFromAll(entry, false);
         }
     }
 
-    private MapHistory history(DungeonMap current) {
-        return current == null ? null : histories.get(current.metadata().mapId().value());
+    private void trimAll() {
+        boolean trimmed;
+        do {
+            trimmed = false;
+            for (MapHistory history : histories.values()) {
+                if (history.undo.size() > MAXIMUM_COMMANDS
+                        || history.estimatedBytes > MAXIMUM_ESTIMATED_BYTES) {
+                    HistoryEntry oldest = history.undo.peekFirst();
+                    if (oldest != null) {
+                        removeFromAll(oldest, true);
+                        recalculateAll();
+                        trimmed = true;
+                        break;
+                    }
+                }
+            }
+        } while (trimmed);
+    }
+
+    private void removeFromAll(HistoryEntry entry, boolean undo) {
+        for (long mapId : entry.mapIds()) {
+            MapHistory history = histories.get(mapId);
+            if (history != null) {
+                (undo ? history.undo : history.redo).remove(entry);
+            }
+        }
+    }
+
+    private void recalculateAll() {
+        for (MapHistory history : histories.values()) {
+            history.estimatedBytes = history.undo.stream().mapToLong(HistoryEntry::encodedBytes).sum()
+                    + history.redo.stream().mapToLong(HistoryEntry::encodedBytes).sum();
+        }
     }
 
     private static long estimatedBytes(DungeonMap before, DungeonMap after) {
@@ -82,24 +185,110 @@ final class DungeonEditHistory {
         return Math.max(4_096L, structuralObjects * 512L);
     }
 
-    private record Change(DungeonMap before, DungeonMap after, long estimatedBytes) {
+    record Step(@Nullable HistoryEntry entry, boolean undo) {
+        static Step empty() {
+            return new Step(null, false);
+        }
+
+        boolean present() {
+            return entry != null;
+        }
+
+        Set<Long> mapIds() {
+            return entry == null ? Set.of() : entry.mapIds();
+        }
+
+        Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps) {
+            if (entry == null) {
+                return Map.of();
+            }
+            return entry.applyTo(currentMaps, undo);
+        }
+    }
+
+    private sealed interface HistoryEntry permits SnapshotEntry, PatchEntry, CompoundPatchEntry {
+        Set<Long> mapIds();
+
+        long encodedBytes();
+
+        Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo);
+    }
+
+    private record SnapshotEntry(DungeonMap before, DungeonMap after, long encodedBytes)
+            implements HistoryEntry {
+        @Override
+        public Set<Long> mapIds() {
+            return Set.of(after.metadata().mapId().value());
+        }
+
+        @Override
+        public Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo) {
+            long mapId = after.metadata().mapId().value();
+            DungeonMap current = requiredMap(currentMaps, mapId);
+            DungeonMap target = undo ? before : after;
+            return Map.of(mapId, DungeonMapAuthoring.restoreContent(target, current.revision() + 1L));
+        }
+    }
+
+    private record PatchEntry(DungeonPatch forward, DungeonPatch inverse) implements HistoryEntry {
+        @Override
+        public Set<Long> mapIds() {
+            return Set.of(forward.mapId().value());
+        }
+
+        @Override
+        public long encodedBytes() {
+            return forward.encodedBytes() + inverse.encodedBytes();
+        }
+
+        @Override
+        public Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo) {
+            long mapId = forward.mapId().value();
+            DungeonMap current = requiredMap(currentMaps, mapId);
+            DungeonPatch selected = (undo ? inverse : forward).rebased(current.revision());
+            return Map.of(mapId, selected.applyTo(current));
+        }
+    }
+
+    private record CompoundPatchEntry(DungeonCompoundPatch forward, DungeonCompoundPatch inverse)
+            implements HistoryEntry {
+        @Override
+        public Set<Long> mapIds() {
+            Set<Long> result = new LinkedHashSet<>();
+            for (DungeonPatch patch : forward.patches()) {
+                result.add(patch.mapId().value());
+            }
+            return Set.copyOf(result);
+        }
+
+        @Override
+        public long encodedBytes() {
+            return forward.encodedBytes() + inverse.encodedBytes();
+        }
+
+        @Override
+        public Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo) {
+            Map<DungeonMapIdentity, Long> revisions = new LinkedHashMap<>();
+            for (long mapId : mapIds()) {
+                DungeonMap current = requiredMap(currentMaps, mapId);
+                revisions.put(current.metadata().mapId(), current.revision());
+            }
+            DungeonCompoundPatch selected = (undo ? inverse : forward).rebased(revisions);
+            return selected.applyTo(currentMaps);
+        }
+    }
+
+    private static DungeonMap requiredMap(Map<Long, DungeonMap> maps, long mapId) {
+        DungeonMap map = maps == null ? null : maps.get(mapId);
+        if (map == null) {
+            throw new IllegalArgumentException("history step requires every affected map");
+        }
+        return map;
     }
 
     private static final class MapHistory {
-        private final Deque<Change> undo = new ArrayDeque<>();
-        private final Deque<Change> redo = new ArrayDeque<>();
+        private final Deque<HistoryEntry> undo = new ArrayDeque<>();
+        private final Deque<HistoryEntry> redo = new ArrayDeque<>();
         private long estimatedBytes;
-
-        private void recalculateBytes() {
-            estimatedBytes = undo.stream().mapToLong(Change::estimatedBytes).sum()
-                    + redo.stream().mapToLong(Change::estimatedBytes).sum();
-        }
-
-        private void trim() {
-            while (undo.size() > MAXIMUM_COMMANDS || estimatedBytes > MAXIMUM_ESTIMATED_BYTES) {
-                Change removed = undo.removeFirst();
-                estimatedBytes -= removed.estimatedBytes();
-            }
-        }
     }
 }

--- a/features/dungeon/application/authored/command/CreateTransitionCommand.java
+++ b/features/dungeon/application/authored/command/CreateTransitionCommand.java
@@ -1,0 +1,46 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.transition.Transition;
+import features.dungeon.domain.core.structure.transition.TransitionAnchor;
+import features.dungeon.domain.core.structure.transition.TransitionDestination;
+import java.util.List;
+
+/** Plans creation of one stable authored transition. */
+public final class CreateTransitionCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long transitionId,
+            TransitionAnchor anchor,
+            TransitionDestination destination
+    ) {
+        if (current == null || transitionId <= 0L || anchor == null || destination == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (current.transitionCatalog().transition(transitionId) != null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (!current.transitionCatalog().canCreate(anchor, destination)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION);
+        }
+        Transition transition = new Transition(
+                transitionId,
+                current.metadata().mapId().value(),
+                "",
+                anchor,
+                destination,
+                null);
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new TransitionChange(null, transition))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/DeleteTransitionCommand.java
+++ b/features/dungeon/application/authored/command/DeleteTransitionCommand.java
@@ -1,0 +1,33 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.transition.Transition;
+import java.util.List;
+
+/** Plans deletion of one unreferenced authored transition. */
+public final class DeleteTransitionCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long transitionId) {
+        if (current == null || transitionId <= 0L) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        Transition transition = current.transitionCatalog().transition(transitionId);
+        if (transition == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        if (!current.transitionCatalog().canDelete(transitionId)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new TransitionChange(transition, null))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonCompoundCommandResult.java
+++ b/features/dungeon/application/authored/command/DungeonCompoundCommandResult.java
@@ -1,0 +1,39 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import java.util.Objects;
+
+/** Typed result for an authored command that may require or mutate multiple maps. */
+public sealed interface DungeonCompoundCommandResult {
+
+    record Rejected(DungeonEditorCommandOutcome.RejectionReason reason)
+            implements DungeonCompoundCommandResult {
+        public Rejected {
+            reason = reason == null ? DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET : reason;
+        }
+    }
+
+    record RequiresMap(long mapId) implements DungeonCompoundCommandResult {
+        public RequiresMap {
+            if (mapId <= 0L) {
+                throw new IllegalArgumentException("required map id must be positive");
+            }
+        }
+    }
+
+    record Accepted(DungeonCompoundPatch patch, DungeonCompoundPatch inverse)
+            implements DungeonCompoundCommandResult {
+        public Accepted {
+            patch = Objects.requireNonNull(patch, "patch");
+            inverse = Objects.requireNonNull(inverse, "inverse");
+            if (!inverse.equals(patch.inverse())) {
+                throw new IllegalArgumentException("accepted compound command requires the exact inverse");
+            }
+        }
+
+        public static Accepted from(DungeonCompoundPatch patch) {
+            DungeonCompoundPatch safePatch = Objects.requireNonNull(patch, "patch");
+            return new Accepted(safePatch, safePatch.inverse());
+        }
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonCompoundPatch.java
+++ b/features/dungeon/application/authored/command/DungeonCompoundPatch.java
@@ -1,0 +1,143 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** One atomic authored command spanning one or more revisioned Dungeon maps. */
+public record DungeonCompoundPatch(
+        List<DungeonPatch> patches,
+        Set<DungeonChunkKey> touchedChunks,
+        Map<DungeonMapIdentity, DungeonPatchResultFacts> resultFactsByMap,
+        long encodedBytes
+) {
+
+    public DungeonCompoundPatch {
+        patches = patches == null ? List.of() : List.copyOf(patches);
+        if (patches.isEmpty() || patches.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("a compound patch requires at least one map patch");
+        }
+        Map<DungeonMapIdentity, DungeonPatch> uniquePatches = patchesByMap(patches);
+        if (uniquePatches.size() != patches.size()) {
+            throw new IllegalArgumentException("a compound patch may contain only one patch per map");
+        }
+        Set<DungeonChunkKey> derivedChunks = derivedChunks(patches);
+        touchedChunks = touchedChunks == null ? derivedChunks : Set.copyOf(touchedChunks);
+        if (!touchedChunks.equals(derivedChunks)) {
+            throw new IllegalArgumentException("compound touched chunks must match its map patches");
+        }
+        Map<DungeonMapIdentity, DungeonPatchResultFacts> derivedFacts = derivedFacts(patches);
+        resultFactsByMap = resultFactsByMap == null ? derivedFacts : Map.copyOf(resultFactsByMap);
+        if (!resultFactsByMap.equals(derivedFacts)) {
+            throw new IllegalArgumentException("compound result facts must match its map patches");
+        }
+        long derivedBytes = derivedBytes(patches);
+        encodedBytes = encodedBytes <= 0L ? derivedBytes : encodedBytes;
+        if (encodedBytes != derivedBytes) {
+            throw new IllegalArgumentException("compound byte weight must match its map patches");
+        }
+    }
+
+    public static DungeonCompoundPatch of(List<DungeonPatch> patches) {
+        List<DungeonPatch> safePatches = patches == null ? List.of() : List.copyOf(patches);
+        return new DungeonCompoundPatch(
+                safePatches,
+                derivedChunks(safePatches),
+                derivedFacts(safePatches),
+                derivedBytes(safePatches));
+    }
+
+    public DungeonCompoundPatch inverse() {
+        return of(patches.stream().map(DungeonPatch::inverse).toList());
+    }
+
+    public DungeonCompoundPatch rebased(Map<DungeonMapIdentity, Long> expectedRevisions) {
+        Map<DungeonMapIdentity, Long> safeRevisions = expectedRevisions == null
+                ? Map.of()
+                : Map.copyOf(expectedRevisions);
+        return of(patches.stream()
+                .map(patch -> patch.rebased(requiredRevision(safeRevisions, patch.mapId())))
+                .toList());
+    }
+
+    public Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps) {
+        Map<Long, DungeonMap> safeCurrentMaps = currentMaps == null ? Map.of() : currentMaps;
+        Map<Long, DungeonMap> result = new LinkedHashMap<>();
+        for (DungeonPatch patch : patches) {
+            long mapId = patch.mapId().value();
+            DungeonMap current = safeCurrentMaps.get(mapId);
+            if (current == null) {
+                throw new IllegalArgumentException("compound patch requires every affected map");
+            }
+            result.put(mapId, patch.applyTo(current));
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(result));
+    }
+
+    @Override
+    public List<DungeonPatch> patches() {
+        return List.copyOf(patches);
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        return Set.copyOf(touchedChunks);
+    }
+
+    @Override
+    public Map<DungeonMapIdentity, DungeonPatchResultFacts> resultFactsByMap() {
+        return Map.copyOf(resultFactsByMap);
+    }
+
+    private static long requiredRevision(Map<DungeonMapIdentity, Long> revisions, DungeonMapIdentity mapId) {
+        Long revision = revisions.get(mapId);
+        if (revision == null) {
+            throw new IllegalArgumentException("compound rebase requires every affected map revision");
+        }
+        return revision;
+    }
+
+    private static Map<DungeonMapIdentity, DungeonPatch> patchesByMap(List<DungeonPatch> patches) {
+        Map<DungeonMapIdentity, DungeonPatch> result = new LinkedHashMap<>();
+        for (DungeonPatch patch : patches) {
+            if (patch != null) {
+                result.put(patch.mapId(), patch);
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+    private static Set<DungeonChunkKey> derivedChunks(List<DungeonPatch> patches) {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        for (DungeonPatch patch : patches) {
+            if (patch != null) {
+                result.addAll(patch.touchedChunks());
+            }
+        }
+        return Set.copyOf(result);
+    }
+
+    private static Map<DungeonMapIdentity, DungeonPatchResultFacts> derivedFacts(List<DungeonPatch> patches) {
+        Map<DungeonMapIdentity, DungeonPatchResultFacts> result = new LinkedHashMap<>();
+        for (DungeonPatch patch : patches) {
+            if (patch != null) {
+                result.put(patch.mapId(), patch.resultFacts());
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+    private static long derivedBytes(List<DungeonPatch> patches) {
+        return Math.max(1L, patches.stream()
+                .filter(Objects::nonNull)
+                .mapToLong(DungeonPatch::encodedBytes)
+                .sum());
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatch.java
+++ b/features/dungeon/application/authored/command/DungeonPatch.java
@@ -94,6 +94,8 @@ public record DungeonPatch(
                         roomClusterChange.before(), roomClusterChange.after());
                 case StairChange stairChange -> changed.withExactStairChange(
                         stairChange.before(), stairChange.after());
+                case TransitionChange transitionChange -> changed.withExactTransitionChange(
+                        transitionChange.before(), transitionChange.after());
             };
         }
         if (changed.equals(safeCurrent)) {

--- a/features/dungeon/application/authored/command/DungeonPatchChange.java
+++ b/features/dungeon/application/authored/command/DungeonPatchChange.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 /** One stable-identity authored entity delta carried by a Dungeon patch. */
 public sealed interface DungeonPatchChange permits FeatureMarkerChange, RoomRegionChange, RoomClusterChange,
-        StairChange {
+        StairChange, TransitionChange {
 
     DungeonMapIdentity mapId();
 

--- a/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
+++ b/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
@@ -19,6 +19,7 @@ public record DungeonPatchEntityRef(
             case ROOM -> DungeonTopologyElementKind.ROOM;
             case FEATURE_MARKER -> DungeonTopologyElementKind.FEATURE_MARKER;
             case STAIR -> DungeonTopologyElementKind.STAIR;
+            case TRANSITION -> DungeonTopologyElementKind.TRANSITION;
             case ROOM_CLUSTER -> null;
         };
         if (expectedTopologyKind == null && topologyRef != null) {
@@ -57,10 +58,18 @@ public record DungeonPatchEntityRef(
                 new DungeonTopologyRef(DungeonTopologyElementKind.STAIR, stairId));
     }
 
+    public static DungeonPatchEntityRef transition(long transitionId) {
+        return new DungeonPatchEntityRef(
+                Kind.TRANSITION,
+                transitionId,
+                new DungeonTopologyRef(DungeonTopologyElementKind.TRANSITION, transitionId));
+    }
+
     public enum Kind {
         ROOM,
         ROOM_CLUSTER,
         FEATURE_MARKER,
-        STAIR
+        STAIR,
+        TRANSITION
     }
 }

--- a/features/dungeon/application/authored/command/TransitionChange.java
+++ b/features/dungeon/application/authored/command/TransitionChange.java
@@ -1,0 +1,80 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.transition.Transition;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Exact before/after delta for one stable authored transition. */
+public record TransitionChange(Transition before, Transition after) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 128L;
+
+    public TransitionChange {
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a transition change requires before or after state");
+        }
+        if (before != null && after != null) {
+            if (before.equals(after)) {
+                throw new IllegalArgumentException("a transition change requires distinct before and after state");
+            }
+            if (before.transitionId() != after.transitionId() || before.mapId() != after.mapId()) {
+                throw new IllegalArgumentException("transition identity must remain stable");
+            }
+        }
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return new DungeonMapIdentity(state().mapId());
+    }
+
+    @Override
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.transition(state().transitionId());
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addChunk(result, before);
+        addChunk(result, after);
+        return Set.copyOf(result);
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES + encodedBytes(before) + encodedBytes(after);
+    }
+
+    @Override
+    public TransitionChange inverse() {
+        return new TransitionChange(after, before);
+    }
+
+    private Transition state() {
+        return after == null ? before : after;
+    }
+
+    private static void addChunk(Set<DungeonChunkKey> result, Transition transition) {
+        if (transition == null) {
+            return;
+        }
+        Cell anchor = transition.anchorCell();
+        if (anchor != null) {
+            result.add(new DungeonChunkKey(
+                    transition.mapId(),
+                    anchor.level(),
+                    Math.floorDiv(anchor.q(), DungeonChunkKey.CHUNK_SIZE),
+                    Math.floorDiv(anchor.r(), DungeonChunkKey.CHUNK_SIZE)));
+        }
+    }
+
+    private static long encodedBytes(Transition transition) {
+        return transition == null
+                ? 1L
+                : transition.description().getBytes(StandardCharsets.UTF_8).length + 64L;
+    }
+}

--- a/features/dungeon/application/authored/command/TransitionDescriptionCommand.java
+++ b/features/dungeon/application/authored/command/TransitionDescriptionCommand.java
@@ -1,0 +1,34 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.transition.Transition;
+import java.util.List;
+
+/** Plans one exact authored transition-description patch. */
+public final class TransitionDescriptionCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, long transitionId, String description) {
+        if (current == null || transitionId <= 0L) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        Transition before = current.transitionCatalog().transition(transitionId);
+        if (before == null) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        Transition after = before.withDescription(description);
+        if (after.equals(before)) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCommandResult.Accepted.from(DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new TransitionChange(before, after))));
+    }
+
+    private static DungeonCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/application/authored/command/TransitionLinkCommand.java
+++ b/features/dungeon/application/authored/command/TransitionLinkCommand.java
@@ -1,0 +1,117 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.transition.Transition;
+import features.dungeon.domain.core.structure.transition.TransitionCatalog;
+import features.dungeon.domain.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkMap;
+import features.dungeon.domain.core.structure.transition.TransitionCatalog.AuthoredTransitionLinkRewrite;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+
+/** Plans one exact atomic transition-link command across its loaded map closure. */
+public final class TransitionLinkCommand {
+
+    public DungeonCompoundCommandResult plan(
+            Collection<DungeonMap> loadedMaps,
+            long sourceMapId,
+            long sourceTransitionId,
+            long targetMapId,
+            long targetTransitionId,
+            boolean bidirectional,
+            Set<Long> knownMissingMapIds
+    ) {
+        Map<Long, DungeonMap> mapsById = mapsById(loadedMaps);
+        AuthoredTransitionLinkRewrite rewrite = TransitionCatalog.authoredTransitionLinkRewrite(
+                catalogMaps(mapsById.values()),
+                sourceMapId,
+                sourceTransitionId,
+                targetMapId,
+                targetTransitionId,
+                bidirectional);
+        OptionalLong requestedMapId = rewrite.requestedMapId();
+        if (requestedMapId.isPresent()) {
+            long requiredMapId = requestedMapId.orElseThrow();
+            if (knownMissingMapIds == null || !knownMissingMapIds.contains(requiredMapId)) {
+                return new DungeonCompoundCommandResult.RequiresMap(requiredMapId);
+            }
+            rewrite = rewrite.acceptMissingRequestedMap();
+        }
+        if (!rewrite.accepted()) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION);
+        }
+        List<DungeonPatch> patches = new ArrayList<>();
+        for (DungeonMap map : mapsById.values()) {
+            TransitionCatalog nextCatalog = rewrite.catalogFor(
+                    map.metadata().mapId().value(),
+                    map.transitionCatalog());
+            List<DungeonPatchChange> changes = transitionChanges(map.transitionCatalog(), nextCatalog);
+            if (!changes.isEmpty()) {
+                patches.add(DungeonPatch.of(map.metadata().mapId(), map.revision(), changes));
+            }
+        }
+        if (patches.isEmpty()) {
+            return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+        }
+        return DungeonCompoundCommandResult.Accepted.from(DungeonCompoundPatch.of(patches));
+    }
+
+    private static List<DungeonPatchChange> transitionChanges(
+            TransitionCatalog before,
+            TransitionCatalog after
+    ) {
+        Map<Long, Transition> afterById = transitionsById(after.transitions());
+        List<DungeonPatchChange> result = new ArrayList<>();
+        for (Transition transition : before.transitions()) {
+            Transition next = afterById.remove(transition.transitionId());
+            if (!transition.equals(next)) {
+                result.add(new TransitionChange(transition, next));
+            }
+        }
+        for (Transition transition : after.transitions()) {
+            if (afterById.containsKey(transition.transitionId())) {
+                result.add(new TransitionChange(null, transition));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static Map<Long, Transition> transitionsById(List<Transition> transitions) {
+        Map<Long, Transition> result = new LinkedHashMap<>();
+        for (Transition transition : transitions) {
+            result.put(transition.transitionId(), transition);
+        }
+        return result;
+    }
+
+    private static Map<Long, DungeonMap> mapsById(Collection<DungeonMap> maps) {
+        Map<Long, DungeonMap> result = new LinkedHashMap<>();
+        for (DungeonMap map : maps == null ? List.<DungeonMap>of() : maps) {
+            if (map != null) {
+                result.put(map.metadata().mapId().value(), map);
+            }
+        }
+        return result;
+    }
+
+    private static List<AuthoredTransitionLinkMap> catalogMaps(Collection<DungeonMap> maps) {
+        List<AuthoredTransitionLinkMap> result = new ArrayList<>();
+        for (DungeonMap map : maps) {
+            result.add(new AuthoredTransitionLinkMap(
+                    map.metadata().mapId().value(),
+                    map.transitionCatalog()));
+        }
+        return List.copyOf(result);
+    }
+
+    private static DungeonCompoundCommandResult.Rejected rejected(
+            DungeonEditorCommandOutcome.RejectionReason reason
+    ) {
+        return new DungeonCompoundCommandResult.Rejected(reason);
+    }
+}

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -19,6 +19,7 @@ import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
 import features.dungeon.domain.core.structure.topology.DungeonMapTopology;
 import features.dungeon.domain.core.structure.topology.SpatialTopology;
 import features.dungeon.domain.core.structure.transition.TransitionCatalog;
+import features.dungeon.domain.core.structure.transition.Transition;
 
 /**
  * Canonical aggregate root state for one authored dungeon map.
@@ -34,8 +35,6 @@ public record DungeonMap(
         FeatureMarkerCatalog featureMarkers,
         long revision
 ) {
-    private static final long NO_TRANSITION_ID = 0L;
-
     public DungeonMap(
             DungeonMapMetadata metadata,
             SpatialTopology topology,
@@ -188,27 +187,6 @@ public record DungeonMap(
         return ROOM_AUTHORING.moveBoundaryStretch(this, clusterId, sourceEdges, deltaQ, deltaR, deltaLevel);
     }
 
-    public DungeonMap saveTransitionDescription(long transitionId, String description) {
-        if (transitionId <= NO_TRANSITION_ID) {
-            return this;
-        }
-        TransitionCatalog nextTransitions = transitionCatalog.withDescription(transitionId, description);
-        return nextTransitions.equals(transitionCatalog)
-                ? this
-                : withTransitionCatalog(nextTransitions, topologyIndex);
-    }
-
-    public boolean canDeleteTransition(long transitionId) {
-        return transitionCatalog.canDelete(transitionId);
-    }
-
-    public DungeonMap deleteTransition(long transitionId) {
-        if (!canDeleteTransition(transitionId)) {
-            return this;
-        }
-        return withTransitionCatalog(transitionCatalog.withoutTransition(transitionId), null);
-    }
-
     public long nextFeatureMarkerId() {
         return featureMarkers.nextMarkerId();
     }
@@ -338,6 +316,13 @@ public record DungeonMap(
                 transitionCatalog,
                 featureMarkers,
                 revision + 1L);
+    }
+
+    public DungeonMap withExactTransitionChange(
+            @Nullable Transition before,
+            @Nullable Transition after
+    ) {
+        return withTransitionCatalog(transitionCatalog.withExactChange(before, after), null);
     }
 
     public DungeonMap withTransitionCatalog(TransitionCatalog nextTransitions) {

--- a/features/dungeon/domain/core/structure/transition/TransitionCatalog.java
+++ b/features/dungeon/domain/core/structure/transition/TransitionCatalog.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.OptionalLong;
 import org.jspecify.annotations.Nullable;
 
@@ -26,31 +27,16 @@ public record TransitionCatalog(List<Transition> transitions) {
         return safeAnchor.isPlaced() && destination != null && destination.isValid();
     }
 
-    public TransitionCatalog withCreated(
-            long transitionId,
-            long mapId,
-            @Nullable TransitionAnchor anchor,
-            @Nullable TransitionDestination destination
-    ) {
-        if (!canCreate(anchor, destination)) {
-            return this;
-        }
-        TransitionAnchor safeAnchor = anchor == null ? TransitionAnchor.none() : anchor;
-        List<Transition> result = new ArrayList<>(transitions);
-        result.add(new Transition(transitionId, mapId, "", safeAnchor, destination, null));
-        return new TransitionCatalog(result);
-    }
-
     public boolean canDelete(long transitionId) {
-        return transitionById(transitionId) != null && !protectedTransition(transitionId);
+        return transition(transitionId) != null && !protectedTransition(transitionId);
     }
 
     public boolean containsTransition(long transitionId) {
-        return transitionById(transitionId) != null;
+        return transition(transitionId) != null;
     }
 
     public @Nullable TransitionDestination destinationByTransitionId(long transitionId) {
-        Transition transition = transitionById(transitionId);
+        Transition transition = transition(transitionId);
         return transition == null ? null : transition.destination();
     }
 
@@ -69,35 +55,6 @@ public record TransitionCatalog(List<Transition> transitions) {
                 targetTransitionId,
                 bidirectional);
         return new AuthoredTransitionLinkRewritePlanner(loadedMaps).rewrite(link);
-    }
-
-    public TransitionCatalog withoutTransition(long transitionId) {
-        if (!canDelete(transitionId)) {
-            return this;
-        }
-        List<Transition> result = new ArrayList<>();
-        for (Transition transition : transitions) {
-            if (transition.transitionId() != transitionId) {
-                result.add(transition);
-            }
-        }
-        return new TransitionCatalog(result);
-    }
-
-    public TransitionCatalog withDescription(long transitionId, String description) {
-        if (transitionId <= NO_TRANSITION_ID) {
-            return this;
-        }
-        List<Transition> result = new ArrayList<>();
-        boolean changed = false;
-        for (Transition transition : transitions) {
-            Transition nextTransition = transition.transitionId() == transitionId
-                    ? transition.withDescription(description)
-                    : transition;
-            result.add(nextTransition);
-            changed = changed || !nextTransition.equals(transition);
-        }
-        return changed ? new TransitionCatalog(result) : this;
     }
 
     public TransitionCatalog withMapLocalAuthoredTransitionLink(AuthoredTransitionLink link) {
@@ -176,7 +133,7 @@ public record TransitionCatalog(List<Transition> transitions) {
         return false;
     }
 
-    private @Nullable Transition transitionById(long transitionId) {
+    public @Nullable Transition transition(long transitionId) {
         if (transitionId <= NO_TRANSITION_ID) {
             return null;
         }
@@ -186,6 +143,33 @@ public record TransitionCatalog(List<Transition> transitions) {
             }
         }
         return null;
+    }
+
+    public TransitionCatalog withExactChange(
+            @Nullable Transition before,
+            @Nullable Transition after
+    ) {
+        Transition identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("transition change requires identity");
+        }
+        if (!Objects.equals(transition(identity.transitionId()), before)) {
+            throw new IllegalStateException("transition patch does not match current authored truth");
+        }
+        List<Transition> nextTransitions = new ArrayList<>();
+        for (Transition transition : transitions) {
+            if (transition.transitionId() == identity.transitionId()) {
+                if (after != null) {
+                    nextTransitions.add(after);
+                }
+            } else {
+                nextTransitions.add(transition);
+            }
+        }
+        if (before == null && after != null) {
+            nextTransitions.add(after);
+        }
+        return new TransitionCatalog(nextTransitions);
     }
 
     private static List<Transition> nonNullTransitions(List<Transition> source) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProjectionInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProjectionInvariantScenarios.java
@@ -22,6 +22,7 @@ import features.dungeon.domain.core.projection.DungeonDerivedState;
 import features.dungeon.domain.core.projection.DungeonDerivedStateProjection;
 import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.transition.Transition;
 import features.dungeon.domain.core.structure.transition.TransitionDestination;
 import features.dungeon.domain.core.structure.transition.TransitionDestinationTarget;
 import features.dungeon.application.travel.projection.TravelActionFacts;
@@ -172,11 +173,13 @@ final class DungeonRuntimeProjectionInvariantScenarios {
     private static void assertRuntimeTransitionProjection() {
         Cell anchor = new Cell(2, 0, 0);
         DungeonMap emptyMap = DungeonMapAuthoring.empty(new DungeonMapIdentity(4L), "Runtime Transitions");
-        DungeonMap map = emptyMap.withTransitionCatalog(emptyMap.transitionCatalog().withCreated(
+        DungeonMap map = withTransition(emptyMap, new Transition(
                 40L,
                 emptyMap.metadata().mapId().value(),
+                "",
                 TransitionAnchor.cell(anchor),
-                TransitionDestination.dungeonMap(9L, 12L)));
+                TransitionDestination.dungeonMap(9L, 12L),
+                null));
         DungeonDerivedState derived = derivedState(
                 List.of(area(DungeonAreaType.ROOM, 11L, "Portalraum", List.of(anchor))),
                 List.of());
@@ -198,11 +201,13 @@ final class DungeonRuntimeProjectionInvariantScenarios {
                 transition.transitionTarget(),
                 "runtime transition projection recomputes transition target from authored destination facts");
 
-        DungeonMap unlinkedMap = emptyMap.withTransitionCatalog(emptyMap.transitionCatalog().withCreated(
+        DungeonMap unlinkedMap = withTransition(emptyMap, new Transition(
                 41L,
                 emptyMap.metadata().mapId().value(),
+                "",
                 TransitionAnchor.cell(anchor),
-                TransitionDestination.unlinkedEntrance()));
+                TransitionDestination.unlinkedEntrance(),
+                null));
         TravelSurfaceFacts unlinkedSurface = project(unlinkedMap, derived, new Cell(2, 0, 0));
         TravelActionFacts unlinkedTransition = firstActionOfKind(unlinkedSurface, TravelActionKind.TRANSITION);
         assertTrue(unlinkedTransition != null, "runtime transition projection publishes unlinked entrance action");
@@ -473,11 +478,7 @@ final class DungeonRuntimeProjectionInvariantScenarios {
     ) {
         DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), mapName);
         for (features.dungeon.domain.core.structure.transition.Transition transition : transitions) {
-            map = map.withTransitionCatalog(map.transitionCatalog().withCreated(
-                    transition.transitionId(),
-                    map.metadata().mapId().value(),
-                    transition.anchor(),
-                    transition.destination()));
+            map = withTransition(map, transition);
         }
         return TravelAuthoredSurfaceProjectionMapper.from(map, derivedState(areas, List.of()));
     }
@@ -514,11 +515,17 @@ final class DungeonRuntimeProjectionInvariantScenarios {
         if (transitionAnchor == null || transitionId <= 0L) {
             return map;
         }
-        return map.withTransitionCatalog(map.transitionCatalog().withCreated(
+        return withTransition(map, new Transition(
                 transitionId,
                 mapId,
+                "",
                 TransitionAnchor.cell(transitionAnchor),
-                TransitionDestination.dungeonMap(99L, 7L)));
+                TransitionDestination.dungeonMap(99L, 7L),
+                null));
+    }
+
+    private static DungeonMap withTransition(DungeonMap map, Transition transition) {
+        return map.withExactTransitionChange(null, transition);
     }
 
     private static DungeonMapRepository repositoryOf(DungeonMap firstMap, DungeonMap secondMap) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonStructureInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonStructureInvariantScenarios.java
@@ -855,11 +855,13 @@ final class DungeonStructureInvariantScenarios {
                         null);
         features.dungeon.domain.core.structure.DungeonMap map = transitionMap(source, oldTarget, target, remoteReference);
 
-        assertFalse(map.canDeleteTransition(1L),
+        assertFalse(map.transitionCatalog().canDelete(1L),
                 "core transition ownership preserves source reverse-link delete protection");
-        assertFalse(map.canDeleteTransition(3L),
+        assertFalse(map.transitionCatalog().canDelete(3L),
                 "core transition ownership preserves referenced-transition delete protection");
-        assertEquals(List.of(1L, 2L, 3L), transitionIds(map.deleteTransition(4L).transitionCatalog().transitions()),
+        assertEquals(List.of(1L, 2L, 3L), transitionIds(map.withExactTransitionChange(
+                        map.transitionCatalog().transition(4L),
+                        null).transitionCatalog().transitions()),
                 "core transition ownership removes deletable transition through core catalog");
         features.dungeon.domain.core.structure.DungeonMap linkedMap =
                 map.withTransitionCatalog(map.transitionCatalog().withMapLocalAuthoredTransitionLink(

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTopologyInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTopologyInvariantScenarios.java
@@ -170,7 +170,10 @@ final class DungeonTopologyInvariantScenarios {
         assertPresent(map, linkedRef, "linked transition topology identity is published after create");
         assertPresent(map, deletableRef, "deletable transition topology identity is published after create");
 
-        DungeonMap described = map.saveTransitionDescription(40L, "A linked passage.");
+        Transition beforeDescription = transitionById(map, 40L);
+        DungeonMap described = map.withExactTransitionChange(
+                beforeDescription,
+                beforeDescription.withDescription("A linked passage."));
         assertEquals(
                 "A linked passage.",
                 transitionById(described, 40L).description(),
@@ -193,10 +196,14 @@ final class DungeonTopologyInvariantScenarios {
         assertPresent(linked, firstRef, "transition topology identity survives link source update");
         assertPresent(linked, linkedRef, "transition topology identity survives link target update");
 
-        DungeonMap rejectedDelete = linked.deleteTransition(40L);
+        if (linked.transitionCatalog().canDelete(40L)) {
+            throw new IllegalStateException("transition topology identity rejects protected delete");
+        }
+        DungeonMap rejectedDelete = linked;
         assertPresent(rejectedDelete, firstRef, "transition topology identity survives protected delete reject");
 
-        DungeonMap deleted = rejectedDelete.deleteTransition(42L);
+        Transition deletable = transitionById(rejectedDelete, 42L);
+        DungeonMap deleted = rejectedDelete.withExactTransitionChange(deletable, null);
         assertAbsent(deleted, deletableRef, "transition topology identity is released after successful delete");
         assertPresent(deleted, firstRef, "unrelated transition topology identity survives another transition delete");
     }
@@ -256,11 +263,14 @@ final class DungeonTopologyInvariantScenarios {
             Cell anchor,
             TransitionDestination destination
     ) {
-        return map.withTransitionCatalog(map.transitionCatalog().withCreated(
+        Transition transition = new Transition(
                 transitionId,
                 map.metadata().mapId().value(),
+                "",
                 TransitionAnchor.cell(anchor),
-                destination));
+                destination,
+                null);
+        return map.withExactTransitionChange(null, transition);
     }
 
     private static Transition transitionById(DungeonMap map, long transitionId) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
@@ -227,6 +227,28 @@ final class DungeonTransitionInvariantScenarios {
                 "transition link use case still writes target reverse link when previous map is missing");
         assertFalse(repository.savedMapIds().contains(missingPreviousMapId),
                 "transition link use case cannot mutate a missing previous map");
+
+        DungeonAuthoredApplicationService.Session authoredSession = services.authored().openSession(dungeonState);
+        assertTrue(services.authored().canUndo(new MapId(sourceMapId)),
+                "compound transition link is available as one source-map undo step");
+        services.authored().undo(new MapId(sourceMapId), authoredSession);
+        assertEquals(
+                TransitionDestination.dungeonMap(missingPreviousMapId, missingPreviousTransitionId),
+                transitionById(repository.savedMap(sourceMapId), sourceTransitionId).destination(),
+                "compound undo restores the source destination");
+        assertEquals(null,
+                transitionById(repository.savedMap(targetMapId), targetTransitionId).linkedTransitionId(),
+                "compound undo restores the target reverse link atomically");
+        assertTrue(services.authored().canRedo(new MapId(targetMapId)),
+                "compound transition link is available as one target-map redo step");
+        services.authored().redo(new MapId(targetMapId), authoredSession);
+        assertEquals(
+                TransitionDestination.dungeonMap(targetMapId, targetTransitionId),
+                transitionById(repository.savedMap(sourceMapId), sourceTransitionId).destination(),
+                "compound redo reapplies the source destination");
+        assertEquals(sourceTransitionId,
+                transitionById(repository.savedMap(targetMapId), targetTransitionId).linkedTransitionId(),
+                "compound redo reapplies the target reverse link atomically");
     }
 
     private static void assertProtectedDeletePolicy() {
@@ -247,10 +269,8 @@ final class DungeonTransitionInvariantScenarios {
         assertFalse(catalog.canDelete(2L), "transition catalog rejects destination-referenced transition delete");
         assertFalse(catalog.canDelete(3L), "transition catalog rejects reverse-linked transition delete");
         assertTrue(catalog.canDelete(4L), "transition catalog allows unreferenced transition delete");
-        assertEquals(List.of(1L, 2L, 3L), transitionIds(catalog.withoutTransition(4L)),
+        assertEquals(List.of(1L, 2L, 3L), transitionIds(catalog.withExactChange(deletable, null)),
                 "transition catalog removes deletable transition");
-        assertEquals(List.of(1L, 2L, 3L, 4L), transitionIds(catalog.withoutTransition(2L)),
-                "transition catalog preserves protected transition");
     }
 
     private static Transition transition(
@@ -370,6 +390,7 @@ final class DungeonTransitionInvariantScenarios {
             savedMapsById.clear();
             for (DungeonMap dungeonMap : dungeonMaps == null ? List.<DungeonMap>of() : dungeonMaps) {
                 savedMapsById.put(dungeonMap.metadata().mapId().value(), dungeonMap);
+                mapsById.put(dungeonMap.metadata().mapId().value(), dungeonMap);
             }
             return List.copyOf(savedMapsById.values());
         }

--- a/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
+++ b/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
@@ -4,9 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import features.dungeon.application.authored.command.DungeonCompoundPatch;
+import features.dungeon.application.authored.command.DungeonPatch;
+import features.dungeon.application.authored.command.TransitionChange;
+import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.transition.Transition;
+import features.dungeon.domain.core.structure.transition.TransitionAnchor;
+import features.dungeon.domain.core.structure.transition.TransitionCatalog;
+import features.dungeon.domain.core.structure.transition.TransitionDestination;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 final class DungeonEditHistoryTest {
@@ -20,10 +30,14 @@ final class DungeonEditHistoryTest {
         history.record(before, after);
 
         assertTrue(history.canUndo(mapId));
-        assertEquals(before, history.undo(after));
+        DungeonMap undone = applyAndComplete(history, after, true);
+        assertEquals(before.metadata(), undone.metadata());
+        assertEquals(after.revision() + 1L, undone.revision());
         assertFalse(history.canUndo(mapId));
         assertTrue(history.canRedo(mapId));
-        assertEquals(after, history.redo(before));
+        DungeonMap redone = applyAndComplete(history, undone, false);
+        assertEquals(after.metadata(), redone.metadata());
+        assertEquals(undone.revision() + 1L, redone.revision());
     }
 
     @Test
@@ -34,11 +48,85 @@ final class DungeonEditHistoryTest {
         DungeonMap replacement = DungeonMapAuthoring.rename(first, "Replacement");
         DungeonEditHistory history = new DungeonEditHistory();
         history.record(first, second);
-        history.undo(second);
+        DungeonMap undone = applyAndComplete(history, second, true);
 
-        history.record(first, replacement);
+        DungeonMap committedReplacement = DungeonMapAuthoring.committedContent(
+                replacement,
+                undone.revision() + 1L);
+        history.record(undone, committedReplacement);
 
         assertFalse(history.canRedo(mapId));
-        assertEquals(first, history.undo(replacement));
+        assertEquals(first.metadata(), applyAndComplete(history, committedReplacement, true).metadata());
+    }
+
+    @Test
+    void compoundHistoryMovesEveryAffectedMapAtomically() {
+        DungeonMap source = transitionMap(11L, 1L, "Source");
+        DungeonMap target = transitionMap(12L, 2L, "Target");
+        Transition sourceBefore = source.transitionCatalog().transition(1L);
+        Transition targetBefore = target.transitionCatalog().transition(2L);
+        DungeonCompoundPatch compound = DungeonCompoundPatch.of(List.of(
+                DungeonPatch.of(
+                        source.metadata().mapId(),
+                        source.revision(),
+                        List.of(new TransitionChange(
+                                sourceBefore,
+                                sourceBefore.withDestination(TransitionDestination.dungeonMap(12L, 2L))))),
+                DungeonPatch.of(
+                        target.metadata().mapId(),
+                        target.revision(),
+                        List.of(new TransitionChange(
+                                targetBefore,
+                                targetBefore.withLinkedTransitionId(1L))))));
+        Map<Long, DungeonMap> changed = compound.applyTo(Map.of(11L, source, 12L, target));
+        DungeonEditHistory history = new DungeonEditHistory();
+        history.recordCompoundPatch(compound);
+
+        assertTrue(history.canUndo(source.metadata().mapId()));
+        assertTrue(history.canUndo(target.metadata().mapId()));
+        DungeonEditHistory.Step undo = history.peekUndo(source.metadata().mapId());
+        Map<Long, DungeonMap> restored = undo.applyTo(changed);
+        history.complete(undo);
+        assertEquals(source.transitionCatalog(), restored.get(11L).transitionCatalog());
+        assertEquals(target.transitionCatalog(), restored.get(12L).transitionCatalog());
+        assertTrue(history.canRedo(source.metadata().mapId()));
+        assertTrue(history.canRedo(target.metadata().mapId()));
+
+        DungeonEditHistory.Step redo = history.peekRedo(target.metadata().mapId());
+        Map<Long, DungeonMap> redone = redo.applyTo(restored);
+        history.complete(redo);
+        assertEquals(changed.get(11L).transitionCatalog(), redone.get(11L).transitionCatalog());
+        assertEquals(changed.get(12L).transitionCatalog(), redone.get(12L).transitionCatalog());
+
+        DungeonMap laterTarget = DungeonMapAuthoring.rename(redone.get(12L), "Later target edit");
+        history.record(redone.get(12L), laterTarget);
+        assertFalse(history.canUndo(source.metadata().mapId()));
+        assertTrue(history.canUndo(target.metadata().mapId()));
+    }
+
+    private static DungeonMap applyAndComplete(
+            DungeonEditHistory history,
+            DungeonMap current,
+            boolean undo
+    ) {
+        DungeonEditHistory.Step step = undo
+                ? history.peekUndo(current.metadata().mapId())
+                : history.peekRedo(current.metadata().mapId());
+        DungeonMap changed = step.applyTo(Map.of(current.metadata().mapId().value(), current))
+                .get(current.metadata().mapId().value());
+        history.complete(step);
+        return changed;
+    }
+
+    private static DungeonMap transitionMap(long mapId, long transitionId, String name) {
+        DungeonMap empty = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), name);
+        Transition transition = new Transition(
+                transitionId,
+                mapId,
+                "",
+                TransitionAnchor.cell(new Cell((int) transitionId, 0, 0)),
+                TransitionDestination.unlinkedEntrance(),
+                null);
+        return empty.withTransitionCatalog(new TransitionCatalog(List.of(transition)));
     }
 }

--- a/test/features/dungeon/application/authored/command/DungeonTransitionPatchCommandsTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonTransitionPatchCommandsTest.java
@@ -1,0 +1,189 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.transition.Transition;
+import features.dungeon.domain.core.structure.transition.TransitionAnchor;
+import features.dungeon.domain.core.structure.transition.TransitionCatalog;
+import features.dungeon.domain.core.structure.transition.TransitionDestination;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DungeonTransitionPatchCommandsTest {
+
+    @Test
+    void transitionCreateDescriptionAndDeleteUseExactPatches() {
+        DungeonMap empty = transitionMap(101L);
+        TransitionAnchor anchor = TransitionAnchor.cell(new Cell(-1, -2, 0));
+        TransitionDestination destination = TransitionDestination.overworldTile(500L, 9L);
+
+        DungeonCommandResult.Accepted createdResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new CreateTransitionCommand().plan(empty, 11L, anchor, destination));
+        assertEquals(
+                DungeonPatchEntityRef.transition(11L),
+                createdResult.patch().resultFacts().affectedEntities().getFirst());
+        assertEquals(Set.of(new DungeonChunkKey(101L, 0, -1, -1)), createdResult.patch().touchedChunks());
+        DungeonMap created = createdResult.patch().applyTo(empty);
+        Transition initial = created.transitionCatalog().transition(11L);
+        assertEquals(destination, initial.destination());
+        assertNull(createdResult.inverse().applyTo(created).transitionCatalog().transition(11L));
+
+        DungeonCommandResult.Accepted describedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new TransitionDescriptionCommand().plan(created, 11L, "  Alter Durchgang  "));
+        DungeonMap described = describedResult.patch().applyTo(created);
+        assertEquals("Alter Durchgang", described.transitionCatalog().transition(11L).description());
+        assertEquals(initial, describedResult.inverse().applyTo(described).transitionCatalog().transition(11L));
+
+        DungeonCommandResult.Accepted deletedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                new DeleteTransitionCommand().plan(described, 11L));
+        DungeonMap deleted = deletedResult.patch().applyTo(described);
+        assertNull(deleted.transitionCatalog().transition(11L));
+        assertEquals(
+                described.transitionCatalog().transition(11L),
+                deletedResult.inverse().applyTo(deleted).transitionCatalog().transition(11L));
+        assertThrows(IllegalArgumentException.class, () -> deletedResult.patch().applyTo(deleted));
+    }
+
+    @Test
+    void invalidCreateNoEffectAndReferencedDeleteRejectWithoutMutation() {
+        Transition target = transition(
+                12L,
+                101L,
+                new Cell(2, 2, 0),
+                TransitionDestination.overworldTile(500L, 9L),
+                null);
+        Transition source = transition(
+                11L,
+                101L,
+                new Cell(1, 1, 0),
+                TransitionDestination.dungeonMap(101L, 12L),
+                null);
+        DungeonMap current = transitionMap(101L, source, target);
+
+        DungeonCommandResult.Rejected invalidCreate = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new CreateTransitionCommand().plan(
+                        current,
+                        13L,
+                        TransitionAnchor.none(),
+                        TransitionDestination.unlinkedEntrance()));
+        DungeonCommandResult.Rejected noEffect = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new TransitionDescriptionCommand().plan(current, 11L, source.description()));
+        DungeonCommandResult.Rejected protectedDelete = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new DeleteTransitionCommand().plan(current, 12L));
+
+        assertEquals(
+                DungeonEditorCommandOutcome.RejectionReason.MISSING_TRANSITION_DESTINATION,
+                invalidCreate.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, noEffect.reason());
+        assertEquals(
+                DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION,
+                protectedDelete.reason());
+        assertEquals(List.of(source, target), current.transitionCatalog().transitions());
+    }
+
+    @Test
+    void crossMapLinkLoadsClosureAndAppliesOneExactCompoundPatch() {
+        DungeonMap sourceMap = transitionMap(101L, transition(
+                11L,
+                101L,
+                new Cell(1, 1, 0),
+                TransitionDestination.dungeonMap(103L, 31L),
+                null));
+        DungeonMap targetMap = transitionMap(102L, transition(
+                21L,
+                102L,
+                new Cell(2, 2, 0),
+                TransitionDestination.unlinkedEntrance(),
+                null));
+        DungeonMap previousMap = transitionMap(103L, transition(
+                31L,
+                103L,
+                new Cell(3, 3, 0),
+                TransitionDestination.unlinkedEntrance(),
+                11L));
+        TransitionLinkCommand command = new TransitionLinkCommand();
+
+        DungeonCompoundCommandResult.RequiresMap requiresMap = assertInstanceOf(
+                DungeonCompoundCommandResult.RequiresMap.class,
+                command.plan(
+                        List.of(sourceMap, targetMap),
+                        101L,
+                        11L,
+                        102L,
+                        21L,
+                        true,
+                        Set.of()));
+        assertEquals(103L, requiresMap.mapId());
+
+        DungeonCompoundCommandResult.Accepted accepted = assertInstanceOf(
+                DungeonCompoundCommandResult.Accepted.class,
+                command.plan(
+                        List.of(sourceMap, targetMap, previousMap),
+                        101L,
+                        11L,
+                        102L,
+                        21L,
+                        true,
+                        Set.of()));
+        DungeonCompoundPatch patch = accepted.patch();
+        assertEquals(Set.of(
+                new DungeonMapIdentity(101L),
+                new DungeonMapIdentity(102L),
+                new DungeonMapIdentity(103L)), patch.resultFactsByMap().keySet());
+        Map<Long, DungeonMap> changed = patch.applyTo(Map.of(
+                101L, sourceMap,
+                102L, targetMap,
+                103L, previousMap));
+        assertEquals(
+                TransitionDestination.dungeonMap(102L, 21L),
+                changed.get(101L).transitionCatalog().transition(11L).destination());
+        assertEquals(11L, changed.get(102L).transitionCatalog().transition(21L).linkedTransitionId());
+        assertNull(changed.get(103L).transitionCatalog().transition(31L).linkedTransitionId());
+        assertEquals(sourceMap.revision() + 1L, changed.get(101L).revision());
+        assertEquals(targetMap.revision() + 1L, changed.get(102L).revision());
+        assertEquals(previousMap.revision() + 1L, changed.get(103L).revision());
+
+        Map<Long, DungeonMap> restored = accepted.inverse().applyTo(changed);
+        assertEquals(sourceMap.transitionCatalog(), restored.get(101L).transitionCatalog());
+        assertEquals(targetMap.transitionCatalog(), restored.get(102L).transitionCatalog());
+        assertEquals(previousMap.transitionCatalog(), restored.get(103L).transitionCatalog());
+    }
+
+    private static DungeonMap transitionMap(long mapId, Transition... transitions) {
+        DungeonMap empty = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), "Transitions " + mapId);
+        return empty.withTransitionCatalog(new TransitionCatalog(List.of(transitions)));
+    }
+
+    private static Transition transition(
+            long transitionId,
+            long mapId,
+            Cell anchor,
+            TransitionDestination destination,
+            Long linkedTransitionId
+    ) {
+        return new Transition(
+                transitionId,
+                mapId,
+                "",
+                TransitionAnchor.cell(anchor),
+                destination,
+                linkedTransitionId);
+    }
+}


### PR DESCRIPTION
## Summary

- migrate transition create, description, delete, and link saves to exact transition patches
- add atomic multi-map `DungeonCompoundPatch` application and shared per-map undo/redo history
- remove replaced direct transition commit routes and update the temporary migration roadmap
- add deterministic command, closure, revision, history-ordering, and production-route coverage

## Validation

- `./gradlew test --tests test.features.dungeon.application.authored.command.DungeonTransitionPatchCommandsTest --tests test.features.dungeon.application.authored.DungeonEditHistoryTest`
- focused M3 patch/history suite
- `./gradlew test --tests test.features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest`
- `./gradlew architectureTest`
- `./gradlew check --console=plain` — BUILD SUCCESSFUL
- `./gradlew installDesktopApp --console=plain` — BUILD SUCCESSFUL
