### PR TITLE
Migrate room geometry commands to exact patches

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,30 +97,32 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.4 are complete on
-  `main` through PR #503. Feature markers, room or cluster semantics, and stair
-  create, geometry update, and delete use exact patches and the shared patch
-  executor; their replaced direct commit routes are deleted.
-- This slice: M3.5 moves transition create, description, delete, and authored
-  link save to exact transition changes. A transition link now yields one
-  `DungeonCompoundPatch` covering every affected map and persists the resulting
-  map set atomically through the existing multi-map repository boundary.
-- Per-session history stores forward and inverse patches for the M3.1 through
-  M3.5 command families. One compound transition entry is shared by every
-  affected map, and undo or redo applies and persists the full map set before
-  moving any history stack.
-- Deterministic proof covers transition identity and topology ref, touched
-  chunks, exact forward and inverse application, closure loading, missing
-  previous-map fallback, atomic multi-map history, later-edit ordering, encoded
-  patch weight, monotonic revisions, and typed rejection of invalid, referenced,
-  missing, and no-effect transition operations.
-- Ordinary commands that still use `executeOperation` retain the temporary
-  full-map `DungeonChangeSet` and snapshot-history path until their remaining
-  M3 geometry and corridor slices migrate. M3.5 introduces no second
-  persistence contract.
-- Next step after this slice merges: M3.6 moves room paint or delete,
-  cluster-boundary edits, and cluster geometry-handle commits to exact room and
-  cluster patches, then deletes their direct commit routes.
+- Current foundation: M0 through M2 and M3.1 through M3.5 are complete on
+  `main` through PR #504. Feature markers, room or cluster semantics, stairs,
+  and transitions use exact patches; transition links use atomic compound
+  patches and shared multi-map history.
+- This slice: M3.6 moves room rectangle paint or delete, cluster-boundary edits,
+  cluster-corner moves, and wall-run stretches to one exact room-geometry patch
+  planner and the shared patch executor. Their production consumers no longer
+  commit through `executeOperation`; preview planning remains repository-free.
+- Room and cluster changes now encode create, update, membership change, and
+  delete states. The planner derives stable-identity changes from the
+  aggregate-owned result and verifies that applying the patch reproduces the
+  complete aggregate exactly before persistence.
+- Newly rebuilt renderable room boundaries materialize stable topology refs in
+  domain truth before persistence. Patch history therefore matches SQLite
+  readback exactly and real shortcut undo or redo remains monotonic.
+- Deterministic and production-route proof covers negative chunks, room and
+  cluster create or delete, exact inverse application, boundary edits, corner
+  movement, wall-run stretch, stable boundary refs, typed protected-wall
+  rejection, preview storage isolation, persistence reload, and undo or redo.
+- Whole-cluster label movement remains with the later connection-handle slice
+  because it also moves attached corridors. Door, corridor, and stair handles
+  plus corridor create or delete retain temporary snapshot history until their
+  remaining M3 slices migrate.
+- Next step after this slice merges: M3.7 moves corridor create and delete,
+  including corridor-owned stair segments, to exact connection patches and
+  deletes their direct commit routes.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -29,6 +29,9 @@ import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
 import features.dungeon.application.authored.command.CreateStairCommand;
 import features.dungeon.application.authored.command.CreateTransitionCommand;
+import features.dungeon.application.authored.command.ClusterBoundaryCommand;
+import features.dungeon.application.authored.command.ClusterBoundaryStretchCommand;
+import features.dungeon.application.authored.command.ClusterCornerCommand;
 import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
 import features.dungeon.application.authored.command.DeleteStairCommand;
 import features.dungeon.application.authored.command.DeleteTransitionCommand;
@@ -36,6 +39,7 @@ import features.dungeon.application.authored.command.FeatureMarkerSemanticsComma
 import features.dungeon.application.authored.command.RoomClusterNameCommand;
 import features.dungeon.application.authored.command.RoomNameCommand;
 import features.dungeon.application.authored.command.RoomNarrationCommand;
+import features.dungeon.application.authored.command.RoomRectangleCommand;
 import features.dungeon.application.authored.command.UpdateStairGeometryCommand;
 import features.dungeon.application.authored.command.TransitionDescriptionCommand;
 import features.dungeon.application.authored.command.TransitionLinkCommand;
@@ -125,6 +129,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final RoomNarrationCommand roomNarrationCommand = new RoomNarrationCommand();
     private final RoomNameCommand roomNameCommand = new RoomNameCommand();
     private final RoomClusterNameCommand roomClusterNameCommand = new RoomClusterNameCommand();
+    private final RoomRectangleCommand roomRectangleCommand = new RoomRectangleCommand();
+    private final ClusterBoundaryCommand clusterBoundaryCommand = new ClusterBoundaryCommand();
+    private final ClusterCornerCommand clusterCornerCommand = new ClusterCornerCommand();
+    private final ClusterBoundaryStretchCommand clusterBoundaryStretchCommand =
+            new ClusterBoundaryStretchCommand();
     private final CreateStairCommand createStairCommand = new CreateStairCommand();
     private final DeleteStairCommand deleteStairCommand = new DeleteStairCommand();
     private final UpdateStairGeometryCommand updateStairGeometryCommand =
@@ -238,10 +247,9 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     public void applyRoomRectangle(MapId mapId, Cell start, Cell end, boolean deleteMode, Session session) {
         Objects.requireNonNull(start, "start");
         Objects.requireNonNull(end, "end");
-        OperationResultData result = mutationPipeline.executeOperation(
+        OperationResultData result = mutationPipeline.executePatchCommand(
                 domainMapId(mapId),
-                deleteMode ? current -> current.deleteRoomRectangle(start, end)
-                        : current -> current.paintRoomRectangle(start, end));
+                current -> roomRectangleCommand.plan(current, start, end, deleteMode));
         publicationOperations.publishMutation(result, session.dungeonState());
     }
 
@@ -258,15 +266,14 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
         List<Edge> safeEdges = List.copyOf(Objects.requireNonNull(edges, "edges"));
         BoundaryKind safeBoundaryKind = Objects.requireNonNull(boundaryKind, "boundaryKind");
-        DungeonEditorCommandOutcome.RejectionReason rejectionReason = !deleteMode
-                ? DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT
-                : safeBoundaryKind == BoundaryKind.WALL
-                        ? DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL
-                        : DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION;
-        OperationResultData result = mutationPipeline.executeOperation(
+        OperationResultData result = mutationPipeline.executePatchCommand(
                 domainMapId(mapId),
-                current -> current.editClusterBoundaries(clusterId, safeEdges, safeBoundaryKind, deleteMode),
-                rejectionReason);
+                current -> clusterBoundaryCommand.plan(
+                        current,
+                        clusterId,
+                        safeEdges,
+                        safeBoundaryKind,
+                        deleteMode));
         publicationOperations.publishMutation(result, session.dungeonState());
     }
 
@@ -938,7 +945,19 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (!DungeonEditorSessionPreviewHelper.directClusterMoveCommitHandle(handleRef.kind())) {
                 return;
             }
-            OperationResultData result = applyHandleMovement(domainMapId(mapId), handleRef, safePreview);
+            OperationResultData result = handleRef.kind() == DungeonEditorHandleKind.CLUSTER_CORNER
+                    ? mutationPipeline.executePatchCommand(
+                            domainMapId(mapId),
+                            current -> clusterCornerCommand.plan(
+                                    current,
+                                    handleRef.clusterId() > 0L
+                                            ? handleRef.clusterId()
+                                            : current.clusterIdForTopologyRef(handleRef.topologyRef()),
+                                    handleRef.cell(),
+                                    safePreview.deltaQ(),
+                                    safePreview.deltaR(),
+                                    safePreview.deltaLevel()))
+                    : applyHandleMovement(domainMapId(mapId), handleRef, safePreview);
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -1047,9 +1066,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         ) {
             DungeonEditorSessionValues.MoveBoundaryStretchPreview safePreview =
                     Objects.requireNonNull(preview, PREVIEW_ARGUMENT);
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.moveBoundaryStretch(
+                    current -> clusterBoundaryStretchCommand.plan(
+                            current,
                             safePreview.clusterId(),
                             DungeonEditorWorkspaceGeometry.unitEdges(safePreview.sourceEdges()),
                             safePreview.deltaQ(),

--- a/features/dungeon/application/authored/command/ClusterBoundaryCommand.java
+++ b/features/dungeon/application/authored/command/ClusterBoundaryCommand.java
@@ -1,0 +1,41 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Edge;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
+import java.util.List;
+
+/** Plans one exact room-cluster boundary edit patch. */
+public final class ClusterBoundaryCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long clusterId,
+            List<Edge> edges,
+            BoundaryKind boundaryKind,
+            boolean deleteMode
+    ) {
+        if (current == null || clusterId <= 0L || edges == null || edges.isEmpty() || boundaryKind == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        List<Edge> safeEdges = List.copyOf(edges);
+        return RoomGeometryPatchPlanner.plan(
+                current,
+                map -> map.editClusterBoundaries(clusterId, safeEdges, boundaryKind, deleteMode),
+                rejectionReason(boundaryKind, deleteMode));
+    }
+
+    private static DungeonEditorCommandOutcome.RejectionReason rejectionReason(
+            BoundaryKind boundaryKind,
+            boolean deleteMode
+    ) {
+        if (!deleteMode) {
+            return DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT;
+        }
+        return boundaryKind == BoundaryKind.WALL
+                ? DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL
+                : DungeonEditorCommandOutcome.RejectionReason.REFERENCED_CONNECTION;
+    }
+}

--- a/features/dungeon/application/authored/command/ClusterBoundaryStretchCommand.java
+++ b/features/dungeon/application/authored/command/ClusterBoundaryStretchCommand.java
@@ -1,0 +1,29 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Edge;
+import features.dungeon.domain.core.structure.DungeonMap;
+import java.util.List;
+
+/** Plans one exact room-cluster wall-run stretch patch. */
+public final class ClusterBoundaryStretchCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long clusterId,
+            List<Edge> sourceEdges,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || clusterId <= 0L || sourceEdges == null || sourceEdges.isEmpty()) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        List<Edge> safeEdges = List.copyOf(sourceEdges);
+        return RoomGeometryPatchPlanner.plan(
+                current,
+                map -> map.moveBoundaryStretch(clusterId, safeEdges, deltaQ, deltaR, deltaLevel),
+                DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+    }
+}

--- a/features/dungeon/application/authored/command/ClusterCornerCommand.java
+++ b/features/dungeon/application/authored/command/ClusterCornerCommand.java
@@ -1,0 +1,27 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+
+/** Plans one exact room-cluster corner movement patch. */
+public final class ClusterCornerCommand {
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long clusterId,
+            Cell corner,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || clusterId <= 0L || corner == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        return RoomGeometryPatchPlanner.plan(
+                current,
+                map -> map.moveClusterCorner(clusterId, corner, deltaQ, deltaR, deltaLevel),
+                DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomClusterChange.java
+++ b/features/dungeon/application/authored/command/RoomClusterChange.java
@@ -6,7 +6,7 @@ import features.dungeon.domain.core.structure.room.RoomCluster;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-/** Exact before/after delta for one stable authored room cluster. */
+/** Exact before/after delta for one authored room-cluster identity. */
 public record RoomClusterChange(
         RoomCluster before,
         RoomCluster after,
@@ -16,32 +16,35 @@ public record RoomClusterChange(
     private static final long BOUNDARY_ENCODING_BYTES = 48L;
 
     public RoomClusterChange {
-        if (before == null || after == null || before.equals(after)) {
-            throw new IllegalArgumentException("a cluster semantic change requires distinct before and after state");
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a cluster change requires before or after state");
         }
-        if (before.clusterId() != after.clusterId() || before.mapId() != after.mapId()) {
-            throw new IllegalArgumentException("room cluster identity must remain stable");
+        if (before != null && after != null) {
+            if (before.equals(after)) {
+                throw new IllegalArgumentException("a cluster change requires distinct before and after state");
+            }
+            if (before.clusterId() != after.clusterId() || before.mapId() != after.mapId()) {
+                throw new IllegalArgumentException("room cluster identity must remain stable");
+            }
         }
         touchedChunks = touchedChunks == null ? Set.of() : Set.copyOf(touchedChunks);
     }
 
     @Override
     public DungeonMapIdentity mapId() {
-        return new DungeonMapIdentity(after.mapId());
+        return new DungeonMapIdentity(state().mapId());
     }
 
     @Override
     public DungeonPatchEntityRef entityRef() {
-        return DungeonPatchEntityRef.roomCluster(after.clusterId());
+        return DungeonPatchEntityRef.roomCluster(state().clusterId());
     }
 
     @Override
     public long encodedBytes() {
         return FIXED_ENCODING_BYTES
-                + before.name().getBytes(StandardCharsets.UTF_8).length
-                + after.name().getBytes(StandardCharsets.UTF_8).length
-                + BOUNDARY_ENCODING_BYTES * (before.orderedAuthoredBoundaries().size()
-                        + after.orderedAuthoredBoundaries().size());
+                + encodedBytes(before)
+                + encodedBytes(after);
     }
 
     @Override
@@ -52,5 +55,16 @@ public record RoomClusterChange(
     @Override
     public Set<DungeonChunkKey> touchedChunks() {
         return Set.copyOf(touchedChunks);
+    }
+
+    private RoomCluster state() {
+        return after == null ? before : after;
+    }
+
+    private static long encodedBytes(RoomCluster cluster) {
+        return cluster == null
+                ? 1L
+                : cluster.name().getBytes(StandardCharsets.UTF_8).length
+                        + BOUNDARY_ENCODING_BYTES * cluster.orderedAuthoredBoundaries().size();
     }
 }

--- a/features/dungeon/application/authored/command/RoomClusterNameCommand.java
+++ b/features/dungeon/application/authored/command/RoomClusterNameCommand.java
@@ -1,15 +1,9 @@
 package features.dungeon.application.authored.command;
 
-import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.api.editor.DungeonEditorCommandOutcome;
-import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.DungeonMap;
-import features.dungeon.domain.core.structure.room.DungeonClusterBoundary;
 import features.dungeon.domain.core.structure.room.RoomCluster;
-import features.dungeon.domain.core.structure.room.RoomRegion;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 /** Plans one exact authored room-cluster-name patch. */
 public final class RoomClusterNameCommand {
@@ -26,34 +20,14 @@ public final class RoomClusterNameCommand {
         if (after.equals(before)) {
             return rejected(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
         }
+        RoomClusterChange change = new RoomClusterChange(
+                before,
+                after,
+                RoomClusterPatchChunks.touchedChunks(current, current, before.clusterId()));
         return DungeonCommandResult.Accepted.from(DungeonPatch.of(
                 current.metadata().mapId(),
                 current.revision(),
-                List.of(new RoomClusterChange(before, after, touchedChunks(current, before)))));
-    }
-
-    private static Set<DungeonChunkKey> touchedChunks(DungeonMap current, RoomCluster cluster) {
-        Set<DungeonChunkKey> result = new LinkedHashSet<>();
-        for (RoomRegion room : current.rooms().roomsInCluster(cluster.clusterId())) {
-            for (Cell cell : room.floorCells()) {
-                addChunk(result, current, cell);
-            }
-        }
-        for (DungeonClusterBoundary boundary : cluster.orderedAuthoredBoundaries()) {
-            addChunk(result, current, boundary.absoluteCell(cluster.center()));
-        }
-        if (result.isEmpty()) {
-            addChunk(result, current, cluster.center());
-        }
-        return Set.copyOf(result);
-    }
-
-    private static void addChunk(Set<DungeonChunkKey> result, DungeonMap current, Cell cell) {
-        result.add(new DungeonChunkKey(
-                current.metadata().mapId().value(),
-                cell.level(),
-                Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
-                Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+                List.of(change)));
     }
 
     private static DungeonCommandResult.Rejected rejected(

--- a/features/dungeon/application/authored/command/RoomClusterPatchChunks.java
+++ b/features/dungeon/application/authored/command/RoomClusterPatchChunks.java
@@ -1,0 +1,55 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.DungeonClusterBoundary;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Derives the chunk closure occupied by one room cluster before and after a patch. */
+final class RoomClusterPatchChunks {
+    private RoomClusterPatchChunks() {
+    }
+
+    static Set<DungeonChunkKey> touchedChunks(DungeonMap before, DungeonMap after, long clusterId) {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addMapChunks(result, before, clusterId);
+        addMapChunks(result, after, clusterId);
+        return Set.copyOf(result);
+    }
+
+    private static void addMapChunks(Set<DungeonChunkKey> result, DungeonMap map, long clusterId) {
+        if (map == null) {
+            return;
+        }
+        Set<DungeonChunkKey> mapChunks = new LinkedHashSet<>();
+        for (RoomRegion room : map.rooms().roomsInCluster(clusterId)) {
+            for (Cell cell : room.floorCells()) {
+                addChunk(mapChunks, map, cell);
+            }
+        }
+        RoomCluster cluster = map.topology().roomCluster(clusterId);
+        if (cluster == null) {
+            result.addAll(mapChunks);
+            return;
+        }
+        for (DungeonClusterBoundary boundary : cluster.orderedAuthoredBoundaries()) {
+            addChunk(mapChunks, map, boundary.absoluteCell(cluster.center()));
+        }
+        if (mapChunks.isEmpty()) {
+            addChunk(mapChunks, map, cluster.center());
+        }
+        result.addAll(mapChunks);
+    }
+
+    private static void addChunk(Set<DungeonChunkKey> result, DungeonMap map, Cell cell) {
+        result.add(new DungeonChunkKey(
+                map.metadata().mapId().value(),
+                cell.level(),
+                Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+    }
+}

--- a/features/dungeon/application/authored/command/RoomGeometryPatchPlanner.java
+++ b/features/dungeon/application/authored/command/RoomGeometryPatchPlanner.java
@@ -1,0 +1,95 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/** Converts one aggregate-owned room geometry operation into exact stable-identity changes. */
+final class RoomGeometryPatchPlanner {
+    private RoomGeometryPatchPlanner() {
+    }
+
+    static DungeonCommandResult plan(
+            DungeonMap current,
+            UnaryOperator<DungeonMap> operation,
+            DungeonEditorCommandOutcome.RejectionReason noEffectReason
+    ) {
+        DungeonMap after = operation.apply(current);
+        if (after == null || after.equals(current)) {
+            return new DungeonCommandResult.Rejected(noEffectReason);
+        }
+        List<DungeonPatchChange> changes = new ArrayList<>();
+        changes.addAll(roomChanges(current, after));
+        changes.addAll(clusterChanges(current, after));
+        if (changes.isEmpty()) {
+            throw new IllegalStateException("room geometry operation changed unencoded authored truth");
+        }
+        DungeonPatch patch = DungeonPatch.of(current.metadata().mapId(), current.revision(), changes);
+        if (!patch.applyTo(current).equals(after)) {
+            throw new IllegalStateException("room geometry patch must reproduce the exact aggregate result");
+        }
+        return DungeonCommandResult.Accepted.from(patch);
+    }
+
+    private static List<DungeonPatchChange> roomChanges(DungeonMap before, DungeonMap after) {
+        Map<Long, RoomRegion> remaining = roomsById(after.rooms().rooms());
+        List<DungeonPatchChange> result = new ArrayList<>();
+        for (RoomRegion room : before.rooms().rooms()) {
+            RoomRegion next = remaining.remove(room.roomId());
+            if (!room.equals(next)) {
+                result.add(new RoomRegionChange(room, next));
+            }
+        }
+        for (RoomRegion room : after.rooms().rooms()) {
+            if (remaining.containsKey(room.roomId())) {
+                result.add(new RoomRegionChange(null, room));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<DungeonPatchChange> clusterChanges(DungeonMap before, DungeonMap after) {
+        Map<Long, RoomCluster> remaining = clustersById(after.topology().roomClusters());
+        List<DungeonPatchChange> result = new ArrayList<>();
+        for (RoomCluster cluster : before.topology().roomClusters()) {
+            RoomCluster next = remaining.remove(cluster.clusterId());
+            if (!cluster.equals(next)) {
+                result.add(new RoomClusterChange(
+                        cluster,
+                        next,
+                        RoomClusterPatchChunks.touchedChunks(before, after, cluster.clusterId())));
+            }
+        }
+        for (RoomCluster cluster : after.topology().roomClusters()) {
+            if (remaining.containsKey(cluster.clusterId())) {
+                result.add(new RoomClusterChange(
+                        null,
+                        cluster,
+                        RoomClusterPatchChunks.touchedChunks(before, after, cluster.clusterId())));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static Map<Long, RoomRegion> roomsById(List<RoomRegion> rooms) {
+        Map<Long, RoomRegion> result = new LinkedHashMap<>();
+        for (RoomRegion room : rooms) {
+            result.put(room.roomId(), room);
+        }
+        return result;
+    }
+
+    private static Map<Long, RoomCluster> clustersById(List<RoomCluster> clusters) {
+        Map<Long, RoomCluster> result = new LinkedHashMap<>();
+        for (RoomCluster cluster : clusters) {
+            result.put(cluster.clusterId(), cluster);
+        }
+        return result;
+    }
+}

--- a/features/dungeon/application/authored/command/RoomRectangleCommand.java
+++ b/features/dungeon/application/authored/command/RoomRectangleCommand.java
@@ -1,0 +1,22 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMap;
+
+/** Plans one exact room paint or delete rectangle patch. */
+public final class RoomRectangleCommand {
+
+    public DungeonCommandResult plan(DungeonMap current, Cell start, Cell end, boolean deleteMode) {
+        if (current == null || start == null || end == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        return RoomGeometryPatchPlanner.plan(
+                current,
+                deleteMode
+                        ? map -> map.deleteRoomRectangle(start, end)
+                        : map -> map.paintRoomRectangle(start, end),
+                DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomRegionChange.java
+++ b/features/dungeon/application/authored/command/RoomRegionChange.java
@@ -11,30 +11,33 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
-/** Exact before/after delta for one stable authored room. */
+/** Exact before/after delta for one authored room identity. */
 public record RoomRegionChange(RoomRegion before, RoomRegion after) implements DungeonPatchChange {
     private static final long FIXED_ENCODING_BYTES = 128L;
     private static final long CELL_ENCODING_BYTES = 16L;
 
     public RoomRegionChange {
-        if (before == null || after == null || before.equals(after)) {
-            throw new IllegalArgumentException("a room semantic change requires distinct before and after state");
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a room change requires before or after state");
         }
-        if (before.roomId() != after.roomId()
-                || before.mapId() != after.mapId()
-                || before.clusterId() != after.clusterId()) {
-            throw new IllegalArgumentException("room identity and cluster membership must remain stable");
+        if (before != null && after != null) {
+            if (before.equals(after)) {
+                throw new IllegalArgumentException("a room change requires distinct before and after state");
+            }
+            if (before.roomId() != after.roomId() || before.mapId() != after.mapId()) {
+                throw new IllegalArgumentException("room identity must remain stable");
+            }
         }
     }
 
     @Override
     public DungeonMapIdentity mapId() {
-        return new DungeonMapIdentity(after.mapId());
+        return new DungeonMapIdentity(state().mapId());
     }
 
     @Override
     public DungeonPatchEntityRef entityRef() {
-        return DungeonPatchEntityRef.room(after.roomId());
+        return DungeonPatchEntityRef.room(state().roomId());
     }
 
     @Override
@@ -55,7 +58,14 @@ public record RoomRegionChange(RoomRegion before, RoomRegion after) implements D
         return new RoomRegionChange(after, before);
     }
 
+    private RoomRegion state() {
+        return after == null ? before : after;
+    }
+
     private static void addChunks(Set<DungeonChunkKey> result, RoomRegion room) {
+        if (room == null) {
+            return;
+        }
         for (Cell cell : room.floorCells()) {
             result.add(new DungeonChunkKey(
                     room.mapId(),
@@ -66,6 +76,9 @@ public record RoomRegionChange(RoomRegion before, RoomRegion after) implements D
     }
 
     private static long encodedBytes(RoomRegion room) {
+        if (room == null) {
+            return 1L;
+        }
         return CELL_ENCODING_BYTES * room.floorCells().size()
                 + textBytes(room.name())
                 + narrationBytes(room.narration());

--- a/features/dungeon/domain/core/structure/room/RoomCluster.java
+++ b/features/dungeon/domain/core/structure/room/RoomCluster.java
@@ -150,6 +150,26 @@ public final class RoomCluster {
         return new RoomClusterDoorBoundaryMovement().moved(this, move);
     }
 
+    /** Materializes stable topology refs for newly authored non-open boundaries. */
+    public RoomCluster withResolvedBoundaryTopologyRefs() {
+        Map<Integer, List<DungeonClusterBoundary>> resolved = new LinkedHashMap<>();
+        for (Map.Entry<Integer, List<DungeonClusterBoundary>> entry : boundariesByLevel.entrySet()) {
+            List<DungeonClusterBoundary> boundaries = new ArrayList<>();
+            for (DungeonClusterBoundary boundary : entry.getValue()) {
+                boundaries.add(new DungeonClusterBoundary(
+                        boundary.clusterId(),
+                        boundary.level(),
+                        boundary.relativeCell(),
+                        boundary.direction(),
+                        boundary.kind(),
+                        boundary.resolvedTopologyRef(center)));
+            }
+            resolved.put(entry.getKey(), List.copyOf(boundaries));
+        }
+        RoomCluster result = new RoomCluster(clusterId, mapId, name, center, resolved);
+        return result.equals(this) ? this : result;
+    }
+
     RoomCluster movedBy(int deltaQ, int deltaR, int deltaLevel) {
         return new RoomCluster(
                 clusterId,

--- a/features/dungeon/domain/core/structure/room/RoomTopologyAuthoring.java
+++ b/features/dungeon/domain/core/structure/room/RoomTopologyAuthoring.java
@@ -8,6 +8,7 @@ import features.dungeon.domain.core.geometry.Edge;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
 import features.dungeon.domain.core.structure.room.RoomTopologyRebuilder.RebuildResult;
+import features.dungeon.domain.core.structure.topology.SpatialTopology;
 
 /**
  * Owns aggregate-level room topology authoring inside the core room structure.
@@ -118,9 +119,13 @@ public final class RoomTopologyAuthoring {
     }
 
     private static DungeonMap withRoomTopology(DungeonMap dungeonMap, RebuildResult rebuild) {
+        SpatialTopology resolvedTopology = rebuild.topology().withRoomClusters(
+                rebuild.topology().roomClusters().stream()
+                        .map(RoomCluster::withResolvedBoundaryTopologyRefs)
+                        .toList());
         return new DungeonMap(
                 dungeonMap.metadata(),
-                rebuild.topology(),
+                resolvedTopology,
                 rebuild.rooms(),
                 dungeonMap.corridors(),
                 dungeonMap.stairs(),

--- a/test/features/dungeon/application/authored/command/DungeonRoomGeometryPatchCommandsTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonRoomGeometryPatchCommandsTest.java
@@ -1,0 +1,151 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Direction;
+import features.dungeon.domain.core.geometry.Edge;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.room.RoomClusterBoundaryMaterialization.BoundaryKind;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DungeonRoomGeometryPatchCommandsTest {
+
+    @Test
+    void roomPaintAndDeleteCarryExactCreateUpdateAndDeleteChanges() {
+        DungeonMap empty = emptyMap();
+        RoomRectangleCommand command = new RoomRectangleCommand();
+
+        DungeonCommandResult.Accepted paintedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                command.plan(empty, new Cell(-2, -2, 0), new Cell(-1, -1, 0), false));
+        assertTrue(paintedResult.patch().changes().stream()
+                .anyMatch(change -> change instanceof RoomRegionChange room
+                        && room.before() == null
+                        && room.after() != null));
+        assertTrue(paintedResult.patch().changes().stream()
+                .anyMatch(change -> change instanceof RoomClusterChange cluster
+                        && cluster.before() == null
+                        && cluster.after() != null));
+        assertEquals(Set.of(new DungeonChunkKey(73L, 0, -1, -1)), paintedResult.patch().touchedChunks());
+        DungeonMap painted = paintedResult.patch().applyTo(empty);
+        assertEquals(empty.revision() + 1L, painted.revision());
+        assertTrue(painted.topology().roomClusters().getFirst().orderedAuthoredBoundaries().stream()
+                .filter(boundary -> boundary.kind().renderable())
+                .allMatch(boundary -> boundary.topologyRef().present()));
+        assertEquals(empty, contentAtRevision(paintedResult.inverse().applyTo(painted), empty.revision()));
+
+        DungeonCommandResult.Accepted deletedResult = assertInstanceOf(
+                DungeonCommandResult.Accepted.class,
+                command.plan(painted, new Cell(-2, -2, 0), new Cell(-1, -1, 0), true));
+        assertTrue(deletedResult.patch().changes().stream()
+                .anyMatch(change -> change instanceof RoomRegionChange room
+                        && room.before() != null
+                        && room.after() == null));
+        assertTrue(deletedResult.patch().changes().stream()
+                .anyMatch(change -> change instanceof RoomClusterChange cluster
+                        && cluster.before() != null
+                        && cluster.after() == null));
+        DungeonMap deleted = deletedResult.patch().applyTo(painted);
+        assertTrue(deleted.rooms().rooms().isEmpty());
+        assertTrue(deleted.topology().roomClusters().isEmpty());
+        assertEquals(painted, contentAtRevision(deletedResult.inverse().applyTo(deleted), painted.revision()));
+    }
+
+    @Test
+    void boundaryAndStretchCommandsReproduceAggregateGeometryAndInverse() {
+        DungeonMap painted = accepted(new RoomRectangleCommand().plan(
+                emptyMap(),
+                new Cell(1, 1, 0),
+                new Cell(2, 2, 0),
+                false)).patch().applyTo(emptyMap());
+        long clusterId = painted.topology().roomClusters().getFirst().clusterId();
+        Edge northWest = Edge.sideOf(new Cell(1, 1, 0), Direction.NORTH);
+        Edge northEast = Edge.sideOf(new Cell(2, 1, 0), Direction.NORTH);
+
+        DungeonCommandResult.Accepted doorResult = accepted(new ClusterBoundaryCommand().plan(
+                painted,
+                clusterId,
+                List.of(northWest),
+                BoundaryKind.DOOR,
+                false));
+        DungeonMap withDoor = doorResult.patch().applyTo(painted);
+        assertEquals(
+                painted.editClusterBoundaries(
+                        clusterId,
+                        List.of(northWest),
+                        BoundaryKind.DOOR,
+                        false),
+                withDoor);
+        assertEquals(painted, contentAtRevision(doorResult.inverse().applyTo(withDoor), painted.revision()));
+
+        DungeonCommandResult.Accepted stretchResult = accepted(new ClusterBoundaryStretchCommand().plan(
+                painted,
+                clusterId,
+                List.of(northWest, northEast),
+                0,
+                -1,
+                0));
+        DungeonMap stretched = stretchResult.patch().applyTo(painted);
+        assertEquals(
+                painted.moveBoundaryStretch(clusterId, List.of(northWest, northEast), 0, -1, 0),
+                stretched);
+        assertEquals(painted, contentAtRevision(stretchResult.inverse().applyTo(stretched), painted.revision()));
+        assertTrue(stretchResult.patch().encodedBytes() > 0L);
+    }
+
+    @Test
+    void cornerMovementIsExactAndInvalidBoundaryDeletionKeepsTypedReason() {
+        DungeonMap painted = accepted(new RoomRectangleCommand().plan(
+                emptyMap(),
+                new Cell(1, 1, 0),
+                new Cell(2, 2, 0),
+                false)).patch().applyTo(emptyMap());
+        long clusterId = painted.topology().roomClusters().getFirst().clusterId();
+        Cell corner = painted.topology().roomClusters().getFirst().authoredBoundaryVertices(0).getFirst();
+
+        DungeonCommandResult.Accepted cornerResult = accepted(new ClusterCornerCommand().plan(
+                painted,
+                clusterId,
+                corner,
+                -1,
+                -1,
+                0));
+        DungeonMap moved = cornerResult.patch().applyTo(painted);
+        assertEquals(painted.moveClusterCorner(clusterId, corner, -1, -1, 0), moved);
+        assertEquals(painted, contentAtRevision(cornerResult.inverse().applyTo(moved), painted.revision()));
+
+        DungeonCommandResult.Rejected rejected = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new ClusterBoundaryCommand().plan(
+                        painted,
+                        clusterId,
+                        List.of(Edge.sideOf(new Cell(1, 1, 0), Direction.NORTH)),
+                        BoundaryKind.WALL,
+                        true));
+        assertEquals(
+                DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL,
+                rejected.reason());
+    }
+
+    private static DungeonCommandResult.Accepted accepted(DungeonCommandResult result) {
+        return assertInstanceOf(DungeonCommandResult.Accepted.class, result);
+    }
+
+    private static DungeonMap emptyMap() {
+        return DungeonMapAuthoring.empty(new DungeonMapIdentity(73L), "Room Geometry Patches");
+    }
+
+    private static DungeonMap contentAtRevision(DungeonMap map, long revision) {
+        assertTrue(map.revision() > revision);
+        return DungeonMapAuthoring.committedContent(map, revision);
+    }
+}


### PR DESCRIPTION
## Summary

- migrate room paint/delete, cluster boundary edits, corner moves, and wall-run stretches to exact patches
- extend room and cluster changes to encode create, update, membership, and delete states
- materialize stable boundary topology refs before persistence so patch history matches SQLite readback
- keep whole-cluster label movement for the later corridor-aware handle slice and update the migration roadmap

## Validation

- `./gradlew test --tests features.dungeon.application.authored.command.DungeonRoomGeometryPatchCommandsTest --tests features.dungeon.application.authored.command.DungeonRoomClusterPatchCommandsTest --tests features.dungeon.application.authored.DungeonEditHistoryTest --console=plain`
- focused real room, cluster-handle, cluster-route, shared-handle, and undo/redo editor routes
- `./gradlew test --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest --tests features.dungeon.application.authored.command.DungeonRoomGeometryPatchCommandsTest --console=plain`
- `./gradlew architectureTest --console=plain`
- `./gradlew check --console=plain` — BUILD SUCCESSFUL
- `./gradlew installDesktopApp --console=plain` — BUILD SUCCESSFUL
