### PR TITLE
feat: Verbindungsgriffe auf exakte Patches migrieren

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,33 +97,34 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.6 are complete on
-  `main` through PR #505. Feature markers, room or cluster semantics, room
-  geometry, stairs, and transitions use exact patches; transition links use
-  atomic compound patches and shared multi-map history.
-- This slice: M3.7 moves corridor create, whole-corridor delete, and targeted
-  branch delete to one exact corridor patch planner and the shared patch
-  executor. Their production consumers no longer commit through
-  `executeOperation`; create and delete previews remain repository-free.
-- Corridor changes encode create, update, and delete states with exact touched
-  chunks. The planner also carries endpoint-created room-cluster boundaries,
-  modified host corridors, and corridor-owned stairs in the same accepted
-  patch, then proves that applying it reproduces the complete aggregate.
-- Topology rebuild now derives current binding membership, order, and ownership
-  from canonical aggregate content while preserving stable labels and the
-  persisted topology-ref mapping for surviving corridor anchors. Deleted refs
-  cannot remain as stale index entries.
-- Deterministic and production-route proof covers same-level and cross-level
-  create, bound-stair create or owner delete, targeted branch delete, stable
-  anchor and door identities, negative-safe touched chunks, typed blocked-route
-  rejection, one-revision commits, exact inverse application, shortcut undo or
-  redo, SQLite reload, and preview storage isolation.
-- Whole-cluster label movement plus door, corridor-anchor, corridor-waypoint,
-  and stair-anchor handles retain temporary snapshot history until the next
-  connection-handle slice. `DungeonChangeSet(before, after)`, snapshot history,
-  and `executeOperation` remain only for those not-yet-migrated M3 routes.
-- Next step after this slice merges: M3.8 moves all remaining connection-handle
-  commits to exact patches and removes their direct operation routes.
+- Current foundation: M0 through M2 and M3.1 through M3.7 are complete on
+  `main` through PR #506. Feature markers, room or cluster semantics, room
+  geometry, stairs, transitions, and corridor create or delete use exact
+  patches; transition links use atomic compound patches and shared multi-map
+  history.
+- This slice: M3.8 moves whole-cluster label, bound and standalone door,
+  corridor-anchor, corridor-waypoint, and stair-anchor commits to one typed
+  move command and the shared connection patch planner. Corner and wall-run
+  handles retain their already-landed specialized patch commands.
+- `executeOperation`, `DungeonEditHistory.SnapshotEntry`, full-map history
+  recording, and structural-object memory estimation are deleted. History now
+  accepts only single-map or compound patches with encoded byte weights.
+- The production consumer dispatches every successful handle release through
+  `executePatchCommand`; the same in-memory handle mutation remains available
+  only to repository-free drag preview after its authored workset is loaded.
+- Deterministic and production-route proof covers multi-entity cluster moves
+  across negative chunks, every handle variant, exact inverse application,
+  typed no-effect and invalid-target rejection, preview storage isolation,
+  one-revision commit, patch shortcut undo or redo, stable identities, and
+  SQLite reload.
+- `DungeonChangeSet(before, after)` remains only as the temporary whole-map
+  persistence bridge used beneath accepted patches, history replay, transition
+  compounds, and catalog rename. M4 owns its replacement with incremental
+  `DungeonUnitOfWork`; no new caller may use it.
+- Next step after this slice merges: M3.9 closes the patch/history milestone by
+  qualifying command and byte retention limits, proving the remaining
+  no-history command exclusions, and tightening the M3 architecture gate before
+  M4 replaces the temporary persistence bridge.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -38,6 +38,7 @@ import features.dungeon.application.authored.command.DeleteCorridorCommand;
 import features.dungeon.application.authored.command.DeleteStairCommand;
 import features.dungeon.application.authored.command.DeleteTransitionCommand;
 import features.dungeon.application.authored.command.FeatureMarkerSemanticsCommand;
+import features.dungeon.application.authored.command.MoveConnectionHandleCommand;
 import features.dungeon.application.authored.command.RoomClusterNameCommand;
 import features.dungeon.application.authored.command.RoomNameCommand;
 import features.dungeon.application.authored.command.RoomNarrationCommand;
@@ -62,16 +63,16 @@ import features.dungeon.domain.core.structure.stair.StairShape;
 import features.dungeon.domain.core.structure.transition.TransitionAnchor;
 import features.dungeon.domain.core.structure.transition.TransitionCatalog;
 import features.dungeon.domain.core.structure.transition.TransitionDestination;
-import features.dungeon.application.editor.interaction.DungeonEditorHandleMutation;
 import features.dungeon.application.editor.interaction.DungeonEditorHandleProjection;
+import features.dungeon.application.editor.interaction.DungeonEditorHandleMutation;
 import features.dungeon.api.DungeonEditorHandleKind;
 import features.dungeon.application.editor.session.DungeonEditorDungeonState;
 import features.dungeon.application.editor.session.DungeonEditorRoomNarrationInput;
 import features.dungeon.application.editor.session.DungeonEditorSessionSnapshot;
 import features.dungeon.application.editor.session.DungeonEditorSessionValues;
-import features.dungeon.application.editor.session.DungeonEditorWorkspaceHandleMovement;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceGeometry;
+import features.dungeon.application.editor.session.DungeonEditorWorkspaceHandleMovement;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapSnapshot;
 import features.dungeon.application.editor.helper.DungeonEditorAuthoredOperationHelper;
@@ -138,6 +139,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final ClusterCornerCommand clusterCornerCommand = new ClusterCornerCommand();
     private final ClusterBoundaryStretchCommand clusterBoundaryStretchCommand =
             new ClusterBoundaryStretchCommand();
+    private final MoveConnectionHandleCommand moveConnectionHandleCommand =
+            new MoveConnectionHandleCommand();
     private final CreateStairCommand createStairCommand = new CreateStairCommand();
     private final DeleteStairCommand deleteStairCommand = new DeleteStairCommand();
     private final UpdateStairGeometryCommand updateStairGeometryCommand =
@@ -619,13 +622,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
     private final class MutationPipeline {
 
-        private OperationResultData executeOperation(
-                @Nullable DungeonMapIdentity mapId,
-                @Nullable AuthoredMapMutation operation
-        ) {
-            return executeOperation(mapId, operation, DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
-        }
-
         private OperationResultData executePatchCommand(
                 DungeonMapIdentity mapId,
                 AuthoredPatchCommand command
@@ -651,34 +647,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     OPERATION_FEEDBACK_POLICY.validationMessages(current, saved),
                     OPERATION_FEEDBACK_POLICY.reactionMessages(current, saved),
                     DungeonEditorCommandOutcome.accepted(saved.revision()));
-        }
-
-        private OperationResultData executeOperation(
-                @Nullable DungeonMapIdentity mapId,
-                @Nullable AuthoredMapMutation operation,
-                DungeonEditorCommandOutcome.RejectionReason rejectionReason
-        ) {
-            DungeonMap current = loadMap(mapId);
-            DungeonMap operationResult = applyOperation(current, operation);
-            boolean changed = !operationResult.equals(current);
-            DungeonMap mutated = changed
-                    ? DungeonMapAuthoring.committedContent(operationResult, current.revision() + 1L)
-                    : current;
-            List<String> validationMessages = OPERATION_FEEDBACK_POLICY.validationMessages(current, mutated);
-            List<String> reactionMessages = OPERATION_FEEDBACK_POLICY.reactionMessages(current, mutated);
-            DungeonDerivedState derived = derive(mutated);
-            DungeonMap saved = changed
-                    ? repository.saveChange(new DungeonChangeSet(current, mutated))
-                    : current;
-            authoredWorkset.put(saved.metadata().mapId().value(), saved);
-            if (changed) {
-                editHistory.record(current, saved);
-            }
-            DungeonEditorCommandOutcome outcome = changed
-                    ? DungeonEditorCommandOutcome.accepted(saved.revision())
-                    : DungeonEditorCommandOutcome.rejected(rejectionReason);
-            return new OperationResultData(
-                    snapshotData(saved, derived), changed, validationMessages, reactionMessages, outcome);
         }
 
         private OperationResultData previewOperation(
@@ -961,7 +929,16 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                                     safePreview.deltaQ(),
                                     safePreview.deltaR(),
                                     safePreview.deltaLevel()))
-                    : applyHandleMovement(domainMapId(mapId), handleRef, safePreview);
+                    : mutationPipeline.executePatchCommand(
+                            domainMapId(mapId),
+                            current -> moveConnectionHandleCommand.planCluster(
+                                    current,
+                                    handleRef.clusterId() > 0L
+                                            ? handleRef.clusterId()
+                                            : current.clusterIdForTopologyRef(handleRef.topologyRef()),
+                                    safePreview.deltaQ(),
+                                    safePreview.deltaR(),
+                                    safePreview.deltaLevel()));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -976,14 +953,12 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (handleRef.kind() != DungeonEditorHandleKind.DOOR) {
                 return;
             }
-            OperationResultData result = mutationPipeline.executeOperation(
+            OperationResultData result = mutationPipeline.executePatchCommand(
                     domainMapId(mapId),
                     current -> {
-                        if (stationary(safePreview)) {
-                            return current;
-                        }
                         if (handleRef.corridorId() > ABSENT_ID) {
-                            return current.moveDoorBinding(
+                            return moveConnectionHandleCommand.planDoorBinding(
+                                    current,
                                     handleRef.corridorId(),
                                     Math.max(0, handleRef.index()),
                                     Math.max(0L, handleRef.roomId()),
@@ -994,7 +969,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                         DungeonTopologyRef topologyRef = handleRef.topologyRef() == null
                                 ? DungeonTopologyRef.empty()
                                 : handleRef.topologyRef();
-                        return current.moveDoorBoundary(
+                        return moveConnectionHandleCommand.planDoorBoundary(
+                                current,
                                 topologyRef,
                                 handleRef.clusterId() > 0L
                                         ? handleRef.clusterId()
@@ -1018,30 +994,28 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             DungeonEditorWorkspaceValues.HandleRef handleRef = safePreview.handleRef();
             OperationResultData result;
             if (handleRef.kind() == DungeonEditorHandleKind.CORRIDOR_ANCHOR) {
-                result = mutationPipeline.executeOperation(
+                result = mutationPipeline.executePatchCommand(
                         domainMapId(mapId),
-                        current -> stationary(safePreview)
-                                ? current
-                                : current.moveCorridorAnchor(
-                                        Math.max(0L, handleRef.corridorId()),
-                                        Math.max(0, handleRef.index()),
-                                        handleRef.topologyRef() == null
-                                                ? DungeonTopologyRef.empty()
-                                                : handleRef.topologyRef(),
-                                        safePreview.deltaQ(),
-                                        safePreview.deltaR(),
-                                        safePreview.deltaLevel()));
+                        current -> moveConnectionHandleCommand.planCorridorAnchor(
+                                current,
+                                Math.max(0L, handleRef.corridorId()),
+                                Math.max(0, handleRef.index()),
+                                handleRef.topologyRef() == null
+                                        ? DungeonTopologyRef.empty()
+                                        : handleRef.topologyRef(),
+                                safePreview.deltaQ(),
+                                safePreview.deltaR(),
+                                safePreview.deltaLevel()));
             } else if (handleRef.kind() == DungeonEditorHandleKind.CORRIDOR_WAYPOINT) {
-                result = mutationPipeline.executeOperation(
+                result = mutationPipeline.executePatchCommand(
                         domainMapId(mapId),
-                        current -> stationary(safePreview)
-                                ? current
-                                : current.moveCorridorWaypoint(
-                                        Math.max(0L, handleRef.corridorId()),
-                                        Math.max(0, handleRef.index()),
-                                        safePreview.deltaQ(),
-                                        safePreview.deltaR(),
-                                        safePreview.deltaLevel()));
+                        current -> moveConnectionHandleCommand.planCorridorWaypoint(
+                                current,
+                                Math.max(0L, handleRef.corridorId()),
+                                Math.max(0, handleRef.index()),
+                                safePreview.deltaQ(),
+                                safePreview.deltaR(),
+                                safePreview.deltaLevel()));
             } else {
                 return;
             }
@@ -1059,7 +1033,15 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (handleRef.kind() != DungeonEditorHandleKind.STAIR_ANCHOR) {
                 return;
             }
-            OperationResultData result = applyHandleMovement(domainMapId(mapId), handleRef, safePreview);
+            OperationResultData result = mutationPipeline.executePatchCommand(
+                    domainMapId(mapId),
+                    current -> moveConnectionHandleCommand.planStairAnchor(
+                            current,
+                            Math.max(0L, handleRef.ownerId()),
+                            Math.max(0, handleRef.index()),
+                            safePreview.deltaQ(),
+                            safePreview.deltaR(),
+                            safePreview.deltaLevel()));
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
@@ -1082,21 +1064,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             publicationOperations.publishMutation(result, session.dungeonState());
         }
 
-        private OperationResultData applyHandleMovement(
-                DungeonMapIdentity mapId,
-                DungeonEditorWorkspaceValues.HandleRef handleRef,
-                DungeonEditorSessionValues.MoveHandlePreview preview
-        ) {
-            return mutationPipeline.executeOperation(
-                    mapId,
-                    current -> HANDLE_MUTATION.apply(
-                            current,
-                            DungeonEditorWorkspaceHandleMovement.from(handleRef),
-                            preview.deltaQ(),
-                            preview.deltaR(),
-                            preview.deltaLevel()));
-        }
-
         private Edge sourceEdge(DungeonEditorWorkspaceValues.HandleRef handleRef) {
             if (handleRef.sourceEdge() != null) {
                 return handleRef.sourceEdge();
@@ -1105,9 +1072,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             return handleRef.direction().edgeOf(cell);
         }
 
-        private boolean stationary(DungeonEditorSessionValues.MoveHandlePreview preview) {
-            return preview.deltaQ() == 0 && preview.deltaR() == 0 && preview.deltaLevel() == 0;
-        }
     }
 
     private final class CatalogOperations {

--- a/features/dungeon/application/authored/DungeonEditHistory.java
+++ b/features/dungeon/application/authored/DungeonEditHistory.java
@@ -3,7 +3,6 @@ package features.dungeon.application.authored;
 import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.domain.core.structure.DungeonMap;
-import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -20,12 +19,6 @@ final class DungeonEditHistory {
     static final long MAXIMUM_ESTIMATED_BYTES = 128L * 1024L * 1024L;
 
     private final Map<Long, MapHistory> histories = new HashMap<>();
-
-    void record(DungeonMap before, DungeonMap after) {
-        if (before != null && after != null && !before.equals(after)) {
-            recordEntry(new SnapshotEntry(before, after, estimatedBytes(before, after)));
-        }
-    }
 
     void recordPatch(DungeonPatch patch) {
         if (patch != null) {
@@ -171,20 +164,6 @@ final class DungeonEditHistory {
         }
     }
 
-    private static long estimatedBytes(DungeonMap before, DungeonMap after) {
-        return estimateMap(before) + estimateMap(after);
-    }
-
-    private static long estimateMap(DungeonMap map) {
-        long structuralObjects = 1L
-                + map.rooms().rooms().size()
-                + map.corridors().size()
-                + map.stairs().stairs().size()
-                + map.transitionCatalog().transitions().size()
-                + map.featureMarkers().markers().size();
-        return Math.max(4_096L, structuralObjects * 512L);
-    }
-
     record Step(@Nullable HistoryEntry entry, boolean undo) {
         static Step empty() {
             return new Step(null, false);
@@ -206,28 +185,12 @@ final class DungeonEditHistory {
         }
     }
 
-    private sealed interface HistoryEntry permits SnapshotEntry, PatchEntry, CompoundPatchEntry {
+    private sealed interface HistoryEntry permits PatchEntry, CompoundPatchEntry {
         Set<Long> mapIds();
 
         long encodedBytes();
 
         Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo);
-    }
-
-    private record SnapshotEntry(DungeonMap before, DungeonMap after, long encodedBytes)
-            implements HistoryEntry {
-        @Override
-        public Set<Long> mapIds() {
-            return Set.of(after.metadata().mapId().value());
-        }
-
-        @Override
-        public Map<Long, DungeonMap> applyTo(Map<Long, DungeonMap> currentMaps, boolean undo) {
-            long mapId = after.metadata().mapId().value();
-            DungeonMap current = requiredMap(currentMaps, mapId);
-            DungeonMap target = undo ? before : after;
-            return Map.of(mapId, DungeonMapAuthoring.restoreContent(target, current.revision() + 1L));
-        }
     }
 
     private record PatchEntry(DungeonPatch forward, DungeonPatch inverse) implements HistoryEntry {

--- a/features/dungeon/application/authored/command/ConnectionPatchPlanner.java
+++ b/features/dungeon/application/authored/command/ConnectionPatchPlanner.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
-/** Converts one aggregate-owned corridor operation into exact room, corridor, and stair changes. */
-final class CorridorPatchPlanner {
-    private CorridorPatchPlanner() {
+/** Converts one connection-affecting aggregate operation into exact room, corridor, and stair changes. */
+final class ConnectionPatchPlanner {
+    private ConnectionPatchPlanner() {
     }
 
     static DungeonCommandResult plan(
@@ -37,7 +37,7 @@ final class CorridorPatchPlanner {
         DungeonMap expected = DungeonMapAuthoring.committedContent(after, patch.committedRevision());
         if (!patched.equals(expected)) {
             throw new IllegalStateException(
-                    "corridor patch must reproduce the exact aggregate result; mismatches="
+                    "connection patch must reproduce the exact aggregate result; mismatches="
                             + mismatches(patched, expected));
         }
         return DungeonCommandResult.Accepted.from(patch);

--- a/features/dungeon/application/authored/command/CreateCorridorCommand.java
+++ b/features/dungeon/application/authored/command/CreateCorridorCommand.java
@@ -25,7 +25,7 @@ public final class CreateCorridorCommand {
             return new DungeonCommandResult.Rejected(
                     DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
         }
-        return CorridorPatchPlanner.plan(
+        return ConnectionPatchPlanner.plan(
                 current,
                 map -> authoring.createCorridor(map, stairId, start, end),
                 DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);

--- a/features/dungeon/application/authored/command/DeleteCorridorCommand.java
+++ b/features/dungeon/application/authored/command/DeleteCorridorCommand.java
@@ -20,7 +20,7 @@ public final class DeleteCorridorCommand {
             return new DungeonCommandResult.Rejected(
                     DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
         }
-        return CorridorPatchPlanner.plan(
+        return ConnectionPatchPlanner.plan(
                 current,
                 map -> authoring.deleteCorridor(map, target),
                 DungeonEditorCommandOutcome.RejectionReason.BLOCKED_ROUTE);

--- a/features/dungeon/application/authored/command/MoveConnectionHandleCommand.java
+++ b/features/dungeon/application/authored/command/MoveConnectionHandleCommand.java
@@ -1,0 +1,142 @@
+package features.dungeon.application.authored.command;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Edge;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import features.dungeon.domain.core.structure.DungeonMap;
+import java.util.function.UnaryOperator;
+
+/** Plans exact patches for authored cluster, door, corridor, and stair handle moves. */
+public final class MoveConnectionHandleCommand {
+
+    public DungeonCommandResult planCluster(
+            DungeonMap current,
+            long clusterId,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || clusterId <= 0L) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveCluster(clusterId, deltaQ, deltaR, deltaLevel));
+    }
+
+    public DungeonCommandResult planDoorBinding(
+            DungeonMap current,
+            long corridorId,
+            int bindingIndex,
+            long roomId,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || corridorId <= 0L || bindingIndex < 0) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveDoorBinding(
+                corridorId,
+                bindingIndex,
+                Math.max(0L, roomId),
+                deltaQ,
+                deltaR,
+                deltaLevel));
+    }
+
+    public DungeonCommandResult planDoorBoundary(
+            DungeonMap current,
+            DungeonTopologyRef topologyRef,
+            long clusterId,
+            long roomId,
+            Edge sourceEdge,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || topologyRef == null || clusterId <= 0L || sourceEdge == null) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveDoorBoundary(
+                topologyRef,
+                clusterId,
+                Math.max(0L, roomId),
+                sourceEdge,
+                deltaQ,
+                deltaR,
+                deltaLevel));
+    }
+
+    public DungeonCommandResult planCorridorAnchor(
+            DungeonMap current,
+            long corridorId,
+            int bindingIndex,
+            DungeonTopologyRef topologyRef,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || corridorId <= 0L || bindingIndex < 0 || topologyRef == null) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveCorridorAnchor(
+                corridorId,
+                bindingIndex,
+                topologyRef,
+                deltaQ,
+                deltaR,
+                deltaLevel));
+    }
+
+    public DungeonCommandResult planCorridorWaypoint(
+            DungeonMap current,
+            long corridorId,
+            int waypointIndex,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || corridorId <= 0L || waypointIndex < 0) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveCorridorWaypoint(
+                corridorId,
+                waypointIndex,
+                deltaQ,
+                deltaR,
+                deltaLevel));
+    }
+
+    public DungeonCommandResult planStairAnchor(
+            DungeonMap current,
+            long stairId,
+            int handleIndex,
+            int deltaQ,
+            int deltaR,
+            int deltaLevel
+    ) {
+        if (current == null || stairId <= 0L || handleIndex < 0) {
+            return invalidTarget();
+        }
+        return plan(current, map -> map.moveStairAnchor(
+                stairId,
+                handleIndex,
+                deltaQ,
+                deltaR,
+                deltaLevel));
+    }
+
+    private static DungeonCommandResult plan(
+            DungeonMap current,
+            UnaryOperator<DungeonMap> operation
+    ) {
+        return ConnectionPatchPlanner.plan(
+                current,
+                operation,
+                DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT);
+    }
+
+    private static DungeonCommandResult invalidTarget() {
+        return new DungeonCommandResult.Rejected(
+                DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET);
+    }
+}

--- a/features/dungeon/application/authored/command/RoomClusterPatchChunks.java
+++ b/features/dungeon/application/authored/command/RoomClusterPatchChunks.java
@@ -3,6 +3,7 @@ package features.dungeon.application.authored.command;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.corridor.Corridor;
 import features.dungeon.domain.core.structure.room.DungeonClusterBoundary;
 import features.dungeon.domain.core.structure.room.RoomCluster;
 import features.dungeon.domain.core.structure.room.RoomRegion;
@@ -18,7 +19,45 @@ final class RoomClusterPatchChunks {
         Set<DungeonChunkKey> result = new LinkedHashSet<>();
         addMapChunks(result, before, clusterId);
         addMapChunks(result, after, clusterId);
+        addDependentCorridorChunks(result, before, after, clusterId);
         return Set.copyOf(result);
+    }
+
+    private static void addDependentCorridorChunks(
+            Set<DungeonChunkKey> result,
+            DungeonMap before,
+            DungeonMap after,
+            long clusterId
+    ) {
+        Set<Long> corridorIds = new LinkedHashSet<>();
+        addDependentCorridorIds(corridorIds, before, clusterId);
+        addDependentCorridorIds(corridorIds, after, clusterId);
+        for (long corridorId : corridorIds) {
+            result.addAll(CorridorPatchChunks.touchedChunks(before, after, corridorId));
+        }
+    }
+
+    private static void addDependentCorridorIds(Set<Long> result, DungeonMap map, long clusterId) {
+        if (map == null) {
+            return;
+        }
+        Set<Long> roomIds = new LinkedHashSet<>();
+        for (RoomRegion room : map.rooms().roomsInCluster(clusterId)) {
+            roomIds.add(room.roomId());
+        }
+        for (Corridor corridor : map.corridors()) {
+            if (referencesCluster(corridor, clusterId, roomIds)) {
+                result.add(corridor.corridorId());
+            }
+        }
+    }
+
+    private static boolean referencesCluster(Corridor corridor, long clusterId, Set<Long> roomIds) {
+        return corridor.roomIds().stream().anyMatch(roomIds::contains)
+                || corridor.bindings().doorBindings().stream()
+                        .anyMatch(binding -> binding.clusterId() == clusterId)
+                || corridor.bindings().waypoints().stream()
+                        .anyMatch(waypoint -> waypoint.clusterId() == clusterId);
     }
 
     private static void addMapChunks(Set<DungeonChunkKey> result, DungeonMap map, long clusterId) {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorStairScenarios.java
@@ -90,6 +90,7 @@ final class DungeonEditorStairScenarios {
         List<String> stableRowsBefore = runtime.database().stairStableState(mapId);
         List<String> pathRowsBefore = runtime.database().stairPathState(mapId);
         List<String> exitRowsBefore = runtime.database().stairExitState(mapId);
+        long revisionBeforeMove = runtime.database().mapRevision(mapId);
         String pathRowBefore = pathRowsBefore.stream()
                 .filter(row -> row.contains("|sort_order=0|")
                         && row.contains("|cell_x=2|")
@@ -158,6 +159,8 @@ final class DungeonEditorStairScenarios {
                 "DE-STAIR-005 keeps stair exit coordinates unchanged for direct path-node movement");
         assertEquals(stableRowsBefore, runtime.database().stairStableState(mapId),
                 "DE-STAIR-005 keeps stair identity, shape, dimensions, and topology refs stable");
+        assertEquals(revisionBeforeMove + 1L, runtime.database().mapRevision(mapId),
+                "DE-STAIR-005 stair-handle patch commits exactly one aggregate revision");
         DungeonEditorMapSurfaceSnapshot committedSurface = runtime.mapSurfaceModel().current();
         assertEquals(DungeonEditorPreview.none(), committedSurface.preview(),
                 "DE-STAIR-005 clears move preview after release");
@@ -167,6 +170,20 @@ final class DungeonEditorStairScenarios {
                 "DE-STAIR-005");
         assertCanvasPaintedAtScene(mapView, 3.5, 2.5,
                 "DE-STAIR-005 rendered canvas paints the moved stair handle");
+
+        fireMapShortcut(mapView, KeyCode.Z, true, false);
+        assertEquals(pathRowsBefore, runtime.database().stairPathState(mapId),
+                "DE-STAIR-005 patch undo restores the original stair path node");
+        assertEquals(revisionBeforeMove + 2L, runtime.database().mapRevision(mapId),
+                "DE-STAIR-005 patch undo restores content as one new revision");
+        assertEquals(stableRowsBefore, runtime.database().stairStableState(mapId),
+                "DE-STAIR-005 patch undo keeps stable stair identity facts");
+
+        fireMapShortcut(mapView, KeyCode.Y, true, false);
+        assertEquals(pathRowsAfter, runtime.database().stairPathState(mapId),
+                "DE-STAIR-005 patch redo restores the moved stair path node");
+        assertEquals(revisionBeforeMove + 3L, runtime.database().mapRevision(mapId),
+                "DE-STAIR-005 patch redo restores content as one new revision");
 
         selectMap(controls, "Stair Anchor Move Reload Hop");
         selectMap(controls, "Stair Anchor Move Map");

--- a/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
+++ b/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
@@ -22,41 +22,54 @@ import org.junit.jupiter.api.Test;
 final class DungeonEditHistoryTest {
     @Test
     void undoAndRedoRemainLocalToOneRunningSessionAndMap() {
-        DungeonMapIdentity mapId = new DungeonMapIdentity(1L);
-        DungeonMap before = DungeonMapAuthoring.empty(mapId, "Before");
-        DungeonMap after = DungeonMapAuthoring.rename(before, "After");
+        DungeonMap before = transitionMap(1L, 1L, "Before");
+        DungeonMapIdentity mapId = before.metadata().mapId();
+        Transition initial = before.transitionCatalog().transition(1L);
+        DungeonPatch patch = DungeonPatch.of(
+                mapId,
+                before.revision(),
+                List.of(new TransitionChange(initial, initial.withDescription("After"))));
+        DungeonMap after = patch.applyTo(before);
         DungeonEditHistory history = new DungeonEditHistory();
 
-        history.record(before, after);
+        history.recordPatch(patch);
 
         assertTrue(history.canUndo(mapId));
         DungeonMap undone = applyAndComplete(history, after, true);
-        assertEquals(before.metadata(), undone.metadata());
+        assertEquals(before.transitionCatalog(), undone.transitionCatalog());
         assertEquals(after.revision() + 1L, undone.revision());
         assertFalse(history.canUndo(mapId));
         assertTrue(history.canRedo(mapId));
         DungeonMap redone = applyAndComplete(history, undone, false);
-        assertEquals(after.metadata(), redone.metadata());
+        assertEquals(after.transitionCatalog(), redone.transitionCatalog());
         assertEquals(undone.revision() + 1L, redone.revision());
     }
 
     @Test
     void newCommitClearsTheRedoBranch() {
-        DungeonMapIdentity mapId = new DungeonMapIdentity(1L);
-        DungeonMap first = DungeonMapAuthoring.empty(mapId, "First");
-        DungeonMap second = DungeonMapAuthoring.rename(first, "Second");
-        DungeonMap replacement = DungeonMapAuthoring.rename(first, "Replacement");
+        DungeonMap first = transitionMap(1L, 1L, "First");
+        DungeonMapIdentity mapId = first.metadata().mapId();
+        Transition initial = first.transitionCatalog().transition(1L);
+        DungeonPatch firstPatch = DungeonPatch.of(
+                mapId,
+                first.revision(),
+                List.of(new TransitionChange(initial, initial.withDescription("Second"))));
+        DungeonMap second = firstPatch.applyTo(first);
         DungeonEditHistory history = new DungeonEditHistory();
-        history.record(first, second);
+        history.recordPatch(firstPatch);
         DungeonMap undone = applyAndComplete(history, second, true);
 
-        DungeonMap committedReplacement = DungeonMapAuthoring.committedContent(
-                replacement,
-                undone.revision() + 1L);
-        history.record(undone, committedReplacement);
+        DungeonPatch replacementPatch = DungeonPatch.of(
+                mapId,
+                undone.revision(),
+                List.of(new TransitionChange(initial, initial.withDescription("Replacement"))));
+        DungeonMap committedReplacement = replacementPatch.applyTo(undone);
+        history.recordPatch(replacementPatch);
 
         assertFalse(history.canRedo(mapId));
-        assertEquals(first.metadata(), applyAndComplete(history, committedReplacement, true).metadata());
+        assertEquals(
+                first.transitionCatalog(),
+                applyAndComplete(history, committedReplacement, true).transitionCatalog());
     }
 
     @Test
@@ -98,8 +111,15 @@ final class DungeonEditHistoryTest {
         assertEquals(changed.get(11L).transitionCatalog(), redone.get(11L).transitionCatalog());
         assertEquals(changed.get(12L).transitionCatalog(), redone.get(12L).transitionCatalog());
 
-        DungeonMap laterTarget = DungeonMapAuthoring.rename(redone.get(12L), "Later target edit");
-        history.record(redone.get(12L), laterTarget);
+        DungeonMap currentTarget = redone.get(12L);
+        Transition currentTargetTransition = currentTarget.transitionCatalog().transition(2L);
+        DungeonPatch laterTargetPatch = DungeonPatch.of(
+                currentTarget.metadata().mapId(),
+                currentTarget.revision(),
+                List.of(new TransitionChange(
+                        currentTargetTransition,
+                        currentTargetTransition.withDescription("Later target edit"))));
+        history.recordPatch(laterTargetPatch);
         assertFalse(history.canUndo(source.metadata().mapId()));
         assertTrue(history.canUndo(target.metadata().mapId()));
     }

--- a/test/features/dungeon/application/authored/command/DungeonConnectionHandlePatchCommandTest.java
+++ b/test/features/dungeon/application/authored/command/DungeonConnectionHandlePatchCommandTest.java
@@ -1,0 +1,112 @@
+package features.dungeon.application.authored.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.geometry.Direction;
+import features.dungeon.domain.core.graph.DungeonTopologyRef;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapAuthoring;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.corridor.DungeonCorridorEndpoint;
+import features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy;
+import features.dungeon.domain.core.structure.room.RoomRegion;
+import features.dungeon.domain.core.structure.stair.StairGeometrySpec;
+import features.dungeon.domain.core.structure.stair.StairShape;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+
+final class DungeonConnectionHandlePatchCommandTest {
+    private static final long MAP_ID = 81L;
+
+    @Test
+    void clusterMoveCarriesExactRoomAndBoundaryChangesAcrossChunks() {
+        DungeonMap current = corridorMap();
+        long clusterId = current.rooms().rooms().getFirst().clusterId();
+        MoveConnectionHandleCommand command = new MoveConnectionHandleCommand();
+
+        DungeonCommandResult.Accepted result = accepted(command.planCluster(current, clusterId, -260, 2, 0));
+
+        assertTrue(result.patch().changes().stream().anyMatch(RoomRegionChange.class::isInstance));
+        assertTrue(result.patch().changes().stream().anyMatch(RoomClusterChange.class::isInstance));
+        assertTrue(result.patch().touchedChunks().stream().anyMatch(chunk -> chunk.chunkQ() == -3));
+        DungeonMap moved = result.patch().applyTo(current);
+        assertEquals(
+                DungeonMapAuthoring.committedContent(
+                        current.moveCluster(clusterId, -260, 2, 0),
+                        current.revision() + 1L),
+                moved);
+        assertEquals(current, contentAtRevision(result.inverse().applyTo(moved), current.revision()));
+    }
+
+    @Test
+    void stairAnchorMoveUsesExactStairChangeAndRejectsNoEffect() {
+        StairGeometrySpec spec = new StairGeometrySpec(
+                StairShape.STRAIGHT,
+                new Cell(2, 2, 0),
+                Direction.NORTH,
+                1,
+                2);
+        DungeonMap empty = emptyMap();
+        DungeonMap current = accepted(new CreateStairCommand().plan(empty, 17L, spec)).patch().applyTo(empty);
+        MoveConnectionHandleCommand command = new MoveConnectionHandleCommand();
+
+        DungeonCommandResult.Accepted result = accepted(command.planStairAnchor(current, 17L, 0, 1, 0, 0));
+        DungeonMap moved = result.patch().applyTo(current);
+        assertTrue(result.patch().changes().stream().allMatch(StairChange.class::isInstance));
+        assertEquals(current.revision() + 1L, moved.revision());
+        assertEquals(current, contentAtRevision(result.inverse().applyTo(moved), current.revision()));
+
+        DungeonCommandResult.Rejected noEffect = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                command.planStairAnchor(current, 17L, 0, 0, 0, 0));
+        DungeonCommandResult.Rejected invalid = assertInstanceOf(
+                DungeonCommandResult.Rejected.class,
+                command.planCorridorWaypoint(current, 0L, 0, 1, 0, 0));
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.NO_EFFECT, noEffect.reason());
+        assertEquals(DungeonEditorCommandOutcome.RejectionReason.INVALID_TARGET, invalid.reason());
+    }
+
+    private static DungeonMap corridorMap() {
+        DungeonMap rooms = emptyMap()
+                .paintRoomRectangle(new Cell(1, 1, 0), new Cell(2, 2, 0))
+                .paintRoomRectangle(new Cell(7, 1, 0), new Cell(8, 2, 0));
+        RoomRegion startRoom = rooms.rooms().rooms().getFirst();
+        RoomRegion endRoom = rooms.rooms().rooms().getLast();
+        Cell startCell = startRoom.floorCells().stream().max(Comparator.comparingInt(Cell::q)).orElseThrow();
+        Cell endCell = endRoom.floorCells().stream().min(Comparator.comparingInt(Cell::q)).orElseThrow();
+        DungeonCorridorEndpoint start = DungeonCorridorEndpoint.door(
+                startRoom.roomId(),
+                startRoom.clusterId(),
+                startCell,
+                Direction.EAST,
+                DungeonTopologyRef.empty());
+        DungeonCorridorEndpoint end = DungeonCorridorEndpoint.door(
+                endRoom.roomId(),
+                endRoom.clusterId(),
+                endCell,
+                Direction.WEST,
+                DungeonTopologyRef.empty());
+        return accepted(new CreateCorridorCommand(new OrthogonalCorridorRoutingPolicy()).plan(
+                rooms,
+                91L,
+                start,
+                end)).patch().applyTo(rooms);
+    }
+
+    private static DungeonMap emptyMap() {
+        return DungeonMapAuthoring.empty(new DungeonMapIdentity(MAP_ID), "Connection Handle Patches");
+    }
+
+    private static DungeonCommandResult.Accepted accepted(DungeonCommandResult result) {
+        return assertInstanceOf(DungeonCommandResult.Accepted.class, result);
+    }
+
+    private static DungeonMap contentAtRevision(DungeonMap map, long revision) {
+        assertTrue(map.revision() > revision);
+        return DungeonMapAuthoring.committedContent(map, revision);
+    }
+}


### PR DESCRIPTION
## Was geändert wurde

- Cluster-Label-, Door-, Corridor-Anchor-, Corridor-Waypoint- und Stair-Anchor-Commits nutzen einen typed Move-Command und exakte Connection-Patches.
- `executeOperation`, Snapshot-History und strukturelle Full-Map-Speicherschätzung sind vollständig entfernt.
- History akzeptiert nur noch invertierbare Single-Map- oder Compound-Patches mit codierter Byte-Gewichtung.
- Die Chunk-Closure von Cluster-Moves umfasst auch veränderte abgeleitete Routen abhängiger Corridors.
- Repository-freie Drag-Preview bleibt getrennt vom Commitpfad erhalten.

## Warum

M3.8 schließt die letzte produktive Snapshot-History-Route der Dungeon-Greenfield-Migration und macht alle Connection-Handle-Commits stabil, exakt und inkrementell beschreibbar.

## Nachweise

- fokussierte Handle-, History- und dependent-corridor Chunk-Tests grün
- alle realen Cluster-, Door-, Corridor- und Stair-Handle-Routen grün (`BUILD SUCCESSFUL in 50s`)
- vollständige `DungeonEditorBehaviorSuiteTest` grün (`BUILD SUCCESSFUL in 1m 29s`)
- `./gradlew architectureTest --console=plain` grün (`BUILD SUCCESSFUL in 35s`)
- `./gradlew check --console=plain` grün (`BUILD SUCCESSFUL in 3m 14s`)
- `./gradlew installDesktopApp --console=plain` grün (`BUILD SUCCESSFUL in 9s`)
