### PR TITLE
feat: Feature-Storage owner-isoliert vorbereiten

### DIFF
--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -140,6 +140,8 @@ public final class AppBootstrap implements AutoCloseable {
     public AppShell createShell() {
         AppShell shell = new AppShell(diagnostics);
         Components components = createComponents();
+        database.prepareRegisteredStores();
+        components.start();
         List<ResolvedContribution> contributions = bindContributions(shell, components);
         contributions.stream()
                 .sorted(Comparator.comparing(contribution -> contribution.spec().key().value()))
@@ -154,7 +156,6 @@ public final class AppBootstrap implements AutoCloseable {
     private Components createComponents() {
         CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(
                 database, executionLane, uiDispatcher, diagnostics);
-        creatures.application().refreshReferenceIndex(new RefreshCreatureReferenceIndexCommand());
         EncounterTableServiceAssembly.Component encounterTables =
                 EncounterTableServiceAssembly.create(
                         database, executionLane, uiDispatcher, diagnostics);
@@ -481,6 +482,14 @@ public final class AppBootstrap implements AutoCloseable {
             SessionPlannerServiceAssembly session,
             SceneFeature.Component scene
     ) {
+        private void start() {
+            creatures.application().refreshReferenceIndex(new RefreshCreatureReferenceIndexCommand());
+            PartyServiceAssembly.start(party);
+            world.start();
+            encounter.start();
+            dungeon.start();
+            hex.start();
+        }
     }
 
     private record ResolvedContribution(ShellContributionSpec spec, ShellBinding binding) {

--- a/docs/catalog/delivery/roadmap-catalog-greenfield.md
+++ b/docs/catalog/delivery/roadmap-catalog-greenfield.md
@@ -60,8 +60,11 @@ from refreshed `origin/main`.
   persistence-backed work through shared global lifecycle mechanisms.
 - Completed milestone: M0 locked the replacement target, persistence contract,
   user-visible behavior, migration order, and deletion gates on 2026-07-19.
-- Next milestone: M1 replaces global migration execution and the startup race with
-  owner-scoped readiness before moving any Catalog provider.
+- Locally completed milestone: M1 replaced global migration execution with owner-scoped
+  definitions, readiness, and handles and passed literal `./gradlew check` on 2026-07-19.
+- Publication state: the M1 pull request and required CI are pending; M2 must start only
+  after that pull request merges.
+- Next milestone: M2 migrates both supported Items predecessor shapes.
 - No Greenfield production route has been implemented yet.
 
 ## M0: Target Lock And Baseline
@@ -103,12 +106,32 @@ from refreshed `origin/main`.
 - retain the current `SqliteConnectionSource` shape only as an internal adapter within M1;
   delete it before M1 exits if no unchanged provider still requires it
 
+The temporary adapter is concretely `SqliteDatabase.connections(...)` returning
+`SqliteConnectionSource`. It remains only for unchanged Encounter, Encounter Table,
+Party, World Planner, Dungeon, Hex, Session Planner, Session Generation, and Scene
+SQLite adapters. Creatures and Items use `FeatureStoreHandle` directly. The adapter
+is deleted with the last unchanged provider during the final compatibility cleanup.
+
 ### Exit Gate
 
 - a newer unrelated owner cannot block a Creature or Item connection
 - no production startup task can race migration registration
 - owner migration failure rolls back that owner and leaves other ready owners usable
 - focused persistence/startup tests and `./gradlew check` are green
+
+### M1 Implementation Evidence
+
+- `SqliteDatabase` prepares immutable owner definitions independently and no longer
+  iterates all registered plans when a handle opens.
+- Creatures and Items consume `FeatureStoreHandle`; unchanged providers remain behind
+  the named temporary adapter above.
+- production composition prepares all eleven registered stores before explicitly
+  starting Creature, Party, World Planner, Encounter, Dungeon, and Hex work.
+- the startup guard failed on the former Encounter and Dungeon constructor work and is
+  green only after both moved behind the explicit start phase.
+- focused `SqliteDatabaseTest` and `SmokeStartupTest` routes are green.
+- literal merge-blocking proof: `./gradlew check --console=plain` returned
+  `BUILD SUCCESSFUL in 6m 29s` after rebasing onto the Encounter batch M2 merge.
 
 ## M2: Provider Compatibility And Items Migration
 

--- a/features/creatures/adapter/sqlite/gateway/local/SqliteCreatureCatalogLocalGateway.java
+++ b/features/creatures/adapter/sqlite/gateway/local/SqliteCreatureCatalogLocalGateway.java
@@ -1,7 +1,8 @@
 package features.creatures.adapter.sqlite.gateway.local;
 
 import platform.diagnostics.NoopDiagnostics;
-import platform.persistence.SqliteConnectionSource;
+import platform.persistence.FeatureStoreDefinition;
+import platform.persistence.FeatureStoreHandle;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
 import org.jspecify.annotations.Nullable;
@@ -22,7 +23,7 @@ import java.util.Objects;
  */
 public final class SqliteCreatureCatalogLocalGateway {
 
-    private final SqliteConnectionSource connections;
+    private final FeatureStoreHandle connections;
     private final CreatureCatalogFilterValuesSqliteStore filterValuesStore = new CreatureCatalogFilterValuesSqliteStore();
     private final CreatureCatalogSearchSqliteStore catalogSearchStore = new CreatureCatalogSearchSqliteStore();
     private final CreatureDetailSqliteStore creatureDetailStore = new CreatureDetailSqliteStore();
@@ -37,9 +38,10 @@ public final class SqliteCreatureCatalogLocalGateway {
 
     public SqliteCreatureCatalogLocalGateway(SqliteDatabase database) {
         CreaturesSchemaMigrator schemaMigrator = new CreaturesSchemaMigrator();
-        this.connections = Objects.requireNonNull(database, "database").connections(
-                "creatures",
-                new SqliteMigration(1, schemaMigrator::ensureSchema));
+        this.connections = Objects.requireNonNull(database, "database").featureStore(
+                FeatureStoreDefinition.of(
+                        "creatures",
+                        new SqliteMigration(1, schemaMigrator::ensureSchema)));
     }
 
     public CreatureFilterValuesRecord loadFilterValues() {

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -84,7 +84,7 @@ public final class DungeonFeature {
                 lane,
                 dispatcher);
         DungeonEditorFeatureRuntimeRoot editorRuntimeRoot =
-                DungeonEditorFeatureRuntimeRoot.create(editorDependencies);
+                DungeonEditorFeatureRuntimeRoot.createUnstarted(editorDependencies);
         DungeonEditorApi editorApi = new DungeonEditorApiFacade(editorRuntimeRoot, dispatcher);
         return new Component(
                 new DungeonEditorContribution(editorApi),
@@ -155,6 +155,10 @@ public final class DungeonFeature {
             authoredApi = Objects.requireNonNull(authoredApi, "authoredApi");
             editorApi = Objects.requireNonNull(editorApi, "editorApi");
             travelApi = Objects.requireNonNull(travelApi, "travelApi");
+        }
+
+        public void start() {
+            ((DungeonEditorApiFacade) editorApi).initialize();
         }
     }
 

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -26,6 +26,10 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
         this.uiDispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
     }
 
+    public void initialize() {
+        runtimeRoot.initialize();
+    }
+
     @Override
     public DungeonEditorState current() {
         return runtimeRoot.currentState();

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -1,6 +1,7 @@
 package features.dungeon.application.editor;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonOverlaySettings;
@@ -17,8 +18,16 @@ public final class DungeonEditorFeatureRuntimeRoot
     private final DungeonEditorStatePublisher statePublisher;
     private final DungeonEditorRuntimeCommands commands;
     private final DungeonEditorPointerWorkflow pointerWorkflow;
+    private final DungeonEditorRuntimeContext context;
+    private final AtomicBoolean initializationRequested = new AtomicBoolean();
 
     public static DungeonEditorFeatureRuntimeRoot create(DungeonEditorRuntimeDependencies dependencies) {
+        DungeonEditorFeatureRuntimeRoot runtime = createUnstarted(dependencies);
+        runtime.initialize();
+        return runtime;
+    }
+
+    public static DungeonEditorFeatureRuntimeRoot createUnstarted(DungeonEditorRuntimeDependencies dependencies) {
         DungeonEditorRuntimeDependencies safeDependencies =
                 Objects.requireNonNull(dependencies, "dependencies");
         DungeonEditorMainViewInteractionState interactionState = new DungeonEditorMainViewInteractionState();
@@ -52,6 +61,7 @@ public final class DungeonEditorFeatureRuntimeRoot
         DungeonEditorMainViewInteractionState safeInteractionState =
                 Objects.requireNonNull(interactionState, "interactionState");
         DungeonEditorRuntimeContext safeContext = Objects.requireNonNull(context, "context");
+        this.context = safeContext;
         platform.execution.ExecutionLane safeExecutionLane =
                 Objects.requireNonNull(executionLane, "executionLane");
         DungeonEditorRuntimeDraftSession draftSession = new DungeonEditorRuntimeDraftSession();
@@ -91,7 +101,12 @@ public final class DungeonEditorFeatureRuntimeRoot
                 commands,
                 safeExecutionLane);
         commands.bindPointerOperations(pointerWorkflow);
-        commands.apply(safeContext::publishCurrent);
+    }
+
+    public void initialize() {
+        if (initializationRequested.compareAndSet(false, true)) {
+            commands.apply(context::publishCurrent);
+        }
     }
 
     public features.dungeon.api.editor.DungeonEditorState currentState() {

--- a/features/encounter/EncounterServiceAssembly.java
+++ b/features/encounter/EncounterServiceAssembly.java
@@ -98,7 +98,8 @@ public final class EncounterServiceAssembly {
                 generatedIoLane,
                 planRepository,
                 uiDispatcher,
-                diagnostics);
+                diagnostics,
+                false);
     }
 
     public static Component create(
@@ -150,7 +151,8 @@ public final class EncounterServiceAssembly {
                 executionLane,
                 planRepository,
                 uiDispatcher,
-                diagnostics);
+                diagnostics,
+                true);
     }
 
     private static Component create(
@@ -172,7 +174,8 @@ public final class EncounterServiceAssembly {
             ExecutionLane generatedIoLane,
             GeneratedEncounterBatchRepository generatedRepository,
             UiDispatcher uiDispatcher,
-            Diagnostics diagnostics
+            Diagnostics diagnostics,
+            boolean start
     ) {
         EncounterPublishedState publishedState = new EncounterPublishedState(
                 java.util.Objects.requireNonNull(uiDispatcher, "uiDispatcher"));
@@ -198,7 +201,7 @@ public final class EncounterServiceAssembly {
                 contextRepository,
                 java.util.Objects.requireNonNull(executionLane, "executionLane"),
                 generatedBatches);
-        return new Component(
+        Component component = new Component(
                 application,
                 application.runtimeContexts(),
                 publishedState.stateModel(),
@@ -207,6 +210,10 @@ public final class EncounterServiceAssembly {
                 publishedState.tuningPreviewModel(),
                 publishedState.savedPlansModel(),
                 publishedState.planBudgetModel());
+        if (start) {
+            component.start();
+        }
+        return component;
     }
 
     public record Component(
@@ -219,6 +226,10 @@ public final class EncounterServiceAssembly {
             features.encounter.api.SavedEncounterPlanListModel savedPlans,
             features.encounter.api.EncounterPlanBudgetModel planBudget
     ) {
+
+        public void start() {
+            ((EncounterApplicationService) application).initialize();
+        }
 
         public ShellContribution stateContribution(
                 CreaturesApi creatures,

--- a/features/encounter/application/EncounterApplicationService.java
+++ b/features/encounter/application/EncounterApplicationService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import platform.execution.DirectExecutionLane;
 import platform.execution.ExecutionLane;
 import features.encounter.domain.generation.EncounterGenerationInputs;
@@ -75,6 +76,7 @@ public final class EncounterApplicationService implements features.encounter.api
     private final ExecutionLane executionLane;
     private final EncounterRuntimeContextApi runtimeContexts;
     private final GeneratedEncounterBatchService generatedBatches;
+    private final AtomicBoolean initializationRequested = new AtomicBoolean();
 
     public EncounterApplicationService(
             EncounterSessionRuntimeAccess runtimeAccess,
@@ -129,7 +131,12 @@ public final class EncounterApplicationService implements features.encounter.api
                         0L,
                         "Encounter runtime contexts are unavailable."));
         this.generatedBatches = generatedBatches;
-        this.executionLane.execute(commands::initialize);
+    }
+
+    public void initialize() {
+        if (initializationRequested.compareAndSet(false, true)) {
+            executionLane.execute(commands::initialize);
+        }
     }
 
     @Override

--- a/features/hex/HexServiceAssembly.java
+++ b/features/hex/HexServiceAssembly.java
@@ -60,7 +60,8 @@ public final class HexServiceAssembly {
                 party,
                 executionLane,
                 uiDispatcher,
-                diagnostics);
+                diagnostics,
+                false);
         return new Component(assembly);
     }
 
@@ -71,6 +72,25 @@ public final class HexServiceAssembly {
             ExecutionLane executionLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
+    ) {
+        this(
+                repository,
+                partyTravelPositions,
+                partyApplicationService,
+                executionLane,
+                uiDispatcher,
+                diagnostics,
+                true);
+    }
+
+    private HexServiceAssembly(
+            HexMapRepository repository,
+            PartyTravelPositionsModel partyTravelPositions,
+            PartyApi partyApplicationService,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics,
+            boolean startReadback
     ) {
         HexMapRepository safeRepository = Objects.requireNonNull(repository, "repository");
         ExecutionLane lane = Objects.requireNonNull(executionLane, "executionLane");
@@ -92,7 +112,12 @@ public final class HexServiceAssembly {
                 travelState,
                 lane,
                 safeDiagnostics);
-        registerTravelReadback(Objects.requireNonNull(partyTravelPositions, "partyTravelPositions"));
+        PartyTravelPositionsModel safeTravelPositions = Objects.requireNonNull(
+                partyTravelPositions, "partyTravelPositions");
+        this.partyTravelPositions = safeTravelPositions;
+        if (startReadback) {
+            start();
+        }
     }
 
     public HexEditorApi editorApplication() {
@@ -114,6 +139,17 @@ public final class HexServiceAssembly {
     private void registerTravelReadback(PartyTravelPositionsModel partyTravelPositions) {
         travelApplicationService.acceptPartyTravelPosition(partyTravelPositions.current());
         partyTravelPositions.subscribe(travelApplicationService::acceptPartyTravelPosition);
+    }
+
+    private final PartyTravelPositionsModel partyTravelPositions;
+    private boolean started;
+
+    private synchronized void start() {
+        if (started) {
+            return;
+        }
+        started = true;
+        registerTravelReadback(partyTravelPositions);
     }
 
     public static final class Component {
@@ -138,6 +174,10 @@ public final class HexServiceAssembly {
 
         public HexTravelModel travelModel() {
             return assembly.travelModel;
+        }
+
+        public void start() {
+            assembly.start();
         }
 
         public ShellContribution mapContribution() {

--- a/features/items/adapter/sqlite/SqliteItemCatalogAdapter.java
+++ b/features/items/adapter/sqlite/SqliteItemCatalogAdapter.java
@@ -15,7 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
-import platform.persistence.SqliteConnectionSource;
+import platform.persistence.FeatureStoreDefinition;
+import platform.persistence.FeatureStoreHandle;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
 
@@ -36,14 +37,14 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
             + "AND (? IS NULL OR cost_cp <= ?) ";
 
     private final SqliteDatabase database;
-    private final SqliteConnectionSource connections;
+    private final FeatureStoreHandle connections;
 
     public SqliteItemCatalogAdapter(SqliteDatabase database) {
         this.database = Objects.requireNonNull(database, "database");
         ItemsSchema schema = new ItemsSchema();
-        connections = database.connections(
+        connections = database.featureStore(FeatureStoreDefinition.of(
                 OWNER,
-                new SqliteMigration(SCHEMA_VERSION, schema::migrate));
+                new SqliteMigration(SCHEMA_VERSION, schema::migrate)));
     }
 
     @Override

--- a/features/party/PartyServiceAssembly.java
+++ b/features/party/PartyServiceAssembly.java
@@ -30,11 +30,13 @@ public final class PartyServiceAssembly {
     }
 
     public static Component create(PartyRosterRepository repository) {
-        return create(
+        Component component = assemble(
                 repository,
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
+        start(component);
+        return component;
     }
 
     public static Component create(
@@ -43,7 +45,7 @@ public final class PartyServiceAssembly {
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
-        return create(
+        return assemble(
                 new SqlitePartyRosterRepository(Objects.requireNonNull(database, "database")),
                 executionLane,
                 uiDispatcher,
@@ -51,6 +53,17 @@ public final class PartyServiceAssembly {
     }
 
     public static Component create(
+            PartyRosterRepository repository,
+            ExecutionLane executionLane,
+            UiDispatcher uiDispatcher,
+            Diagnostics diagnostics
+    ) {
+        Component component = assemble(repository, executionLane, uiDispatcher, diagnostics);
+        start(component);
+        return component;
+    }
+
+    private static Component assemble(
             PartyRosterRepository repository,
             ExecutionLane executionLane,
             UiDispatcher uiDispatcher,
@@ -70,7 +83,6 @@ public final class PartyServiceAssembly {
                 publishedState,
                 Objects.requireNonNull(executionLane, "executionLane"),
                 Objects.requireNonNull(diagnostics, "diagnostics"));
-        application.refreshPublishedState();
         return new Component(
                 application,
                 snapshot,
@@ -82,6 +94,11 @@ public final class PartyServiceAssembly {
                 dayCalculation,
                 new PartyTopBarContribution(application, snapshot, daySummary, mutation),
                 new AdventuringDayTopBarContribution(daySummary, dayCalculation, application));
+    }
+
+    public static void start(Component component) {
+        PartyApi application = Objects.requireNonNull(component, "component").application();
+        ((PartyApplicationService) application).refreshPublishedState();
     }
 
     public record Component(

--- a/features/worldplanner/WorldPlannerServiceAssembly.java
+++ b/features/worldplanner/WorldPlannerServiceAssembly.java
@@ -64,7 +64,10 @@ public final class WorldPlannerServiceAssembly {
                 executionLane,
                 uiDispatcher,
                 diagnostics);
-        return new Component(assembly.createApplicationService(), assembly.snapshotModel());
+        return new Component(
+                assembly,
+                assembly.createApplicationServiceWithoutStarting(),
+                assembly.snapshotModelWithoutStarting());
     }
 
     public WorldPlannerServiceAssembly(
@@ -83,6 +86,10 @@ public final class WorldPlannerServiceAssembly {
 
     public WorldPlannerApplicationService createApplicationService() {
         scheduleInitialSnapshot();
+        return createApplicationServiceWithoutStarting();
+    }
+
+    private WorldPlannerApplicationService createApplicationServiceWithoutStarting() {
         return new WorldPlannerApplicationService(
                 repository,
                 referenceValidator,
@@ -93,6 +100,10 @@ public final class WorldPlannerServiceAssembly {
 
     public WorldPlannerSnapshotModel snapshotModel() {
         scheduleInitialSnapshot();
+        return snapshotModelWithoutStarting();
+    }
+
+    private WorldPlannerSnapshotModel snapshotModelWithoutStarting() {
         return publishedState.snapshotModel();
     }
 
@@ -117,12 +128,15 @@ public final class WorldPlannerServiceAssembly {
 
         private final WorldPlannerApplicationService application;
         private final WorldPlannerSnapshotModel snapshot;
+        private final WorldPlannerServiceAssembly assembly;
         private @Nullable WorldPlannerInspectorController activeInspectorController;
 
         private Component(
+                WorldPlannerServiceAssembly assembly,
                 WorldPlannerApplicationService application,
                 WorldPlannerSnapshotModel snapshot
         ) {
+            this.assembly = Objects.requireNonNull(assembly, "assembly");
             this.application = Objects.requireNonNull(application, "application");
             this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
         }
@@ -133,6 +147,10 @@ public final class WorldPlannerServiceAssembly {
 
         public WorldPlannerSnapshotModel snapshot() {
             return snapshot;
+        }
+
+        public void start() {
+            assembly.scheduleInitialSnapshot();
         }
 
         public void openNpcInspector(

--- a/platform/persistence/FeatureStoreDefinition.java
+++ b/platform/persistence/FeatureStoreDefinition.java
@@ -1,0 +1,81 @@
+package platform.persistence;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** Immutable schema definition for one feature-owned store in the shared database file. */
+public record FeatureStoreDefinition(
+        String owner,
+        List<SqliteMigration> migrations,
+        Validator validator
+) {
+
+    private static final Pattern OWNER_PATTERN = Pattern.compile("[a-z][a-z0-9-]*");
+
+    public FeatureStoreDefinition {
+        owner = normalizeOwner(owner);
+        migrations = normalizeMigrations(migrations);
+        validator = Objects.requireNonNull(validator, "validator");
+    }
+
+    public static FeatureStoreDefinition of(String owner, SqliteMigration... migrations) {
+        return new FeatureStoreDefinition(
+                owner,
+                Arrays.asList(migrations == null ? new SqliteMigration[0] : migrations),
+                connection -> { });
+    }
+
+    public static FeatureStoreDefinition validated(
+            String owner,
+            Validator validator,
+            SqliteMigration... migrations
+    ) {
+        return new FeatureStoreDefinition(
+                owner,
+                Arrays.asList(migrations == null ? new SqliteMigration[0] : migrations),
+                validator);
+    }
+
+    int supportedVersion() {
+        return migrations.isEmpty() ? 0 : migrations.getLast().version();
+    }
+
+    List<Integer> versions() {
+        return migrations.stream().map(SqliteMigration::version).toList();
+    }
+
+    private static String normalizeOwner(String owner) {
+        String safeOwner = Objects.requireNonNull(owner, "owner").toLowerCase(Locale.ROOT);
+        if (!OWNER_PATTERN.matcher(safeOwner).matches()) {
+            throw new IllegalArgumentException("invalid migration owner");
+        }
+        return safeOwner;
+    }
+
+    private static List<SqliteMigration> normalizeMigrations(List<SqliteMigration> migrations) {
+        List<SqliteMigration> plan = new ArrayList<>(Objects.requireNonNull(migrations, "migrations"));
+        if (plan.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("migration plan must not contain null");
+        }
+        plan.sort(Comparator.comparingInt(SqliteMigration::version));
+        int expected = 1;
+        for (SqliteMigration migration : plan) {
+            if (migration.version() != expected++) {
+                throw new IllegalArgumentException("migration versions must be contiguous from one");
+            }
+        }
+        return List.copyOf(plan);
+    }
+
+    @FunctionalInterface
+    public interface Validator {
+        void validate(Connection connection) throws SQLException;
+    }
+}

--- a/platform/persistence/FeatureStoreHandle.java
+++ b/platform/persistence/FeatureStoreHandle.java
@@ -1,0 +1,11 @@
+package platform.persistence;
+
+import java.util.Optional;
+
+/** Owner-bound connection capability for one prepared feature store. */
+public interface FeatureStoreHandle extends SqliteConnectionSource {
+
+    String owner();
+
+    Optional<FeatureStoreReadiness> readiness();
+}

--- a/platform/persistence/FeatureStoreReadiness.java
+++ b/platform/persistence/FeatureStoreReadiness.java
@@ -1,0 +1,9 @@
+package platform.persistence;
+
+/** Result of preparing one feature-owned SQLite schema. */
+public enum FeatureStoreReadiness {
+    READY,
+    MIGRATION_FAILED,
+    NEWER_SCHEMA,
+    CORRUPT
+}

--- a/platform/persistence/FeatureStoreUnavailableException.java
+++ b/platform/persistence/FeatureStoreUnavailableException.java
@@ -1,0 +1,19 @@
+package platform.persistence;
+
+import java.sql.SQLException;
+import java.util.Objects;
+
+/** Payload-free failure raised when a feature store did not reach READY. */
+public final class FeatureStoreUnavailableException extends SQLException {
+
+    private final FeatureStoreReadiness readiness;
+
+    public FeatureStoreUnavailableException(FeatureStoreReadiness readiness) {
+        super("SQLite feature store is unavailable: " + Objects.requireNonNull(readiness, "readiness"));
+        this.readiness = readiness;
+    }
+
+    public FeatureStoreReadiness readiness() {
+        return readiness;
+    }
+}

--- a/platform/persistence/SqliteDatabase.java
+++ b/platform/persistence/SqliteDatabase.java
@@ -20,11 +20,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Collections;
 import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,7 +39,6 @@ public final class SqliteDatabase implements AutoCloseable {
     private static final String APP_DATA_DIR_NAME = "salt-marcher";
     private static final String MIGRATIONS_TABLE = "sm_schema_versions";
     private static final byte[] SQLITE_HEADER = "SQLite format 3\0".getBytes(StandardCharsets.US_ASCII);
-    private static final Pattern OWNER_PATTERN = Pattern.compile("[a-z][a-z0-9-]*");
     private static final Pattern BACKUP_VERSION_PATTERN = Pattern.compile(".*\\.backup-v(\\d+)\\.sqlite");
     private static final DiagnosticId INTEGRITY_FAILURE =
             new DiagnosticId("persistence.integrity-failure");
@@ -53,8 +50,9 @@ public final class SqliteDatabase implements AutoCloseable {
     private final Path databasePath;
     private final Diagnostics diagnostics;
     private final FileMover fileMover;
-    private final Map<String, List<SqliteMigration>> migrationPlans = new LinkedHashMap<>();
+    private final Map<String, StoreHandle> stores = new LinkedHashMap<>();
     private boolean prepared;
+    private boolean storesSealed;
     private boolean closed;
 
     public SqliteDatabase(Path databasePath, Diagnostics diagnostics) {
@@ -129,15 +127,51 @@ public final class SqliteDatabase implements AutoCloseable {
         }
     }
 
-    public synchronized SqliteConnectionSource connections(String owner, SqliteMigration... migrations) {
-        String safeOwner = requireOwner(owner);
-        List<SqliteMigration> plan = normalizedPlan(migrations);
-        List<SqliteMigration> existing = migrationPlans.get(safeOwner);
-        if (existing != null && !versions(existing).equals(versions(plan))) {
+    /**
+     * Registers an immutable feature-store definition and returns its owner-bound handle.
+     * Registration is complete before production storage preparation begins.
+     */
+    public synchronized FeatureStoreHandle featureStore(FeatureStoreDefinition definition) {
+        FeatureStoreDefinition safeDefinition = Objects.requireNonNull(definition, "definition");
+        StoreHandle existing = stores.get(safeDefinition.owner());
+        if (existing != null && !existing.definition.versions().equals(safeDefinition.versions())) {
             throw new IllegalArgumentException("migration owner registered with a different version plan");
         }
-        migrationPlans.putIfAbsent(safeOwner, plan);
-        return this::openConnection;
+        if (existing != null) {
+            return existing;
+        }
+        if (storesSealed) {
+            throw new IllegalStateException("feature stores are already prepared");
+        }
+        StoreHandle registered = new StoreHandle(safeDefinition);
+        stores.put(safeDefinition.owner(), registered);
+        return registered;
+    }
+
+    /** Temporary adapter for unchanged SQLite providers during the storage migration. */
+    public synchronized SqliteConnectionSource connections(String owner, SqliteMigration... migrations) {
+        return featureStore(FeatureStoreDefinition.of(owner, migrations));
+    }
+
+    /**
+     * Seals registration and prepares every owner independently. A failed or newer owner
+     * does not prevent another owner from becoming ready.
+     */
+    public synchronized Map<String, FeatureStoreReadiness> prepareRegisteredStores() {
+        storesSealed = true;
+        try {
+            prepare();
+        } catch (NewerPlatformSchemaException exception) {
+            markAllStores(FeatureStoreReadiness.NEWER_SCHEMA);
+            return readinessSnapshot();
+        } catch (SQLException exception) {
+            markAllStores(FeatureStoreReadiness.CORRUPT);
+            return readinessSnapshot();
+        }
+        for (StoreHandle store : stores.values()) {
+            prepareStore(store);
+        }
+        return readinessSnapshot();
     }
 
     public synchronized void prepare() throws SQLException {
@@ -158,20 +192,27 @@ public final class SqliteDatabase implements AutoCloseable {
         closed = true;
     }
 
-    private Connection openConnection() throws SQLException {
-        prepare();
-        synchronized (this) {
-            requireOpen();
-        }
+    private Connection openConnection(StoreHandle store) throws SQLException {
         Connection connection = null;
         try {
-            // Connection setup changes WAL mode and may execute idempotent DDL or feature
-            // migrations. Serialize only that initialization window for this database lifecycle;
-            // returned connections and their feature transactions remain independently concurrent.
             synchronized (this) {
                 requireOpen();
+                if (store.readiness == null) {
+                    try {
+                        prepare();
+                    } catch (NewerPlatformSchemaException exception) {
+                        markAllStores(FeatureStoreReadiness.NEWER_SCHEMA);
+                    } catch (SQLException exception) {
+                        markAllStores(FeatureStoreReadiness.CORRUPT);
+                    }
+                    if (store.readiness == null) {
+                        prepareStore(store);
+                    }
+                }
+                if (store.readiness != FeatureStoreReadiness.READY) {
+                    throw new FeatureStoreUnavailableException(store.readiness);
+                }
                 connection = openConfigured(databasePath);
-                migrate(connection, registeredPlans());
             }
             return connection;
         } catch (SQLException | RuntimeException exception) {
@@ -202,10 +243,11 @@ public final class SqliteDatabase implements AutoCloseable {
             }
             int version = platformVersion(snapshot);
             if (version > PLATFORM_SCHEMA_VERSION) {
-                throw new SQLException("SQLite platform schema is newer than this application.");
+                throw new NewerPlatformSchemaException();
             }
             try {
                 assertForeignKeys(snapshot);
+                restoreTest(snapshot);
             } catch (SQLException exception) {
                 diagnostics.failure(INTEGRITY_FAILURE, exception.getClass());
                 throw exception;
@@ -219,31 +261,41 @@ public final class SqliteDatabase implements AutoCloseable {
         }
     }
 
-    private void migrate(Connection connection, Map<String, List<SqliteMigration>> plans) throws SQLException {
+    private void prepareStore(StoreHandle store) {
+        if (store.readiness != null) {
+            return;
+        }
+        try (Connection connection = openConfigured(databasePath)) {
+            migrate(connection, store.definition);
+            store.readiness = FeatureStoreReadiness.READY;
+        } catch (NewerFeatureSchemaException | NewerPlatformSchemaException exception) {
+            store.readiness = FeatureStoreReadiness.NEWER_SCHEMA;
+        } catch (SQLException | RuntimeException exception) {
+            store.readiness = FeatureStoreReadiness.MIGRATION_FAILED;
+            diagnostics.failure(MIGRATION_FAILURE, exception.getClass());
+        }
+    }
+
+    private void migrate(Connection connection, FeatureStoreDefinition definition) throws SQLException {
         boolean previousAutoCommit = connection.getAutoCommit();
         connection.setAutoCommit(false);
         try {
             ensurePlatformMetadata(connection);
-            for (Map.Entry<String, List<SqliteMigration>> entry : plans.entrySet()) {
-                String owner = entry.getKey();
-                List<SqliteMigration> plan = entry.getValue();
-                int storedVersion = storedFeatureVersion(connection, owner);
-                int supportedVersion = plan.isEmpty() ? 0 : plan.getLast().version();
-                if (storedVersion > supportedVersion) {
-                    throw new SQLException("SQLite feature schema is newer than this application.");
-                }
-                for (SqliteMigration migration : plan) {
-                    if (migration.version() > storedVersion) {
-                        migration.action().apply(connection);
-                        storeFeatureVersion(connection, owner, migration.version());
-                    }
+            int storedVersion = storedFeatureVersion(connection, definition.owner());
+            if (storedVersion > definition.supportedVersion()) {
+                throw new NewerFeatureSchemaException();
+            }
+            for (SqliteMigration migration : definition.migrations()) {
+                if (migration.version() > storedVersion) {
+                    migration.action().apply(connection);
+                    storeFeatureVersion(connection, definition.owner(), migration.version());
                 }
             }
+            definition.validator().validate(connection);
             assertConnectionIntegrity(connection);
             connection.commit();
         } catch (SQLException | RuntimeException exception) {
             rollback(connection, exception);
-            diagnostics.failure(MIGRATION_FAILURE, exception.getClass());
             if (exception instanceof SQLException sqlException) {
                 throw sqlException;
             }
@@ -256,7 +308,7 @@ public final class SqliteDatabase implements AutoCloseable {
     private void ensurePlatformMetadata(Connection connection) throws SQLException {
         int version = pragmaInt(connection, "PRAGMA user_version");
         if (version > PLATFORM_SCHEMA_VERSION) {
-            throw new SQLException("SQLite platform schema is newer than this application.");
+            throw new NewerPlatformSchemaException();
         }
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE IF NOT EXISTS " + MIGRATIONS_TABLE
@@ -424,6 +476,19 @@ public final class SqliteDatabase implements AutoCloseable {
     private static void assertForeignKeys(Path path) throws SQLException {
         try (Connection connection = openReadOnly(path)) {
             assertConnectionForeignKeys(connection);
+        }
+    }
+
+    private void restoreTest(Path snapshot) throws SQLException {
+        Path restoreProbe = snapshot.resolveSibling("restore-probe.db");
+        try {
+            Files.copy(snapshot, restoreProbe, StandardCopyOption.REPLACE_EXISTING);
+            assertPhysicalIntegrity(restoreProbe);
+            assertForeignKeys(restoreProbe);
+        } catch (IOException exception) {
+            throw new SQLException("Could not restore-test SQLite backup.", exception);
+        } finally {
+            deleteIfExists(restoreProbe);
         }
     }
 
@@ -610,36 +675,57 @@ public final class SqliteDatabase implements AutoCloseable {
         }
     }
 
-    private static List<SqliteMigration> normalizedPlan(SqliteMigration[] migrations) {
-        List<SqliteMigration> plan = new ArrayList<>(Arrays.asList(
-                migrations == null ? new SqliteMigration[0] : migrations));
-        if (plan.stream().anyMatch(Objects::isNull)) {
-            throw new IllegalArgumentException("migration plan must not contain null");
+    private void markAllStores(FeatureStoreReadiness readiness) {
+        for (StoreHandle store : stores.values()) {
+            store.readiness = readiness;
         }
-        plan.sort(Comparator.comparingInt(SqliteMigration::version));
-        int expected = 1;
-        for (SqliteMigration migration : plan) {
-            if (migration.version() != expected++) {
-                throw new IllegalArgumentException("migration versions must be contiguous from one");
-            }
-        }
-        return List.copyOf(plan);
     }
 
-    private synchronized Map<String, List<SqliteMigration>> registeredPlans() {
-        return Collections.unmodifiableMap(new LinkedHashMap<>(migrationPlans));
+    private Map<String, FeatureStoreReadiness> readinessSnapshot() {
+        Map<String, FeatureStoreReadiness> readiness = new LinkedHashMap<>();
+        stores.forEach((owner, store) -> readiness.put(owner, store.readiness));
+        return Map.copyOf(readiness);
     }
 
-    private static List<Integer> versions(List<SqliteMigration> plan) {
-        return plan.stream().map(SqliteMigration::version).toList();
+    private final class StoreHandle implements FeatureStoreHandle {
+
+        private final FeatureStoreDefinition definition;
+        private volatile FeatureStoreReadiness readiness;
+
+        private StoreHandle(FeatureStoreDefinition definition) {
+            this.definition = definition;
+        }
+
+        @Override
+        public String owner() {
+            return definition.owner();
+        }
+
+        @Override
+        public java.util.Optional<FeatureStoreReadiness> readiness() {
+            return java.util.Optional.ofNullable(readiness);
+        }
+
+        @Override
+        public Connection openConnection() throws SQLException {
+            return SqliteDatabase.this.openConnection(this);
+        }
+    }
+
+    private static final class NewerFeatureSchemaException extends SQLException {
+        private NewerFeatureSchemaException() {
+            super("SQLite feature schema is newer than this application.");
+        }
+    }
+
+    private static final class NewerPlatformSchemaException extends SQLException {
+        private NewerPlatformSchemaException() {
+            super("SQLite platform schema is newer than this application.");
+        }
     }
 
     private static String requireOwner(String owner) {
-        String safeOwner = Objects.requireNonNull(owner, "owner").toLowerCase(Locale.ROOT);
-        if (!OWNER_PATTERN.matcher(safeOwner).matches()) {
-            throw new IllegalArgumentException("invalid migration owner");
-        }
-        return safeOwner;
+        return FeatureStoreDefinition.of(owner).owner();
     }
 
     private void requireOpen() throws SQLException {

--- a/test/app/SmokeStartupTest.java
+++ b/test/app/SmokeStartupTest.java
@@ -2,10 +2,12 @@ package app;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.DriverManager;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -18,10 +20,13 @@ import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.Pane;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import shell.api.ContributionKey;
 import shell.host.AppShell;
 import platform.diagnostics.NoopDiagnostics;
+import platform.execution.ExecutionLane;
 import platform.persistence.SqliteDatabase;
+import platform.ui.DirectUiDispatcher;
 
 @org.junit.jupiter.api.Tag("ui")
 public final class SmokeStartupTest {
@@ -84,6 +89,24 @@ public final class SmokeStartupTest {
             }
         });
         openTempSqliteConnection();
+    }
+
+    @Test
+    void preparesEveryFeatureStoreBeforeFirstServiceWork(@TempDir Path temporaryDirectory) throws Exception {
+        runOnFx(() -> {
+            Path databasePath = temporaryDirectory.resolve("startup-order.sqlite");
+            try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+                StoragePreparedLane lane = new StoragePreparedLane(databasePath);
+                try (AppBootstrap bootstrap = new AppBootstrap(
+                        NoopDiagnostics.INSTANCE,
+                        lane,
+                        DirectUiDispatcher.INSTANCE,
+                        database)) {
+                    bootstrap.createShell();
+                    require(lane.executions > 0, "Expected explicitly started service work.");
+                }
+            }
+        });
     }
 
     private static void runOnFx(ThrowingRunnable action) throws Exception {
@@ -161,6 +184,57 @@ public final class SmokeStartupTest {
     private static void require(boolean condition, String message) {
         if (!condition) {
             throw new IllegalStateException(message);
+        }
+    }
+
+    private static final class StoragePreparedLane implements ExecutionLane {
+
+        private static final Set<String> EXPECTED_OWNERS = Set.of(
+                "creatures",
+                "dungeon",
+                "encounter",
+                "encounter-table",
+                "hex",
+                "items",
+                "party",
+                "scene",
+                "session-generation",
+                "session-planner",
+                "world-planner");
+
+        private final Path databasePath;
+        private int executions;
+
+        private StoragePreparedLane(Path databasePath) {
+            this.databasePath = databasePath;
+        }
+
+        @Override
+        public void execute(Runnable work) {
+            assertAllStoresPrepared();
+            executions++;
+            work.run();
+        }
+
+        private void assertAllStoresPrepared() {
+            try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+                    var statement = connection.createStatement();
+                    var result = statement.executeQuery("SELECT owner FROM sm_schema_versions")) {
+                java.util.HashSet<String> actual = new java.util.HashSet<>();
+                while (result.next()) {
+                    actual.add(result.getString(1));
+                }
+                require(
+                        actual.equals(EXPECTED_OWNERS),
+                        "Service work started before all feature stores were prepared: " + actual);
+            } catch (java.sql.SQLException exception) {
+                throw new IllegalStateException("Service work started before storage preparation.", exception);
+            }
+        }
+
+        @Override
+        public void close() {
+            // Owned by the bootstrap; no external resources in this proof lane.
         }
     }
 

--- a/test/features/encounter/application/EncounterRuntimeMechanismsTest.java
+++ b/test/features/encounter/application/EncounterRuntimeMechanismsTest.java
@@ -23,6 +23,7 @@ final class EncounterRuntimeMechanismsTest {
         RecordingLane lane = new RecordingLane();
         RecordingActions actions = new RecordingActions();
         EncounterApplicationService application = new EncounterApplicationService(actions, lane);
+        application.initialize();
 
         assertEquals(1, lane.pending());
         assertTrue(actions.calls.isEmpty());

--- a/test/platform/persistence/SqliteDatabaseTest.java
+++ b/test/platform/persistence/SqliteDatabaseTest.java
@@ -145,20 +145,79 @@ final class SqliteDatabaseTest {
     }
 
     @Test
-    void runsEveryRegisteredFeaturePlanOnceInRegistrationOrder() throws Exception {
-        Path databasePath = temporaryDirectory.resolve("ordered.db");
-        List<String> order = new ArrayList<>();
-        SqliteDatabase database = new SqliteDatabase(databasePath, (id, type) -> { });
-        SqliteConnectionSource first = database.connections(
-                "first", new SqliteMigration(1, connection -> order.add("first")));
-        database.connections("second", new SqliteMigration(1, connection -> order.add("second")));
+    void newerUnrelatedOwnerDoesNotBlockReadyStore() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("owner-isolation.db");
+        try (SqliteDatabase initial = new SqliteDatabase(databasePath, (id, type) -> { })) {
+            initial.featureStore(FeatureStoreDefinition.of(
+                    "future-owner",
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE future_rows(id INTEGER PRIMARY KEY)")),
+                    new SqliteMigration(2, connection -> connection.createStatement().execute(
+                            "ALTER TABLE future_rows ADD COLUMN label TEXT"))));
+            initial.featureStore(FeatureStoreDefinition.of(
+                    "healthy-owner",
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE healthy_rows(id INTEGER PRIMARY KEY)"))));
+            assertEquals(
+                    FeatureStoreReadiness.READY,
+                    initial.prepareRegisteredStores().get("future-owner"));
+        }
 
-        try (var ignored = first.openConnection()) {
-            assertEquals(List.of("first", "second"), order);
+        try (SqliteDatabase current = new SqliteDatabase(databasePath, (id, type) -> { })) {
+            FeatureStoreHandle future = current.featureStore(FeatureStoreDefinition.of(
+                    "future-owner",
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE future_rows(id INTEGER PRIMARY KEY)"))));
+            FeatureStoreHandle healthy = current.featureStore(FeatureStoreDefinition.of(
+                    "healthy-owner",
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE healthy_rows(id INTEGER PRIMARY KEY)"))));
+
+            var readiness = current.prepareRegisteredStores();
+
+            assertEquals(FeatureStoreReadiness.NEWER_SCHEMA, readiness.get("future-owner"));
+            assertEquals(FeatureStoreReadiness.READY, readiness.get("healthy-owner"));
+            FeatureStoreUnavailableException unavailable = assertThrows(
+                    FeatureStoreUnavailableException.class,
+                    future::openConnection);
+            assertEquals(FeatureStoreReadiness.NEWER_SCHEMA, unavailable.readiness());
+            try (var connection = healthy.openConnection()) {
+                connection.createStatement().execute("INSERT INTO healthy_rows(id) VALUES(1)");
+            }
         }
-        try (var ignored = first.openConnection()) {
-            assertEquals(List.of("first", "second"), order);
+    }
+
+    @Test
+    void failedOwnerRollsBackAndLeavesOtherPreparedOwnerUsable() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("owner-failure-isolation.db");
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, diagnostics)) {
+            FeatureStoreHandle broken = database.featureStore(FeatureStoreDefinition.validated(
+                    "broken-owner",
+                    connection -> {
+                        throw new SQLException("private payload");
+                    },
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE partial_rows(id INTEGER)"))));
+            FeatureStoreHandle healthy = database.featureStore(FeatureStoreDefinition.of(
+                    "healthy-owner",
+                    new SqliteMigration(1, connection -> connection.createStatement().execute(
+                            "CREATE TABLE complete_rows(id INTEGER PRIMARY KEY)"))));
+
+            var readiness = database.prepareRegisteredStores();
+
+            assertEquals(FeatureStoreReadiness.MIGRATION_FAILED, readiness.get("broken-owner"));
+            assertEquals(FeatureStoreReadiness.READY, readiness.get("healthy-owner"));
+            assertThrows(FeatureStoreUnavailableException.class, broken::openConnection);
+            try (var connection = healthy.openConnection();
+                    var partial = connection.prepareStatement(
+                            "SELECT name FROM sqlite_master WHERE type='table' AND name='partial_rows'");
+                    var partialResult = partial.executeQuery()) {
+                assertFalse(partialResult.next());
+                connection.createStatement().execute("INSERT INTO complete_rows(id) VALUES(1)");
+            }
         }
+        assertEquals(List.of("persistence.migration-failure"), diagnostics.ids);
     }
 
     @Test
@@ -272,9 +331,11 @@ final class SqliteDatabaseTest {
         RecordingDiagnostics diagnostics = new RecordingDiagnostics();
         SqliteDatabase database = new SqliteDatabase(databasePath, diagnostics);
 
-        assertThrows(SQLException.class,
+        FeatureStoreUnavailableException unavailable = assertThrows(
+                FeatureStoreUnavailableException.class,
                 () -> database.connections("seed", seedMigration()).openConnection());
 
+        assertEquals(FeatureStoreReadiness.CORRUPT, unavailable.readiness());
         assertArrayEquals(corrupt, Files.readAllBytes(databasePath));
         assertEquals(
                 List.of("persistence.integrity-failure", "persistence.recovery-failure"),
@@ -545,9 +606,11 @@ final class SqliteDatabaseTest {
         }
         SqliteDatabase database = new SqliteDatabase(databasePath, (id, type) -> { });
 
-        assertThrows(SQLException.class,
+        FeatureStoreUnavailableException unavailable = assertThrows(
+                FeatureStoreUnavailableException.class,
                 () -> database.connections("seed", seedMigration()).openConnection());
 
+        assertEquals(FeatureStoreReadiness.NEWER_SCHEMA, unavailable.readiness());
         try (var connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath)) {
             assertEquals(99, pragmaInt(connection, "PRAGMA user_version"));
         }


### PR DESCRIPTION
## Ziel

Schließt Katalog-Roadmap M1 ab: owner-isolierte SQLite-Readiness und deterministische Startphasen vor jeglicher Feature-Arbeit.

## Umsetzung

- immutable `FeatureStoreDefinition` mit Migrationen und Owner-Validator
- owner-gebundene `FeatureStoreHandle` mit `READY`, `MIGRATION_FAILED`, `NEWER_SCHEMA`, `CORRUPT`
- keine Schleife über fremde Migrationspläne mehr beim Öffnen einer Connection
- unabhängige Owner-Transaktionen, Rollback und typisierte Fail-closed-Handles
- Restore-Probe für die verifizierte Vor-Migrationskopie
- Creatures und Items auf vorbereitete Handles umgestellt
- Bootstrap in Komposition, Storage-Vorbereitung, Service-Start und Shell-Aktivierung getrennt
- implizite Starts von Party, World Planner, Encounter, Dungeon und Hex aus dem Produktions-Kompositionspfad entfernt
- Roadmap mit realem M1-Stand und benanntem Übergangsadapter aktualisiert

## Nachweis

- fokussierte Persistenztests: grün
- `SmokeStartupTest`: erster Service-Task sieht alle elf vorbereiteten Owner
- Rebase auf Encounter-Batch M2 semantisch aufgelöst; Batch-Funktion bleibt erhalten
- `git diff --check`: grün
- `./gradlew check --console=plain`: `BUILD SUCCESSFUL in 6m 29s`
