### PR TITLE
docs: define Session Planner greenfield roadmap

### DIFF
--- a/docs/encounter/README.md
+++ b/docs/encounter/README.md
@@ -1,16 +1,9 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-18
 Source of Truth: Entry point and document map for the encounter feature.
 
 # Encounter Feature README
-
-## Purpose
-
-The encounter feature owns runtime encounter generation for the currently
-active party and saved encounter-plan roster truth. It composes party state and
-creature catalog data into rule-oriented encounter suggestions, then persists
-only the user-accepted roster when the user saves a plan.
 
 ## Documentation Set
 
@@ -21,29 +14,8 @@ only the user-accepted roster when the user saves a plan.
 - [Plan Budget Contract](contract/contract-encounter-plan-budget.md)
 - [Builder Inputs Contract](contract/contract-encounter-builder-inputs.md)
 - [Encounter State Contract](contract/contract-encounter-state.md)
-- [Generated Import Contract](contract/contract-encounter-generated-import.md)
+- [Generated Preparation Contract](contract/contract-encounter-generated-import.md)
+- [Architecture](architecture/architecture-encounter.md)
 - [Runtime Context Contract](contract/contract-encounter-runtime-contexts.md)
 - [Encounter Table Feature README](../encountertable/README.md)
 - [Encounter UI](requirements/requirements-encounter-state-tab.md)
-
-## Scope
-
-In scope:
-
-- deriving encounter budgets from the active party
-- reading saved encounter plans as party-specific budget summaries for planner
-  surfaces
-- filtering the creature catalog into encounter-ready candidates
-- generating and ranking multiple encounter alternatives
-- adding catalog creature rows into a manual runtime roster
-- saving and opening encounter-plan rosters
-- atomically importing generated-origin encounter specifications as saved plans
-- preserving one independent builder, initiative, combat, and result runtime
-  for every running Scene context
-
-Out of scope:
-
-- Scene workspace, party, location, NPC, or disposition truth
-- dungeon room placement or biome ownership
-- bootstrap or shell policy
-- generated reward, packing, audit, or session-scene ownership

--- a/docs/encounter/architecture/architecture-encounter.md
+++ b/docs/encounter/architecture/architecture-encounter.md
@@ -1,0 +1,160 @@
+Status: Active Target
+Owner: Encounter Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Encounter structure, generated-batch orchestration,
+publication, execution, and quality decisions.
+
+# Encounter Architecture
+
+## Objective
+
+Encounter provides manual and generated roster construction while remaining the
+only owner of saved Encounter-plan truth. Generated preparation resolves one
+ordered intent batch into concrete rosters before any write and publishes the
+complete saved-plan mapping only after one successful idempotent batch commit.
+
+## Stakeholders And Concerns
+
+- Game masters need useful concrete rosters, stable saved plans, and unchanged
+  visible state when preparation fails.
+- Session Planner needs one ordered all-or-nothing batch seam and bounded
+  summary reads.
+- Party, Creatures, Encounter Table, and World Planner maintainers need their
+  facts consumed only through public APIs.
+- Encounter maintainers need one saved-plan write model shared by manual and
+  generated flows.
+- Verification maintainers need deterministic batch fixtures, query bounds,
+  atomic failure proof, and stage timing.
+
+This document owns Encounter structure and quality decisions. User-visible
+behavior belongs to requirements, write-model truth to the domain, and command,
+compatibility, and persistence semantics to contracts.
+
+## Topology And Dependency Direction
+
+```text
+features/encounter/api/
+features/encounter/domain/
+features/encounter/application/
+features/encounter/adapter/sqlite/
+features/encounter/adapter/javafx/
+features/encounter/EncounterFeature
+```
+
+Domain code depends on no API carriers, SQL, JavaFX, platform service, or
+foreign feature. Application code translates public commands and foreign API
+results, invokes Encounter policies, and depends outward only on
+feature-owned ports. SQLite and JavaFX adapters implement those ports.
+Composition is the only construction point.
+
+Encounter may consume `PartyApi`, `CreaturesApi`, `EncounterTableApi`, and
+`WorldPlannerApi`. Session Planner consumes `EncounterApi`; Encounter never
+calls Session Planner or Session Generation and never reads a foreign
+repository or table directly.
+
+## Generated-Batch Orchestration
+
+```text
+prepareGeneratedBatch(command)
+  -> validate complete ordered intent batch
+  -> load one union creature-candidate snapshot
+  -> resolve and validate every concrete roster in memory
+  -> publish complete prepared batch or one failure
+
+commitGeneratedBatch(command)
+  -> validate identity, batch fingerprint, and every EncounterPlan
+  -> write all plans, roster rows, and canonical generated origins
+  -> publish complete ordered plan mapping or one failure
+```
+
+Prepare and commit are separate because Session Planner must validate the whole
+cross-feature preparation before Encounter truth becomes durable. The prepared
+batch is transient typed state. Commit creates ordinary `EncounterPlan`
+aggregates and retains generated origin only for audit and idempotency.
+
+Manual builder generation remains an independent application use case but uses
+the same Encounter math, candidate, ranking, and saved-plan invariants. It does
+not create a second plan model or generated-batch writer.
+
+## Execution
+
+- command dispatch and immutable snapshot application are the only Encounter
+  work allowed on the JavaFX thread
+- foreign reads and SQLite work run on I/O execution
+- deterministic candidate evaluation and roster construction run on bounded
+  CPU execution
+- candidate search never runs inside a database transaction
+- cancellation stops avoidable preparation work before commit; a commit that
+  has started resolves as one complete success or failure
+- preparation is not submitted as one global serial chain
+
+## Publication Semantics
+
+Prepare publishes one complete ordered `PreparedEncounterRoster` batch or no
+applicable batch. Commit publishes one complete ordered Encounter-number-to-plan
+mapping or no mapping. A validation, resolution, conflict, cancellation, or
+storage failure does not publish a partial set and does not advance visible
+saved-plan state.
+
+Runtime builder, initiative, combat, and result state is published as immutable
+revisioned Encounter state. Generated-batch completion does not mutate those
+runtime sessions. Saved-plan summary batch reads preserve request order and
+report missing identities explicitly.
+
+## Quality Targets
+
+- one generated prepare performs one candidate-snapshot read for the complete
+  intent union; query count is independent of Encounter, CR/role-block, and
+  selected-roster-member cardinality
+- commit uses one Encounter transaction with set-based plan, roster, and origin
+  writes and exposes no partial rows
+- one workspace hydration request uses one saved-plan summary batch read rather
+  than one read per scene or plan
+- deterministic fixture replay yields the same ordered concrete rosters for
+  the same intent batch, candidate snapshot, engine meaning, and preparation
+  identity
+- the shared warmed fixture of three generated Encounters records candidate
+  load, roster construction, commit, and summary hydration separately and fits
+  within the Session Planner 2-second p95 end-to-end target over 20 runs
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- concrete creature identities and positive quantities exist for the complete
+  batch before any write
+- one union candidate snapshot supports joint deterministic selection and
+  deliberate roster diversity
+- one idempotent generated-batch commit is the publication boundary
+- manual and generated plans share `EncounterPlan` ownership and invariants
+- permanent historical-origin read compatibility coexists with one canonical
+  write representation
+
+Rejected alternatives:
+
+- abstract XP/role slot persistence as a saved Encounter plan
+- exact-XP point queries per slot or creature-detail reads per roster member
+- first-match selection that accidentally repeats equivalent rosters
+- one transaction per generated Encounter or a duplicate generated-origin
+  writer
+- rewards, packing, audits, session scenes, or copied creature statblocks in
+  Encounter persistence
+- cross-feature database access, JavaFX orchestration, a shared workflow
+  transaction, or compensating deletion
+
+## Enforcement And Proof
+
+Architecture enforcement rejects foreign implementation imports, repositories
+crossing `EncounterApi`, JavaFX-owned orchestration, and a second saved-plan
+write model. Production-route proof owns ordered all-or-nothing preparation,
+idempotent equal retry, conflicting retry, atomic rollback, bounded candidate
+and summary reads, deterministic roster quality, and JavaFX passivity.
+
+## References
+
+- [Requirements](../requirements/requirements-encounter.md)
+- [Domain](../domain/domain-encounter.md)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Encounter Persistence](../contract/contract-encounter-persistence.md)
+- [Session Planner Architecture](../../sessionplanner/architecture/architecture-session-planner.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/encounter/contract/contract-encounter-generated-import.md
+++ b/docs/encounter/contract/contract-encounter-generated-import.md
@@ -1,115 +1,115 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Typed atomic import of generated encounter specifications into
-Encounter-owned saved plans.
+Owner: Encounter Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Batched preparation and atomic commit of generated Encounter
+rosters.
 
-# Encounter Generated Import Contract
+# Encounter Generated Preparation Contract
 
-## Purpose, Owner, And Consumer
+## Purpose And Ownership
 
-Encounter owns the conversion of one Session Generation encounter batch into
-saved Encounter plans. Session Planner is the consumer. The operation crosses
-only `EncounterApi`; Session Planner and Session Generation never write
-Encounter persistence.
+Encounter owns the conversion of one ordered Session Generation intent batch
+into concrete saved Encounter rosters. Session Planner is the consumer. The
+boundary contains no rewards, packing, audits, session scenes, repository
+types, or persistence rows.
 
-This contract imports encounter specifications only. It does not import
-generated rewards, packing, audits, session scenes, or Session Generation
-catalog rows.
-
-## Non-Blocking Operation
-
-The public operation is:
+## Public Operations
 
 ```text
-importGeneratedPlans(GeneratedEncounterPlanImportCommand)
-  -> GeneratedEncounterPlanImportResult
+prepareGeneratedBatch(PrepareGeneratedEncounterBatchCommand)
+  -> PreparedGeneratedEncounterBatchResult
+
+commitGeneratedBatch(CommitGeneratedEncounterBatchCommand)
+  -> CommittedGeneratedEncounterBatchResult
+
+loadGeneratedPlanSummaries(GeneratedEncounterPlanSummaryBatchQuery)
+  -> GeneratedEncounterPlanSummaryBatchResult
 ```
 
-It completes asynchronously and MUST NOT resolve creature detail or touch
-SQLite on the JavaFX thread.
+All operations are asynchronous. The summary query accepts unique Encounter
+plan identities and returns existing structured summaries in request order,
+with missing identities reported explicitly rather than omitted.
 
-The command contains:
+The prepare command contains a stable preparation identity, generation-run
+identity, declared engine version, and an ordered non-empty list of intents.
+Each intent has one unique positive Encounter number, display label, target XP,
+difficulty, and non-empty ordered CR-and-role blocks with positive quantity and
+XP.
 
-- one `GeneratedEncounterPlanSource` with non-blank engine version and stable
-  generation-run identity
-- an ordered non-empty list of `GeneratedEncounterPlanSpec`
-- per spec, a unique positive encounter number, display label, and non-empty
-  ordered list of typed slots
-- per slot, positive XP and one typed requested encounter role
+## Batch Resolution
 
-The engine version is persisted origin metadata for audit and idempotency. It
-is not a UI ruleset label.
+Encounter validates the whole command, then obtains one immutable creature
+candidate snapshot containing all fields needed to resolve the batch. It does
+not query exact XP once per block or load creature detail once per selected
+member.
 
-## Resolution And Result
+Encounter-owned deterministic policy resolves the intents jointly. It may
+reuse candidates across Encounters unless a declared source constraint forbids
+that, but it avoids accidental identical rosters when equivalent alternatives
+exist. Role and CR are selection inputs, not persisted creature truth.
 
-Encounter resolves every slot against current creature facts through the
-Creatures public boundary. Resolution uses Encounter-owned selection policy and
-produces a non-empty saved roster for every spec. No foreign statblock or
-generation catalog row is copied into Encounter storage.
+Success returns one `PreparedEncounterRoster` per intent in request order. Each
+contains:
 
-Success returns exactly one `ImportedPlan` mapping for every requested
-encounter number, in request order. Each mapping contains a positive
-Encounter-owned saved-plan identity. No internal row, repository, or creature
-detail crosses the API.
+- Encounter number and normalized roster fingerprint
+- concrete stable creature identities, quantities, and display names
+- total creature count, adjusted XP, difficulty, and display summary
 
-Typed statuses are:
+Prepare performs no persistence write. If any intent is invalid or
+unresolvable, it returns no roster draft.
 
-- `SUCCESS`: the entire batch exists durably and the full mapping is returned
-- `INVALID_REQUEST`: source, ordering, identity, role, XP, or slot validation
-  failed
-- `UNRESOLVABLE`: at least one slot could not produce a valid roster from
-  current creature facts
-- `STORAGE_FAILURE`: migration or atomic persistence failed
+## Atomic Commit And Retry
 
-Non-success results contain no plan mapping. Display-safe messages contain no
-SQL, exception text, paths, or creature payloads.
+Commit accepts the stable preparation and generation-run identities plus the
+complete prepared batch. It revalidates batch identity, roster fingerprints,
+and saved-plan invariants, then inserts every plan, roster row, and
+generated-origin row in one Encounter transaction.
 
-## Atomicity And Retry
+Generated batch identity is unique by `(engineVersion, preparationIdentity)`
+and stores the normalized batch fingerprint and cardinality. An identical
+completed retry returns the existing ordered mapping without duplicate plans.
+A subset, superset, reordered batch, partial stored origin, or mismatched
+fingerprint returns `CONFLICT` and writes nothing.
 
-The batch is one Encounter consistency boundary:
+Success returns exactly one Encounter plan ID and structured saved-plan summary
+per Encounter number. No partial mapping is returned.
 
-- resolve and validate every spec before persistence
-- insert every saved plan, roster row, and generated-origin row in one SQLite
-  transaction
-- roll back the whole batch on any validation, resolution, or storage failure
-- never return a partial mapping
+## Status And Errors
 
-Generated batch identity is unique by `(engine_version, generation_id)` and
-stores one normalized batch fingerprint plus its encounter cardinality. Its
-ordered origin rows remain unique by `(engine_version, generation_id,
-encounter_number)`. Retrying an already completed identical batch returns the
-existing complete mapping without creating duplicate plans. A subset,
-superset, reordered batch, partial stored origin set, or retry whose normalized
-spec differs from the stored origin is a closed failure and writes nothing.
+Statuses are `SUCCESS`, `INVALID_REQUEST`, `UNRESOLVABLE`, `CONFLICT`, and
+`STORAGE_FAILURE`. Display-safe messages contain no SQL, exception text, paths,
+catalog payloads, or creature detail. Non-success returns no applicable draft
+or committed mapping.
 
-The normalized identity includes encounter order, encounter number, slot
-order, XP, and requested role. `displayLabel` is explicitly non-semantic for
-retry identity: the first successful import owns the persisted saved-plan
-label, and later identical retries do not rename it.
+## Persistence And Compatibility
 
-## Persistence And Migration
+Saved plans retain optional generated origin, normalized roster fingerprint,
+declared batch cardinality, and order. Manual plans have no generated origin.
+Deleting or changing a Session Generation run does not cascade into Encounter.
 
-The saved-plan root retains optional generated origin: engine version,
-generation-run identity, encounter number, deterministic normalized batch and
-spec fingerprints, declared batch cardinality, and stable batch order. Manual
-saved plans have no generated origin.
+Existing canonical generated origins remain readable. Preparation commits
+retain preparation identity, engine version, generation-run identity, and a
+concrete roster fingerprint. When a canonical historical origin lacks the
+canonical identity fields, the owning adapter derives their stable compatibility
+meaning from the validated historical fields on read.
 
-The origin columns and uniqueness rule are introduced by a new contiguous
-Encounter feature migration under the existing feature owner key. The
-migration does not rewrite manual plans and does not create a second saved-plan
-table. Deleting or changing a Session Generation run does not cascade into
-Encounter storage.
+Writes always use only the canonical generated-origin representation. Historical
+origin columns or carriers are never written alongside it, and read
+compatibility never authorizes a second writer, dual writes, or reinterpretation
+of an existing origin.
 
-## Verification Notes
+## Performance Contract
 
-This boundary is review-owned until production-route tests cover invalid
-commands, all-or-nothing resolution, transaction rollback, complete ordered
-mapping, identical retry, mismatched retry, and non-blocking completion.
+- one candidate snapshot read serves the complete prepared batch
+- persistence uses one transaction and set-based row writes
+- `loadGeneratedPlanSummaries` hydrates the complete requested identity set as
+  one batch operation
+- read query count is bounded by data family, not Encounter, block, or roster
+  member count
 
 ## References
 
-- [Encounter Domain Model](../domain/domain-encounter.md)
+- [Encounter Domain](../domain/domain-encounter.md)
 - [Encounter Persistence](contract-encounter-persistence.md)
 - [Session Generation Contract](../../sessiongeneration/contract/contract-session-generation.md)
 - [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md)

--- a/docs/encounter/domain/domain-encounter.md
+++ b/docs/encounter/domain/domain-encounter.md
@@ -1,239 +1,132 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Encounter feature ownership, saved-plan write model, runtime
-generation policy, and domain invariants.
+Last Reviewed: 2026-07-18
+Source of Truth: Encounter ownership, write model, derived runtime state, and
+domain invariants.
 
 # Encounter Domain Model
 
-## Context Role
+## Context Role And Ownership
+
+Context Name: `Encounter`
 
 Context Role: Roster Truth Context
-Context Name: Encounter
 
-- `encounter` owns saved encounter-plan roster truth.
-- It also owns runtime encounter-generation policy for creating suggested
-  rosters from the active party, creature catalog, and encounter tables.
-- It does not own party truth, creature truth, or encounter-table membership.
-- It consumes foreign facts only through `PartyApi`, `CreaturesApi`,
-  `EncounterTableApi`, and `WorldPlannerApi`.
+Encounter owns saved encounter-plan roster truth and encounter-generation
+policy. Party membership, creature facts, encounter-table membership, World
+Planner facts, Session Generation rewards, and Session Planner scenes remain
+foreign truth.
 
 ## Published Language
 
-`EncounterApi` owns view-facing immutable runtime state plus shared request and
-chooser-display language.
+`EncounterApi` publishes Encounter-owned immutable language for:
 
-- immutable, revisioned `EncounterStateSnapshot`, `ApplyEncounterStateCommand`,
-  and typed command results
-- immutable, revisioned `EncounterBuilderInputs`,
-  `UpdateEncounterBuilderInputsCommand`, and typed update results
-- `EncounterTuningPreviewResult`
+- `EncounterPlanId`, `EncounterPlan`, saved-plan summaries, and planning facts
+- difficulty bands, thresholds, tuning choices, candidate diagnostics, and
+  generated alternatives
+- revisioned builder, initiative, combat, and result runtime state
+- ordered generated intents, prepared concrete roster summaries, generated
+  batch outcomes, and Encounter-number-to-plan mappings
 
-It also owns shared request/read vocabulary such as difficulty bands, tuning
-preview labels, one saved-plan chooser display carrier, and status enums.
+Public commands and foreign API results are translated before they enter
+Encounter policies or the write model. API carriers, repositories, persistence
+rows, and foreign internal models are not Encounter domain truth.
 
-Generated import publishes `GeneratedEncounterPlanSource`, ordered
-`GeneratedEncounterPlanSpec` and typed XP-and-role slots, plus one atomic import
-result mapping encounter numbers to saved-plan identities. These carriers are
-translation language; they do not become the saved-plan aggregate model.
+## Write Model
 
-`EncounterDifficultyBand.AUTO` and Auto tuning sentinels are public request
-language only. The application boundary resolves them into concrete generation
-values before invoking draft construction.
-
-Saved encounter plans publish only the chooser display language reused by the
-encounter builder. SessionPlanner-specific list and budget/detail facts leave
-the feature through `EncounterApi`; no second reply channel or repository is a
-cross-feature boundary. The chooser
-surface is intentionally thin and does not mirror the internal
-`EncounterPlanSummary` record. Creature details remain owned by the creatures
-context and are reloaded when a saved plan is opened.
-
-The generation and plan models MUST NOT depend on API carriers as invariant
-inputs. The application boundary translates public commands and foreign API results into
-encounter application values before invoking policies, factories, or plan
-ports.
-
-## Application Boundary
-
-The application boundary coordinates foreign party, creature, encounter-table,
-and world-planner inputs, translates foreign API results into encounter
-application values, and delegates generation or saved-plan work. It publishes
-only encounter-owned immutable, revisioned API state instead of exporting
-internal session carriers.
-
-Generation orchestration coordinates foreign APIs without owning their truth.
-A separate budget read exposes party-derived encounter thresholds without
-constructing a generated encounter. A saved-plan budget read exposes one plan
-as party-specific planning facts for downstream planning surfaces.
-The catalog tuning preview remains a read-only Encounter API result.
-
-Saved-plan use cases own save, list, and load orchestration through one
-feature-owned persistence port. The SQLite adapter persists plan and creature
-rows; the domain model keeps the saved roster invariant independent of storage
-shape.
-
-Generated-plan import resolves all typed slots through current creature facts,
-validates the full batch, and delegates one atomic batch write. Reward and
-Session Planner mutations remain outside Encounter.
-
-## Architecture Constraints
-
-- Encounter owns saved-plan roster truth, balancing, candidate narrowing, and
-  ranking behavior.
-- Application code owns orchestration and foreign-API coordination.
-- Domain code owns immutable generation facts, named balancing and ranking
-  policies, deterministic draft construction, and the saved-plan aggregate.
-- Package and helper decomposition inside those roles is an internal choice,
-  not a compatibility or architecture contract.
-
-## Write Model And Derived State
-
-Write Model: Saved Encounter Plans
-
-The encounter write model persists accepted encounter rosters as saved plans.
-Each saved plan owns:
+`EncounterPlan` is the Encounter write model and aggregate root. It owns:
 
 - stable plan identity
-- user-visible plan name
-- optional generated encounter label
-- ordered creature identity and quantity rows
-- optional generated origin containing engine version, generation-run
-  identity, encounter number, and normalized-spec fingerprint
+- user-visible plan name and optional generated encounter label
+- ordered `EncounterPlanCreature` values containing creature identity,
+  quantity, and last-known display name
+- optional immutable generated origin identifying the preparation, generation
+  run, engine meaning, Encounter number, and normalized roster
 
-It derives:
+An `EncounterPlan` contains at least one creature. It does not embed creature
+statblocks, party members, initiative, combat HP, generated rewards, packing,
+audits, session scenes, or dungeon placement.
 
-- party-specific encounter thresholds
-- encounter-ready candidate pools
-- encounter-table-constrained candidate pools
-- world-location and faction constrained encounter-table pools
-- finite world-faction stock caps for generated statblocks
-- role hints for encounter composition
-- ranked encounter alternatives
-- generator diagnostics describing the resolved difficulty/tuning attempt,
-  search quality, stop category, candidate-pool size, and attempt/evaluation
-  counts
-- party-derived budget summaries for the active runtime session
-- party-derived saved-plan planning facts for downstream planner surfaces
-- party-derived tuning preview labels for catalog encounter controls
+Generated preparation carriers translate a complete proposed batch into
+ordinary `EncounterPlan` aggregates. They are not a second write model.
 
-Generated alternatives remain ephemeral derived state until the user saves the
-current roster as an encounter plan.
+## Derived And Runtime State
 
-The current builder, initiative, combat, and result session state is
-domain-owned runtime state. It is not persisted as a saved encounter plan, but
-it is also not view-owned mutable state.
+Encounter derives:
 
-## Aggregate Model
+- active-party difficulty thresholds and daily-budget context
+- candidate pools constrained by filters, encounter tables, World Planner
+  sources, and finite stock caps
+- role hints, ranked alternatives, fallback advice, and generation diagnostics
+- party-specific planning facts for saved plans
+- prepared concrete generated-roster batches
 
-Aggregate Root: EncounterPlan
+Generated alternatives and prepared batches remain transient until saved. The
+current builder, initiative, combat, and result session state is Encounter-owned
+runtime state, not persisted `EncounterPlan` truth and not view-owned mutable
+state.
 
-`EncounterPlan` owns the saved encounter roster. It stores only encounter-plan
-identity, display labels, and creature quantities. It does not embed creature
-statblocks, party members, initiative, combat HP, loot resolution, or dungeon
-room placement.
+## Mutation Language
 
-- `EncounterPlan` owns plan identity and roster membership.
-- `EncounterPlanCreature` owns one creature-id and quantity pair.
-- `EncounterPlanSummary` owns list-screen summary language.
-- A feature-owned application port owns outbound saved-plan persistence.
+Encounter supports:
 
-Generation values, policies, and factories remain stateless domain modules used
-to construct candidate rosters before a saved plan exists.
+- generate encounter alternatives
+- save the current roster as an Encounter plan
+- load or list saved Encounter plans
+- prepare one ordered generated-intent batch as concrete rosters
+- commit one complete prepared batch as saved Encounter plans
 
-## Commands And Invariants
+## Invariants
 
-Commands entering the model are:
-
-- generate encounter
-- save current encounter plan
-- list saved encounter plans
-- load saved encounter plan
-- atomically import generated encounter specifications
-
-Core invariants:
-
-- the active party is the balancing baseline for generation
-- encounter math is computed from public party data, not duplicated persistence
-- selected encounter tables replace creature filter sourcing for that
-  generation pass
-- selected world locations and factions may narrow encounter tables and finite
-  stock caps, but they do not transfer world-planner ownership into encounter
-- Auto difficulty and Auto tuning are resolved deterministically from the
-  generation seed and request fingerprint before draft enumeration
-- a non-empty candidate pool with no viable draft is distinguished from an
-  empty candidate pool
-- foreign feature internals remain hidden behind their API boundaries
-- generator ranking must be deterministic for the same inputs
-- a saved plan must contain at least one creature
-- saved plans store creature identity and quantity, not creature truth
-- generated origin is unique per engine version, generation identity, and
-  encounter number
-- every generated spec resolves to a non-empty roster before any member of its
-  batch is persisted
-- one generated batch is all-or-nothing and an identical completed retry is
-  idempotent
+- the active party is the balancing baseline for runtime generation
+- encounter math uses current public Party facts rather than copied Party truth
+- selected encounter tables replace creature-filter sourcing for that pass
+- selected World Planner sources may narrow encounter tables and stock caps but
+  do not transfer World Planner ownership
+- Auto difficulty and tuning resolve deterministically from the generation
+  seed and request meaning before alternatives are enumerated
+- a non-empty candidate pool with no viable roster is distinct from an empty
+  candidate pool
+- ranking is deterministic for the same inputs
+- saved plans contain at least one concrete creature identity with positive
+  quantity and never own creature statblocks
+- generated origin is unique for one engine meaning, preparation identity, and
+  Encounter number
+- every generated intent resolves to one concrete non-empty roster before any
+  plan from the batch becomes durable
+- the complete generated batch is all-or-nothing and an identical completed
+  retry denotes the same saved plans
 - generated origin never transfers reward, packing, audit, or session-scene
   ownership into Encounter
 
-## Consistency Model
-
-Encounter generation reads party, creature, and encounter-table snapshots
-through their public APIs. It does not save party,
-creature, or encounter-table state.
-
-Saved encounter plans are persisted through an encounter-owned application
-port. Opening a plan rebuilds the runtime roster from
-the saved creature identities and current creature details; initiative, combat,
-result, and generator-alternative state are cleared because they are session
-runtime state.
-
-Generated batch import is one persistence consistency boundary. Resolution
-failure or a mismatched retry writes nothing. Once imported, the roster follows
-the same saved-plan invariants as a manually saved plan; its origin remains
-immutable audit and idempotency metadata.
-
-## Ubiquitous Language
-
-- `EncounterDifficultyBand`: requested difficulty intent.
-- `EncounterDifficultyTargets`: policy thresholds for the active party.
-- `EncounterDraft`: candidate generated encounter before export.
-- `EncounterCandidateProfile`: creature candidate enriched for generation.
-- `GeneratedEncounter`: exported generated encounter suggestion.
-- `EncounterPlan`: saved encounter roster aggregate.
-- `SavedEncounterPlanChoice`: published saved-plan chooser display row.
-- `EncounterPlanFact`: Session Planner-facing saved-plan planning readout
-  exposed by `EncounterApi`.
-- `GeneratedEncounterPlanSource`: immutable generation origin.
-- `GeneratedEncounterPlanSpec`: ordered generated encounter slots awaiting
-  Encounter-owned creature resolution.
-
 ## Domain Policies
 
-- difficulty evaluation uses encounter thresholds plus monster-count
-  multipliers
-- candidate filtering may narrow by creature type, subtype, and biome
-- generator tuning may prefer smaller or larger creature counts, narrower or
-  wider XP spread, and lower or higher statblock diversity
-- Auto generation first tries a neutral resolved configuration, then up to a
-  bounded set of seeded variants, and returns an exact match when a resolved
-  target difficulty is met
-- when no exact match exists but drafts are available, generation returns the
-  best-ranked fallback with a fallback advisory instead of treating it as a
-  creature-source failure
-- role hints are heuristic derived state; they do not become persisted creature
+- difficulty evaluation uses party thresholds and monster-count multipliers
+- candidate filtering may narrow by creature type, subtype, biome, selected
+  tables, World Planner sources, and finite stock
+- tuning may prefer different creature counts, XP spread, and statblock
+  diversity
+- Auto generation tries a neutral configuration and then a bounded seeded set
+  of alternatives
+- when no exact difficulty match exists but valid rosters do, the best-ranked
+  fallback is returned with an advisory
+- role hints are heuristic derived state and never persisted creature truth
+- saved plans preserve roster composition only; combat state is never plan
   truth
-- the feature may enrich final suggestions with creature-detail tags without
-  changing creature ownership
-- saved plans preserve roster composition only; combat state is never saved as
-  plan truth
+
+## Consistency Boundary
+
+One `EncounterPlan` is the manual-save consistency boundary. One generated
+batch is a larger all-or-nothing consistency boundary containing multiple
+ordinary Encounter plans with immutable generated origins. Opening a plan
+rebuilds runtime state from current creature detail and clears prior initiative,
+combat, result, and generated-alternative runtime state.
 
 ## References
 
-- [Feature Spec](../requirements/requirements-encounter.md)
+- [Feature Requirements](../requirements/requirements-encounter.md)
 - [Encounter Persistence](../contract/contract-encounter-persistence.md)
-- [Encounter Builder Inputs Contract](../contract/contract-encounter-builder-inputs.md)
 - [Encounter Saved Plans Contract](../contract/contract-encounter-saved-plans.md)
-- [Encounter State Contract](../contract/contract-encounter-state.md)
-- [Generated Import Contract](../contract/contract-encounter-generated-import.md)
-- [Encounter UI](../requirements/requirements-encounter-state-tab.md)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Architecture](../architecture/architecture-encounter.md)
+- [Encounter Runtime UI](../requirements/requirements-encounter-state-tab.md)

--- a/docs/encounter/requirements/requirements-encounter.md
+++ b/docs/encounter/requirements/requirements-encounter.md
@@ -1,6 +1,6 @@
-Status: Active
+Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
+Last Reviewed: 2026-07-18
 Source of Truth: User-facing behavior and acceptance criteria for the
 encounter feature.
 
@@ -17,8 +17,9 @@ Provide a runtime encounter builder that:
 - lets catalog creature rows build a manual encounter roster
 - saves and opens created encounter rosters as persistent encounter plans
 - can use selected encounter tables as curated generator sources
-- atomically imports one applied Session Generation encounter batch as
-  Encounter-owned saved plans
+- resolves one ordered group of Session Generation intents into concrete
+  creature rosters
+  and publishes it as Encounter-owned saved plans
 
 ## Non-Goals
 
@@ -41,14 +42,13 @@ Provide a runtime encounter builder that:
    plan into the builder.
 7. The user starts initiative and combat from the current builder roster.
 
-Generated import is a separate Session Planner-driven flow:
+Generated preparation is a separate Session Planner-driven flow:
 
-1. Session Planner applies one current Session Generation preview.
-2. Encounter validates the generated source and all ordered encounter specs.
-3. Encounter resolves every typed XP-and-role slot through current creature
-   facts.
-4. Encounter saves the entire generated batch or none of it and returns the
-   complete encounter-number-to-plan-id mapping.
+1. Session Planner requests a complete ordered group of generated encounters.
+2. Encounter resolves every requested encounter into a concrete roster while
+   preserving request order.
+3. Success makes the complete group available as saved plans; failure leaves
+   the previously visible saved-plan set unchanged.
 
 ## Expected Capabilities
 
@@ -80,15 +80,12 @@ Generated import is a separate Session Planner-driven flow:
 - list saved encounter plans from the encounter title row
 - open a saved encounter plan into Creation mode and clear initiative, combat,
   result, and generated-alternative runtime state
-- accept a non-blocking typed generated-origin import without exposing
-  repositories or persistence rows
-- preserve generated origin for idempotent retry while treating every imported
-  roster as ordinary Encounter-owned saved-plan truth
+- return concrete creature identities, quantities, display names, total count,
+  adjusted XP, and difficulty in every prepared roster summary
+- treat every generated roster as ordinary Encounter-owned saved-plan truth
 
 ## Acceptance Criteria
 
-- the encounter feature depends only on public party, creature, and
-  encounter-table APIs for generation
 - saved encounter plans persist only creature identity, quantity, display name,
   and generated label; creature statblocks remain creature-owned
 - generated alternatives remain derived runtime output until explicitly saved
@@ -106,13 +103,13 @@ Generated import is a separate Session Planner-driven flow:
   generated statblock counts from exceeding finite faction stock caps
 - opening a saved plan replaces the builder roster and returns the state tab to
   Creation mode
-- one generated import returns either every requested plan mapping in encounter
-  order or no mapping and no newly saved plan
-- an invalid or unresolvable member prevents the entire generated batch from
-  being persisted
-- retrying an identical completed generated origin does not create duplicate
+- generated preparation publishes every concrete roster in request order or
+  publishes none of them
+- invalid, unresolvable, or failed generated preparation leaves the previously
+  visible saved-plan set unchanged
+- retrying an identical completed preparation creates no visible duplicate
   plans
-- generated import stores no reward, packing, audit, session-scene, or copied
+- generated preparation stores no reward, packing, audit, session-scene, or copied
   creature-detail truth
 
 ## References
@@ -121,4 +118,5 @@ Generated import is a separate Session Planner-driven flow:
 - [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
 - [Encounter Persistence Contract](../contract/contract-encounter-persistence.md) (line 1)
 - [Encounter Table Feature Spec](../../encountertable/requirements/requirements-encountertable.md) (line 1)
-- [Generated Import Contract](../contract/contract-encounter-generated-import.md)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Architecture](../architecture/architecture-encounter.md)

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Aaron (Product Owner)
-Last Reviewed: 2026-07-17
+Last Reviewed: 2026-07-18
 Source of Truth: Owner-confirmed SaltMarcher Now, Next, and Later direction
 linked to GitHub issues.
 
@@ -9,7 +9,9 @@ linked to GitHub issues.
 ## Now
 
 - Build encounter planning and management for preparation and table play
-  ([#433](https://github.com/ThonkTank/Salt-Marcher/issues/433)).
+  ([#433](https://github.com/ThonkTank/Salt-Marcher/issues/433)); the ordered
+  Session preparation replacement lives in the temporary
+  [Session Planner Greenfield Roadmap](../sessionplanner/delivery/roadmap-session-planner-greenfield.md).
 - Manage scenes as the current in-game state with relevant NPCs, places, and
   context in one place
   ([#434](https://github.com/ThonkTank/Salt-Marcher/issues/434)).

--- a/docs/sessiongeneration/README.md
+++ b/docs/sessiongeneration/README.md
@@ -1,23 +1,14 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Entry point and document map for the Session Generation
-feature.
+Owner: Session Generation Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Entry point and document map for Session Generation.
 
-# Session Generation Feature Docs
-
-## Purpose
-
-`sessiongeneration` owns deterministic encounter-and-reward generation from a
-normalized party-level request and an immutable reference-catalog snapshot. It
-publishes generation previews and stored generation results. It does not own
-Session Planner records, party members, creature statblocks, or saved Encounter
-plans.
+# Session Generation Feature
 
 ## Document Set
 
 - [Requirements](requirements/requirements-session-generation.md)
-- [Domain Model](domain/domain-session-generation.md)
+- [Domain](domain/domain-session-generation.md)
 - [API And Persistence Contract](contract/contract-session-generation.md)
 - [Architecture](architecture/architecture-session-generation.md)
 

--- a/docs/sessiongeneration/architecture/architecture-session-generation.md
+++ b/docs/sessiongeneration/architecture/architecture-session-generation.md
@@ -1,17 +1,33 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Session Generation feature seams, pipeline, dependency
-direction, and architecture rationale.
+Owner: Session Generation Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Session Generation seams, pipeline, execution, and dependency
+direction.
 
 # Session Generation Architecture
 
-## Entity, Stakeholders, And Concerns
+## Purpose
 
-This specification describes the `sessiongeneration` feature. It serves
-maintainers of the deterministic engine, reference catalog, persistence, and
-Session Planner integration. It answers how generation stays reproducible,
-diagnosable, non-blocking, UI-free, and isolated from foreign feature truth.
+Session Generation provides deterministic encounter-and-reward computation as
+one UI-free capability. It must be independently testable, preserve the staged
+reference behavior, expose structured loot, and avoid using SQLite round trips
+as workflow transport.
+
+## Stakeholders And Concerns
+
+- Session Planner needs a complete deterministic value that can continue
+  directly into preparation and can later be made durable idempotently.
+- Encounter needs ordered structured intents without reward or persistence
+  internals.
+- Session Generation maintainers need pure stage seams, stable catalog meaning,
+  and normalized immutable storage.
+- Verification maintainers need independent engine, catalog, persistence, and
+  reward-read measurements plus deterministic fixture replay.
+
+This document owns execution, dependency direction, publication semantics, and
+architecture quality targets. Observable result behavior belongs to
+requirements; run truth belongs to the domain; API and storage semantics belong
+to the contract.
 
 ## Target Topology
 
@@ -19,110 +35,134 @@ diagnosable, non-blocking, UI-free, and isolated from foreign feature truth.
 features/sessiongeneration/api/
 features/sessiongeneration/domain/
 features/sessiongeneration/application/
+features/sessiongeneration/adapter/resource/
 features/sessiongeneration/adapter/sqlite/
 features/sessiongeneration/SessionGenerationFeature
 resources/sessiongeneration/
 ```
 
-The feature has no JavaFX adapter and contributes no shell surface.
-`SessionGenerationFeature` receives platform execution, persistence, and local
-diagnostics capabilities from `app` and publishes one `SessionGenerationApi`.
-`app` supplies that API explicitly to Session Planner.
+`SessionGenerationFeature` receives bounded CPU execution, I/O execution,
+persistence, and local diagnostics from application composition. It publishes
+one `SessionGenerationApi` and no JavaFX or shell contribution.
 
-## Runtime View
+## Runtime
 
 ```text
-Session Planner JavaFX
-  -> Session Planner application
-  -> SessionGenerationApi
-  -> Session Generation application
-  -> catalog port + pure GenerationEngine
-  -> generated-run persistence port
-  -> immutable GenerationResult
+Session Planner preparation
+  -> SessionGenerationApi.draft
+  -> cached immutable catalog snapshot
+  -> pure staged GenerationEngine
+  -> GeneratedRunDraft in memory
+  -> SessionGenerationApi.commit
+  -> one atomic normalized write
 ```
 
-Session Planner translates its participant and control state into the public
-request. Session Generation does not call Session Planner, Party, Creatures, or
-Encounter. Applying a result is a separate Session Planner workflow that calls
-Encounter's generated-origin import API and then mutates Session Planner truth.
+The successful draft continues directly into Encounter drafting and Session
+Planner assembly. Commit adds durability once the full prepared session is
+valid. It never requires a save, reload, and equality comparison in the hot
+path.
 
-## Pure Generation Pipeline
+## Publication Semantics
 
-The engine retains stage boundaries because their intermediate values are
-needed for deterministic diagnosis and parity checks:
+The API publishes only complete immutable operation results. `draft` publishes
+either one complete `GeneratedRunDraft` or one typed failure; no stage result or
+partially populated reward collection crosses the boundary. `commit` publishes
+the durable identity for exactly the submitted semantic draft. `load` and
+reward batch reads publish immutable typed values with stable request ordering.
 
-1. request normalization and session-context calculation
-2. encounter-target allocation
-3. role block and encounter-candidate construction
-4. deterministic encounter selection, difficulty, and bossiness
-5. treasure budget, channel, theme, and slot planning
-6. non-magic and magic loot resolution
-7. packing
-8. reward aggregation and formatting
-9. hard audits and warnings
+Session Generation publishes no view state and initiates no consumer refresh.
+The calling application owns cancellation and whether a late result is still
+eligible for use. Cancellation prevents avoidable remaining work but never
+turns a partial stage value into a public success.
 
-Each stage consumes immutable typed values and returns immutable typed values.
-The application layer loads one complete catalog snapshot, invokes the stages,
-assigns a run identity only after successful audits, persists the aggregate,
-and maps it to the public result. SQL rows and API carriers are translated at
-their boundaries and are not domain inputs.
+## Pipeline
 
-## Boundaries And Dependency Direction
+The engine retains pure typed stage seams for session context, encounter target
+allocation, candidate construction and selection, treasure planning, loot
+resolution, packing, output, and audits. Each stage consumes immutable values
+and returns immutable values. The engine performs no API mapping, persistence,
+resource loading, clock access, diagnostics, or foreign-feature call.
 
-- API depends only on JDK values and feature-neutral asynchronous contracts.
-- Domain depends on no API, platform, SQL, JavaFX, shell, or foreign feature.
-- Application depends on API, domain, feature-owned ports, execution, and local
-  diagnostics; it does not depend on adapters or UI.
-- The resource adapter implements the immutable catalog port; the SQLite
-  adapter implements only run persistence. Neither contains generation rules.
-- Composition is the only place that constructs adapters and application
-  services.
-- Bundled resources are catalog input. They do not become a second executable
-  rules engine.
-- All persistence and resource access is off the JavaFX thread.
-- The engine and one catalog snapshot are read-only during a run. Late
-  asynchronous completion cannot overwrite newer Session Planner preview
-  state because Session Planner checks both its active request token and the
-  preview fingerprint.
+The application layer validates API input, obtains one already-validated
+catalog snapshot, invokes the engine on CPU execution, assigns stable run
+identity and content fingerprint after hard audits, and maps the result. The
+persistence adapter validates and writes the same semantic candidate; it does
+not rerun generation rules.
 
-Forbidden shortcuts include direct Session Planner database reads, Encounter
-repository use, JavaFX controls in this feature, a shell service locator,
-catalog-driven reflection, JSON aggregate storage, and a single generator
-method that hides all stage boundaries.
+## Catalog Lifecycle
 
-## Decisions And Rationale
+One catalog artifact is validated and cached by `(catalogVersion,
+catalogContentHash)`. Concurrent requests share the immutable snapshot. Artifact
+loading runs once per version and never occurs inside a SQLite transaction.
+A failed refresh cannot replace the last valid snapshot for an already pinned
+version.
 
-- A separate UI-free feature was chosen because generated proposals, reference
-  catalogs, and reproducibility are durable concerns distinct from authored
-  sessions and saved encounter rosters.
-- Session Planner owns the interaction because generation is part of its user
-  flow; a second feature tab or ruleset chooser would split one task across
-  surfaces.
-- The source pipeline is retained as pure stage seams because stage-level
-  values localize parity drift and hard-audit failures. The spreadsheet sheet
-  layout itself is not reproduced.
-- Immutable content-addressed catalog artifacts plus self-contained stored run
-  results were chosen instead of duplicating shipped reference rows into the
-  user's mutable SQLite database. The artifact address derives from the
-  versioned, sorted table inventory and its dimensions and file hashes; source
-  workbook hashes and URLs remain provenance rather than runtime identity.
-- Reusing the existing Encounter runtime generator was rejected because it
-  owns different candidate inputs, tuning, and observable behavior.
-- A proof-of-concept compatibility layer was rejected because it would create
-  two schemas and two meanings for generation truth before release.
+## Boundaries
 
-## Quality And Verification
+- API uses JDK and feature-neutral async values only.
+- Domain depends on no API, SQL, JavaFX, platform, or foreign feature.
+- Application depends inward on domain and outward on feature-owned ports.
+- Resource and SQLite adapters implement those ports and contain no generation
+  policy.
+- Composition is the only construction point.
+- Session Generation does not call Session Planner, Party, Creatures, or
+  Encounter.
+- Concrete creature selection remains Encounter-owned.
 
-The architecture targets deterministic reproducibility, JavaFX responsiveness,
-atomic stored results, local diagnosability, and replaceable catalog content.
-For an equal normalized request, engine version, and catalog content hash, a
-stage-by-stage comparison must be equal before persistence identity is added.
+Forbidden shortcuts include direct foreign database reads, Encounter
+repositories, JavaFX controls, shell service lookup, mutable global catalog
+state, JSON run persistence, opaque formatted-text output, and one monolithic
+generator method hiding stage boundaries.
 
-Target-package dependency direction is mechanically enforced when the feature
-is included in `architectureTest`; pure-stage, asynchronous production-route,
-and persistence atomicity remain test-owned. The absence of a JavaFX adapter,
-foreign implementation imports, proof-of-concept dual reads, and opaque
-aggregate payloads is review-owned unless a named gate covers it.
+## Execution And Performance
+
+Pure drafting runs on bounded CPU execution. Catalog and SQLite work run on I/O
+execution. Transactions contain only validation against prepared rows and
+database writes. Multiple independent generation drafts are not globally
+serialized; caller cancellation stops avoidable stage work.
+
+The application publishes stage duration and candidate cardinality diagnostics
+without content. Stage benchmarks and the Session Planner end-to-end fixture
+detect algorithmic regressions. Persistence round-trip tests remain separate
+from engine benchmarks so slow I/O is not misdiagnosed as generation cost.
+
+Measurable architecture targets are:
+
+- `draft` performs zero SQLite operations and runs generation only on bounded
+  CPU execution; catalog loading and all persistence run on I/O execution
+- requests are not globally serialized; parallelism is bounded by the supplied
+  executors and transactions contain no catalog load or generation search
+- catalog validation happens at most once per catalog content identity before
+  reuse of its immutable snapshot
+- commit, load, and reward hydration use query families bounded by operation,
+  never one query per encounter, treasure, item line, or packing row
+- the Golden input is replayed as a deterministic engine fixture, while the
+  shared warmed three-Encounter reference fixture records catalog, engine,
+  commit, and reward-read stages separately and remains inside the Session
+  Planner 2-second p95 end-to-end target over 20 runs
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- Session Generation remains a separate UI-free feature because deterministic
+  reward truth, catalog identity, audits, and immutable run history have one
+  lifecycle.
+- The engine uses pure typed stages so parity and performance are attributable
+  to named computation boundaries.
+- Draft and commit are separate operations so a complete prepared session can
+  be validated before a run becomes durable.
+- Runs use normalized immutable persistence and idempotent content-checked
+  commit so structured rewards and reproducibility survive one rendering.
+
+Rejected alternatives:
+
+- saving and reloading a run as in-process workflow transport
+- a monolithic generator that hides stage values and audit boundaries
+- JavaFX publication or a second generation UI
+- a remote generator service, rules plugin framework, event bus, shared
+  cross-feature transaction, or compensating deletion
+- compatibility with unadopted proof-of-concept schemas or Java carriers
 
 ## Sources
 
@@ -131,6 +171,6 @@ aggregate payloads is review-owned unless a named gate covers it.
 - Preserved original:
   `/home/aaron/Schreibtisch/projects/references/.tools/markdown/saltmarcher-encounter-loot-generation-design-2026-07-16.md`
 - [Requirements](../requirements/requirements-session-generation.md)
-- [Domain Model](../domain/domain-session-generation.md)
+- [Domain](../domain/domain-session-generation.md)
 - [Contract](../contract/contract-session-generation.md)
 - [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/sessiongeneration/contract/contract-session-generation.md
+++ b/docs/sessiongeneration/contract/contract-session-generation.md
@@ -1,176 +1,129 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Session Generation public API, stored-result schema semantics,
-compatibility, migration, validation, and error behavior.
+Owner: Session Generation Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Session Generation API, persistence, compatibility, and error
+semantics.
 
 # Session Generation API And Persistence Contract
 
-## Purpose, Owners, And Consumers
+## Owner And Consumers
 
-`sessiongeneration` owns this feature boundary and its stored generation truth.
-Session Planner is the primary API consumer. The Session Generation application
-and SQLite adapter are the only writers of generation runs and catalog
-snapshots.
-
-This contract does not define the Session Planner flow, generation formulas,
-Encounter import behavior, or source architecture; those remain with their
-neighboring owners.
+Session Generation owns this boundary and all stored generation-run truth.
+Session Planner is the primary consumer. Only Session Generation writes its
+normalized run schema. Encounter consumes encounter intents only through the
+Session Planner preparation workflow and never writes generation storage.
 
 ## Non-Blocking API
 
-`SessionGenerationApi` exposes two non-blocking typed operations:
+`SessionGenerationApi` exposes:
 
-- `generate(GenerationRequest) -> GenerationResponse`
-- `load(GenerationRunId) -> GenerationResponse`
+```text
+draft(GenerationRequest) -> GenerationDraftResponse
+commit(CommitGenerationRunCommand) -> GenerationRunResponse
+load(GenerationRunId) -> GenerationRunResponse
+loadRewards(GenerationRewardBatchQuery) -> GenerationRewardBatchResponse
+```
 
-Both operations complete asynchronously and MUST NOT perform file or SQLite
-work on the JavaFX thread.
+Every operation completes asynchronously and performs no file or SQLite work
+on the JavaFX thread.
 
-`GenerationRequest` requires ordered unique `PartyLevelCount` values, exact
-decimal `adventureDayFraction`, optional encounter count, and seed. It contains
-no JavaFX, SQL, Session Planner persistence, or foreign domain types.
+`GenerationRequest` contains one opaque preparation identity, ordered unique
+party-level counts, exact adventure-day fraction, optional encounter count, and
+seed. It contains no SQL, JavaFX, Session Planner persistence, or foreign
+domain carriers.
 
-A successful `GenerationResponse` contains exactly one immutable
-`GenerationResult`. The result contains run identity, engine and catalog
-metadata, seed, session summary, ordered encounter targets and encounters,
-treasures, loot items, packing, reward summary, formatted text, and audits.
-Failure contains no partial result.
+A successful draft response contains one complete structured
+`GeneratedRunDraft` with stable run identity and normalized content
+fingerprint. Commit accepts that draft, validates it again, and returns its
+durable identity. Load returns the immutable structured run. Batch reward reads
+accept unique run-and-treasure identities and preserve request order.
 
-The API publishes typed statuses:
+Public statuses distinguish success, invalid request, not found, catalog
+failure, generation failure, identity conflict, and storage failure. A
+non-success result contains no partial draft, run, or reward list.
 
-- `SUCCESS`: a stored run was produced or loaded and all hard audits pass
-- `NOT_FOUND`: the requested run identity does not exist
-- `INVALID_REQUEST`: input validation failed
-- `CATALOG_FAILURE`: no complete valid catalog snapshot could be loaded
-- `GENERATION_FAILURE`: candidate coverage or another hard generation
-  invariant failed
-- `STORAGE_FAILURE`: migration, read, or atomic write failed
+## Draft Identity And Commit
 
-Messages are display-safe summaries. Adapter exceptions, SQL, file paths,
-catalog payloads, and authored session content MUST NOT cross the API.
+Run identity is assigned only after a complete draft passes hard audits and is
+stable for preparation identity, engine version, and catalog content hash. The
+content fingerprint covers normalized inputs and every semantic persisted
+child in stable order. It excludes creation time and optional formatted text.
 
-## Validation
+Commit is idempotent:
 
-- levels MUST be unique and from 1 through 20
-- counts MUST be non-negative and total party count MUST be positive
-- adventure-day fraction MUST be an exact non-negative decimal
-- explicit encounter count MUST be from 1 through 10
-- run IDs, versions, and hashes MUST be non-blank typed values
-- success MUST have one result; non-success MUST have none
-- all aggregate invariants in the domain owner MUST pass before persistence
-- load MUST reconstruct typed values and reject corrupt, orphaned, duplicate,
-  unknown-enum, or out-of-order stored rows as `STORAGE_FAILURE`
+- a new identity and valid draft insert the root and every child once
+- an existing identity with the same fingerprint and reconstructed semantic
+  value returns success without rewriting rows
+- an existing identity with different content returns `IDENTITY_CONFLICT`
+- no consumer must load the just-committed run to continue the same workflow
 
-## Normalized Relational Run Persistence
+## Normalized Persistence
 
-The persistence-lifecycle owner key is `session-generation`. The immutable
-catalog artifact is not duplicated into mutable runtime SQLite tables. Its
-manifest and content-hashed TSV files are the canonical catalog owner; each
-self-contained run pins the artifact version and catalog-content hash it used.
-The catalog-content hash is SHA-256 over the catalog version plus the
-canonical filename-sorted inventory of table names, dimensions, and per-file
-SHA-256 values. It therefore identifies the shipped artifact independently of
-where its source workbook was hosted. `sourceSha256` and `sourceUrl` remain
-manifest provenance and MUST NOT be substituted for artifact identity.
+The persistence lifecycle owner key remains `session-generation`. The logical
+schema stores:
 
-The logical SQLite schema is:
+- run identity, content fingerprint, engine version, catalog version and
+  content hash, seed, exact adventure-day fraction, session summary, reward
+  summary, and optional formatted output
+- normalized party-level counts
+- ordered encounter targets, encounters, and selected role/CR blocks
+- ordered treasures, concrete loot item lines, and packing rows
+- ordered typed warnings and audits
 
-- `session_generation_runs`: opaque run ID, engine version, catalog version
-  and content hash,
-  seed, exact adventure-day fraction, derived session summary, reward summary,
-  and formatted output
-- `session_generation_party_levels`: normalized request level counts
-- `session_generation_encounter_targets`: ordered target detail
-- `session_generation_encounters` and
-  `session_generation_encounter_blocks`: the selected encounter and its
-  ordered selected blocks per target
-- `session_generation_treasures`, `session_generation_loot_items`, and
-  `session_generation_packing_rows`: generated reward structure
-- `session_generation_audits`: ordered typed pass, warning, or failure facts
+Every child uses the run identity plus generation-local identity and explicit
+ordering where order affects behavior. Exact decimals are lossless; money uses
+copper-piece units; enums use constrained canonical codes. Composite foreign
+keys prevent cross-run anchors and packing references.
 
-Every child row has a foreign key to its owning run and an explicit
-stable identity plus `sort_order` where ordering affects behavior. Typed
-vocabulary is stored as constrained canonical codes. Exact decimals are stored
-losslessly as canonical decimal text or scaled integers; money is stored in
-copper-piece units. Booleans and optional references use explicit constrained
-columns.
+The schema MUST NOT store JSON aggregates, Java serialization, delimiter-packed
+records, copied catalog families, unselected candidate search space, or
+formatted text as the only representation of structured facts.
 
-Run child primary keys are the run ID plus their generation-local identity.
-Selected encounter
-blocks, packing rows, and encounter anchors use composite foreign keys to
-prevent cross-run references.
+One run and all children insert in one transaction. A failure leaves no visible
+partial root. Load reconstructs typed values and fails on corrupt, orphaned,
+duplicate, unknown-enum, fingerprint-mismatched, or out-of-order rows.
 
-The canonical model MUST NOT store a generated run, catalog family, or reward
-as JSON, Java serialization, delimiter-packed text, or one opaque payload
-column. Human-readable formatted output is an additional derived output, not
-the persistence format for structured facts.
+## Catalog Boundary
 
-The complete encounter candidate search space and its unselected blocks are
-transient engine state and MUST NOT be persisted in normalized tables, opaque
-payloads, or formatted output. Persistence retains only targets, selected
-encounters, their selected blocks, and the candidate-coverage audit outcome.
+The shipped catalog remains a read-only versioned artifact. Its content hash is
+SHA-256 over catalog version plus the canonical filename-sorted inventory,
+dimensions, and per-file hashes. Resource validation is all-or-nothing and
+includes required families, identities, vocabularies, ordering, and
+cross-references before one immutable snapshot is cached.
 
-Catalog artifact identity is `(catalog_version, catalog_content_hash)`. The
-resource adapter validates the complete manifest, exact required table
-inventory, dimensions, per-file hashes, recomputed catalog-content hash,
-closed vocabularies, identities, ordering, and material cross-references before
-exposing one immutable snapshot. This includes the decision-type and loot-source
-families even though the generator does not publish them directly. Run children
-have no update path; the root and all children are inserted once in a single
-transaction.
+Runs pin catalog version and content hash. Source URL and source-file hash are
+provenance and do not replace runtime artifact identity.
 
-## Migration And Initialization
+## Compatibility And Migration
 
-Feature migrations are contiguous, monotonic, begin at version `1`, and run
-through the shared persistence lifecycle under owner key `session-generation`.
-Version `1` creates only the normalized immutable-run schema. Catalog loading
-is a separate read-only resource boundary and fails closed unless all required
-families, identities, enum codes, references, ordering constraints, and hashes
-validate.
+Migrations remain contiguous and monotonic under the existing owner key. An
+applied migration is never rewritten. A newer database version fails closed.
 
-Later schema or catalog changes add a new migration; they MUST NOT rewrite an
-already recorded migration or silently reinterpret stored engine or catalog
-versions. A database with a newer feature version fails closed under the shared
-persistence lifecycle.
+Existing canonical runs remain loadable with their recorded engine and catalog
+meaning. Canonical migrations may add content fingerprints and indexes but MUST
+NOT reinterpret existing rows. When a canonical run lacks a stored fingerprint,
+the adapter derives it from its validated typed rows for comparison without
+rewriting the run.
 
-There is deliberately no compatibility contract for PR #478 or any other
-proof-of-concept generation schema, file, JSON shape, Java carrier, table name,
-or stored run. The canonical migration MUST NOT detect, copy, dual-read,
-backfill, or retain those surfaces. Existing canonical SaltMarcher data owned
-by other features remains untouched.
+Unadopted proof-of-concept schemas, files, JSON shapes, Java carriers, and
+tables have no compatibility status and are never accepted as canonical input.
+Only the normalized contract in this document and canonical migrations under
+the `session-generation` owner key are durable.
 
-## Atomicity And Error Behavior
+## Diagnostics And Errors
 
-- catalog artifact validation is all-or-nothing
-- run generation happens over one already loaded immutable snapshot
-- successful run persistence inserts the root and every child in one
-  transaction; failure leaves no visible run root or partial children
-- a failed load or write does not replace a previously published successful
-  response
-- catalog parse, validation, or reference failures surface as
-  `CATALOG_FAILURE`
-- no candidate coverage or hard audit failure surfaces as
-  `GENERATION_FAILURE`, not a partial success
-- SQLite readiness, migration, integrity, or operation failures surface as
-  `STORAGE_FAILURE`
+Diagnostics may record operation, stable run or catalog identity, stage,
+duration, cardinality, and failure class. They exclude generated item text,
+authored session content, SQL, exception payloads, secrets, and local paths.
+Public messages are display-safe.
 
-Technical diagnostics use stable run or catalog identities and failure class
-only. They MUST NOT record generated item text, session-authored content,
-secrets, raw SQL, or local paths.
+## Verification Ownership
 
-## Compatibility And Verification
-
-Internal Java carriers have no compatibility obligation while consumers move
-atomically in one green slice. Persisted canonical rows retain their declared
-engine and catalog meaning. A changed calculation profile requires a new engine
-version; changed reference content requires a new catalog content hash.
-
-This contract is review-owned except for shared lifecycle behavior and package
-boundaries already enforced by project gates. Production-route tests must
-cover asynchronous completion, typed status mapping, normalized round-trip,
-atomic rollback, deterministic reload, migration from an empty canonical
-database, and fail-closed newer versions.
+Production-route proof covers async completion, deterministic draft equality,
+idempotent and conflicting commit, normalized round-trip, atomic rollback,
+batch reward ordering, catalog failure, empty canonical migration, and load of
+existing canonical runs. Architecture enforcement owns the absence of JavaFX,
+foreign implementation imports, and opaque aggregate storage.
 
 ## Sources
 
@@ -179,5 +132,5 @@ database, and fail-closed newer versions.
 - Preserved original:
   `/home/aaron/Schreibtisch/projects/references/.tools/markdown/saltmarcher-encounter-loot-generation-design-2026-07-16.md`
 - [Shared Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
-- [Domain Model](../domain/domain-session-generation.md)
+- [Domain](../domain/domain-session-generation.md)
 - [Source Architecture](../../project/architecture/source-architecture.md)

--- a/docs/sessiongeneration/domain/domain-session-generation.md
+++ b/docs/sessiongeneration/domain/domain-session-generation.md
@@ -1,137 +1,101 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Session Generation domain language, immutable aggregate,
-deterministic policies, and invariants.
+Owner: Session Generation Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Generation language, deterministic policies, immutable runs,
+and invariants.
 
 # Session Generation Domain Model
 
 ## Context Role And Ownership
 
-Context Name: SessionGeneration
+Context Name: `SessionGeneration`
 
 Context Role: Generated Proposal Context
 
-`sessiongeneration` owns generation requests translated into domain input,
-deterministic generation policy, immutable generated runs, audits, and the
-versioned reference catalog used by those runs. It does not own Session Planner
-records, party-character identity, creature statblocks, or Encounter saved-plan
-rosters.
-
-The application boundary accepts public request carriers, translates them into
-domain values, selects one complete catalog snapshot, invokes the engine, and
-stores a completed aggregate. Session Planner and Encounter translation remains
-outside this domain.
+The context owns normalized generation input, deterministic generation policy,
+encounter intents, rewards, packing, warnings, audits, immutable generated
+runs, and the versioned reference-catalog meaning recorded by those runs. It
+owns neither authored sessions nor concrete creatures, Encounter rosters, or
+saved Encounter plans.
 
 ## Published Language
 
-The public language uses typed values for:
+The public language contains typed values for:
 
-- `GenerationRunId`, `GenerationRequest`, `GenerationResponse`, and
-  `GenerationStatus`
-- `PartyLevelCount`, `AdventureDayFraction`, `EncounterCount`, and `Seed`
-- `SessionSummary`, `EncounterTarget`, `GeneratedEncounter`,
-  `SelectedEncounterBlock`, `TreasurePlan`, `LootItemLine`, `PackingRow`,
-  `RewardSummary`, and `GenerationAudit`
-- `EncounterDifficulty`, `EncounterRole`, `StockClass`, `RewardChannel`,
-  `LootRole`, `MagicRarity`, `DecisionType`, and `AuditStatus`
-- `EngineVersion`, `CatalogVersion`, and `CatalogContentHash`
+- `GenerationRunId`, normalized generation input, and seed
+- session summary, encounter target, encounter intent, and CR-and-role block
+- treasure plan, loot item line, packing row, and reward summary
+- warning and audit outcome
+- engine version, catalog version, and catalog content hash
 
-Closed vocabularies cross boundaries as enums or value types, not string
-round-trips. Unknown imported catalog vocabulary is rejected or translated by
-the catalog adapter before domain generation; it does not create a second
-domain enum.
+Closed vocabulary crosses the boundary as enums or value types. Versions are
+audit metadata, not user-selectable ruleset labels.
 
-Engine and catalog versions are audit and reproducibility metadata. They are
-not user-selectable ruleset labels.
+## Write Model And Derived State
 
-## Immutable Aggregate
+`GeneratedRun` is the immutable Session Generation write model. It owns:
 
-Aggregate Root: `GeneratedRun`
+- stable run identity and normalized input
+- catalog and engine identity
+- ordered encounter targets and encounter intents
+- ordered treasures, item lines, packing rows, and reward summary
+- optional formatted output, typed warnings, and audits
 
-A successful run is immutable after creation and owns:
+There is no update command. A changed request produces a different run.
 
-- stable generation identity, seed, engine version, catalog version, and
-  catalog content hash
-- normalized level counts and session context
-- ordered encounter targets and selected encounters with their selected blocks
-- ordered treasure plans, loot lines, packing rows, reward summary, and
-  formatted output
-- ordered audit outcomes and warnings
+`GeneratedRunDraft` is transient derived state containing the same semantic
+generation result before it becomes durable. It is complete and immutable but
+is not stored truth and cannot be observed as a partial `GeneratedRun`.
 
-The aggregate stores generated facts, not foreign entities. Encounter entries
-describe generation slots and roles; they do not become saved Encounter plans
-until Encounter imports them. Reward entries remain Session Generation truth;
-Session Planner stores only stable references to them.
+Encounter intents describe CR, role, XP, and quantity requirements. They do not
+contain selected creature identity and never claim to be a concrete Encounter.
+Reward detail remains Session Generation truth; consumers retain stable
+references and resolve detail through Session Generation.
 
-There is no update command for a completed run. A changed request creates a new
-run. Load is a read of the same immutable aggregate.
+## Deterministic Engine
 
-The complete encounter candidate search space is derived generation-stage
-state. The engine constructs and ranks it deterministically, selects the
-encounter and blocks needed by the result, records candidate coverage through
-the audit vocabulary, and then discards the remaining candidates. Candidate
-enumeration order and unselected candidates are not durable aggregate truth.
+`GenerationEngine` is a pure policy over normalized `GenerationInput` and one
+immutable `ReferenceCatalogSnapshot`. Its named stages are:
 
-## Deterministic Engine And Catalog
+1. session context
+2. encounter target allocation
+3. encounter intent construction and selection
+4. treasure planning
+5. non-magic and magic item resolution
+6. packing
+7. reward aggregation and formatting
+8. warnings and hard audits
 
-`GenerationEngine` is a pure domain policy over `GenerationInput` and one
-`ReferenceCatalogSnapshot`. The snapshot is immutable, has one stable ordered
-row sequence per catalog family, and is identified by version plus content
-hash.
+The same normalized input, engine version, and catalog content hash produce the
+same domain values. Wall-clock time, locale defaults, database order, hash
+iteration, and volatile randomness cannot influence output.
 
-Determinism means the same normalized input, engine version, and catalog
-content hash produce the same domain values before run identity and storage
-metadata are attached. Seeded choices use positive modulo semantics and stable
-tie-breakers. Hash-map iteration, wall-clock time, locale defaults, database
-row accidents, or volatile randomness MUST NOT affect a run.
-
-The reference catalog owns progression, CR, role-band, encounter-pattern,
-loot, modifier, relation, theme, magic, variant, decision-type, spell,
-enspelling, curse, container, and source vocabulary. Catalog rows are reference
-facts, not mutable members of a `GeneratedRun`.
-
-## Commands And Invariants
-
-Commands are:
-
-- generate a new run from normalized inputs
-- load an existing run by stable identity
-
-Core invariants are:
+## Invariants
 
 - party levels are unique and from 1 through 20; counts are non-negative and
-  their sum is positive
-- explicit encounter count is from 1 through 10
+  total count is positive
+- explicit encounter count is 1 through 10
 - encounter numbers and targets are contiguous and ordered from 1
 - encounter targets sum exactly to the session XP target
-- every selected encounter refers to one target and retains the ordered blocks
-  that form its generated composition
-- treasure, loot-line, packing-row, and audit identities are unique within the
-  run
-- candidate coverage is at least one for every encounter target before the
-  transient candidate set is discarded, and that outcome is retained as an
-  audit fact
-- at most one quest treasure and at most one treasure per encounter anchor
-  exist; encounter anchors are unique
-- non-magic slot totals and magic counts equal the session-context targets
-- magic lines contribute zero gold value and remain additional to gold budget
-- every loot line has one packing result and every packing result is valid
-  before a run is applicable
-- no hard audit is failed in a successful applicable run
-- exact reference-catalog row selections are not cross-catalog invariants
+- every encounter target has one non-empty structured intent
+- treasure, item-line, packing-row, and audit identities are unique within a
+  run or draft
+- at most one quest treasure and at most one treasure per Encounter anchor
+  exist
+- non-magic slot totals and magic counts equal the calculated targets
+- every item line has one valid packing result
+- hard audit failure prevents an applicable draft or run
+- one run identity denotes exactly one normalized semantic result
+- exact catalog-row selection is not a cross-version invariant
 
-Fallbacks that still produce a valid reference result add typed warnings.
-Missing candidate coverage, invalid catalog references, or any failed hard
-invariant prevents successful aggregate creation.
+The complete encounter candidate search space is transient stage state. Only
+selected intents and candidate-coverage audits become run truth.
 
 ## Consistency Boundary
 
-One generated run and all of its owned children are committed atomically. The
-shipped catalog artifact is a separate read-only consistency boundary: a run
-pins the catalog version and content hash it used, and its structured result is
-self-contained, so a later artifact version cannot reinterpret historical
-output.
+One `GeneratedRun` and all of its owned values form one immutable consistency
+boundary. A run pins engine version, catalog version, and catalog content hash
+and remains self-contained after creation.
 
 ## Sources
 

--- a/docs/sessiongeneration/requirements/requirements-session-generation.md
+++ b/docs/sessiongeneration/requirements/requirements-session-generation.md
@@ -1,156 +1,113 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Observable Session Generation behavior, adopted reference-rule
-parity, and acceptance criteria.
+Owner: Session Generation Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Observable generation results, rule parity, and acceptance.
 
 # Session Generation Requirements
 
 ## Goal And Scope
 
-Session Generation MUST let a Session Planner user create a reproducible,
-reviewable preview of encounter targets, encounter compositions, and rewards,
-then apply that exact preview to the current session through the owning feature
-boundaries.
+Given normalized party levels, an adventure-day fraction, optional encounter
+count, and seed, Session Generation MUST produce one deterministic structured
+result containing encounter intents, rewards, packing, warnings, and audits.
+After the result is saved and reopened, its structured meaning MUST be
+equivalent to the result first presented for the same generation.
 
-The affected user is a game master preparing an authored Session Planner
-record. Session Generation owns the generated proposal. Session Planner owns
-the preview interaction and applied session references; Encounter owns saved
-encounter plans.
+Session Planner is the primary consumer. Encounter converts generated encounter
+intents into concrete rosters. Session Generation does not own UI, authored
+sessions, Party members, creature facts, or saved Encounter plans.
 
-## Non-Goals
+## User-Observable Result
 
-- editing party membership, creature truth, or saved Encounter plans
-- replacing the existing Encounter builder and its runtime generator
-- making generated output authoritative before the user applies it
-- exposing a ruleset selector or ruleset-version label in the UI
-- reproducing spreadsheet row identities or exact selected candidates, items,
-  containers, monetary totals, or final formatted text
-- importing or preserving proof-of-concept generation data
+Through Session Planner, a successful generation contributes:
 
-## Inputs And User Flow
+- ordered encounter targets and typed role/CR composition intents
+- generated reward channels and encounter anchors
+- concrete generated item lines with quantity, value, magic, curse, and packing
+  facts when applicable
+- display summaries, warnings, and audit outcome
+- stable run and treasure identities used by the prepared session
 
-1. Session Planner resolves the current session participants to counts per
-   level and supplies the adventure-day fraction, optional encounter count,
-   and seed.
-2. The user requests generation without leaving the Session Planner surface.
-3. Generation runs without blocking the JavaFX thread. The existing session
-   remains usable while the request is pending.
-4. Success shows one structured preview containing encounter targets,
-   generated encounter summaries, rewards, warnings, and audit outcome. The UI
-   MUST NOT show a ruleset label.
-5. The preview is not applied automatically. Session Planner locks Apply when
-   the preview fingerprint no longer matches the current generation inputs.
-6. The user regenerates after a stale lock or applies the still-current
-   preview. Apply imports all generated encounters through Encounter's atomic
-   generated-origin operation, then records the returned encounter-plan and
-   generated-reward references in one Session Planner mutation.
-7. Failure leaves both the authored session and the last stable preview
-   unchanged and shows an actionable status.
+Generated loot is structured result data. Formatted text is an optional derived
+rendering and MUST NOT be the only reward output. Engine and catalog versions
+are audit metadata, not user-selectable ruleset controls.
 
-An empty party is a visible invalid-input state. An omitted encounter count
-activates deterministic automatic calculation; an explicit value MUST be from
-1 through 10. Party levels MUST be from 1 through 20, player counts MUST be
-non-negative, the total player count MUST be positive, and the adventure-day
-fraction MUST be non-negative.
+## Inputs And Validation
+
+Party levels are unique and from 1 through 20. Counts are non-negative and sum
+to a positive party size. The adventure-day fraction is an exact non-negative
+decimal. An explicit encounter count is from 1 through 10; omission activates
+deterministic automatic calculation. The seed is explicit.
+
+Invalid input produces no result. Catalog, generation, and saving failures are
+distinguishable and expose no partial result.
 
 ## Adopted Rule-Parity Profile
 
-The target adopts the executed rule groups documented in sections 3 through 15
-of the preserved reference as the `saltmarcher-v1` calculation profile, with
-the explicit acceptance boundary below. This is behavioral rule parity, not a
-spreadsheet row-selection or seeded-output compatibility promise.
+The target retains the executed rule groups in sections 3 through 15 of the
+preserved owner-provided reference as the `saltmarcher-v1` behavior profile.
+This is stage and invariant parity, not spreadsheet-row or exact-item parity.
 
-The implementation MUST preserve these behavioral rule groups:
+The engine MUST preserve:
 
-- normalize the request, retain the explicit seed, calculate party count,
-  daily XP, session XP, interpolated average level, gold pools, magic targets,
-  treasure count, and non-magic slots as specified by the reference
-- allocate encounter targets so their exact sum equals session XP; use the
-  reference medium-to-deadly weighting and assign rounding remainder to the
-  last target
-- build role-banded CR blocks and one-, two-, or three-role patterns, use the
-  effective-monster-count multiplier, rank by absolute target delta with
-  stable tie-breaking, and make the seeded choice among the best eligible
-  candidates
-- retain the position-based EASY, MEDIUM, HARD, and DEADLY labels and the
-  reference bossiness ordering
-- preserve normal versus overstock budgets, reward-channel caps, theme and
-  magic distribution, descending slot allocation, dynamic per-line budget,
-  role proportions, candidate tolerances, contextual bulk behavior, coin,
-  adorned, useful, flavor, magic, enspelled, curse, packing, and formatting
-  rules
-- use positive modulo semantics, stable explicit ordering, and deterministic
-  selection; no volatile random source may influence a run
-- preserve documented fallbacks as typed warnings where the reference still
-  produces output; a missing encounter candidate or failing hard invariant
-  makes the preview non-applicable
-- run the per-generation hard invariants and budget tolerances from reference
-  section 15 before publishing an applicable result
+- request normalization, session XP, gold pools, magic targets, treasure count,
+  and non-magic slot calculation
+- exact-sum encounter target allocation, role bands, patterns, effective
+  monster count, ranking, seeded choice, difficulty labels, and bossiness
+- normal and overstock budgets, channel caps, theme and magic distribution,
+  descending slots, dynamic line budgets, loot roles, candidate tolerances,
+  bulk behavior, coins, adorned/useful/flavor items, magic, enspelling, curses,
+  packing, and formatting
+- positive modulo, explicit stable ordering, deterministic selection, typed
+  fallbacks, hard audits, and budget tolerances
 
-Catalog content is SaltMarcher-owned. Rule parity does not require importing
-the spreadsheet's exact active rows or their row order. The engine applies the
-adopted rules to the active, versioned SaltMarcher catalog and therefore MAY
-use its own stable keyed entropy and MAY select different candidates, loot,
-magic items, or containers. The spreadsheet's per-cell seed multipliers and
-exact selected rows are explicitly outside compatibility; deterministic
-selection, distribution, caps, tolerances, and hard invariants remain required.
+SaltMarcher owns catalog content. The engine may use stable keyed entropy and
+different active catalog rows. Exact selected candidates, items, containers,
+monetary totals, formatted text, spreadsheet row identities, and per-cell seed
+multipliers are outside compatibility.
 
 ## Golden Acceptance Boundary
 
-For the preserved input of two level-3 players, two level-4 players, adventure
-day fraction `0.6`, explicit encounter count `3`, and seed `179974`, the only
-Golden Master output required by this feature is:
+For two level-3 players, two level-4 players, adventure-day fraction `0.6`,
+explicit encounter count `3`, and seed `179974`, the required Golden output is:
 
 ```text
 encounterTargets = [680, 1000, 1800]
 ```
 
-Exact encounter candidates or CR compositions, selected loot items, container
-assignments, reward totals, and formatted text are explicitly not Golden
-parity requirements.
+No exact encounter candidate, creature roster, loot item, packing choice, or
+formatted-text snapshot is Golden compatibility.
 
-## Visible States And Errors
+## Result Completeness And Stability
 
-- `idle`: no preview exists
-- `generating`: the request is in flight and Apply is unavailable
-- `ready`: all hard audits pass and Apply is available
-- `stale`: a preview remains readable, but Apply is locked until regeneration
-- `invalid`: input validation failed
-- `failed`: the catalog, generation, or storage operation failed without
-  replacing stable state
-
-Warnings MUST remain visible with the preview and MUST NOT be represented as
-successful hard audits. A hard audit failure MUST prevent Apply.
+- generation completes asynchronously without blocking the visible planner
+- success exposes one complete structured result; consumers never observe an
+  intermediate encounter-only or reward-only result
+- failed hard audits prevent success; non-blocking fallbacks remain visible as
+  typed warnings
+- saved and reopened results retain the same encounters, rewards, packing,
+  warnings, audits, seed, and recorded engine/catalog meaning
+- repeating an already completed request does not create visible duplicates
+- reward details remain available as structured fields rather than only as
+  formatted text
 
 ## Acceptance Criteria
 
-- the generation call and stored-result load are non-blocking typed operations
-- the same normalized request, engine semantics, and catalog snapshot produce
-  the same structured result apart from persistence identity and timestamps
+- equal normalized input, engine version, and catalog content hash produce
+  equal structured results
 - encounter targets sum exactly to session XP
-- generated results retain seed, engine version, catalog version, catalog
-  content hash, structured audits, and stable generation identity
-- a preview never mutates Session Planner or Encounter truth before Apply
-- changing any fingerprint input locks Apply while leaving the stale preview
-  visible
-- Apply never imports a partial encounter batch
-- the UI contains no ruleset selector or ruleset-version label
-- the Golden input produces exactly `[680, 1000, 1800]` as its target list;
-  no exact item, container, candidate, or text snapshot is required
-
-## Verification Notes
-
-Every `MUST` above is review-owned until a production-route test names it.
-Determinism is checked by repeated equal requests; parity is checked at stage
-boundaries, and the Golden acceptance checks only the target list declared
-above.
+- every applicable result retains seed, versions, content hash, structured
+  encounters, rewards, packing, warnings, and audits
+- concrete item lines survive save and reopen as typed fields with equivalent
+  meaning
+- failed generation or saving exposes no partial generated result
+- the Golden input produces exactly `[680, 1000, 1800]`
 
 ## Sources
 
 - Readable owner-provided reference:
   `/home/aaron/Schreibtisch/projects/references/saltmarcher/session-generation/encounter-loot-generation-design.md`
-- Preserved original recorded by that reference:
+- Preserved original:
   `/home/aaron/Schreibtisch/projects/references/.tools/markdown/saltmarcher-encounter-loot-generation-design-2026-07-16.md`
 - Original locator: `local-owner-provided document`, snapshot 2026-07-16
 - [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md)

--- a/docs/sessionplanner/README.md
+++ b/docs/sessionplanner/README.md
@@ -1,47 +1,36 @@
-Status: Draft
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Entry point and document map for the session planner feature.
+Status: Active Target
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Entry point and document map for the Session Planner feature.
 
-# Session Planner Feature Docs
+# Session Planner Feature
 
-## Purpose
+## Reading Order
 
-The `sessionplanner` feature owns the authored planning record for one
-adventure session. It combines session-local participant references, ordered
-encounter references, budget allocations, encounter-day assumptions, and
-selection state into one persisted session record.
-
-It does not own party truth, encounter-plan roster truth, creature truth,
-generated reward truth, loot truth, or generation rules.
+1. Read [Requirements](requirements/requirements-session-planner.md) for the
+   observable preparation flow and compact workspace.
+2. Read [Domain](domain/domain-session-planner.md) for authored truth and
+   invariants.
+3. Read [Persistence Contract](contract/contract-session-planner-persistence.md)
+   for stored references and write behavior.
+4. Read [Architecture](architecture/architecture-session-planner.md) for the
+   preparation workflow, workspace snapshot, concurrency, and performance
+   decisions.
+5. Read the temporary
+   [Greenfield Roadmap](delivery/roadmap-session-planner-greenfield.md) only
+   while implementing or reviewing the replacement. It owns sequence and
+   deletion gates, not durable behavior or architecture.
 
 ## Document Set
 
-### Requirements
+- [Requirements](requirements/requirements-session-planner.md)
+- [Domain](domain/domain-session-planner.md)
+- [Persistence Contract](contract/contract-session-planner-persistence.md)
+- [Architecture](architecture/architecture-session-planner.md)
+- [Temporary Greenfield Roadmap](delivery/roadmap-session-planner-greenfield.md)
 
-- [Session Planner Requirements](./requirements/requirements-session-planner.md)
+## Neighboring Owners
 
-### Architecture
-
-- [Session Planner Architecture](./architecture/architecture-session-planner.md)
-
-### Contract
-
-- [Session Planner Persistence Contract](./contract/contract-session-planner-persistence.md)
-
-### Domain
-
-- [Session Planner Domain Model](./domain/domain-session-planner.md)
-
-## Integrations
-
-- [Session Generation Feature](../sessiongeneration/README.md)
-- [Encounter Generated Import](../encounter/contract/contract-encounter-generated-import.md)
-- Session Planner publishes every prepared scene through a revisioned,
-  I/O-free catalog. Scene imports create independent copies; later planner
-  edits do not mutate running scenes.
-
-## References
-
-- [Party Feature Overview](../party/README.md) (line 1)
-- [Encounter Feature Overview](../encounter/README.md) (line 1)
+- [Session Generation](../sessiongeneration/README.md)
+- [Encounter](../encounter/README.md)
+- [Party](../party/README.md)

--- a/docs/sessionplanner/architecture/architecture-session-planner.md
+++ b/docs/sessionplanner/architecture/architecture-session-planner.md
@@ -1,19 +1,33 @@
 Status: Active Target
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Session Planner feature ownership, public seams, and target
-dependency direction.
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Session Planner structure, preparation orchestration,
+publication, concurrency, and quality decisions.
 
 # Session Planner Architecture
 
-## Entity And Concerns
+## Objective
 
-This specification serves maintainers of persisted sessions, planner UI, and
-Party, Encounter, or World Planner integration. Session Planner owns session
-records, ordered scenes, participant references, allocations, rests,
-placeholders, selection, and the current-session pointer. It does not own party
-characters, encounter rosters, creature truth, World Planner details, or
-generated-run truth.
+The target supports one responsive preparation command that publishes concrete
+Encounter rosters, structured rewards, and one coherent editable workspace
+revision. Persistence is durable truth rather than in-process transport, and
+latency stays bounded by provider family rather than saved or generated row
+count.
+
+## Stakeholders And Concerns
+
+- Game masters need one responsive action, coherent progress, and one complete
+  editable result.
+- Session Planner maintainers need one orchestration owner, explicit foreign
+  seams, and no persistence transport hidden in the workflow.
+- Session Generation, Encounter, Party, and World Planner maintainers need their
+  truth accessed only through their public APIs.
+- Verification maintainers need observable revision behavior, fixed query
+  families, stage timing, and one reproducible reference fixture.
+
+This document owns structural and quality decisions for preparation and
+workspace publication. Product outcomes belong to requirements, write-model
+truth to domain documents, and payload or persistence semantics to contracts.
 
 ## Target Topology
 
@@ -26,58 +40,192 @@ features/sessionplanner/adapter/javafx/
 features/sessionplanner/SessionPlannerFeature
 ```
 
-The application composition supplies `PartyApi`, `EncounterApi`,
-`SessionGenerationApi`, and `WorldPlannerApi` explicitly. `SessionPlannerFeature` exposes
-`SessionPlannerApi` plus constructed shell contributions.
+Session Planner remains one feature in the local modular monolith. It receives
+`PartyApi`, `EncounterApi`, `SessionGenerationApi`, and `WorldPlannerApi`
+explicitly from application composition. It exposes `SessionPlannerApi`, one
+workspace snapshot publication, prepared-scene publication, and passive shell
+contributions.
 
-## Boundaries
+## One Workspace State
 
-- `SessionPlannerApi` owns typed workflows, results, catalog queries, and one
-  immutable revisioned session-planner state surface.
-- Domain code owns session-record invariants without JavaFX, SQL, shell, or
-  foreign-feature dependencies.
-- Application code re-reads foreign facts through provider APIs and translates
-  them into planner-owned values.
-- Application code resolves session participants, creates the preview
-  fingerprint and one request token, calls the UI-free
-  `SessionGenerationApi`, discards results whose token is no longer current,
-  and coordinates Apply through Encounter's generated-origin import API.
-- The SQLite adapter persists only planner-owned truth and stable foreign IDs.
-- The JavaFX adapter uses `SessionPlannerApi`, `shell.api`, and feature-neutral
-  platform UI contracts only; it renders controls, timeline, and state without
-  mutating feature state directly.
-- Applied reward detail remains Session Generation truth. Session Planner
-  persists only scene-to-generation-and-treasure references plus a last-known
-  label.
+`SessionPlannerWorkspaceSnapshot` is the sole view-facing planner state. One
+revision contains:
 
-Persistence-backed calls are non-blocking. Failed writes retain the last stable
-state; late asynchronous results cannot replace a newer revision.
+- session catalog and current session
+- resolved participant summaries and budget
+- ordered scene summaries and selected-scene detail
+- linked Encounter summaries and structured generated rewards
+- preparation status and stage progress
+- display-safe missing-reference and failure states
 
-Apply has two explicit consistency boundaries. Encounter first resolves and
-persists the complete generated encounter batch atomically. Only a complete
-number-to-plan-id mapping may enter the Session Planner aggregate, whose scenes
-and reward references are then written in one planner transaction. A planner
-write failure leaves no partial planner mutation; generated Encounter plans
-remain Encounter-owned and a retry uses their persisted generated origin.
-Encounter-channel rewards reference their generated encounter scene. Quest and
-environment rewards are represented by encounter-free Session scenes, keeping
-every generated reward reference within the Session Planner aggregate.
+`SessionPlannerWorkspaceAssembler` loads one planner snapshot, collects foreign
+IDs, performs one batch read per owning feature, and joins immutable results in
+memory. The JavaFX adapter renders that revision and dispatches typed intents;
+it performs no provider calls, persistence, orchestration, or independent
+projection refresh.
 
-## Shell Surface
+Publication is latest-revision-wins. One authored mutation or foreign-provider
+revision schedules at most one coalesced assembly. Scene, participant, controls,
+and state-panel views do not subscribe to separate planner projections.
 
-Session Planner remains one left-bar contribution using cockpit controls, main,
-and state slots. Explicit composition changes construction, not accepted
-observable behavior.
+## Publication Semantics
 
-## Verification
+The application publishes one immutable workspace value at a time. Each value
+contains the source `SessionRevision`, one monotonically increasing publication
+revision, and the preparation status that applies to that source revision.
+Assembly begins from a captured planner snapshot; foreign results are joined
+only if that capture is still current. Completion from a stale capture is
+discarded and cannot overwrite a newer publication.
 
-Target dependency direction is mechanically enforced by `architectureTest`.
-JUnit production routes own persisted-session, integration, and UI proof.
+An in-progress or failed preparation updates status around the last stable
+authored workspace. Only a successful final Session Planner commit may publish
+new authored prepared content. JavaFX applies a complete immutable value in one
+dispatch and never combines sections from different revisions.
+
+## Prepare Session Use Case
+
+```text
+JavaFX Generate intent
+  -> SessionPlannerApi.prepareSession(command)
+  -> capture plan revision + generation inputs + preparation identity
+  -> SessionGenerationApi.draft(request)
+  -> EncounterApi.prepareGeneratedBatch(batch)
+  -> validate PreparedSessionDraft
+  -> commit generation run || commit Encounter plan batch
+  -> replace SessionPlan references
+  -> assemble and publish one workspace revision
+```
+
+The two foreign commits may run concurrently after complete in-memory
+validation. Session Planner commits only after both succeed. The preparation
+identity is derived from session identity, source revision, normalized inputs,
+and seed; Session Generation and Encounter retain it with their content
+fingerprints. A planner write failure therefore leaves reusable immutable
+foreign artifacts rather than triggering compensating deletion.
+
+Preparation never uses persistence as message transport. The generated draft
+and concrete Encounter roster drafts remain typed in-memory values until the
+commit stage. Session Generation validates again at its write boundary;
+Encounter validates the full concrete batch before its transaction.
+
+## Responsibility Boundaries
+
+Session Planner owns:
+
+- the user command, replacement confirmation, captured fingerprint, progress,
+  cancellation, orchestration, and final planner mutation
+- planner-owned session and workspace state
+- translating foreign results into planner references
+
+Session Generation owns:
+
+- deterministic encounter intents, reward generation, audits, catalog
+  identity, immutable generation-run persistence, and typed reward reads
+
+Encounter owns:
+
+- one batch creature-candidate snapshot, concrete roster selection, encounter
+  math, saved-plan validation, and atomic idempotent plan persistence
+
+Party and World Planner own their facts. No feature imports another feature's
+implementation package or repository.
+
+## Execution And Cancellation
+
+- the JavaFX dispatcher only captures intents and applies completed immutable
+  snapshots
+- pure generation and Encounter draft construction run on bounded CPU work
+- resource and SQLite work run on I/O execution; database transactions remain
+  short and contain no generation search
+- no global serial lane encloses the whole preparation workflow
+- each request has a cancellation token and captured fingerprint
+- a newer request, session switch, or relevant authored revision cancels or
+  invalidates older work
+- late completion may contribute diagnostics but cannot publish or commit
+  against a stale fingerprint
+
+Stage timings record stable request identity, stage, duration, candidate count,
+and query count only. Diagnostics exclude authored text, creature payloads,
+generated item text, SQL, and local paths.
+
+## Compact JavaFX Composition
+
+The accepted master-detail timeline remains. The controls adapter renders one
+horizontal preparation toolbar with progressive disclosure for participant
+detail. Saved-plan search belongs to the selected-scene inspector. The Generate
+button and progress share the toolbar; there is no separate preparation card or
+Apply control. Generated rewards use structured cards, while manual loot notes
+use a separate presentation type.
+
+## Performance Model
+
+The hot path has bounded service calls:
+
+- one Party resolution read
+- one immutable Session Generation catalog snapshot per catalog version
+- one Encounter candidate batch read for all generated intents
+- one generation-run transaction and one Encounter-plan batch transaction
+- one Session Planner replacement transaction
+- one batch workspace assembly after commit
+
+It forbids per-slot creature queries, per-creature detail reads, loading every
+saved Encounter plan to render controls, repeated full Session catalogs during
+one assembly, save-then-reload equality checks, and independent projection
+fan-out.
+
+Measurable architecture targets are:
+
+- Generate dispatch and immutable snapshot application are the only
+  preparation work allowed on the JavaFX thread; in-progress publication is
+  eligible for the next pulse.
+- one workspace assembly performs one planner read and at most one batch read
+  each from Party, Encounter, Session Generation, and World Planner, independent
+  of scene, saved-plan, reward, slot, and roster-member cardinality
+- the warmed reference fixture is two level-3 and two level-4 participants,
+  `0.6` adventure days, and three encounters over 20 runs; the complete editable
+  publication must satisfy the 2-second p95 product target
+- catalog initialization, migration, and cold caches are measured separately;
+  each CPU, foreign-read, commit, assembly, and JavaFX-apply stage records its
+  own duration and query count
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- `prepareSession` is the sole preparation use case; it validates one complete
+  typed in-memory preparation before durable commits.
+- The master-detail workspace renders one revisioned workspace snapshot.
+- Encounter preparation produces concrete rosters from one batch candidate
+  boundary; abstract slots are not a planner result.
+- Generated reward truth remains in Session Generation and is batch-projected
+  into Session Planner through stable references.
+- Revision guards, idempotent foreign commits, and one final optimistic planner
+  commit provide retry safety without shared storage ownership.
+
+Rejected alternatives:
+
+- backend preview/apply and save/reload workflow transport
+- multiple independently refreshed planner projections
+- copied foreign reward, creature, Party, or World Planner truth
+- a shared cross-feature transaction, workflow database, saga store, or event
+  bus
+- a remote generator service, dynamic rules plugin system, or second generation
+  UI
+
+## Enforcement And Proof
+
+Architecture enforcement rejects JavaFX orchestration, foreign implementation
+imports, repositories crossing APIs, Session Generation JavaFX code, and
+planner persistence of foreign detail. Production-route proof owns stale-result
+rejection, idempotent retry, all-or-nothing replacement, structured reward
+projection, concrete Encounter rosters, bounded query counts, responsiveness,
+and the warmed reference-fixture threshold.
 
 ## References
 
-- [Session Planner Persistence Contract](../contract/contract-session-planner-persistence.md)
-- [Session Planner Requirements](../requirements/requirements-session-planner.md)
-- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Requirements](../requirements/requirements-session-planner.md)
+- [Domain](../domain/domain-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
 - [Session Generation Architecture](../../sessiongeneration/architecture/architecture-session-generation.md)
-- [Encounter Generated Import](../../encounter/contract/contract-encounter-generated-import.md)
+- [Encounter Generated Preparation](../../encounter/contract/contract-encounter-generated-import.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/sessionplanner/contract/contract-session-planner-persistence.md
+++ b/docs/sessionplanner/contract/contract-session-planner-persistence.md
@@ -1,134 +1,146 @@
-Status: Draft
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Persistence path, reference rules, and error behavior for the
-`sessionplanner` session record.
+Status: Active Target
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Session Planner stored truth, reference semantics, writes, and
+error behavior.
 
 # Session Planner Persistence Contract
 
-## Purpose
+## Owner And Boundary
 
-This contract defines the persisted storage boundary for the `sessionplanner`
-feature.
+The Session Planner SQLite adapter is the only writer of planner-owned session
+records. It implements a feature-owned application port and remains private to
+`SessionPlannerFeature`. SQL records, schema carriers, repositories, and
+adapter failures never cross `SessionPlannerApi`.
 
-Current state persists multiple session records with stable
-  session identity, user-visible display names, and a current-session pointer
-and exposes create/open/rename/delete operations through a planner-owned
-boundary.
+## Final Prepared-Session Commit Operation
 
-Target state:
+The application port exposes one final replacement operation:
 
-- `sessionplanner` keeps persisting its own session record without storing
-  foreign domain internals
+```text
+commitPreparedSession(CommitPreparedSessionCommand)
+  -> CommitPreparedSessionResult
+```
 
-## Adapter Boundary
+`CommitPreparedSessionCommand` contains:
 
-- The session-planner SQLite adapter satisfies planner-owned application ports
-  and remains private to the session-planner composition entry point.
-- The application composition supplies `SessionPlannerApi` explicitly;
-  registry, discovery, mutable published models, repositories, gateways,
-  mappers, and schema types are not public boundaries.
-- SQL records and adapter failures MUST NOT cross `SessionPlannerApi`.
+- target `SessionPlanId` and `expectedRevision`
+- stable preparation identity and normalized prepared-content fingerprint
+- the complete replacement scene order, rests, selection, manual loot notes,
+  and generated reward references
+- already-committed generation-run identity and the complete ordered mapping of
+  generated Encounter numbers to Encounter-plan identities
+
+It contains no foreign domain object, repository carrier, progress state, or
+partially prepared content.
+
+`CommitPreparedSessionResult` is exactly one of:
+
+- `SUCCESS(previousRevision, committedRevision, committedSession)`
+- `INVALID(validationErrors)`
+- `STALE(expectedRevision, currentRevision)`
+- `NOT_FOUND(sessionPlanId)`
+- `STORAGE_FAILURE(displaySafeMessage)`
+
+`SUCCESS` advances the revision exactly once. Every non-success result writes
+nothing. In particular, `STALE` is the optimistic-revision outcome and never
+silently retries against `currentRevision`.
 
 ## Stored Truth
 
-The persisted session record stores only sessionplanner-owned truth:
+The normalized session record stores:
 
-- stable session identity
-- user-visible session display name
-- session-local participant references to party characters
-- exact `encounterDays` planning input
-- ordered session-owned scenes
-- optional references from a scene to an encounter-owned saved plan
-- session-owned scene title and scene notes per scene
-- optional stable World Planner location reference per scene
-- per-scene budget percentages or equivalent planner-owned allocation data
-  when an encounter plan is linked
-- selected scene context
-- session-local rests, placeholders, and planner status or selection truth
-- ordered generated reward references containing session scene identity, typed
-  Session Generation run identity, treasure identity, and a last-known display
-  label
+- stable session identity, display name, and revision
+- the current-session pointer
+- session-local participant references
+- exact adventure-day fraction
+- ordered scenes with title, notes, optional World Planner location ID, and
+  optional Encounter-plan ID
+- allocation data for encounter-linked scenes
+- selected scene identity
+- rests between scenes
+- manual loot notes
+- ordered generated reward references with scene ID, typed generation-run ID,
+  treasure ID, and last-known display label
 
-The session record does not persist:
+It MUST NOT store party membership or character detail, Encounter rosters,
+creature facts, copied World Planner detail, generated item lines, reward
+values, packing rows, audits, catalog rows, generation drafts, preparation
+fingerprints, or progress state.
 
-- party membership truth
-- party character details beyond stable references
-- encounter rosters or copied encounter creature rows
-- creature statblocks or creature lifecycle truth
-- copied World Planner location details
-- loot-object internals or fake gold-budget fields
-- generation previews, preview fingerprints, engine or catalog metadata,
-  encounter-generation specifications, generated reward contents, packing, or
-  audit rows
+`lastKnownLabel` is a display fallback for an unavailable foreign reward. It is
+not reward truth and MUST NOT replace a successful typed reward projection.
 
 ## Reference Rules
 
-- party characters are stored only as stable session participant references
-- scene entries are session-owned truth; their encounter reference is optional
-  and, when present, is stored only as a stable reference to an
-  encounter-owned saved plan
-- World Planner locations are stored only as stable references; location
-  display/detail truth remains World Planner-owned
-- foreign truth must be re-read through the owning public boundary when a
-  session is opened
-- session-owned scene ordering, allocations, rests, placeholders, and selection
-  state remain in sessionplanner persistence even when foreign source data is
-  reloaded
-- every generated reward reference MUST name an existing session-owned scene.
-  Quest and environment rewards use encounter-free scenes; encounter-channel
-  rewards use their generated encounter scene. Run and treasure identities
-  remain foreign stable references and are not SQLite foreign keys into another
-  feature's tables
-- `lastKnownLabel` is a planner-owned display fallback and MUST NOT be treated
-  as generated reward truth
+- foreign identities are stored as typed stable references, not cross-feature
+  SQLite foreign keys
+- every reward reference names an existing scene in the same session
+- Encounter-channel rewards reference their generated encounter scene
+- quest and environment rewards reference encounter-free scenes
+- a missing foreign object remains visibly unavailable; Session Planner does
+  not recreate it from copied data
+- deleting or editing a scene removes or changes only planner-owned references
+- Session Planner never cascades deletion into Party, Encounter, World Planner,
+  or Session Generation storage
 
-## Validation And Error Behavior
+## Writes And Revisions
 
-- session-plan writes MUST reject malformed session identity, participant
-  reference, encounter reference, or allocation payloads instead of silently
-  persisting partial planner truth
-- `encounterDays` MUST be stored as an exact decimal value, not a lossy
-  floating-point approximation
-- persistence payloads MUST reject copied foreign rosters, character detail,
-  creature detail, and loot internals
-- generated reward writes MUST reject non-positive scene or treasure
-  identities, blank generation-run identities, orphaned session-scene
-  references, duplicate ordered references, and malformed labels
-- storage and schema failures MUST surface through Session Planner API result
-  statuses instead of leaking adapter exceptions to consumers
-- failed writes MUST keep the last stable planner-owned current session state
-  visible instead of publishing a half-persisted mutation
-- applying one generation MUST persist all new scene and generated reward
-  references in the same Session Planner transaction
+Every authored command uses optimistic revision validation. A successful write
+replaces the root and affected child collections in one Session Planner
+transaction, advances the revision once, and returns the committed snapshot.
+A stale revision or invalid payload writes nothing.
 
-## Stability Rules
+`commitPreparedSession` is one replacement write. It preserves session
+identity, display name, participants, and adventure-day fraction while
+atomically replacing generated scenes, rests, manual loot notes, reward
+references, selection, and revision. The command accepts only already-persisted
+generation-run and Encounter-plan identities returned by their owning APIs.
 
-- session-plan persistence remains behind a feature-owned application port
-  implemented by the Session Planner SQLite adapter and wired by the feature
-  composition entry point
-- sessionplanner persistence stays the canonical home for session-owned
-  allocations and selection state even when later workflows trigger encounter
-  or loot mutations through foreign boundaries
-- the current pointer model identifies the active persisted session and does
-  not collapse the persisted catalog back to a single-session domain limit
-- the canonical normalized generated-reward child table is introduced by a
-  contiguous Session Planner feature migration and is replaced atomically with
-  the other child collections for one session
+Before any write, the adapter validates target identity and revision, the
+prepared-content fingerprint, exact decimals, contiguous ordering, positive
+foreign identities, unique scene and reward keys, valid rest gaps,
+scene-local reward references, a complete Encounter-number mapping, and all
+optional reference shapes. Partial child replacement is forbidden.
 
-## Verification Notes
+## Cross-Feature Retry
 
-- This contract is currently `Review-Owned`.
-- Review must reject persisted fields that duplicate encounter rosters, party
-  character internals, creature detail, or loot internals.
-- Review must reject persisted preview fingerprints or copied Session
-  Generation result rows.
-- Review must reject persistence types or internal collaborators crossing
-  `SessionPlannerApi`.
+Session Generation and Encounter commits precede the Session Planner write and
+are idempotent by deterministic origin plus content fingerprint. If the planner
+write fails, their immutable artifacts remain valid foreign truth. Retrying the
+same preparation reuses them; it does not create duplicates or delete them as
+compensation.
+
+This contract deliberately does not create a cross-feature transaction or a
+workflow journal in Session Planner persistence. In-flight preparation state is
+runtime state. A process restart may require the user to request preparation
+again; idempotency makes that retry safe.
+
+## Migration And Compatibility
+
+Feature migrations remain contiguous under the existing Session Planner owner
+key. New columns or child tables are added by a new migration and never by
+rewriting an applied migration.
+
+Existing canonical sessions remain readable throughout the replacement.
+Legacy manual loot-placeholder rows migrate losslessly to manual loot notes.
+Existing generated reward references retain their run and treasure identities.
+No migration copies foreign reward or roster detail into Session Planner.
+
+Real user data is never deleted or rewritten destructively without the
+owner-approved backup boundary.
+
+## Error Contract
+
+Validation errors identify the invalid command field or invariant without
+echoing authored content. Failure messages are display-safe and contain no SQL,
+exception text, paths, generated item payloads, or authored notes. A failure
+leaves the last stable workspace revision visible.
 
 ## References
 
-- [Session Planner Domain Model](../domain/domain-session-planner.md) (line 1)
-- [Session Planner Architecture](../architecture/architecture-session-planner.md) (line 1)
-- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Domain](../domain/domain-session-planner.md)
+- [Architecture](../architecture/architecture-session-planner.md)
+- [Shared Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
 - [Session Generation Contract](../../sessiongeneration/contract/contract-session-generation.md)
+- [Encounter Generated Preparation](../../encounter/contract/contract-encounter-generated-import.md)

--- a/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
+++ b/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
@@ -1,0 +1,441 @@
+Status: Temporary Migration
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Ordered replacement milestones, compatibility budget, deletion
+gates, and current migration position for Session preparation.
+
+# Session Planner Greenfield Roadmap
+
+## Purpose
+
+This roadmap replaces the current Session Planner generation workflow with the
+durable target defined by the Session Planner, Session Generation, and
+Encounter owner documents. It preserves accepted user behavior while allowing
+internal APIs, state models, persistence flow, execution, and JavaFX
+composition to be rebuilt without compatibility obligation beyond the explicit
+budget below.
+
+This file owns temporary order and migration status. It does not own durable
+behavior, domain truth, contracts, architecture, or test inventories. Delete it
+after M6 closes every named legacy boundary and the owner accepts the result.
+
+## Authoritative Facts
+
+- Session Planner owns authored session plans and the preparation interaction.
+- Party, Encounter, World Planner, and Session Generation retain their own
+  truth; Session Planner stores stable references and planner metadata.
+- Generate is one user action. Empty sessions apply the complete result
+  directly; replacing existing content requires prior confirmation.
+- A successful generated session contains concrete Encounter-owned saved
+  rosters and structured Session Generation rewards, not only labels or text.
+- The completed generated session is immediately editable.
+- The master-detail scene workspace remains; controls, Generate, and state
+  summary become compact.
+- Backend replacement precedes architecture enforcement and performance proof;
+  the frontend converges only after those seams are stable.
+- Existing canonical Session Planner, Session Generation, and Encounter data
+  remains readable. Proof-of-concept schema and Java compatibility are not
+  retained.
+
+## Current Structural Problem
+
+The current workflow models one click as a hidden preview followed by Apply.
+Session Generation saves and reloads the result before the workflow can
+continue. Encounter then resolves abstract XP-and-role slots through repeated
+creature lookups. Session Planner publishes several projections that rebuild
+overlapping context, hydrate saved plans and creatures repeatedly, and project
+generated reward truth mainly through fallback labels. One global serial
+execution lane can serialize CPU generation, I/O, projection, and unrelated
+commands.
+
+The result can be technically persisted while still looking like generic text:
+Encounter composition is selected after generation with weak diversity, and
+the planner does not render the structured loot rows the generator already
+owns. Latency grows with saved plans, scenes, slots, and roster members instead
+of staying bounded by data family.
+
+The principal current evidence is
+`features/sessionplanner/application/SessionGenerationCoordinator.java`,
+`features/sessionplanner/application/SessionPlannerProjection.java`,
+`features/sessionplanner/application/SessionPlannerPublishedState.java`,
+`features/encounter/application/GeneratedEncounterPlanImportService.java`, and
+`platform/execution/SerialExecutionLane.java`.
+
+PR #512 at reviewed commit `58660a1ec` is the visual and interaction donor for
+the accepted master-detail surface. It is not the backend migration base: M6
+adapts its useful layout and editing behavior only after the target application
+seams and enforcement are complete.
+
+## Target Outcome
+
+The completed replacement has:
+
+- one `prepareSession` application use case and no UI preview/apply chain
+- one complete typed `PreparedSessionDraft` before any durable commit
+- Session Generation draft and idempotent commit operations with no hot-path
+  save/reload transport
+- Encounter batch preparation from one creature candidate snapshot, concrete
+  roster summaries, and one atomic idempotent commit
+- structured generated reward batch reads and reward cards
+- one immutable revisioned Session Planner workspace snapshot assembled from
+  bounded batch reads
+- bounded CPU execution, separate short I/O transactions, cancellation, and
+  latest-fingerprint-wins publication
+- one compact preparation toolbar, selected-scene Encounter search, compact
+  state summary, and the accepted master-detail scene workspace
+- production-route proof for consistency, query bounds, responsiveness, and
+  the reference performance fixture
+- no legacy preview model, abstract generated-slot import, repeated projection
+  fan-out, or generation use of the global serial lane
+
+The target remains a local modular monolith. It adds no remote service,
+cross-feature database transaction, event bus, workflow database, rules plugin
+system, or second generation surface.
+
+## Surface Disposition
+
+The deletion milestone column is authoritative. A rejected surface is deleted
+in that milestone only; earlier milestones may stop adding callers but may not
+create a second retirement owner.
+
+| Current surface | Decision | Migration consequence | Deletion milestone |
+| --- | --- | --- | --- |
+| `SessionPlan`, scene order, participants, allocations, rests, and foreign references | Adopt | Preserve ownership and observable authored behavior. | - |
+| Master-detail scene workspace, auto-commit editing, reorder, budget editing, summary | Adopt | Retain as the final JavaFX foundation. | - |
+| Pure staged Session Generation engine and immutable normalized run | Adapt | Keep rules and run truth; split in-memory draft from idempotent commit. | - |
+| Current `generate`/`load` save-reload workflow transport and its deprecated delegates | Reject | Continue with the typed in-memory draft and persist once. | M3 |
+| Preview fingerprint and request token | Adapt | Become preparation fingerprint and cancellation/latest-wins guard. | - |
+| Backend preview/Apply commands, models, coordinator, projection, and persistence assumptions | Reject | Use one Session Planner preparation command and one final planner commit. | M3 |
+| UI auto-Apply dispatch and hidden second-command chaining | Reject | One Generate intent reaches ready state directly. | M3 |
+| Preview/Apply UI chrome and nested preparation controls | Reject | Render one compact preparation toolbar with no preview surface. | M6 |
+| XP/role slot import, first-match selection, and per-slot or per-member creature queries | Reject | Use one candidate snapshot and concrete roster-batch preparation. | M2 |
+| Duplicate generated-origin writer | Reject | Use one atomic idempotent Encounter batch commit. | M2 |
+| Backend `LootPlaceholder`/fallback-label projection of available generated reward truth | Reject | Batch-project typed Session Generation reward detail. | M4 |
+| Generated loot-placeholder UI presentation | Reject | Render structured reward cards and separate manual notes. | M6 |
+| Independent planner publications and repeated context or foreign-detail projection | Reject | Use one coalesced workspace snapshot. | M4 |
+| Full saved Encounter catalog in controls | Reject | Search and attach from the selected-scene inspector. | M6 |
+| Global serial lane for the preparation hot path | Reject | Use bounded CPU work, I/O execution, and short transactions. | M5 |
+| Compatibility constructors, duplicate APIs other than the M1 delegates, and no-op fallbacks introduced by migration | Reject | Keep only canonical target seams. | M5 |
+| Version/revision guards and failed-write stable state | Adopt | Preserve and prove across the new workflow. | - |
+
+## Delete And Retire Rule
+
+The migration is incomplete while production depends on any rejected surface
+in the disposition table. Each milestone's Delete section executes only its
+assigned rows. Backend preview/Apply behavior belongs to M3; visually retained
+preview/Apply chrome belongs to M6 and may not carry orchestration after M3.
+
+## Temporary Compatibility Budget
+
+Two temporary surfaces are allowed:
+
+1. M4 may add one package-private `LegacySessionPlannerPublicationAdapter` that
+   derives the existing view publications from the new workspace snapshot. It
+   performs no reads or writes and is deleted in M6.
+2. M1 may retain the current Session Generation `generate/load` API methods as
+   deprecated delegates while the production caller moves. They receive no new
+   caller and are deleted in M3.
+
+Existing canonical generated-origin rows may be normalized by the owning
+persistence adapter on read. That is durable data compatibility, not permission
+for dual writes or a second origin model. No other bridge, shadow state,
+parallel schema, nullable dependency, or dual-write path may cross a milestone.
+
+## Dependency Order
+
+```text
+M0 Target Lock And Roadmap
+  -> M1 Session Generation Draft/Commit
+      -> M2 Concrete Encounter Batch Preparation
+          -> M3 Prepare Session Orchestration And Persistence
+              -> M4 Workspace Snapshot And Structured Projection
+                  -> M5 Enforcement, Performance, And Legacy Deletion
+                      -> M6 Compact Frontend And Owner Acceptance
+```
+
+## Chosen Migration Strategy
+
+Use a backend-first replacement with one vertical production route at every
+milestone. M1 makes Session Generation capable of drafting and committing its
+own truth; M2 does the same for concrete Encounter batches; M3 replaces the
+preparation orchestration only after both APIs exist; M4 consolidates reads and
+publication on top of those delivered batch boundaries; M5 makes the new shape
+enforceable and proves its performance; M6 then compacts a passive UI against
+stable application state.
+
+This order prevents frontend work from hardening the current preview model and
+keeps every intermediate branch runnable. It also localizes rollback: before
+M3 the accepted workflow still uses its old calls, while after M3 the new path
+owns preparation behavior and the old workflow can be deleted. M4 changes only
+how already-owned facts are assembled and published.
+
+Rejected alternatives:
+
+- compact the current UI first: this would preserve the slow projection and
+  preview/apply seams behind cleaner chrome
+- optimize point queries in place: this would leave abstract encounters,
+  save/reload transport, and duplicate publications as permanent concepts
+- merge Session Generation into Encounter: reward/audit truth and saved-roster
+  truth have different ownership and lifecycles
+- use a shared transaction, saga store, or event bus: local idempotent commits
+  provide the required consistency with less infrastructure and fewer failure
+  modes
+- maintain old and new workflows in parallel until final cutover: that would
+  create two behavior owners and invalidate production-route proof
+
+## Verification Thesis
+
+The replacement is accepted only when proof follows the production route from
+one Generate intent to one published editable workspace. Unit proof may isolate
+pure generation and Encounter selection policies, but cannot substitute for
+cross-feature consistency, real SQLite adapters, bounded query counts, JavaFX
+responsiveness, or owner-visible output. Every milestone refreshes whitespace,
+`./gradlew check`, and desktop-install proof after its final diff. M5 owns the
+stable benchmark and architecture gates; M6 additionally owns final owner
+acceptance after the last UI diff.
+
+## Current Migration Position
+
+- Current foundation: the owner documents define the greenfield target and this
+  roadmap is the only migration sequence owner.
+- Current milestone: M0 remains open until every M0 document criterion is true
+  and the final candidate has literal green `git diff --check`,
+  `./gradlew check`, and `./gradlew installDesktopApp` results. Whitespace proof
+  alone does not close M0.
+- Next milestone: M1 captures stage baselines and replaces Session Generation's
+  hot-path persistence contract before planner orchestration changes.
+
+## Delivery Rules
+
+Every milestone, including documentation-only M0, MUST:
+
+1. finish its final diff with green `git diff --check`, `./gradlew check`, and
+   `./gradlew installDesktopApp`
+2. preserve a runnable production Session Planner
+3. for M1 through M6, move a real production route toward the target rather
+   than testing a parallel implementation
+4. delete replaced code in the assigned milestone unless the compatibility
+   budget names it
+5. perform no destructive rewrite of real user data
+6. keep JavaFX passive and foreign truth behind public owning APIs
+7. record literal benchmark parameters and results for performance-changing
+   milestones without turning this roadmap into a report archive
+8. for milestones with behavior changes, leave owner-visible behavior ready to
+   test
+
+## M0: Target Lock And Roadmap
+
+### Deliver
+
+- remove preview/apply as target behavior and current-state prose from durable
+  owner docs
+- define one-click preparation, concrete Encounter rosters, structured rewards,
+  one workspace snapshot, bounded execution, and performance acceptance
+- align Session Planner, Session Generation, and Encounter ownership
+- establish this roadmap as the sole migration and deletion owner
+
+### Exit Gate
+
+- durable requirements contain only observable behavior
+- domain documents identify each write model and invariant once
+- contracts define draft/commit, idempotency, batch reads, data compatibility,
+  and error vocabulary
+- architecture defines orchestration, execution, publication, quality targets,
+  and rejected alternatives
+- every rejected current surface has one deletion milestone
+- final `git diff --check` is green
+- final `./gradlew check` is green
+- final `./gradlew installDesktopApp` is green
+
+## M1: Session Generation Draft And Commit
+
+### Deliver
+
+- capture separate catalog-load, engine, persistence, and reward-read baselines
+- publish typed `draft`, idempotent `commit`, `load`, and reward batch-read
+  operations
+- keep generation stages pure and run them on bounded CPU execution
+- cache one validated immutable catalog snapshot per content identity
+- add normalized run content fingerprint and canonical-row compatibility read
+- expose structured reward detail without formatted-text dependence
+
+### Exit Gate
+
+- draft performs no SQLite write
+- commit persists exactly the supplied semantic draft once
+- equal retry succeeds and identity/content conflict fails closed
+- canonical runs still load with their recorded engine/catalog meaning
+- engine, persistence, and reward-read benchmarks are independently visible
+
+### Retain Temporarily
+
+- the current production `generate`/`load` delegates remain only for the caller
+  that M3 replaces; M3 deletes them and their save-reload continuation
+
+## M2: Concrete Encounter Batch Preparation
+
+### Deliver
+
+- publish Encounter prepare and commit operations for one generated intent batch
+- load one union candidate snapshot for the complete batch
+- deterministically create diverse concrete rosters and structured summaries
+- persist the exact prepared batch atomically with idempotent origin
+- batch-hydrate saved-plan summaries used by downstream planning
+
+### Exit Gate
+
+- every prepared Encounter has stable creature identities and positive
+  quantities before any write
+- no exact-XP or creature-detail query runs once per block or roster member
+- any unresolvable intent returns no draft; any commit failure writes no plan
+- equal retry returns the complete existing mapping
+- the prepared summaries expose label, roster, count, adjusted XP, and
+  difficulty
+
+### Delete
+
+- current abstract generated-plan spec and slot import
+- first-match exact-XP selection policy and per-slot creature queries
+- duplicate generated-origin write path
+
+## M3: Prepare Session Orchestration And Persistence
+
+### Deliver
+
+- add one `prepareSession` use case with confirmation, fingerprint,
+  cancellation, progress, and latest-wins behavior
+- assemble and validate one complete `PreparedSessionDraft` in memory
+- commit Session Generation and Encounter artifacts idempotently, then replace
+  Session Planner references in one transaction
+- migrate manual placeholders to manual loot notes without losing data
+
+### Exit Gate
+
+- one Generate intent reaches ready state without a second UI command
+- stale, cancelled, invalid, or failed preparation changes no session
+- successful preparation produces real saved Encounter rosters and typed reward
+  references
+- retry after either foreign or planner storage failure creates no duplicates
+- existing canonical sessions and generated reward references reopen
+
+### Delete
+
+- backend preview and Apply commands, models, coordinator, generation-preview
+  projection, and persistence assumptions
+- UI auto-Apply dispatch and hidden second-command chaining
+- deprecated Session Generation API delegates
+- production generate/load save-reload continuation and generated-result
+  equality checks used only as workflow transport
+
+## M4: Workspace Snapshot And Structured Projection
+
+### Deliver
+
+- introduce `SessionPlannerWorkspaceSnapshot` and one application-owned
+  assembler using the delivered Party, Encounter, Session Generation, and World
+  Planner batch reads
+- coalesce mutation and foreign-provider refresh into one latest-revision-wins
+  publication
+- batch-project structured generated rewards into the workspace
+- introduce the single permitted legacy publication adapter if still needed
+
+### Exit Gate
+
+- all four visible planner regions render from one coherent revision
+- one assembly performs one planner read and at most one batch read per foreign
+  owner
+- generated Encounter and reward detail is typed and no longer label-only
+- query-count proof fails on per-scene, per-plan, reward, or creature reads
+- stale assembly cannot replace a newer session revision
+
+### Delete
+
+- provider reads and context reconstruction from individual projections
+- duplicate saved-plan, reward, and creature hydration inside one refresh
+- backend generated `LootPlaceholder` and fallback-label projection when typed
+  reward truth is available
+
+## M5: Enforcement, Performance, And Legacy Deletion
+
+### Deliver
+
+- enforce JavaFX passivity, feature dependency direction, single workspace
+  publication, and absence of retired preview or slot-import types
+- add production-route consistency, cancellation, retry, query-bound, and
+  reference-fixture performance proof
+- remove remaining global-serial-lane use from the preparation path
+- measure and optimize stage hotspots using the new diagnostics
+
+### Exit Gate
+
+- architecture gates mechanically reject every enforceable retired boundary
+- bounded query proof is independent of scene, saved-plan, slot, and member
+  cardinality
+- warmed canonical three-Encounter fixture is within 2 seconds p95 over 20 runs
+- JavaFX thread proof covers dispatch and immutable snapshot application only
+- `./gradlew check` is green after the final backend deletion diff
+
+### Delete
+
+- compatibility constructors, duplicate APIs other than the M1 delegates,
+  no-op routes, and global-serial preparation orchestration
+- temporary backend metrics or probes that are not part of local diagnostics
+
+## M6: Compact Frontend And Owner Acceptance
+
+### Deliver
+
+- render one compact preparation toolbar with progressive participant detail
+- place saved-Encounter search and attach actions in the selected-scene
+  inspector
+- render structured reward cards and separate manual loot notes
+- compact the state summary while retaining budget and selection context
+- complete visual, interaction, generation-quality, and latency acceptance with
+  the owner
+
+### Exit Gate
+
+- no nested preparation panel, redundant Generate card, permanent participant
+  detail block, or full saved-plan control list remains
+- the master-detail workflow retains edit, reorder, allocation, and selection
+  behavior
+- generated sessions visibly contain concrete rosters and structured loot
+- all changed behavior has production-route proof, `./gradlew check` and desktop
+  install are green, and the owner approves the complete feature
+
+### Delete
+
+- `LegacySessionPlannerPublicationAdapter`
+- old controls, generation panel, preview/Apply chrome, generated
+  loot-placeholder rendering, full saved-plan controls list, and duplicate state
+  widgets
+- this roadmap and its README link after the final migration merge
+
+## Risks And Dependencies
+
+- Encounter diversity is a policy concern, not only a query optimization. M2
+  must prove deterministic alternatives and avoid accidental identical rosters
+  when equivalent candidates exist.
+- Existing canonical origin rows cannot be destructively rewritten. The
+  Encounter adapter must normalize old and new origins behind one domain model.
+- Foreign artifacts may exist without a Session Planner reference after a
+  failed final write. They are immutable and idempotent; retry reuses them.
+  Automatic deletion would be unsafe and is rejected.
+- Catalog cold-load time can hide hot-path improvements. M1 and M5 report cold
+  initialization separately from warmed preparation.
+- The frontend change must not recreate provider orchestration while compacting
+  layout. M6 consumes only the application snapshot and typed intents.
+
+## Remaining Uncertainty
+
+- The exact current query and stage-time baseline is not durable product truth;
+  M1 measures it on the named fixture before optimization.
+- Creature availability may make some role/CR intent combinations impossible.
+  M2 must define and prove deterministic fallback quality without weakening the
+  all-or-nothing batch result.
+- Canonical databases may contain older generated origins in combinations not
+  represented by fixtures. M2 inventories shapes through read-only migration
+  tests before removing the old writer.
+- The open master-detail frontend may merge before or during backend work. Its
+  observable layout is adopted, but M6 rebases it onto the target workspace
+  snapshot rather than retaining its internal models.

--- a/docs/sessionplanner/domain/domain-session-planner.md
+++ b/docs/sessionplanner/domain/domain-session-planner.md
@@ -1,150 +1,113 @@
-Status: Draft
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Session planner context role, session-record ownership, and
-domain invariants.
+Status: Active Target
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Session Planner language, authored truth, and invariants.
 
 # Session Planner Domain Model
 
-## Context Role
+## Context Role And Ownership
 
-Context Role: Roster Truth Context
-Context Name: SessionPlanner
+Context Name: `SessionPlanner`
 
-- `sessionplanner` owns the authored planning record for one adventure session
-- its public boundary is `SessionPlannerApi`
-- it does not own party truth, encounter-plan roster truth, creature truth, or
-  generated-run truth
+Context Role: Authored Session Preparation Context
+
+Session Planner owns the editable preparation record for one session. Party,
+Encounter, Creatures, World Planner, and Session Generation retain their own
+truth. Session Planner records stable references to foreign truth without
+copying that truth into its model.
 
 ## Published Language
 
-`SessionPlannerApi` owns planner commands, rest-kind vocabulary, and immutable
-revisioned planner state.
+The feature publishes:
 
-- the feature publishes planner-owned workflows and one immutable state surface
-- it does not publish encounter persistence carriers, creature-detail carriers,
-  or party mutation carriers; those stay owned by their original contexts
-- generation preview state publishes a typed fingerprint and readiness state;
-  it does not republish engine or catalog versions as a user-selectable ruleset
+- `SessionPlanId`, `SessionSceneId`, and optimistic `SessionRevision`
+- session catalog summaries and authored-session commands
+- `PrepareSessionCommand` and `PreparationStatus`
+- immutable session and scene summaries containing typed foreign references
 
-## Application Boundary
+SQL rows, repositories, JavaFX controls, and foreign internal models are not
+part of the published language.
 
-The Session Planner application coordinates:
+## Write Model
 
-- session-plan reads and writes through a planner-owned repository port
-- active-party composition reads needed to resolve participant references
-- party-based adventuring-day calculations
-- saved encounter-plan budget reads through the encounter public boundary
-- generation previews through `SessionGenerationApi`
-- generated-plan batch import through Encounter's public boundary
-- session-local workflow mutations
-- publication of immutable, revisioned planner API state
+`SessionPlan` is the sole Session Planner write model and aggregate root. It
+owns:
 
-- planner state is exposed only through `SessionPlannerApi`
-- the application boundary remains orchestration only while `SessionPlan` owns the
-  authored planning truth
-- party and encounter rules stay in their owning contexts
-
-## Aggregate Model
-
-Aggregate Root: SessionPlan
-
-`SessionPlan` owns the persisted planning record for one session. It stores:
-
-- stable session identity
-- user-visible session display name
+- stable identity, display name, and revision
 - session-local participant references
-- exact `encounterDays` planning input
-- ordered session-owned scenes
-- optional encounter-plan reference for each scene
-- session-owned scene title, notes, and optional World Planner location
-  reference for each scene
-- per-scene budget allocations when an encounter plan is linked
-- selected scene context
-- placed rests and loot placeholders
-- ordered references from session scenes to generated rewards, consisting of
-  scene identity, typed generation-run identity, treasure identity, and a
-  last-known display label
-- session-local status and selection truth
+- exact encounter-day fraction
+- ordered scenes with title, notes, and optional World Planner location ID
+- optional Encounter plan ID and planner-owned allocation per scene
+- selected scene identity
+- rests between scenes
+- manual loot notes
+- ordered generated reward references consisting of scene ID, generation-run
+  ID, treasure ID, and a last-known display fallback
 
-It derives:
+It does not embed party details, Encounter rosters, creature details, World
+Planner records, generated item lines, packing rows, audits, or engine metadata.
+Preparation work that has not replaced the aggregate is transient derived
+state, never a second write model or authored truth.
 
-- total planned encounter XP from linked encounter-owned summaries
-- remaining and exceeded XP budget
-- recommended rest counts
-- importable saved encounter-plan budget summaries
-- whether the current generation preview fingerprint still matches the current
-  session and generation controls
+## Mutation Language And Invariants
 
-The aggregate does not embed party membership, encounter rosters, creature
-detail, generated encounter specifications, generated reward contents, packing
-rows, audits, engine versions, or catalog snapshots.
+Mutation language covers:
 
-`GenerationPreviewLock` is derived runtime state, not part of `SessionPlan`.
-Its fingerprint covers session identity and revision, resolved participant
-levels, adventure-day fraction, optional encounter count, and seed. It is
-`READY` only when those values still match the preview and all hard audits
-pass; otherwise it is `STALE` or non-applicable.
-
-## Commands And Invariants
-
-Commands entering the runtime model are:
-
-- create session plan
-- add or remove session participant reference
-- add or remove a session scene
-- attach or detach saved encounter-plan reference on a scene
-- update scene title, scene notes, and optional World Planner location
-  reference for a scene
-- reorder scenes
-- change scene allocation when an encounter plan is linked
-- set or clear a rest in one scene gap
-- add or remove a loot placeholder
-- select the current session scene context
-- accept one current generation preview after Encounter returns the complete
-  generated-plan import mapping
+- create, open, rename, or delete a session
+- add or remove a session participant reference
+- add, edit, remove, or reorder a scene
+- attach or detach one saved Encounter plan
+- change one linked-scene allocation
+- set or clear one rest in a scene gap
+- add or remove one manual loot note
+- select one scene
+- replace prepared content as one complete authored mutation
 
 Core invariants:
 
-- planner XP math is based on public party and encounter reads only
-- session participant count is the number of session participant references
-- the persistence model holds multiple session records and one current
-  session pointer
-- scenes keep the session-local order chosen by the planner
-- rests can exist only between adjacent scenes
-- each scene may refer to one encounter-owned saved plan, but scenes may also
-  have no linked encounter
-- each scene may reference one World Planner location by stable ID
-  without copying location detail
-- sessionplanner persists only references and planner-owned metadata, never
-  foreign encounter or party internals
-- loot placeholders do not contribute fake XP or fake gold values
-- a generation preview cannot mutate the aggregate before Apply
-- one Apply mutation adds imported encounter-plan references in generation
-  order and adds only stable generated-reward references
-- every generated reward reference names an existing session scene
-- every generated reward reference uses a non-blank typed generation-run
-  identity and positive treasure identity
-- encounter-channel rewards reference their generated encounter scene; quest
-  and environment rewards create encounter-free session scenes
-- removing a scene prunes its generated reward references
-- preview fingerprints and preview contents are derived runtime state and are
-  never persisted as authored session truth
+- the current pointer names one existing persisted session
+- a session revision changes for every authored mutation
+- participant references are unique within a session
+- scene identities and order are unique within a session
+- rests exist only between adjacent scenes
+- each scene references at most one Encounter plan and one World Planner
+  location
+- generated reward references name an existing session scene and one positive
+  treasure identity in one non-blank generation run
+- encounter-channel rewards reference their generated Encounter scene; quest
+  and environment rewards reference encounter-free scenes
+- manual loot notes never masquerade as generated reward detail
+- incomplete preparation never mutates `SessionPlan`
+- prepared-content replacement applies to the exact session identity and
+  revision it read; concurrent authored edits reject the replacement
+- removing a scene removes its planner-owned reward references without deleting
+  foreign generated runs or saved Encounter plans
 
-## Consistency Model
+## Derived State
 
-- reopening a session restores session-owned participant refs, scene order,
-  allocations, selection, rests, and placeholders
-- party, encounter, creature, and later loot truth are re-read through their
-  owning boundaries instead of being copied into session persistence
-- generated reward detail is re-read from Session Generation by run and
-  treasure identity; the last-known label remains a display fallback only
+Session Planner derives, without creating another write model:
+
+- participant summaries and planning readiness
+- budget, planned XP, remaining or exceeded XP, and rest guidance
+- ordered scene summaries and selected-scene detail
+- linked and attachable Encounter summaries
+- hydrated generated rewards and manual loot-note presentation
+- preparation lifecycle, stage, warnings, and retry availability
+
+All presentation sections for one published view describe the same source
+`SessionRevision`.
+
+## Consistency Boundary
+
+One `SessionPlan` mutation is the Session Planner consistency boundary. Foreign
+generated runs and saved Encounter plans remain immutable truth in their owning
+contexts even when a planner reference is absent or later removed. Session
+Planner never compensates by deleting that foreign truth.
 
 ## References
 
-- [Session Planner Requirements](../requirements/requirements-session-planner.md) (line 1)
-- [Session Planner Architecture](../architecture/architecture-session-planner.md) (line 1)
-- [Session Planner Persistence Contract](../contract/contract-session-planner-persistence.md) (line 1)
-- [Party Domain Model](../../party/domain/domain-party.md) (line 1)
-- [Encounter Domain Model](../../encounter/domain/domain-encounter.md) (line 1)
-- [Session Generation Domain Model](../../sessiongeneration/domain/domain-session-generation.md)
+- [Requirements](../requirements/requirements-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
+- [Architecture](../architecture/architecture-session-planner.md)
+- [Encounter Domain](../../encounter/domain/domain-encounter.md)
+- [Session Generation Domain](../../sessiongeneration/domain/domain-session-generation.md)

--- a/docs/sessionplanner/requirements/requirements-session-planner.md
+++ b/docs/sessionplanner/requirements/requirements-session-planner.md
@@ -1,181 +1,148 @@
-Status: Draft
-Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: User-facing behavior and acceptance criteria for the session
-planner session record and planning workspace.
+Status: Active Target
+Owner: Session Planner Feature
+Last Reviewed: 2026-07-18
+Source of Truth: Observable Session Planner behavior and acceptance criteria.
 
 # Session Planner Requirements
 
 ## Goal
 
-Provide one session-owned planning surface that:
+Give a game master one compact workspace for authoring and preparing a session.
+The planner MUST support manual planning and one-click deterministic preparation
+that produces editable scenes with concrete saved encounters and structured
+generated rewards.
 
-- creates or loads one persisted session plan
-- stores session-local participant references without mutating party
-  membership
-- uses those session participants as the planning baseline
-- stores how many encounter days the session covers
-- stores ordered session-owned scenes with title, notes, and an optional World
-  Planner location reference
-- lets a scene optionally reference one saved encounter plan; scenes are not
-  encounters and may exist without an encounter
-- shows the session XP budget and the remaining or exceeded amount
-- attaches saved encounter plans as optional scene encounter references
-- recommends how many short and long rests the planned encounter XP implies
-- lets the user place rests between planned scenes
-- previews deterministic session generation before it changes the authored plan
-- applies a current preview as encounter-plan and generated-reward references
+## Authored Planning
+
+The user can:
+
+- create, open, rename, and delete persisted session plans
+- add or remove session participants without changing Party membership
+- set the adventure-day fraction used for planning
+- add, edit, remove, and reorder session-owned scenes
+- give a scene a title, notes, and optional World Planner location
+- attach or detach one saved Encounter plan through an action on the selected
+  scene
+- allocate encounter budget per encounter-linked scene
+- see session XP budget, planned XP, remaining or exceeded XP, and recommended
+  rests
+- place short and long rests only between adjacent scenes
+- record manual loot notes without presenting them as generated loot
+- select a scene and edit all planner-owned fields after generation
+
+Scenes exist independently of encounters. Encounter rosters, creature details,
+party members, locations, and generated reward contents remain owned by their
+source features.
+
+## Compact Workspace
+
+The Session Planner is one master-detail workspace:
+
+- the main area shows the ordered scene list and the selected scene inspector
+- the controls slot uses one compact preparation toolbar rather than nested
+  cards
+- session selection and session actions, participant summary, adventure-day
+  input, optional encounter count, Generate, progress, and failure status fit
+  in that toolbar
+- participant detail may expand on demand without permanently consuming the
+  controls slot
+- saved Encounter plans are searched and attached from the selected scene;
+  the controls slot does not render the full saved-plan catalog
+- the state slot shows a compact budget and selection summary
+- generated rewards appear as structured reward cards in their owning scene;
+  manual loot notes remain visually and semantically distinct
+
+The Generate action MUST remain available without exposing a ruleset selector,
+engine version, catalog version, or an intermediate Apply button.
+
+## Session Preparation Flow
+
+1. The user selects a session and requests generation.
+2. If replacing existing scenes, rests, generated reward references, or manual
+   loot notes would be destructive, the planner asks for explicit confirmation
+   before work starts. An empty session needs no confirmation.
+3. Preparation runs asynchronously. The existing workspace remains usable and
+   shows stage progress while encounters and rewards are prepared.
+4. Success publishes the complete generated session as the current editable
+   planner state without an intermediate preview or second Apply action.
+
+If the selected session or relevant inputs change while preparation is
+running, the older result MUST NOT replace the newer authored state. Invalid
+input, generation failure, encounter resolution failure, or saving failure
+leaves the existing session unchanged and exposes an actionable stage status.
+A retry of the same request MUST NOT create visible duplicate runs, Encounter
+plans, scenes, or rewards.
+
+## Generated Output
+
+Every generated encounter scene MUST reference a real Encounter-owned saved
+plan whose concrete roster contains stable creature identities and quantities.
+The scene shows at least the plan label, difficulty, adjusted XP, creature
+count, and concrete roster summary.
+
+Every generated reward MUST be visible as structured Session Generation truth,
+including its channel and generated item lines with quantities. Value, magic,
+curse, and packing facts are shown when present. Encounter-channel rewards
+attach to their generated encounter scene. Quest and environment rewards use
+encounter-free scenes. A generated reward MUST NOT be projected as a manual
+loot placeholder or reduced to a last-known label while its source is
+available.
+
+Generated scenes and planner-owned metadata are editable after preparation.
+Editing or removing a scene does not mutate or delete the immutable generation
+run or Encounter-owned saved plan.
+
+## Visible Preparation States
+
+- `idle`: no preparation is running
+- `confirming-replacement`: destructive replacement awaits the user's choice
+- `generating`: Session Generation is computing encounters and rewards
+- `resolving-encounters`: concrete Encounter rosters are being prepared
+- `saving`: the complete prepared result is being saved
+- `ready`: the authored session contains the completed result
+- `invalid`: current inputs cannot produce a session
+- `failed`: a stage failed and authored truth is unchanged
+
+The last stable workspace remains visible in every non-ready state.
 
 ## Non-Goals
 
-- editing encounter-plan rosters inside the session planner
-- mutating party membership when a character is added to or removed from a
-  session
-- copying encounter rosters, party character details, creature statblocks, or
-  loot internals into sessionplanner-owned truth
-- copying World Planner location details into sessionplanner-owned truth
-- deriving gold budgets from provisional heuristics
-- owning generation formulas, generated reward detail, or generated encounter
-  import
-- replacing the encounter state tab or the party dropdown
-- showing a generation ruleset selector or ruleset-version label
+- editing Encounter rosters or creature statblocks inside Session Planner
+- mutating Party membership
+- copying foreign domain internals into Session Planner persistence
+- exposing generation rulesets or catalog versions as user controls
+- a second generation tab or a long-lived preview workflow
+- deriving a gold budget from provisional heuristics
 
-## Primary User Flow
+## Performance Acceptance
 
-1. The user opens the Session Planner left-bar tab.
-2. The user creates a new session or opens an existing persisted session.
-3. The planner reads session-local participant refs plus the current foreign
-   party and encounter summaries needed for planning.
-4. The user adds or removes party characters from the session without changing
-   party membership.
-5. The user adds one or more scenes to the session.
-6. The user optionally links saved encounter plans to scenes.
-7. The user records scene title, notes, and an optional World Planner location
-   reference on each scene.
-8. The planner updates the planned XP total, remaining budget, and rest
-   recommendation.
-9. The user reorders scenes, adjusts budget allocations for encounter-linked
-   scenes, and places short or long rests between scenes.
-10. The user selects one session scene for the preparatory state-panel
-   context.
-11. The user requests a generation preview. The planner fingerprints the
-    current session identity and revision, resolved participant levels,
-    adventure-day fraction, optional encounter count, and seed.
-12. The user reviews the generated encounters, rewards, warnings, and audit
-    outcome. The preview does not mutate the session.
-13. If any fingerprint input changes, the preview remains visible as stale and
-    Apply is locked until the user regenerates.
-14. The user applies a current preview. Encounter first imports the complete
-    generated encounter batch atomically; after explicit destructive
-    confirmation Session Planner replaces the current scene, rest, and manual
-    loot-placeholder content with the returned plan references in generation
-    order and stable generated-reward references. Session identity,
-    participants, and adventure-day fraction remain unchanged.
-    Encounter-channel rewards attach to their generated encounter scenes;
-    quest and environment rewards create encounter-free session scenes.
-
-## Expected Capabilities
-
-- create or reopen a session-owned planning record
-- show session participant count, level spread, and planning readiness
-- show the total XP budget for the current session participants
-- show planned encounter XP, remaining XP, and over-budget XP when applicable
-- visually distinguish in-budget and over-budget planning states
-- show recommended short-rest and long-rest counts derived from the planned
-  encounter XP
-- show how many rests are currently placed in the timeline
-- add blank session-owned scenes without requiring an encounter plan
-- optionally attach saved encounter plans through the encounter public boundary
-  instead of touching encounter persistence directly
-- show scene cards with title, notes, optional World Planner location ID, and
-  encounter detail only when a saved encounter plan is linked
-- allow scene reordering
-- allow budget-percent changes per scene when an encounter plan is linked
-- allow short-rest or long-rest placement only in the gaps between scenes
-- preserve selected scene context for the preparatory state panel
-- allow loot placeholders that do not affect XP math and do not claim a gold
-  budget is already available
-- request a non-blocking Session Generation preview and keep the last stable
-  preview visible while a newer request is pending or fails
-- distinguish ready, stale, invalid, and failed generation states
-- lock Apply when the preview fingerprint differs from current inputs or when
-  a hard generation audit failed
-- show no ruleset selector or ruleset-version label
-- apply only the exact current generation identity, import all generated
-  encounters as one Encounter batch, and store reward references rather than
-  copied generated reward detail
-
-## Visible States
-
-Current state:
-
-- the first implementation is an open scaffold
-- the planner now persists a session catalog with stable session identity,
-  user-visible session names, and one current-session pointer as
-  planner-owned truth
-- scene rows now persist session-owned scene title, scene notes, optional World
-  Planner location reference, and optional encounter-plan reference
-- XP budget and rest recommendation are real party-based calculations
-- imported encounter-linked scene cards use real encounter-plan budget reads
-- gold budgeting remains a visible placeholder
-- loot placeholders are structural only
-- generated previews are derived runtime state and are not part of the authored
-  session until successfully applied
-
-Target state:
-
-- `sessionplanner` persists session-local planning truth as its own authored
-  record
-- later iterations may attach real loot and gold rules and richer encounter
-  composition controls without changing the owning feature boundary
-- applied generations add encounter-plan references and stable generated reward
-  references without transferring generation truth into Session Planner
+- Generate shows visible in-progress feedback by the next UI pulse and does not
+  freeze editing, selection, scrolling, or cancellation while work continues.
+- A newer preparation request or relevant session edit remains authoritative;
+  late completion from older work never replaces the visible workspace.
+- On the warmed reference desktop fixture, the canonical input of two level-3
+  and two level-4 participants, `0.6` adventure days, and three encounters MUST
+  publish the completed editable session within 2 seconds at p95 over 20 runs.
+  First-use initialization and schema migration are outside this warmed target.
 
 ## Acceptance Criteria
 
-- the session planner is a dedicated left-bar tab and not a dropdown or global
-  state tab
-- the planner can create or load a session-owned planning record instead of
-  rebuilding all state as transient-only runtime orchestration
-- the planner depends only on public party and encounter application-service
-  boundaries
-- linked encounter plans contribute real adjusted XP to the planner budget;
-  blank scenes contribute no XP
-- the planner stores only session-local references and planning allocations,
-  not foreign encounter rosters or party-character internals
-- scene location links store World Planner location IDs, not copied location
-  detail
-- the planner shows when linked encounter plans stay within the XP budget and
-  when they exceed it
-- recommended rests update when the imported encounter XP total changes
-- placed rests can appear only between adjacent scenes
-- loot placeholders stay visible while gold budgeting remains explicitly marked
-  as unavailable
-- requesting generation does not mutate scenes, rests, selections, encounter
-  plans, or generated reward references
-- a preview fingerprint covers session identity and revision plus every
-  generation input; any mismatch leaves the preview readable but locks Apply
-- a failed generation request keeps the last stable preview and authored
-  session unchanged
-- Apply is available only for a current preview whose hard audits pass
-- Encounter import succeeds for the whole generated batch before Session
-  Planner persists its scene and reward references; a partial import result is
-  never applied
-- persisted generated reward references contain only session scene identity,
-  typed Session Generation run identity, treasure identity, ordering, and a
-  last-known display label
-- quest and environment rewards become encounter-free Session scenes, while an
-  encounter-channel reward references its corresponding generated encounter
-  scene
-- removing a scene removes its generated reward references without deleting
-  the Session Generation run or Encounter-owned saved plan
-- the Session Planner generation UI shows no ruleset selector or ruleset label
+- the Session Planner is a dedicated left-bar tab with the compact
+  master-detail structure above
+- manual planning survives close and reopen
+- linked Encounter plans contribute real adjusted XP; blank scenes contribute
+  none
+- one Generate action produces concrete saved Encounter rosters and structured
+  generated rewards without a second Apply action
+- destructive replacement requires confirmation; failed or stale preparation
+  changes no authored session content
+- retry does not expose duplicate or partial generated content
+- the UI stays responsive and meets the warmed reference-fixture target
 
 ## References
 
-- [Session Planner Architecture](../architecture/architecture-session-planner.md) (line 1)
-- [Session Planner Persistence Contract](../contract/contract-session-planner-persistence.md) (line 1)
-- [Session Planner Domain Model](../domain/domain-session-planner.md) (line 1)
-- [Encounter Plan Budget Contract](../../encounter/contract/contract-encounter-plan-budget.md) (line 1)
+- [Domain](../domain/domain-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
+- [Architecture](../architecture/architecture-session-planner.md)
 - [Session Generation Requirements](../../sessiongeneration/requirements/requirements-session-generation.md)
-- [Encounter Generated Import Contract](../../encounter/contract/contract-encounter-generated-import.md)
+- [Encounter Requirements](../../encounter/requirements/requirements-encounter.md)


### PR DESCRIPTION
## Ergebnis
- legt die temporaere Session-Planner-Greenfield-Roadmap M0 bis M6 an
- richtet Requirements, Domain, Contracts und Architecture von Session Planner, Session Generation und Encounter auf den Zielzustand aus
- definiert konkretes Encounter-Batch-Preparing, strukturierte Rewards, eine Workspace-Publikation, Performanceziele und Legacy-Loeschgates

## Proof
- git diff --check: gruen
- lokale Einzelprobe SmokeStartupTest auf aktuellem main: gruen
- ./gradlew check: lokaler Gradle-Test-Worker bricht ohne reproduzierbares Testfinding mit EOFException beziehungsweise fehlender in-progress-results-generic.bin ab; CI muss den Merge-Proof liefern

Der PR bleibt Draft, bis required CI gruen ist.