### PR TITLE
Session-Generierung auf Draft und Commit umstellen

### DIFF
--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -8,6 +8,7 @@ import org.jspecify.annotations.Nullable;
 import platform.diagnostics.Diagnostics;
 import platform.diagnostics.SystemLoggerDiagnostics;
 import platform.execution.ExecutionLane;
+import platform.execution.BoundedExecutionLane;
 import platform.execution.SerialExecutionLane;
 import platform.persistence.SqliteDatabase;
 import platform.ui.JavaFxUiDispatcher;
@@ -45,6 +46,8 @@ public final class AppBootstrap implements AutoCloseable {
 
     private final Diagnostics diagnostics;
     private final ExecutionLane executionLane;
+    private final ExecutionLane sessionGenerationCpuLane;
+    private final ExecutionLane sessionGenerationIoLane;
     private final UiDispatcher uiDispatcher;
     private final SqliteDatabase database;
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -58,6 +61,11 @@ public final class AppBootstrap implements AutoCloseable {
         this(
                 diagnostics,
                 new SerialExecutionLane(diagnostics),
+                new BoundedExecutionLane(
+                        diagnostics,
+                        "session-generation-cpu",
+                        Math.max(2, Runtime.getRuntime().availableProcessors() - 1)),
+                new BoundedExecutionLane(diagnostics, "session-generation-io", 2),
                 new JavaFxUiDispatcher(),
                 SqliteDatabase.defaultDatabase(SqliteDatabase.DEFAULT_DATABASE_FILE_NAME, diagnostics));
     }
@@ -68,8 +76,29 @@ public final class AppBootstrap implements AutoCloseable {
             UiDispatcher uiDispatcher,
             SqliteDatabase database
     ) {
+        this(
+                diagnostics,
+                executionLane,
+                new BoundedExecutionLane(diagnostics, "session-generation-cpu", 2),
+                new BoundedExecutionLane(diagnostics, "session-generation-io", 2),
+                uiDispatcher,
+                database);
+    }
+
+    AppBootstrap(
+            Diagnostics diagnostics,
+            ExecutionLane executionLane,
+            ExecutionLane sessionGenerationCpuLane,
+            ExecutionLane sessionGenerationIoLane,
+            UiDispatcher uiDispatcher,
+            SqliteDatabase database
+    ) {
         this.diagnostics = java.util.Objects.requireNonNull(diagnostics, "diagnostics");
         this.executionLane = java.util.Objects.requireNonNull(executionLane, "executionLane");
+        this.sessionGenerationCpuLane = java.util.Objects.requireNonNull(
+                sessionGenerationCpuLane, "sessionGenerationCpuLane");
+        this.sessionGenerationIoLane = java.util.Objects.requireNonNull(
+                sessionGenerationIoLane, "sessionGenerationIoLane");
         this.uiDispatcher = java.util.Objects.requireNonNull(uiDispatcher, "uiDispatcher");
         this.database = java.util.Objects.requireNonNull(database, "database");
     }
@@ -134,7 +163,8 @@ public final class AppBootstrap implements AutoCloseable {
         HexServiceAssembly.Component hex = HexServiceAssembly.create(
                 database, party.travelPositions(), party.application(),
                 executionLane, uiDispatcher, diagnostics);
-        SessionGenerationApi generation = SessionGenerationServiceAssembly.create(database, executionLane);
+        SessionGenerationApi generation = SessionGenerationServiceAssembly.create(
+                database, sessionGenerationCpuLane, sessionGenerationIoLane);
         SessionPlannerServiceAssembly session = SessionPlannerServiceAssembly.create(
                 database,
                 party.application(),
@@ -431,6 +461,8 @@ public final class AppBootstrap implements AutoCloseable {
             catalog.close();
             catalogComponent = null;
         }
+        sessionGenerationCpuLane.close();
+        sessionGenerationIoLane.close();
         executionLane.close();
         database.close();
     }

--- a/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
+++ b/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
@@ -196,13 +196,21 @@ acceptance after the last UI diff.
 
 ## Current Migration Position
 
-- Current foundation: M0 is merged. The owner documents define the greenfield
-  target, and this roadmap is the only migration sequence owner.
-- Current milestone: M1 captures stage baselines and replaces Session
-  Generation's hot-path persistence contract before planner orchestration
+- Current foundation: M0 and M1 are merged. Session Generation now publishes
+  the typed draft/commit/load/reward-read boundary, commits immutable semantic
+  drafts idempotently, and uses separately owned bounded CPU and I/O execution.
+- Current milestone: M2 replaces abstract generated Encounter slots with one
+  concrete deterministic prepare-and-commit batch before planner orchestration
   changes.
 - M0 closure: documentation whitespace, required `check`, and desktop install
   proof are green after the final owner-language diff.
+- M1 closure: the Golden fixture uses two level-3 and two level-4 characters,
+  adventure-day fraction `0.6`, three Encounters, and seed `179974`. Its final
+  independent JUnit baselines recorded catalog load `0.212s`, pure engine
+  `0.629s`, persistence commit plus canonical load `1.271s`, and structured
+  reward batch read `0.320s`. Final `git diff --check`, focused production-route
+  and architecture proof, required `check` (`4m 29s`), and desktop install
+  (`14s`) are green after the last M1 code diff.
 
 ## Delivery Rules
 

--- a/features/sessiongeneration/SessionGenerationServiceAssembly.java
+++ b/features/sessiongeneration/SessionGenerationServiceAssembly.java
@@ -14,11 +14,16 @@ public final class SessionGenerationServiceAssembly {
     private SessionGenerationServiceAssembly() {
     }
 
-    public static SessionGenerationApi create(SqliteDatabase database, ExecutionLane executionLane) {
+    public static SessionGenerationApi create(
+            SqliteDatabase database,
+            ExecutionLane cpuLane,
+            ExecutionLane ioLane
+    ) {
         return new SessionGenerationService(
                 new TsvGenerationCatalog(),
                 new SqliteGenerationRunRepository(Objects.requireNonNull(database, "database")),
                 new SessionGenerationEngine(),
-                Objects.requireNonNull(executionLane, "executionLane"));
+                Objects.requireNonNull(cpuLane, "cpuLane"),
+                Objects.requireNonNull(ioLane, "ioLane"));
     }
 }

--- a/features/sessiongeneration/adapter/sqlite/persistence/GenerationRewardSqliteReader.java
+++ b/features/sessiongeneration/adapter/sqlite/persistence/GenerationRewardSqliteReader.java
@@ -1,0 +1,127 @@
+package features.sessiongeneration.adapter.sqlite.persistence;
+
+import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GenerationRewardBatch;
+import features.sessiongeneration.domain.generation.GenerationRewardReference;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+final class GenerationRewardSqliteReader {
+
+    static final int MAX_KEYS_PER_QUERY = 400;
+
+    GenerationRewardBatch load(Connection connection, List<GenerationRewardReference> requested) throws SQLException {
+        List<GenerationRewardReference> callerOrder = List.copyOf(requested);
+        if (callerOrder.isEmpty()) {
+            return new GenerationRewardBatch(List.of(), List.of());
+        }
+        List<GenerationRewardReference> unique = List.copyOf(new LinkedHashSet<>(callerOrder));
+        Map<GenerationRewardReference, GenerationRewardBatch.ResolvedReward> byReference = new LinkedHashMap<>();
+        for (int start = 0; start < unique.size(); start += MAX_KEYS_PER_QUERY) {
+            loadChunk(connection, unique.subList(start, Math.min(start + MAX_KEYS_PER_QUERY, unique.size())), byReference);
+        }
+        List<GenerationRewardBatch.ResolvedReward> resolved = new ArrayList<>();
+        List<GenerationRewardReference> missing = new ArrayList<>();
+        for (GenerationRewardReference reference : callerOrder) {
+            GenerationRewardBatch.ResolvedReward detail = byReference.get(reference);
+            if (detail == null) {
+                missing.add(reference);
+            } else {
+                resolved.add(detail);
+            }
+        }
+        return new GenerationRewardBatch(resolved, missing);
+    }
+
+    private static void loadChunk(
+            Connection connection,
+            List<GenerationRewardReference> references,
+            Map<GenerationRewardReference, GenerationRewardBatch.ResolvedReward> target
+    ) throws SQLException {
+        String predicates = String.join(" OR ", java.util.Collections.nCopies(
+                references.size(), "(treasure.run_id = ? AND treasure.treasure_id = ?)"));
+        String sql = "SELECT treasure.*, loot.line_id, loot.role, loot.item_id, loot.display_text, "
+                + "loot.quantity, loot.unit_cp, loot.actual_cp, loot.total_capacity, loot.allowed_containers, "
+                + "loot.magic_rarity, loot.cursed, loot.sort_order AS loot_order, packing.container_type, "
+                + "packing.container_count, packing.container_id, packing.valid "
+                + "FROM " + SessionGenerationSchema.TREASURES + " treasure "
+                + "LEFT JOIN " + SessionGenerationSchema.LOOT + " loot ON loot.run_id = treasure.run_id "
+                + "AND loot.treasure_id = treasure.treasure_id "
+                + "LEFT JOIN " + SessionGenerationSchema.PACKING + " packing ON packing.run_id = loot.run_id "
+                + "AND packing.line_id = loot.line_id WHERE " + predicates
+                + " ORDER BY treasure.run_id, treasure.treasure_id, loot.sort_order";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            int parameter = 1;
+            for (GenerationRewardReference reference : references) {
+                statement.setString(parameter++, reference.runId());
+                statement.setInt(parameter++, reference.treasureId());
+            }
+            try (ResultSet rows = statement.executeQuery()) {
+                Map<GenerationRewardReference, RewardAccumulator> loaded = new LinkedHashMap<>();
+                while (rows.next()) {
+                    GenerationRewardReference reference = new GenerationRewardReference(
+                            rows.getString("run_id"), rows.getInt("treasure_id"));
+                    RewardAccumulator reward = loaded.get(reference);
+                    if (reward == null) {
+                        reward = new RewardAccumulator(
+                                reference,
+                                new GeneratedRun.TreasurePlan(
+                                        reference.treasureId(),
+                                        GeneratedRun.StockClass.valueOf(rows.getString("stock_class")),
+                                        GeneratedRun.RewardChannel.valueOf(rows.getString("reward_channel")),
+                                        rows.getInt("anchor_encounter_no"), rows.getString("theme"),
+                                        rows.getString("magic_type"), rows.getLong("target_cp"),
+                                        rows.getInt("nonmagic_slots"), rows.getInt("magic_slots")));
+                        loaded.put(reference, reward);
+                    }
+                    int lineId = rows.getInt("line_id");
+                    if (!rows.wasNull()) {
+                        reward.add(
+                                new GeneratedRun.LootLine(
+                                        lineId, reference.treasureId(),
+                                        GeneratedRun.LootRole.valueOf(rows.getString("role")),
+                                        rows.getString("item_id"), rows.getString("display_text"),
+                                        rows.getLong("quantity"), rows.getLong("unit_cp"), rows.getLong("actual_cp"),
+                                        new BigDecimal(rows.getString("total_capacity")),
+                                        rows.getString("allowed_containers"), rows.getString("magic_rarity"),
+                                        rows.getBoolean("cursed")),
+                                new GeneratedRun.PackingRow(
+                                        lineId, reference.treasureId(), rows.getString("container_type"),
+                                        rows.getInt("container_count"), rows.getString("container_id"),
+                                        rows.getBoolean("valid")));
+                    }
+                }
+                loaded.forEach((reference, reward) -> target.put(reference, reward.toResolved()));
+            }
+        }
+    }
+
+    private static final class RewardAccumulator {
+        private final GenerationRewardReference reference;
+        private final GeneratedRun.TreasurePlan treasure;
+        private final List<GeneratedRun.LootLine> loot = new ArrayList<>();
+        private final List<GeneratedRun.PackingRow> packing = new ArrayList<>();
+
+        private RewardAccumulator(GenerationRewardReference reference, GeneratedRun.TreasurePlan treasure) {
+            this.reference = reference;
+            this.treasure = treasure;
+        }
+
+        void add(GeneratedRun.LootLine line, GeneratedRun.PackingRow row) {
+            loot.add(line);
+            packing.add(row);
+        }
+
+        GenerationRewardBatch.ResolvedReward toResolved() {
+            return new GenerationRewardBatch.ResolvedReward(reference, treasure, loot, packing);
+        }
+    }
+}

--- a/features/sessiongeneration/adapter/sqlite/persistence/GenerationRunSqliteReader.java
+++ b/features/sessiongeneration/adapter/sqlite/persistence/GenerationRunSqliteReader.java
@@ -25,10 +25,17 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 final class GenerationRunSqliteReader {
 
     Optional<GeneratedRun> load(Connection connection, String runId) throws SQLException {
+        return loadStored(connection, runId).map(StoredGeneratedRun::run);
+    }
+
+    Optional<StoredGeneratedRun> loadStored(Connection connection, String runId) throws SQLException {
         String sql = "SELECT * FROM " + SessionGenerationSchema.RUNS + " WHERE run_id = ?";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, runId);
@@ -44,14 +51,18 @@ final class GenerationRunSqliteReader {
                 RewardSummary rewards = new RewardSummary(
                         result.getLong("normal_actual_cp"), result.getLong("overstock_actual_cp"),
                         result.getInt("magic_count"));
-                return Optional.of(new GeneratedRun(
+                GeneratedRun run = new GeneratedRun(
                         runId, result.getString("engine_version"), result.getString("catalog_version"),
                         result.getString("catalog_hash"), result.getLong("seed"), loadParty(connection, runId),
                         session, loadTargets(connection, runId), loadEncounters(connection, runId),
                         loadTreasures(connection, runId), loadLoot(connection, runId), loadPacking(connection, runId),
-                        rewards, result.getString("formatted_text"), loadAudits(connection, runId)));
+                        rewards, result.getString("formatted_text"), loadAudits(connection, runId));
+                return Optional.of(new StoredGeneratedRun(run, result.getString("content_fingerprint")));
             }
         }
+    }
+
+    record StoredGeneratedRun(GeneratedRun run, @Nullable String storedFingerprint) {
     }
 
     private static List<PartyLevel> loadParty(Connection connection, String runId) throws SQLException {
@@ -95,8 +106,11 @@ final class GenerationRunSqliteReader {
                         new BigDecimal(rows.getString("boss_score"))));
             }
         }
+        Map<Integer, List<EncounterBlock>> blocks = loadBlocks(connection, runId);
         List<EncounterPlan> result = new ArrayList<>();
-        for (EncounterRow row : loaded) result.add(row.toPlan(loadBlocks(connection, runId, row.number())));
+        for (EncounterRow row : loaded) {
+            result.add(row.toPlan(blocks.getOrDefault(row.number(), List.of())));
+        }
         return List.copyOf(result);
     }
 
@@ -170,24 +184,28 @@ final class GenerationRunSqliteReader {
         }
     }
 
-    private static List<EncounterBlock> loadBlocks(Connection connection, String runId, int encounterNo)
+    private static Map<Integer, List<EncounterBlock>> loadBlocks(Connection connection, String runId)
             throws SQLException {
         String sql = "SELECT * FROM " + SessionGenerationSchema.ENCOUNTER_BLOCKS
-                + " WHERE run_id = ? AND encounter_no = ? ORDER BY block_order";
+                + " WHERE run_id = ? ORDER BY encounter_no, block_order";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, runId);
-            statement.setInt(2, encounterNo);
             try (ResultSet rows = statement.executeQuery()) {
-                List<EncounterBlock> result = new ArrayList<>();
-                int expectedOrder = 0;
+                Map<Integer, List<EncounterBlock>> mutable = new LinkedHashMap<>();
+                Map<Integer, Integer> expectedOrders = new LinkedHashMap<>();
                 while (rows.next()) {
-                    requireOrder(rows.getInt("block_order"), expectedOrder++, "encounter block");
-                    result.add(new EncounterBlock(
+                    int encounterNo = rows.getInt("encounter_no");
+                    int expectedOrder = expectedOrders.getOrDefault(encounterNo, 0);
+                    requireOrder(rows.getInt("block_order"), expectedOrder, "encounter block");
+                    expectedOrders.put(encounterNo, expectedOrder + 1);
+                    mutable.computeIfAbsent(encounterNo, ignored -> new ArrayList<>()).add(new EncounterBlock(
                             rows.getString("block_id"), EncounterRole.valueOf(rows.getString("role")),
                             rows.getInt("challenge_code"), rows.getString("challenge_label"),
                             rows.getLong("unit_xp"), rows.getInt("quantity")));
                 }
-                return List.copyOf(result);
+                Map<Integer, List<EncounterBlock>> result = new LinkedHashMap<>();
+                mutable.forEach((number, values) -> result.put(number, List.copyOf(values)));
+                return Map.copyOf(result);
             }
         }
     }

--- a/features/sessiongeneration/adapter/sqlite/persistence/GenerationRunSqliteWriter.java
+++ b/features/sessiongeneration/adapter/sqlite/persistence/GenerationRunSqliteWriter.java
@@ -1,6 +1,7 @@
 package features.sessiongeneration.adapter.sqlite.persistence;
 
 import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
 import features.sessiongeneration.domain.generation.GeneratedRun.Audit;
 import features.sessiongeneration.domain.generation.GeneratedRun.EncounterBlock;
 import features.sessiongeneration.domain.generation.GeneratedRun.EncounterPlan;
@@ -16,8 +17,9 @@ import java.sql.SQLException;
 
 final class GenerationRunSqliteWriter {
 
-    void insert(Connection connection, GeneratedRun run) throws SQLException {
-        insertRun(connection, run);
+    void insert(Connection connection, GeneratedRunDraft draft) throws SQLException {
+        GeneratedRun run = draft.run();
+        insertRun(connection, run, draft.contentFingerprint());
         insertParty(connection, run);
         insertTargets(connection, run);
         insertEncounters(connection, run);
@@ -27,7 +29,33 @@ final class GenerationRunSqliteWriter {
         insertAudits(connection, run);
     }
 
-    private static void insertRun(Connection connection, GeneratedRun run) throws SQLException {
+    void insertLegacyV1(Connection connection, GeneratedRun run) throws SQLException {
+        insertRunV1(connection, run);
+        insertParty(connection, run);
+        insertTargets(connection, run);
+        insertEncounters(connection, run);
+        insertTreasures(connection, run);
+        insertLoot(connection, run);
+        insertPacking(connection, run);
+        insertAudits(connection, run);
+    }
+
+    private static void insertRun(Connection connection, GeneratedRun run, String contentFingerprint)
+            throws SQLException {
+        String sql = "INSERT INTO " + SessionGenerationSchema.RUNS + " ("
+                + "run_id, owner, schema_version, engine_version, catalog_version, catalog_hash, seed, "
+                + "adventure_fraction, encounter_count, party_count, day_xp_budget, session_xp_target, average_level, "
+                + "normal_budget_cp, overstock_budget_cp, nonmagic_slots, normal_magic, overstock_magic, treasure_count, "
+                + "normal_actual_cp, overstock_actual_cp, magic_count, formatted_text, content_fingerprint) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            bindRun(statement, run);
+            statement.setString(24, contentFingerprint);
+            statement.executeUpdate();
+        }
+    }
+
+    private static void insertRunV1(Connection connection, GeneratedRun run) throws SQLException {
         String sql = "INSERT INTO " + SessionGenerationSchema.RUNS + " ("
                 + "run_id, owner, schema_version, engine_version, catalog_version, catalog_hash, seed, "
                 + "adventure_fraction, encounter_count, party_count, day_xp_budget, session_xp_target, average_level, "
@@ -35,32 +63,36 @@ final class GenerationRunSqliteWriter {
                 + "normal_actual_cp, overstock_actual_cp, magic_count, formatted_text) "
                 + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            SessionContext session = run.session();
-            statement.setString(1, run.runId());
-            statement.setString(2, SqliteGenerationRunRepository.OWNER);
-            statement.setInt(3, SqliteGenerationRunRepository.SCHEMA_VERSION);
-            statement.setString(4, run.engineVersion());
-            statement.setString(5, run.catalogVersion());
-            statement.setString(6, run.catalogContentHash());
-            statement.setLong(7, run.seed());
-            statement.setString(8, session.adventureDayFraction().toPlainString());
-            statement.setInt(9, session.encounterCount());
-            statement.setInt(10, session.partyCount());
-            statement.setLong(11, session.dayXpBudget());
-            statement.setLong(12, session.sessionXpTarget());
-            statement.setString(13, session.averageLevel().toPlainString());
-            statement.setLong(14, session.normalBudgetCp());
-            statement.setLong(15, session.overstockBudgetCp());
-            statement.setInt(16, session.nonMagicSlots());
-            statement.setInt(17, session.normalMagic());
-            statement.setInt(18, session.overstockMagic());
-            statement.setInt(19, session.treasureCount());
-            statement.setLong(20, run.rewards().normalActualCp());
-            statement.setLong(21, run.rewards().overstockActualCp());
-            statement.setInt(22, run.rewards().magicCount());
-            statement.setString(23, run.formattedText());
+            bindRun(statement, run);
             statement.executeUpdate();
         }
+    }
+
+    private static void bindRun(PreparedStatement statement, GeneratedRun run) throws SQLException {
+        SessionContext session = run.session();
+        statement.setString(1, run.runId());
+        statement.setString(2, SqliteGenerationRunRepository.OWNER);
+        statement.setInt(3, SqliteGenerationRunRepository.RUN_SCHEMA_VERSION);
+        statement.setString(4, run.engineVersion());
+        statement.setString(5, run.catalogVersion());
+        statement.setString(6, run.catalogContentHash());
+        statement.setLong(7, run.seed());
+        statement.setString(8, session.adventureDayFraction().toPlainString());
+        statement.setInt(9, session.encounterCount());
+        statement.setInt(10, session.partyCount());
+        statement.setLong(11, session.dayXpBudget());
+        statement.setLong(12, session.sessionXpTarget());
+        statement.setString(13, session.averageLevel().toPlainString());
+        statement.setLong(14, session.normalBudgetCp());
+        statement.setLong(15, session.overstockBudgetCp());
+        statement.setInt(16, session.nonMagicSlots());
+        statement.setInt(17, session.normalMagic());
+        statement.setInt(18, session.overstockMagic());
+        statement.setInt(19, session.treasureCount());
+        statement.setLong(20, run.rewards().normalActualCp());
+        statement.setLong(21, run.rewards().overstockActualCp());
+        statement.setInt(22, run.rewards().magicCount());
+        statement.setString(23, run.formattedText());
     }
 
     private static void insertParty(Connection connection, GeneratedRun run) throws SQLException {

--- a/features/sessiongeneration/adapter/sqlite/persistence/SessionGenerationSchema.java
+++ b/features/sessiongeneration/adapter/sqlite/persistence/SessionGenerationSchema.java
@@ -18,7 +18,7 @@ final class SessionGenerationSchema {
 
     private static final String RUN_REFERENCE = "run_id TEXT NOT NULL REFERENCES " + RUNS + "(run_id), ";
 
-    void migrate(Connection connection) throws SQLException {
+    void migrateV1(Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE IF NOT EXISTS " + RUNS + " ("
                     + "run_id TEXT PRIMARY KEY, "
@@ -70,6 +70,12 @@ final class SessionGenerationSchema {
             statement.execute("CREATE TABLE IF NOT EXISTS " + AUDITS + " (" + RUN_REFERENCE
                     + "audit_order INTEGER NOT NULL, code TEXT NOT NULL, status TEXT NOT NULL, detail TEXT NOT NULL, "
                     + "PRIMARY KEY(run_id, audit_order))");
+        }
+    }
+
+    void migrateV2(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("ALTER TABLE " + RUNS + " ADD COLUMN content_fingerprint TEXT");
         }
     }
 }

--- a/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepository.java
+++ b/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepository.java
@@ -1,10 +1,17 @@
 package features.sessiongeneration.adapter.sqlite.persistence;
 
-import features.sessiongeneration.domain.generation.GeneratedRun;
-import features.sessiongeneration.domain.generation.GenerationRunRepository;
+import features.sessiongeneration.adapter.sqlite.persistence.GenerationRunSqliteReader.StoredGeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
 import features.sessiongeneration.domain.generation.GeneratedRunValidator;
+import features.sessiongeneration.domain.generation.GenerationContentFingerprint;
+import features.sessiongeneration.domain.generation.GenerationRewardBatch;
+import features.sessiongeneration.domain.generation.GenerationRewardReference;
+import features.sessiongeneration.domain.generation.GenerationRunCommitResult;
+import features.sessiongeneration.domain.generation.GenerationRunIdentityConflictException;
+import features.sessiongeneration.domain.generation.GenerationRunRepository;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import platform.persistence.SqliteConnectionSource;
@@ -14,66 +21,113 @@ import platform.persistence.SqliteMigration;
 public final class SqliteGenerationRunRepository implements GenerationRunRepository {
 
     public static final String OWNER = "session-generation";
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
+    static final int RUN_SCHEMA_VERSION = 1;
 
     private final SqliteConnectionSource connections;
     private final GenerationRunSqliteReader reader = new GenerationRunSqliteReader();
     private final GenerationRunSqliteWriter writer = new GenerationRunSqliteWriter();
+    private final GenerationRewardSqliteReader rewardReader = new GenerationRewardSqliteReader();
     private final GeneratedRunValidator validator = new GeneratedRunValidator();
 
     public SqliteGenerationRunRepository(SqliteDatabase database) {
         SessionGenerationSchema schema = new SessionGenerationSchema();
         connections = Objects.requireNonNull(database, "database").connections(
                 OWNER,
-                new SqliteMigration(SCHEMA_VERSION, schema::migrate));
+                new SqliteMigration(1, schema::migrateV1),
+                new SqliteMigration(2, schema::migrateV2));
+    }
+
+    SqliteGenerationRunRepository(SqliteConnectionSource connections) {
+        this.connections = Objects.requireNonNull(connections, "connections");
     }
 
     @Override
-    public GeneratedRun save(GeneratedRun run) {
-        Objects.requireNonNull(run, "run");
-        validator.validate(run);
+    public GenerationRunCommitResult commit(GeneratedRunDraft draft) {
+        validateDraft(draft);
         try (Connection connection = connections.openConnection()) {
-            return saveTransaction(connection, run);
+            return commitTransaction(connection, draft);
+        } catch (GenerationRunIdentityConflictException exception) {
+            throw exception;
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to persist session-generation run.", exception);
+            throw new IllegalStateException("Failed to commit session-generation run.", exception);
         }
     }
 
     @Override
-    public Optional<GeneratedRun> load(String runId) {
+    public Optional<GeneratedRunDraft> load(String runId) {
         Objects.requireNonNull(runId, "runId");
         try (Connection connection = connections.openConnection()) {
-            Optional<GeneratedRun> loaded = reader.load(connection, runId);
-            loaded.ifPresent(validator::validate);
-            return loaded;
+            return reader.loadStored(connection, runId).map(this::validatedDraft);
         } catch (SQLException | IllegalArgumentException exception) {
             throw new IllegalStateException("Failed to load session-generation run.", exception);
         }
     }
 
-    private GeneratedRun saveTransaction(Connection connection, GeneratedRun run) throws SQLException {
+    @Override
+    public GenerationRewardBatch loadRewards(List<GenerationRewardReference> references) {
+        List<GenerationRewardReference> safeReferences = List.copyOf(references);
+        if (safeReferences.isEmpty()) {
+            return new GenerationRewardBatch(List.of(), List.of());
+        }
+        try (Connection connection = connections.openConnection()) {
+            return rewardReader.load(connection, safeReferences);
+        } catch (SQLException | IllegalArgumentException exception) {
+            throw new IllegalStateException("Failed to load session-generation rewards.", exception);
+        }
+    }
+
+    private GenerationRunCommitResult commitTransaction(Connection connection, GeneratedRunDraft draft)
+            throws SQLException {
         boolean autoCommit = connection.getAutoCommit();
         connection.setAutoCommit(false);
         try {
-            Optional<GeneratedRun> existing = reader.load(connection, run.runId());
-            if (existing.isPresent()) {
-                validator.validate(existing.get());
+            try {
+                // Insert-first acquires SQLite write intent without creating a stale read snapshot.
+                // A concurrent/equal identity resolves through the root uniqueness constraint,
+                // after which rollback plus canonical reread decides already-present vs conflict.
+                writer.insert(connection, draft);
+                connection.commit();
+                return new GenerationRunCommitResult(draft, GenerationRunCommitResult.Outcome.INSERTED);
+            } catch (SQLException insertionFailure) {
                 connection.rollback();
-                if (!existing.get().equals(run)) {
-                    throw new IllegalStateException("immutable generation run id collision");
+                Optional<StoredGeneratedRun> raced = reader.loadStored(connection, draft.run().runId());
+                if (raced.isPresent()) {
+                    return decideExisting(raced.orElseThrow(), draft);
                 }
-                return existing.get();
+                throw insertionFailure;
             }
-            writer.insert(connection, run);
-            connection.commit();
-            GeneratedRun stored = reader.load(connection, run.runId()).orElseThrow();
-            validator.validate(stored);
-            return stored;
         } catch (SQLException | RuntimeException exception) {
             connection.rollback();
             throw exception;
         } finally {
             connection.setAutoCommit(autoCommit);
+        }
+    }
+
+    private GenerationRunCommitResult decideExisting(StoredGeneratedRun stored, GeneratedRunDraft requested) {
+        GeneratedRunDraft existing = validatedDraft(stored);
+        if (!existing.contentFingerprint().equals(requested.contentFingerprint())) {
+            throw new GenerationRunIdentityConflictException(requested.run().runId());
+        }
+        return new GenerationRunCommitResult(existing, GenerationRunCommitResult.Outcome.ALREADY_PRESENT);
+    }
+
+    private GeneratedRunDraft validatedDraft(StoredGeneratedRun stored) {
+        validator.validate(stored.run());
+        String derived = GenerationContentFingerprint.v1(stored.run());
+        if (stored.storedFingerprint() != null && !stored.storedFingerprint().equals(derived)) {
+            throw new IllegalStateException("stored generation content fingerprint does not match semantic rows");
+        }
+        return new GeneratedRunDraft(stored.run(), derived);
+    }
+
+    private void validateDraft(GeneratedRunDraft draft) {
+        Objects.requireNonNull(draft, "draft");
+        validator.validate(draft.run());
+        String derived = GenerationContentFingerprint.v1(draft.run());
+        if (!draft.contentFingerprint().equals(derived)) {
+            throw new IllegalStateException("generation draft content fingerprint does not match semantic content");
         }
     }
 }

--- a/features/sessiongeneration/api/CommitGenerationRunCommand.java
+++ b/features/sessiongeneration/api/CommitGenerationRunCommand.java
@@ -1,0 +1,10 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+
+public record CommitGenerationRunCommand(GenerationDraft draft) {
+
+    public CommitGenerationRunCommand {
+        draft = Objects.requireNonNull(draft, "draft");
+    }
+}

--- a/features/sessiongeneration/api/GenerationDraft.java
+++ b/features/sessiongeneration/api/GenerationDraft.java
@@ -1,0 +1,14 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+
+public record GenerationDraft(GenerationResult result, String contentFingerprint) {
+
+    public GenerationDraft {
+        result = Objects.requireNonNull(result, "result");
+        contentFingerprint = Objects.requireNonNull(contentFingerprint, "contentFingerprint").trim();
+        if (!contentFingerprint.matches("v1:[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("content fingerprint must use the v1 SHA-256 format");
+        }
+    }
+}

--- a/features/sessiongeneration/api/GenerationDraftResponse.java
+++ b/features/sessiongeneration/api/GenerationDraftResponse.java
@@ -1,0 +1,32 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record GenerationDraftResponse(
+        GenerationStatus status,
+        String message,
+        Optional<GenerationDraft> draft
+) {
+
+    public GenerationDraftResponse {
+        status = Objects.requireNonNull(status, "status");
+        message = Objects.requireNonNullElse(message, "");
+        draft = Objects.requireNonNull(draft, "draft");
+        requirePayload(status, draft.isPresent());
+    }
+
+    public static GenerationDraftResponse success(GenerationDraft draft) {
+        return new GenerationDraftResponse(GenerationStatus.SUCCESS, "", Optional.of(draft));
+    }
+
+    public static GenerationDraftResponse failure(GenerationStatus status, String message) {
+        return new GenerationDraftResponse(status, message, Optional.empty());
+    }
+
+    private static void requirePayload(GenerationStatus status, boolean present) {
+        if ((status == GenerationStatus.SUCCESS) != present) {
+            throw new IllegalArgumentException("draft payload does not match response status");
+        }
+    }
+}

--- a/features/sessiongeneration/api/GenerationPreparationIdentity.java
+++ b/features/sessiongeneration/api/GenerationPreparationIdentity.java
@@ -1,0 +1,21 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+
+/** Opaque caller-owned identity for one preparation attempt. */
+public record GenerationPreparationIdentity(String value) {
+
+    private static final GenerationPreparationIdentity LEGACY = new GenerationPreparationIdentity("legacy");
+
+    public GenerationPreparationIdentity {
+        value = Objects.requireNonNull(value, "value").trim();
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("preparation identity must not be empty");
+        }
+    }
+
+    /** Temporary identity used only by the M3-bound compatibility generation caller. */
+    public static GenerationPreparationIdentity legacy() {
+        return LEGACY;
+    }
+}

--- a/features/sessiongeneration/api/GenerationRequest.java
+++ b/features/sessiongeneration/api/GenerationRequest.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 
 public record GenerationRequest(
+        GenerationPreparationIdentity preparationIdentity,
         List<PartyLevel> party,
         BigDecimal adventureDayFraction,
         OptionalInt encounterCount,
@@ -14,6 +15,7 @@ public record GenerationRequest(
 ) {
 
     public GenerationRequest {
+        preparationIdentity = Objects.requireNonNull(preparationIdentity, "preparationIdentity");
         party = List.copyOf(Objects.requireNonNull(party, "party")).stream()
                 .sorted(Comparator.comparingInt(PartyLevel::level))
                 .toList();
@@ -35,6 +37,17 @@ public record GenerationRequest(
                 && (encounterCount.getAsInt() < 1 || encounterCount.getAsInt() > 10)) {
             throw new IllegalArgumentException("encounter count must be between 1 and 10");
         }
+    }
+
+    /** Temporary constructor for the coordinator removed in M3. */
+    @Deprecated(forRemoval = true)
+    public GenerationRequest(
+            List<PartyLevel> party,
+            BigDecimal adventureDayFraction,
+            OptionalInt encounterCount,
+            long seed
+    ) {
+        this(GenerationPreparationIdentity.legacy(), party, adventureDayFraction, encounterCount, seed);
     }
 
     public record PartyLevel(int level, int players) {

--- a/features/sessiongeneration/api/GenerationResult.java
+++ b/features/sessiongeneration/api/GenerationResult.java
@@ -10,6 +10,7 @@ public record GenerationResult(
         String catalogVersion,
         String catalogContentHash,
         long seed,
+        List<PartyLevel> party,
         SessionSummary session,
         List<EncounterTarget> encounterTargets,
         List<Encounter> encounters,
@@ -26,6 +27,7 @@ public record GenerationResult(
         engineVersion = required(engineVersion, "engineVersion");
         catalogVersion = required(catalogVersion, "catalogVersion");
         catalogContentHash = required(catalogContentHash, "catalogContentHash");
+        party = List.copyOf(party);
         session = Objects.requireNonNull(session, "session");
         encounterTargets = List.copyOf(encounterTargets);
         encounters = List.copyOf(encounters);
@@ -35,6 +37,9 @@ public record GenerationResult(
         rewards = Objects.requireNonNull(rewards, "rewards");
         formattedText = Objects.requireNonNull(formattedText, "formattedText");
         audits = List.copyOf(audits);
+    }
+
+    public record PartyLevel(int level, int players) {
     }
 
     private static String required(String value, String name) {
@@ -73,6 +78,8 @@ public record GenerationResult(
             String monsterSummary,
             int monsterCount,
             BigDecimal multiplier,
+            int maxChallengeCode,
+            BigDecimal bossScore,
             List<EncounterBlock> blocks
     ) {
 
@@ -82,6 +89,7 @@ public record GenerationResult(
     }
 
     public record EncounterBlock(
+            String id,
             EncounterRole requestedRole,
             int challengeCode,
             String challengeLabel,

--- a/features/sessiongeneration/api/GenerationRewardBatchQuery.java
+++ b/features/sessiongeneration/api/GenerationRewardBatchQuery.java
@@ -1,0 +1,10 @@
+package features.sessiongeneration.api;
+
+import java.util.List;
+
+public record GenerationRewardBatchQuery(List<GenerationRewardReference> references) {
+
+    public GenerationRewardBatchQuery {
+        references = List.copyOf(references);
+    }
+}

--- a/features/sessiongeneration/api/GenerationRewardBatchResponse.java
+++ b/features/sessiongeneration/api/GenerationRewardBatchResponse.java
@@ -1,0 +1,48 @@
+package features.sessiongeneration.api;
+
+import java.util.List;
+import java.util.Objects;
+
+public record GenerationRewardBatchResponse(
+        GenerationStatus status,
+        String message,
+        List<ResolvedReward> resolved,
+        List<GenerationRewardReference> missing
+) {
+
+    public GenerationRewardBatchResponse {
+        status = Objects.requireNonNull(status, "status");
+        message = Objects.requireNonNullElse(message, "");
+        resolved = List.copyOf(resolved);
+        missing = List.copyOf(missing);
+        if (status != GenerationStatus.SUCCESS && (!resolved.isEmpty() || !missing.isEmpty())) {
+            throw new IllegalArgumentException("failed reward response must not expose partial results");
+        }
+    }
+
+    public static GenerationRewardBatchResponse success(
+            List<ResolvedReward> resolved,
+            List<GenerationRewardReference> missing
+    ) {
+        return new GenerationRewardBatchResponse(GenerationStatus.SUCCESS, "", resolved, missing);
+    }
+
+    public static GenerationRewardBatchResponse failure(GenerationStatus status, String message) {
+        return new GenerationRewardBatchResponse(status, message, List.of(), List.of());
+    }
+
+    public record ResolvedReward(
+            GenerationRewardReference reference,
+            GenerationResult.Treasure treasure,
+            List<GenerationResult.LootItem> lootItems,
+            List<GenerationResult.Packing> packing
+    ) {
+
+        public ResolvedReward {
+            reference = Objects.requireNonNull(reference, "reference");
+            treasure = Objects.requireNonNull(treasure, "treasure");
+            lootItems = List.copyOf(lootItems);
+            packing = List.copyOf(packing);
+        }
+    }
+}

--- a/features/sessiongeneration/api/GenerationRewardReference.java
+++ b/features/sessiongeneration/api/GenerationRewardReference.java
@@ -1,0 +1,13 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+
+public record GenerationRewardReference(GenerationRunId runId, int treasureId) {
+
+    public GenerationRewardReference {
+        runId = Objects.requireNonNull(runId, "runId");
+        if (treasureId <= 0) {
+            throw new IllegalArgumentException("treasure id must be positive");
+        }
+    }
+}

--- a/features/sessiongeneration/api/GenerationRunResponse.java
+++ b/features/sessiongeneration/api/GenerationRunResponse.java
@@ -1,0 +1,43 @@
+package features.sessiongeneration.api;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record GenerationRunResponse(
+        GenerationStatus status,
+        String message,
+        Optional<GenerationResult> result,
+        Optional<CommitOutcome> commitOutcome
+) {
+
+    public GenerationRunResponse {
+        status = Objects.requireNonNull(status, "status");
+        message = Objects.requireNonNullElse(message, "");
+        result = Objects.requireNonNull(result, "result");
+        commitOutcome = Objects.requireNonNull(commitOutcome, "commitOutcome");
+        if ((status == GenerationStatus.SUCCESS) != result.isPresent()) {
+            throw new IllegalArgumentException("run payload does not match response status");
+        }
+        if (status != GenerationStatus.SUCCESS && commitOutcome.isPresent()) {
+            throw new IllegalArgumentException("failed run response must not expose a commit outcome");
+        }
+    }
+
+    public static GenerationRunResponse success(GenerationResult result) {
+        return new GenerationRunResponse(GenerationStatus.SUCCESS, "", Optional.of(result), Optional.empty());
+    }
+
+    public static GenerationRunResponse committed(GenerationResult result, CommitOutcome outcome) {
+        return new GenerationRunResponse(
+                GenerationStatus.SUCCESS, "", Optional.of(result), Optional.of(outcome));
+    }
+
+    public static GenerationRunResponse failure(GenerationStatus status, String message) {
+        return new GenerationRunResponse(status, message, Optional.empty(), Optional.empty());
+    }
+
+    public enum CommitOutcome {
+        INSERTED,
+        ALREADY_PRESENT
+    }
+}

--- a/features/sessiongeneration/api/GenerationStatus.java
+++ b/features/sessiongeneration/api/GenerationStatus.java
@@ -6,5 +6,6 @@ public enum GenerationStatus {
     INVALID_REQUEST,
     CATALOG_FAILURE,
     GENERATION_FAILURE,
+    IDENTITY_CONFLICT,
     STORAGE_FAILURE
 }

--- a/features/sessiongeneration/api/SessionGenerationApi.java
+++ b/features/sessiongeneration/api/SessionGenerationApi.java
@@ -4,7 +4,21 @@ import java.util.concurrent.CompletionStage;
 
 public interface SessionGenerationApi {
 
+    CompletionStage<GenerationDraftResponse> draft(GenerationRequest request);
+
+    CompletionStage<GenerationRunResponse> commit(CommitGenerationRunCommand command);
+
+    // M1 cannot overload the deprecated load method by return type. M3 removes that delegate and
+    // promotes this canonical operation to the owner-contract name `load`.
+    CompletionStage<GenerationRunResponse> loadRun(GenerationRunId runId);
+
+    CompletionStage<GenerationRewardBatchResponse> loadRewards(GenerationRewardBatchQuery query);
+
+    /** @deprecated M3 replaces the preview workflow that needs generate-and-commit transport. */
+    @Deprecated(forRemoval = true)
     CompletionStage<GenerationResponse> generate(GenerationRequest request);
 
+    /** @deprecated M3 replaces the Apply continuation that reloads the just-generated run. */
+    @Deprecated(forRemoval = true)
     CompletionStage<GenerationResponse> load(GenerationRunId runId);
 }

--- a/features/sessiongeneration/application/GenerationResultMapper.java
+++ b/features/sessiongeneration/application/GenerationResultMapper.java
@@ -3,6 +3,7 @@ package features.sessiongeneration.application;
 import features.sessiongeneration.api.GenerationResult;
 import features.sessiongeneration.api.GenerationRunId;
 import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
 
 final class GenerationResultMapper {
 
@@ -16,6 +17,8 @@ final class GenerationResultMapper {
                 run.catalogVersion(),
                 run.catalogContentHash(),
                 run.seed(),
+                run.party().stream().map(value -> new GenerationResult.PartyLevel(
+                        value.level(), value.players())).toList(),
                 new GenerationResult.SessionSummary(
                         run.session().partyCount(), run.session().adventureDayFraction(),
                         run.session().encounterCount(), run.session().dayXpBudget(),
@@ -29,7 +32,9 @@ final class GenerationResultMapper {
                         encounter.encounterNumber(), encounter.targetXp(), encounter.adjustedXp(),
                         GenerationResult.Difficulty.valueOf(encounter.difficulty().name()), encounter.candidateId(),
                         encounter.monsterSummary(), encounter.monsterCount(), encounter.multiplier(),
+                        encounter.maxChallengeCode(), encounter.bossScore(),
                         encounter.blocks().stream().map(block -> new GenerationResult.EncounterBlock(
+                                block.id(),
                                 encounterRole(block.role()),
                                 block.challengeCode(), block.challengeLabel(), block.unitXp(), block.quantity()))
                                 .toList())).toList(),
@@ -51,6 +56,51 @@ final class GenerationResultMapper {
                 run.audits().stream().map(audit -> new GenerationResult.Audit(
                         audit.code(), GenerationResult.AuditStatus.valueOf(audit.status().name()), audit.detail()))
                         .toList());
+    }
+
+    static GeneratedRunDraft toDomain(features.sessiongeneration.api.GenerationDraft draft) {
+        GenerationResult result = draft.result();
+        GeneratedRun run = new GeneratedRun(
+                result.runId().value(), result.engineVersion(), result.catalogVersion(), result.catalogContentHash(),
+                result.seed(),
+                result.party().stream().map(value -> new GeneratedRun.PartyLevel(
+                        value.level(), value.players())).toList(),
+                new GeneratedRun.SessionContext(
+                        result.session().partyCount(), result.session().adventureDayFraction(),
+                        result.session().encounterCount(), result.session().dayXpBudget(),
+                        result.session().sessionXpTarget(), result.session().averageLevel(),
+                        result.session().normalBudgetCp(), result.session().overstockBudgetCp(),
+                        result.session().nonMagicSlots(), result.session().normalMagic(),
+                        result.session().overstockMagic(), result.session().treasureCount()),
+                result.encounterTargets().stream().map(value -> new GeneratedRun.EncounterTarget(
+                        value.encounterNumber(), value.targetXp())).toList(),
+                result.encounters().stream().map(value -> new GeneratedRun.EncounterPlan(
+                        value.encounterNumber(), value.targetXp(), value.adjustedXp(),
+                        GeneratedRun.Difficulty.valueOf(value.difficulty().name()), value.candidateId(),
+                        value.monsterSummary(), value.monsterCount(), value.multiplier(), value.maxChallengeCode(),
+                        value.bossScore(), value.blocks().stream().map(block -> new GeneratedRun.EncounterBlock(
+                                block.id(), GeneratedRun.EncounterRole.valueOf(block.requestedRole().name()),
+                                block.challengeCode(), block.challengeLabel(), block.monsterXp(), block.count()))
+                                .toList())).toList(),
+                result.treasures().stream().map(value -> new GeneratedRun.TreasurePlan(
+                        value.treasureId(), GeneratedRun.StockClass.valueOf(value.stockClass().name()),
+                        GeneratedRun.RewardChannel.valueOf(value.channel().name()), value.anchorEncounterNumber(),
+                        value.theme(), value.magicType(), value.targetCp(), value.nonMagicSlots(), value.magicSlots()))
+                        .toList(),
+                result.lootItems().stream().map(value -> new GeneratedRun.LootLine(
+                        value.lineId(), value.treasureId(), GeneratedRun.LootRole.valueOf(value.role().name()),
+                        value.itemId(), value.text(), value.quantity(), value.unitCp(), value.actualCp(),
+                        value.totalCapacity(), value.allowedContainers(), value.magicRarity(), value.cursed())).toList(),
+                result.packing().stream().map(value -> new GeneratedRun.PackingRow(
+                        value.lineId(), value.treasureId(), value.containerType(), value.containerCount(),
+                        value.containerId(), value.valid())).toList(),
+                new GeneratedRun.RewardSummary(
+                        result.rewards().normalActualCp(), result.rewards().overstockActualCp(),
+                        result.rewards().magicCount()),
+                result.formattedText(),
+                result.audits().stream().map(value -> new GeneratedRun.Audit(
+                        value.code(), GeneratedRun.AuditStatus.valueOf(value.status().name()), value.detail())).toList());
+        return new GeneratedRunDraft(run, draft.contentFingerprint());
     }
 
     private static GenerationResult.EncounterRole encounterRole(GeneratedRun.EncounterRole role) {

--- a/features/sessiongeneration/application/GenerationRunIdentity.java
+++ b/features/sessiongeneration/application/GenerationRunIdentity.java
@@ -1,0 +1,30 @@
+package features.sessiongeneration.application;
+
+import features.sessiongeneration.api.GenerationPreparationIdentity;
+import features.sessiongeneration.domain.generation.GeneratedRun;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class GenerationRunIdentity {
+
+    private GenerationRunIdentity() {
+    }
+
+    static String assign(GenerationPreparationIdentity preparationIdentity, GeneratedRun generated) {
+        if (preparationIdentity.equals(GenerationPreparationIdentity.legacy())) {
+            return generated.runId();
+        }
+        String canonical = "session-generation-run-v1\n"
+                + preparationIdentity.value().replace("\r\n", "\n").replace('\r', '\n') + "\n"
+                + generated.engineVersion() + "\n"
+                + generated.catalogContentHash();
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                    .digest(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 unavailable", exception);
+        }
+    }
+}

--- a/features/sessiongeneration/application/SessionGenerationService.java
+++ b/features/sessiongeneration/application/SessionGenerationService.java
@@ -1,20 +1,33 @@
 package features.sessiongeneration.application;
 
+import features.sessiongeneration.api.CommitGenerationRunCommand;
+import features.sessiongeneration.api.GenerationDraft;
+import features.sessiongeneration.api.GenerationDraftResponse;
 import features.sessiongeneration.api.GenerationRequest;
 import features.sessiongeneration.api.GenerationResponse;
+import features.sessiongeneration.api.GenerationRewardBatchQuery;
+import features.sessiongeneration.api.GenerationRewardBatchResponse;
+import features.sessiongeneration.api.GenerationRewardReference;
 import features.sessiongeneration.api.GenerationRunId;
+import features.sessiongeneration.api.GenerationRunResponse;
 import features.sessiongeneration.api.GenerationStatus;
 import features.sessiongeneration.api.SessionGenerationApi;
 import features.sessiongeneration.domain.catalog.GenerationCatalog;
+import features.sessiongeneration.domain.catalog.GenerationCatalog.CatalogSnapshot;
 import features.sessiongeneration.domain.generation.GeneratedRun;
-import features.sessiongeneration.domain.generation.GenerationInput;
-import features.sessiongeneration.domain.generation.GenerationRunRepository;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
 import features.sessiongeneration.domain.generation.GeneratedRunValidator;
+import features.sessiongeneration.domain.generation.GenerationInput;
+import features.sessiongeneration.domain.generation.GenerationRewardBatch;
+import features.sessiongeneration.domain.generation.GenerationRunCommitResult;
+import features.sessiongeneration.domain.generation.GenerationRunIdentityConflictException;
+import features.sessiongeneration.domain.generation.GenerationRunRepository;
 import features.sessiongeneration.domain.generation.SessionGenerationEngine;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 import platform.execution.ExecutionLane;
 
 public final class SessionGenerationService implements SessionGenerationApi {
@@ -22,44 +35,113 @@ public final class SessionGenerationService implements SessionGenerationApi {
     private final GenerationCatalog catalog;
     private final GenerationRunRepository repository;
     private final SessionGenerationEngine engine;
-    private final ExecutionLane executionLane;
+    private final ExecutionLane cpuLane;
+    private final ExecutionLane ioLane;
     private final GeneratedRunValidator validator = new GeneratedRunValidator();
 
     public SessionGenerationService(
             GenerationCatalog catalog,
             GenerationRunRepository repository,
             SessionGenerationEngine engine,
-            ExecutionLane executionLane
+            ExecutionLane cpuLane,
+            ExecutionLane ioLane
     ) {
         this.catalog = Objects.requireNonNull(catalog, "catalog");
         this.repository = Objects.requireNonNull(repository, "repository");
         this.engine = Objects.requireNonNull(engine, "engine");
-        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.cpuLane = Objects.requireNonNull(cpuLane, "cpuLane");
+        this.ioLane = Objects.requireNonNull(ioLane, "ioLane");
     }
 
+    @Override
+    public CompletionStage<GenerationDraftResponse> draft(GenerationRequest request) {
+        CompletableFuture<GenerationDraftResponse> response = new CompletableFuture<>();
+        if (request == null) {
+            response.complete(GenerationDraftResponse.failure(
+                    GenerationStatus.INVALID_REQUEST, "Generation request is required."));
+            return response;
+        }
+        schedule(ioLane, response, () -> {
+            CatalogSnapshot snapshot;
+            try {
+                snapshot = catalog.load();
+            } catch (IllegalArgumentException | IllegalStateException exception) {
+                response.complete(GenerationDraftResponse.failure(
+                        GenerationStatus.CATALOG_FAILURE, "Generation catalog is unavailable or invalid."));
+                return;
+            }
+            schedule(cpuLane, response, () -> response.complete(draftNow(request, snapshot)),
+                    () -> GenerationDraftResponse.failure(
+                            GenerationStatus.GENERATION_FAILURE, "Generation execution is unavailable."));
+        }, () -> GenerationDraftResponse.failure(
+                GenerationStatus.CATALOG_FAILURE, "Generation catalog execution is unavailable."));
+        return response;
+    }
+
+    @Override
+    public CompletionStage<GenerationRunResponse> commit(CommitGenerationRunCommand command) {
+        CompletableFuture<GenerationRunResponse> response = new CompletableFuture<>();
+        if (command == null) {
+            response.complete(GenerationRunResponse.failure(
+                    GenerationStatus.INVALID_REQUEST, "Generation draft is required."));
+            return response;
+        }
+        executeIo(response, () -> commitNow(command), () -> GenerationRunResponse.failure(
+                GenerationStatus.STORAGE_FAILURE, "Generation run could not be persisted."));
+        return response;
+    }
+
+    @Override
+    public CompletionStage<GenerationRunResponse> loadRun(GenerationRunId runId) {
+        CompletableFuture<GenerationRunResponse> response = new CompletableFuture<>();
+        if (runId == null) {
+            response.complete(GenerationRunResponse.failure(
+                    GenerationStatus.INVALID_REQUEST, "Generation run id is required."));
+            return response;
+        }
+        executeIo(response, () -> loadNow(runId), () -> GenerationRunResponse.failure(
+                GenerationStatus.STORAGE_FAILURE, "Generation run could not be loaded."));
+        return response;
+    }
+
+    @Override
+    public CompletionStage<GenerationRewardBatchResponse> loadRewards(GenerationRewardBatchQuery query) {
+        CompletableFuture<GenerationRewardBatchResponse> response = new CompletableFuture<>();
+        if (query == null) {
+            response.complete(GenerationRewardBatchResponse.failure(
+                    GenerationStatus.INVALID_REQUEST, "Generation reward query is required."));
+            return response;
+        }
+        executeIo(response, () -> loadRewardsNow(query), () -> GenerationRewardBatchResponse.failure(
+                GenerationStatus.STORAGE_FAILURE, "Generation rewards could not be loaded."));
+        return response;
+    }
+
+    @Deprecated(forRemoval = true)
     @Override
     public CompletionStage<GenerationResponse> generate(GenerationRequest request) {
-        CompletableFuture<GenerationResponse> response = new CompletableFuture<>();
-        if (request == null) {
-            response.complete(GenerationResponse.failure(GenerationStatus.INVALID_REQUEST, "Generation request is required."));
-            return response;
-        }
-        execute(response, () -> generateNow(request));
-        return response;
+        return draft(request).thenCompose(draftResponse -> {
+            if (draftResponse.status() != GenerationStatus.SUCCESS || draftResponse.draft().isEmpty()) {
+                return CompletableFuture.completedFuture(GenerationResponse.failure(
+                        draftResponse.status(), draftResponse.message()));
+            }
+            GenerationDraft draft = draftResponse.draft().orElseThrow();
+            return commit(new CommitGenerationRunCommand(draft)).thenApply(commitResponse ->
+                    commitResponse.status() == GenerationStatus.SUCCESS
+                            ? GenerationResponse.success(draft.result())
+                            : GenerationResponse.failure(commitResponse.status(), commitResponse.message()));
+        });
     }
 
+    @Deprecated(forRemoval = true)
     @Override
     public CompletionStage<GenerationResponse> load(GenerationRunId runId) {
-        CompletableFuture<GenerationResponse> response = new CompletableFuture<>();
-        if (runId == null) {
-            response.complete(GenerationResponse.failure(GenerationStatus.INVALID_REQUEST, "Generation run id is required."));
-            return response;
-        }
-        execute(response, () -> loadNow(runId));
-        return response;
+        return loadRun(runId).thenApply(response -> response.status() == GenerationStatus.SUCCESS
+                ? GenerationResponse.success(response.result().orElseThrow())
+                : GenerationResponse.failure(response.status(), response.message()));
     }
 
-    private GenerationResponse generateNow(GenerationRequest request) {
+    private GenerationDraftResponse draftNow(GenerationRequest request, CatalogSnapshot snapshot) {
         GenerationInput input;
         try {
             input = new GenerationInput(
@@ -68,62 +150,155 @@ public final class SessionGenerationService implements SessionGenerationApi {
                             .toList(),
                     request.adventureDayFraction(), request.encounterCount(), request.seed());
         } catch (IllegalArgumentException exception) {
-            return GenerationResponse.failure(GenerationStatus.INVALID_REQUEST, "Generation input is invalid.");
+            return GenerationDraftResponse.failure(GenerationStatus.INVALID_REQUEST, "Generation input is invalid.");
         }
         GeneratedRun generated;
         try {
-            generated = engine.generate(input, catalog.load());
+            generated = engine.generate(input, snapshot);
+            generated = withRunId(generated, GenerationRunIdentity.assign(request.preparationIdentity(), generated));
         } catch (IllegalArgumentException | IllegalStateException exception) {
-            return GenerationResponse.failure(GenerationStatus.CATALOG_FAILURE, "Generation catalog is unavailable or invalid.");
+            return GenerationDraftResponse.failure(
+                    GenerationStatus.GENERATION_FAILURE, "Generation could not be completed.");
         }
-        if (generated.audits().stream().anyMatch(
-                audit -> audit.status() == GeneratedRun.AuditStatus.FAIL)) {
-            return GenerationResponse.failure(
-                    GenerationStatus.GENERATION_FAILURE,
-                    "Generation invariants could not be satisfied.");
+        if (generated.audits().stream().anyMatch(audit -> audit.status() == GeneratedRun.AuditStatus.FAIL)) {
+            return GenerationDraftResponse.failure(
+                    GenerationStatus.GENERATION_FAILURE, "Generation invariants could not be satisfied.");
         }
         try {
             validator.validate(generated);
-            return GenerationResponse.success(GenerationResultMapper.toApi(repository.save(generated)));
+            GeneratedRunDraft domainDraft = GeneratedRunDraft.from(generated);
+            return GenerationDraftResponse.success(new GenerationDraft(
+                    GenerationResultMapper.toApi(domainDraft.run()), domainDraft.contentFingerprint()));
         } catch (IllegalStateException exception) {
-            return GenerationResponse.failure(GenerationStatus.STORAGE_FAILURE, "Generation run could not be persisted.");
+            return GenerationDraftResponse.failure(
+                    GenerationStatus.GENERATION_FAILURE, "Generation invariants could not be satisfied.");
         }
     }
 
-    private GenerationResponse loadNow(GenerationRunId runId) {
+    private GenerationRunResponse commitNow(CommitGenerationRunCommand command) {
+        GeneratedRunDraft draft;
+        try {
+            draft = GenerationResultMapper.toDomain(command.draft());
+            validator.validate(draft.run());
+            if (!draft.contentFingerprint().equals(
+                    features.sessiongeneration.domain.generation.GenerationContentFingerprint.v1(draft.run()))) {
+                return GenerationRunResponse.failure(
+                        GenerationStatus.INVALID_REQUEST, "Generation draft is invalid.");
+            }
+        } catch (IllegalArgumentException | IllegalStateException exception) {
+            return GenerationRunResponse.failure(GenerationStatus.INVALID_REQUEST, "Generation draft is invalid.");
+        }
+        try {
+            GenerationRunCommitResult committed = repository.commit(draft);
+            return GenerationRunResponse.committed(
+                    GenerationResultMapper.toApi(committed.draft().run()),
+                    committed.outcome() == GenerationRunCommitResult.Outcome.INSERTED
+                            ? GenerationRunResponse.CommitOutcome.INSERTED
+                            : GenerationRunResponse.CommitOutcome.ALREADY_PRESENT);
+        } catch (GenerationRunIdentityConflictException exception) {
+            return GenerationRunResponse.failure(
+                    GenerationStatus.IDENTITY_CONFLICT, "Generation run identity is already in use.");
+        } catch (IllegalStateException exception) {
+            return GenerationRunResponse.failure(
+                    GenerationStatus.STORAGE_FAILURE, "Generation run could not be persisted.");
+        }
+    }
+
+    private GenerationRunResponse loadNow(GenerationRunId runId) {
         try {
             return repository.load(runId.value())
+                    .map(GeneratedRunDraft::run)
                     .map(run -> {
                         validator.validate(run);
                         return GenerationResultMapper.toApi(run);
                     })
-                    .map(GenerationResponse::success)
-                    .orElseGet(() -> GenerationResponse.failure(
+                    .map(GenerationRunResponse::success)
+                    .orElseGet(() -> GenerationRunResponse.failure(
                             GenerationStatus.NOT_FOUND, "Generation run was not found."));
         } catch (IllegalStateException exception) {
-            return GenerationResponse.failure(GenerationStatus.STORAGE_FAILURE, "Generation run could not be loaded.");
+            return GenerationRunResponse.failure(
+                    GenerationStatus.STORAGE_FAILURE, "Generation run could not be loaded.");
         }
     }
 
-    private void execute(CompletableFuture<GenerationResponse> response, Operation operation) {
+    private GenerationRewardBatchResponse loadRewardsNow(GenerationRewardBatchQuery query) {
         try {
-            executionLane.execute(() -> {
-                try {
-                    response.complete(operation.run());
-                } catch (RuntimeException exception) {
-                    response.complete(GenerationResponse.failure(
-                            GenerationStatus.STORAGE_FAILURE,
-                            "Generation operation could not be completed."));
-                }
-            });
-        } catch (RuntimeException exception) {
-            response.complete(GenerationResponse.failure(
-                    GenerationStatus.STORAGE_FAILURE, "Generation execution is unavailable."));
+            List<features.sessiongeneration.domain.generation.GenerationRewardReference> references =
+                    query.references().stream().map(reference ->
+                            new features.sessiongeneration.domain.generation.GenerationRewardReference(
+                                    reference.runId().value(), reference.treasureId())).toList();
+            GenerationRewardBatch batch = repository.loadRewards(references);
+            return GenerationRewardBatchResponse.success(
+                    batch.resolved().stream().map(SessionGenerationService::toApi).toList(),
+                    batch.missing().stream().map(SessionGenerationService::toApi).toList());
+        } catch (IllegalArgumentException exception) {
+            return GenerationRewardBatchResponse.failure(
+                    GenerationStatus.INVALID_REQUEST, "Generation reward query is invalid.");
+        } catch (IllegalStateException exception) {
+            return GenerationRewardBatchResponse.failure(
+                    GenerationStatus.STORAGE_FAILURE, "Generation rewards could not be loaded.");
         }
     }
 
-    @FunctionalInterface
-    private interface Operation {
-        GenerationResponse run();
+    private static GenerationRewardBatchResponse.ResolvedReward toApi(GenerationRewardBatch.ResolvedReward reward) {
+        GeneratedRun.TreasurePlan treasure = reward.treasure();
+        return new GenerationRewardBatchResponse.ResolvedReward(
+                toApi(reward.reference()),
+                new features.sessiongeneration.api.GenerationResult.Treasure(
+                        treasure.treasureId(),
+                        features.sessiongeneration.api.GenerationResult.StockClass.valueOf(
+                                treasure.stockClass().name()),
+                        features.sessiongeneration.api.GenerationResult.RewardChannel.valueOf(
+                                treasure.channel().name()),
+                        treasure.anchorEncounterNumber(), treasure.theme(), treasure.magicType(), treasure.targetCp(),
+                        treasure.nonMagicSlots(), treasure.magicSlots()),
+                reward.loot().stream().map(line -> new features.sessiongeneration.api.GenerationResult.LootItem(
+                        line.lineId(), line.treasureId(),
+                        features.sessiongeneration.api.GenerationResult.LootRole.valueOf(line.role().name()),
+                        line.itemId(), line.text(), line.quantity(), line.unitCp(), line.actualCp(),
+                        line.totalCapacity(), line.allowedContainers(), line.magicRarity(), line.cursed())).toList(),
+                reward.packing().stream().map(row -> new features.sessiongeneration.api.GenerationResult.Packing(
+                        row.lineId(), row.treasureId(), row.containerType(), row.containerCount(),
+                        row.containerId(), row.valid())).toList());
+    }
+
+    private static GenerationRewardReference toApi(
+            features.sessiongeneration.domain.generation.GenerationRewardReference reference
+    ) {
+        return new GenerationRewardReference(new GenerationRunId(reference.runId()), reference.treasureId());
+    }
+
+    private static GeneratedRun withRunId(GeneratedRun run, String runId) {
+        return new GeneratedRun(
+                runId, run.engineVersion(), run.catalogVersion(), run.catalogContentHash(), run.seed(),
+                run.party(), run.session(), run.encounterTargets(), run.encounters(), run.treasures(), run.loot(),
+                run.packing(), run.rewards(), run.formattedText(), run.audits());
+    }
+
+    private <T> void executeIo(
+            CompletableFuture<T> response,
+            Supplier<T> operation,
+            Supplier<T> failure
+    ) {
+        schedule(ioLane, response, () -> {
+            try {
+                response.complete(operation.get());
+            } catch (RuntimeException exception) {
+                response.complete(failure.get());
+            }
+        }, failure);
+    }
+
+    private static <T> void schedule(
+            ExecutionLane lane,
+            CompletableFuture<T> response,
+            Runnable operation,
+            Supplier<T> failure
+    ) {
+        try {
+            lane.execute(operation);
+        } catch (RuntimeException exception) {
+            response.complete(failure.get());
+        }
     }
 }

--- a/features/sessiongeneration/domain/generation/GeneratedRunDraft.java
+++ b/features/sessiongeneration/domain/generation/GeneratedRunDraft.java
@@ -1,0 +1,19 @@
+package features.sessiongeneration.domain.generation;
+
+import java.util.Objects;
+
+/** Complete transient generation truth before it is committed as an immutable run. */
+public record GeneratedRunDraft(GeneratedRun run, String contentFingerprint) {
+
+    public GeneratedRunDraft {
+        run = Objects.requireNonNull(run, "run");
+        contentFingerprint = Objects.requireNonNull(contentFingerprint, "contentFingerprint").trim();
+        if (!contentFingerprint.matches("v1:[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("content fingerprint must use the v1 SHA-256 format");
+        }
+    }
+
+    public static GeneratedRunDraft from(GeneratedRun run) {
+        return new GeneratedRunDraft(run, GenerationContentFingerprint.v1(run));
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationContentFingerprint.java
+++ b/features/sessiongeneration/domain/generation/GenerationContentFingerprint.java
@@ -1,0 +1,165 @@
+package features.sessiongeneration.domain.generation;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+/** Canonical semantic fingerprint for normalized persisted generation content. */
+public final class GenerationContentFingerprint {
+
+    private GenerationContentFingerprint() {
+    }
+
+    public static String v1(GeneratedRun run) {
+        Objects.requireNonNull(run, "run");
+        CanonicalWriter writer = new CanonicalWriter();
+        writer.text("session-generation-content-fingerprint");
+        writer.text("v1");
+        writer.text(run.runId());
+        writer.text(run.engineVersion());
+        writer.text(run.catalogVersion());
+        writer.text(run.catalogContentHash());
+        writer.integer(run.seed());
+        writer.list(run.party(), (value, output) -> {
+            output.integer(value.level());
+            output.integer(value.players());
+        });
+        GeneratedRun.SessionContext session = run.session();
+        writer.integer(session.partyCount());
+        writer.decimal(session.adventureDayFraction());
+        writer.integer(session.encounterCount());
+        writer.integer(session.dayXpBudget());
+        writer.integer(session.sessionXpTarget());
+        writer.decimal(session.averageLevel());
+        writer.integer(session.normalBudgetCp());
+        writer.integer(session.overstockBudgetCp());
+        writer.integer(session.nonMagicSlots());
+        writer.integer(session.normalMagic());
+        writer.integer(session.overstockMagic());
+        writer.integer(session.treasureCount());
+        writer.list(run.encounterTargets(), (value, output) -> {
+            output.integer(value.encounterNumber());
+            output.integer(value.targetXp());
+        });
+        writer.list(run.encounters(), (value, output) -> {
+            output.integer(value.encounterNumber());
+            output.integer(value.targetXp());
+            output.integer(value.adjustedXp());
+            output.text(value.difficulty().name());
+            output.text(value.candidateId());
+            output.text(value.monsterSummary());
+            output.integer(value.monsterCount());
+            output.decimal(value.multiplier());
+            output.integer(value.maxChallengeCode());
+            output.decimal(value.bossScore());
+            output.list(value.blocks(), (block, blockOutput) -> {
+                blockOutput.text(block.id());
+                blockOutput.text(block.role().name());
+                blockOutput.integer(block.challengeCode());
+                blockOutput.text(block.challengeLabel());
+                blockOutput.integer(block.unitXp());
+                blockOutput.integer(block.quantity());
+            });
+        });
+        writer.list(run.treasures(), (value, output) -> {
+            output.integer(value.treasureId());
+            output.text(value.stockClass().name());
+            output.text(value.channel().name());
+            output.integer(value.anchorEncounterNumber());
+            output.text(value.theme());
+            output.text(value.magicType());
+            output.integer(value.targetCp());
+            output.integer(value.nonMagicSlots());
+            output.integer(value.magicSlots());
+        });
+        writer.list(run.loot(), (value, output) -> {
+            output.integer(value.lineId());
+            output.integer(value.treasureId());
+            output.text(value.role().name());
+            output.text(value.itemId());
+            output.text(value.text());
+            output.integer(value.quantity());
+            output.integer(value.unitCp());
+            output.integer(value.actualCp());
+            output.decimal(value.totalCapacity());
+            output.text(value.allowedContainers());
+            output.text(value.magicRarity());
+            output.bool(value.cursed());
+        });
+        writer.list(run.packing(), (value, output) -> {
+            output.integer(value.lineId());
+            output.integer(value.treasureId());
+            output.text(value.containerType());
+            output.integer(value.containerCount());
+            output.text(value.containerId());
+            output.bool(value.valid());
+        });
+        writer.integer(run.rewards().normalActualCp());
+        writer.integer(run.rewards().overstockActualCp());
+        writer.integer(run.rewards().magicCount());
+        writer.list(run.audits(), (value, output) -> {
+            output.text(value.code());
+            output.text(value.status().name());
+            output.text(value.detail());
+        });
+        return "v1:" + writer.finish();
+    }
+
+    private static final class CanonicalWriter {
+        private final MessageDigest digest;
+
+        private CanonicalWriter() {
+            try {
+                digest = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException exception) {
+                throw new IllegalStateException("SHA-256 unavailable", exception);
+            }
+        }
+
+        String finish() {
+            return HexFormat.of().formatHex(digest.digest());
+        }
+
+        void text(String value) {
+            byte[] normalized = normalizeText(value).getBytes(StandardCharsets.UTF_8);
+            writeInt(normalized.length);
+            digest.update(normalized);
+        }
+
+        void decimal(BigDecimal value) {
+            BigDecimal normalized = Objects.requireNonNull(value, "decimal").stripTrailingZeros();
+            text(normalized.signum() == 0 ? "0" : normalized.toPlainString());
+        }
+
+        void integer(long value) {
+            for (int shift = Long.SIZE - Byte.SIZE; shift >= 0; shift -= Byte.SIZE) {
+                digest.update((byte) (value >>> shift));
+            }
+        }
+
+        void bool(boolean value) {
+            digest.update((byte) (value ? 1 : 0));
+        }
+
+        <T> void list(List<T> values, BiConsumer<T, CanonicalWriter> encoder) {
+            List<T> safeValues = List.copyOf(values);
+            writeInt(safeValues.size());
+            safeValues.forEach(value -> encoder.accept(value, this));
+        }
+
+        private static String normalizeText(String value) {
+            return Objects.requireNonNullElse(value, "").replace("\r\n", "\n").replace('\r', '\n');
+        }
+
+        private void writeInt(int value) {
+            for (int shift = Integer.SIZE - Byte.SIZE; shift >= 0; shift -= Byte.SIZE) {
+                digest.update((byte) (value >>> shift));
+            }
+        }
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationRewardBatch.java
+++ b/features/sessiongeneration/domain/generation/GenerationRewardBatch.java
@@ -1,0 +1,24 @@
+package features.sessiongeneration.domain.generation;
+
+import java.util.List;
+
+public record GenerationRewardBatch(List<ResolvedReward> resolved, List<GenerationRewardReference> missing) {
+
+    public GenerationRewardBatch {
+        resolved = List.copyOf(resolved);
+        missing = List.copyOf(missing);
+    }
+
+    public record ResolvedReward(
+            GenerationRewardReference reference,
+            GeneratedRun.TreasurePlan treasure,
+            List<GeneratedRun.LootLine> loot,
+            List<GeneratedRun.PackingRow> packing
+    ) {
+
+        public ResolvedReward {
+            loot = List.copyOf(loot);
+            packing = List.copyOf(packing);
+        }
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationRewardReference.java
+++ b/features/sessiongeneration/domain/generation/GenerationRewardReference.java
@@ -1,0 +1,16 @@
+package features.sessiongeneration.domain.generation;
+
+import java.util.Objects;
+
+public record GenerationRewardReference(String runId, int treasureId) {
+
+    public GenerationRewardReference {
+        runId = Objects.requireNonNull(runId, "runId").trim();
+        if (runId.isEmpty()) {
+            throw new IllegalArgumentException("run id must not be empty");
+        }
+        if (treasureId <= 0) {
+            throw new IllegalArgumentException("treasure id must be positive");
+        }
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationRunCommitResult.java
+++ b/features/sessiongeneration/domain/generation/GenerationRunCommitResult.java
@@ -1,0 +1,16 @@
+package features.sessiongeneration.domain.generation;
+
+import java.util.Objects;
+
+public record GenerationRunCommitResult(GeneratedRunDraft draft, Outcome outcome) {
+
+    public GenerationRunCommitResult {
+        draft = Objects.requireNonNull(draft, "draft");
+        outcome = Objects.requireNonNull(outcome, "outcome");
+    }
+
+    public enum Outcome {
+        INSERTED,
+        ALREADY_PRESENT
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationRunIdentityConflictException.java
+++ b/features/sessiongeneration/domain/generation/GenerationRunIdentityConflictException.java
@@ -1,0 +1,8 @@
+package features.sessiongeneration.domain.generation;
+
+public final class GenerationRunIdentityConflictException extends IllegalStateException {
+
+    public GenerationRunIdentityConflictException(String runId) {
+        super("generation run identity already denotes different semantic content: " + runId);
+    }
+}

--- a/features/sessiongeneration/domain/generation/GenerationRunRepository.java
+++ b/features/sessiongeneration/domain/generation/GenerationRunRepository.java
@@ -1,10 +1,13 @@
 package features.sessiongeneration.domain.generation;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface GenerationRunRepository {
 
-    GeneratedRun save(GeneratedRun run);
+    GenerationRunCommitResult commit(GeneratedRunDraft draft);
 
-    Optional<GeneratedRun> load(String runId);
+    Optional<GeneratedRunDraft> load(String runId);
+
+    GenerationRewardBatch loadRewards(List<GenerationRewardReference> references);
 }

--- a/features/sessionplanner/SessionPlannerServiceAssembly.java
+++ b/features/sessionplanner/SessionPlannerServiceAssembly.java
@@ -21,6 +21,11 @@ import features.party.api.AdventuringDayCalculationModel;
 import features.party.api.PartyApi;
 import features.sessiongeneration.api.GenerationRequest;
 import features.sessiongeneration.api.GenerationResponse;
+import features.sessiongeneration.api.CommitGenerationRunCommand;
+import features.sessiongeneration.api.GenerationDraftResponse;
+import features.sessiongeneration.api.GenerationRewardBatchQuery;
+import features.sessiongeneration.api.GenerationRewardBatchResponse;
+import features.sessiongeneration.api.GenerationRunResponse;
 import features.sessiongeneration.api.GenerationRunId;
 import features.sessiongeneration.api.GenerationStatus;
 import features.sessiongeneration.api.SessionGenerationApi;
@@ -255,6 +260,34 @@ public final class SessionPlannerServiceAssembly {
 
     private static SessionGenerationApi unavailableGeneration() {
         return new SessionGenerationApi() {
+            @Override
+            public java.util.concurrent.CompletionStage<GenerationDraftResponse> draft(GenerationRequest request) {
+                return CompletableFuture.completedFuture(GenerationDraftResponse.failure(
+                        GenerationStatus.CATALOG_FAILURE, "Session generation is not configured."));
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<GenerationRunResponse> commit(
+                    CommitGenerationRunCommand command
+            ) {
+                return CompletableFuture.completedFuture(GenerationRunResponse.failure(
+                        GenerationStatus.STORAGE_FAILURE, "Session generation is not configured."));
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<GenerationRunResponse> loadRun(GenerationRunId runId) {
+                return CompletableFuture.completedFuture(GenerationRunResponse.failure(
+                        GenerationStatus.NOT_FOUND, "Session generation is not configured."));
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<GenerationRewardBatchResponse> loadRewards(
+                    GenerationRewardBatchQuery query
+            ) {
+                return CompletableFuture.completedFuture(GenerationRewardBatchResponse.failure(
+                        GenerationStatus.STORAGE_FAILURE, "Session generation is not configured."));
+            }
+
             @Override
             public java.util.concurrent.CompletionStage<GenerationResponse> generate(GenerationRequest request) {
                 return CompletableFuture.completedFuture(GenerationResponse.failure(

--- a/features/sessionplanner/application/SessionGenerationFailureMessages.java
+++ b/features/sessionplanner/application/SessionGenerationFailureMessages.java
@@ -16,6 +16,7 @@ final class SessionGenerationFailureMessages {
             case INVALID_REQUEST -> "Die Generierungsanfrage ist ungültig. Bitte Session-Eingaben prüfen.";
             case CATALOG_FAILURE -> "Der Generierungskatalog konnte nicht geladen werden. Bitte erneut versuchen.";
             case GENERATION_FAILURE -> "Vorschau konnte nicht erzeugt werden. Bitte erneut versuchen.";
+            case IDENTITY_CONFLICT -> "Die Generierungsidentität ist bereits belegt. Bitte Vorschau neu erzeugen.";
             case STORAGE_FAILURE -> "Vorschau konnte nicht gespeichert werden. Bitte erneut versuchen.";
             case NOT_FOUND -> "Generierungsergebnis wurde nicht gefunden. Bitte Vorschau neu erzeugen.";
             case SUCCESS -> "Vorschau konnte nicht erzeugt werden. Bitte erneut versuchen.";
@@ -31,6 +32,7 @@ final class SessionGenerationFailureMessages {
             case INVALID_REQUEST -> "Persistierte Vorschau ist ungültig. Bitte Vorschau neu erzeugen.";
             case CATALOG_FAILURE -> "Der Generierungskatalog konnte nicht geladen werden. Bitte erneut versuchen.";
             case GENERATION_FAILURE -> "Persistierte Vorschau konnte nicht verarbeitet werden. Bitte erneut versuchen.";
+            case IDENTITY_CONFLICT -> "Persistierte Vorschau hat einen Identitätskonflikt. Bitte neu erzeugen.";
             case STORAGE_FAILURE -> "Persistierte Vorschau konnte nicht geladen werden. Bitte erneut versuchen.";
             case SUCCESS -> "Persistierte Vorschau konnte nicht geladen werden. Bitte erneut versuchen.";
         };

--- a/platform/execution/BoundedExecutionLane.java
+++ b/platform/execution/BoundedExecutionLane.java
@@ -1,0 +1,71 @@
+package platform.execution;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+
+/** Fixed-size execution lane for independently schedulable bounded work. */
+public final class BoundedExecutionLane implements ExecutionLane {
+
+    private static final DiagnosticId TASK_FAILURE = new DiagnosticId("execution.task-failure");
+
+    private final Diagnostics diagnostics;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final ExecutorService executor;
+
+    public BoundedExecutionLane(Diagnostics diagnostics, String threadName, int parallelism) {
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
+        String safeName = Objects.requireNonNull(threadName, "threadName").trim();
+        if (safeName.isEmpty()) {
+            throw new IllegalArgumentException("thread name must not be empty");
+        }
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be positive");
+        }
+        AtomicInteger sequence = new AtomicInteger();
+        executor = Executors.newFixedThreadPool(parallelism, task -> {
+            Thread thread = new Thread(task, safeName + "-" + sequence.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @Override
+    public void execute(Runnable work) {
+        Runnable safeWork = Objects.requireNonNull(work, "work");
+        if (closed.get()) {
+            throw new RejectedExecutionException("execution lane is closed");
+        }
+        executor.execute(() -> {
+            try {
+                safeWork.run();
+            } catch (RuntimeException exception) {
+                diagnostics.failure(TASK_FAILURE, exception.getClass());
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            executor.shutdown();
+        }
+        boolean interrupted = false;
+        while (!executor.isTerminated()) {
+            try {
+                executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException exception) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/platform/persistence/SqliteDatabase.java
+++ b/platform/persistence/SqliteDatabase.java
@@ -163,12 +163,21 @@ public final class SqliteDatabase implements AutoCloseable {
         synchronized (this) {
             requireOpen();
         }
-        Connection connection = openConfigured(databasePath);
+        Connection connection = null;
         try {
-            migrate(connection, registeredPlans());
+            // Connection setup changes WAL mode and may execute idempotent DDL or feature
+            // migrations. Serialize only that initialization window for this database lifecycle;
+            // returned connections and their feature transactions remain independently concurrent.
+            synchronized (this) {
+                requireOpen();
+                connection = openConfigured(databasePath);
+                migrate(connection, registeredPlans());
+            }
             return connection;
         } catch (SQLException | RuntimeException exception) {
-            connection.close();
+            if (connection != null) {
+                connection.close();
+            }
             if (exception instanceof SQLException sqlException) {
                 throw sqlException;
             }

--- a/test/app/AppBootstrapLifecycleTest.java
+++ b/test/app/AppBootstrapLifecycleTest.java
@@ -1,0 +1,51 @@
+package app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.ExecutionLane;
+import platform.persistence.SqliteDatabase;
+import platform.ui.DirectUiDispatcher;
+
+final class AppBootstrapLifecycleTest {
+
+    @TempDir
+    java.nio.file.Path temporaryDirectory;
+
+    @Test
+    void bootstrapClosesBothOwnedSessionGenerationLanesExactlyOnce() {
+        RecordingLane shared = new RecordingLane();
+        RecordingLane generationCpu = new RecordingLane();
+        RecordingLane generationIo = new RecordingLane();
+        AppBootstrap bootstrap = new AppBootstrap(
+                NoopDiagnostics.INSTANCE,
+                shared,
+                generationCpu,
+                generationIo,
+                DirectUiDispatcher.INSTANCE,
+                new SqliteDatabase(temporaryDirectory.resolve("lifecycle.sqlite"), NoopDiagnostics.INSTANCE));
+
+        bootstrap.close();
+        bootstrap.close();
+
+        assertEquals(1, generationCpu.closes);
+        assertEquals(1, generationIo.closes);
+        assertEquals(1, shared.closes);
+    }
+
+    private static final class RecordingLane implements ExecutionLane {
+        private int closes;
+
+        @Override
+        public void execute(Runnable work) {
+            work.run();
+        }
+
+        @Override
+        public void close() {
+            closes++;
+        }
+    }
+}

--- a/test/features/sessiongeneration/SessionGenerationStageBaselineTest.java
+++ b/test/features/sessiongeneration/SessionGenerationStageBaselineTest.java
@@ -1,0 +1,80 @@
+package features.sessiongeneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import features.sessiongeneration.adapter.resource.TsvGenerationCatalog;
+import features.sessiongeneration.adapter.sqlite.persistence.SqliteGenerationRunRepository;
+import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
+import features.sessiongeneration.domain.generation.GenerationInput;
+import features.sessiongeneration.domain.generation.GenerationRewardReference;
+import features.sessiongeneration.domain.generation.SessionGenerationEngine;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.persistence.SqliteDatabase;
+
+final class SessionGenerationStageBaselineTest {
+
+    @TempDir
+    java.nio.file.Path temporaryDirectory;
+
+    @Test
+    void baselineCatalogLoadProductionResourceScenario() {
+        var snapshot = new TsvGenerationCatalog().load();
+
+        assertEquals("catalog-2026-07-16", snapshot.version());
+        assertEquals("10e7b8c2f3d43c0868e2ce0c3bf8471b72ed4d5327fc633452e0245d32f416f6",
+                snapshot.contentHash());
+    }
+
+    @Test
+    void baselinePureEngineGoldenScenario() {
+        GeneratedRun generated = generate();
+
+        assertEquals(List.of(680L, 1000L, 1800L), generated.encounterTargets().stream()
+                .map(GeneratedRun.EncounterTarget::targetXp).toList());
+    }
+
+    @Test
+    void baselinePersistenceCommitAndCanonicalLoadScenario() {
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate());
+        try (SqliteDatabase database = new SqliteDatabase(
+                temporaryDirectory.resolve("commit-load.sqlite"), NoopDiagnostics.INSTANCE)) {
+            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
+
+            repository.commit(draft);
+
+            assertEquals(draft, repository.load(draft.run().runId()).orElseThrow());
+        }
+    }
+
+    @Test
+    void baselineStructuredRewardBatchReadScenario() {
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate());
+        try (SqliteDatabase database = new SqliteDatabase(
+                temporaryDirectory.resolve("reward-read.sqlite"), NoopDiagnostics.INSTANCE)) {
+            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
+            repository.commit(draft);
+
+            var batch = repository.loadRewards(List.of(
+                    new GenerationRewardReference(draft.run().runId(), draft.run().treasures().getFirst().treasureId())));
+
+            assertEquals(1, batch.resolved().size());
+            assertFalse(batch.resolved().getFirst().loot().isEmpty());
+            assertEquals(List.of(), batch.missing());
+        }
+    }
+
+    private static GeneratedRun generate() {
+        return new SessionGenerationEngine().generate(
+                new GenerationInput(
+                        List.of(new GeneratedRun.PartyLevel(3, 2), new GeneratedRun.PartyLevel(4, 2)),
+                        new BigDecimal("0.6"), OptionalInt.of(3), 179974L),
+                new TsvGenerationCatalog().load());
+    }
+}

--- a/test/features/sessiongeneration/adapter/resource/TsvGenerationCatalogManifestTest.java
+++ b/test/features/sessiongeneration/adapter/resource/TsvGenerationCatalogManifestTest.java
@@ -2,6 +2,7 @@ package features.sessiongeneration.adapter.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
@@ -14,6 +15,8 @@ import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 final class TsvGenerationCatalogManifestTest {
@@ -36,6 +39,44 @@ final class TsvGenerationCatalogManifestTest {
 
         assertEquals(ARTIFACT_HASH, snapshot.contentHash());
         assertNotEquals(SOURCE_HASH, snapshot.contentHash());
+    }
+
+    @Test
+    void oneServiceInstanceReusesExactlyOneValidatedSnapshotForItsContentIdentity() {
+        AtomicInteger reads = new AtomicInteger();
+        TsvGenerationCatalog.ResourceLoader classpath = classpath();
+        TsvGenerationCatalog catalog = new TsvGenerationCatalog(file -> {
+            reads.incrementAndGet();
+            return classpath.read(file);
+        });
+
+        var first = catalog.load();
+        int readsAfterValidation = reads.get();
+        var second = catalog.load();
+
+        assertSame(first, second);
+        assertEquals(ARTIFACT_HASH, first.contentHash());
+        assertEquals(readsAfterValidation, reads.get());
+    }
+
+    @Test
+    void failedValidationIsNeverPublishedAndAValidRetryCanBecomeTheCachedSnapshot() {
+        AtomicBoolean firstManifest = new AtomicBoolean(true);
+        TsvGenerationCatalog.ResourceLoader classpath = classpath();
+        TsvGenerationCatalog catalog = new TsvGenerationCatalog(file -> {
+            byte[] content = classpath.read(file);
+            if (file.equals("manifest.json") && firstManifest.getAndSet(false)) {
+                return new String(content, StandardCharsets.UTF_8)
+                        .replace(ARTIFACT_HASH, "0".repeat(64)).getBytes(StandardCharsets.UTF_8);
+            }
+            return content;
+        });
+
+        assertThrows(IllegalStateException.class, catalog::load);
+        var validated = catalog.load();
+
+        assertEquals(ARTIFACT_HASH, validated.contentHash());
+        assertSame(validated, catalog.load());
     }
 
     @Test

--- a/test/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepositoryTest.java
+++ b/test/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepositoryTest.java
@@ -1,21 +1,33 @@
 package features.sessiongeneration.adapter.sqlite.persistence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import features.sessiongeneration.adapter.resource.TsvGenerationCatalog;
 import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
 import features.sessiongeneration.domain.generation.GenerationInput;
+import features.sessiongeneration.domain.generation.GenerationRewardReference;
+import features.sessiongeneration.domain.generation.GenerationRunCommitResult;
+import features.sessiongeneration.domain.generation.GenerationRunIdentityConflictException;
 import features.sessiongeneration.domain.generation.SessionGenerationEngine;
 import java.math.BigDecimal;
 import java.sql.DriverManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import platform.diagnostics.NoopDiagnostics;
 import platform.persistence.SqliteDatabase;
+import platform.persistence.SqliteMigration;
 
 final class SqliteGenerationRunRepositoryTest {
 
@@ -23,97 +35,247 @@ final class SqliteGenerationRunRepositoryTest {
     java.nio.file.Path temporaryDirectory;
 
     @Test
-    void immutableRelationalRunRoundTripsWithoutBinaryPayload() throws Exception {
+    void firstCommitInsertsEqualRetryIsAlreadyPresentAndRoundTripPreservesMeaning() throws Exception {
         java.nio.file.Path databasePath = temporaryDirectory.resolve("roundtrip.sqlite");
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
             SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
-            GeneratedRun generated = generate(179974L);
 
-            assertEquals(generated, repository.save(generated));
-            assertEquals(generated, repository.load(generated.runId()).orElseThrow());
+            assertEquals(GenerationRunCommitResult.Outcome.INSERTED, repository.commit(draft).outcome());
+            assertEquals(GenerationRunCommitResult.Outcome.ALREADY_PRESENT, repository.commit(draft).outcome());
+            assertEquals(draft, repository.load(draft.run().runId()).orElseThrow());
         }
 
         try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
                 var statement = connection.createStatement();
-                var rows = statement.executeQuery("SELECT owner, schema_version FROM session_generation_runs")) {
+                var rows = statement.executeQuery(
+                        "SELECT owner, schema_version, content_fingerprint FROM session_generation_runs")) {
             assertTrue(rows.next());
             assertEquals("session-generation", rows.getString(1));
             assertEquals(1, rows.getInt(2));
+            assertEquals(draft.contentFingerprint(), rows.getString(3));
+        }
+    }
+
+    @Test
+    void sameIdentityWithDifferentSemanticFingerprintFailsClosed() {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("conflict.sqlite");
+        GeneratedRun original = generate(179974L);
+        GeneratedRun changed = withSeed(original, original.seed() + 1L);
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
+            repository.commit(GeneratedRunDraft.from(original));
+
+            assertThrows(GenerationRunIdentityConflictException.class,
+                    () -> repository.commit(GeneratedRunDraft.from(changed)));
+            assertEquals(original, repository.load(original.runId()).orElseThrow().run());
+        }
+    }
+
+    @Test
+    void equalConcurrentCommitRaceConvergesOnOneInsertAndOneAlreadyPresent() throws Exception {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("race.sqlite");
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE);
+                var workers = Executors.newFixedThreadPool(2)) {
+            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
+            CountDownLatch ready = new CountDownLatch(2);
+            CountDownLatch start = new CountDownLatch(1);
+            List<java.util.concurrent.Future<GenerationRunCommitResult.Outcome>> outcomes = new ArrayList<>();
+            for (int index = 0; index < 2; index++) {
+                outcomes.add(workers.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return repository.commit(draft).outcome();
+                }));
+            }
+            ready.await();
+            start.countDown();
+
+            assertEquals(
+                    java.util.Set.of(
+                            GenerationRunCommitResult.Outcome.INSERTED,
+                            GenerationRunCommitResult.Outcome.ALREADY_PRESENT),
+                    java.util.Set.of(outcomes.get(0).get(), outcomes.get(1).get()));
         }
     }
 
     @Test
     void failedChildInsertRollsBackEntireImmutableRun() throws Exception {
         java.nio.file.Path databasePath = temporaryDirectory.resolve("rollback.sqlite");
-        GeneratedRun first = generate(179974L);
-        GeneratedRun blocked = generate(179975L);
+        GeneratedRunDraft first = GeneratedRunDraft.from(generate(179974L));
+        GeneratedRunDraft blocked = GeneratedRunDraft.from(generate(179975L));
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
             SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
-            repository.save(first);
+            repository.commit(first);
             try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
                     var statement = connection.createStatement()) {
                 statement.execute("CREATE TRIGGER fail_generation_loot BEFORE INSERT ON session_generation_loot_items "
                         + "BEGIN SELECT RAISE(ABORT, 'forced rollback'); END");
             }
 
-            assertThrows(IllegalStateException.class, () -> repository.save(blocked));
-            assertTrue(repository.load(blocked.runId()).isEmpty());
-            assertTrue(repository.load(first.runId()).isPresent());
+            assertThrows(IllegalStateException.class, () -> repository.commit(blocked));
+            assertTrue(repository.load(blocked.run().runId()).isEmpty());
+            assertTrue(repository.load(first.run().runId()).isPresent());
         }
     }
 
     @Test
-    void loadRejectsCorruptedAggregateSummary() throws Exception {
-        java.nio.file.Path databasePath = temporaryDirectory.resolve("corrupt.sqlite");
-        GeneratedRun generated = generate(179974L);
+    void v1CanonicalRowsMigrateAndDeriveFingerprintWithoutReadRewrite() throws Exception {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("legacy-v1.sqlite");
+        GeneratedRun legacy = generate(179974L);
+        SessionGenerationSchema schema = new SessionGenerationSchema();
+        try (SqliteDatabase v1 = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE);
+                var connection = v1.connections(
+                        SqliteGenerationRunRepository.OWNER,
+                        new SqliteMigration(1, schema::migrateV1)).openConnection()) {
+            new GenerationRunSqliteWriter().insertLegacyV1(connection, legacy);
+        }
+
+        GeneratedRunDraft loaded;
+        try (SqliteDatabase migrated = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            loaded = new SqliteGenerationRunRepository(migrated).load(legacy.runId()).orElseThrow();
+        }
+        assertEquals(legacy, loaded.run());
+
+        try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+                var statement = connection.createStatement();
+                var rows = statement.executeQuery(
+                        "SELECT content_fingerprint FROM session_generation_runs WHERE run_id = '" + legacy.runId() + "'")) {
+            assertTrue(rows.next());
+            assertNull(rows.getString(1));
+        }
+    }
+
+    @Test
+    void rewardBatchPreservesCallerOrderDuplicatesAndMissingAcrossChunks() {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("rewards.sqlite");
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
             SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
-            repository.save(generated);
+            repository.commit(draft);
+            GenerationRewardReference present = new GenerationRewardReference(draft.run().runId(), 1);
+            GenerationRewardReference missing = new GenerationRewardReference(draft.run().runId(), 999);
+            List<GenerationRewardReference> requested = new ArrayList<>();
+            requested.add(present);
+            requested.add(missing);
+            requested.add(present);
+            for (int index = 1; index <= GenerationRewardSqliteReader.MAX_KEYS_PER_QUERY; index++) {
+                requested.add(new GenerationRewardReference("missing-run-" + index, 1));
+            }
+
+            AtomicInteger queries = new AtomicInteger();
+            SqliteGenerationRunRepository counted = new SqliteGenerationRunRepository(
+                    () -> countingConnection(databasePath, queries));
+            var batch = counted.loadRewards(requested);
+
+            assertEquals(List.of(present, present), batch.resolved().stream()
+                    .map(value -> value.reference()).toList());
+            assertEquals(requested.size() - 2, batch.missing().size());
+            assertEquals(missing, batch.missing().getFirst());
+            assertEquals(draft.run().treasures().getFirst(), batch.resolved().getFirst().treasure());
+            assertEquals(
+                    draft.run().loot().stream().filter(line -> line.treasureId() == 1).toList(),
+                    batch.resolved().getFirst().loot());
+            assertEquals(2, queries.get());
+        }
+    }
+
+    @Test
+    void emptyRewardBatchOpensNoSqliteConnection() {
+        SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(
+                () -> { throw new AssertionError("empty reward batch must not open SQLite"); });
+
+        assertTrue(repository.loadRewards(List.of()).resolved().isEmpty());
+    }
+
+    @Test
+    void rewardBatchDeduplicatesSqlKeysButReconstructsEveryCallerDuplicate() {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("reward-dedup.sqlite");
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            new SqliteGenerationRunRepository(database).commit(draft);
+            GenerationRewardReference repeated = new GenerationRewardReference(draft.run().runId(), 1);
+            List<GenerationRewardReference> requested = java.util.Collections.nCopies(
+                    GenerationRewardSqliteReader.MAX_KEYS_PER_QUERY + 1, repeated);
+            AtomicInteger queries = new AtomicInteger();
+            SqliteGenerationRunRepository counted = new SqliteGenerationRunRepository(
+                    () -> countingConnection(databasePath, queries));
+
+            var batch = counted.loadRewards(requested);
+
+            assertEquals(requested.size(), batch.resolved().size());
+            assertEquals(1, queries.get());
+        }
+    }
+
+    @Test
+    void loadRejectsCorruptedAggregateSummaryAndFingerprint() throws Exception {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("corrupt.sqlite");
+        GeneratedRunDraft generated = GeneratedRunDraft.from(generate(179974L));
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
+            repository.commit(generated);
             try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
                     var statement = connection.createStatement()) {
                 statement.executeUpdate("UPDATE session_generation_runs SET normal_actual_cp = normal_actual_cp + 1");
             }
 
-            assertThrows(IllegalStateException.class, () -> repository.load(generated.runId()));
+            assertThrows(IllegalStateException.class, () -> repository.load(generated.run().runId()));
         }
     }
 
     @Test
-    void loadRejectsGappedEncounterBlockOrder() throws Exception {
-        assertOrderCorruptionRejected(
-                "block-order.sqlite",
-                "UPDATE session_generation_encounter_blocks SET block_order = 99 "
-                        + "WHERE rowid = (SELECT rowid FROM session_generation_encounter_blocks LIMIT 1)");
-    }
-
-    @Test
-    void loadRejectsGappedAuditOrder() throws Exception {
-        assertOrderCorruptionRejected(
-                "audit-order.sqlite",
-                "UPDATE session_generation_audits SET audit_order = 99 "
-                        + "WHERE audit_order = 0");
-    }
-
-    private void assertOrderCorruptionRejected(String fileName, String updateSql) throws Exception {
-        java.nio.file.Path databasePath = temporaryDirectory.resolve(fileName);
-        GeneratedRun generated = generate(179974L);
+    void canonicalLoadUsesFixedQueryFamiliesRatherThanPerEncounterReads() {
+        java.nio.file.Path databasePath = temporaryDirectory.resolve("load-query-bound.sqlite");
+        GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
-            SqliteGenerationRunRepository repository = new SqliteGenerationRunRepository(database);
-            repository.save(generated);
-            try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
-                    var statement = connection.createStatement()) {
-                statement.executeUpdate(updateSql);
-            }
+            new SqliteGenerationRunRepository(database).commit(draft);
+            AtomicInteger queries = new AtomicInteger();
+            SqliteGenerationRunRepository counted = new SqliteGenerationRunRepository(
+                    () -> countingConnection(databasePath, queries));
 
-            assertThrows(IllegalStateException.class, () -> repository.load(generated.runId()));
+            assertEquals(draft, counted.load(draft.run().runId()).orElseThrow());
+            assertEquals(9, queries.get());
         }
     }
 
-    private static GeneratedRun generate(long seed) {
+    private static GeneratedRun withSeed(GeneratedRun run, long seed) {
+        return new GeneratedRun(
+                run.runId(), run.engineVersion(), run.catalogVersion(), run.catalogContentHash(), seed,
+                run.party(), run.session(), run.encounterTargets(), run.encounters(), run.treasures(), run.loot(),
+                run.packing(), run.rewards(), run.formattedText(), run.audits());
+    }
+
+    static GeneratedRun generate(long seed) {
         return new SessionGenerationEngine().generate(
                 new GenerationInput(
                         List.of(new GeneratedRun.PartyLevel(3, 2), new GeneratedRun.PartyLevel(4, 2)),
                         new BigDecimal("0.6"), OptionalInt.of(3), seed),
                 new TsvGenerationCatalog().load());
     }
+
+    private static java.sql.Connection countingConnection(
+            java.nio.file.Path databasePath,
+            AtomicInteger queries
+    ) throws java.sql.SQLException {
+        java.sql.Connection delegate = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+        try (var statement = delegate.createStatement()) {
+            statement.execute("PRAGMA foreign_keys = ON");
+        }
+        return (java.sql.Connection) Proxy.newProxyInstance(
+                SqliteGenerationRunRepositoryTest.class.getClassLoader(),
+                new Class<?>[] {java.sql.Connection.class},
+                (proxy, method, arguments) -> {
+                    if (method.getName().equals("prepareStatement")) {
+                        queries.incrementAndGet();
+                    }
+                    try {
+                        return method.invoke(delegate, arguments);
+                    } catch (InvocationTargetException exception) {
+                        throw exception.getCause();
+                    }
+                });
+    }
+
 }

--- a/test/features/sessiongeneration/application/SessionGenerationServiceTest.java
+++ b/test/features/sessiongeneration/application/SessionGenerationServiceTest.java
@@ -1,14 +1,19 @@
 package features.sessiongeneration.application;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import features.sessiongeneration.api.GenerationRequest;
+import features.sessiongeneration.api.GenerationPreparationIdentity;
+import features.sessiongeneration.api.CommitGenerationRunCommand;
 import features.sessiongeneration.api.GenerationRunId;
 import features.sessiongeneration.api.GenerationStatus;
 import features.sessiongeneration.domain.catalog.GenerationCatalog;
-import features.sessiongeneration.domain.generation.GeneratedRun;
+import features.sessiongeneration.domain.generation.GeneratedRunDraft;
+import features.sessiongeneration.domain.generation.GenerationRewardBatch;
+import features.sessiongeneration.domain.generation.GenerationRewardReference;
+import features.sessiongeneration.domain.generation.GenerationRunCommitResult;
 import features.sessiongeneration.domain.generation.GenerationRunRepository;
 import features.sessiongeneration.domain.generation.SessionGenerationEngine;
 import java.math.BigDecimal;
@@ -16,60 +21,145 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import platform.execution.ExecutionLane;
+import platform.execution.BoundedExecutionLane;
+import platform.diagnostics.NoopDiagnostics;
 
 final class SessionGenerationServiceTest {
 
     @Test
-    void generateDoesNoCatalogOrPersistenceWorkOnCallerThread() {
-        QueuedLane lane = new QueuedLane();
+    void draftUsesIoThenCpuAndPerformsZeroRepositoryAccess() {
+        QueuedLane cpu = new QueuedLane();
+        QueuedLane io = new QueuedLane();
         RecordingCatalog catalog = new RecordingCatalog();
         RecordingRepository repository = new RecordingRepository();
         SessionGenerationService service = new SessionGenerationService(
-                catalog, repository, new SessionGenerationEngine(), lane);
+                catalog, repository, new SessionGenerationEngine(), cpu, io);
 
-        var completion = service.generate(new GenerationRequest(
-                List.of(new GenerationRequest.PartyLevel(3, 2), new GenerationRequest.PartyLevel(4, 2)),
-                new BigDecimal("0.6"), OptionalInt.of(3), 179974L)).toCompletableFuture();
+        var completion = service.draft(request()).toCompletableFuture();
 
         assertFalse(completion.isDone());
         assertFalse(catalog.loaded);
-        assertFalse(repository.saved);
-        lane.runNext();
-        assertTrue(completion.isDone());
+        assertEquals(1, io.size());
+        assertEquals(0, cpu.size());
+        io.runNext();
         assertTrue(catalog.loaded);
-        assertTrue(repository.saved);
-        assertTrue(completion.join().status() == GenerationStatus.SUCCESS);
+        assertFalse(repository.accessed);
+        assertEquals(1, cpu.size());
+        cpu.runNext();
+        assertEquals(GenerationStatus.SUCCESS, completion.join().status());
+        assertFalse(repository.accessed);
+    }
+
+    @Test
+    void deprecatedGenerateExecutesRealDraftThenCommitsExactSuppliedSemanticValue() {
+        QueuedLane cpu = new QueuedLane();
+        QueuedLane io = new QueuedLane();
+        RecordingRepository repository = new RecordingRepository();
+        SessionGenerationService service = new SessionGenerationService(
+                new RecordingCatalog(), repository, new SessionGenerationEngine(), cpu, io);
+
+        var completion = service.generate(request()).toCompletableFuture();
+        io.runNext();
+        cpu.runNext();
+        assertFalse(completion.isDone());
+        io.runNext();
+
+        assertEquals(GenerationStatus.SUCCESS, completion.join().status());
+        assertEquals(completion.join().result().orElseThrow().runId().value(), repository.committed.run().runId());
+        assertEquals(repository.committed.contentFingerprint(),
+                features.sessiongeneration.domain.generation.GenerationContentFingerprint.v1(
+                        repository.committed.run()));
     }
 
     @Test
     void failedHardAuditReturnsGenerationFailureWithoutPersistence() {
-        QueuedLane lane = new QueuedLane();
+        QueuedLane cpu = new QueuedLane();
+        QueuedLane io = new QueuedLane();
         RecordingRepository repository = new RecordingRepository();
         SessionGenerationService service = new SessionGenerationService(
-                new MissingCandidateCatalog(), repository, new SessionGenerationEngine(), lane);
+                new MissingCandidateCatalog(), repository, new SessionGenerationEngine(), cpu, io);
 
-        var completion = service.generate(new GenerationRequest(
+        var completion = service.draft(new GenerationRequest(
+                new GenerationPreparationIdentity("preparation:test:failure"),
                 List.of(new GenerationRequest.PartyLevel(3, 4)),
                 new BigDecimal("0.6"), OptionalInt.of(3), 7L)).toCompletableFuture();
-        lane.runNext();
+        io.runNext();
+        cpu.runNext();
 
         assertEquals(GenerationStatus.GENERATION_FAILURE, completion.join().status());
-        assertFalse(repository.saved);
+        assertFalse(repository.accessed);
     }
 
     @Test
-    void unexpectedOperationFailureAlwaysCompletesWithStorageFailure() {
-        QueuedLane lane = new QueuedLane();
+    void loadFailureCompletesOnIoLaneWithStorageFailure() {
+        QueuedLane cpu = new QueuedLane();
+        QueuedLane io = new QueuedLane();
         SessionGenerationService service = new SessionGenerationService(
-                new RecordingCatalog(), new ThrowingRepository(), new SessionGenerationEngine(), lane);
+                new RecordingCatalog(), new ThrowingRepository(), new SessionGenerationEngine(), cpu, io);
 
-        var completion = service.load(new GenerationRunId("broken-run")).toCompletableFuture();
-        lane.runNext();
+        var completion = service.loadRun(new GenerationRunId("broken-run")).toCompletableFuture();
+        assertEquals(0, cpu.size());
+        io.runNext();
 
         assertTrue(completion.isDone());
         assertEquals(GenerationStatus.STORAGE_FAILURE, completion.join().status());
+    }
+
+    @Test
+    void catalogAndPersistenceUseIoWhilePureDraftCompletionUsesCpu() {
+        AtomicReference<String> catalogThread = new AtomicReference<>();
+        AtomicReference<String> draftThread = new AtomicReference<>();
+        RecordingRepository repository = new RecordingRepository();
+        GenerationCatalog catalog = () -> {
+            catalogThread.set(Thread.currentThread().getName());
+            return new features.sessiongeneration.adapter.resource.TsvGenerationCatalog().load();
+        };
+        try (BoundedExecutionLane cpu = new BoundedExecutionLane(
+                        NoopDiagnostics.INSTANCE, "session-generation-cpu-test", 2);
+                BoundedExecutionLane io = new BoundedExecutionLane(
+                        NoopDiagnostics.INSTANCE, "session-generation-io-test", 2)) {
+            SessionGenerationService service = new SessionGenerationService(
+                    catalog, repository, new SessionGenerationEngine(), cpu, io);
+            var drafted = service.draft(request()).thenApply(response -> {
+                draftThread.set(Thread.currentThread().getName());
+                return response.draft().orElseThrow();
+            }).toCompletableFuture().join();
+            service.commit(new CommitGenerationRunCommand(drafted)).toCompletableFuture().join();
+        }
+
+        assertTrue(catalogThread.get().startsWith("session-generation-io-test-"));
+        assertTrue(draftThread.get().startsWith("session-generation-cpu-test-"));
+        assertTrue(repository.commitThread.startsWith("session-generation-io-test-"));
+    }
+
+    @Test
+    void runIdentityUsesPreparationEngineAndCatalogContentNotCatalogLabel() {
+        var catalog = new features.sessiongeneration.adapter.resource.TsvGenerationCatalog().load();
+        var generated = new SessionGenerationEngine().generate(
+                new features.sessiongeneration.domain.generation.GenerationInput(
+                        List.of(new features.sessiongeneration.domain.generation.GeneratedRun.PartyLevel(3, 4)),
+                        new BigDecimal("0.6"), OptionalInt.of(3), 179974L),
+                catalog);
+        var relabeled = new features.sessiongeneration.domain.generation.GeneratedRun(
+                generated.runId(), generated.engineVersion(), "label-only-change", generated.catalogContentHash(),
+                generated.seed(), generated.party(), generated.session(), generated.encounterTargets(),
+                generated.encounters(), generated.treasures(), generated.loot(), generated.packing(),
+                generated.rewards(), generated.formattedText(), generated.audits());
+        GenerationPreparationIdentity preparation = new GenerationPreparationIdentity("preparation:stable-id");
+
+        assertEquals(
+                GenerationRunIdentity.assign(preparation, generated),
+                GenerationRunIdentity.assign(preparation, relabeled));
+    }
+
+    private static GenerationRequest request() {
+        return new GenerationRequest(
+                new GenerationPreparationIdentity("preparation:test:canonical"),
+                List.of(new GenerationRequest.PartyLevel(3, 2), new GenerationRequest.PartyLevel(4, 2)),
+                new BigDecimal("0.6"), OptionalInt.of(3), 179974L);
     }
 
     private static final class RecordingCatalog implements GenerationCatalog {
@@ -96,29 +186,45 @@ final class SessionGenerationServiceTest {
     }
 
     private static final class RecordingRepository implements GenerationRunRepository {
-        private boolean saved;
+        private boolean accessed;
+        private GeneratedRunDraft committed;
+        private String commitThread;
 
         @Override
-        public GeneratedRun save(GeneratedRun run) {
-            saved = true;
-            return run;
+        public GenerationRunCommitResult commit(GeneratedRunDraft draft) {
+            accessed = true;
+            committed = draft;
+            commitThread = Thread.currentThread().getName();
+            return new GenerationRunCommitResult(draft, GenerationRunCommitResult.Outcome.INSERTED);
         }
 
         @Override
-        public Optional<GeneratedRun> load(String runId) {
+        public Optional<GeneratedRunDraft> load(String runId) {
+            accessed = true;
             return Optional.empty();
+        }
+
+        @Override
+        public GenerationRewardBatch loadRewards(List<GenerationRewardReference> references) {
+            accessed = true;
+            return new GenerationRewardBatch(List.of(), references);
         }
     }
 
     private static final class ThrowingRepository implements GenerationRunRepository {
 
         @Override
-        public GeneratedRun save(GeneratedRun run) {
+        public GenerationRunCommitResult commit(GeneratedRunDraft draft) {
             throw new IllegalArgumentException("malformed stored aggregate");
         }
 
         @Override
-        public Optional<GeneratedRun> load(String runId) {
+        public Optional<GeneratedRunDraft> load(String runId) {
+            throw new IllegalArgumentException("malformed stored aggregate");
+        }
+
+        @Override
+        public GenerationRewardBatch loadRewards(List<GenerationRewardReference> references) {
             throw new IllegalArgumentException("malformed stored aggregate");
         }
     }
@@ -129,6 +235,10 @@ final class SessionGenerationServiceTest {
         @Override
         public void execute(Runnable task) {
             work.add(task);
+        }
+
+        int size() {
+            return work.size();
         }
 
         void runNext() {

--- a/test/features/sessiongeneration/domain/generation/GenerationContentFingerprintTest.java
+++ b/test/features/sessiongeneration/domain/generation/GenerationContentFingerprintTest.java
@@ -1,0 +1,87 @@
+package features.sessiongeneration.domain.generation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import features.sessiongeneration.adapter.resource.TsvGenerationCatalog;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+
+final class GenerationContentFingerprintTest {
+
+    @Test
+    void goldenV1FingerprintPinsExplicitCanonicalEncoding() {
+        assertEquals(
+                "v1:516fa4819d031daa841d10ca6c89b58277440077c1270fd7fc11d8b24e453b81",
+                GenerationContentFingerprint.v1(goldenRun()));
+    }
+
+    @Test
+    void v1NormalizesDecimalsAndLineEndingsAndExcludesFormattedText() {
+        GeneratedRun source = goldenRun();
+        List<GeneratedRun.LootLine> lineFeedLoot = new ArrayList<>(source.loot());
+        GeneratedRun.LootLine first = lineFeedLoot.getFirst();
+        lineFeedLoot.set(0, new GeneratedRun.LootLine(
+                first.lineId(), first.treasureId(), first.role(), first.itemId(), first.text() + "\ncontinued",
+                first.quantity(), first.unitCp(), first.actualCp(), first.totalCapacity(), first.allowedContainers(),
+                first.magicRarity(), first.cursed()));
+        GeneratedRun lineFeed = copy(source, source.session(), lineFeedLoot, source.formattedText());
+        GeneratedRun normalized = copy(
+                lineFeed,
+                new GeneratedRun.SessionContext(
+                        source.session().partyCount(), new BigDecimal("0.6000"),
+                        source.session().encounterCount(), source.session().dayXpBudget(),
+                        source.session().sessionXpTarget(), new BigDecimal("3.5000"),
+                        source.session().normalBudgetCp(), source.session().overstockBudgetCp(),
+                        source.session().nonMagicSlots(), source.session().normalMagic(),
+                        source.session().overstockMagic(), source.session().treasureCount()),
+                lineFeed.loot().stream().map(line -> new GeneratedRun.LootLine(
+                        line.lineId(), line.treasureId(), line.role(), line.itemId(),
+                        line.text().replace("\n", "\r\n"), line.quantity(), line.unitCp(), line.actualCp(),
+                        line.totalCapacity().setScale(4), line.allowedContainers(), line.magicRarity(), line.cursed()))
+                        .toList(),
+                "different optional rendering\r\n");
+
+        assertEquals(
+                GenerationContentFingerprint.v1(lineFeed),
+                GenerationContentFingerprint.v1(normalized));
+    }
+
+    @Test
+    void v1PreservesSemanticListOrder() {
+        GeneratedRun source = goldenRun();
+        List<GeneratedRun.Audit> reversed = new ArrayList<>(source.audits());
+        java.util.Collections.reverse(reversed);
+        GeneratedRun reordered = new GeneratedRun(
+                source.runId(), source.engineVersion(), source.catalogVersion(), source.catalogContentHash(),
+                source.seed(), source.party(), source.session(), source.encounterTargets(), source.encounters(),
+                source.treasures(), source.loot(), source.packing(), source.rewards(), source.formattedText(), reversed);
+
+        assertNotEquals(
+                GenerationContentFingerprint.v1(source),
+                GenerationContentFingerprint.v1(reordered));
+    }
+
+    private static GeneratedRun goldenRun() {
+        return new SessionGenerationEngine().generate(
+                new GenerationInput(
+                        List.of(new GeneratedRun.PartyLevel(3, 2), new GeneratedRun.PartyLevel(4, 2)),
+                        new BigDecimal("0.6"), OptionalInt.of(3), 179974L),
+                new TsvGenerationCatalog().load());
+    }
+
+    private static GeneratedRun copy(
+            GeneratedRun source,
+            GeneratedRun.SessionContext session,
+            List<GeneratedRun.LootLine> loot,
+            String formattedText
+    ) {
+        return new GeneratedRun(
+                source.runId(), source.engineVersion(), source.catalogVersion(), source.catalogContentHash(),
+                source.seed(), source.party(), session, source.encounterTargets(), source.encounters(),
+                source.treasures(), loot, source.packing(), source.rewards(), formattedText, source.audits());
+    }
+}

--- a/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
+++ b/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
@@ -103,6 +103,33 @@ public final class SessionPlannerCatalogTest {
         CompletableFuture<GenerationResponse> pending = new CompletableFuture<>();
         SessionGenerationApi delayedGeneration = new SessionGenerationApi() {
             @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationDraftResponse> draft(
+                    GenerationRequest request
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRunResponse> commit(
+                    features.sessiongeneration.api.CommitGenerationRunCommand command
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRunResponse> loadRun(
+                    GenerationRunId runId
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRewardBatchResponse>
+                    loadRewards(features.sessiongeneration.api.GenerationRewardBatchQuery query) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public java.util.concurrent.CompletionStage<GenerationResponse> generate(GenerationRequest request) {
                 return pending;
             }
@@ -762,6 +789,7 @@ public final class SessionPlannerCatalogTest {
                 "catalog-2026-07-16",
                 "10e7b8c2f3d43c0868e2ce0c3bf8471b72ed4d5327fc633452e0245d32f416f6",
                 179_974L,
+                List.of(new GenerationResult.PartyLevel(4, 1)),
                 new GenerationResult.SessionSummary(
                         1, BigDecimal.ONE, 1, 1_000L, 100L, BigDecimal.valueOf(4L),
                         100L, 20L, 1, 0, 0, 1),
@@ -769,7 +797,9 @@ public final class SessionPlannerCatalogTest {
                 List.of(new GenerationResult.Encounter(
                         1, 100L, 100L, GenerationResult.Difficulty.MEDIUM,
                         "candidate", "Generated creature", 1, BigDecimal.ONE,
+                        1, BigDecimal.ZERO,
                         List.of(new GenerationResult.EncounterBlock(
+                                "block-1",
                                 GenerationResult.EncounterRole.STANDARD, 1, "1/2", 100L, 1)))),
                 List.of(new GenerationResult.Treasure(
                         1, GenerationResult.StockClass.NORMAL, GenerationResult.RewardChannel.ENCOUNTER,
@@ -783,6 +813,33 @@ public final class SessionPlannerCatalogTest {
                 List.of(new GenerationResult.Audit(
                         "final-output", GenerationResult.AuditStatus.PASS, "ok")));
         return new SessionGenerationApi() {
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationDraftResponse> draft(
+                    GenerationRequest request
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRunResponse> commit(
+                    features.sessiongeneration.api.CommitGenerationRunCommand command
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRunResponse> loadRun(
+                    GenerationRunId runId
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public java.util.concurrent.CompletionStage<features.sessiongeneration.api.GenerationRewardBatchResponse>
+                    loadRewards(features.sessiongeneration.api.GenerationRewardBatchQuery query) {
+                throw new UnsupportedOperationException();
+            }
+
             @Override
             public java.util.concurrent.CompletionStage<GenerationResponse> generate(GenerationRequest request) {
                 return CompletableFuture.completedFuture(GenerationResponse.success(result));

--- a/test/features/sessionplanner/application/SessionGenerationCoordinatorTest.java
+++ b/test/features/sessionplanner/application/SessionGenerationCoordinatorTest.java
@@ -353,6 +353,7 @@ final class SessionGenerationCoordinatorTest {
                 "catalog-2026-07-16",
                 "10e7b8c2f3d43c0868e2ce0c3bf8471b72ed4d5327fc633452e0245d32f416f6",
                 seed,
+                List.of(new GenerationResult.PartyLevel(3, 2)),
                 new GenerationResult.SessionSummary(
                         2, new BigDecimal("0.6"), 1, 1000L, 100L,
                         new BigDecimal("3.5"), 1000L, 200L, 3, 0, 0, 3),
@@ -366,7 +367,10 @@ final class SessionGenerationCoordinatorTest {
                         "1 × creature",
                         1,
                         BigDecimal.ONE,
+                        1,
+                        BigDecimal.ZERO,
                         List.of(new GenerationResult.EncounterBlock(
+                                "block-1",
                                 GenerationResult.EncounterRole.STANDARD,
                                 1,
                                 "1/2",
@@ -436,6 +440,32 @@ final class SessionGenerationCoordinatorTest {
 
         private RecordingGeneration(GenerationResult result) {
             this.result = result;
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationDraftResponse> draft(
+                GenerationRequest request
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRunResponse> commit(
+                features.sessiongeneration.api.CommitGenerationRunCommand command
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRunResponse> loadRun(GenerationRunId runId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRewardBatchResponse> loadRewards(
+                features.sessiongeneration.api.GenerationRewardBatchQuery query
+        ) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/test/platform/execution/BoundedExecutionLaneTest.java
+++ b/test/platform/execution/BoundedExecutionLaneTest.java
@@ -1,0 +1,55 @@
+package platform.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import platform.diagnostics.NoopDiagnostics;
+
+final class BoundedExecutionLaneTest {
+
+    @Test
+    void boundedLaneRunsIndependentWorkConcurrentlyOnExplicitlyNamedWorkers() throws Exception {
+        Set<String> workers = ConcurrentHashMap.newKeySet();
+        CountDownLatch started = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch completed = new CountDownLatch(2);
+        try (BoundedExecutionLane lane = new BoundedExecutionLane(
+                NoopDiagnostics.INSTANCE, "generation-cpu-proof", 2)) {
+            for (int index = 0; index < 2; index++) {
+                lane.execute(() -> {
+                    workers.add(Thread.currentThread().getName());
+                    started.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        completed.countDown();
+                    }
+                });
+            }
+            assertTrue(started.await(5, TimeUnit.SECONDS));
+            release.countDown();
+            assertTrue(completed.await(5, TimeUnit.SECONDS));
+        }
+
+        assertEquals(2, workers.size());
+        assertTrue(workers.stream().allMatch(name -> name.startsWith("generation-cpu-proof-")));
+    }
+
+    @Test
+    void closeRejectsNewWork() {
+        BoundedExecutionLane lane = new BoundedExecutionLane(
+                NoopDiagnostics.INSTANCE, "generation-io-proof", 1);
+        lane.close();
+
+        assertThrows(RejectedExecutionException.class, () -> lane.execute(() -> { }));
+    }
+}

--- a/test/platform/persistence/SqliteDatabaseTest.java
+++ b/test/platform/persistence/SqliteDatabaseTest.java
@@ -73,6 +73,49 @@ final class SqliteDatabaseTest {
     }
 
     @Test
+    void concurrentConnectionInitializationSerializesMigrationMetadataWithoutSerializingUse() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("concurrent-open.db");
+        AtomicInteger migrations = new AtomicInteger();
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, (id, type) -> { });
+                var workers = java.util.concurrent.Executors.newFixedThreadPool(2)) {
+            SqliteConnectionSource source = database.connections("concurrent", new SqliteMigration(1, connection -> {
+                migrations.incrementAndGet();
+                connection.createStatement().execute(
+                        "CREATE TABLE concurrent_rows(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+            }));
+            CountDownLatch ready = new CountDownLatch(2);
+            CountDownLatch start = new CountDownLatch(1);
+            List<java.util.concurrent.Future<Void>> opened = new ArrayList<>();
+            for (int id = 1; id <= 2; id++) {
+                int rowId = id;
+                opened.add(workers.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    try (var connection = source.openConnection();
+                            var statement = connection.prepareStatement(
+                                    "INSERT INTO concurrent_rows(id, value) VALUES(?, ?)")) {
+                        statement.setInt(1, rowId);
+                        statement.setString(2, "row-" + rowId);
+                        statement.executeUpdate();
+                    }
+                    return null;
+                }));
+            }
+            ready.await();
+            start.countDown();
+            for (var openedConnection : opened) {
+                openedConnection.get();
+            }
+            assertEquals(1, migrations.get());
+            try (var connection = source.openConnection();
+                    var rows = connection.createStatement().executeQuery("SELECT COUNT(*) FROM concurrent_rows")) {
+                assertTrue(rows.next());
+                assertEquals(2, rows.getInt(1));
+            }
+        }
+    }
+
+    @Test
     void maintenanceBackupIsIntegrityCheckedAndRestoreTestedBeforePublication() throws Exception {
         Path databasePath = temporaryDirectory.resolve("maintenance.db");
         SqliteMigration migration = seedMigration();


### PR DESCRIPTION
## Was sich ändert

- führt den typisierten Session-Generation-Pfad `draft` → idempotentes `commit` sowie kanonisches Laden und strukturierte Reward-Batch-Reads ein
- persistiert einen normalisierten v1-Inhaltsfingerabdruck mit kompatiblem Lesen kanonischer v1-Zeilen
- trennt begrenzte CPU- und I/O-Ausführung und behält `generate`/`load` ausschließlich als bis M3 befristete Produktionsdelegates
- behebt die bei Concurrent-Commit-Proof entdeckte SQLite-Initialisierungsrace ohne Feature-Transaktionen global zu serialisieren
- stellt die kanonische Roadmap auf M2 und dokumentiert vier getrennte M1-Baselines

## Warum

M1 ersetzt SQLite-Save/Reload als internen Workflow-Transport durch einen vollständigen unveränderlichen Draft und einen exakt-einmaligen, inhaltsgeprüften Commit. Damit können M2 und M3 konkrete Encounter-Batches und die einheitliche Session-Vorbereitung auf einem stabilen Produktionsvertrag aufbauen.

## Auswirkung

Der bestehende Session-Planner-Pfad bleibt beobachtbar erhalten, läuft intern aber bereits über den neuen Draft/Commit-Vertrag. Gleichartige Wiederholungen sind erfolgreich, Identitätskonflikte schlagen geschlossen fehl, und strukturierte Rewards bleiben ohne Formattext-Abhängigkeit abrufbar.

## Verifikation

- `git diff --check`
- fokussierter Produktions-, Concurrency-, Lifecycle- und Architektur-Lauf: `BUILD SUCCESSFUL in 31s`
- `./gradlew check --console=plain`: `BUILD SUCCESSFUL in 4m 29s`
- finaler `./gradlew check --console=plain` nach Roadmap-Diff: `BUILD SUCCESSFUL in 2s`
- `./gradlew installDesktopApp --console=plain`: `BUILD SUCCESSFUL in 14s`
- finale Installation nach Roadmap-Diff: `BUILD SUCCESSFUL in 2s`
