### PR TITLE
docs: define catalog greenfield migration

### DIFF
--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -1,18 +1,36 @@
 Status: Active
 Owner: Catalog Feature
-Last Reviewed: 2026-07-17
+Last Reviewed: 2026-07-18
 Source of Truth: Entry point for the consolidated reference workspace.
 
 # Catalog Feature
 
-Catalog owns presentation aggregation only. It combines immutable APIs and
-models from Creatures, Items, Encounter, Encounter Table, and World Planner
-inside one `Katalog` left-bar tab. Provider features retain all domain,
-persistence, command, and inspector-action ownership.
+Catalog is the application capability for finding, evaluating, and explicitly
+handing reference content to another active workspace. It presents Creatures,
+Items, saved Encounters, World Planner records, and Encounter Tables inside one
+`Katalog` left-bar tab.
 
-## Documents
+## Reading Order
 
-- [Requirements](requirements/requirements-catalog.md)
-- [Architecture](architecture/architecture-catalog.md)
+1. Read [Catalog Requirements](requirements/requirements-catalog.md) for
+   user-visible behavior and acceptance criteria.
+2. Read [Catalog Architecture](architecture/architecture-catalog.md) for the
+   durable target structure, ownership, and dependency direction.
+3. Read the temporary
+   [Catalog Greenfield Roadmap](delivery/roadmap-catalog-greenfield.md) only
+   when implementing or reviewing the migration. It owns sequencing and
+   deletion gates, not durable behavior or architecture.
 
-Catalog owns no persistence contract and no domain model.
+## Document Set
+
+### Requirements
+
+- [Catalog Requirements](requirements/requirements-catalog.md)
+
+### Architecture
+
+- [Catalog Architecture](architecture/architecture-catalog.md)
+
+### Temporary Delivery
+
+- [Catalog Greenfield Roadmap](delivery/roadmap-catalog-greenfield.md)

--- a/docs/catalog/architecture/architecture-catalog.md
+++ b/docs/catalog/architecture/architecture-catalog.md
@@ -1,69 +1,162 @@
 Status: Active Target
 Owner: Catalog Feature
-Last Reviewed: 2026-07-17
-Source of Truth: Catalog presentation boundary and dependency direction.
+Last Reviewed: 2026-07-18
+Source of Truth: Catalog application ownership, presentation boundary, and
+dependency direction.
 
 # Catalog Architecture
 
-## Stakeholders And Concerns
+## Entity, Stakeholders, And Concerns
 
-Players need one predictable reference workspace. Feature maintainers need
-domain ownership to remain local, while UI maintainers need a single place to
-compose reference sections. The primary risks are Catalog becoming a shared
-domain, importing foreign JavaFX adapters, or reintroducing synchronous I/O.
+Catalog is the application capability for finding, evaluating, and explicitly
+handing reference content to another active workspace. GMs need one predictable
+reference surface during preparation and table play. Feature maintainers need
+provider truth and validation to remain cohesive. UI maintainers need one state
+and lifecycle model rather than separate section-specific orchestration stacks.
 
-## Context And Boundaries
+The primary concerns are responsive asynchronous lookup, stable workspace
+state, explicit side effects, provider independence, consistent presentation,
+and complete retirement of the current JavaFX-owned orchestration.
 
-`features/catalog` owns one JavaFX adapter and one feature-root composition
-entry point. It consumes only foreign `feature.api` models and commands.
-Provider-owned inspector actions are passed into Catalog by `app`; Catalog
-does not import their adapters. Items callbacks are returned asynchronously and
-are dispatched to JavaFX before view mutation.
+## Target Topology
 
-Catalog composes provider dependencies as `CatalogDataSources` and outward UI
-routes as `CatalogActionRoutes`; raw positional callback lists are forbidden.
-Its typed `CatalogSectionId` coordinator owns seven persistent presentation
-sections. Every section exposes one controls root, one content root, and
-idempotent activation/deactivation hooks. The fixed section rail and active
-controls are rendered in `COCKPIT_CONTROLS`; the active section content is
-rendered in `COCKPIT_MAIN`. Section labels are display text, never selection
-identity or branching keys.
+```text
+features/catalog/
+├── application/
+│   ├── CatalogWorkspaceController
+│   ├── monster/MonsterCatalogController
+│   ├── items/ItemsCatalogController
+│   ├── encounters/SavedEncounterCatalogController
+│   ├── world/WorldReferenceCatalogController
+│   └── tables/EncounterTableCatalogController
+├── adapter/javafx/
+│   ├── CatalogContribution
+│   ├── CatalogWorkspaceView
+│   ├── CatalogSectionHost
+│   └── CatalogTableScaffold
+└── CatalogFeature
+```
 
-Creature browsing uses the request/response `CreatureCatalogQueryApi`. Each
-Catalog query owns its completion and Catalog discards late results by its
-local request revision. Scene and World Planner consume the separately
-refreshed `CreatureReferenceIndexModel`; they MUST NOT issue or publish Catalog
-page queries. This split prevents one feature's search lifecycle from replacing
-another feature's visible rows.
+Catalog owns an application and JavaFX role. It owns no domain or persistence
+role because it defines no durable business truth and stores no reference
+records.
 
-`CatalogSectionFrame` owns only shared table chrome. Provider-specific columns,
-commands, and Inspector routes remain injected composition. The controls host
-preserves the established Monster filter surface and swaps only the visible
-category controls. Catalog writes Encounter pool filters through the partial
-pool command and never writes Encounter tuning.
+## Application Ownership
 
-Catalog has no domain, application, or SQLite role because it owns no durable
-truth or orchestration. `app` registers Catalog once and does not register the
-World Planner contribution. Encounter remains a global state-tab contribution,
-and Scene remains its own runtime navigation contribution.
+`CatalogWorkspaceController` owns the active section, the lifetime of every
+section controller, and immutable workspace publication. It delegates queries
+and actions to the controller that owns the selected section; it does not
+contain provider-specific filter or mapping logic.
 
-Section nodes remain alive while the user switches sections, preserving
-filters, selection, paging, and drafts. Monster table columns are configured
-once; result publication updates rows and restores selection by creature id.
-Nested section `TabPane`s and controls embedded in main content are forbidden.
+Every section controller owns:
 
-## Enforcement And Rationale
+- its Catalog-specific query and draft state
+- its request revision and current result projection
+- stable selection identity, sort, and paging where applicable
+- translation between user intents and provider APIs or typed outward routes
+- activation, deactivation, and subscription cleanup
 
-`architectureTest` mechanically enforces cross-feature API-only dependencies
-and valid feature roles. UI tests own section completeness, common slot
-placement, state preservation, stable Monster columns, and Scene/Catalog query
-independence. Inspector ownership and absence of duplicate shell registration
-remain behavior-test and review-owned.
-This split keeps aggregation replaceable without moving provider truth into a
-new shared layer.
+`WorldReferenceCatalogController` may serve the NPC, faction, and location
+sections because they share one provider snapshot and lifecycle. Their
+published section states remain distinct.
+
+Every section publishes an immutable `CatalogResultState<Row>` with a typed
+status covering loading, ready, empty, invalid input, unavailable, and failed
+outcomes. A section-specific state wraps that result together with its filters,
+selection id, page, and unfinished input. JavaFX properties and nodes do not
+cross into application state.
+
+## Provider And Action Boundaries
+
+`CatalogFeature.create(CatalogProviders, CatalogRoutes)` is the feature-root
+composition entry point. `CatalogProviders` groups required dependencies by
+section as `MonsterProviders`, `ItemsProviders`, `SavedEncounterProviders`,
+`WorldReferenceProviders`, and `EncounterTableProviders`. Required providers
+are never nullable and have no no-op fallback.
+
+`CatalogRoutes` groups semantic outward capabilities:
+
+- `CreatureInspectorRoute`
+- `ItemInspectorRoute`
+- `WorldInspectorRoutes`
+- `EncounterHandoff`
+- `SceneHandoff`
+
+Catalog application code may consume foreign feature APIs. It MUST NOT import a
+foreign domain, application, composition root, JavaFX adapter, or persistence
+adapter. Provider-owned Inspector content is supplied through the typed routes;
+Catalog does not rebuild foreign editors.
+
+Creature details load and open through one route so a global detail selection
+and Inspector push cannot race. Encounter and Scene changes occur only through
+explicit handoff intents.
+
+## Monster Query And Encounter Filters
+
+Catalog owns the visible Monster query draft. It sends the query to the
+creature catalog provider and maps the relevant filter values to an Encounter
+pool-filter command. Encounter owns the canonical generation-filter truth and
+publishes readback when it changes elsewhere.
+
+Catalog never reads or writes Encounter tuning. Difficulty, balance, amount,
+and diversity remain Encounter-owned inputs and presentation.
+
+Catalog page queries remain independent from the creature reference index used
+by Scene and World Planner. A Scene or World Planner refresh therefore cannot
+replace the Catalog's visible page lifecycle.
+
+## JavaFX Boundary
+
+The JavaFX adapter renders immutable application state and translates raw
+control events into application intents. It performs no provider query,
+cross-feature command coordination, or subscription ownership.
+
+`CatalogTableScaffold` owns shared header, result status, table behavior,
+stable-id selection, optional paging, keyboard interaction, accessibility, and
+the action-column layout. Section renderers supply columns, filters, and the
+available typed actions. The seven section roots remain alive for the active
+Catalog binding so switching sections does not discard local view state.
+
+## Lifecycle And Concurrency
+
+Activating Catalog registers provider subscriptions and applies each current
+snapshot before accepting later publications. Deactivating Catalog unregisters
+subscriptions, invalidates in-flight request generations, and retains immutable
+workspace state for later reactivation. Closing the Catalog component releases
+all remaining resources.
+
+Persistence- or file-backed provider calls remain non-blocking. Each request
+captures a local revision; a result may publish only when its revision is still
+current. Application publication uses the feature-neutral UI dispatcher before
+the JavaFX adapter mutates controls.
+
+## Decisions And Rejected Alternatives
+
+- A JavaFX-only aggregator is rejected because Catalog already owns query,
+  lifecycle, projection, and handoff use cases.
+- A Catalog domain or copied provider database is rejected because it would
+  duplicate provider truth and introduce synchronization invariants without a
+  user need.
+- A dynamic section plugin registry is rejected because seven statically known
+  sections do not justify discovery or runtime extension machinery.
+- Broad data-source and callback bags are rejected because they hide per-section
+  dependencies and permit silent no-op behavior.
+- Long-lived compatibility adapters are rejected. The migration may retain one
+  internal adapter only under the deletion budget owned by the delivery
+  roadmap.
+
+## Enforcement And Verification Ownership
+
+`architectureTest` mechanically enforces valid feature roles, foreign API-only
+dependencies, and the absence of JavaFX dependencies from Catalog application
+code. UI behavior tests own the seven-section workspace, state preservation,
+stable-id selection, visible result states, and explicit handoff behavior.
+Lifecycle tests own balanced subscription and request invalidation behavior.
+Final visual and interaction acceptance remains owner manual testing.
 
 ## References
 
+- [Catalog Requirements](../requirements/requirements-catalog.md)
 - [Source Architecture](../../project/architecture/source-architecture.md)
 - [Feature Boundaries](../../project/architecture/patterns/feature-boundaries.md)
-- [Catalog Requirements](../requirements/requirements-catalog.md)
+- [Shell Layer](../../project/architecture/patterns/shell-layer.md)

--- a/docs/catalog/delivery/roadmap-catalog-greenfield.md
+++ b/docs/catalog/delivery/roadmap-catalog-greenfield.md
@@ -1,0 +1,280 @@
+Status: Temporary Migration
+Owner: Catalog Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Ordered migration milestones, deletion gates, and current
+migration position for the Catalog greenfield replacement.
+
+# Catalog Greenfield Roadmap
+
+## Purpose
+
+This roadmap replaces the shipped JavaFX-owned Catalog orchestration with the
+durable application-centered target in the Catalog requirements and
+architecture. It owns temporary sequence and deletion gates, not user-visible
+behavior or permanent architecture. It is deleted after M5 closes every legacy
+boundary named below.
+
+The migration preserves accepted Catalog behavior while replacing internal
+types, packages, state models, and composition seams without compatibility
+obligation.
+
+## Authoritative Facts
+
+- One `Katalog` tab exposes Monster, Items, Encounter, NPCs, Fraktionen, Orte,
+  and Encounter-Tabellen.
+- Section switching preserves filters, selection, paging, and unfinished input.
+- Details open without implicitly changing Encounter or Scene state.
+- Encounter and Scene changes require explicit named actions.
+- Monster filters also constrain Encounter generation; Encounter tuning remains
+  outside Catalog.
+- Scene activity cannot replace the visible Monster query lifecycle.
+- Internal Java types and package forms have no compatibility obligation while
+  all production consumers move within this roadmap.
+
+## Target Outcome
+
+The completed Catalog has:
+
+- one application-owned workspace and immutable state publication path
+- one controller per independent section lifecycle, with a shared World
+  Reference controller for NPCs, factions, and locations
+- one result-state vocabulary and stable-id selection model
+- one passive JavaFX workspace and shared table scaffold
+- typed per-section provider dependencies and semantic outward routes
+- Encounter-owned canonical pool-filter truth and no Catalog tuning dependency
+- explicit subscription cleanup and stale-request rejection
+- no legacy World Planner workspace binding, broad callback bag, no-op route,
+  or JavaFX-owned provider orchestration
+
+Catalog remains part of the local modular monolith. The roadmap adds no Catalog
+domain, persistence, remote service, Gradle module, or dynamic plugin system.
+
+## Surface Disposition
+
+| Current surface | Decision | Migration consequence |
+| --- | --- | --- |
+| `CatalogWorkspace`, `CatalogSectionId`, persistent section roots | Adapt | Retain the behavior inside the application-owned lifecycle. |
+| Foreign immutable APIs and models | Adopt | Consume only through provider APIs or typed routes. |
+| `CatalogDataSources` and `CatalogActionRoutes` | Reject | Replace with grouped providers and semantic routes. |
+| `CatalogContribution` provider orchestration | Reject | Move use cases into section controllers. |
+| Monster controls/content models | Replace | Publish one Monster section state without tuning fields. |
+| Items and saved-Encounter section-local orchestration | Replace | Adopt common result, lifecycle, and table behavior. |
+| Generic reference selection by object equality | Reject | Preserve selection by stable provider id. |
+| World Planner Inspector editors | Adopt | Retain as provider-owned Inspector content. |
+| World Planner full workspace binding | Reject | Delete after World Reference migration. |
+| Existing production UI tests | Adapt | Keep behavioral proof while replacing structural assumptions. |
+
+## Compatibility Budget
+
+M1 may introduce exactly one package-private `LegacyCatalogBindingAdapter` to
+render the existing Catalog views from the new application seam while later
+sections migrate.
+
+- It has no public API and no new production caller beyond `CatalogFeature`.
+- It may not introduce nullable providers, no-op actions, or duplicate durable
+  state.
+- M2 through M4 remove the legacy surfaces it wraps.
+- M5 deletes the adapter and mechanically rejects its return.
+
+No other compatibility layer may survive a milestone boundary.
+
+## Milestone Dependency Order
+
+```text
+M0 Target Lock And Documentation
+  -> M1 Application Seam And Lifecycle
+      -> M2 Monster Vertical Slice
+          -> M3 Items And Saved Encounters
+              -> M4 World References And Encounter Tables
+                  -> M5 Convergence, Legacy Deletion, And Acceptance
+```
+
+## Current Migration Position
+
+- Current foundation: the shipped Catalog exposes all seven accepted sections
+  through persistent JavaFX roots, uses provider APIs, and has green focused UI
+  and architecture proof. Query, subscription, projection, and handoff
+  coordination remain split across the JavaFX adapter and bespoke sections.
+- Current milestone: M0 target lock is delivered by the documentation change
+  that introduces this roadmap and aligns Catalog requirements and architecture.
+- Next step after M0 merges: M1 publishes the application seam and lifecycle
+  while preserving the existing production UI through the one permitted
+  temporary adapter.
+
+## Delivery Rules
+
+Every implementation milestone must:
+
+1. preserve the runnable production Catalog and pass `./gradlew check`
+2. move at least one real production path to the target application seam
+3. delete replaced code in the same milestone unless it is explicitly covered
+   by the single compatibility budget
+4. keep JavaFX passive and provider truth in its owning feature
+5. add production-route proof for changed observable behavior
+6. finish with a literal green desktop install after the full check
+
+## M0: Target Lock And Documentation
+
+### Deliver
+
+- keep Catalog requirements limited to observable behavior and acceptance
+- replace the presentation-only architecture with the application-centered
+  target, boundaries, decisions, and enforcement ownership
+- route the temporary migration only from the Catalog README
+- establish this roadmap as the sole migration status and sequencing owner
+
+### Exit Gate
+
+- no durable Catalog document calls the feature a presentation-only aggregator
+- requirements contain no package, application-layer, persistence-owner, or
+  provider-implementation decisions
+- architecture defines application ownership, provider boundaries, state,
+  lifecycle, concurrency, and rejected alternatives
+- every legacy surface named by M1 through M5 has one deletion milestone
+- documentation whitespace proof is green
+
+## M1: Application Seam And Lifecycle
+
+### Deliver
+
+- add `CatalogFeature.create(CatalogProviders, CatalogRoutes)`
+- add `CatalogWorkspaceController`, immutable workspace publication, and typed
+  activation, deactivation, and close behavior
+- define `CatalogResultState<Row>` and the section-specific state wrappers
+- define grouped required providers and semantic Inspector, Encounter, and
+  Scene routes
+- introduce the single permitted `LegacyCatalogBindingAdapter`
+- move subscription ownership and current-snapshot application out of JavaFX
+
+### Exit Gate
+
+- one application-owned lifecycle drives the production Catalog binding
+- activate/deactivate cycles balance every provider subscription
+- no stale request can publish after deactivation or a newer revision
+- the visible Catalog remains behaviorally unchanged
+
+### Delete
+
+- direct subscription ownership from `CatalogContribution`
+- constructor-triggered provider refresh work in JavaFX-facing models
+- nullable required World Reference providers in the new seam
+
+## M2: Monster Vertical Slice
+
+### Deliver
+
+- move Monster query, filter draft, sort, page, selection, and request revision
+  into `MonsterCatalogController`
+- introduce `CatalogTableScaffold` with Monster as its first production adopter
+- make Creature Inspector opening one atomic typed route
+- map visible Monster filters to Encounter pool-filter commands and readback
+- retain the separate creature reference-index lifecycle used outside Catalog
+
+### Exit Gate
+
+- Monster rows and selection derive from one application state revision
+- late query results cannot replace newer rows
+- filter changes update visible results and Encounter pool filters without
+  changing tuning
+- Scene refresh cannot alter Monster state
+
+### Delete
+
+- Catalog tuning sliders, projections, preview subscriptions, and input fields
+- the old Monster `CatalogViewModel`, controls content state, and main content
+  state after their final production consumer moves
+- the two-step global Creature detail selection plus Inspector race
+
+## M3: Items And Saved Encounters
+
+### Deliver
+
+- move Items filters, validation, query revision, paging, and detail loading to
+  `ItemsCatalogController`
+- publish all Items result states through the common result vocabulary
+- move saved-plan state and confirmation intent to
+  `SavedEncounterCatalogController`
+- adopt the shared table scaffold and stable-id selection in both sections
+
+### Exit Gate
+
+- Items I/O remains off the JavaFX thread and every result status is visible
+- stale Item page or detail results cannot replace newer requests
+- saved-plan replacement requires confirmation exactly when requested by
+  Encounter
+- switching sections preserves both section states
+
+### Delete
+
+- `ItemsCatalogSection` query and Inspector orchestration
+- `SavedEncounterCatalogSection` provider subscription and command orchestration
+- their bespoke table, status, and paging implementations
+
+## M4: World References And Encounter Tables
+
+### Deliver
+
+- publish separate NPC, faction, and location states from one
+  `WorldReferenceCatalogController`
+- preserve selection by stable NPC, faction, and location ids
+- migrate Encounter Tables to `EncounterTableCatalogController`
+- route create, Inspector, Encounter-source, Scene-member, and Scene-location
+  intents through semantic routes
+- keep World Planner validation and editor content provider-owned
+
+### Exit Gate
+
+- empty, unavailable, and failed provider snapshots remain distinguishable
+- refreshing labels or relationships preserves a still-present selection
+- default row opening changes only Inspector content
+- every explicit handoff reaches exactly its named destination
+
+### Delete
+
+- generic reference selection by object equality
+- JavaFX-owned reference label joins and handoff commands
+- the old World Planner controls/main/state workspace binding and unused views
+
+## M5: Convergence, Legacy Deletion, And Acceptance
+
+### Deliver
+
+- move all remaining views to the application state and shared JavaFX scaffold
+- simplify application composition to grouped providers and semantic routes
+- close architecture, lifecycle, async, UI, and handoff proof gaps
+- complete owner visual and interaction acceptance
+
+### Exit Gate
+
+- zero JavaFX-owned provider queries, subscriptions, or cross-feature commands
+- zero Catalog imports from foreign implementation packages
+- all seven sections use the common state and interaction contract
+- `./gradlew check` and desktop install are green after the final deletion diff
+- owner approves the complete Catalog behavior
+
+### Delete
+
+- `LegacyCatalogBindingAdapter`
+- `CatalogDataSources`, `CatalogActionRoutes`, compatibility constructors, and
+  no-op action fallbacks
+- obsolete section frames, content models, input events, and duplicate chrome
+- this roadmap and its README link after the migration merge
+
+## Risks And Dependencies
+
+- Monster filters serve both browsing and Encounter generation; M2 must prove
+  both routes rather than treating one as a projection detail.
+- Provider snapshot models have different error vocabularies; controllers map
+  them to Catalog status without erasing provider diagnostics.
+- The current shell has activation hooks but no general disposal API. M1 must
+  close the Catalog component from application lifecycle as well as deactivate
+  the active binding.
+- Existing tests encode current JavaFX structure. Each milestone preserves the
+  behavioral oracle while deleting assertions that require retired internals.
+
+## References
+
+- [Catalog Requirements](../requirements/requirements-catalog.md)
+- [Catalog Architecture](../architecture/architecture-catalog.md)
+- [Catalog Feature Index](../README.md)
+- [Documentation Standard](../../project/documentation.md)

--- a/docs/catalog/requirements/requirements-catalog.md
+++ b/docs/catalog/requirements/requirements-catalog.md
@@ -1,17 +1,28 @@
 Status: Active
 Owner: Catalog Feature
-Last Reviewed: 2026-07-17
+Last Reviewed: 2026-07-18
 Source of Truth: User-visible consolidated catalog behavior.
 
 # Catalog Requirements
 
 ## Goal
 
-Reference content MUST be reachable from one `Katalog` navigation entry rather
-than separate feature navigation tabs. The workspace serves game preparation
-and running-session lookup without taking ownership from provider features.
+The GM MUST be able to find, evaluate, and explicitly hand reference content
+to an active Encounter or Scene from one `Katalog` navigation entry. The
+workspace serves both game preparation and running-session lookup.
 
-## Required Behavior
+## Primary Flows
+
+1. The GM opens `Katalog`, chooses one of the seven visible sections, and uses
+   that section's search or filters.
+2. The GM opens a selected record in the Inspector without changing Encounter
+   or Scene state.
+3. The GM uses an explicit action when a Monster, NPC, faction, location, or
+   Encounter Table should affect the active Encounter or focused Scene.
+4. The GM switches sections and later returns without losing unfinished input
+   or the previous result position.
+
+## Target Behavior
 
 - The workspace MUST expose Monster, Items, Encounter, NPCs, Fraktionen, Orte,
   and Encounter-Tabellen as distinct visible sections.
@@ -20,7 +31,10 @@ and running-session lookup without taking ownership from provider features.
   and its results MUST appear in the main area.
 - Switching sections MUST preserve each section's filters, selection, paging,
   and unfinished input for the lifetime of the Catalog workspace.
-- Sections MUST use consistent tabular result chrome.
+- Sections MUST use consistent table, status, paging, keyboard, and selection
+  behavior while retaining section-specific columns, filters, and actions.
+- Every section MUST distinguish loading, empty, unavailable, invalid-input,
+  and failed outcomes whenever the underlying operation can produce them.
 - Monster search and encounter-builder controls MUST preserve their accepted
   behavior, including creature details and explicit add-to-Encounter and
   add-to-focused-Scene actions.
@@ -30,15 +44,15 @@ and running-session lookup without taking ownership from provider features.
 - Saved encounters MUST open in the global Encounter state tab. If the focused
   Encounter has unsaved roster changes, opening another plan MUST require an
   explicit discard confirmation.
-- NPC, faction, and location details and edit actions MUST open through
-  World-Planner-owned inspector content.
+- NPC, faction, and location details and edit actions MUST remain available in
+  the Inspector.
 - NPCs MUST support explicit Encounter and focused-Scene actions. Factions,
   locations, and Encounter tables MUST support explicit Encounter-source
   actions; locations MUST support assigning the focused Scene location.
 - Selecting or opening a row alone MUST NOT mutate Encounter or Scene state.
-- Creature pool filters remain Catalog-owned and constrain Encounter
-  generation. Difficulty, balance, amount, and diversity controls MUST live in
-  a collapsible section in the global Encounter state tab.
+- Changes to the visible Monster filters MUST also constrain Encounter
+  generation. Difficulty, balance, amount, and diversity controls MUST remain
+  in a collapsible section in the global Encounter state tab.
 - The separate World Planner navigation entry and local state-panel slot MUST
   not be registered. World data and edit capabilities remain available through
   Catalog and Inspector.
@@ -47,19 +61,28 @@ and running-session lookup without taking ownership from provider features.
 
 ## Non-Goals
 
-Catalog does not persist reference data, define dispositions, import external
-items, own encounter runtime state, or duplicate provider command logic.
+Catalog does not edit creature statblocks, import external items, replace the
+Encounter or Scene workspaces, or expose a second World Planner workspace.
 
 ## Acceptance Criteria
 
-Automated UI tests MUST prove one Catalog contribution contains all seven
-sections in the common controls/main structure, preserves section state,
-retains stable Monster columns and selection across result refreshes, routes
-saved-plan confirmation, renders explicit Items states, and remains unchanged
-when Scene initializes. They MUST also prove the explicit Encounter and Scene
-routes and that Encounter tuning is absent from Catalog controls.
-Architecture proof MUST reject Catalog imports from foreign adapters. Final
-visual and interaction acceptance remains owner manual testing.
+- One `Katalog` contribution shows all seven sections in the common controls
+  and main workspace.
+- Switching through every section and returning preserves each section's
+  current query, filter draft, selected record, page, and unfinished input.
+- Refreshing provider results preserves a still-present selected record by its
+  stable identity.
+- Each reachable result state renders a distinct visible outcome and leaves the
+  JavaFX event thread responsive.
+- Opening details changes only Inspector content.
+- Each explicit Encounter or Scene action changes only its named destination.
+- Opening a saved Encounter with unsaved roster changes requires confirmation
+  before replacement.
+- Encounter tuning controls are absent from Catalog and remain available in the
+  global Encounter state tab.
+- Activating or refreshing Scene does not change the visible Monster query,
+  rows, sort, page, selection, or loading state.
+- Final visual and interaction acceptance remains owner manual testing.
 
 ## References
 


### PR DESCRIPTION
## Summary

- redefine Catalog as an application capability with passive JavaFX presentation
- keep requirements limited to observable seven-section behavior and acceptance
- add the temporary M0-M5 greenfield migration roadmap with explicit deletion gates

## Why

The merged Catalog currently preserves the intended user-visible workspace but still owns query, subscription, projection, and handoff orchestration inside JavaFX. This change locks the replacement target before production migration begins.

## Validation

- `git diff --check`
- new-roadmap whitespace check via `git diff --no-index --check`
- `./gradlew check --console=plain` — BUILD SUCCESSFUL in 4m 47s

## Impact

Documentation only. No production behavior, tests, persistence, or user data changed.