### PR TITLE
M3.9: Patch-History-Grenzen und Architektur-Gates absichern

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,34 +97,33 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.7 are complete on
-  `main` through PR #506. Feature markers, room or cluster semantics, room
-  geometry, stairs, transitions, and corridor create or delete use exact
-  patches; transition links use atomic compound patches and shared multi-map
-  history.
-- This slice: M3.8 moves whole-cluster label, bound and standalone door,
-  corridor-anchor, corridor-waypoint, and stair-anchor commits to one typed
-  move command and the shared connection patch planner. Corner and wall-run
-  handles retain their already-landed specialized patch commands.
-- `executeOperation`, `DungeonEditHistory.SnapshotEntry`, full-map history
-  recording, and structural-object memory estimation are deleted. History now
-  accepts only single-map or compound patches with encoded byte weights.
-- The production consumer dispatches every successful handle release through
-  `executePatchCommand`; the same in-memory handle mutation remains available
-  only to repository-free drag preview after its authored workset is loaded.
-- Deterministic and production-route proof covers multi-entity cluster moves
-  across negative chunks, every handle variant, exact inverse application,
-  typed no-effect and invalid-target rejection, preview storage isolation,
-  one-revision commit, patch shortcut undo or redo, stable identities, and
-  SQLite reload.
+- Current foundation: M0 through M2 and M3.1 through M3.8 are complete on
+  `main` through PR #507. Every authored Editor commit now enters history only
+  as an exact single-map or compound patch; snapshot history and its whole-map
+  operation route are deleted.
+- This slice: M3.9 closes the patch/history milestone. Production defaults
+  retain at most `200` committed commands or `128 MiB` of measured forward and
+  inverse patch bytes, while deterministic limit injection qualifies eviction
+  without changing the shipped limits.
+- The shared `MEDIUM` qualification dataset proves byte-budget enforcement with
+  a real `10,000`-cell room patch. Command-limit proof applies and undoes exact
+  patches after the oldest entry is evicted.
+- The real map-view shortcut route places tool change, selection, camera pan,
+  repository-free preview, and typed exterior-wall rejection between one
+  authored commit and undo. One shortcut undo still removes that commit,
+  proving that every intervening action creates no history entry.
+- The M3 architecture gate permits history entries to retain only forward and
+  inverse `DungeonPatch` or `DungeonCompoundPatch` payloads, rejects complete
+  `DungeonMap` fields in patch carriers, and prevents new application consumers
+  from adopting the temporary whole-map persistence bridge.
 - `DungeonChangeSet(before, after)` remains only as the temporary whole-map
   persistence bridge used beneath accepted patches, history replay, transition
   compounds, and catalog rename. M4 owns its replacement with incremental
   `DungeonUnitOfWork`; no new caller may use it.
-- Next step after this slice merges: M3.9 closes the patch/history milestone by
-  qualifying command and byte retention limits, proving the remaining
-  no-history command exclusions, and tightening the M3 architecture gate before
-  M4 replaces the temporary persistence bridge.
+- Next step after this slice merges: open M4 by replacing the temporary
+  repository boundary with explicit catalog, window-read, and incremental
+  unit-of-work ports, then move one production consumer at a time and delete
+  each replaced whole-map route in its owning slice.
 
 ## M0: Target Lock And Baseline
 

--- a/features/dungeon/application/authored/DungeonEditHistory.java
+++ b/features/dungeon/application/authored/DungeonEditHistory.java
@@ -16,9 +16,26 @@ import org.jspecify.annotations.Nullable;
 /** Per-running-editor-session authored undo/redo history. */
 final class DungeonEditHistory {
     static final int MAXIMUM_COMMANDS = 200;
-    static final long MAXIMUM_ESTIMATED_BYTES = 128L * 1024L * 1024L;
+    static final long MAXIMUM_ENCODED_BYTES = 128L * 1024L * 1024L;
 
     private final Map<Long, MapHistory> histories = new HashMap<>();
+    private final int maximumCommands;
+    private final long maximumEncodedBytes;
+
+    DungeonEditHistory() {
+        this(MAXIMUM_COMMANDS, MAXIMUM_ENCODED_BYTES);
+    }
+
+    DungeonEditHistory(int maximumCommands, long maximumEncodedBytes) {
+        if (maximumCommands < 1) {
+            throw new IllegalArgumentException("history command limit must be positive");
+        }
+        if (maximumEncodedBytes < 1L) {
+            throw new IllegalArgumentException("history encoded-byte limit must be positive");
+        }
+        this.maximumCommands = maximumCommands;
+        this.maximumEncodedBytes = maximumEncodedBytes;
+    }
 
     void recordPatch(DungeonPatch patch) {
         if (patch != null) {
@@ -134,8 +151,8 @@ final class DungeonEditHistory {
         do {
             trimmed = false;
             for (MapHistory history : histories.values()) {
-                if (history.undo.size() > MAXIMUM_COMMANDS
-                        || history.estimatedBytes > MAXIMUM_ESTIMATED_BYTES) {
+                if (history.undo.size() > maximumCommands
+                        || history.encodedBytes > maximumEncodedBytes) {
                     HistoryEntry oldest = history.undo.peekFirst();
                     if (oldest != null) {
                         removeFromAll(oldest, true);
@@ -159,7 +176,7 @@ final class DungeonEditHistory {
 
     private void recalculateAll() {
         for (MapHistory history : histories.values()) {
-            history.estimatedBytes = history.undo.stream().mapToLong(HistoryEntry::encodedBytes).sum()
+            history.encodedBytes = history.undo.stream().mapToLong(HistoryEntry::encodedBytes).sum()
                     + history.redo.stream().mapToLong(HistoryEntry::encodedBytes).sum();
         }
     }
@@ -252,6 +269,6 @@ final class DungeonEditHistory {
     private static final class MapHistory {
         private final Deque<HistoryEntry> undo = new ArrayDeque<>();
         private final Deque<HistoryEntry> redo = new ArrayDeque<>();
-        private long estimatedBytes;
+        private long encodedBytes;
     }
 }

--- a/test/architecture/dungeon/DungeonPatchHistoryArchitectureTest.java
+++ b/test/architecture/dungeon/DungeonPatchHistoryArchitectureTest.java
@@ -1,0 +1,126 @@
+package architecture.dungeon;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import architecture.AnalyzeMainClasses;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.List;
+import java.util.Map;
+
+@AnalyzeMainClasses
+public final class DungeonPatchHistoryArchitectureTest {
+
+    private static final String HISTORY_ENTRY =
+            "features.dungeon.application.authored.DungeonEditHistory$HistoryEntry";
+    private static final String PATCH_ENTRY =
+            "features.dungeon.application.authored.DungeonEditHistory$PatchEntry";
+    private static final String COMPOUND_PATCH_ENTRY =
+            "features.dungeon.application.authored.DungeonEditHistory$CompoundPatchEntry";
+    private static final String PATCH =
+            "features.dungeon.application.authored.command.DungeonPatch";
+    private static final String COMPOUND_PATCH =
+            "features.dungeon.application.authored.command.DungeonCompoundPatch";
+    private static final String DUNGEON_MAP =
+            "features.dungeon.domain.core.structure.DungeonMap";
+    private static final String CHANGE_SET =
+            "features.dungeon.application.authored.port.DungeonChangeSet";
+    private static final String AUTHORED_SERVICE =
+            "features.dungeon.application.authored.DungeonAuthoredApplicationService";
+
+    private DungeonPatchHistoryArchitectureTest() {
+    }
+
+    @ArchTest
+    static final ArchRule historyEntriesRetainOnlyForwardAndInversePatches =
+            classes()
+                    .that()
+                    .implement(HISTORY_ENTRY)
+                    .should(retainOnlyExactPatchPayloads())
+                    .allowEmptyShould(false);
+
+    @ArchTest
+    static final ArchRule patchCarriersDoNotContainCompleteDungeonMaps =
+            classes()
+                    .that()
+                    .haveFullyQualifiedName(PATCH)
+                    .or()
+                    .haveFullyQualifiedName(COMPOUND_PATCH)
+                    .should(notStoreCompleteDungeonMaps())
+                    .allowEmptyShould(false);
+
+    @ArchTest
+    static final ArchRule temporaryWholeMapPersistenceBridgeHasOneApplicationConsumer =
+            classes()
+                    .that()
+                    .resideInAPackage("features.dungeon.application.authored..")
+                    .should(keepChangeSetAtItsTemporaryOwner());
+
+    private static ArchCondition<JavaClass> retainOnlyExactPatchPayloads() {
+        Map<String, String> allowedPayloads = Map.of(
+                PATCH_ENTRY, PATCH,
+                COMPOUND_PATCH_ENTRY, COMPOUND_PATCH);
+        return new ArchCondition<>("retain exactly one forward and one inverse patch") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                String payloadType = allowedPayloads.get(item.getName());
+                List<JavaField> fields = instanceFields(item);
+                boolean valid = payloadType != null
+                        && fields.size() == 2
+                        && fields.stream().allMatch(field -> field.getRawType().getName().equals(payloadType));
+                if (!valid) {
+                    events.add(SimpleConditionEvent.violated(
+                            item,
+                            item.getName() + " must store only forward and inverse patch payloads"));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> notStoreCompleteDungeonMaps() {
+        return new ArchCondition<>("not store complete DungeonMap values") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (JavaField field : instanceFields(item)) {
+                    boolean containsMap = field.getAllInvolvedRawTypes().stream()
+                            .anyMatch(type -> type.getName().equals(DUNGEON_MAP));
+                    if (containsMap) {
+                        events.add(SimpleConditionEvent.violated(
+                                field,
+                                field.getFullName() + " must not carry a complete DungeonMap"));
+                    }
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> keepChangeSetAtItsTemporaryOwner() {
+        return new ArchCondition<>("keep DungeonChangeSet at its temporary M4 deletion owner") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean dependsOnChangeSet = item.getDirectDependenciesFromSelf().stream()
+                        .anyMatch(dependency -> dependency.getTargetClass().getName().equals(CHANGE_SET));
+                if (dependsOnChangeSet
+                        && !item.getName().equals(AUTHORED_SERVICE)
+                        && !item.getName().startsWith(AUTHORED_SERVICE + "$")
+                        && !item.getPackageName().equals("features.dungeon.application.authored.port")) {
+                    events.add(SimpleConditionEvent.violated(
+                            item,
+                            item.getName() + " must not become another DungeonChangeSet consumer"));
+                }
+            }
+        };
+    }
+
+    private static List<JavaField> instanceFields(JavaClass item) {
+        return item.getFields().stream()
+                .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))
+                .toList();
+    }
+}

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
@@ -81,6 +81,69 @@ final class DungeonEditorMapControlsScenarios {
         assertEquals(1L, runtime.database().countChunksForMap(mapId),
                 "DE-HISTORY-001 committed edit persists the affected chunk inventory");
 
+        click(button(controls, "Auswahl"));
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_PRESSED,
+                MouseButton.PRIMARY,
+                viewport.sceneToScreenX(2.5),
+                viewport.sceneToScreenY(2.5),
+                false);
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_RELEASED,
+                MouseButton.PRIMARY,
+                viewport.sceneToScreenX(2.5),
+                viewport.sceneToScreenY(2.5),
+                false);
+        assertTrue(runtime.stateModel().current().selection().topologyRef().id() > 0L,
+                "DE-HISTORY-003 room selection reaches a stable authored target");
+        dragMap(mapView, MouseButton.MIDDLE, 300, 300, 330, 320);
+        viewport = binding.mapContentModel().currentViewport();
+
+        click(button(controls, "Raum"));
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_PRESSED,
+                MouseButton.PRIMARY,
+                viewport.sceneToScreenX(5.5),
+                viewport.sceneToScreenY(5.5),
+                false);
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_DRAGGED,
+                MouseButton.PRIMARY,
+                viewport.sceneToScreenX(6.5),
+                viewport.sceneToScreenY(6.5),
+                false);
+        assertTrue(runtime.mapSurfaceModel().current().preview()
+                        instanceof DungeonEditorPreview.RoomRectanglePreview,
+                "DE-HISTORY-003 preview is active before cancellation");
+        fireMapShortcut(mapView, KeyCode.ESCAPE);
+
+        click(button(controls, "Wand"));
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_PRESSED,
+                MouseButton.SECONDARY,
+                viewport.sceneToScreenX(2.5),
+                viewport.sceneToScreenY(1.0),
+                false);
+        fireMapMouse(
+                mapView,
+                MouseEvent.MOUSE_RELEASED,
+                MouseButton.SECONDARY,
+                viewport.sceneToScreenX(2.5),
+                viewport.sceneToScreenY(1.0),
+                false);
+        assertEquals(
+                features.dungeon.api.editor.DungeonEditorCommandOutcome.RejectionReason.PROTECTED_EXTERIOR_WALL,
+                ((features.dungeon.api.editor.DungeonEditorCommandOutcome.Rejected)
+                        runtime.controlsModel().current().commandOutcome()).reason(),
+                "DE-HISTORY-003 exterior-wall delete reaches the typed rejection route");
+        assertEquals(2L, runtime.database().mapRevision(mapId),
+                "DE-HISTORY-003 tool, selection, camera, preview, and rejection do not commit a revision");
+
         fireMapShortcut(mapView, KeyCode.Z, true, false);
         assertEquals(0L, runtime.database().countRoomsForMap(mapId),
                 "DE-HISTORY-001 shortcut undo restores the prior authored map");

--- a/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
+++ b/test/features/dungeon/application/authored/DungeonEditHistoryTest.java
@@ -6,20 +6,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.DungeonPatch;
+import features.dungeon.application.authored.command.RoomRegionChange;
 import features.dungeon.application.authored.command.TransitionChange;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.room.DungeonRoomNarration;
+import features.dungeon.domain.core.structure.room.RoomRegion;
 import features.dungeon.domain.core.structure.transition.Transition;
 import features.dungeon.domain.core.structure.transition.TransitionAnchor;
 import features.dungeon.domain.core.structure.transition.TransitionCatalog;
 import features.dungeon.domain.core.structure.transition.TransitionDestination;
+import features.dungeon.qualification.DungeonQualificationDataset;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 final class DungeonEditHistoryTest {
+    @Test
+    void productionRetentionLimitsMatchTheRequirements() {
+        assertEquals(200, DungeonEditHistory.MAXIMUM_COMMANDS);
+        assertEquals(128L * 1024L * 1024L, DungeonEditHistory.MAXIMUM_ENCODED_BYTES);
+    }
+
     @Test
     void undoAndRedoRemainLocalToOneRunningSessionAndMap() {
         DungeonMap before = transitionMap(1L, 1L, "Before");
@@ -124,6 +136,54 @@ final class DungeonEditHistoryTest {
         assertTrue(history.canUndo(target.metadata().mapId()));
     }
 
+    @Test
+    void commandLimitEvictsTheOldestCommittedPatch() {
+        DungeonMap current = transitionMap(1L, 1L, "Initial");
+        DungeonMapIdentity mapId = current.metadata().mapId();
+        DungeonEditHistory history = new DungeonEditHistory(2, Long.MAX_VALUE);
+
+        for (String description : List.of("First", "Second", "Third")) {
+            DungeonPatch patch = descriptionPatch(current, description);
+            current = patch.applyTo(current);
+            history.recordPatch(patch);
+        }
+
+        current = applyAndComplete(history, current, true);
+        assertEquals("Second", current.transitionCatalog().transition(1L).description());
+        current = applyAndComplete(history, current, true);
+        assertEquals("First", current.transitionCatalog().transition(1L).description());
+        assertFalse(history.canUndo(mapId));
+    }
+
+    @Test
+    void encodedByteLimitUsesTheMediumQualificationPatchPayload() {
+        DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(1L), "Medium history map");
+        Set<Cell> cells = DungeonQualificationDataset.MEDIUM.authoredCells()
+                .map(cell -> new Cell(cell.q(), cell.r(), cell.level()))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        RoomRegion room = new RoomRegion(
+                1L,
+                map.metadata().mapId().value(),
+                1L,
+                "Medium room",
+                cells,
+                DungeonRoomNarration.empty());
+        DungeonPatch patch = DungeonPatch.of(
+                map.metadata().mapId(),
+                map.revision(),
+                List.of(new RoomRegionChange(null, room)));
+        long encodedHistoryBytes = patch.encodedBytes() + patch.inverse().encodedBytes();
+
+        DungeonEditHistory exactBudget = new DungeonEditHistory(200, encodedHistoryBytes);
+        exactBudget.recordPatch(patch);
+        assertTrue(exactBudget.canUndo(map.metadata().mapId()));
+
+        DungeonEditHistory undersizedBudget = new DungeonEditHistory(200, encodedHistoryBytes - 1L);
+        undersizedBudget.recordPatch(patch);
+        assertFalse(undersizedBudget.canUndo(map.metadata().mapId()));
+        assertTrue(encodedHistoryBytes >= 32L * DungeonQualificationDataset.MEDIUM.authoredCellCount());
+    }
+
     private static DungeonMap applyAndComplete(
             DungeonEditHistory history,
             DungeonMap current,
@@ -136,6 +196,14 @@ final class DungeonEditHistoryTest {
                 .get(current.metadata().mapId().value());
         history.complete(step);
         return changed;
+    }
+
+    private static DungeonPatch descriptionPatch(DungeonMap current, String description) {
+        Transition before = current.transitionCatalog().transition(1L);
+        return DungeonPatch.of(
+                current.metadata().mapId(),
+                current.revision(),
+                List.of(new TransitionChange(before, before.withDescription(description))));
     }
 
     private static DungeonMap transitionMap(long mapId, long transitionId, String name) {


### PR DESCRIPTION
## Änderungen

- qualifiziert die produktiven History-Grenzen von 200 Commands und 128 MiB anhand kodierter Forward-/Inverse-Patch-Bytes
- beweist Byte-Eviction mit dem gemeinsamen MEDIUM-Datensatz aus 10.000 Zellen
- erweitert die reale Map-View-Undo-Route um Toolwechsel, Auswahl, Kamera, Preview und typisierte Ablehnung ohne History-Eintrag
- ergänzt ArchUnit-Gates gegen Snapshot-/Whole-map-History-Payloads und neue `DungeonChangeSet`-Konsumenten
- aktualisiert die temporäre Greenfield-Roadmap und schließt M3

## Wirkung

Undo/Redo behält ausschließlich exakte Patch-Payloads innerhalb der requirements-eigenen Command- und Byte-Limits. Nicht-committende Editor-Aktionen bleiben nachweislich history-frei. Der bestehende Whole-map-Persistenz-Bridge bleibt bis M4 auf seinen dokumentierten Owner begrenzt.

## Verifikation

- `./gradlew test --tests features.dungeon.application.authored.DungeonEditHistoryTest --console=plain`
- `./gradlew architectureTest --console=plain`
- `./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest.mapControlsBehavior --console=plain`
- `./gradlew check --console=plain`
- `./gradlew installDesktopApp --console=plain`
