### PR TITLE
docs: link Session Planner roadmap owners

### DIFF
--- a/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
+++ b/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
@@ -438,3 +438,11 @@ Every milestone, including documentation-only M0, MUST:
 - The open master-detail frontend may merge before or during backend work. Its
   observable layout is adopted, but M6 rebases it onto the target workspace
   snapshot rather than retaining its internal models.
+
+## References
+
+- [Session Planner Owners](../README.md)
+- [Session Generation Owners](../../sessiongeneration/README.md)
+- [Encounter Owners](../../encounter/README.md)
+- [Source Architecture](../../project/architecture/source-architecture.md)
+- [Documentation Placement](../../project/documentation.md)


### PR DESCRIPTION
## Ergebnis
- verlinkt die dauerhaften Session-Planner-, Session-Generation-, Encounter-, Source-Architecture- und Dokumentations-Owner direkt aus der temporaeren Roadmap

## Proof
- git diff --check: gruen