### PR TITLE
M4.1: Metadaten-only Dungeon-Katalogspeicher

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -97,33 +97,51 @@ and commit boundaries. M7 starts only after both are complete.
 
 ## Current Migration State
 
-- Current foundation: M0 through M2 and M3.1 through M3.8 are complete on
-  `main` through PR #507. Every authored Editor commit now enters history only
-  as an exact single-map or compound patch; snapshot history and its whole-map
-  operation route are deleted.
-- This slice: M3.9 closes the patch/history milestone. Production defaults
-  retain at most `200` committed commands or `128 MiB` of measured forward and
-  inverse patch bytes, while deterministic limit injection qualifies eviction
-  without changing the shipped limits.
-- The shared `MEDIUM` qualification dataset proves byte-budget enforcement with
-  a real `10,000`-cell room patch. Command-limit proof applies and undoes exact
-  patches after the oldest entry is evicted.
-- The real map-view shortcut route places tool change, selection, camera pan,
-  repository-free preview, and typed exterior-wall rejection between one
-  authored commit and undo. One shortcut undo still removes that commit,
-  proving that every intervening action creates no history entry.
-- The M3 architecture gate permits history entries to retain only forward and
-  inverse `DungeonPatch` or `DungeonCompoundPatch` payloads, rejects complete
-  `DungeonMap` fields in patch carriers, and prevents new application consumers
-  from adopting the temporary whole-map persistence bridge.
+- Current foundation: M0 through M3 are complete on `main` through PR #508.
+  Every authored Editor commit enters history only as an exact single-map or
+  compound patch, requirements-owned command and encoded-byte retention limits
+  are qualified, and non-committing production actions are history-free.
+- This slice: M4.1 introduces the metadata-only `DungeonCatalogStore` and moves
+  production map search, create, rename, and delete to it. Catalog reads return
+  stable headers without authored geometry; create and rename write only the
+  `dungeon_maps` row and advance the map revision exactly once where required.
+- M4.1 removes catalog identity allocation, full-map create, catalog search,
+  and delete methods from `DungeonMapRepository`. The remaining repository is
+  explicitly temporary and may serve only the M4 window/UoW migration.
 - `DungeonChangeSet(before, after)` remains only as the temporary whole-map
   persistence bridge used beneath accepted patches, history replay, transition
-  compounds, and catalog rename. M4 owns its replacement with incremental
-  `DungeonUnitOfWork`; no new caller may use it.
-- Next step after this slice merges: open M4 by replacing the temporary
-  repository boundary with explicit catalog, window-read, and incremental
-  unit-of-work ports, then move one production consumer at a time and delete
-  each replaced whole-map route in its owning slice.
+  compounds, and ordinary authored commits. M4 owns its replacement with
+  incremental `DungeonUnitOfWork`; no new caller may use it.
+- Next step after this slice merges: M4.2 installs the canonical Dungeon-only
+  schema and entity-to-chunk membership while keeping the current whole-map
+  bridge only long enough to prove equivalent production readback.
+
+### Active Slice Contract: M4.1 Catalog Store
+
+- **Goal and current evidence:** split catalog metadata from the umbrella
+  whole-map repository. Before this slice, search mapped header-only SQL rows
+  into synthetic `DungeonMap` values, create reserved and deleted an id before
+  writing a full empty map, and rename loaded then rewrote the full aggregate.
+- **Owners and implementation surface:** this roadmap plus the Dungeon
+  architecture, domain, and persistence contract govern
+  `DungeonCatalogStore`, `DungeonMapHeader`, the authored application service,
+  SQLite gateway/repository composition, and their application, architecture,
+  persistence, and production Editor tests.
+- **Invariants:** search returns stable id/name/revision headers without authored
+  geometry; create inserts one revision-one map header; rename changes only the
+  header and advances revision once; delete preserves SQLite cascade behavior;
+  a loaded workset remains aligned without another whole-map read.
+- **Later-slice exclusions:** M4.1 does not replace the schema, introduce window
+  or closure values, migrate patch writes, or remove whole-map reads needed by
+  commands and travel. M4.2 through M4.6 own those changes.
+- **Deletion boundary:** remove catalog id allocation, search, and delete from
+  `DungeonMapRepository`, and remove catalog create/rename full-map writes. The
+  remaining repository and combined SQLite adapter are temporary M4 surfaces.
+- **Acceptance and proof:** real Editor catalog create/search/rename/delete
+  remains observable across SQLite reload; create is revision one, rename is
+  revision two with unchanged geometry rows; an application test makes every
+  whole-map repository call fail; an architecture gate forbids `DungeonMap`
+  from the catalog port; final acceptance is literal green `./gradlew check`.
 
 ## M0: Target Lock And Baseline
 
@@ -342,6 +360,102 @@ Make sparse access and local writes real at the persistence boundary.
   successful write
 - reject malformed or incomplete identity closure instead of cloning or
   synthesizing authored entities
+
+### Target Model And Chosen Strategy
+
+M4 replaces the umbrella repository by responsibility and in dependency order:
+
+- `DungeonCatalogStore` owns metadata-only map headers and catalog mutations.
+  Its values contain map id, normalized name, and committed revision only.
+- `DungeonWindowStore` owns explicit chunk reads and command-specific identity
+  closure. A window result contains its map header, requested chunk content
+  revisions, each intersecting stable entity once, and explicit continuation
+  refs for geometry outside the loaded set. A closure result is revision-bound
+  and either complete for every requested stable identity or rejected as
+  incomplete/malformed; it never manufactures a partial `DungeonMap` that can
+  be mistaken for the whole aggregate.
+- `DungeonUnitOfWork` accepts `DungeonPatch` or `DungeonCompoundPatch`, validates
+  every expected map revision, and returns committed map/chunk revisions plus
+  the patch result facts already known by the command. Single-map and compound
+  writes share the same row-level mutation machinery and transaction owner.
+
+The SQLite adapter remains one implementation package but is split internally
+by these ports. Canonical entity rows remain the only authored owner;
+`dungeon_entity_chunks` and `dungeon_chunks` are replaceable source-local
+indexes. Command planning consumes a loaded window plus explicit closure, while
+preview consumes only that in-memory workset. Successful commit publication
+uses the returned patch facts and does not reload the map.
+
+Rejected alternatives:
+
+- keeping `DungeonMapRepository` and placing three target facades in front of
+  it would preserve the same hidden full-map dependency and is rejected
+- persisting patches by diffing two mapped full records would retain the
+  ordinary whole-map writer under a new name and is rejected
+- representing a loaded window as an unmarked partial `DungeonMap` would allow
+  commands to infer unseen truth and is rejected
+- replacing schema, reads, writes, and every consumer in one slice would make
+  rollback and operation-count failures hard to localize and is rejected
+
+### Surface Disposition
+
+| Surface | Decision | M4 consequence |
+| --- | --- | --- |
+| `DungeonPatch`, `DungeonCompoundPatch`, stable entity refs, chunk keys | Adopt | direct UoW input and spatial index keys |
+| SQLite gateway and entity-specific persistence helpers | Adapt | split into catalog, window/closure, and row-level commit paths |
+| `DungeonMapRepository`, `DungeonMapRecord`, full-record mapper/writer | Reject | temporary only; delete after the last consumer moves |
+| room anchors, duplicated cluster floor/vertices, inventory-only chunks | Reject | destructive Dungeon-only schema replacement in M4.2 |
+| command-specific closure requirements | Investigate | bounded M4.3 implementation inventory; every command family must name required refs before it moves |
+
+### Migration Slices
+
+1. **Catalog store:** publish `DungeonCatalogStore`, move real catalog CRUD and
+   search, prove metadata-only SQL and revision behavior, and delete catalog
+   methods from the umbrella repository.
+2. **Canonical schema and membership:** install one destructive Dungeon-only
+   schema migration with room-cell, cluster-boundary, chunk revision, and
+   entity-membership rows. Adapt the temporary full-map bridge to those rows so
+   production remains runnable, prove Party/Hex tables untouched, and delete
+   room-anchor plus duplicated cluster geometry tables and mappers.
+3. **Window and closure reads:** publish immutable window/header/continuation
+   and revision-bound closure values, query only explicit chunks through entity
+   membership, and move the Editor cold viewport/load path. Prove cross-chunk
+   identity uniqueness, negative chunks, stable ordering, no catalog hydration,
+   and typed malformed/incomplete closure rejection.
+4. **Single-map unit of work:** implement row-level insert/update/remove for
+   every patch change kind, entity membership, affected chunk revisions, and
+   map revision in one transaction. Move ordinary commits and undo/redo,
+   publish returned result facts without readback, and delete `DungeonChangeSet`
+   plus the single-map full-record writer.
+5. **Compound unit of work:** commit all map patches through the same row-level
+   machinery in one SQLite transaction. Move transition-link commit and shared
+   history replay, prove rollback from every failure point, and delete the
+   multi-map compatibility writer.
+6. **Read-path closure:** move remaining Editor command hydration and Dungeon
+   travel reads to windows/closures, delete full-map repository methods,
+   `DungeonMapRecord` and its full-record loader/mapper, then tighten the M4
+   architecture gate before M5 or M6 starts.
+
+Slice order follows the dependency chain: catalog has no geometry dependency;
+window and incremental write correctness require canonical rows and membership;
+compound writes reuse proven single-map mutations; the final read deletion is
+safe only after Editor and travel consumers both have window routes. A schema
+proof failure stops M4.2, and an entity family whose closure cannot be stated
+becomes a bounded M4.3 blocker rather than permission to load the whole map.
+
+### Milestone Verification Thesis
+
+- Catalog proof demonstrates zero authored-content hydration, not merely equal
+  catalog output.
+- Schema proof demonstrates canonical stored truth and Dungeon-only destructive
+  scope on the real SQLite migration path.
+- Window proof measures requested chunks, returned unique identities,
+  continuations, and repository round trips on the shared sparse datasets.
+- UoW proof observes exact affected rows, membership, chunk revisions, map
+  revisions, returned result facts, and transaction rollback; green aggregate
+  equality alone is insufficient.
+- Production Editor and travel routes remain the behavior oracle throughout;
+  focused adapter tests support but do not replace them.
 
 ### Exit Gate
 

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -16,6 +16,7 @@ import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
 import features.dungeon.application.authored.DungeonAuthoredPublishedState;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.editor.DungeonEditorPublishedState;
 import features.dungeon.application.editor.DungeonEditorApiFacade;
@@ -55,8 +56,11 @@ public final class DungeonFeature {
         PartyApi safeParty = Objects.requireNonNull(party, "party");
         ExecutionLane lane = Objects.requireNonNull(executionLane, "executionLane");
         UiDispatcher dispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
+        SqliteDungeonMapRepository stores =
+                new SqliteDungeonMapRepository(Objects.requireNonNull(database, "database"));
         Runtime runtime = createRuntime(
-                new SqliteDungeonMapRepository(Objects.requireNonNull(database, "database")),
+                stores,
+                stores,
                 safeParty.activeParty(),
                 safeParty.travelPositions(),
                 safeParty,
@@ -82,6 +86,7 @@ public final class DungeonFeature {
     }
 
     static Runtime createRuntime(
+            DungeonCatalogStore catalogStore,
             DungeonMapRepository repository,
             ActivePartyModel activeParty,
             PartyTravelPositionsModel partyTravelPositions,
@@ -98,7 +103,10 @@ public final class DungeonFeature {
         DungeonAuthoredPublishedState authoredPublishedState = new DungeonAuthoredPublishedState(dispatcher);
         CorridorRoutingPolicy corridorRoutingPolicy = new OrthogonalCorridorRoutingPolicy();
         DungeonAuthoredApplicationService authoredMaps = new DungeonAuthoredApplicationService(
-                Objects.requireNonNull(repository, "repository"), authoredPublishedState, corridorRoutingPolicy);
+                Objects.requireNonNull(catalogStore, "catalogStore"),
+                Objects.requireNonNull(repository, "repository"),
+                authoredPublishedState,
+                corridorRoutingPolicy);
         DungeonEditorRuntimeApplicationService editor =
                 new DungeonEditorRuntimeApplicationService(authoredMaps, editorPublishedState);
         DungeonTravelPartyGateway partyGateway = new DungeonTravelPartyGateway(

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteGateway.java
@@ -49,7 +49,7 @@ public final class DungeonSqliteGateway {
         identityReservation = new DungeonSqliteIdentityReservation(connections);
     }
 
-    public List<DungeonMapRecord> searchMaps(String query) {
+    public List<DungeonMapRecord> searchMapHeaders(String query) {
         String normalized = query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
         try (Connection connection = connectionSupport.openReadyConnection();
             PreparedStatement statement = connection.prepareStatement(
@@ -97,6 +97,44 @@ public final class DungeonSqliteGateway {
             return DungeonSqliteConnectionSupport.findMap(connection, mapId);
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to load dungeon map from SQLite.", exception);
+        }
+    }
+
+    public DungeonMapRecord createMapHeader(String mapName) {
+        String safeName = requireMapName(mapName);
+        try (Connection connection = connectionSupport.openReadyConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                     INSERT_INTO + DungeonPersistenceSchema.MAPS_TABLE
+                             + "(name, revision) VALUES(?,1)",
+                     Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, safeName);
+            statement.executeUpdate();
+            try (ResultSet resultSet = statement.getGeneratedKeys()) {
+                if (!resultSet.next()) {
+                    throw new IllegalStateException("No key returned for Dungeon map insert");
+                }
+                return new DungeonMapRecord(resultSet.getLong(1), safeName, 1L, null);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to create Dungeon map header in SQLite.", exception);
+        }
+    }
+
+    public DungeonMapRecord renameMapHeader(long mapId, String mapName) {
+        String safeName = requireMapName(mapName);
+        try (Connection connection = connectionSupport.openReadyConnection();
+             PreparedStatement update = connection.prepareStatement(
+                     "UPDATE " + DungeonPersistenceSchema.MAPS_TABLE
+                             + " SET name=?, revision=revision+1 WHERE dungeon_map_id=?")) {
+            update.setString(1, safeName);
+            update.setLong(2, mapId);
+            if (update.executeUpdate() == 0) {
+                throw new IllegalArgumentException("Unknown Dungeon map: " + mapId);
+            }
+            return mapHeader(connection, mapId).orElseThrow(() ->
+                    new IllegalStateException("Renamed Dungeon map header is missing: " + mapId));
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to rename Dungeon map header in SQLite.", exception);
         }
     }
 
@@ -164,33 +202,36 @@ public final class DungeonSqliteGateway {
         }
     }
 
-    public long nextMapId() {
-        try (Connection connection = connectionSupport.openReadyConnection();
-             PreparedStatement statement = connection.prepareStatement(
-                     INSERT_INTO + DungeonPersistenceSchema.MAPS_TABLE + "(name) VALUES(?)",
-                     Statement.RETURN_GENERATED_KEYS)) {
-            statement.setString(1, "Dungeon Map");
-            statement.executeUpdate();
-            try (ResultSet resultSet = statement.getGeneratedKeys()) {
-                if (!resultSet.next()) {
-                    throw new IllegalStateException(
-                            "No key returned for " + DungeonPersistenceSchema.MAPS_TABLE + " insert");
-                }
-                long mapId = resultSet.getLong(1);
-                DungeonSqliteMapRecordWriter.deleteMap(connection, mapId);
-                return mapId;
-            }
-        } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to allocate dungeon map identity from SQLite.", exception);
-        }
-    }
-
     public long nextStairId() {
         return identityReservation.nextStairId();
     }
 
     public long nextTransitionId() {
         return identityReservation.nextTransitionId();
+    }
+
+    private static Optional<DungeonMapRecord> mapHeader(Connection connection, long mapId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                SELECT_MAP_COLUMNS + SQL_FROM + DungeonPersistenceSchema.MAPS_TABLE
+                        + " WHERE dungeon_map_id=?")) {
+            statement.setLong(1, mapId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next()
+                        ? Optional.of(new DungeonMapRecord(
+                                resultSet.getLong("dungeon_map_id"),
+                                resultSet.getString("name"),
+                                resultSet.getLong("revision"),
+                                null))
+                        : Optional.empty();
+            }
+        }
+    }
+
+    private static String requireMapName(String mapName) {
+        if (mapName == null || mapName.isBlank()) {
+            throw new IllegalArgumentException("mapName must not be blank");
+        }
+        return mapName.trim();
     }
 
 }

--- a/features/dungeon/adapter/sqlite/repository/SqliteDungeonMapRepository.java
+++ b/features/dungeon/adapter/sqlite/repository/SqliteDungeonMapRepository.java
@@ -3,9 +3,12 @@ package features.dungeon.adapter.sqlite.repository;
 import platform.persistence.SqliteDatabase;
 import features.dungeon.adapter.sqlite.gateway.DungeonSqliteGateway;
 import features.dungeon.adapter.sqlite.mapper.DungeonMapRecordMapper;
+import features.dungeon.adapter.sqlite.model.DungeonMapRecord;
 import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.authored.port.DungeonChangeSet;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 
 import java.util.List;
@@ -15,7 +18,7 @@ import java.util.Set;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.api.DungeonViewportRequest;
 
-public final class SqliteDungeonMapRepository implements DungeonMapRepository {
+public final class SqliteDungeonMapRepository implements DungeonCatalogStore, DungeonMapRepository {
 
     private final DungeonSqliteGateway gateway;
 
@@ -29,11 +32,6 @@ public final class SqliteDungeonMapRepository implements DungeonMapRepository {
 
     SqliteDungeonMapRepository(DungeonSqliteGateway gateway) {
         this.gateway = Objects.requireNonNull(gateway, "gateway");
-    }
-
-    @Override
-    public DungeonMapIdentity nextMapId() {
-        return new DungeonMapIdentity(gateway.nextMapId());
     }
 
     @Override
@@ -55,10 +53,22 @@ public final class SqliteDungeonMapRepository implements DungeonMapRepository {
     }
 
     @Override
-    public List<DungeonMap> searchByName(String query) {
-        return gateway.searchMaps(query).stream()
-                .map(DungeonMapRecordMapper::toDomain)
+    public List<DungeonMapHeader> search(String query) {
+        return gateway.searchMapHeaders(query).stream()
+                .map(SqliteDungeonMapRepository::toHeader)
                 .toList();
+    }
+
+    @Override
+    public DungeonMapHeader create(String mapName) {
+        return toHeader(gateway.createMapHeader(mapName));
+    }
+
+    @Override
+    public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+        return toHeader(gateway.renameMapHeader(
+                Objects.requireNonNull(mapId, "mapId").value(),
+                mapName));
     }
 
     @Override
@@ -102,5 +112,12 @@ public final class SqliteDungeonMapRepository implements DungeonMapRepository {
     @Override
     public Set<DungeonChunkKey> findAvailableChunks(DungeonViewportRequest request) {
         return gateway.findAvailableChunks(request);
+    }
+
+    private static DungeonMapHeader toHeader(DungeonMapRecord record) {
+        return new DungeonMapHeader(
+                new DungeonMapIdentity(record.mapId()),
+                record.name(),
+                record.revision());
     }
 }

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -22,7 +22,9 @@ import features.dungeon.domain.core.projection.DungeonDerivedState;
 import features.dungeon.domain.core.projection.DungeonDerivedStateProjection;
 import features.dungeon.domain.core.projection.DungeonMapFacts;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.application.authored.port.DungeonChangeSet;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.application.authored.command.DungeonCommandResult;
 import features.dungeon.application.authored.command.DungeonCompoundCommandResult;
 import features.dungeon.application.authored.command.DungeonCompoundPatch;
@@ -106,6 +108,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private static final String DEFAULT_DESCRIPTION = "";
     private static final String PREVIEW_ARGUMENT = "preview";
 
+    private final DungeonCatalogStore catalogStore;
     private final DungeonMapRepository repository;
     private final DungeonAuthoredPublishedState publishedState;
     private final CorridorRoutingPolicy corridorRoutingPolicy;
@@ -161,17 +164,20 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
     private final LoadOperations loadOperations = new LoadOperations();
 
     public DungeonAuthoredApplicationService(
+            DungeonCatalogStore catalogStore,
             DungeonMapRepository repository,
             DungeonAuthoredPublishedState publishedState
     ) {
-        this(repository, publishedState, new OrthogonalCorridorRoutingPolicy());
+        this(catalogStore, repository, publishedState, new OrthogonalCorridorRoutingPolicy());
     }
 
     public DungeonAuthoredApplicationService(
+            DungeonCatalogStore catalogStore,
             DungeonMapRepository repository,
             DungeonAuthoredPublishedState publishedState,
             CorridorRoutingPolicy corridorRoutingPolicy
     ) {
+        this.catalogStore = Objects.requireNonNull(catalogStore, "catalogStore");
         this.repository = Objects.requireNonNull(repository, "repository");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
         this.corridorRoutingPolicy = Objects.requireNonNull(corridorRoutingPolicy, "corridorRoutingPolicy");
@@ -1117,33 +1123,31 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
 
         private DungeonMapIdentity createMap(String requestedMapName) {
-            DungeonMapIdentity mapIdentity = repository.nextMapId();
             String mapName = requestedMapName == null || requestedMapName.isBlank()
                     ? DEFAULT_MAP_NAME
                     : requestedMapName;
-            DungeonMap dungeonMap = DungeonMapAuthoring.empty(mapIdentity, mapName);
-            DungeonMap saved = repository.save(dungeonMap);
-            authoredWorkset.put(saved.metadata().mapId().value(), saved);
-            return saved.metadata().mapId();
+            DungeonMapHeader created = catalogStore.create(mapName);
+            DungeonMap emptyMap = DungeonMapAuthoring.committedContent(
+                    DungeonMapAuthoring.empty(created.mapId(), created.mapName()),
+                    created.revision());
+            authoredWorkset.put(created.mapId().value(), emptyMap);
+            return created.mapId();
         }
 
         private DungeonMapIdentity renameMap(DungeonMapIdentity mapIdentity, String requestedMapName) {
-            DungeonMap foundMap = loadMap(mapIdentity);
-            if (!foundMap.metadata().mapId().equals(mapIdentity)) {
-                throw new IllegalArgumentException("Unknown dungeon map: " + mapIdentity.value());
-            }
             String mapName = requestedMapName == null || requestedMapName.isBlank()
                     ? DEFAULT_MAP_NAME
                     : requestedMapName;
-            DungeonMap renamed = repository.saveChange(new DungeonChangeSet(
-                    foundMap,
-                    DungeonMapAuthoring.rename(foundMap, mapName)));
-            authoredWorkset.put(renamed.metadata().mapId().value(), renamed);
-            return renamed.metadata().mapId();
+            DungeonMapHeader renamed = catalogStore.rename(mapIdentity, mapName);
+            authoredWorkset.computeIfPresent(mapIdentity.value(), (ignored, current) ->
+                    DungeonMapAuthoring.committedContent(
+                            DungeonMapAuthoring.rename(current, renamed.mapName()),
+                            renamed.revision()));
+            return renamed.mapId();
         }
 
         private DungeonMapIdentity deleteMap(DungeonMapIdentity mapIdentity) {
-            repository.delete(mapIdentity);
+            catalogStore.delete(mapIdentity);
             authoredWorkset.remove(mapIdentity.value());
             editHistory.remove(mapIdentity);
             return mapIdentity;
@@ -1152,10 +1156,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         private CatalogResult searchCatalog(String query) {
             String effectiveQuery = query == null ? "" : query;
             List<MapSummaryData> summaries = new ArrayList<>();
-            for (DungeonMap map : repository.searchByName(effectiveQuery)) {
+            for (DungeonMapHeader map : catalogStore.search(effectiveQuery)) {
                 summaries.add(new MapSummaryData(
-                        map.metadata().mapId(),
-                        map.metadata().mapName(),
+                        map.mapId(),
+                        map.mapName(),
                         map.revision()));
             }
             summaries.sort(mapSummaryOrder);

--- a/features/dungeon/application/authored/port/DungeonCatalogStore.java
+++ b/features/dungeon/application/authored/port/DungeonCatalogStore.java
@@ -1,0 +1,16 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.List;
+
+/** Metadata-only catalog reads and mutations for authored Dungeon maps. */
+public interface DungeonCatalogStore {
+
+    List<DungeonMapHeader> search(String query);
+
+    DungeonMapHeader create(String mapName);
+
+    DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName);
+
+    void delete(DungeonMapIdentity mapId);
+}

--- a/features/dungeon/application/authored/port/DungeonMapHeader.java
+++ b/features/dungeon/application/authored/port/DungeonMapHeader.java
@@ -1,0 +1,22 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.Objects;
+
+/** Metadata-only authored map identity returned by the catalog store. */
+public record DungeonMapHeader(
+        DungeonMapIdentity mapId,
+        String mapName,
+        long revision
+) {
+    public DungeonMapHeader {
+        mapId = Objects.requireNonNull(mapId, "mapId");
+        if (mapName == null || mapName.isBlank()) {
+            throw new IllegalArgumentException("mapName must not be blank");
+        }
+        mapName = mapName.trim();
+        if (revision < 1L) {
+            throw new IllegalArgumentException("revision must be positive");
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonMapRepository.java
+++ b/features/dungeon/application/authored/port/DungeonMapRepository.java
@@ -3,26 +3,22 @@ package features.dungeon.application.authored.port;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.DungeonMap;
 
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.api.DungeonViewportRequest;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import features.dungeon.api.DungeonChunkKey;
-import features.dungeon.api.DungeonViewportRequest;
 
 /**
  * Repository contract for authored dungeon maps.
  */
 public interface DungeonMapRepository {
 
-    DungeonMapIdentity nextMapId();
-
     long nextStairId();
 
     long nextTransitionId();
 
     Optional<DungeonMap> findById(DungeonMapIdentity mapId);
-
-    List<DungeonMap> searchByName(String query);
 
     Optional<DungeonMap> firstMap();
 
@@ -38,8 +34,6 @@ public interface DungeonMapRepository {
      * and returns the saved readback for each committed map.
      */
     List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps);
-
-    void delete(DungeonMapIdentity mapId);
 
     default Set<DungeonChunkKey> findAvailableChunks(DungeonViewportRequest request) {
         return Set.of();

--- a/test/app/persistence/SqliteDungeonHexPlannerAdaptersTest.java
+++ b/test/app/persistence/SqliteDungeonHexPlannerAdaptersTest.java
@@ -35,7 +35,7 @@ final class SqliteDungeonHexPlannerAdaptersTest {
                     "session-planner", 2,
                     "world-planner", 2);
 
-            assertTrue(dungeons.searchByName("").isEmpty());
+            assertTrue(dungeons.search("").isEmpty());
             assertTrue(hexMaps.listMaps().isEmpty());
             assertTrue(sessions.listSessions().isEmpty());
             assertTrue(world.load().npcs().isEmpty());

--- a/test/architecture/dungeon/DungeonStoragePortArchitectureTest.java
+++ b/test/architecture/dungeon/DungeonStoragePortArchitectureTest.java
@@ -1,0 +1,40 @@
+package architecture.dungeon;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import architecture.AnalyzeMainClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeMainClasses
+public final class DungeonStoragePortArchitectureTest {
+
+    private static final String CATALOG_STORE =
+            "features.dungeon.application.authored.port.DungeonCatalogStore";
+    private static final String DUNGEON_MAP =
+            "features.dungeon.domain.core.structure.DungeonMap";
+    private static final String AUTHORED_SERVICE =
+            "features.dungeon.application.authored.DungeonAuthoredApplicationService";
+
+    private DungeonStoragePortArchitectureTest() {
+    }
+
+    @ArchTest
+    static final ArchRule catalogStoreRemainsMetadataOnly =
+            noClasses()
+                    .that()
+                    .haveFullyQualifiedName(CATALOG_STORE)
+                    .should()
+                    .dependOnClassesThat()
+                    .haveFullyQualifiedName(DUNGEON_MAP);
+
+    @ArchTest
+    static final ArchRule authoredServiceUsesTheDedicatedCatalogPort =
+            classes()
+                    .that()
+                    .haveFullyQualifiedName(AUTHORED_SERVICE)
+                    .should()
+                    .dependOnClassesThat()
+                    .haveFullyQualifiedName(CATALOG_STORE);
+}

--- a/test/features/dungeon/DungeonTestAssembly.java
+++ b/test/features/dungeon/DungeonTestAssembly.java
@@ -8,6 +8,7 @@ import features.dungeon.api.DungeonEditorStateModel;
 import features.dungeon.api.DungeonMapCatalogModel;
 import features.dungeon.api.TravelDungeonModel;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.editor.DungeonEditorRuntimeApplicationService;
 import features.dungeon.application.travel.DungeonTravelRuntimeApplicationService;
@@ -29,6 +30,7 @@ public final class DungeonTestAssembly {
     }
 
     public static Component create(
+            DungeonCatalogStore catalogStore,
             DungeonMapRepository repository,
             ActivePartyModel activeParty,
             PartyTravelPositionsModel partyTravelPositions,
@@ -36,6 +38,7 @@ public final class DungeonTestAssembly {
             PartyMutationModel partyMutation
     ) {
         return create(
+                catalogStore,
                 repository,
                 activeParty,
                 partyTravelPositions,
@@ -47,6 +50,7 @@ public final class DungeonTestAssembly {
     }
 
     public static Component create(
+            DungeonCatalogStore catalogStore,
             DungeonMapRepository repository,
             ActivePartyModel activeParty,
             PartyTravelPositionsModel partyTravelPositions,
@@ -57,6 +61,7 @@ public final class DungeonTestAssembly {
             Diagnostics diagnostics
     ) {
         DungeonFeature.Runtime runtime = DungeonFeature.createRuntime(
+                catalogStore,
                 repository,
                 activeParty,
                 partyTravelPositions,

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapCatalogScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapCatalogScenarios.java
@@ -82,6 +82,9 @@ final class DungeonEditorMapCatalogScenarios {
                 .findFirst()
                 .orElseThrow();
         assertTrue(selected.mapId().value() > 0L, "DE-MAP-001 selected Gamma map has a stable id");
+        assertEquals(1L, selected.revision(), "DE-MAP-001 created catalog header starts at revision one");
+        assertEquals(1L, runtime.database().mapRevision(selected.mapId().value()),
+                "DE-MAP-001 metadata-only create persists revision one");
         assertEquals(selected.mapId(), controlsSnapshot.selectedMapId(), "DE-MAP-001 controls snapshot selects Gamma");
         assertPreparedSelectedMapAligned(
                 runtime,
@@ -125,12 +128,16 @@ final class DungeonEditorMapCatalogScenarios {
                 "DE-MAP-002 old selected dungeon_maps name is gone");
         assertEquals(geometryRowsBefore, runtime.database().countAuthoredGeometryRows(alphaMapId),
                 "DE-MAP-002 leaves authored geometry rows unchanged");
+        assertEquals(2L, runtime.database().mapRevision(alphaMapId),
+                "DE-MAP-002 metadata-only rename advances the map revision once");
         DungeonEditorControlsSnapshot controlsSnapshot = runtime.controlsModel().current();
         assertEquals(alphaMapId, controlsSnapshot.selectedMapId().value(),
                 "DE-MAP-002 selection remains on the renamed map id");
         assertTrue(
                 controlsSnapshot.maps().stream().anyMatch(map ->
-                        map.mapId().value() == alphaMapId && "Alpha Prime".equals(map.mapName())),
+                        map.mapId().value() == alphaMapId
+                                && "Alpha Prime".equals(map.mapName())
+                                && map.revision() == 2L),
                 "DE-MAP-002 published catalog contains renamed map");
         assertPreparedCatalogEntries(
                 controls,

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
@@ -24,6 +24,7 @@ import features.dungeon.domain.core.geometry.Direction;
 import features.dungeon.domain.core.geometry.DungeonBoundaryKey;
 import features.dungeon.domain.core.geometry.Edge;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.api.DungeonEditorControlsModel;
 import features.dungeon.api.DungeonEditorMapSurfaceModel;
 import features.dungeon.api.DungeonEditorStateModel;
@@ -63,8 +64,8 @@ class DungeonEditorTestPersistence {
         static TestRuntime create() {
             DatabaseAssertions database = new DatabaseAssertions();
             database.clearDungeonData();
-            DungeonTestAssembly.Component dungeon =
-                    createDungeonServices(new SqliteDungeonMapRepository());
+            SqliteDungeonMapRepository stores = new SqliteDungeonMapRepository();
+            DungeonTestAssembly.Component dungeon = createDungeonServices(stores, stores);
             DungeonEditorRuntimeDependencies dependencies =
                     DungeonEditorTestPersistence.editorDependencies(dungeon);
             DungeonEditorApi api = new DungeonEditorApiFacade(
@@ -80,9 +81,13 @@ class DungeonEditorTestPersistence {
         }
     }
 
-    static DungeonTestAssembly.Component createDungeonServices(DungeonMapRepository repository) {
+    static DungeonTestAssembly.Component createDungeonServices(
+            DungeonCatalogStore catalogStore,
+            DungeonMapRepository repository
+    ) {
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(new EmptyPartyRosterRepository());
         return DungeonTestAssembly.create(
+                catalogStore,
                 repository,
                 party.activeParty(),
                 party.travelPositions(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProjectionInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProjectionInvariantScenarios.java
@@ -37,6 +37,8 @@ import features.dungeon.application.travel.projection.TravelSurfaceProjection;
 import features.dungeon.application.travel.projection.TravelTransitionTarget;
 import features.dungeon.application.travel.session.TravelDungeonSessionSurface.LocationKind;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.domain.core.structure.DungeonMapMetadata;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
@@ -226,7 +228,7 @@ final class DungeonRuntimeProjectionInvariantScenarios {
             TravelActionFacts unlinkedTransition,
             SelectedAction selectedAction
     ) {
-        DungeonMapRepository repository = repositoryOf(
+        DungeonTestStore repository = repositoryOf(
                 unlinkedMap,
                 DungeonMapAuthoring.empty(new DungeonMapIdentity(99L), "Unused Target"));
         TravelPositionFacts transitionPosition = java.util.Objects.requireNonNull(
@@ -437,7 +439,7 @@ final class DungeonRuntimeProjectionInvariantScenarios {
                 List.of(new Cell(9, 9, 0)),
                 0L,
                 null);
-        DungeonMapRepository repository = repositoryOf(firstMap, selectedMap);
+        DungeonTestStore repository = repositoryOf(firstMap, selectedMap);
         TravelRuntimeFixture services = travelServices(repository);
         DungeonTravelRuntimeApplicationService travel = services.dungeon().travel();
 
@@ -528,16 +530,14 @@ final class DungeonRuntimeProjectionInvariantScenarios {
         return map.withExactTransitionChange(null, transition);
     }
 
-    private static DungeonMapRepository repositoryOf(DungeonMap firstMap, DungeonMap secondMap) {
+    private interface DungeonTestStore extends DungeonCatalogStore, DungeonMapRepository {
+    }
+
+    private static DungeonTestStore repositoryOf(DungeonMap firstMap, DungeonMap secondMap) {
         Map<Long, DungeonMap> mapsById = Map.of(
                 firstMap.metadata().mapId().value(), firstMap,
                 secondMap.metadata().mapId().value(), secondMap);
-        return new DungeonMapRepository() {
-            @Override
-            public DungeonMapIdentity nextMapId() {
-                throw new UnsupportedOperationException();
-            }
-
+        return new DungeonTestStore() {
             @Override
             public long nextStairId() {
                 throw new UnsupportedOperationException();
@@ -554,8 +554,18 @@ final class DungeonRuntimeProjectionInvariantScenarios {
             }
 
             @Override
-            public List<DungeonMap> searchByName(String query) {
+            public List<DungeonMapHeader> search(String query) {
                 return List.of();
+            }
+
+            @Override
+            public DungeonMapHeader create(String mapName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+                throw new UnsupportedOperationException();
             }
 
             @Override
@@ -654,10 +664,11 @@ final class DungeonRuntimeProjectionInvariantScenarios {
                 .orElse(DungeonMapAuthoring.empty(new DungeonMapIdentity(1L), "Dungeon Map"));
     }
 
-    private static TravelRuntimeFixture travelServices(DungeonMapRepository repository) {
+    private static TravelRuntimeFixture travelServices(DungeonTestStore repository) {
         PartyServiceAssembly.Component party =
                 PartyServiceAssembly.create(new InMemoryPartyRosterRepository());
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
+                repository,
                 repository,
                 party.activeParty(),
                 party.travelPositions(),

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
@@ -9,6 +9,8 @@ import features.dungeon.DungeonTestAssembly;
 import features.dungeon.domain.core.geometry.Cell;
 import features.dungeon.domain.core.geometry.Direction;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.domain.core.structure.DungeonMapMetadata;
@@ -198,7 +200,7 @@ final class DungeonTransitionInvariantScenarios {
         MissingPreviousMapRepository repository =
                 new MissingPreviousMapRepository(sourceMap, targetMap, missingPreviousMapId);
         DungeonTestAssembly.Component services =
-                DungeonEditorTestPersistence.createDungeonServices(repository);
+                DungeonEditorTestPersistence.createDungeonServices(repository, repository);
         DungeonEditorDungeonState dungeonState = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService.OperationResult result = services
                 .editor()
@@ -330,7 +332,7 @@ final class DungeonTransitionInvariantScenarios {
         return List.copyOf(result);
     }
 
-    private static final class MissingPreviousMapRepository implements DungeonMapRepository {
+    private static final class MissingPreviousMapRepository implements DungeonCatalogStore, DungeonMapRepository {
         private final Map<Long, DungeonMap> mapsById = new LinkedHashMap<>();
         private final long missingPreviousMapId;
         private final List<Long> requestedMapIds = new ArrayList<>();
@@ -344,11 +346,6 @@ final class DungeonTransitionInvariantScenarios {
             mapsById.put(sourceMap.metadata().mapId().value(), sourceMap);
             mapsById.put(targetMap.metadata().mapId().value(), targetMap);
             this.missingPreviousMapId = missingPreviousMapId;
-        }
-
-        @Override
-        public DungeonMapIdentity nextMapId() {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -371,8 +368,18 @@ final class DungeonTransitionInvariantScenarios {
         }
 
         @Override
-        public List<DungeonMap> searchByName(String query) {
+        public List<DungeonMapHeader> search(String query) {
             return List.of();
+        }
+
+        @Override
+        public DungeonMapHeader create(String mapName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTravelProjectionLevelTest.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTravelProjectionLevelTest.java
@@ -440,8 +440,10 @@ public final class DungeonTravelProjectionLevelTest {
             database.clearPartyData();
             PartyServiceAssembly.Component party =
                     PartyServiceAssembly.create(new SqlitePartyRosterRepository());
+            SqliteDungeonMapRepository dungeonStores = new SqliteDungeonMapRepository();
             DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
-                    new SqliteDungeonMapRepository(),
+                    dungeonStores,
+                    dungeonStores,
                     party.activeParty(),
                     party.travelPositions(),
                     party.application(),

--- a/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
+++ b/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
@@ -2,6 +2,8 @@ package features.dungeon.application.authored;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.application.authored.port.DungeonMapRepository;
 import features.dungeon.application.editor.session.DungeonEditorDungeonState;
 import features.dungeon.application.editor.session.DungeonEditorSessionValues;
@@ -20,6 +22,7 @@ final class DungeonAuthoredPreviewWorksetTest {
         CountingRepository repository = new CountingRepository();
         DungeonAuthoredApplicationService service = new DungeonAuthoredApplicationService(
                 repository,
+                repository,
                 new DungeonAuthoredPublishedState(DirectUiDispatcher.INSTANCE));
         DungeonAuthoredApplicationService.Session session = service.openSession(new DungeonEditorDungeonState());
         DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
@@ -34,14 +37,9 @@ final class DungeonAuthoredPreviewWorksetTest {
         assertEquals(1, repository.findByIdCalls);
     }
 
-    private static final class CountingRepository implements DungeonMapRepository {
+    private static final class CountingRepository implements DungeonCatalogStore, DungeonMapRepository {
         private final DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(1L), "Map");
         private int findByIdCalls;
-
-        @Override
-        public DungeonMapIdentity nextMapId() {
-            return new DungeonMapIdentity(2L);
-        }
 
         @Override
         public long nextStairId() {
@@ -60,8 +58,18 @@ final class DungeonAuthoredPreviewWorksetTest {
         }
 
         @Override
-        public List<DungeonMap> searchByName(String query) {
-            return List.of(map);
+        public List<DungeonMapHeader> search(String query) {
+            return List.of(header(map));
+        }
+
+        @Override
+        public DungeonMapHeader create(String mapName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -81,6 +89,13 @@ final class DungeonAuthoredPreviewWorksetTest {
 
         @Override
         public void delete(DungeonMapIdentity mapId) {
+        }
+
+        private static DungeonMapHeader header(DungeonMap dungeonMap) {
+            return new DungeonMapHeader(
+                    dungeonMap.metadata().mapId(),
+                    dungeonMap.metadata().mapName(),
+                    dungeonMap.revision());
         }
     }
 }

--- a/test/features/dungeon/application/authored/DungeonCatalogStoreApplicationTest.java
+++ b/test/features/dungeon/application/authored/DungeonCatalogStoreApplicationTest.java
@@ -1,0 +1,139 @@
+package features.dungeon.application.authored;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonMapCatalogResponse;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonChangeSet;
+import features.dungeon.application.authored.port.DungeonMapHeader;
+import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.editor.session.DungeonEditorDungeonState;
+import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
+import features.dungeon.domain.core.structure.DungeonMap;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import platform.ui.DirectUiDispatcher;
+
+final class DungeonCatalogStoreApplicationTest {
+
+    @Test
+    void catalogLifecycleNeverUsesTheTemporaryWholeMapRepository() {
+        InMemoryCatalogStore catalog = new InMemoryCatalogStore();
+        DungeonAuthoredPublishedState publishedState =
+                new DungeonAuthoredPublishedState(DirectUiDispatcher.INSTANCE);
+        DungeonAuthoredApplicationService service = new DungeonAuthoredApplicationService(
+                catalog,
+                new FailingWholeMapRepository(),
+                publishedState);
+        DungeonAuthoredApplicationService.Session session =
+                service.openSession(new DungeonEditorDungeonState());
+
+        session.createMapCatalog("Gamma");
+        session.searchMaps("");
+        DungeonMapCatalogResponse.MapList created =
+                (DungeonMapCatalogResponse.MapList) publishedState.mapCatalogModel().current();
+        assertEquals(1, created.maps().size());
+        assertEquals("Gamma", created.maps().getFirst().mapName());
+        assertEquals(1L, created.maps().getFirst().revision());
+
+        session.renameMapCatalog(new MapId(created.maps().getFirst().mapId().value()), "Gamma Prime");
+        session.searchMaps("Prime");
+        DungeonMapCatalogResponse.MapList renamed =
+                (DungeonMapCatalogResponse.MapList) publishedState.mapCatalogModel().current();
+        assertEquals(1, renamed.maps().size());
+        assertEquals("Gamma Prime", renamed.maps().getFirst().mapName());
+        assertEquals(2L, renamed.maps().getFirst().revision());
+
+        session.deleteMapCatalog(new MapId(renamed.maps().getFirst().mapId().value()));
+        assertTrue(((DungeonMapCatalogResponse.MapList) publishedState.mapCatalogModel().current())
+                .maps()
+                .isEmpty());
+    }
+
+    private static final class InMemoryCatalogStore implements DungeonCatalogStore {
+        private final List<DungeonMapHeader> headers = new ArrayList<>();
+        private long nextMapId = 1L;
+
+        @Override
+        public List<DungeonMapHeader> search(String query) {
+            String needle = query == null ? "" : query.toLowerCase(java.util.Locale.ROOT);
+            return headers.stream()
+                    .filter(header -> header.mapName().toLowerCase(java.util.Locale.ROOT).contains(needle))
+                    .toList();
+        }
+
+        @Override
+        public DungeonMapHeader create(String mapName) {
+            DungeonMapHeader created = new DungeonMapHeader(
+                    new DungeonMapIdentity(nextMapId++),
+                    mapName,
+                    1L);
+            headers.add(created);
+            return created;
+        }
+
+        @Override
+        public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+            for (int index = 0; index < headers.size(); index++) {
+                DungeonMapHeader current = headers.get(index);
+                if (current.mapId().equals(mapId)) {
+                    DungeonMapHeader renamed =
+                            new DungeonMapHeader(mapId, mapName, current.revision() + 1L);
+                    headers.set(index, renamed);
+                    return renamed;
+                }
+            }
+            throw new IllegalArgumentException("Unknown map: " + mapId.value());
+        }
+
+        @Override
+        public void delete(DungeonMapIdentity mapId) {
+            headers.removeIf(header -> header.mapId().equals(mapId));
+        }
+    }
+
+    private static final class FailingWholeMapRepository implements DungeonMapRepository {
+        @Override
+        public long nextStairId() {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public long nextTransitionId() {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public Optional<DungeonMap> findById(DungeonMapIdentity mapId) {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public Optional<DungeonMap> firstMap() {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public DungeonMap save(DungeonMap dungeonMap) {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public DungeonMap saveChange(DungeonChangeSet changeSet) {
+            throw unexpectedCall();
+        }
+
+        @Override
+        public List<DungeonMap> saveAll(List<DungeonMap> dungeonMaps) {
+            throw unexpectedCall();
+        }
+
+        private static AssertionError unexpectedCall() {
+            return new AssertionError("catalog lifecycle must not use whole-map persistence");
+        }
+    }
+}

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -18,6 +18,8 @@ import platform.ui.DirectUiDispatcher;
 import platform.ui.UiDispatcher;
 import features.dungeon.DungeonTestAssembly;
 import features.dungeon.application.authored.port.DungeonMapRepository;
+import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.domain.core.structure.DungeonMap;
 import features.dungeon.domain.core.structure.DungeonMapAuthoring;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -246,7 +248,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
     }
 
     private static DungeonEditorFeatureRuntimeRoot createRuntime(
-            DungeonMapRepository repository,
+            InMemoryDungeonRepository repository,
             QueuedExecutionLane lane,
             UiDispatcher dispatcher
     ) {
@@ -254,6 +256,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
                 new InMemoryPartyRepository(), lane, dispatcher, (id, type) -> { });
         lane.runAll();
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
+                repository,
                 repository,
                 party.activeParty(),
                 party.travelPositions(),
@@ -269,13 +272,14 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
                 dispatcher));
     }
 
-    private static DungeonEditorFeatureRuntimeRoot createRuntimeDirect(DungeonMapRepository repository) {
+    private static DungeonEditorFeatureRuntimeRoot createRuntimeDirect(InMemoryDungeonRepository repository) {
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
                 new InMemoryPartyRepository(),
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 (id, type) -> { });
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
+                repository,
                 repository,
                 party.activeParty(),
                 party.travelPositions(),
@@ -374,7 +378,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         }
     }
 
-    private static final class InMemoryDungeonRepository implements DungeonMapRepository {
+    private static final class InMemoryDungeonRepository implements DungeonCatalogStore, DungeonMapRepository {
         private final Map<Long, DungeonMap> maps = new LinkedHashMap<>();
         private int reads;
 
@@ -385,11 +389,6 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
 
         int size() {
             return maps.size();
-        }
-
-        @Override
-        public DungeonMapIdentity nextMapId() {
-            return new DungeonMapIdentity(maps.keySet().stream().mapToLong(Long::longValue).max().orElse(0L) + 1L);
         }
 
         @Override
@@ -409,12 +408,28 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         }
 
         @Override
-        public List<DungeonMap> searchByName(String query) {
+        public List<DungeonMapHeader> search(String query) {
             reads++;
             String safeQuery = query == null ? "" : query.toLowerCase(java.util.Locale.ROOT);
             return maps.values().stream()
                     .filter(map -> map.metadata().mapName().toLowerCase(java.util.Locale.ROOT).contains(safeQuery))
+                    .map(InMemoryDungeonRepository::header)
                     .toList();
+        }
+
+        @Override
+        public DungeonMapHeader create(String mapName) {
+            long mapId = maps.keySet().stream().mapToLong(Long::longValue).max().orElse(0L) + 1L;
+            DungeonMap map = DungeonMapAuthoring.empty(new DungeonMapIdentity(mapId), mapName);
+            maps.put(mapId, map);
+            return header(map);
+        }
+
+        @Override
+        public DungeonMapHeader rename(DungeonMapIdentity mapId, String mapName) {
+            DungeonMap renamed = DungeonMapAuthoring.rename(maps.get(mapId.value()), mapName);
+            maps.put(mapId.value(), renamed);
+            return header(renamed);
         }
 
         @Override
@@ -440,6 +455,13 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         @Override
         public void delete(DungeonMapIdentity mapId) {
             maps.remove(mapId.value());
+        }
+
+        private static DungeonMapHeader header(DungeonMap map) {
+            return new DungeonMapHeader(
+                    map.metadata().mapId(),
+                    map.metadata().mapName(),
+                    map.revision());
         }
     }
 }

--- a/test/shell/host/SessionPlannerShellLayoutTest.java
+++ b/test/shell/host/SessionPlannerShellLayoutTest.java
@@ -219,8 +219,9 @@ public final class SessionPlannerShellLayoutTest {
                 encounter.planBudget(), null);
         HexServiceAssembly hex = new HexServiceAssembly(
                 new SqliteHexMapRepository(), party.travelPositions(), party.application());
+        SqliteDungeonMapRepository dungeonStores = new SqliteDungeonMapRepository();
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
-                new SqliteDungeonMapRepository(), party.activeParty(), party.travelPositions(),
+                dungeonStores, dungeonStores, party.activeParty(), party.travelPositions(),
                 party.application(), party.mutation());
         return new LayoutServices(party, creatures, tables, encounter, session, hex, dungeon);
     }


### PR DESCRIPTION
## Änderung

- führt `DungeonCatalogStore` und stabile `DungeonMapHeader` ein
- bewegt produktives Erstellen, Suchen, Umbenennen und Löschen auf metadaten-only SQLite-Operationen
- entfernt Katalog-ID-Allokation, Suche und Delete aus dem temporären Whole-Map-Repository
- ergänzt Anwendung-, Architektur- und reale JavaFX/SQLite-Revisionsbeweise
- plant die M4-Slices und Löschgrenzen entscheidungsvollständig in der temporären Roadmap

## Wirkung

Katalogoperationen hydratisieren oder schreiben keine authored Geometrie mehr. Create startet bei Revision 1; Rename verändert nur den Header und erhöht die Revision genau einmal.

## Verifikation

- `./gradlew test --tests features.dungeon.application.authored.DungeonCatalogStoreApplicationTest --console=plain`
- `./gradlew architectureTest --console=plain`
- `./gradlew uiTest --tests features.dungeon.adapter.javafx.editor.DungeonEditorBehaviorSuiteTest.mapCatalogBehavior --console=plain`
- `./gradlew check --console=plain` — grün in 3m23s
- `./gradlew installDesktopApp --console=plain` — grün in 8s