### PR TITLE
docs: Katalog-Greenfield-Migration festlegen

### DIFF
--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -16,6 +16,8 @@ Items, saved Encounters, World Planner records, and Encounter Tables inside one
    user-visible behavior and acceptance criteria.
 2. Read [Catalog Architecture](architecture/architecture-catalog.md) for the
    durable target structure, ownership, and dependency direction.
+3. During the replacement only, read the temporary
+   [Catalog Greenfield Roadmap](delivery/roadmap-catalog-greenfield.md).
 
 ## Document Set
 
@@ -26,3 +28,8 @@ Items, saved Encounters, World Planner records, and Encounter Tables inside one
 ### Architecture
 
 - [Catalog Architecture](architecture/architecture-catalog.md)
+
+### Delivery
+
+- [Catalog Greenfield Roadmap](delivery/roadmap-catalog-greenfield.md) -- temporary;
+  delete after final acceptance.

--- a/docs/catalog/architecture/architecture-catalog.md
+++ b/docs/catalog/architecture/architecture-catalog.md
@@ -1,162 +1,196 @@
 Status: Active Target
 Owner: Catalog Feature
-Last Reviewed: 2026-07-18
-Source of Truth: Catalog application ownership, presentation boundary, and
-dependency direction.
+Last Reviewed: 2026-07-19
+Source of Truth: Catalog application ownership, typed section composition,
+presentation boundary, lifecycle, and dependency direction.
 
 # Catalog Architecture
 
-## Entity, Stakeholders, And Concerns
+## Purpose And Boundary
 
-Catalog is the application capability for finding, evaluating, and explicitly
-handing reference content to another active workspace. GMs need one predictable
-reference surface during preparation and table play. Feature maintainers need
-provider truth and validation to remain cohesive. UI maintainers need one state
-and lifecycle model rather than separate section-specific orchestration stacks.
+Catalog is the read-and-handoff workspace for reference content. It owns the
+user's transient browsing experience: active section, unfinished input,
+committed query, result lifecycle, sort, page, selection, and explicit actions.
+It owns no creature, item, Encounter, World Planner, or Encounter Table truth
+and has no persistence adapter.
 
-The primary concerns are responsive asynchronous lookup, stable workspace
-state, explicit side effects, provider independence, consistent presentation,
-and complete retirement of the current JavaFX-owned orchestration.
+Provider features remain the sole owners of durable records, validation,
+migrations, details, and mutations. Catalog consumes only their public APIs.
+Encounter owns generation pool criteria; the visible Monster filter editor
+edits that typed capability and queries Creatures with the accepted revision.
 
 ## Target Topology
 
 ```text
 features/catalog/
 ├── application/
-│   ├── CatalogWorkspaceController
-│   ├── monster/MonsterCatalogController
-│   ├── items/ItemsCatalogController
-│   ├── encounters/SavedEncounterCatalogController
-│   ├── world/WorldReferenceCatalogController
-│   └── tables/EncounterTableCatalogController
+│   ├── CatalogWorkspace
+│   ├── BrowseSession
+│   ├── CatalogSectionDefinition
+│   ├── CatalogSectionState
+│   └── CatalogResult
 ├── adapter/javafx/
 │   ├── CatalogContribution
 │   ├── CatalogWorkspaceView
-│   ├── CatalogSectionHost
-│   └── CatalogTableScaffold
+│   ├── CatalogSectionRenderer
+│   └── CatalogControlFactory
 └── CatalogFeature
 ```
 
-Catalog owns an application and JavaFX role. It owns no domain or persistence
-role because it defines no durable business truth and stores no reference
-records.
+The seven sections are statically and explicitly composed. They are not seven
+controllers or JavaFX view classes. Each is a typed definition that supplies
+provider query translation, immutable filter fields, columns, stable identity,
+and available actions to shared application and presentation mechanisms.
 
-## Application Ownership
+Runtime discovery and a plugin registry are rejected because the product owns
+exactly seven sections and has no extension need.
 
-`CatalogWorkspaceController` owns the active section, the lifetime of every
-section controller, and immutable workspace publication. It delegates queries
-and actions to the controller that owns the selected section; it does not
-contain provider-specific filter or mapping logic.
+## Typed Section Definition
 
-Every section controller owns:
+`CatalogSectionDefinition<Q, R, K>` contains:
 
-- its Catalog-specific query and draft state
-- its request revision and current result projection
-- stable selection identity, sort, and paging where applicable
-- translation between user intents and provider APIs or typed outward routes
-- activation, deactivation, and subscription cleanup
+- stable section id, label, and initial immutable query draft
+- typed filter specifications with getters and immutable updaters
+- provider query function and provider-result translation
+- stable row identity and table column specifications
+- optional paging and typed row or section actions
+- optional provider revision observation used only while the section is active
 
-`WorldReferenceCatalogController` may serve the NPC, faction, and location
-sections because they share one provider snapshot and lifecycle. Their
-published section states remain distinct.
+Filter specifications are a sealed family for text search, single choice,
+multi-choice, range, and tri-state values. They do not use string-keyed maps,
+untyped values, reflection, JavaFX nodes, CSS classes, or provider persistence
+types.
 
-Every section publishes an immutable `CatalogResultState<Row>` with a typed
-status covering loading, ready, empty, invalid input, unavailable, and failed
-outcomes. A section-specific state wraps that result together with its filters,
-selection id, page, and unfinished input. JavaFX properties and nodes do not
-cross into application state.
+Provider APIs keep their own result vocabularies. The definition translates at
+the real consumer boundary into one Catalog result model rather than requiring
+providers to depend on Catalog.
 
-## Provider And Action Boundaries
+## Browse Session And Workspace State
 
-`CatalogFeature.create(CatalogProviders, CatalogRoutes)` is the feature-root
-composition entry point. `CatalogProviders` groups required dependencies by
-section as `MonsterProviders`, `ItemsProviders`, `SavedEncounterProviders`,
-`WorldReferenceProviders`, and `EncounterTableProviders`. Required providers
-are never nullable and have no no-op fallback.
+One reusable `BrowseSession<Q, R, K>` owns the lifecycle shared by all sections:
 
-`CatalogRoutes` groups semantic outward capabilities:
+- unfinished draft and last committed query
+- 200 ms debounce and immediate Enter submission
+- request epoch and cancellation or invalidation of superseded work
+- page, total, stable selection, provider revision, and stale marker
+- immutable result state: uninitialized, loading, refreshing, ready, empty,
+  invalid, unavailable, or failed
 
-- `CreatureInspectorRoute`
-- `ItemInspectorRoute`
-- `WorldInspectorRoutes`
-- `EncounterHandoff`
-- `SceneHandoff`
+Only the selected session is active. Activating a section observes its provider
+and queries when uninitialized, stale, or edited. Deactivating it releases the
+subscription and invalidates in-flight publication while retaining immutable
+state. An inactive section performs no query, option load, or provider
+subscription.
 
-Catalog application code may consume foreign feature APIs. It MUST NOT import a
-foreign domain, application, composition root, JavaFX adapter, or persistence
-adapter. Provider-owned Inspector content is supplied through the typed routes;
-Catalog does not rebuild foreign editors.
+The workspace owns the active section and the seven retained session states.
+It publishes one revisioned immutable snapshot. JavaFX state is never the
+source of unfinished input or selection.
 
-Creature details load and open through one route so a global detail selection
-and Inspector push cannot race. Encounter and Scene changes occur only through
-explicit handoff intents.
+A refresh retains the last successful rows while exposing `refreshing`. A
+failure may retain that read-only result with a retry action, but it cannot be
+reported as current success. A selected identity survives refresh only when it
+is present in the accepted result.
 
-## Monster Query And Encounter Filters
+## Actions And Cross-Feature State
 
-Catalog owns the visible Monster query draft. It sends the query to the
-creature catalog provider and maps the relevant filter values to an Encounter
-pool-filter command. Encounter owns the canonical generation-filter truth and
-publishes readback when it changes elsewhere.
+Selecting or opening a row is read-only with respect to Encounter and Scene.
+Every external change uses a named typed action and returns a typed action
+outcome for visible feedback.
 
-Catalog never reads or writes Encounter tuning. Difficulty, balance, amount,
-and diversity remain Encounter-owned inputs and presentation.
+Catalog consumes exact routes for:
 
-Catalog page queries remain independent from the creature reference index used
-by Scene and World Planner. A Scene or World Planner refresh therefore cannot
-replace the Catalog's visible page lifecycle.
+- provider-owned details and editors in the Inspector
+- adding a Creature or NPC to Encounter or focused Scene
+- opening a saved Encounter with the provider-owned discard decision
+- selecting faction, location, or Encounter Table sources for Encounter
+- assigning the focused Scene location
 
-## JavaFX Boundary
+Catalog does not coordinate a cross-provider transaction. A future action that
+requires one must be owned by the feature that owns the consistency boundary,
+not by callbacks or a Catalog database.
 
-The JavaFX adapter renders immutable application state and translates raw
-control events into application intents. It performs no provider query,
-cross-feature command coordination, or subscription ownership.
+Monster generation filters have one canonical owner: Encounter. Catalog keeps
+only the unfinished editor value required to show invalid or not-yet-debounced
+input. An accepted filter command returns or publishes its revision; the
+Creature query records that revision so late readback cannot replace newer
+visible work.
 
-`CatalogTableScaffold` owns shared header, result status, table behavior,
-stable-id selection, optional paging, keyboard interaction, accessibility, and
-the action-column layout. Section renderers supply columns, filters, and the
-available typed actions. The seven section roots remain alive for the active
-Catalog binding so switching sections does not discard local view state.
+## JavaFX Presentation
 
-## Lifecycle And Concurrency
+`CatalogSectionRenderer` is the only section result and control renderer. It
+constructs the selected section from the sealed filter specifications, column
+specifications, paging capability, action specifications, and immutable state.
+Changing section rebinds or rebuilds this one renderer; application state, not
+seven retained node trees, preserves work.
 
-Activating Catalog registers provider subscriptions and applies each current
-snapshot before accepting later publications. Deactivating Catalog unregisters
-subscriptions, invalidates in-flight request generations, and retains immutable
-workspace state for later reactivation. Closing the Catalog component releases
-all remaining resources.
+`CatalogControlFactory` owns the approved Catalog visual roles and creates all
+interactive controls. Section definitions cannot construct controls or assign
+styles. The renderer owns:
 
-Persistence- or file-backed provider calls remain non-blocking. Each request
-captures a local revision; a result may publish only when its revision is still
-current. Application publication uses the feature-neutral UI dispatcher before
-the JavaFX adapter mutates controls.
+- the persistent section selector and compact wrapping controls area
+- inside-label search, selection, range, and filter controls
+- active-filter chips and clear behavior
+- status, empty and failure presentation, retry, table, paging, keyboard,
+  accessibility, and stable-id selection
+- the shared 28 px control and 12 px regular type contract, plus the compact
+  chip information style
 
-## Decisions And Rejected Alternatives
+Section-specific behavior is limited to typed data, columns, filters, and
+actions. A one-off JavaFX escape hatch is not a supported section capability.
 
-- A JavaFX-only aggregator is rejected because Catalog already owns query,
-  lifecycle, projection, and handoff use cases.
-- A Catalog domain or copied provider database is rejected because it would
-  duplicate provider truth and introduce synchronization invariants without a
-  user need.
-- A dynamic section plugin registry is rejected because seven statically known
-  sections do not justify discovery or runtime extension machinery.
-- Broad data-source and callback bags are rejected because they hide per-section
-  dependencies and permit silent no-op behavior.
-- Long-lived compatibility adapters are rejected. The migration may retain one
-  internal adapter only under the deletion budget owned by the delivery
-  roadmap.
+## Persistence, Execution, And Failure Isolation
 
-## Enforcement And Verification Ownership
+Catalog never receives `SqliteDatabase`, JDBC, paths, or migration plans.
+Provider services are created only after their owner-scoped storage readiness
+is known under the [persistence lifecycle](../../project/contract/persistence-lifecycle.md).
 
-`architectureTest` mechanically enforces valid feature roles, foreign API-only
-dependencies, and the absence of JavaFX dependencies from Catalog application
-code. UI behavior tests own the seven-section workspace, state preservation,
-stable-id selection, visible result states, and explicit handoff behavior.
-Lifecycle tests own balanced subscription and request invalidation behavior.
-Final visual and interaction acceptance remains owner manual testing.
+Persistence-backed queries run outside the JavaFX thread. Independent provider
+reads may execute concurrently on a bounded I/O executor; ordered writes are
+serialized by their owning feature or store, not by one application-wide queue.
+One provider's newer schema, migration failure, unavailable source, or query
+failure becomes only that section's typed unavailable or failed state.
+
+Diagnostics remain payload-free and local. A visible failure carries a stable
+local diagnostic id and retryability, not SQL, paths, or exception messages.
+
+## Composition And Enforcement
+
+`CatalogFeature` receives the seven definitions plus the UI dispatcher and
+constructs the workspace and contribution. `app` explicitly supplies provider
+APIs and outward routes; neither Catalog nor shell locates services.
+
+Permanent architecture proof enforces:
+
+- Catalog application imports provider APIs but no foreign implementation,
+  JavaFX, JDBC, or persistence package
+- Catalog has no domain or SQLite role
+- exactly seven definitions are explicitly composed
+- section definitions contain no JavaFX nodes or style decisions
+- only the shared renderer and control factory construct Catalog controls and tables
+- no section-specific lifecycle controller or JavaFX section class returns
+- inactive sections cannot acquire subscriptions or issue provider calls in
+  production-route lifecycle tests
+
+Automated checks are evidence for these boundaries, not authority to retain a
+superseded topology.
+
+## Rejected Alternatives
+
+- Seven controllers and seven JavaFX section roots are rejected because they
+  duplicate one browsing lifecycle and one presentation grammar.
+- Eager activation is rejected because invisible sections have no user work to
+  perform and failures or latency must remain isolated.
+- A dynamic form map is rejected because it sacrifices typed update semantics.
+- A Catalog-owned read database is rejected because it duplicates provider
+  truth and creates synchronization invariants.
+- One global serial execution lane is rejected because independent reads and
+  failures do not share an ordering invariant.
 
 ## References
 
 - [Catalog Requirements](../requirements/requirements-catalog.md)
+- [Catalog Greenfield Roadmap](../delivery/roadmap-catalog-greenfield.md)
+- [Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
 - [Source Architecture](../../project/architecture/source-architecture.md)
 - [Feature Boundaries](../../project/architecture/patterns/feature-boundaries.md)
 - [Shell Layer](../../project/architecture/patterns/shell-layer.md)

--- a/docs/catalog/delivery/roadmap-catalog-greenfield.md
+++ b/docs/catalog/delivery/roadmap-catalog-greenfield.md
@@ -1,0 +1,231 @@
+Status: Temporary Migration
+Owner: Catalog Feature
+Last Reviewed: 2026-07-19
+Source of Truth: Catalog replacement order, slice boundaries, deletion gates,
+current migration state, and finish criteria.
+
+# Catalog Greenfield Roadmap
+
+## Purpose
+
+This roadmap replaces the current Catalog implementation as one complete
+production cutover. It does not preserve internal Catalog classes, eager
+section lifecycles, the shared global execution queue, or architecture tests
+that require seven independently assembled JavaFX sections.
+
+Observable behavior is owned by the [Catalog requirements](../requirements/requirements-catalog.md).
+The permanent target is owned by the [Catalog architecture](../architecture/architecture-catalog.md),
+and shared storage compatibility is owned by the
+[persistence lifecycle](../../project/contract/persistence-lifecycle.md).
+
+No intermediate slice is an approved product fallback. Each slice must leave a
+green repository, but the replacement is installed only after M5 removes the
+old runtime and the complete migration is qualified.
+
+## Fixed Delivery Decisions
+
+- Start from current `origin/main`; do not merge the superseded Catalog controls branch.
+- Preserve the approved seven-section visual design and explicit handoff behavior.
+- Use one physical SQLite database with owner-scoped readiness and connection handles.
+- Prepare storage before any feature starts background work.
+- Keep Provider truth in Creatures, Items, Encounter, World Planner, and Encounter Tables;
+  Catalog owns no stored records.
+- Keep exactly seven statically composed sections, but render them through one generic renderer.
+- Activate and query only the selected section. Preserve inactive section state without I/O.
+- Apply search and filter edits after 200 ms of inactivity; Enter submits immediately.
+- Ship no long-lived dual runtime. Temporary translation surfaces are named in their
+  milestone and deleted at that milestone's exit.
+- Do not modify real local data before an owner-approved, restore-tested backup and
+  migration rehearsal on a copy.
+
+## Dependency Order
+
+```text
+M0 Target Lock And Baseline
+  -> M1 Owner-Scoped Storage And Startup
+      -> M2 Provider Compatibility And Items Migration
+          -> M3 Catalog Browse Runtime
+              -> M4 Single JavaFX Renderer
+                  -> M5 Atomic Cutover, Deletion, And Qualification
+```
+
+Use one feature branch and one pull request per milestone. Merge only after
+literal green `./gradlew check` and required PR CI, then start the next milestone
+from refreshed `origin/main`.
+
+## Current Migration State
+
+- Current foundation: the shipped Catalog has seven sections and typed provider APIs,
+  but eagerly activates every section, builds parallel JavaFX section trees, and runs
+  persistence-backed work through shared global lifecycle mechanisms.
+- Completed milestone: M0 locked the replacement target, persistence contract,
+  user-visible behavior, migration order, and deletion gates on 2026-07-19.
+- Next milestone: M1 replaces global migration execution and the startup race with
+  owner-scoped readiness before moving any Catalog provider.
+- No Greenfield production route has been implemented yet.
+
+## M0: Target Lock And Baseline
+
+### Deliver
+
+- align Catalog requirements and architecture with live search, lazy activation,
+  one renderer, provider truth, typed outcomes, and explicit actions
+- replace the global migration semantics in the persistence contract with owner-scoped
+  readiness and fail-isolated compatibility
+- define the required synthetic database fixtures for the legacy Items shape, the flawed
+  intermediate Items shape, and a foreign owner whose schema is newer than the running application
+- retain current production behavior tests as the observable baseline; do not preserve
+  their structural assumptions as target rules
+
+### Exit Gate
+
+- owner documents contain no contradictory Catalog lifecycle, renderer, or persistence rule
+- this roadmap has no unresolved implementation choice for M1
+- `git diff --check` and `./gradlew check` are green
+
+## M1: Owner-Scoped Storage And Startup
+
+### Deliver
+
+- replace dynamic global migration execution with immutable owner definitions and
+  owner-scoped connection handles
+- add typed readiness: `READY`, `MIGRATION_FAILED`, `NEWER_SCHEMA`, and `CORRUPT`
+- make connection opening validate and migrate only its owner
+- split application startup into composition, storage preparation, service start, and
+  shell activation; no feature may enqueue storage work before preparation completes
+- retain one verified physical backup and local recovery behavior without exposing paths
+  or payloads in diagnostics
+
+### Production Consumer And Deletion Gate
+
+- move Creatures and Items to prepared owner handles
+- delete the all-registered-plans loop from connection opening and tests that require it
+- retain the current `SqliteConnectionSource` shape only as an internal adapter within M1;
+  delete it before M1 exits if no unchanged provider still requires it
+
+### Exit Gate
+
+- a newer unrelated owner cannot block a Creature or Item connection
+- no production startup task can race migration registration
+- owner migration failure rolls back that owner and leaves other ready owners usable
+- focused persistence/startup tests and `./gradlew check` are green
+
+## M2: Provider Compatibility And Items Migration
+
+### Deliver
+
+- introduce an Items schema whose table names and structural signature are unambiguous
+- migrate both supported predecessor shapes transactionally:
+  legacy `id/slug/is_magic/requires_attunement` and intermediate
+  `source_key/magic/attunement`
+- preserve stable item identity, details, tags, nullable provenance, and read-only behavior
+- return typed provider availability and compatibility failures without leaking JDBC
+- add production-route provider tests against synthetic predecessor databases
+
+### Migration And Deletion Gate
+
+- legacy numeric identity is retained only as migration provenance; the stable target id
+  is `legacy:<slug>` for legacy rows and the provider's canonical source key otherwise
+- unknown structural signatures fail before mutation
+- row identity, tag ownership, semantic fields, integrity, and foreign keys are validated
+  before commit
+- delete old Items tables and shape-detection code from the target database after the
+  transactional copy validates; retain only the versioned migration step required for
+  supported upgrades
+
+### Exit Gate
+
+- both predecessor fixtures migrate exactly once and reopen without further writes
+- failed validation leaves the complete before-state unchanged
+- Items failure does not affect Creature search
+- focused provider tests and `./gradlew check` are green
+
+## M3: Catalog Browse Runtime
+
+### Deliver
+
+- replace section-specific lifecycle controllers with a reusable typed `BrowseSession`
+- add typed section definitions for Monster, Items, saved Encounters, NPCs, factions,
+  locations, and Encounter Tables
+- own draft, committed query, request epoch, paging, stable selection, staleness, and
+  result state in immutable application state
+- activate only the selected session; cancel or invalidate superseded work and retain
+  inactive state without subscriptions or provider calls
+- use Encounter-owned pool criteria as the canonical Monster generation-filter truth
+- distinguish uninitialized, loading, refreshing, ready, empty, invalid, unavailable,
+  and failed results
+
+### Deletion Gate
+
+- delete the five current section controller families and eager `sections.activate()` loop
+- delete tests that require Items or other inactive sections to load during Catalog activation
+- retain no duplicate per-section request revision or lifecycle implementation
+
+### Exit Gate
+
+- switching through all sections preserves draft, query, page, selection, and result
+- inactive sections perform zero provider calls
+- only the newest debounced or immediate request may publish
+- explicit details and handoffs retain accepted behavior
+- focused application tests and `./gradlew check` are green
+
+## M4: Single JavaFX Renderer
+
+### Deliver
+
+- render every section from typed search, choice, multi-choice, range, tri-state, column,
+  paging, and action specifications
+- keep one control factory, one result/table renderer, one status model, and one keyboard
+  and selection implementation
+- preserve the approved 28 px control, 12 px regular type, inside-label, compact wrapping,
+  and visible result-workspace behavior at supported window sizes
+- retain section-specific columns, filters, and actions as data and typed callbacks rather
+  than JavaFX subclasses
+
+### Deletion Gate
+
+- delete all seven concrete `*CatalogSection` JavaFX classes, `MonsterCatalogControls`,
+  parallel scaffold ownership, and architecture tests that require those classes
+- forbid section definitions from constructing or styling JavaFX controls
+- keep only one renderer tree for the selected section; application state, not retained
+  nodes, preserves inactive work
+
+### Exit Gate
+
+- all seven sections pass the same measured visual and interaction contract
+- UI tests drive production Catalog application routes rather than self-testing fixtures
+- `uiTest`, architecture proof, and `./gradlew check` are green
+
+## M5: Atomic Cutover, Deletion, And Qualification
+
+### Deliver
+
+- rehearse the complete storage and Catalog upgrade on an isolated copy of the installed
+  database and record literal semantic readback without committing user data
+- remove the old Catalog runtime, obsolete compatibility code, false architecture rules,
+  and superseded documentation
+- run failure-isolation, migration rollback, startup-order, debounce, stale-result,
+  responsive UI, and explicit-action qualification through production routes
+- perform independent architecture and quality review after the final code and document diff
+
+### Finish Criteria
+
+- every Catalog provider remains independently readable or reports its own typed failure
+- all seven sections use the single renderer and lazy BrowseSession runtime
+- no current source or test references the deleted eager/controller/scaffold topology
+- literal final `./gradlew check` is green
+- the owner approves the restore-tested real-data migration, desktop installation, and
+  manual visible behavior
+- the feature PR is merged with required CI green, this roadmap is deleted, and Catalog
+  plus project README delivery links are cleaned up
+
+## Risks And Escalation
+
+- An unknown Items schema signature, inability to preserve stable identity, or failed
+  restore rehearsal stops M2/M5 before real-data mutation.
+- A Catalog action requiring a cross-provider atomic transaction is an architecture
+  blocker; do not hide it behind callbacks or a shared Catalog database.
+- A section that cannot be expressed by the typed renderer must justify a new reusable
+  capability in Catalog architecture before adding a one-off JavaFX escape hatch.
+- Unrelated feature migrations may continue in separate worktrees. Catalog slices must
+  refresh from merged `origin/main` between milestones and never absorb their dirty state.

--- a/docs/catalog/requirements/requirements-catalog.md
+++ b/docs/catalog/requirements/requirements-catalog.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Catalog Feature
-Last Reviewed: 2026-07-18
+Last Reviewed: 2026-07-19
 Source of Truth: User-visible consolidated catalog behavior.
 
 # Catalog Requirements
@@ -29,12 +29,32 @@ workspace serves both game preparation and running-session lookup.
 - One persistent section selector MUST remain at the top of the Catalog
   controls area. The selected section's controls MUST always appear below it,
   and its results MUST appear in the main area.
+- Search text and filter edits MUST update the selected section automatically
+  after 200 ms without another edit. Enter MUST submit the current valid input
+  immediately. All seven sections use this behavior when they expose search or
+  filters.
+- Only the selected section may load or observe provider results. Switching
+  sections MUST stop invisible work without discarding that section's input,
+  accepted result, selection, sort, or page.
+- Every section MUST use the same compact control hierarchy: one wrapping row
+  for search and section actions, wrapping inside-labeled filters, removable
+  active-filter chips, and one feedback area when those capabilities exist.
+  Empty regions MUST not render placeholders or consume space.
+- Equivalent section, search, filter, sort, paging, and action controls MUST
+  render at 28 pixels high with the same 12-pixel regular-weight type style.
+  Removable filter chips use the shared compact information style.
+- Search and filter meaning MUST appear inside the interactive element through
+  its prompt or displayed value. Redundant field-side labels, `FILTER`, and
+  `AKTIONEN` headings MUST not appear.
 - Switching sections MUST preserve each section's filters, selection, paging,
   and unfinished input for the lifetime of the Catalog workspace.
 - Sections MUST use consistent table, status, paging, keyboard, and selection
   behavior while retaining section-specific columns, filters, and actions.
 - Every section MUST distinguish loading, empty, unavailable, invalid-input,
   and failed outcomes whenever the underlying operation can produce them.
+- Refreshing an already successful section MUST keep its accepted rows visible
+  while communicating that they are being refreshed. A failed refresh MUST not
+  present stale rows as current success.
 - Monster search and encounter-builder controls MUST preserve their accepted
   behavior, including creature details and explicit add-to-Encounter and
   add-to-focused-Scene actions.
@@ -68,6 +88,13 @@ Encounter or Scene workspaces, or expose a second World Planner workspace.
 
 - One `Katalog` contribution shows all seven sections in the common controls
   and main workspace.
+- At 1150×700 and 900×650, the selected section retains the persistent selector,
+  compact controls, and a visible result workspace without horizontal scrolling.
+- Equivalent controls satisfy the shared 28-pixel and 12-pixel visual contract,
+  use inside labels, and do not render redundant group headings.
+- Typing several characters inside 200 ms publishes only the final query;
+  Enter publishes the current valid query immediately.
+- Inactive sections issue no provider query and retain their last state.
 - Switching through every section and returning preserves each section's
   current query, filter draft, selected record, page, and unfinished input.
 - Refreshing provider results preserves a still-present selected record by its

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -41,8 +41,8 @@ lives under `docs/<feature>/`; see [docs/README.md](../README.md).
 
 ## Delivery
 
-- Temporary delivery documents are routed from their feature README. Current:
-  [Dungeon Greenfield Roadmap](../dungeon/delivery/roadmap-dungeon-greenfield.md).
+- [Active Project Delivery](delivery/README.md) routes temporary migrations.
+  Feature roadmaps remain owned and retired by their feature.
 
 ## Verification
 

--- a/docs/project/architecture/patterns/application-composition.md
+++ b/docs/project/architecture/patterns/application-composition.md
@@ -14,6 +14,9 @@ shell remains passive and feature behavior remains feature-owned.
 
 - `app` MUST construct platform services and feature entry points explicitly in
   dependency order.
+- `app` MUST compose immutable feature storage definitions and complete
+  owner-scoped storage preparation before constructing or starting any service
+  that can enqueue persistence work.
 - `app` may import a feature's exact composition-root package and public API;
   it MUST NOT import that feature's domain, application, or adapter packages.
 - `app` MUST pass typed dependencies into feature and shell constructors.
@@ -26,6 +29,9 @@ shell remains passive and feature behavior remains feature-owned.
   discovery, service registries, and service locators are forbidden.
 - `app` MUST own lifecycle shutdown for executors, database resources, and the
   JavaFX application. It MUST NOT own feature state or business decisions.
+- Startup phases are explicit: compose definitions, prepare storage, construct
+  services, start feature work, register shell contributions. Constructor or
+  composition side effects MUST NOT perform persistence work.
 
 `architectureTest` mechanically enforces the target dependency direction.
 Startup behavior remains production-route JUnit proof.

--- a/docs/project/contract/persistence-lifecycle.md
+++ b/docs/project/contract/persistence-lifecycle.md
@@ -1,102 +1,151 @@
 Status: Active Target
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-16
-Source of Truth: Shared SQLite location, connection, migration execution,
-integrity, backup, and recovery contract.
+Last Reviewed: 2026-07-19
+Source of Truth: Shared SQLite location, owner-scoped readiness, connection,
+migration, integrity, backup, and recovery semantics.
 
 # Persistence Lifecycle
 
 ## Purpose And Boundary
 
-SaltMarcher uses one local SQLite database. This contract owns only the shared
-database lifecycle consumed by feature SQLite adapters. Feature persistence
-contracts remain the owners of stored truth, schemas, row validation, and
-migration bodies.
+SaltMarcher uses one local SQLite database. Platform persistence owns physical
+file safety, connection configuration, the feature-version ledger, owner-scoped
+preparation, backup, and recovery. Feature SQLite adapters own their stored
+truth, table signatures, row validation, and migration bodies.
 
-`app` owns one `platform.persistence` lifecycle instance and closes it after
-the execution lane has drained. SQLite adapters receive feature-scoped
-connection sources from that instance. API, domain, application, JavaFX, and
-shell code MUST NOT access JDBC or database files.
+`app` composes immutable `FeatureStoreDefinition` values before it starts any
+feature work. Preparation returns one `FeatureStoreReadiness` per owner. Ready
+features receive only their `FeatureStoreHandle`; they never receive the global
+registry or another owner's plan.
 
-## Compatible Location And Connection
+API, domain, application, JavaFX, Catalog, and shell code do not access JDBC,
+database files, or migration types.
 
-The database file remains `game.db` below:
+## Location And Connection
+
+The database remains `game.db` below:
 
 - `$XDG_DATA_HOME/salt-marcher/` when `XDG_DATA_HOME` is non-blank;
 - `${user.home}/.local/share/salt-marcher/` otherwise.
 
-Every writable connection MUST enable and verify WAL journal mode, enable
-foreign keys, use a 5000 ms busy timeout, and use SQLite `NORMAL` synchronous
-mode. Connections are operation-scoped and closed by the consuming adapter;
-the shared lifecycle retains no open JDBC connection.
+Every writable connection enables and verifies WAL mode, enables foreign keys,
+uses a 5000 ms busy timeout, and uses SQLite `NORMAL` synchronous mode.
+Connections are operation-scoped and closed by the owning adapter.
 
-## Version And Migration Contract
+Opening a handle connection validates only platform compatibility and that
+handle's prepared owner. It MUST NOT iterate, validate, or migrate other
+registered owners.
 
-`PRAGMA user_version` owns the platform lifecycle schema version. Version `1`
-introduces the feature migration ledger `sm_schema_versions`. A database with a
-newer platform or feature version MUST fail closed without replacement or
-downgrade.
+## Definitions, Preparation, And Readiness
 
-Each feature registers one stable lowercase owner key and a contiguous
-monotonic migration sequence beginning at `1`. Registration order in app
-composition is execution order. All registered pending migrations run once in
-one SQLite transaction before the requested feature operation receives its
-connection. A migration MUST be idempotent, MUST NOT commit or change
-auto-commit itself, and MUST update only schema and stored truth owned by its
-feature. A failure rolls back schema, data, platform version, and feature
-version together.
+`FeatureStoreDefinition` contains one stable lowercase owner key, target
+version, contiguous monotonic migration steps beginning at `1`, and a final
+owner validator. Definitions are immutable after composition. Registering or
+discovering a migration as a side effect of opening a connection is forbidden.
 
-The compatibility floor is an existing pre-ledger database at platform and
-feature version `0`. The initial feature readiness migrations are recorded as
-each feature's version `1` migration. Later schema changes add a new ordered
-step; they MUST NOT rewrite the meaning of an already recorded version.
+Before feature services start, the coordinator:
 
-## Integrity, Backup, And Recovery
+1. loads the driver and verifies the primary database or initializes an empty one
+2. reads platform and owner versions without mutation
+3. rejects a newer platform globally without replacement or downgrade
+4. creates and restore-tests one verified pre-migration snapshot when any
+   supported owner has pending work
+5. prepares owners in deterministic composition order, one transaction per owner
+6. validates owner rows, full physical integrity, and foreign keys before each commit
+7. returns immutable readiness for every owner
 
-Before the lifecycle first mutates an existing healthy database, the platform
-MUST run full `integrity_check` and `foreign_key_check`, then create a
-WAL-consistent SQLite snapshot with `VACUUM INTO`. The local backup name embeds
-the compatible platform version as `game.db.backup-vN.sqlite`. A replacement
-backup is accepted only after the same integrity checks succeed.
+Readiness is:
 
-If the primary is physically corrupt, the lifecycle MAY restore the highest
-verified backup whose platform version is not newer than the application. It
-MUST first preserve the corrupt primary and its active WAL/SHM or rollback-
-journal sidecars under a local quarantine name, MUST verify the recovered
-primary, and MUST leave the backup intact. If no verified compatible backup
-exists, recovery fails closed and the complete database family remains byte-
-for-byte untouched. An unknown newer version is not corruption and MUST never
-trigger recovery.
+- `READY`: the owner matches its supported target and validation succeeded
+- `MIGRATION_FAILED`: a supported migration or owner validation rolled back
+- `NEWER_SCHEMA`: stored owner version is newer than this application
+- `CORRUPT`: physical integrity prevents safe access
 
-After pending migrations, integrity and foreign-key checks MUST pass before
-commit. Logical feature-row validation and feature-specific error statuses
-remain owned by the feature contracts.
+`MIGRATION_FAILED` and `NEWER_SCHEMA` fail closed for that owner only. They do
+not prevent unrelated ready handles from opening connections. Physical database
+corruption and a newer platform version remain global because no safe shared
+file access exists.
 
-An explicit feature maintenance operation that replaces local reference data
-MUST request a feature-named maintenance backup immediately before its replace
-transaction. The platform creates a WAL-consistent snapshot, verifies it,
-copies it to an isolated restore probe, verifies that probe, deletes the probe,
-and only then publishes a timestamped local maintenance backup receipt. The
-feature MUST fail before mutation if any step fails. This mechanism is not a
-permission to run maintenance during startup or against automated-test user
-data.
+No feature may enqueue a persistence operation before its readiness is known.
+An unavailable feature exposes its existing typed storage or availability
+result and performs no write.
+
+## Migration Contract
+
+`PRAGMA user_version` owns the platform format. `sm_schema_versions` maps one
+owner to its current feature version.
+
+Each migration:
+
+- runs once inside the coordinator-owned owner transaction
+- is idempotent but never changes auto-commit, commits, or updates the ledger itself
+- reads and writes only its feature's stored truth
+- recognizes every supported predecessor through explicit structural validation
+- aborts before destructive work when the stored signature is unknown
+- copies and validates replacement rows before dropping or renaming predecessor tables
+
+The coordinator records the new owner version only after the migration action
+and owner validator succeed. Failure rolls back schema, rows, and owner version
+for that transaction.
+
+An already recorded version never changes meaning. Supporting another legacy
+shape requires a new migration or an explicitly versioned predecessor
+translator, not rewriting a released step.
+
+## Backup And Recovery
+
+Before first mutation of an existing healthy database, platform persistence
+runs full `integrity_check` and `foreign_key_check`, creates a WAL-consistent
+snapshot with `VACUUM INTO`, verifies it, copies it to an isolated restore
+probe, verifies the probe, and only then permits owner migration.
+
+The local backup name embeds the compatible platform version. Migration failure
+never replaces the primary with a backup and never deletes the verified backup.
+
+If the primary is physically corrupt, the lifecycle may restore the highest
+verified backup whose platform version is supported. It first preserves the
+complete corrupt database family under a local quarantine name, verifies the
+restored primary, and keeps the backup. Unknown newer versions are not
+corruption and never trigger recovery.
+
+An explicit feature maintenance operation that replaces reference data requests
+a feature-named maintenance backup immediately before its transaction. Startup
+does not perform external imports or paid/network work.
+
+## Execution And Shutdown
+
+The persistence lifecycle does not impose one global application execution
+queue. Independent reads may use a bounded I/O executor. A feature that requires
+ordered mutations owns a serial mutation lane or transaction boundary for that
+truth.
+
+Shutdown first prevents new application work, then drains feature executors,
+then closes the persistence lifecycle. A closed or unready handle rejects work
+with a typed local failure and never opens JDBC.
 
 ## Errors, Privacy, And Proof
 
-Lifecycle failures surface as storage failure through existing feature-owned
-result vocabularies. Technical diagnostics use stable IDs plus failure classes
-only; paths, SQL, exception messages, secrets, and authored content MUST NOT be
-recorded or transmitted.
+Technical diagnostics use stable ids, owner key, operation class, readiness,
+and failure class only. They do not contain paths, SQL, exception messages,
+secrets, or user-authored content and are not transmitted.
 
-Automated proof MUST use isolated temporary databases. Recovery qualification
-requires a verified snapshot, physical corruption of the isolated primary,
-successful restore with semantic row readback, quarantine preservation, and a
-no-backup case that proves fail-closed byte preservation. Automated proof MUST
-NOT open, copy, migrate, corrupt, or restore real local user data.
+Automated proof uses isolated synthetic databases and covers:
+
+- each supported predecessor schema and repeated reopen
+- an unrelated owner with a newer version while a ready owner remains usable
+- owner migration and validation rollback with byte-equivalent owned rows
+- startup that cannot execute feature storage work before readiness
+- verified backup, restore probe, physical corruption recovery, quarantine, and
+  no-compatible-backup fail-closed behavior
+
+Automated proof never opens, copies, migrates, corrupts, or restores real local
+user data. Real-data migration requires an owner-approved restore-tested backup
+and rehearsal against an isolated copy.
 
 ## References
 
 - [Source Architecture](../architecture/source-architecture.md)
 - [Application Composition](../architecture/patterns/application-composition.md)
+- [Catalog Architecture](../../catalog/architecture/architecture-catalog.md)
 - [Resource Policy](../policies/resource-policy.md)
 - Feature persistence contracts under `docs/<feature>/contract/`

--- a/docs/project/delivery/README.md
+++ b/docs/project/delivery/README.md
@@ -1,0 +1,18 @@
+Status: Active
+Owner: SaltMarcher Team
+Last Reviewed: 2026-07-19
+Source of Truth: Routing to active temporary migration roadmaps.
+
+# Active Project Delivery
+
+This directory routes active migrations. It does not own product behavior,
+architecture, contracts, proof history, or feature status beyond these links.
+
+## Active Migrations
+
+- [Catalog Greenfield Roadmap](../../catalog/delivery/roadmap-catalog-greenfield.md)
+- [Dungeon Greenfield Roadmap](../../dungeon/delivery/roadmap-dungeon-greenfield.md)
+- [Session Planner Greenfield Roadmap](../../sessionplanner/delivery/roadmap-session-planner-greenfield.md)
+
+Each roadmap is temporary and is removed after its own finish criteria are
+met. Durable decisions remain in the linked owner documents.


### PR DESCRIPTION
## Ziel

Legt den Greenfield-Zielzustand und die ausführbare M0–M5-Roadmap für die vollständige Katalog-Migration fest.

## Inhalt

- trennt Anforderungen, Architektur, Persistenzvertrag und Delivery-Roadmap
- definiert provider-eigene fachliche und persistente Wahrheit
- definiert owner-isolierte Storage-Readiness statt globaler Schema-Kopplung
- definiert eine generische BrowseSession und genau einen Katalog-Renderer
- bindet jeden Folgeslice an eigenes PR, grünes `./gradlew check` und Löschung ersetzter Pfade
- verankert als Scope-Regel: Änderungen reichen so weit wie für den Zielzustand nötig

## Nachweis

- `git diff --check`
- `./gradlew check --console=plain`
- Ergebnis: `BUILD SUCCESSFUL in 4m 43s`
