### PR TITLE
feat: Session-Planner-Frontend als Master-Detail neu gestalten

### DIFF
--- a/docs/project/architecture/patterns/shell-layer.md
+++ b/docs/project/architecture/patterns/shell-layer.md
@@ -1,6 +1,6 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-18
 Source of Truth: Shell host responsibilities and stable public shell contracts.
 
 # Shell Layer Standard
@@ -20,6 +20,65 @@ not own feature logic, business behavior, or feature state mutation.
 - provide shell-owned inspector, navigation, and session capabilities through
   narrow shell contracts
 - keep concrete shell host internals private from feature code
+
+## Cockpit Layout
+
+The shell renders a fixed cockpit frame. Its geometry and the role of each surface are stable
+and shared by every feature: features supply content into named slots, they do not control the
+frame. Getting this model right matters — treating the panels as a horizontal strip or
+repurposing a reserved panel produces layouts that fight the shell.
+
+**Chrome (outside the grid)**
+
+- **Left bar** — tab selection / feature navigation. Populated by `ShellLeftBarTabSpec`
+  contributions, rendered by `ShellNavigationSidebar`. Each tab carries a `ShellLeftBarTabMode`
+  (`RUNTIME` | `EDITOR`).
+- **Top bar** — global, permanent popups that stay available across tab switches (for example
+  the party popup). Populated by `ShellTopBarSpec` contributions, rendered by
+  `ShellToolbarStrip`.
+
+**2×2 panel grid** (`ShellWorkspacePane`): a horizontal split between a left column
+`VBox(CONTROLS, MAIN)` and a right column `SplitPane(DETAILS, STATE)`.
+
+```
+ Left bar │ ┌ Top bar — permanent popups (e.g. party) ──────────────┐
+  (tabs)  │ ├───────────────────────────┬───────────────────────────┤
+          │ │ CONTROLS (narrow, horiz.) │ DETAILS  (small window)   │
+          │ ├───────────────────────────┼───────────────────────────┤
+          │ │ MAIN     (large primary)  │ STATE    (narrow, vertical)│
+          │ └───────────────────────────┴───────────────────────────┘
+```
+
+- **CONTROLS** (`COCKPIT_CONTROLS`, top-left) — a narrow, horizontally arranged control strip.
+- **MAIN** (`COCKPIT_MAIN`, bottom-left) — the large primary work surface; feature-local
+  master/detail and editors live here.
+- **DETAILS** (`COCKPIT_DETAILS`, top-right) — a small window: the shell-owned content
+  inspector (`InspectorPane`) for inspecting content entities (locations, NPCs, monster stat
+  blocks, item descriptions). Reserved — see below.
+- **STATE** (`COCKPIT_STATE`, bottom-right) — a narrow, vertical status / summary column.
+
+**Slot ↔ contribution rules** (enforced by `ShellSlotValidator`):
+
+| Contribution (`ShellContributionSpec`) | must provide | must NOT provide |
+| --- | --- | --- |
+| `ShellLeftBarTabSpec` | `COCKPIT_MAIN` | `TOP_BAR`, `COCKPIT_DETAILS` |
+| `ShellTopBarSpec` | `TOP_BAR` | all `COCKPIT_*` |
+| `ShellStateTabSpec` | `COCKPIT_STATE` | `TOP_BAR`, `COCKPIT_CONTROLS`, `COCKPIT_MAIN`, `COCKPIT_DETAILS` |
+
+A left-bar tab therefore owns MAIN and may additionally fill CONTROLS and STATE, but never
+DETAILS or TOP_BAR.
+
+**`COCKPIT_DETAILS` is reserved.** No contribution type may target it — it is exclusively
+shell-owned and hosts the content inspector. Features surface content into it only through the
+`InspectorSink` / `InspectorEntrySpec` contract (reference:
+`features/worldplanner/adapter/javafx/WorldPlannerInspectorController`), never by claiming the
+slot. Do not repurpose DETAILS as a feature editor or as a second content column; feature-local
+detail and editor UI belongs inside MAIN (or STATE).
+
+**Source of truth (implementation):** `shell/host/ShellWorkspacePane.java` (grid + dividers),
+`shell/api/ShellSlot.java` (slot enum), `shell/host/ShellSlotValidator.java` (slot rules),
+`shell/host/ShellToolbarStrip.java` (top bar), `shell/host/ShellNavigationSidebar.java`
+(left bar).
 
 ## Boundaries
 

--- a/features/sessionplanner/adapter/javafx/SessionGenerationPanel.java
+++ b/features/sessionplanner/adapter/javafx/SessionGenerationPanel.java
@@ -1,88 +1,78 @@
 package features.sessionplanner.adapter.javafx;
 
-import java.util.List;
 import java.util.OptionalInt;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import javafx.scene.Node;
+import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.geometry.Pos;
-import features.sessionplanner.api.PreviewGeneratedSessionCommand;
 import features.sessionplanner.api.ApplyGeneratedSessionCommand;
+import features.sessionplanner.api.PreviewGeneratedSessionCommand;
 import features.sessionplanner.api.SessionGenerationPreviewModel;
 import features.sessionplanner.api.SessionGenerationPreviewSnapshot;
 import features.sessionplanner.api.SessionGenerationPreviewStatus;
 
+/**
+ * Ein-Klick-Generierung: „Session generieren" baut in einem Schritt eine vollständige, sofort
+ * editierbare Session — ohne sichtbare Vorschau oder Text-Zusammenfassung. Intern wird der
+ * bestehende Vertrag unsichtbar verkettet: {@code previewGeneratedSession} liefert Attempt-Token
+ * und Generation-Id, danach folgt unmittelbar {@code applyGeneratedSession}. Nur wenn die Session
+ * bereits Inhalt hat (destruktives Ersetzen), erscheint genau eine minimale Rückfrage.
+ */
 final class SessionGenerationPanel extends VBox {
 
-    private static final long DEFAULT_SEED = 179_974L;
+    private final Button generateButton = accentButton("Session generieren");
     private final TextField encounterCount = new TextField();
-    private final TextField seed = new TextField(Long.toString(DEFAULT_SEED));
     private final Label status = label("");
-    private final Label summary = label("");
-    private final VBox encounters = new VBox(4);
-    private final VBox treasures = new VBox(4);
-    private final VBox audits = new VBox(2);
-    private final Button preview = button("Vorschau erzeugen");
-    private final Button apply = button("Anwenden");
-    private final VBox confirmation = new VBox(4);
+    private final VBox confirmation = new VBox(6);
+    private final Button confirmReplace = accentButton("Ersetzen");
+
     private Consumer<PreviewGeneratedSessionCommand> previewHandler = ignored -> { };
     private Runnable draftChangedHandler = () -> { };
     private Consumer<ApplyGeneratedSessionCommand> applyHandler = ignored -> { };
-    private SessionGenerationPreviewSnapshot renderedPreview = SessionGenerationPreviewSnapshot.idle();
-    private ApplyGeneratedSessionCommand confirmationCommand;
+    private BooleanSupplier existingContentSupplier = () -> false;
+
+    private boolean sessionActive;
+    private boolean pendingGenerate;
+    private ApplyGeneratedSessionCommand pendingApply;
 
     SessionGenerationPanel() {
         super(6);
         getStyleClass().addAll("session-planner-card", "session-generation-panel");
+
         encounterCount.setPromptText("Auto");
-        encounterCount.setPrefColumnCount(4);
+        encounterCount.setPrefColumnCount(3);
         encounterCount.getStyleClass().add("compact");
-        seed.setPromptText("Seed");
-        seed.setPrefColumnCount(9);
-        seed.getStyleClass().add("compact");
-        encounterCount.textProperty().addListener((observable, previous, current) -> draftChanged());
-        seed.textProperty().addListener((observable, previous, current) -> draftChanged());
+
+        generateButton.setMaxWidth(Double.MAX_VALUE);
+        generateButton.setOnAction(event -> requestGeneration());
+
         status.getStyleClass().add("text-secondary");
-        summary.getStyleClass().add("session-generation-summary");
-        preview.setOnAction(event -> publishPreview());
-        apply.setOnAction(event -> openConfirmation());
-        Button cancel = button("Abbrechen");
-        cancel.setOnAction(event -> showConfirmation(false));
-        Button confirm = button("Ersetzen bestätigen");
-        confirm.getStyleClass().add("accent");
-        confirm.setOnAction(event -> {
-            ApplyGeneratedSessionCommand command = confirmationCommand;
-            showConfirmation(false);
-            if (command != null) {
-                applyHandler.accept(command);
-            }
-        });
+        status.setWrapText(true);
+
+        Button cancel = flatButton("Abbrechen");
+        cancel.setOnAction(event -> dismissConfirmation());
+        confirmReplace.setOnAction(event -> confirmReplacement());
         confirmation.getChildren().setAll(
-                label("Alle aktuellen Szenen, Rasten und Loot-Einträge werden ersetzt. Gespeicherte Encounter-Pläne bleiben erhalten."),
-                new HBox(6, cancel, confirm));
+                label("Die aktuelle Session (Szenen, Rasten, Loot) wird ersetzt."),
+                new HBox(6, cancel, confirmReplace));
         confirmation.getStyleClass().add("session-generation-confirmation");
-        showConfirmation(false);
-        HBox inputs = new HBox(6,
-                label("Encounter"), encounterCount,
-                label("Seed"), seed);
-        inputs.setAlignment(Pos.CENTER_LEFT);
-        inputs.getStyleClass().add("session-generation-inputs");
+        setConfirmationVisible(false);
+
+        HBox actionRow = new HBox(6,
+                generateButton, label("Anzahl", "text-secondary"), encounterCount);
+        actionRow.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(generateButton, javafx.scene.layout.Priority.ALWAYS);
+
         getChildren().setAll(
                 label("Session generieren", "session-planner-card-title"),
-                inputs,
-                preview,
+                actionRow,
                 status,
-                summary,
-                section("Encounter", encounters),
-                section("Schätze", treasures),
-                section("Audits", audits),
-                apply,
                 confirmation);
-        show(SessionGenerationPreviewSnapshot.idle());
+        setSessionActive(false);
     }
 
     void onPreview(Consumer<PreviewGeneratedSessionCommand> handler) {
@@ -97,181 +87,134 @@ final class SessionGenerationPanel extends VBox {
         draftChangedHandler = handler == null ? () -> { } : handler;
     }
 
+    void setExistingContentSupplier(BooleanSupplier supplier) {
+        existingContentSupplier = supplier == null ? () -> false : supplier;
+    }
+
+    void setSessionActive(boolean active) {
+        this.sessionActive = active;
+        if (!active) {
+            dismissConfirmation();
+            pendingGenerate = false;
+        }
+        updateGenerateEnabled();
+    }
+
     void bind(SessionGenerationPreviewModel model) {
         if (model == null) {
             return;
         }
-        model.subscribe(this::show);
-        show(model.current());
+        model.subscribe(this::onSnapshot);
+        onSnapshot(model.current());
     }
 
-    private void publishPreview() {
-        OptionalInt count = parseCount(encounterCount.getText());
-        if (!encounterCount.getText().isBlank() && count.isEmpty()) {
-            showLocalError("Encounter-Anzahl muss zwischen 1 und 10 liegen.");
+    private void requestGeneration() {
+        if (!sessionActive) {
             return;
         }
-        long parsedSeed;
+        OptionalInt count;
         try {
-            parsedSeed = Long.parseLong(seed.getText().trim());
-        } catch (NumberFormatException exception) {
-            showLocalError("Seed muss eine nichtnegative Ganzzahl sein.");
+            count = parseCount(encounterCount.getText());
+        } catch (IllegalArgumentException invalid) {
+            status.setText("Encounter-Anzahl muss zwischen 1 und 10 liegen.");
             return;
         }
-        if (parsedSeed < 0L) {
-            showLocalError("Seed muss eine nichtnegative Ganzzahl sein.");
-            return;
+        dismissConfirmation();
+        pendingGenerate = true;
+        status.setText("Session wird generiert …");
+        updateGenerateEnabled();
+        long seed = System.nanoTime() & Long.MAX_VALUE;
+        previewHandler.accept(new PreviewGeneratedSessionCommand(count, seed));
+    }
+
+    private void onSnapshot(SessionGenerationPreviewSnapshot snapshot) {
+        SessionGenerationPreviewSnapshot safe =
+                snapshot == null ? SessionGenerationPreviewSnapshot.idle() : snapshot;
+        SessionGenerationPreviewStatus state = safe.status();
+
+        if (pendingGenerate) {
+            if (state == SessionGenerationPreviewStatus.READY && safe.applyEnabled()) {
+                pendingGenerate = false;
+                ApplyGeneratedSessionCommand command = new ApplyGeneratedSessionCommand(
+                        safe.attemptToken(), safe.sessionId(), safe.generationId());
+                if (existingContentSupplier.getAsBoolean()) {
+                    pendingApply = command;
+                    setConfirmationVisible(true);
+                    status.setText("Session vorhanden — Ersetzen bestätigen.");
+                } else {
+                    applyHandler.accept(command);
+                    status.setText("Session wird angewandt …");
+                }
+            } else if (state == SessionGenerationPreviewStatus.ERROR) {
+                pendingGenerate = false;
+                status.setText(safe.message().isBlank()
+                        ? "Session konnte nicht generiert werden." : safe.message());
+            }
+        } else if (state == SessionGenerationPreviewStatus.APPLIED) {
+            status.setText("Session generiert.");
+        } else if (state == SessionGenerationPreviewStatus.ERROR && !safe.message().isBlank()) {
+            status.setText(safe.message());
         }
-        apply.setDisable(true);
-        showConfirmation(false);
-        previewHandler.accept(new PreviewGeneratedSessionCommand(count, parsedSeed));
+        updateGenerateEnabled(state);
     }
 
-    private void show(SessionGenerationPreviewSnapshot snapshot) {
-        SessionGenerationPreviewSnapshot safe = snapshot == null
-                ? SessionGenerationPreviewSnapshot.idle()
-                : snapshot;
-        renderedPreview = safe;
-        showConfirmation(false);
-        status.setText(statusText(safe));
-        summary.setText(summaryText(safe));
-        encounters.getChildren().setAll(encounterCards(safe));
-        treasures.getChildren().setAll(treasureCards(safe));
-        audits.getChildren().setAll(auditLines(safe));
-        apply.setDisable(!safe.applyEnabled());
-        boolean applying = safe.status() == SessionGenerationPreviewStatus.APPLYING;
-        encounterCount.setDisable(applying);
-        seed.setDisable(applying);
-        preview.setDisable(safe.status() == SessionGenerationPreviewStatus.GENERATING
-                || applying);
-    }
-
-    private void showLocalError(String message) {
-        status.setText(message);
-        apply.setDisable(true);
-        showConfirmation(false);
-    }
-
-    private void draftChanged() {
-        if (renderedPreview.status() == SessionGenerationPreviewStatus.APPLYING) {
-            return;
+    private void confirmReplacement() {
+        ApplyGeneratedSessionCommand command = pendingApply;
+        dismissConfirmation();
+        if (command != null) {
+            status.setText("Session wird angewandt …");
+            applyHandler.accept(command);
         }
-        apply.setDisable(true);
-        showConfirmation(false);
-        draftChangedHandler.run();
     }
 
-    private static String statusText(SessionGenerationPreviewSnapshot snapshot) {
-        if (!snapshot.message().isBlank()) {
-            return snapshot.message();
-        }
-        return switch (snapshot.status()) {
-            case IDLE -> "Teilnehmer und Session-Tage bestimmen die Vorschau.";
-            case GENERATING -> "Vorschau wird erzeugt …";
-            case READY -> "Vorschau ist bereit.";
-            case STALE -> "Die Session wurde geändert. Bitte Vorschau neu erzeugen.";
-            case APPLYING -> "Generierte Session wird angewandt …";
-            case APPLIED -> "Generierte Session wurde angewandt.";
-            case ERROR -> "Vorschau konnte nicht erzeugt werden.";
-        };
+    private void dismissConfirmation() {
+        pendingApply = null;
+        setConfirmationVisible(false);
     }
 
-    private static String summaryText(SessionGenerationPreviewSnapshot snapshot) {
-        if (snapshot.generationId().isBlank()) {
-            return "";
-        }
-        var value = snapshot.summary();
-        return value.partyCount() + " Spieler · "
-                + value.encounterCount() + " Encounter · "
-                + value.sessionXpTarget() + " Ziel-XP · "
-                + value.treasureCount() + " Schätze · Seed "
-                + snapshot.seed() + " · Katalog " + shortHash(snapshot.catalogHash());
+    private void setConfirmationVisible(boolean visible) {
+        confirmation.setVisible(visible);
+        confirmation.setManaged(visible);
     }
 
-    private static List<Node> encounterCards(SessionGenerationPreviewSnapshot snapshot) {
-        return snapshot.encounters().stream()
-                .map(encounter -> (Node) label(
-                        "#" + encounter.encounterNumber() + " · "
-                                + encounter.targetXp() + " XP · "
-                                + encounter.difficulty() + " · "
-                                + encounter.roleSummary() + "\n"
-                                + encounter.monsterSummary(),
-                        "session-planner-plan-card", "session-generation-result-card"))
-                .toList();
+    private void updateGenerateEnabled() {
+        updateGenerateEnabled(SessionGenerationPreviewStatus.IDLE);
     }
 
-    private static List<Node> treasureCards(SessionGenerationPreviewSnapshot snapshot) {
-        return snapshot.treasures().stream()
-                .map(treasure -> (Node) label(
-                        "#" + treasure.treasureId() + " · "
-                                + treasure.channel() + " · "
-                                + treasure.stockClass() + " · "
-                                + treasure.targetCp() + " CP\n"
-                                + treasure.title() + "\n"
-                                + String.join("\n", treasure.lines()),
-                        "session-planner-plan-card", "session-generation-result-card"))
-                .toList();
-    }
-
-    private static List<Node> auditLines(SessionGenerationPreviewSnapshot snapshot) {
-        return snapshot.audits().stream()
-                .map(audit -> (Node) label(
-                        audit.status() + " · " + audit.code() + " · " + audit.detail(),
-                        "session-generation-audit",
-                        "session-generation-audit-" + audit.status().toLowerCase(java.util.Locale.ROOT)))
-                .toList();
+    private void updateGenerateEnabled(SessionGenerationPreviewStatus state) {
+        boolean busy = pendingGenerate
+                || state == SessionGenerationPreviewStatus.GENERATING
+                || state == SessionGenerationPreviewStatus.APPLYING;
+        generateButton.setDisable(!sessionActive || busy);
+        encounterCount.setDisable(!sessionActive || busy);
     }
 
     private static OptionalInt parseCount(String text) {
         if (text == null || text.isBlank()) {
             return OptionalInt.empty();
         }
-        try {
-            int count = Integer.parseInt(text.trim());
-            return count >= 1 && count <= 10 ? OptionalInt.of(count) : OptionalInt.empty();
-        } catch (NumberFormatException exception) {
-            return OptionalInt.empty();
+        int count = Integer.parseInt(text.trim());
+        if (count < 1 || count > 10) {
+            throw new IllegalArgumentException("Encounter count must be between 1 and 10");
         }
-    }
-
-    private void showConfirmation(boolean visible) {
-        if (!visible) {
-            confirmationCommand = null;
-        }
-        confirmation.setVisible(visible);
-        confirmation.setManaged(visible);
-    }
-
-    private void openConfirmation() {
-        if (!renderedPreview.applyEnabled()) {
-            return;
-        }
-        confirmationCommand = new ApplyGeneratedSessionCommand(
-                renderedPreview.attemptToken(),
-                renderedPreview.sessionId(),
-                renderedPreview.generationId());
-        confirmation.setVisible(true);
-        confirmation.setManaged(true);
-    }
-
-    private static String shortHash(String hash) {
-        return hash == null || hash.length() <= 12 ? String.valueOf(hash) : hash.substring(0, 12);
-    }
-
-    private static VBox section(String title, Node content) {
-        return new VBox(3, label(title, "session-planner-card-title"), content);
+        return OptionalInt.of(count);
     }
 
     private static Label label(String text, String... styles) {
         Label label = new Label(text == null ? "" : text);
-        label.setWrapText(true);
         label.getStyleClass().addAll(styles);
         return label;
     }
 
-    private static Button button(String text) {
+    private static Button accentButton(String text) {
         Button button = new Button(text);
-        button.getStyleClass().add("compact");
+        button.getStyleClass().addAll("compact", "accent");
+        return button;
+    }
+
+    private static Button flatButton(String text) {
+        Button button = new Button(text);
+        button.getStyleClass().addAll("compact", "flat");
         return button;
     }
 }

--- a/features/sessionplanner/adapter/javafx/SessionPlannerBinder.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerBinder.java
@@ -100,6 +100,7 @@ final class SessionPlannerBinder {
         generationPanel.onDraftChanged(() -> planner.generatedSessionDraftChanged(
                 new SessionGenerationDraftChangedCommand()));
         generationPanel.onApply(planner::applyGeneratedSession);
+        generationPanel.setExistingContentSupplier(viewModel::hasScenes);
         generationPanel.bind(generationPreviewModel);
 
         timelineView.onAddScene(() -> ifSession(viewModel, () -> planner.addScene(new AddSessionSceneCommand())));

--- a/features/sessionplanner/adapter/javafx/SessionPlannerControlsView.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerControlsView.java
@@ -11,15 +11,17 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 /**
- * Linke Steuerspalte: Session-Setup (Teilnehmer hinzufügen/entfernen, Encounter-Tage),
- * Generierungs-Panel und die Liste gespeicherter Encounter-Pläne. Die Setup-Eingabefelder sind
- * persistent, damit Combobox-Auswahl und Tippen nicht bei jedem Readback zurückgesetzt werden.
+ * Steuerspalte des Session Planners im {@code COCKPIT_CONTROLS}-Slot: kompaktes Session-Setup
+ * (Teilnehmer, Encounter-Tage), die prominente Ein-Klick-Generierung und die Liste gespeicherter
+ * Encounter-Pläne zum Anhängen an die gewählte Szene. Die Setup-Eingabefelder sind persistent,
+ * damit Combobox-Auswahl und Tippen nicht bei jedem Readback zurückgesetzt werden.
  */
 public final class SessionPlannerControlsView extends ScrollPane {
 
@@ -28,10 +30,11 @@ public final class SessionPlannerControlsView extends ScrollPane {
     private static final String STYLE_FLAT = "flat";
     private static final String STYLE_TEXT_SECONDARY = "text-secondary";
 
+    private final SessionGenerationPanel generationPanel;
     private final Label statusLabel = statusLabel();
     private final ComboBox<SessionPlannerViewModel.ControlsProjection.ParticipantChoiceModel> partyMemberSelector =
             new ComboBox<>();
-    private final Button addParticipantButton = button("Hinzufuegen", STYLE_ACCENT);
+    private final Button addParticipantButton = button("Hinzufügen", STYLE_ACCENT);
     private final TextField encounterDaysField = new TextField();
     private final Button setEncounterDaysButton = button("Setzen", STYLE_FLAT);
     private final VBox participantRows = new VBox(4);
@@ -46,8 +49,10 @@ public final class SessionPlannerControlsView extends ScrollPane {
         this(null);
     }
 
-    SessionPlannerControlsView(Node generationPanel) {
+    SessionPlannerControlsView(SessionGenerationPanel generationPanel) {
+        this.generationPanel = generationPanel;
         partyMemberSelector.setPromptText("Spieler");
+        partyMemberSelector.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(partyMemberSelector, Priority.ALWAYS);
         addParticipantButton.setOnAction(event -> {
             var choice = partyMemberSelector.getValue();
@@ -60,7 +65,7 @@ public final class SessionPlannerControlsView extends ScrollPane {
         HBox.setHgrow(encounterDaysField, Priority.ALWAYS);
         setEncounterDaysButton.setOnAction(event -> setEncounterDaysHandler.accept(encounterDaysField.getText()));
 
-        setContent(content(generationPanel));
+        setContent(content());
         getStyleClass().add("session-planner-controls-scroll");
         setFitToWidth(true);
         setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
@@ -90,7 +95,7 @@ public final class SessionPlannerControlsView extends ScrollPane {
         show(viewModel.controlsProjectionProperty().get());
     }
 
-    private VBox content(Node generationPanel) {
+    private VBox content() {
         VBox content = new VBox(12);
         content.getStyleClass().add("session-planner-controls");
         content.getChildren().add(statusLabel);
@@ -121,6 +126,9 @@ public final class SessionPlannerControlsView extends ScrollPane {
 
     private void applySetup(SessionPlannerViewModel.ControlsProjection.SetupModel setup) {
         boolean disabled = setup.sessionActionsDisabled();
+        if (generationPanel != null) {
+            generationPanel.setSessionActive(!disabled);
+        }
 
         long previousSelection = partyMemberSelector.getValue() == null ? 0L : partyMemberSelector.getValue().characterId();
         partyMemberSelector.getItems().setAll(setup.partyMemberChoices());
@@ -157,7 +165,7 @@ public final class SessionPlannerControlsView extends ScrollPane {
             rows.add(label("Keine Session-Teilnehmer.", STYLE_TEXT_SECONDARY, "session-planner-empty"));
         } else {
             for (var participant : participants) {
-                Button remove = button("X", STYLE_FLAT);
+                Button remove = iconButton("✕", "Teilnehmer entfernen");
                 remove.setDisable(disabled);
                 remove.setOnAction(event -> removeParticipantHandler.accept(participant.characterId()));
                 Label name = label(participant.name(), "session-planner-plan-name");
@@ -173,7 +181,7 @@ public final class SessionPlannerControlsView extends ScrollPane {
     private void showPlans(List<SessionPlannerViewModel.ControlsProjection.AvailablePlanModel> plans) {
         if (plans.isEmpty()) {
             plansBox.getChildren().setAll(label(
-                    "Keine gespeicherten Encounter-Plaene.",
+                    "Keine gespeicherten Encounter-Pläne.",
                     STYLE_TEXT_SECONDARY,
                     "session-planner-empty"));
             return;
@@ -231,6 +239,14 @@ public final class SessionPlannerControlsView extends ScrollPane {
         Button button = new Button(text);
         button.getStyleClass().add(STYLE_COMPACT);
         button.getStyleClass().addAll(styleClasses);
+        return button;
+    }
+
+    private static Button iconButton(String glyph, String tooltip) {
+        Button button = new Button(glyph);
+        button.getStyleClass().addAll(STYLE_COMPACT, STYLE_FLAT, "session-planner-icon-button");
+        button.setTooltip(new Tooltip(tooltip));
+        button.setAccessibleText(tooltip);
         return button;
     }
 }

--- a/features/sessionplanner/adapter/javafx/SessionPlannerTimelineMainView.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerTimelineMainView.java
@@ -2,12 +2,10 @@ package features.sessionplanner.adapter.javafx;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.LongConsumer;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -16,8 +14,14 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -25,27 +29,35 @@ import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 
 /**
- * Szenen-Board als Single-Open-Akkordeon. Zu jedem Zeitpunkt ist höchstens eine Szene aufgeklappt
- * und damit editierbar; alle anderen sind read-only Zeilen. Aktualisierungen der Projektion werden
- * per {@code sceneToken} reconziliert (kein {@code setAll}-Vollneubau bei jedem Readback), sodass die
- * geöffnete Editor-Karte inklusive Fokus/Cursor über Mutationen hinweg stabil bleibt.
+ * Master-Detail-Ansicht des Session Planners im {@code COCKPIT_MAIN}-Slot. Links eine kompakte,
+ * per Drag&amp;Drop umsortierbare Szenenliste (Master) mit Rast-Verbindern; rechts der
+ * mechanik-zentrierte Szenen-Inspector (Detail) für die aktuell gewählte Szene. Auswahl (nicht
+ * Aufklappen) treibt den Inspector. Aktualisierungen werden per {@code sceneToken} reconziliert,
+ * sodass Fokus/Cursor und unbestätigte Eingaben über Mutationen hinweg stabil bleiben. Es gibt nur
+ * ein Speichermodell: Editorfelder committen automatisch bei Fokusverlust bzw. Szenenwechsel.
  */
-public final class SessionPlannerTimelineMainView extends ScrollPane {
+public final class SessionPlannerTimelineMainView extends SplitPane {
 
     private static final String STYLE_TEXT_SECONDARY = "text-secondary";
     private static final String STYLE_COMPACT = "compact";
     private static final String STYLE_ACCENT = "accent";
     private static final String STYLE_FLAT = "flat";
     private static final BigDecimal ALLOCATION_STEP = BigDecimal.TEN;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
 
-    private final VBox rows = new VBox(8);
-    private final Label emptyLabel = styledLabel("Noch keine Szenen.", STYLE_TEXT_SECONDARY, "session-planner-empty");
-    private final Button addSceneButton = compactButton("Szene hinzufuegen", STYLE_ACCENT);
-    private final Map<Long, SceneCard> sceneCards = new LinkedHashMap<>();
+    private final VBox rows = new VBox(6);
+    private final Label emptyLabel = styledLabel(
+            "Noch keine Szenen. Lege eine Szene an oder generiere eine Session.",
+            STYLE_TEXT_SECONDARY, "session-planner-empty");
+    private final Button addSceneButton = compactButton("+ Szene", STYLE_ACCENT);
+    private final ProgressBar overallBudgetBar = new ProgressBar(0);
+    private final Label overallBudgetLabel = styledLabel("", STYLE_TEXT_SECONDARY);
+    private final Map<Long, SceneRow> sceneRows = new LinkedHashMap<>();
     private final Map<Integer, RestSeparator> restSeparators = new LinkedHashMap<>();
+    private final SceneInspector inspector = new SceneInspector();
 
-    private long openSceneToken;
-    private SceneCard openCard;
+    private List<SessionPlannerViewModel.TimelineProjection.SceneModel> currentScenes = List.of();
+    private boolean sessionActive;
 
     private Runnable addSceneHandler = () -> { };
     private LongConsumer selectSceneHandler = ignored -> { };
@@ -60,13 +72,28 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
     private LongConsumer removeLootHandler = ignored -> { };
 
     public SessionPlannerTimelineMainView() {
-        VBox content = new VBox(12, rows);
-        content.getStyleClass().add("session-planner-main");
         addSceneButton.setOnAction(event -> addSceneHandler.run());
-        setContent(content);
-        getStyleClass().add("session-planner-main-scroll");
-        setFitToWidth(true);
-        setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+
+        VBox listContent = new VBox(6, rows);
+        listContent.getStyleClass().add("session-planner-scene-list");
+        ScrollPane listScroll = new ScrollPane(listContent);
+        listScroll.getStyleClass().add("session-planner-main-scroll");
+        listScroll.setFitToWidth(true);
+        listScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+
+        overallBudgetBar.getStyleClass().addAll("session-planner-budget-bar", "session-planner-budget-ok");
+        overallBudgetBar.setMaxWidth(Double.MAX_VALUE);
+        VBox footer = new VBox(3, overallBudgetLabel, overallBudgetBar);
+        footer.getStyleClass().add("session-planner-budget-footer");
+
+        BorderPane masterPane = new BorderPane(listScroll);
+        masterPane.setBottom(footer);
+        masterPane.getStyleClass().add("session-planner-master");
+
+        getStyleClass().add("session-planner-master-detail");
+        getItems().setAll(masterPane, inspector);
+        setDividerPositions(0.54);
+        SplitPane.setResizableWithParent(inspector, Boolean.TRUE);
     }
 
     // --- typed callbacks -------------------------------------------------------------------
@@ -120,7 +147,9 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
             return;
         }
         viewModel.timelineProjectionProperty().addListener((ignored, before, after) -> render(after));
+        viewModel.summaryProjectionProperty().addListener((ignored, before, after) -> renderSummary(after));
         render(viewModel.timelineProjectionProperty().get());
+        renderSummary(viewModel.summaryProjectionProperty().get());
     }
 
     // --- rendering / reconciliation --------------------------------------------------------
@@ -130,27 +159,20 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
             return;
         }
         boolean disabled = projection.sessionActionsDisabled();
+        sessionActive = !disabled;
         List<SessionPlannerViewModel.TimelineProjection.SceneModel> scenes = projection.scenes();
         List<SessionPlannerViewModel.TimelineProjection.RestGapModel> restGaps = projection.restGaps();
-
-        Set<Long> presentTokens = new HashSet<>();
-        for (var scene : scenes) {
-            presentTokens.add(scene.sceneToken());
-        }
-        if (openSceneToken != 0L && !presentTokens.contains(openSceneToken)) {
-            openSceneToken = 0L;
-            openCard = null;
-        }
+        currentScenes = scenes;
 
         List<Node> desired = new ArrayList<>();
         if (scenes.isEmpty()) {
-            desired.add(emptyLabel);
+            desired.add(disabled ? sessionPrompt() : emptyLabel);
         } else {
             for (int index = 0; index < scenes.size(); index++) {
                 var scene = scenes.get(index);
-                SceneCard card = sceneCards.computeIfAbsent(scene.sceneToken(), SceneCard::new);
-                card.update(scene, index + 1, scene.sceneToken() == openSceneToken, disabled);
-                desired.add(card);
+                SceneRow row = sceneRows.computeIfAbsent(scene.sceneToken(), SceneRow::new);
+                row.update(scene, index + 1, scene.selected(), disabled);
+                desired.add(row);
                 if (index < restGaps.size()) {
                     var gap = restGaps.get(index);
                     RestSeparator separator = restSeparators.computeIfAbsent(gap.gapIndex(), ignored -> new RestSeparator());
@@ -160,218 +182,402 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
             }
         }
         addSceneButton.setDisable(disabled);
-        desired.add(addSceneButton);
+        if (!disabled) {
+            desired.add(addSceneButton);
+        }
 
-        sceneCards.keySet().removeIf(token -> !presentTokens.contains(token));
+        java.util.Set<Long> presentTokens = new java.util.HashSet<>();
+        scenes.forEach(scene -> presentTokens.add(scene.sceneToken()));
+        sceneRows.keySet().removeIf(token -> !presentTokens.contains(token));
         restSeparators.keySet().removeIf(gapIndex -> gapIndex >= restGaps.size());
 
         if (!rows.getChildren().equals(desired)) {
             rows.getChildren().setAll(desired);
         }
+
+        inspector.showSelection(selectedScene(scenes), disabled);
     }
 
-    private void toggle(SceneCard card) {
-        if (openCard == card) {
-            collapse(card);
+    private void renderSummary(SessionPlannerViewModel.SummaryProjection summary) {
+        if (summary == null || !summary.budgetAvailable()) {
+            overallBudgetLabel.setText("");
+            overallBudgetBar.setProgress(0);
+            overallBudgetBar.setVisible(false);
+            overallBudgetBar.setManaged(false);
             return;
         }
-        if (openCard != null) {
-            collapse(openCard);
+        overallBudgetBar.setVisible(true);
+        overallBudgetBar.setManaged(true);
+        overallBudgetBar.setProgress(clampFraction(summary.progressFraction()));
+        overallBudgetBar.getStyleClass().removeAll("session-planner-budget-ok", "session-planner-budget-over");
+        overallBudgetBar.getStyleClass().add(summary.overBudget()
+                ? "session-planner-budget-over" : "session-planner-budget-ok");
+        overallBudgetLabel.setText(summary.overBudget()
+                ? "Budget: " + formatXp(summary.plannedEncounterXp()) + " / " + formatXp(summary.totalBudgetXp())
+                        + " XP · " + formatXp(summary.overBudgetXp()) + " XP über Budget"
+                : "Budget: " + formatXp(summary.plannedEncounterXp()) + " / " + formatXp(summary.totalBudgetXp())
+                        + " XP · " + formatXp(summary.remainingXp()) + " XP frei");
+    }
+
+    private static SessionPlannerViewModel.TimelineProjection.SceneModel selectedScene(
+            List<SessionPlannerViewModel.TimelineProjection.SceneModel> scenes
+    ) {
+        for (var scene : scenes) {
+            if (scene.selected()) {
+                return scene;
+            }
         }
-        expand(card);
+        return null;
     }
 
-    private void expand(SceneCard card) {
-        openCard = card;
-        openSceneToken = card.sceneToken;
-        card.setExpanded(true);
-        card.loadEditorFromModel();
-        selectSceneHandler.accept(card.sceneToken);
+    private Node sessionPrompt() {
+        Label headline = styledLabel("Keine Session gewählt.", "session-planner-plan-name");
+        Label hint = styledLabel(
+                "Wähle links oben eine Session oder lege eine neue an.",
+                STYLE_TEXT_SECONDARY, "session-planner-empty");
+        VBox box = new VBox(6, headline, hint);
+        box.setAlignment(Pos.TOP_LEFT);
+        return box;
     }
 
-    private void collapse(SceneCard card) {
-        card.commitIfDirty();
-        card.setExpanded(false);
-        if (openCard == card) {
-            openCard = null;
-            openSceneToken = 0L;
+    private int indexOfToken(long sceneToken) {
+        for (int index = 0; index < currentScenes.size(); index++) {
+            if (currentScenes.get(index).sceneToken() == sceneToken) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    /** Übersetzt eine Drop-Reihenfolge in eine Folge von Ein-Schritt-Moves (die API kennt nur
+     * hoch/runter). Jeder Move re-published synchron; das {@code sceneToken} bleibt stabil. */
+    private void reorderScene(long sourceToken, int targetIndex) {
+        int sourceIndex = indexOfToken(sourceToken);
+        if (sourceIndex < 0 || targetIndex < 0 || sourceIndex == targetIndex) {
+            return;
+        }
+        boolean up = targetIndex < sourceIndex;
+        int steps = Math.abs(targetIndex - sourceIndex);
+        for (int step = 0; step < steps; step++) {
+            moveHandler.handle(sourceToken, up);
         }
     }
 
-    // --- scene card ------------------------------------------------------------------------
+    // --- master row ------------------------------------------------------------------------
 
-    private final class SceneCard extends VBox {
+    private final class SceneRow extends HBox {
 
         private final long sceneToken;
-        private final Button toggleButton = compactButton("▶", STYLE_FLAT);
-        private final Label headerTitle = styledLabel("", "session-planner-encounter-title");
-        private final Label headerBudget = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final ProgressBar headerBar = new ProgressBar(0);
-        private final Label headerLocation = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final Button removeButton = compactButton("X", STYLE_FLAT);
+        private final Label dragHandle = styledLabel("⠿", STYLE_TEXT_SECONDARY, "session-planner-drag-handle");
+        private final Label positionLabel = styledLabel("", "session-planner-scene-position");
+        private final Label titleLabel = styledLabel("", "session-planner-encounter-title");
+        private final ProgressBar miniBar = new ProgressBar(0);
+        private final Label budgetLabel = styledLabel("", STYLE_TEXT_SECONDARY);
+        private final Label locationChip = styledLabel("", STYLE_TEXT_SECONDARY, "session-planner-location-chip");
 
-        private final Label encounterName = styledLabel("", "session-planner-plan-name");
-        private final Label encounterDetail = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final Label encounterBudget = styledLabel("", "session-planner-encounter-budget");
-        private final Label encounterComparison = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final Label encounterBase = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final VBox encounterSummary = new VBox(4);
-
-        private final TextField titleField = new TextField();
-        private final LocationComboBox locationBox = new LocationComboBox();
-        private final TextArea notesField = new TextArea();
-        private final Label allocationLabel = styledLabel("", STYLE_TEXT_SECONDARY);
-        private final Button decreaseAllocation = compactButton("-10%", STYLE_FLAT);
-        private final Button increaseAllocation = compactButton("+10%", STYLE_FLAT);
-        private final Button moveUp = compactButton("Hoch", STYLE_FLAT);
-        private final Button moveDown = compactButton("Runter", STYLE_FLAT);
-        private final VBox lootRows = new VBox(6);
-        private final Button addLoot = compactButton("Loot-Platzhalter", STYLE_ACCENT);
-        private final VBox editor = new VBox(6);
-
-        private SessionPlannerViewModel.TimelineProjection.SceneModel model;
-        private String loadedTitle = "";
-        private String loadedNotes = "";
-        private long loadedLocationId;
-
-        private SceneCard(long sceneToken) {
+        private SceneRow(long sceneToken) {
+            super(8);
             this.sceneToken = sceneToken;
-            getStyleClass().add("session-planner-encounter-card");
-            setSpacing(6);
-
-            headerBar.getStyleClass().addAll("session-planner-budget-bar", "session-planner-budget-ok");
-            headerBar.setPrefWidth(80);
-            headerBar.setMaxWidth(80);
-            toggleButton.getStyleClass().add("session-planner-scene-toggle");
-            toggleButton.setOnAction(event -> toggle(this));
-            HBox header = new HBox(8, toggleButton, headerTitle, headerBar, headerBudget, spacer(), headerLocation, removeButton);
-            header.setAlignment(Pos.CENTER_LEFT);
-            header.getStyleClass().add("session-planner-encounter-header");
-            header.setOnMouseClicked(event -> toggle(this));
-            removeButton.setOnAction(event -> removeSceneHandler.accept(sceneToken));
-
-            encounterSummary.getChildren().setAll(
-                    encounterName, encounterDetail, encounterBudget, encounterComparison, encounterBase);
-            encounterSummary.getStyleClass().add("session-planner-scene-encounter-summary");
-
-            titleField.setPromptText("Szenentitel");
-            titleField.getStyleClass().add(STYLE_COMPACT);
-            notesField.setPromptText("Szenennotizen");
-            notesField.setPrefRowCount(2);
-            notesField.getStyleClass().add(STYLE_COMPACT);
-            Button save = compactButton("Szene speichern", STYLE_ACCENT);
-            save.setOnAction(event -> saveNow());
-
-            decreaseAllocation.setOnAction(event -> adjustAllocation(ALLOCATION_STEP.negate()));
-            increaseAllocation.setOnAction(event -> adjustAllocation(ALLOCATION_STEP));
-            moveUp.setOnAction(event -> moveHandler.handle(sceneToken, true));
-            moveDown.setOnAction(event -> moveHandler.handle(sceneToken, false));
-            addLoot.setOnAction(event -> addLootHandler.accept(sceneToken));
-
-            editor.getChildren().setAll(
-                    encounterSummary,
-                    titleField,
-                    actionRow(locationBox, save),
-                    notesField,
-                    actionRow(allocationLabel, decreaseAllocation, increaseAllocation),
-                    actionRow(moveUp, moveDown),
-                    new VBox(6, new HBox(8, styledLabel("Loot", "session-planner-gap-title"), addLoot), lootRows));
-            editor.setVisible(false);
-            editor.setManaged(false);
-
-            getChildren().setAll(header, editor);
+            setAlignment(Pos.CENTER_LEFT);
+            getStyleClass().add("session-planner-scene-row");
+            miniBar.getStyleClass().addAll("session-planner-budget-bar", "session-planner-budget-ok");
+            miniBar.setPrefWidth(56);
+            miniBar.setMaxWidth(56);
+            getChildren().setAll(dragHandle, positionLabel, titleLabel, spacer(), miniBar, budgetLabel, locationChip);
+            setOnMouseClicked(event -> select());
+            configureDragAndDrop();
         }
 
         private void update(
                 SessionPlannerViewModel.TimelineProjection.SceneModel scene,
                 int position,
-                boolean expanded,
+                boolean selected,
                 boolean disabled
         ) {
-            this.model = scene;
-            headerTitle.setText("Szene " + position + ": " + scene.displayTitle());
-            headerBudget.setText(scene.budgetPercentageText());
-            headerBar.setProgress(clampFraction(scene.budgetFraction()));
-            headerLocation.setText(scene.locationLabel());
-            removeButton.setDisable(disabled);
+            positionLabel.setText(position + ".");
+            titleLabel.setText(scene.displayTitle());
+            boolean linked = scene.linkedEncounterPlan();
+            miniBar.setProgress(clampFraction(scene.budgetFraction()));
+            show(miniBar, linked);
+            budgetLabel.setText(linked ? scene.budgetPercentageText() : "—");
+            String location = scene.locationLabel();
+            boolean hasLocation = location != null && !location.isBlank() && !"Keine Location".equals(location);
+            locationChip.setText(hasLocation ? location : "");
+            show(locationChip, hasLocation);
+            getStyleClass().remove("session-planner-scene-row-selected");
+            if (selected) {
+                getStyleClass().add("session-planner-scene-row-selected");
+            }
+            dragHandle.setDisable(disabled);
+        }
 
+        private void select() {
+            inspector.commitIfDirty();
+            selectSceneHandler.accept(sceneToken);
+        }
+
+        private void configureDragAndDrop() {
+            setOnDragDetected(event -> {
+                if (!sessionActive) {
+                    return;
+                }
+                Dragboard dragboard = startDragAndDrop(TransferMode.MOVE);
+                ClipboardContent content = new ClipboardContent();
+                content.putString(Long.toString(sceneToken));
+                dragboard.setContent(content);
+                event.consume();
+            });
+            setOnDragOver(event -> {
+                if (event.getGestureSource() != this && event.getDragboard().hasString()) {
+                    event.acceptTransferModes(TransferMode.MOVE);
+                }
+                event.consume();
+            });
+            setOnDragEntered(event -> {
+                if (event.getGestureSource() != this && event.getDragboard().hasString()) {
+                    getStyleClass().add("session-planner-scene-row-drop");
+                }
+                event.consume();
+            });
+            setOnDragExited(event -> {
+                getStyleClass().remove("session-planner-scene-row-drop");
+                event.consume();
+            });
+            setOnDragDropped(event -> {
+                boolean completed = false;
+                if (event.getDragboard().hasString()) {
+                    long sourceToken = parseToken(event.getDragboard().getString());
+                    if (sourceToken > 0L && sourceToken != sceneToken) {
+                        reorderScene(sourceToken, indexOfToken(sceneToken));
+                        completed = true;
+                    }
+                }
+                getStyleClass().remove("session-planner-scene-row-drop");
+                event.setDropCompleted(completed);
+                event.consume();
+            });
+        }
+    }
+
+    // --- scene inspector (detail) ----------------------------------------------------------
+
+    private final class SceneInspector extends ScrollPane {
+
+        private final Label headerTitle = styledLabel("", "session-planner-inspector-title");
+        private final Button removeButton = iconButton("✕", "Szene entfernen", "Szene entfernen");
+
+        private final Label encounterName = styledLabel("", "session-planner-plan-name");
+        private final Label encounterDetail = styledLabel("", STYLE_TEXT_SECONDARY);
+        private final Label encounterComparison = styledLabel("", STYLE_TEXT_SECONDARY);
+        private final Label encounterBase = styledLabel("", STYLE_TEXT_SECONDARY);
+        private final VBox encounterSummary = new VBox(3, encounterName, encounterDetail, encounterComparison, encounterBase);
+
+        private final TextField budgetField = new TextField();
+        private final Button decreaseAllocation = compactButton("-10", STYLE_FLAT);
+        private final Button increaseAllocation = compactButton("+10", STYLE_FLAT);
+        private final ProgressBar budgetBar = new ProgressBar(0);
+        private final VBox budgetSection = new VBox(4);
+
+        private final TextField titleField = new TextField();
+        private final LocationComboBox locationBox = new LocationComboBox();
+        private final TextArea notesField = new TextArea();
+
+        private final VBox lootRows = new VBox(4);
+        private final Button addLoot = compactButton("+ Loot-Platzhalter", STYLE_FLAT);
+
+        private final VBox editor = new VBox(12);
+        private final Label placeholder = styledLabel(
+                "Wähle links eine Szene, um sie zu bearbeiten.",
+                STYLE_TEXT_SECONDARY, "session-planner-empty");
+        private final VBox content = new VBox(12);
+
+        private SessionPlannerViewModel.TimelineProjection.SceneModel model;
+        private long loadedToken;
+        private String loadedTitle = "";
+        private String loadedNotes = "";
+        private long loadedLocationId;
+
+        private SceneInspector() {
+            getStyleClass().add("session-planner-inspector-scroll");
+            setFitToWidth(true);
+            setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+
+            HBox header = new HBox(8, headerTitle, spacer(), removeButton);
+            header.setAlignment(Pos.CENTER_LEFT);
+            header.getStyleClass().add("session-planner-inspector-header");
+            removeButton.setOnAction(event -> {
+                if (loadedToken > 0L) {
+                    removeSceneHandler.accept(loadedToken);
+                }
+            });
+
+            encounterSummary.getStyleClass().add("session-planner-scene-encounter-summary");
+
+            budgetField.setPromptText("%");
+            budgetField.setPrefColumnCount(4);
+            budgetField.getStyleClass().add(STYLE_COMPACT);
+            budgetField.setOnAction(event -> commitBudgetFromField());
+            budgetField.focusedProperty().addListener((observable, was, focused) -> {
+                if (!focused) {
+                    commitBudgetFromField();
+                }
+            });
+            decreaseAllocation.setOnAction(event -> adjustAllocation(ALLOCATION_STEP.negate()));
+            increaseAllocation.setOnAction(event -> adjustAllocation(ALLOCATION_STEP));
+            budgetBar.getStyleClass().addAll("session-planner-budget-bar", "session-planner-budget-ok");
+            budgetBar.setMaxWidth(Double.MAX_VALUE);
+            HBox budgetRow = new HBox(6,
+                    styledLabel("Budget", "session-planner-card-title"), budgetField,
+                    styledLabel("%", STYLE_TEXT_SECONDARY), decreaseAllocation, increaseAllocation);
+            budgetRow.setAlignment(Pos.CENTER_LEFT);
+            budgetSection.getChildren().setAll(budgetRow, budgetBar);
+
+            titleField.setPromptText("Szenentitel");
+            titleField.getStyleClass().add(STYLE_COMPACT);
+            titleField.setOnAction(event -> commitIfDirty());
+            titleField.focusedProperty().addListener((observable, was, focused) -> {
+                if (!focused) {
+                    commitIfDirty();
+                }
+            });
+            locationBox.getSelectionModel().selectedItemProperty().addListener((observable, before, after) -> commitIfDirty());
+            notesField.setPromptText("Szenennotizen");
+            notesField.setPrefRowCount(3);
+            notesField.setWrapText(true);
+            notesField.getStyleClass().add(STYLE_COMPACT);
+            notesField.focusedProperty().addListener((observable, was, focused) -> {
+                if (!focused) {
+                    commitIfDirty();
+                }
+            });
+            VBox detailsSection = new VBox(6,
+                    styledLabel("Details", "session-planner-card-title"),
+                    titleField, locationBox, notesField);
+
+            addLoot.setOnAction(event -> {
+                if (loadedToken > 0L) {
+                    addLootHandler.accept(loadedToken);
+                }
+            });
+            VBox lootSection = new VBox(6,
+                    new HBox(8, styledLabel("Loot", "session-planner-card-title"), spacer(), addLoot),
+                    lootRows);
+
+            editor.getChildren().setAll(header, card(encounterSummary), card(budgetSection),
+                    card(detailsSection), card(lootSection));
+            content.getChildren().setAll(placeholder);
+            content.getStyleClass().add("session-planner-inspector");
+            setContent(content);
+        }
+
+        private void showSelection(
+                SessionPlannerViewModel.TimelineProjection.SceneModel scene,
+                boolean disabled
+        ) {
+            if (scene == null) {
+                if (loadedToken != 0L) {
+                    loadedToken = 0L;
+                }
+                if (!content.getChildren().equals(List.of(placeholder))) {
+                    content.getChildren().setAll(placeholder);
+                }
+                return;
+            }
+            boolean tokenChanged = scene.sceneToken() != loadedToken;
+            this.model = scene;
+            if (!content.getChildren().equals(List.of(editor))) {
+                content.getChildren().setAll(editor);
+            }
+            if (tokenChanged) {
+                loadEditorFromModel(scene);
+            }
+            updateReadOnly(scene, disabled);
+        }
+
+        private void loadEditorFromModel(SessionPlannerViewModel.TimelineProjection.SceneModel scene) {
+            loadedToken = scene.sceneToken();
+            titleField.setText(scene.sceneTitle());
+            notesField.setText(scene.sceneNotes());
+            locationBox.setChoices(scene.locationChoices(), scene.locationId());
+            loadedTitle = scene.sceneTitle();
+            loadedNotes = scene.sceneNotes();
+            loadedLocationId = scene.locationId();
+        }
+
+        private void updateReadOnly(
+                SessionPlannerViewModel.TimelineProjection.SceneModel scene,
+                boolean disabled
+        ) {
+            headerTitle.setText("Szene: " + scene.displayTitle());
+            removeButton.setDisable(disabled);
             boolean linked = scene.linkedEncounterPlan();
             if (linked) {
                 encounterName.setText(scene.linkedEncounterName());
-                encounterDetail.setText(scene.linkedEncounterCreatureCount() + " Kreaturen" + generatedSuffix(scene));
-                encounterBudget.setText(scene.budgetPercentageText() + " Budget · Ziel " + scene.targetXpText() + " XP");
-                encounterComparison.setText(scene.comparisonText() + " · " + scene.linkedEncounterDifficultyLabel());
+                encounterDetail.setText(scene.linkedEncounterCreatureCount() + " Kreaturen · "
+                        + scene.linkedEncounterDifficultyLabel() + generatedSuffix(scene));
+                encounterComparison.setText(scene.comparisonText());
                 encounterBase.setText("Base " + scene.linkedEncounterTotalBaseXp() + " XP · Multiplikator x"
                         + String.format(Locale.US, "%.2f", scene.linkedEncounterXpMultiplier()));
             } else {
-                encounterName.setText("Keine Begegnung verknuepft.");
-                encounterDetail.setText("");
-                encounterBudget.setText("");
+                encounterName.setText("Keine Begegnung verknüpft.");
+                encounterDetail.setText("Hänge links eine gespeicherte Begegnung an, um XP zu verplanen.");
                 encounterComparison.setText("");
                 encounterBase.setText("");
             }
-            show(encounterDetail, linked);
-            show(encounterBudget, linked);
             show(encounterComparison, linked);
             show(encounterBase, linked);
 
-            allocationLabel.setText("Budget " + scene.budgetPercentageText());
+            if (!budgetField.isFocused()) {
+                budgetField.setText(plainPercent(scene.budgetPercentage()));
+            }
+            budgetBar.setProgress(clampFraction(scene.budgetFraction()));
+            budgetField.setDisable(disabled || !linked);
             decreaseAllocation.setDisable(disabled || !linked);
             increaseAllocation.setDisable(disabled || !linked);
-            moveUp.setDisable(disabled || !scene.canMoveUp());
-            moveDown.setDisable(disabled || !scene.canMoveDown());
+
+            titleField.setDisable(disabled);
+            locationBox.setDisable(disabled);
+            notesField.setDisable(disabled);
             addLoot.setDisable(disabled);
             renderLoot(scene, disabled);
-            setExpanded(expanded);
-        }
-
-        private void setExpanded(boolean expanded) {
-            toggleButton.setText(expanded ? "▼" : "▶");
-            editor.setVisible(expanded);
-            editor.setManaged(expanded);
-        }
-
-        /** Lädt die Editor-Felder aus dem Modell. Nur beim Aufklappen aufrufen — nie bei jedem Readback,
-         * damit unbestätigte Eingaben nicht überschrieben werden. */
-        private void loadEditorFromModel() {
-            if (model == null) {
-                return;
-            }
-            titleField.setText(model.sceneTitle());
-            notesField.setText(model.sceneNotes());
-            locationBox.setChoices(model.locationChoices(), model.locationId());
-            loadedTitle = model.sceneTitle();
-            loadedNotes = model.sceneNotes();
-            loadedLocationId = model.locationId();
-        }
-
-        private void saveNow() {
-            loadedTitle = titleField.getText().trim();
-            loadedNotes = notesField.getText().trim();
-            loadedLocationId = locationBox.selectedLocationId();
-            saveSceneHandler.handle(sceneToken, loadedTitle, loadedNotes, loadedLocationId);
         }
 
         private void commitIfDirty() {
-            if (!editor.isVisible()) {
+            if (loadedToken <= 0L) {
                 return;
             }
             String title = titleField.getText().trim();
             String notes = notesField.getText().trim();
             long locationId = locationBox.selectedLocationId();
             if (!title.equals(loadedTitle) || !notes.equals(loadedNotes) || locationId != loadedLocationId) {
-                saveSceneHandler.handle(sceneToken, title, notes, locationId);
+                saveSceneHandler.handle(loadedToken, title, notes, locationId);
                 loadedTitle = title;
                 loadedNotes = notes;
                 loadedLocationId = locationId;
             }
         }
 
-        private void adjustAllocation(BigDecimal delta) {
-            if (model == null) {
+        private void commitBudgetFromField() {
+            if (model == null || loadedToken <= 0L || !model.linkedEncounterPlan()) {
                 return;
             }
-            allocationHandler.handle(sceneToken, model.budgetPercentage().add(delta));
+            BigDecimal parsed = SessionPlannerVocabulary.parsePositiveDecimal(budgetField.getText());
+            if (parsed == null) {
+                budgetField.setText(plainPercent(model.budgetPercentage()));
+                return;
+            }
+            BigDecimal clamped = parsed.min(HUNDRED).max(BigDecimal.ZERO);
+            if (clamped.compareTo(model.budgetPercentage()) != 0) {
+                allocationHandler.handle(loadedToken, clamped);
+            }
+        }
+
+        private void adjustAllocation(BigDecimal delta) {
+            if (model == null || loadedToken <= 0L) {
+                return;
+            }
+            BigDecimal next = model.budgetPercentage().add(delta).min(HUNDRED).max(BigDecimal.ZERO);
+            allocationHandler.handle(loadedToken, next);
         }
 
         private void renderLoot(
@@ -380,11 +586,11 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         ) {
             List<Node> cards = new ArrayList<>();
             if (scene.lootPlaceholders().isEmpty()) {
-                cards.add(styledLabel("Keine Loot-Platzhalter fuer diese Szene.",
+                cards.add(styledLabel("Keine Loot-Platzhalter für diese Szene.",
                         STYLE_TEXT_SECONDARY, "session-planner-empty"));
             } else {
                 for (var loot : scene.lootPlaceholders()) {
-                    Button remove = compactButton("Entfernen", STYLE_FLAT);
+                    Button remove = iconButton("✕", "Loot-Platzhalter entfernen", "Entfernen");
                     remove.setDisable(disabled);
                     remove.setOnAction(event -> removeLootHandler.accept(loot.token()));
                     HBox row = new HBox(8, styledLabel(loot.label()), spacer(), remove);
@@ -432,8 +638,8 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         ) {
             this.leftSceneToken = gap.leftSceneToken();
             this.rightSceneToken = gap.rightSceneToken();
-            label.setText(gap.hasAssignedRest() ? "Rast: " + gap.label() : "Keine Rast zwischen den Szenen");
-            label.getStyleClass().removeAll("session-planner-gap-active");
+            label.setText(gap.hasAssignedRest() ? "Rast: " + gap.label() : "Keine Rast");
+            label.getStyleClass().remove("session-planner-gap-active");
             if (gap.hasAssignedRest()) {
                 label.getStyleClass().add("session-planner-gap-active");
             }
@@ -450,6 +656,7 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
         private LocationComboBox() {
             setPromptText("Location");
+            setMaxWidth(Double.MAX_VALUE);
             getStyleClass().add(STYLE_COMPACT);
             setConverter(new StringConverter<>() {
                 @Override
@@ -489,6 +696,23 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
 
     // --- shared helpers --------------------------------------------------------------------
 
+    private static long parseToken(String value) {
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            return 0L;
+        }
+    }
+
+    private static String plainPercent(BigDecimal percentage) {
+        BigDecimal safe = percentage == null ? BigDecimal.ZERO : percentage.stripTrailingZeros();
+        return safe.toPlainString();
+    }
+
+    private static String formatXp(int value) {
+        return java.text.NumberFormat.getIntegerInstance(Locale.GERMANY).format(Math.max(0, value));
+    }
+
     private static double clampFraction(double value) {
         if (value < 0) {
             return 0;
@@ -501,10 +725,10 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         node.setManaged(visible);
     }
 
-    private static HBox actionRow(Node... actions) {
-        HBox row = new HBox(6, actions);
-        row.setAlignment(Pos.CENTER_LEFT);
-        return row;
+    private static VBox card(Node body) {
+        VBox card = new VBox(6, body);
+        card.getStyleClass().add("session-planner-card");
+        return card;
     }
 
     private static Region spacer() {
@@ -523,6 +747,14 @@ public final class SessionPlannerTimelineMainView extends ScrollPane {
         Button button = new Button(text);
         button.getStyleClass().add(STYLE_COMPACT);
         button.getStyleClass().addAll(emphasisStyles);
+        return button;
+    }
+
+    private static Button iconButton(String glyph, String tooltip, String accessibleText) {
+        Button button = new Button(glyph);
+        button.getStyleClass().addAll(STYLE_COMPACT, STYLE_FLAT, "session-planner-icon-button");
+        button.setTooltip(new Tooltip(tooltip));
+        button.setAccessibleText(accessibleText);
         return button;
     }
 

--- a/features/sessionplanner/adapter/javafx/SessionPlannerViewModel.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerViewModel.java
@@ -79,6 +79,10 @@ final class SessionPlannerViewModel {
         return latestSession.session().sessionId() > 0L;
     }
 
+    boolean hasScenes() {
+        return !latestSceneTimeline.sessionScenes().isEmpty();
+    }
+
     void updateSelectorFilter(String nextFilterText) {
         catalogContentModel.updateSelectorFilter(nextFilterText);
     }
@@ -230,7 +234,7 @@ final class SessionPlannerViewModel {
                         plan.name(),
                         plan.summaryText(),
                         plan.statusText(),
-                        "An Session anhaengen",
+                        "An Session anhängen",
                         "accent",
                         !importEnabled);
             }

--- a/resources/salt-marcher.css
+++ b/resources/salt-marcher.css
@@ -1760,3 +1760,79 @@
     -fx-shape: "";
     -fx-padding: 0;
 }
+
+/* --- Session Planner: Master-Detail redesign ---------------------------------------- */
+.session-planner-master-detail {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+}
+.session-planner-master-detail > .split-pane-divider {
+    -fx-padding: 0 1 0 1;
+    -fx-background-color: -sm-border-subtle;
+}
+.session-planner-master {
+    -fx-background-color: transparent;
+}
+.session-planner-scene-list {
+    -fx-padding: 4 6 4 6;
+    -fx-spacing: 6;
+}
+.session-planner-budget-footer {
+    -fx-padding: 8 10 8 10;
+    -fx-spacing: 4;
+    -fx-background-color: rgba(255, 255, 255, 0.03);
+    -fx-border-color: -sm-border-subtle transparent transparent transparent;
+}
+.session-planner-scene-row {
+    -fx-padding: 7 10 7 10;
+    -fx-spacing: 8;
+    -fx-background-color: rgba(255, 255, 255, 0.04);
+    -fx-background-radius: 8;
+    -fx-border-color: -sm-border-subtle;
+    -fx-border-radius: 8;
+    -fx-cursor: hand;
+}
+.session-planner-scene-row-selected {
+    -fx-background-color: rgba(83, 169, 140, 0.16);
+    -fx-border-color: -sm-accent;
+}
+.session-planner-scene-row-drop {
+    -fx-border-color: -sm-accent-hover;
+    -fx-border-style: segments(4, 4);
+}
+.session-planner-drag-handle {
+    -fx-cursor: open-hand;
+    -fx-opacity: 0.6;
+}
+.session-planner-scene-position {
+    -fx-font-weight: bold;
+    -fx-text-fill: -sm-text-primary;
+    -fx-min-width: 20;
+}
+.session-planner-location-chip {
+    -fx-padding: 1 7 1 7;
+    -fx-background-color: rgba(255, 255, 255, 0.06);
+    -fx-background-radius: 999;
+}
+.session-planner-inspector-scroll {
+    -fx-background-color: transparent;
+}
+.session-planner-inspector-scroll > .viewport {
+    -fx-background-color: transparent;
+}
+.session-planner-inspector {
+    -fx-padding: 10 12 10 12;
+    -fx-spacing: 12;
+    -fx-background-color: rgba(255, 255, 255, 0.02);
+}
+.session-planner-inspector-header {
+    -fx-padding: 0 0 2 0;
+}
+.session-planner-inspector-title {
+    -fx-font-weight: bold;
+    -fx-font-size: 1.05em;
+}
+.session-planner-icon-button {
+    -fx-min-width: 26;
+    -fx-padding: 2 6 2 6;
+}

--- a/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
+++ b/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
@@ -99,29 +99,13 @@ public final class SessionPlannerCatalogTest {
     }
 
     @Test
-    void generationDraftEditWhilePendingUsesApplicationInvalidationRoute() throws Exception {
-        CompletableFuture<GenerationResponse> pending = new CompletableFuture<>();
-        SessionGenerationApi delayedGeneration = new SessionGenerationApi() {
-            @Override
-            public java.util.concurrent.CompletionStage<GenerationResponse> generate(GenerationRequest request) {
-                return pending;
-            }
-
-            @Override
-            public java.util.concurrent.CompletionStage<GenerationResponse> load(GenerationRunId runId) {
-                return pending;
-            }
-        };
-        runOnFxThread(() -> assertPendingDraftInvalidation(delayedGeneration));
-    }
-
-    @Test
     void generationInputsAreDisabledWhileApplyIsInFlight() throws Exception {
         runOnFxThread(SessionPlannerCatalogTest::assertApplyingInputsDisabled);
     }
 
     private static void assertApplyingInputsDisabled() {
         SessionGenerationPanel panel = new SessionGenerationPanel();
+        panel.setSessionActive(true);
         SessionGenerationPreviewSnapshot applying = new SessionGenerationPreviewSnapshot(
                 SessionGenerationPreviewStatus.APPLYING,
                 "Generierte Session wird angewandt …",
@@ -138,36 +122,7 @@ public final class SessionPlannerCatalogTest {
         panel.bind(new SessionGenerationPreviewModel(() -> applying, listener -> () -> { }));
 
         assertTrue(textField(panel, "Auto").isDisabled(), "encounter-count input is disabled while applying");
-        assertTrue(textField(panel, "Seed").isDisabled(), "seed input is disabled while applying");
-        assertTrue(button(panel, "Vorschau erzeugen").isDisabled(), "preview action is disabled while applying");
-    }
-
-    private static void assertPendingDraftInvalidation(SessionGenerationApi generation) {
-        SessionPlannerTestServices services = services(generation);
-        seedActiveParty(services);
-        SessionPlannerServiceAssembly planner = services.planner();
-        ShellBinding binding = new SessionPlannerContribution(
-                planner.application(), planner.currentSessionModel(), planner.catalogModel(),
-                planner.participantsModel(), planner.sceneTimelineModel(), planner.statePanelModel(),
-                planner.generationPreviewModel()).bind();
-        Parent controls = slot(binding, ShellSlot.COCKPIT_CONTROLS, Parent.class);
-        Stage stage = new Stage();
-        stage.setScene(new Scene(controls, 420.0, 720.0));
-        stage.show();
-        planner.application().createSession(new SessionPlannerCatalogCommand.CreateSessionCommand("Pending"));
-        layout(controls);
-
-        button(controls, "Vorschau erzeugen").fire();
-        assertEquals(features.sessionplanner.api.SessionGenerationPreviewStatus.GENERATING,
-                planner.generationPreviewModel().current().status(),
-                "preview remains pending until provider completion");
-
-        textField(controls, "Seed").setText("179975");
-
-        assertEquals(features.sessionplanner.api.SessionGenerationPreviewStatus.STALE,
-                planner.generationPreviewModel().current().status(),
-                "seed edit invalidates pending attempt through application state");
-        assertTrue(button(controls, "Anwenden").isDisabled(), "pending draft edit keeps Apply disabled");
+        assertTrue(button(panel, "Session generieren").isDisabled(), "generate action is disabled while applying");
     }
 
     private static void runTest() {
@@ -214,19 +169,19 @@ public final class SessionPlannerCatalogTest {
         button(controls, "Setzen").fire();
         assertEquals("2", current.current().session().encounterDaysText(), "session content mutation before rename");
 
-        button(main, "Szene hinzufuegen").fire();
+        button(main, "+ Szene").fire();
         layout(main);
         assertEquals(Integer.valueOf(1), Integer.valueOf(sceneTimeline.current().sessionScenes().size()),
                 "add scene creates one session scene");
         assertEquals(Long.valueOf(0L),
                 Long.valueOf(sceneTimeline.current().sessionScenes().getFirst().linkedEncounterPlanId()),
                 "added scene has no linked encounter plan");
-        expandScene(main, 0);
-        assertTrue(hasLabel(main, "Keine Begegnung verknuepft."), "expanded blank scene shows no false encounter data");
-        button(main, "X").fire();
+        selectScene(main, 0);
+        assertTrue(hasLabel(main, "Keine Begegnung verknüpft."), "selected blank scene shows no false encounter data");
+        buttonByAccessibleText(main, "Szene entfernen").fire();
         layout(main);
         assertEquals(Integer.valueOf(0), Integer.valueOf(sceneTimeline.current().sessionScenes().size()),
-                "scene X removes only the session scene representation");
+                "scene remove clears the session scene representation");
 
         renameSelectedSession(controls, "Alpha Prime");
         SessionPlannerSessionSnapshot renamedCurrent = current.current();
@@ -311,23 +266,36 @@ public final class SessionPlannerCatalogTest {
                 .filter(ComboBox.class::isInstance)
                 .count();
         assertTrue(selectorCount >= 1L, "controls expose the party selector alongside the catalog selector");
-        assertTrue(button(controls, "Hinzufuegen").isDisabled(), "party add button starts disabled");
+        assertTrue(button(controls, "Hinzufügen").isDisabled(), "party add button starts disabled");
         assertTrue(hasLabel(controls, "Session-Setup"), "controls expose the session setup section");
     }
 
-    private static void expandScene(Parent main, int index) {
-        List<Button> toggles = descendants(main).stream()
+    private static void selectScene(Parent main, int index) {
+        List<Node> rows = descendants(main).stream()
+                .filter(node -> node.getStyleClass().contains("session-planner-scene-row"))
+                .toList();
+        if (index >= rows.size()) {
+            throw new AssertionError("Scene row not found at index " + index);
+        }
+        clickNode(rows.get(index));
+        layout(main);
+    }
+
+    private static void clickNode(Node node) {
+        javafx.event.Event.fireEvent(node, new javafx.scene.input.MouseEvent(
+                javafx.scene.input.MouseEvent.MOUSE_CLICKED,
+                0.0, 0.0, 0.0, 0.0, javafx.scene.input.MouseButton.PRIMARY, 1,
+                false, false, false, false,
+                false, false, false, false, false, false, null));
+    }
+
+    private static Button buttonByAccessibleText(Parent parent, String accessibleText) {
+        return descendants(parent).stream()
                 .filter(Button.class::isInstance)
                 .map(Button.class::cast)
-                .filter(button -> button.getStyleClass().contains("session-planner-scene-toggle"))
-                .toList();
-        if (index >= toggles.size()) {
-            throw new AssertionError("Scene toggle not found at index " + index);
-        }
-        if ("▶".equals(toggles.get(index).getText())) {
-            toggles.get(index).fire();
-        }
-        layout(main);
+                .filter(button -> accessibleText.equals(button.getAccessibleText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Button not found by accessible text: " + accessibleText));
     }
 
     private static void assertSceneLootTargetsSceneCards() {
@@ -418,77 +386,74 @@ public final class SessionPlannerCatalogTest {
         comboBoxContaining(controls, "Cora - Level 4");
 
         comboBoxByPrompt(controls, "Spieler").getSelectionModel().selectFirst();
-        button(controls, "Hinzufuegen").fire();
+        button(controls, "Hinzufügen").fire();
         layout(controls);
         assertEquals(Integer.valueOf(1), Integer.valueOf(participants.current().participants().size()),
                 "participant add through setup section publishes one participant");
         assertEquals("Cora", participants.current().participants().getFirst().name(),
                 "participant add through setup section resolves active party member");
         assertTrue(hasLabel(controls, "Cora"), "participant add renders selected player in controls");
-        button(controls, "X").fire();
+        buttonByAccessibleText(controls, "Teilnehmer entfernen").fire();
         layout(controls);
         assertEquals(Integer.valueOf(0), Integer.valueOf(participants.current().participants().size()),
                 "participant remove through setup section publishes empty participants");
 
-        button(controls, "An Session anhaengen").fire();
+        button(controls, "An Session anhängen").fire();
         layout(main);
-        button(controls, "An Session anhaengen").fire();
+        button(controls, "An Session anhängen").fire();
         layout(main);
         SessionPlannerSceneTimelineProjection afterAttach = sceneTimeline.current();
         assertEquals(Integer.valueOf(2), Integer.valueOf(afterAttach.sessionScenes().size()),
-                "saved encounter attach through controls creates two scene cards");
+                "saved encounter attach through controls creates two scene rows");
         assertEquals(Long.valueOf(SAVED_ENCOUNTER_PLAN_ID),
                 Long.valueOf(afterAttach.sessionScenes().getFirst().linkedEncounterPlanId()),
                 "saved encounter attach publishes linked plan id");
-        expandScene(main, 0);
-        assertTrue(hasLabel(main, "Ash Gate Ambush"), "expanded scene card renders linked plan name");
+        selectScene(main, 0);
+        assertTrue(hasLabel(main, "Ash Gate Ambush"), "selected scene inspector renders linked plan name");
 
-        long firstScene = afterAttach.sessionScenes().get(0).sceneToken();
         long secondScene = afterAttach.sessionScenes().get(1).sceneToken();
         textField(main, "Szenentitel").setText("Gate Alarm");
         textArea(main, "Szenennotizen").setText("ring twice");
         selectComboBoxItem(main, "#" + locationId + " | Old Gate");
-        button(main, "Szene speichern").fire();
         layout(main);
         SessionPlannerSceneTimelineProjection afterSave = sceneTimeline.current();
         assertEquals("Gate Alarm", afterSave.sessionScenes().getFirst().sceneTitle(),
-                "scene save through card stores title");
+                "scene edit auto-commits title");
         assertEquals("ring twice", afterSave.sessionScenes().getFirst().sceneNotes(),
-                "scene save through card stores notes");
+                "scene edit auto-commits notes");
         assertEquals(Long.valueOf(locationId), Long.valueOf(afterSave.sessionScenes().getFirst().locationId()),
-                "scene save through card stores location id");
-        assertTrue(hasLabel(main, "Old Gate"), "scene header renders saved location label");
+                "scene edit auto-commits location id");
+        assertTrue(hasLabel(main, "Old Gate"), "scene row renders saved location label");
 
-        expandScene(main, 0);
-        buttons(main, "Loot-Platzhalter").getFirst().fire();
+        button(main, "+ Loot-Platzhalter").fire();
         layout(main);
         assertEquals(Integer.valueOf(1),
                 Integer.valueOf(sceneTimeline.current().sessionScenes().getFirst().lootPlaceholders().size()),
-                "loot add through scene card publishes placeholder");
+                "loot add through inspector publishes placeholder");
         assertTrue(hasLabel(main, "Loot-Platzhalter 1"), "loot add renders placeholder label");
-        button(main, "Entfernen").fire();
+        buttonByAccessibleText(main, "Entfernen").fire();
         layout(main);
         assertEquals(Integer.valueOf(0),
                 Integer.valueOf(sceneTimeline.current().sessionScenes().getFirst().lootPlaceholders().size()),
-                "loot remove through scene card clears placeholder");
+                "loot remove through inspector clears placeholder");
 
-        buttons(main, "+10%").getFirst().fire();
+        buttons(main, "+10").getFirst().fire();
         layout(main);
         assertEquals("60", sceneTimeline.current().sessionScenes().getFirst()
                         .budgetPercentage().stripTrailingZeros().toPlainString(),
-                "allocation increase through scene card raises first scene");
-        buttons(main, "-10%").getFirst().fire();
+                "allocation increase through inspector raises first scene");
+        buttons(main, "-10").getFirst().fire();
         layout(main);
         assertEquals("50", sceneTimeline.current().sessionScenes().getFirst()
                         .budgetPercentage().stripTrailingZeros().toPlainString(),
-                "allocation decrease through scene card restores first scene");
+                "allocation decrease through inspector restores first scene");
 
-        expandScene(main, 1);
+        selectScene(main, 1);
         assertEquals(Long.valueOf(secondScene), Long.valueOf(current.current().session().selectedEncounterId()),
-                "expanding a scene card selects it as the current scene");
+                "selecting a scene row selects it as the current scene");
         assertTrue(sceneTimeline.current().sessionScenes().stream()
                         .anyMatch(scene -> scene.sceneToken() == secondScene && scene.selected()),
-                "expanding a scene card publishes the selected scene");
+                "selecting a scene row publishes the selected scene");
 
         button(main, "Kurze Rast").fire();
         layout(main);
@@ -500,22 +465,11 @@ public final class SessionPlannerCatalogTest {
         assertEquals(SessionPlannerRestKind.NONE, sceneTimeline.current().restGaps().getFirst().restKind(),
                 "rest clear through gap separator publishes no rest");
 
-        expandScene(main, 0);
-        enabledButtons(main, "Runter").getFirst().fire();
-        layout(main);
-        assertEquals(Long.valueOf(secondScene),
-                Long.valueOf(sceneTimeline.current().sessionScenes().getFirst().sceneToken()),
-                "scene move down through card reorders first scene");
-        enabledButtons(main, "Hoch").getFirst().fire();
-        layout(main);
-        assertEquals(Long.valueOf(firstScene),
-                Long.valueOf(sceneTimeline.current().sessionScenes().getFirst().sceneToken()),
-                "scene move up through card restores order");
-
-        buttons(main, "X").getFirst().fire();
+        selectScene(main, 0);
+        buttonByAccessibleText(main, "Szene entfernen").fire();
         layout(main);
         assertEquals(Integer.valueOf(1), Integer.valueOf(sceneTimeline.current().sessionScenes().size()),
-                "scene remove through linked scene card removes one scene");
+                "scene remove through inspector removes one scene");
     }
 
     private static void assertProductionRouteGeneratedSession(
@@ -525,54 +479,28 @@ public final class SessionPlannerCatalogTest {
             features.sessionplanner.api.SessionPlannerSceneTimelineModel sceneTimeline
     ) {
         comboBoxByPrompt(controls, "Spieler").getSelectionModel().selectFirst();
-        button(controls, "Hinzufuegen").fire();
+        button(controls, "Hinzufügen").fire();
         layout(controls);
         assertEquals(Integer.valueOf(1), Integer.valueOf(participants.current().participants().size()),
                 "generation route has one resolved session participant");
-        int scenesBeforePreview = sceneTimeline.current().sessionScenes().size();
+        assertTrue(sceneTimeline.current().sessionScenes().size() >= 1,
+                "session carries existing scenes before generation");
 
-        button(controls, "Vorschau erzeugen").fire();
+        button(controls, "Session generieren").fire();
         layout(controls);
+        Button replace = button(controls, "Ersetzen");
+        assertTrue(isEffectivelyVisible(replace),
+                "one-click generation on a session with content reveals the replace confirmation");
+        assertTrue(!hasLabelContaining(controls, "saltmarcher-v1"), "generation exposes no ruleset label");
 
-        assertEquals(Integer.valueOf(scenesBeforePreview), Integer.valueOf(sceneTimeline.current().sessionScenes().size()),
-                "preview performs no Session mutation");
-        assertTrue(hasLabelContaining(controls, "Seed 179974"), "preview renders seed provenance");
-        assertTrue(!hasLabelContaining(controls, "saltmarcher-v1"), "preview exposes no ruleset label");
-        assertTrue(!button(controls, "Anwenden").isDisabled(), "green preview enables Apply");
-
-        button(controls, "Anwenden").fire();
-        assertTrue(hasLabelContaining(controls, "Alle aktuellen Szenen"), "Apply reveals replacement warning");
-        Button confirmation = button(controls, "Ersetzen bestätigen");
-        textField(controls, "Auto").setText("1");
-        layout(controls);
-        assertTrue(button(controls, "Anwenden").isDisabled(),
-                "encounter-count edit invalidates the ready preview");
-        assertTrue(!isEffectivelyVisible(confirmation), "encounter-count edit closes Apply confirmation");
-
-        button(controls, "Vorschau erzeugen").fire();
-        layout(controls);
-        button(controls, "Anwenden").fire();
-        confirmation = button(controls, "Ersetzen bestätigen");
-        textField(controls, "Seed").setText("179975");
-        layout(controls);
-        assertTrue(button(controls, "Anwenden").isDisabled(), "seed edit invalidates the ready preview");
-        assertTrue(!isEffectivelyVisible(confirmation), "seed edit closes Apply confirmation");
-
-        textField(controls, "Seed").setText("179974");
-        button(controls, "Vorschau erzeugen").fire();
-        layout(controls);
-        button(controls, "Anwenden").fire();
-        button(controls, "Ersetzen bestätigen").fire();
+        replace.fire();
         layout(main);
 
         assertEquals(Integer.valueOf(1), Integer.valueOf(sceneTimeline.current().sessionScenes().size()),
-                "confirmed Apply replaces the timeline");
+                "confirmed generation replaces the timeline");
         assertEquals(Long.valueOf(901L),
                 Long.valueOf(sceneTimeline.current().sessionScenes().getFirst().linkedEncounterPlanId()),
-                "confirmed Apply attaches imported Encounter plan");
-        expandScene(main, 0);
-        assertTrue(hasLabel(main, "ENCOUNTER · Generated cache"),
-                "applied generated reward reopens through the normal timeline projection");
+                "confirmed generation attaches imported Encounter plan");
     }
 
     private static void seedActiveParty(SessionPlannerTestServices services) {

--- a/test/shell/host/SessionPlannerShellLayoutTest.java
+++ b/test/shell/host/SessionPlannerShellLayoutTest.java
@@ -119,14 +119,11 @@ public final class SessionPlannerShellLayoutTest {
                 "planner scroll controls stay inside the shell controls panel");
         assertTrue(plannerControls.getVbarPolicy() != ScrollPane.ScrollBarPolicy.NEVER,
                 "planner controls keep vertical scrolling available");
-        assertTrue(plannerMain.getVbarPolicy() != ScrollPane.ScrollBarPolicy.NEVER,
-                "planner main keeps vertical scrolling available");
-        assertTrue(plannerMain.isFitToWidth(), "planner main scroll content fits available width");
+        assertTrue(plannerMain.getItems().size() == 2,
+                "planner main hosts the master-detail split (scene list + inspector)");
         assertTrue(descendants(plannerMain).stream()
-                        .filter(javafx.scene.control.Button.class::isInstance)
-                        .map(javafx.scene.control.Button.class::cast)
-                        .anyMatch(button -> "Szene hinzufuegen".equals(button.getText())),
-                "planner main renders the scene board in the main slot");
+                        .anyMatch(node -> node.getStyleClass().contains("session-planner-scene-list")),
+                "planner main renders the master scene list in the main slot");
         assertTrue(descendants(plannerControls).stream()
                         .filter(Label.class::isInstance)
                         .map(Label.class::cast)


### PR DESCRIPTION
## Warum

Das alte Session-Planner-Frontend (JavaFX-Cockpit) war aus UX-/Design-Sicht schwach:
ein überladenes Single-Open-Akkordeon, das Übersicht **und** Detail-Editor gleichzeitig macht,
umständliche Bedienung (Umsortieren nur über Hoch/Runter, Budget nur ±10 %, doppeltes
Speichermodell) und eine leicht übersehbare Generierungs-Bestätigung. Dieses PR denkt die
Oberfläche als **Master-Detail** neu.

## Was sich ändert

**MAIN — Master-Detail statt Akkordeon**
- Links eine kompakte, **per Drag&Drop** umsortierbare Szenenliste (Nummer, Titel, Mini-Budget,
  Ort-Chip, Rast-Verbinder), rechts der mechanik-zentrierte **Szenen-Inspector**.
- Auswahl statt Aufklappen — nur eine Szene im Editor, die Liste bleibt ruhig.

**Bedienung**
- **Direkte Budget-Eingabe** (Zahlenfeld + ±10) statt nur ±10 %-Buttons.
- **Ein einziges Speichermodell**: Auto-Commit bei Feld-Blur / Szenenwechsel / Enter;
  der redundante „Szene speichern"-Button entfällt.
- Icon-Buttons mit Tooltip/Accessible-Text statt kryptischer Glyphen; **Onboarding-Leerzustand**
  statt grauem `setDisable`, wenn keine Session gewählt ist.

**Generierung — Ein-Klick**
- „Session generieren" erzeugt **direkt eine fertige, editierbare Session** (interne
  `preview → apply`-Verkettung, keine sichtbare Vorschau/Text-Zusammenfassung).
- Bestehende Session → **eine** minimale Ersetzen-Rückfrage; leere Session → reibungslos.

**Doku & Optik**
- Kanonisches **Shell-Layout** (Left/Top bar + 2×2-Panel-Grid + reservierter, ausschließlich
  shell-eigener `COCKPIT_DETAILS`-Slot) in `docs/project/architecture/patterns/shell-layer.md`
  festgehalten, damit künftige Arbeit nicht von einem falschen Layout ausgeht.
- Dunkles Cockpit aufgeräumt (neue `session-planner-*`-Style-Klassen, `-sm-`-Tokens; kein
  `setStyle`).

Domäne/Application bleiben unangetastet — nur die UI-Schicht ändert sich.

## Verifikation

- `compileJava` + `compileTestJava` grün.
- Beide UI-Tests neu geschrieben und grün (`SessionPlannerCatalogTest`,
  `SessionPlannerShellLayoutTest`) — sie fahren die neuen Flows real durch (Monocle-Headless):
  Szene anlegen/wählen/bearbeiten/entfernen, Budget, Rasten, Loot, Ein-Klick-Generierung + Ersetzen.
- Gesamte `features.sessionplanner.*`- und `architecture.*`-Suite (inkl. ArchUnit-Layering/Styling)
  grün.

## Bewusst separat (Follow-ups)

- **Phase 3**: Ort/Monster/Item einer Szene per `InspectorSink` in den reservierten
  DETAILS-Inspektor schieben (feature-übergreifend).
- **CONTROLS wirklich „schmal + horizontal"**: braucht eine `ShellWorkspacePane`-Änderung
  (betrifft alle Features) — cross-cutting, hier nicht enthalten.
- **`statePanelModel`**-Toter-Code-Entfernung (berührt Contribution/AppBootstrap/Tests breit).
- **Drag&Drop-Reorder** ist implementiert, aber nicht per Unit-Test abgedeckt (DnD-Event-
  Simulation ist headless unpraktikabel; die `moveEncounter`-Commands sind domänenseitig getestet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
