### PR TITLE
feat: Korridorbefehle auf exakte Patches migrieren

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,32 +97,33 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.5 are complete on
-  `main` through PR #504. Feature markers, room or cluster semantics, stairs,
-  and transitions use exact patches; transition links use atomic compound
-  patches and shared multi-map history.
-- This slice: M3.6 moves room rectangle paint or delete, cluster-boundary edits,
-  cluster-corner moves, and wall-run stretches to one exact room-geometry patch
-  planner and the shared patch executor. Their production consumers no longer
-  commit through `executeOperation`; preview planning remains repository-free.
-- Room and cluster changes now encode create, update, membership change, and
-  delete states. The planner derives stable-identity changes from the
-  aggregate-owned result and verifies that applying the patch reproduces the
-  complete aggregate exactly before persistence.
-- Newly rebuilt renderable room boundaries materialize stable topology refs in
-  domain truth before persistence. Patch history therefore matches SQLite
-  readback exactly and real shortcut undo or redo remains monotonic.
-- Deterministic and production-route proof covers negative chunks, room and
-  cluster create or delete, exact inverse application, boundary edits, corner
-  movement, wall-run stretch, stable boundary refs, typed protected-wall
-  rejection, preview storage isolation, persistence reload, and undo or redo.
-- Whole-cluster label movement remains with the later connection-handle slice
-  because it also moves attached corridors. Door, corridor, and stair handles
-  plus corridor create or delete retain temporary snapshot history until their
-  remaining M3 slices migrate.
-- Next step after this slice merges: M3.7 moves corridor create and delete,
-  including corridor-owned stair segments, to exact connection patches and
-  deletes their direct commit routes.
+- Current foundation: M0 through M2 and M3.1 through M3.6 are complete on
+  `main` through PR #505. Feature markers, room or cluster semantics, room
+  geometry, stairs, and transitions use exact patches; transition links use
+  atomic compound patches and shared multi-map history.
+- This slice: M3.7 moves corridor create, whole-corridor delete, and targeted
+  branch delete to one exact corridor patch planner and the shared patch
+  executor. Their production consumers no longer commit through
+  `executeOperation`; create and delete previews remain repository-free.
+- Corridor changes encode create, update, and delete states with exact touched
+  chunks. The planner also carries endpoint-created room-cluster boundaries,
+  modified host corridors, and corridor-owned stairs in the same accepted
+  patch, then proves that applying it reproduces the complete aggregate.
+- Topology rebuild now derives current binding membership, order, and ownership
+  from canonical aggregate content while preserving stable labels and the
+  persisted topology-ref mapping for surviving corridor anchors. Deleted refs
+  cannot remain as stale index entries.
+- Deterministic and production-route proof covers same-level and cross-level
+  create, bound-stair create or owner delete, targeted branch delete, stable
+  anchor and door identities, negative-safe touched chunks, typed blocked-route
+  rejection, one-revision commits, exact inverse application, shortcut undo or
+  redo, SQLite reload, and preview storage isolation.
+- Whole-cluster label movement plus door, corridor-anchor, corridor-waypoint,
+  and stair-anchor handles retain temporary snapshot history until the next
+  connection-handle slice. `DungeonChangeSet(before, after)`, snapshot history,
+  and `executeOperation` remain only for those not-yet-migrated M3 routes.
+- Next step after this slice merges: M3.8 moves all remaining connection-handle
+  commits to exact patches and removes their direct operation routes.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/adapter/sqlite/mapper/DungeonMapRecordMapper.java
+++ b/features/dungeon/adapter/sqlite/mapper/DungeonMapRecordMapper.java
@@ -14,6 +14,7 @@ import features.dungeon.domain.core.structure.topology.DungeonMapTopology;
 import features.dungeon.domain.core.structure.topology.SpatialTopology;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
 import features.dungeon.domain.core.structure.transition.Transition;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -40,11 +41,23 @@ public final class DungeonMapRecordMapper {
         List<Transition> transitions = DungeonTransitionRecordMapperSupport.toTransitions(resolvedRecord.transitions());
         FeatureMarkerCatalog featureMarkers =
                 DungeonFeatureMarkerRecordMapperSupport.toFeatureMarkers(resolvedRecord.featureMarkers());
-        DungeonMapTopology topologyIndex =
-                DungeonMapTopology.merge(
-                        new DungeonMapTopology(DungeonCorridorConnectionReadMapperSupport.toAnchorTopologyBindings(
-                                resolvedRecord.corridors())),
-                        DungeonTopologyElementRecordMapperSupport.toTopologyIndex(resolvedRecord.topologyElements()));
+        DungeonMapTopology storedTopology =
+                DungeonTopologyElementRecordMapperSupport.toTopologyIndex(resolvedRecord.topologyElements());
+        List<DungeonMapTopology.DungeonTopologyBinding> topologyBindings = new ArrayList<>();
+        for (DungeonMapTopology.DungeonTopologyBinding anchorBinding
+                : DungeonCorridorConnectionReadMapperSupport.toAnchorTopologyBindings(resolvedRecord.corridors())) {
+            DungeonMapTopology.DungeonTopologyBinding storedBinding = storedTopology.binding(anchorBinding.ref());
+            topologyBindings.add(storedBinding == null
+                    ? anchorBinding
+                    : new DungeonMapTopology.DungeonTopologyBinding(
+                            anchorBinding.ref(),
+                            anchorBinding.clusterId(),
+                            anchorBinding.corridorId(),
+                            anchorBinding.localElementId(),
+                            storedBinding.label()));
+        }
+        topologyBindings.addAll(storedTopology.bindings());
+        DungeonMapTopology topologyIndex = new DungeonMapTopology(topologyBindings);
         return DungeonMapAuthoring.authored(
                 new DungeonMapIdentity(resolvedRecord.mapId()),
                 resolvedRecord.name(),

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -27,12 +27,14 @@ import features.dungeon.application.authored.command.DungeonCommandResult;
 import features.dungeon.application.authored.command.DungeonCompoundCommandResult;
 import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.CreateFeatureMarkerCommand;
+import features.dungeon.application.authored.command.CreateCorridorCommand;
 import features.dungeon.application.authored.command.CreateStairCommand;
 import features.dungeon.application.authored.command.CreateTransitionCommand;
 import features.dungeon.application.authored.command.ClusterBoundaryCommand;
 import features.dungeon.application.authored.command.ClusterBoundaryStretchCommand;
 import features.dungeon.application.authored.command.ClusterCornerCommand;
 import features.dungeon.application.authored.command.DeleteFeatureMarkerCommand;
+import features.dungeon.application.authored.command.DeleteCorridorCommand;
 import features.dungeon.application.authored.command.DeleteStairCommand;
 import features.dungeon.application.authored.command.DeleteTransitionCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
@@ -107,6 +109,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final DungeonAuthoredPublishedState publishedState;
     private final CorridorRoutingPolicy corridorRoutingPolicy;
     private final CorridorMapAuthoring corridorAuthoring;
+    private final CreateCorridorCommand createCorridorCommand;
+    private final DeleteCorridorCommand deleteCorridorCommand;
     /* Pointer previews operate on this immutable authored workset. */
     private final ConcurrentMap<Long, DungeonMap> authoredWorkset = new ConcurrentHashMap<>();
     private final DungeonEditHistory editHistory = new DungeonEditHistory();
@@ -169,6 +173,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
         this.corridorRoutingPolicy = Objects.requireNonNull(corridorRoutingPolicy, "corridorRoutingPolicy");
         corridorAuthoring = new CorridorMapAuthoring(this.corridorRoutingPolicy);
+        createCorridorCommand = new CreateCorridorCommand(this.corridorRoutingPolicy);
+        deleteCorridorCommand = new DeleteCorridorCommand(this.corridorRoutingPolicy);
     }
 
     public Session openSession(DungeonEditorDungeonState dungeonState) {
@@ -808,22 +814,20 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         ) {
             DungeonCorridorEndpoint startEndpoint = corridorEndpoint(start);
             DungeonCorridorEndpoint endEndpoint = corridorEndpoint(end);
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> current.createCorridor(
-                            corridorRoutingPolicy,
+                    current -> createCorridorCommand.plan(
+                            current,
                             stairIdForCorridor(current, startEndpoint, endEndpoint, true),
                             startEndpoint,
-                            endEndpoint),
-                    DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
+                            endEndpoint));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
         private void deleteCorridor(MapId mapId, CorridorDeletionTarget target, Session session) {
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
-                    current -> corridorAuthoring.deleteCorridor(current, target),
-                    DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
+                    current -> deleteCorridorCommand.plan(current, target));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 

--- a/features/dungeon/application/authored/command/CorridorChange.java
+++ b/features/dungeon/application/authored/command/CorridorChange.java
@@ -1,0 +1,83 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.component.CorridorAnchor;
+import features.dungeon.domain.core.component.CorridorAnchorRef;
+import features.dungeon.domain.core.component.CorridorDoorBinding;
+import features.dungeon.domain.core.component.CorridorWaypoint;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.corridor.Corridor;
+import java.util.Set;
+
+/** Exact before/after delta for one authored corridor identity. */
+public record CorridorChange(
+        Corridor before,
+        Corridor after,
+        Set<DungeonChunkKey> touchedChunks
+) implements DungeonPatchChange {
+    private static final long FIXED_ENCODING_BYTES = 128L;
+
+    public CorridorChange {
+        if (before == null && after == null) {
+            throw new IllegalArgumentException("a corridor change requires before or after state");
+        }
+        if (before != null && after != null) {
+            if (before.equals(after)) {
+                throw new IllegalArgumentException("a corridor change requires distinct before and after state");
+            }
+            if (before.corridorId() != after.corridorId() || before.mapId() != after.mapId()) {
+                throw new IllegalArgumentException("corridor identity must remain stable");
+            }
+        }
+        touchedChunks = touchedChunks == null ? Set.of() : Set.copyOf(touchedChunks);
+    }
+
+    @Override
+    public DungeonMapIdentity mapId() {
+        return new DungeonMapIdentity(state().mapId());
+    }
+
+    @Override
+    public DungeonPatchEntityRef entityRef() {
+        return DungeonPatchEntityRef.corridor(state().corridorId());
+    }
+
+    @Override
+    public long encodedBytes() {
+        return FIXED_ENCODING_BYTES + encodedBytes(before) + encodedBytes(after);
+    }
+
+    @Override
+    public CorridorChange inverse() {
+        return new CorridorChange(after, before, touchedChunks);
+    }
+
+    @Override
+    public Set<DungeonChunkKey> touchedChunks() {
+        return Set.copyOf(touchedChunks);
+    }
+
+    private Corridor state() {
+        return after == null ? before : after;
+    }
+
+    private static long encodedBytes(Corridor corridor) {
+        if (corridor == null) {
+            return 1L;
+        }
+        long result = 32L + 8L * corridor.roomIds().size();
+        for (CorridorWaypoint ignored : corridor.bindings().waypoints()) {
+            result += 32L;
+        }
+        for (CorridorDoorBinding ignored : corridor.bindings().doorBindings()) {
+            result += 64L;
+        }
+        for (CorridorAnchor ignored : corridor.bindings().anchorBindings()) {
+            result += 40L;
+        }
+        for (CorridorAnchorRef ignored : corridor.bindings().anchorRefs()) {
+            result += 24L;
+        }
+        return result;
+    }
+}

--- a/features/dungeon/application/authored/command/CorridorPatchChunks.java
+++ b/features/dungeon/application/authored/command/CorridorPatchChunks.java
@@ -1,0 +1,84 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.component.CorridorDoorBinding;
+import features.dungeon.domain.core.component.CorridorWaypoint;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.projection.DungeonAreaType;
+import features.dungeon.domain.core.projection.DungeonDerivedStateProjection;
+import features.dungeon.domain.core.projection.DungeonState;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.corridor.Corridor;
+import features.dungeon.domain.core.structure.room.RoomCluster;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Derives the chunk closure occupied by one corridor before and after a patch. */
+final class CorridorPatchChunks {
+    private static final DungeonDerivedStateProjection PROJECTION = new DungeonDerivedStateProjection();
+
+    private CorridorPatchChunks() {
+    }
+
+    static Set<DungeonChunkKey> touchedChunks(DungeonMap before, DungeonMap after, long corridorId) {
+        Set<DungeonChunkKey> result = new LinkedHashSet<>();
+        addMapChunks(result, before, corridorId);
+        addMapChunks(result, after, corridorId);
+        return Set.copyOf(result);
+    }
+
+    private static void addMapChunks(Set<DungeonChunkKey> result, DungeonMap map, long corridorId) {
+        if (map == null) {
+            return;
+        }
+        int initialSize = result.size();
+        for (DungeonState aggregate : PROJECTION.project(map).aggregates()) {
+            if (aggregate.kind() == DungeonAreaType.CORRIDOR && aggregate.id() == corridorId) {
+                for (Cell cell : aggregate.cells()) {
+                    addChunk(result, map, cell);
+                }
+            }
+        }
+        if (result.size() != initialSize) {
+            return;
+        }
+        Corridor corridor = corridor(map, corridorId);
+        if (corridor == null) {
+            return;
+        }
+        for (CorridorWaypoint waypoint : corridor.bindings().waypoints()) {
+            RoomCluster cluster = map.topology().roomCluster(waypoint.clusterId());
+            addChunk(result, map, waypoint.absoluteCell(cluster == null
+                    ? new Cell(0, 0, waypoint.level())
+                    : cluster.center()));
+        }
+        corridor.bindings().anchorBindings().forEach(anchor -> addChunk(result, map, anchor.position()));
+        for (CorridorDoorBinding door : corridor.bindings().doorBindings()) {
+            RoomCluster cluster = map.topology().roomCluster(door.clusterId());
+            Cell center = cluster == null ? new Cell(0, 0, door.relativeCell().level()) : cluster.center();
+            Cell roomCell = new Cell(
+                    center.q() + door.relativeCell().q(),
+                    center.r() + door.relativeCell().r(),
+                    door.relativeCell().level());
+            addChunk(result, map, roomCell);
+            addChunk(result, map, door.direction().neighborOf(roomCell));
+        }
+    }
+
+    private static Corridor corridor(DungeonMap map, long corridorId) {
+        for (Corridor corridor : map.corridors()) {
+            if (corridor.corridorId() == corridorId) {
+                return corridor;
+            }
+        }
+        return null;
+    }
+
+    private static void addChunk(Set<DungeonChunkKey> result, DungeonMap map, Cell cell) {
+        result.add(new DungeonChunkKey(
+                map.metadata().mapId().value(),
+                cell.level(),
+                Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE)));
+    }
+}

--- a/features/dungeon/application/authored/command/CorridorPatchPlanner.java
+++ b/features/dungeon/application/authored/command/CorridorPatchPlanner.java
@@ -1,0 +1,121 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.corridor.Corridor;
+import features.dungeon.domain.core.structure.stair.Stair;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/** Converts one aggregate-owned corridor operation into exact room, corridor, and stair changes. */
+final class CorridorPatchPlanner {
+    private CorridorPatchPlanner() {
+    }
+
+    static DungeonCommandResult plan(
+            DungeonMap current,
+            UnaryOperator<DungeonMap> operation,
+            DungeonEditorCommandOutcome.RejectionReason noEffectReason
+    ) {
+        DungeonMap after = operation.apply(current);
+        if (after == null || after.equals(current)) {
+            return new DungeonCommandResult.Rejected(noEffectReason);
+        }
+        List<DungeonPatchChange> changes = new ArrayList<>(RoomGeometryPatchPlanner.changes(current, after));
+        changes.addAll(corridorChanges(current, after));
+        changes.addAll(stairChanges(current, after));
+        if (changes.isEmpty()) {
+            throw new IllegalStateException("corridor operation changed unencoded authored truth");
+        }
+        DungeonPatch patch = DungeonPatch.of(current.metadata().mapId(), current.revision(), changes);
+        DungeonMap patched = patch.applyTo(current);
+        DungeonMap expected = DungeonMapAuthoring.committedContent(after, patch.committedRevision());
+        if (!patched.equals(expected)) {
+            throw new IllegalStateException(
+                    "corridor patch must reproduce the exact aggregate result; mismatches="
+                            + mismatches(patched, expected));
+        }
+        return DungeonCommandResult.Accepted.from(patch);
+    }
+
+    private static List<String> mismatches(DungeonMap patched, DungeonMap expected) {
+        List<String> result = new ArrayList<>();
+        addMismatch(result, "metadata", patched.metadata(), expected.metadata());
+        addMismatch(result, "topology", patched.topology(), expected.topology());
+        addMismatch(result, "topologyIndex", patched.topologyIndex(), expected.topologyIndex());
+        addMismatch(result, "rooms", patched.rooms(), expected.rooms());
+        addMismatch(result, "corridors", patched.corridors(), expected.corridors());
+        addMismatch(result, "stairs", patched.stairs(), expected.stairs());
+        addMismatch(result, "transitions", patched.transitionCatalog(), expected.transitionCatalog());
+        addMismatch(result, "featureMarkers", patched.featureMarkers(), expected.featureMarkers());
+        addMismatch(result, "revision", patched.revision(), expected.revision());
+        return List.copyOf(result);
+    }
+
+    private static void addMismatch(List<String> result, String field, Object patched, Object expected) {
+        if (!Objects.equals(patched, expected)) {
+            result.add(field);
+        }
+    }
+
+    private static List<DungeonPatchChange> corridorChanges(DungeonMap before, DungeonMap after) {
+        Map<Long, Corridor> remaining = corridorsById(after.corridors());
+        List<DungeonPatchChange> result = new ArrayList<>();
+        for (Corridor corridor : before.corridors()) {
+            Corridor next = remaining.remove(corridor.corridorId());
+            if (!corridor.equals(next)) {
+                result.add(new CorridorChange(
+                        corridor,
+                        next,
+                        CorridorPatchChunks.touchedChunks(before, after, corridor.corridorId())));
+            }
+        }
+        for (Corridor corridor : after.corridors()) {
+            if (remaining.containsKey(corridor.corridorId())) {
+                result.add(new CorridorChange(
+                        null,
+                        corridor,
+                        CorridorPatchChunks.touchedChunks(before, after, corridor.corridorId())));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<DungeonPatchChange> stairChanges(DungeonMap before, DungeonMap after) {
+        Map<Long, Stair> remaining = stairsById(after.stairs().stairs());
+        List<DungeonPatchChange> result = new ArrayList<>();
+        for (Stair stair : before.stairs().stairs()) {
+            Stair next = remaining.remove(stair.stairId());
+            if (!stair.equals(next)) {
+                result.add(new StairChange(stair, next));
+            }
+        }
+        for (Stair stair : after.stairs().stairs()) {
+            if (remaining.containsKey(stair.stairId())) {
+                result.add(new StairChange(null, stair));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static Map<Long, Corridor> corridorsById(List<Corridor> corridors) {
+        Map<Long, Corridor> result = new LinkedHashMap<>();
+        for (Corridor corridor : corridors) {
+            result.put(corridor.corridorId(), corridor);
+        }
+        return result;
+    }
+
+    private static Map<Long, Stair> stairsById(List<Stair> stairs) {
+        Map<Long, Stair> result = new LinkedHashMap<>();
+        for (Stair stair : stairs) {
+            result.put(stair.stairId(), stair);
+        }
+        return result;
+    }
+}

--- a/features/dungeon/application/authored/command/CreateCorridorCommand.java
+++ b/features/dungeon/application/authored/command/CreateCorridorCommand.java
@@ -1,0 +1,33 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.corridor.CorridorMapAuthoring;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
+import java.util.Objects;
+
+/** Plans one exact corridor creation patch, including resolved endpoints and bound stairs. */
+public final class CreateCorridorCommand {
+    private final CorridorMapAuthoring authoring;
+
+    public CreateCorridorCommand(CorridorRoutingPolicy routingPolicy) {
+        authoring = new CorridorMapAuthoring(Objects.requireNonNull(routingPolicy, "routingPolicy"));
+    }
+
+    public DungeonCommandResult plan(
+            DungeonMap current,
+            long stairId,
+            DungeonCorridorEndpoint start,
+            DungeonCorridorEndpoint end
+    ) {
+        if (current == null || start == null || end == null) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        return CorridorPatchPlanner.plan(
+                current,
+                map -> authoring.createCorridor(map, stairId, start, end),
+                DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
+    }
+}

--- a/features/dungeon/application/authored/command/DeleteCorridorCommand.java
+++ b/features/dungeon/application/authored/command/DeleteCorridorCommand.java
@@ -1,0 +1,28 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.corridor.CorridorDeletionTarget;
+import features.dungeon.domain.core.structure.corridor.CorridorMapAuthoring;
+import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
+import java.util.Objects;
+
+/** Plans one exact corridor or corridor-branch deletion patch. */
+public final class DeleteCorridorCommand {
+    private final CorridorMapAuthoring authoring;
+
+    public DeleteCorridorCommand(CorridorRoutingPolicy routingPolicy) {
+        authoring = new CorridorMapAuthoring(Objects.requireNonNull(routingPolicy, "routingPolicy"));
+    }
+
+    public DungeonCommandResult plan(DungeonMap current, CorridorDeletionTarget target) {
+        if (current == null || target == null || !target.hasCorridor()) {
+            return new DungeonCommandResult.Rejected(
+                    DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+        }
+        return CorridorPatchPlanner.plan(
+                current,
+                map -> authoring.deleteCorridor(map, target),
+                DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);
+    }
+}

--- a/features/dungeon/application/authored/command/DungeonPatch.java
+++ b/features/dungeon/application/authored/command/DungeonPatch.java
@@ -96,6 +96,8 @@ public record DungeonPatch(
                         stairChange.before(), stairChange.after());
                 case TransitionChange transitionChange -> changed.withExactTransitionChange(
                         transitionChange.before(), transitionChange.after());
+                case CorridorChange corridorChange -> changed.withExactCorridorChange(
+                        corridorChange.before(), corridorChange.after());
             };
         }
         if (changed.equals(safeCurrent)) {

--- a/features/dungeon/application/authored/command/DungeonPatchChange.java
+++ b/features/dungeon/application/authored/command/DungeonPatchChange.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 /** One stable-identity authored entity delta carried by a Dungeon patch. */
 public sealed interface DungeonPatchChange permits FeatureMarkerChange, RoomRegionChange, RoomClusterChange,
-        StairChange, TransitionChange {
+        StairChange, TransitionChange, CorridorChange {
 
     DungeonMapIdentity mapId();
 

--- a/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
+++ b/features/dungeon/application/authored/command/DungeonPatchEntityRef.java
@@ -20,6 +20,7 @@ public record DungeonPatchEntityRef(
             case FEATURE_MARKER -> DungeonTopologyElementKind.FEATURE_MARKER;
             case STAIR -> DungeonTopologyElementKind.STAIR;
             case TRANSITION -> DungeonTopologyElementKind.TRANSITION;
+            case CORRIDOR -> DungeonTopologyElementKind.CORRIDOR;
             case ROOM_CLUSTER -> null;
         };
         if (expectedTopologyKind == null && topologyRef != null) {
@@ -65,11 +66,19 @@ public record DungeonPatchEntityRef(
                 new DungeonTopologyRef(DungeonTopologyElementKind.TRANSITION, transitionId));
     }
 
+    public static DungeonPatchEntityRef corridor(long corridorId) {
+        return new DungeonPatchEntityRef(
+                Kind.CORRIDOR,
+                corridorId,
+                new DungeonTopologyRef(DungeonTopologyElementKind.CORRIDOR, corridorId));
+    }
+
     public enum Kind {
         ROOM,
         ROOM_CLUSTER,
         FEATURE_MARKER,
         STAIR,
-        TRANSITION
+        TRANSITION,
+        CORRIDOR
     }
 }

--- a/features/dungeon/application/authored/command/RoomGeometryPatchPlanner.java
+++ b/features/dungeon/application/authored/command/RoomGeometryPatchPlanner.java
@@ -24,9 +24,7 @@ final class RoomGeometryPatchPlanner {
         if (after == null || after.equals(current)) {
             return new DungeonCommandResult.Rejected(noEffectReason);
         }
-        List<DungeonPatchChange> changes = new ArrayList<>();
-        changes.addAll(roomChanges(current, after));
-        changes.addAll(clusterChanges(current, after));
+        List<DungeonPatchChange> changes = new ArrayList<>(changes(current, after));
         if (changes.isEmpty()) {
             throw new IllegalStateException("room geometry operation changed unencoded authored truth");
         }
@@ -35,6 +33,13 @@ final class RoomGeometryPatchPlanner {
             throw new IllegalStateException("room geometry patch must reproduce the exact aggregate result");
         }
         return DungeonCommandResult.Accepted.from(patch);
+    }
+
+    static List<DungeonPatchChange> changes(DungeonMap before, DungeonMap after) {
+        List<DungeonPatchChange> result = new ArrayList<>();
+        result.addAll(roomChanges(before, after));
+        result.addAll(clusterChanges(before, after));
+        return List.copyOf(result);
     }
 
     private static List<DungeonPatchChange> roomChanges(DungeonMap before, DungeonMap after) {

--- a/features/dungeon/domain/core/structure/DungeonMap.java
+++ b/features/dungeon/domain/core/structure/DungeonMap.java
@@ -6,6 +6,7 @@ import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.geometry.Edge;
 import features.dungeon.domain.core.graph.DungeonTopologyRef;
 import features.dungeon.domain.core.structure.corridor.Corridor;
+import features.dungeon.domain.core.structure.corridor.CorridorNetwork;
 import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
 import features.dungeon.domain.core.structure.corridor.CorridorRoutingPolicy;
 import features.dungeon.domain.core.structure.feature.FeatureMarkerCatalog;
@@ -275,7 +276,7 @@ public record DungeonMap(
         return new DungeonMap(
                 metadata,
                 topology,
-                null,
+                topologyIndex,
                 nextRooms,
                 corridors,
                 stairs,
@@ -292,7 +293,7 @@ public record DungeonMap(
         return new DungeonMap(
                 metadata,
                 nextTopology,
-                null,
+                topologyIndex,
                 rooms,
                 corridors,
                 stairs,
@@ -309,7 +310,7 @@ public record DungeonMap(
         return new DungeonMap(
                 metadata,
                 topology,
-                null,
+                topologyIndex,
                 rooms,
                 corridors,
                 nextStairs,
@@ -323,6 +324,25 @@ public record DungeonMap(
             @Nullable Transition after
     ) {
         return withTransitionCatalog(transitionCatalog.withExactChange(before, after), null);
+    }
+
+    public DungeonMap withExactCorridorChange(
+            @Nullable Corridor before,
+            @Nullable Corridor after
+    ) {
+        List<Corridor> nextCorridors = new CorridorNetwork(corridors)
+                .withExactChange(before, after)
+                .corridors();
+        return new DungeonMap(
+                metadata,
+                topology,
+                topologyIndex,
+                rooms,
+                nextCorridors,
+                stairs,
+                transitionCatalog,
+                featureMarkers,
+                revision + 1L);
     }
 
     public DungeonMap withTransitionCatalog(TransitionCatalog nextTransitions) {

--- a/features/dungeon/domain/core/structure/corridor/CorridorEndpointResolution.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorEndpointResolution.java
@@ -119,10 +119,12 @@ final class CorridorEndpointResolution {
         return new DungeonMap(
                 dungeonMap.metadata(),
                 rebuild.topology(),
+                dungeonMap.topologyIndex(),
                 rebuild.rooms(),
                 dungeonMap.corridors(),
                 dungeonMap.stairs(),
                 dungeonMap.transitionCatalog(),
+                dungeonMap.featureMarkers(),
                 dungeonMap.revision() + 1L);
     }
 

--- a/features/dungeon/domain/core/structure/corridor/CorridorNetwork.java
+++ b/features/dungeon/domain/core/structure/corridor/CorridorNetwork.java
@@ -3,7 +3,9 @@ package features.dungeon.domain.core.structure.corridor;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 import features.dungeon.domain.core.component.CorridorAnchor;
 import features.dungeon.domain.core.component.CorridorAnchorRef;
 
@@ -33,6 +35,30 @@ public record CorridorNetwork(List<Corridor> corridors) {
             if (corridor.corridorId() != corridorId) {
                 result.add(corridor);
             }
+        }
+        return new CorridorNetwork(result);
+    }
+
+    public CorridorNetwork withExactChange(@Nullable Corridor before, @Nullable Corridor after) {
+        Corridor identity = after == null ? before : after;
+        if (identity == null) {
+            throw new IllegalArgumentException("corridor change requires identity");
+        }
+        if (!Objects.equals(corridorById(identity.corridorId()), before)) {
+            throw new IllegalStateException("corridor patch does not match current authored truth");
+        }
+        List<Corridor> result = new ArrayList<>();
+        for (Corridor corridor : corridors) {
+            if (corridor.corridorId() == identity.corridorId()) {
+                if (after != null) {
+                    result.add(after);
+                }
+            } else {
+                result.add(corridor);
+            }
+        }
+        if (before == null && after != null) {
+            result.add(after);
         }
         return new CorridorNetwork(result);
     }

--- a/features/dungeon/domain/core/structure/topology/DungeonMapTopology.java
+++ b/features/dungeon/domain/core/structure/topology/DungeonMapTopology.java
@@ -1,7 +1,7 @@
 package features.dungeon.domain.core.structure.topology;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -164,80 +164,46 @@ public record DungeonMapTopology(
     }
 
     public static DungeonMapTopology merge(@Nullable DungeonMapTopology primary, DungeonMapTopology fallback) {
-        Map<DungeonTopologyRef, DungeonTopologyBinding> result = new LinkedHashMap<>();
-        addPrimaryBindings(result, primary);
-        addFallbackBindings(result, fallback);
-        return new DungeonMapTopology(new ArrayList<>(result.values()));
-    }
-
-    private static void addPrimaryBindings(
-            Map<DungeonTopologyRef, DungeonTopologyBinding> result,
-            @Nullable DungeonMapTopology primary
-    ) {
-        for (DungeonTopologyBinding binding : primary == null ? List.<DungeonTopologyBinding>of() : primary.bindings()) {
-            if (binding.ref().present()) {
-                result.put(binding.ref(), binding);
+        List<DungeonTopologyBinding> primaryBindings = primary == null ? List.of() : primary.bindings();
+        Map<DungeonTopologyRef, DungeonTopologyBinding> previousByRef = new HashMap<>();
+        Map<AnchorIdentity, DungeonTopologyBinding> previousAnchors = new HashMap<>();
+        for (DungeonTopologyBinding binding : primaryBindings) {
+            previousByRef.putIfAbsent(binding.ref(), binding);
+            if (binding.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR) {
+                previousAnchors.putIfAbsent(AnchorIdentity.from(binding), binding);
             }
         }
-    }
-
-    private static void addFallbackBindings(
-            Map<DungeonTopologyRef, DungeonTopologyBinding> result,
-            DungeonMapTopology fallback
-    ) {
-        for (DungeonTopologyBinding binding : fallback == null ? List.<DungeonTopologyBinding>of() : fallback.bindings()) {
-            addFallbackBinding(result, binding);
-        }
-    }
-
-    private static void addFallbackBinding(
-            Map<DungeonTopologyRef, DungeonTopologyBinding> result,
-            DungeonTopologyBinding binding
-    ) {
-        if (!binding.ref().present()) {
-            return;
-        }
-        DungeonTopologyBinding existing = result.get(binding.ref());
-        if (existing != null) {
-            result.put(binding.ref(), withLocalIdentity(existing, binding));
-            return;
-        }
-        if (!hasSameCorridorAnchorLocalIdentity(result, binding)) {
-            result.put(binding.ref(), binding);
-        }
-    }
-
-    private static DungeonTopologyBinding withLocalIdentity(
-            DungeonTopologyBinding existing,
-            DungeonTopologyBinding fallback
-    ) {
-        if (existing.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR
-                && fallback.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR) {
-            return new DungeonTopologyBinding(
-                    fallback.ref(),
-                    fallback.clusterId(),
-                    fallback.corridorId(),
-                    existing.localElementId(),
-                    fallback.label());
-        }
-        return existing;
-    }
-
-    private static boolean hasSameCorridorAnchorLocalIdentity(
-            Map<DungeonTopologyRef, DungeonTopologyBinding> bindings,
-            DungeonTopologyBinding candidate
-    ) {
-        if (candidate.ref().kind() != DungeonTopologyElementKind.CORRIDOR_ANCHOR) {
-            return false;
-        }
-        for (DungeonTopologyBinding existing : bindings.values()) {
-            if (existing.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR
-                    && existing.corridorId() == candidate.corridorId()
-                    && existing.localElementId() == candidate.localElementId()) {
-                return true;
+        List<DungeonTopologyBinding> result = new ArrayList<>();
+        for (DungeonTopologyBinding derived
+                : fallback == null ? List.<DungeonTopologyBinding>of() : fallback.bindings()) {
+            if (!derived.ref().present()) {
+                continue;
             }
+            DungeonTopologyBinding previous = derived.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR
+                    ? previousAnchors.get(AnchorIdentity.from(derived))
+                    : previousByRef.get(derived.ref());
+            result.add(previous == null ? derived : withStableFacts(previous, derived));
         }
-        return false;
+        return new DungeonMapTopology(result);
+    }
+
+    private static DungeonTopologyBinding withStableFacts(
+            DungeonTopologyBinding previous,
+            DungeonTopologyBinding derived
+    ) {
+        boolean corridorAnchor = derived.ref().kind() == DungeonTopologyElementKind.CORRIDOR_ANCHOR;
+        return new DungeonTopologyBinding(
+                corridorAnchor ? previous.ref() : derived.ref(),
+                derived.clusterId(),
+                derived.corridorId(),
+                corridorAnchor ? previous.localElementId() : derived.localElementId(),
+                previous.label());
+    }
+
+    private record AnchorIdentity(long corridorId, long localElementId) {
+        private static AnchorIdentity from(DungeonTopologyBinding binding) {
+            return new AnchorIdentity(binding.corridorId(), binding.localElementId());
+        }
     }
 
     public @Nullable DungeonTopologyBinding binding(DungeonTopologyRef ref) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorCorridorScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorCorridorScenarios.java
@@ -565,6 +565,7 @@ final class DungeonEditorCorridorScenarios {
         assertPointerTarget(binding.mapContentModel(), doorTwo,
                 DungeonEditorRuntimePointerTarget.TargetKind.HANDLE, "DE-COR-014 second door");
         AuthoredCorridorState beforeFirstClick = AuthoredCorridorState.capture(runtime, binding, mapId);
+        long revisionBeforeCreate = runtime.database().mapRevision(mapId);
         DungeonMapContentModel.Viewport viewport = binding.mapContentModel().currentViewport();
 
         clickMap(mapView, MouseButton.PRIMARY,
@@ -593,6 +594,8 @@ final class DungeonEditorCorridorScenarios {
 
         long newCorridorId = singleNewCorridorId(corridorIdsBefore, runtime.database().corridorIdsForMap(mapId),
                 "DE-COR-014");
+        assertEquals(revisionBeforeCreate + 1L, runtime.database().mapRevision(mapId),
+                "DE-COR-014 corridor create commits exactly one aggregate revision");
         assertCorridorDoorBindingCount(runtime.database().corridorStableConnectionState(mapId), newCorridorId, 2,
                 "DE-COR-014");
         assertEquals(doorRowsBefore, runtime.database().doorBoundaryState(mapId),
@@ -610,6 +613,26 @@ final class DungeonEditorCorridorScenarios {
                 runtimePointerTarget(binding.mapContentModel(), fallbackCorridorBody.getX(), fallbackCorridorBody.getY())
                         .elementKind(),
                 "DE-COR-014 fallback body remains a semantic corridor target");
+
+        fireMapShortcut(mapView, KeyCode.Z, true, false);
+        assertEquals(corridorIdsBefore, runtime.database().corridorIdsForMap(mapId),
+                "DE-COR-014 patch undo removes the created corridor");
+        assertEquals(revisionBeforeCreate + 2L, runtime.database().mapRevision(mapId),
+                "DE-COR-014 patch undo restores content as one new revision");
+        assertEquals(doorRowsBefore, runtime.database().doorBoundaryState(mapId),
+                "DE-COR-014 patch undo preserves reused door identities");
+
+        fireMapShortcut(mapView, KeyCode.Y, true, false);
+        assertTrue(runtime.database().corridorIdsForMap(mapId).contains(newCorridorId),
+                "DE-COR-014 patch redo restores the created corridor identity");
+        assertEquals(revisionBeforeCreate + 3L, runtime.database().mapRevision(mapId),
+                "DE-COR-014 patch redo restores content as one new revision");
+        assertCorridorCreatedInSnapshot(
+                runtime.mapSurfaceModel().current(),
+                binding.mapContentModel(),
+                newCorridorId,
+                expectedCells,
+                "DE-COR-014 redo");
         selectMap(controls, "Corridor Vertical Fallback Reload Hop");
         selectMap(controls, "Corridor Vertical Fallback Map");
         assertCorridorCreatedInSnapshot(
@@ -729,6 +752,7 @@ final class DungeonEditorCorridorScenarios {
                 "DE-COR-006 fixture starts with authored A1 at (6,5,0)");
         click(button(controls, "Korridor"));
         DungeonMapContentModel.Viewport viewport = binding.mapContentModel().currentViewport();
+        long revisionBeforeDelete = runtime.database().mapRevision(mapId);
 
         clickMap(
                 mapView,
@@ -737,6 +761,8 @@ final class DungeonEditorCorridorScenarios {
                 viewport.sceneToScreenY(anchorCenter.getY()),
                 false);
 
+        assertEquals(revisionBeforeDelete + 1L, runtime.database().mapRevision(mapId),
+                "DE-COR-006 corridor branch delete commits exactly one aggregate revision");
         assertCorridorDoorBindingCount(runtime.database().corridorStableConnectionState(mapId), corridorId, 2,
                 "DE-COR-006 keeps both surviving door endpoints");
         assertNoCorridorAnchorRef(runtime.database().corridorStableConnectionState(mapId), corridorId, anchorRef.id(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
@@ -1162,6 +1162,7 @@ final class DungeonEditorStairScenarios {
         Set<Long> corridorIdsBefore = runtime.database().corridorIdsForMap(mapId);
         List<String> stairRowsBefore = runtime.database().stairStableState(mapId);
         assertTrue(stairRowsBefore.isEmpty(), "DE-STAIR-008 fixture starts without stair rows");
+        long revisionBeforeCorridor = runtime.database().mapRevision(mapId);
         click(button(controls, "-"));
         click(button(controls, "Korridor"));
         assertEquals(DungeonEditorToolSelection.family(DungeonEditorToolFamily.CORRIDOR),
@@ -1199,6 +1200,8 @@ final class DungeonEditorStairScenarios {
 
         long newCorridorId = singleNewCorridorId(corridorIdsBefore, runtime.database().corridorIdsForMap(mapId),
                 "DE-STAIR-008");
+        assertEquals(revisionBeforeCorridor + 1L, runtime.database().mapRevision(mapId),
+                "DE-STAIR-008 cross-level corridor and bound stair commit exactly one aggregate revision");
         List<String> stableCorridorState = runtime.database().corridorStableConnectionState(mapId);
         assertCorridorDoorBindingCount(stableCorridorState, newCorridorId, 2, "DE-STAIR-008");
         List<String> stairRowsAfter = runtime.database().stairStableState(mapId);

--- a/test/features/dungeon/application/authored/command/DungeonCorridorPatchCommandsTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonCorridorPatchCommandsTest.java
@@ -1,0 +1,259 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.component.CorridorAnchor;
+import features.dungeon.domain.core.component.CorridorAnchorRef;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Direction;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring.AuthoredContent;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.corridor.Corridor;
+import features.dungeon.domain.core.structure.corridor.CorridorBindings;
+import features.dungeon.domain.core.structure.corridor.CorridorDeletionTarget;
+import features.dungeon.domain.core.structure.corridor.CorridorRoomSet;
+import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class DungeonCorridorPatchCommandsTest {
+
+    @Test
+    void sameLevelCreateAndDeleteUseExactCorridorAndBoundaryChanges() {
+        DungeonMap current = endpointMap(0, 0);
+        Endpoints endpoints = endpoints(current, 0, 0);
+        CreateCorridorCommand create = new CreateCorridorCommand(new OrthogonalCorridorRoutingPolicy());
+
+        DungeonCommandResult.Accepted createdResult = accepted(create.plan(
+                current,
+                91L,
+                endpoints.start(),
+                endpoints.end()));
+        assertTrue(createdResult.patch().changes().stream()
+                .anyMatch(change -> change instanceof CorridorChange corridor
+                        && corridor.before() == null
+                        && corridor.after() != null));
+        assertTrue(createdResult.patch().changes().stream()
+                .anyMatch(RoomClusterChange.class::isInstance));
+        CorridorChange corridorChange = createdResult.patch().changes().stream()
+                .filter(CorridorChange.class::isInstance)
+                .map(CorridorChange.class::cast)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                DungeonPatchEntityRef.corridor(corridorChange.after().corridorId()),
+                corridorChange.entityRef());
+        assertTrue(!createdResult.patch().touchedChunks().isEmpty());
+        DungeonMap created = createdResult.patch().applyTo(current);
+        DungeonMap domainResult = current.createCorridor(
+                new OrthogonalCorridorRoutingPolicy(),
+                91L,
+                endpoints.start(),
+                endpoints.end());
+        assertEquals(
+                DungeonMapAuthoring.committedContent(domainResult, current.revision() + 1L),
+                created);
+        assertEquals(current.revision() + 1L, created.revision());
+        assertTrue(created.corridors().getLast().bindings().doorBindings().stream().allMatch(door ->
+                created.topologyIndex().binding(door.topologyRef()).corridorId()
+                        == created.corridors().getLast().corridorId()));
+        assertEquals(current, contentAtRevision(createdResult.inverse().applyTo(created), current.revision()));
+
+        long corridorId = created.corridors().getLast().corridorId();
+        DungeonCommandResult.Accepted deletedResult = accepted(new DeleteCorridorCommand(
+                new OrthogonalCorridorRoutingPolicy()).plan(
+                        created,
+                        CorridorDeletionTarget.wholeCorridor(corridorId)));
+        CorridorChange deletedCorridor = deletedResult.patch().changes().stream()
+                .filter(CorridorChange.class::isInstance)
+                .map(CorridorChange.class::cast)
+                .filter(change -> change.entityRef().id() == corridorId)
+                .findFirst()
+                .orElseThrow();
+        assertNull(deletedCorridor.after());
+        DungeonMap deleted = deletedResult.patch().applyTo(created);
+        assertTrue(deleted.corridors().stream().noneMatch(corridor -> corridor.corridorId() == corridorId));
+        assertEquals(created, contentAtRevision(deletedResult.inverse().applyTo(deleted), created.revision()));
+    }
+
+    @Test
+    void crossLevelCreateAndOwnerDeleteCarryBoundStairInSamePatch() {
+        DungeonMap current = endpointMap(0, 1);
+        Endpoints endpoints = endpoints(current, 0, 1);
+        DungeonCommandResult.Accepted createdResult = accepted(new CreateCorridorCommand(
+                new OrthogonalCorridorRoutingPolicy()).plan(
+                        current,
+                        92L,
+                        endpoints.start(),
+                        endpoints.end()));
+        StairChange stairCreated = createdResult.patch().changes().stream()
+                .filter(StairChange.class::isInstance)
+                .map(StairChange.class::cast)
+                .findFirst()
+                .orElseThrow();
+        assertNull(stairCreated.before());
+        assertEquals(92L, stairCreated.after().stairId());
+        assertTrue(stairCreated.after().corridorId() > 0L);
+        DungeonMap created = createdResult.patch().applyTo(current);
+        assertEquals(92L, created.stairs().stairs().getFirst().stairId());
+
+        long corridorId = created.corridors().getLast().corridorId();
+        DungeonCommandResult.Accepted deletedResult = accepted(new DeleteCorridorCommand(
+                new OrthogonalCorridorRoutingPolicy()).plan(
+                        created,
+                        CorridorDeletionTarget.wholeCorridor(corridorId)));
+        StairChange stairDeleted = deletedResult.patch().changes().stream()
+                .filter(StairChange.class::isInstance)
+                .map(StairChange.class::cast)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(92L, stairDeleted.before().stairId());
+        assertNull(stairDeleted.after());
+        DungeonMap deleted = deletedResult.patch().applyTo(created);
+        assertTrue(deleted.stairs().stairs().isEmpty());
+        assertEquals(created, contentAtRevision(deletedResult.inverse().applyTo(deleted), created.revision()));
+    }
+
+    @Test
+    void negativeCoordinatesUseFloorDividedTouchedChunks() {
+        DungeonMap current = emptyMap()
+                .paintRoomRectangle(new Cell(-130, -2, 0), new Cell(-129, -1, 0))
+                .paintRoomRectangle(new Cell(-124, -2, 0), new Cell(-123, -1, 0));
+        Endpoints endpoints = endpoints(current, 0, 0);
+
+        DungeonCommandResult.Accepted created = accepted(new CreateCorridorCommand(
+                new OrthogonalCorridorRoutingPolicy()).plan(
+                        current,
+                        93L,
+                        endpoints.start(),
+                        endpoints.end()));
+
+        assertTrue(created.patch().touchedChunks().stream().anyMatch(chunk -> chunk.chunkQ() == -3));
+        assertTrue(created.patch().touchedChunks().stream().anyMatch(chunk -> chunk.chunkQ() == -2));
+        assertTrue(created.patch().touchedChunks().stream().allMatch(chunk -> chunk.chunkR() == -1));
+    }
+
+    @Test
+    void referencedOwnerDeleteAndInvalidCreateRejectWithStableReasons() {
+        Corridor owner = new Corridor(
+                10L,
+                73L,
+                0,
+                new CorridorRoomSet(List.of()),
+                new CorridorBindings(
+                        List.of(),
+                        List.of(),
+                        List.of(new CorridorAnchor(1L, 10L, new Cell(1, 0, 0))),
+                        List.of()));
+        Corridor dependent = new Corridor(
+                11L,
+                73L,
+                0,
+                new CorridorRoomSet(List.of()),
+                new CorridorBindings(
+                        List.of(),
+                        List.of(),
+                        List.of(),
+                        List.of(new CorridorAnchorRef(10L, 1L))));
+        DungeonMap empty = emptyMap();
+        DungeonMap protectedMap = DungeonMapAuthoring.authored(
+                empty.metadata().mapId(),
+                empty.metadata().mapName(),
+                new AuthoredContent(
+                        empty.topology(),
+                        empty.topologyIndex(),
+                        empty.rooms(),
+                        List.of(owner, dependent),
+                        empty.stairs(),
+                        empty.transitionCatalog().transitions(),
+                        empty.featureMarkers()),
+                empty.revision());
+        long protectedRevision = protectedMap.revision();
+        List<Corridor> protectedCorridors = protectedMap.corridors();
+
+        DungeonCommandResult.Rejected protectedDelete = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new DeleteCorridorCommand(new OrthogonalCorridorRoutingPolicy()).plan(
+                        protectedMap,
+                        CorridorDeletionTarget.wholeCorridor(10L)));
+        DungeonCommandResult.Rejected invalidCreate = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                new CreateCorridorCommand(new OrthogonalCorridorRoutingPolicy()).plan(
+                        empty,
+                        0L,
+                        null,
+                        null));
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE, protectedDelete.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, invalidCreate.reason());
+        assertEquals(protectedRevision, protectedMap.revision());
+        assertEquals(protectedCorridors, protectedMap.corridors());
+    }
+
+    private static Endpoints endpoints(DungeonMap map, int startLevel, int endLevel) {
+        RoomRegion startRoom = roomAtLevel(map, startLevel);
+        RoomRegion endRoom = map.rooms().rooms().stream()
+                .filter(room -> room.primaryLevel() == endLevel && room.roomId() != startRoom.roomId())
+                .findFirst()
+                .orElseThrow();
+        Cell startCell = startRoom.floorCells().stream()
+                .max(java.util.Comparator.comparingInt(Cell::q))
+                .orElseThrow();
+        Cell endCell = endRoom.floorCells().stream()
+                .min(java.util.Comparator.comparingInt(Cell::q))
+                .orElseThrow();
+        return new Endpoints(
+                DungeonCorridorEndpoint.door(
+                        startRoom.roomId(),
+                        startRoom.clusterId(),
+                        startCell,
+                        Direction.EAST,
+                        DungeonTopologyRef.empty()),
+                DungeonCorridorEndpoint.door(
+                        endRoom.roomId(),
+                        endRoom.clusterId(),
+                        endCell,
+                        Direction.WEST,
+                        DungeonTopologyRef.empty()));
+    }
+
+    private static DungeonMap endpointMap(int startLevel, int endLevel) {
+        DungeonMap map = emptyMap().paintRoomRectangle(
+                new Cell(1, 1, startLevel),
+                new Cell(2, 2, startLevel));
+        return map.paintRoomRectangle(
+                new Cell(7, 1, endLevel),
+                new Cell(8, 2, endLevel));
+    }
+
+    private static RoomRegion roomAtLevel(DungeonMap map, int level) {
+        return map.rooms().rooms().stream()
+                .filter(room -> room.primaryLevel() == level)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static DungeonCommandResult.Accepted accepted(DungeonCommandResult result) {
+        return assertInstanceOf(DungeonCommandResult.Accepted.class, result);
+    }
+
+    private static DungeonMap emptyMap() {
+        return DungeonMapAuthoring.empty(new DungeonMapIdentity(73L), "Corridor Patches");
+    }
+
+    private static DungeonMap contentAtRevision(DungeonMap map, long revision) {
+        assertTrue(map.revision() > revision);
+        return DungeonMapAuthoring.committedContent(map, revision);
+    }
+
+    private record Endpoints(DungeonCorridorEndpoint start, DungeonCorridorEndpoint end) {
+    }
+}


### PR DESCRIPTION
## Was geändert wurde

- Corridor-Create, Whole-Delete und Branch-Delete planen exakte `CorridorChange`-Patches.
- Endpoint-erzeugte Clustergrenzen, veränderte Host-Corridors und corridor-gebundene Stairs werden atomar im selben Patch getragen.
- Der reale Authored-Consumer nutzt den gemeinsamen Patch-Executor; der ersetzte direkte `executeOperation`-Commitpfad ist entfernt.
- Der abgeleitete Topology-Index verwirft stale Bindings, bewahrt aber stabile Labels und persistierte Corridor-Anchor-Refs.
- Produktionsrouten beweisen einen Revisionsschritt, Persistenz-Reload sowie Patch-Undo/Redo.

## Warum

M3.7 der Dungeon-Greenfield-Migration ersetzt Snapshot-Commit und Snapshot-History für Corridor-Erstellung und -Löschung durch stabile, invertierbare Entity-Deltas.

## Nachweise

- `./gradlew test --tests features.dungeon.application.authored.command.DungeonCorridorPatchCommandsTest --console=plain`
- vollständige `DungeonEditorBehaviorSuiteTest` (`BUILD SUCCESSFUL in 1m 26s`)
- `./gradlew architectureTest --console=plain` (`BUILD SUCCESSFUL in 39s`)
- `./gradlew check --console=plain` (`BUILD SUCCESSFUL in 2m 57s`)
- `./gradlew installDesktopApp --console=plain` (`BUILD SUCCESSFUL in 9s`)
