### PR TITLE
feat: Items-Katalog sicher auf Schema v2 migrieren

### DIFF
--- a/docs/catalog/delivery/roadmap-catalog-greenfield.md
+++ b/docs/catalog/delivery/roadmap-catalog-greenfield.md
@@ -62,9 +62,11 @@ from refreshed `origin/main`.
   user-visible behavior, migration order, and deletion gates on 2026-07-19.
 - Locally completed milestone: M1 replaced global migration execution with owner-scoped
   definitions, readiness, and handles and passed literal `./gradlew check` on 2026-07-19.
-- Publication state: the M1 pull request and required CI are pending; M2 must start only
+- M1 publication: PR #530 merged with required CI green.
+- Locally completed milestone: M2 migrates both supported Items predecessor shapes into
+  the unambiguous version-2 target and passed literal `./gradlew check` on 2026-07-19.
+- Publication state: the M2 pull request and required CI are pending; M3 starts only
   after that pull request merges.
-- Next milestone: M2 migrates both supported Items predecessor shapes.
 - No Greenfield production route has been implemented yet.
 
 ## M0: Target Lock And Baseline
@@ -162,6 +164,20 @@ is deleted with the last unchanged provider during the final compatibility clean
 - failed validation leaves the complete before-state unchanged
 - Items failure does not affect Creature search
 - focused provider tests and `./gradlew check` are green
+
+### M2 Implementation Evidence
+
+- target tables are `items_catalog_entries` and `items_catalog_tags` under owner version `2`.
+- the released v1 step remains unchanged; v2 classifies the exact legacy, intermediate,
+  or target signature before mutation.
+- the legacy fixture preserves `legacy:<slug>` identity, numeric provenance, semantic
+  fields, normalized tags, raw source-property text, and nullable attribution.
+- the intermediate fixture preserves canonical source keys, details, tags, and attribution.
+- both fixtures reopen at version `2` without predecessor tables or repeat migration.
+- the unknown fixture retains its original schema, row, and owner version; Items reports
+  `INCOMPATIBLE` while a Creature production adapter remains `READY` and readable.
+- all Items tests are green; literal `./gradlew check --console=plain` returned
+  `BUILD SUCCESSFUL in 5m 43s` on the final code and documentation diff.
 
 ## M3: Catalog Browse Runtime
 

--- a/docs/items/contract/contract-items-persistence.md
+++ b/docs/items/contract/contract-items-persistence.md
@@ -15,11 +15,41 @@ it does not access SQLite or the public HTTP source.
 
 ## Ownership And Compatibility
 
-Items owns the `items` and `item_tags` SQLite tables. Stable source keys from
-the pinned `/api/2014` API are persisted as text identifiers. Schema migration
-is registered under the `items` owner in the shared `SqliteDatabase`; Items
+Items owns the unambiguous target tables `items_catalog_entries` and
+`items_catalog_tags`. Stable source keys from the pinned `/api/2014` API are
+persisted as text identifiers. Schema migration is registered under the
+`items` owner and consumed through one prepared `FeatureStoreHandle`; Items
 does not open a parallel connection lifecycle. A source-version change requires
 an explicit migration decision and full re-import.
+
+Target owner version `2` has one structural signature: exact entry and tag
+columns, `source_key` and `(item_source_key, tag)` primary keys, a cascading tag
+foreign key, and a unique nullable `legacy_id`. Owner validation checks this
+signature, item identity, boolean domains, tag ownership, physical integrity,
+and foreign keys before the handle becomes `READY`.
+
+## Supported Upgrade Shapes
+
+Owner version `1` was historically written for two incompatible table shapes.
+Version `2` therefore classifies structure before creating, copying, dropping,
+or renaming anything and supports exactly:
+
+- legacy `items(id, slug, is_magic, requires_attunement, ...)` with
+  `item_tags(item_id, tag)`;
+- intermediate `items(source_key, magic, attunement, ...)` with
+  `item_tags(item_source_key, tag)`.
+
+Legacy identity becomes `legacy:<slug>` while the numeric id remains only in
+nullable migration provenance. The migration preserves names, categories,
+magic and attunement facts, attunement condition, costs, weight, damage, armor,
+description, normalized tags, source text, and otherwise nullable provenance.
+Intermediate canonical source keys and attribution remain unchanged.
+
+Both upgrades run inside the owner transaction. Target row and tag counts,
+identity, tag ownership, and the final target signature are validated before
+the predecessor tables are dropped and before owner version `2` commits. An
+unknown or mixed signature returns typed `INCOMPATIBLE`, rolls back the complete
+owner transaction, and does not affect another provider's readiness.
 
 ## Import Boundary
 
@@ -46,9 +76,9 @@ upstream fields remain absent rather than being synthesized.
 ## Query Contract
 
 Catalog queries accept optional filters and a bounded page. Invalid bounds
-return an invalid-query result. Missing tables or zero imported rows return an
-unavailable result. Storage failures return a storage-error result without
-changing published prior state.
+return an invalid-query result. Zero imported rows return an unavailable
+result. An unsupported schema returns an incompatible result. Storage failures
+return a storage-error result without changing published prior state.
 
 All catalog reads and explicit imports return `CompletionStage` results and
 schedule blocking work through the supplied `ExecutionLane`. SQLite and HTTP
@@ -58,6 +88,7 @@ consumer may dispatch only the resulting immutable projection back to JavaFX.
 ## Error And Compatibility Behavior
 
 - Missing or zero-row imported data returns `UNAVAILABLE`.
+- An unsupported or newer Items schema returns `INCOMPATIBLE` without mutation.
 - Invalid cost bounds return `INVALID_QUERY` without querying rows.
 - Missing detail keys return `NOT_FOUND`.
 - SQLite failures return `STORAGE_ERROR`; execution-lane rejection returns
@@ -65,18 +96,21 @@ consumer may dispatch only the resulting immutable projection back to JavaFX.
 - Import distinguishes source, validation, backup, storage, and execution
   failures. No failure status permits partial replacement.
 
-The schema owner version starts at 1. Additive compatible schema changes use a
-later Items-owned migration. A source-version change or incompatible shape
-requires an explicit migration decision and full re-import; public API callers
-must not infer persistence compatibility from table layout.
+The schema owner target is version `2`. Released version `1` remains immutable
+as the historical intermediate creation step; version `2` is the only
+structural translator for both supported v1 shapes. Later compatible changes
+use a new Items-owned migration. A source-version change or any other shape
+requires an explicit migration decision; public API callers never infer
+compatibility from JDBC or table layout.
 
 ## Verification Ownership
 
-Production-route tests own proof that queries use the shared SQLite lifecycle,
-that both source indexes and their detail documents are parsed, that blocking
-work is scheduled through `ExecutionLane`, and that a failed replacement rolls
-back both Items-owned tables. Repository `check` remains the merge-blocking
-proof owner.
+Production-route tests own proof that both predecessor fixtures migrate once,
+unknown signatures remain unchanged, Items failure leaves Creature reads usable,
+queries use the shared SQLite lifecycle, both source indexes and their detail
+documents are parsed, blocking work is scheduled through `ExecutionLane`, and a
+failed replacement rolls back both Items-owned tables. Repository `check`
+remains the merge-blocking proof owner.
 
 ## Attribution
 

--- a/docs/items/requirements/requirements-items-catalog.md
+++ b/docs/items/requirements/requirements-items-catalog.md
@@ -24,7 +24,8 @@ assignment, crafting, and authored item editing are non-goals.
   attunement, damage or armor facts when available, and source attribution in
   the Inspector.
 - Empty, invalid-filter, loading, unavailable-data, and storage-error states
-  are explicit.
+  are explicit; an incompatible local Items schema is distinguished from a
+  missing import.
 - The surface contains no create, edit, delete, loot generation, assignment,
   or inventory action.
 
@@ -46,4 +47,6 @@ assignment, crafting, and authored item editing are non-goals.
   imported projection
 - a missing import is an isolated Items unavailable state and does not break
   other Catalog contents
+- an incompatible Items schema is an isolated Items failure and does not break
+  Monster or other provider-backed Catalog contents
 - no Item UI or application command mutates imported item truth

--- a/features/catalog/application/ItemsCatalogController.java
+++ b/features/catalog/application/ItemsCatalogController.java
@@ -308,6 +308,7 @@ public final class ItemsCatalogController implements CatalogLifecycle {
                     CatalogResultState.Status.INVALID_INPUT, List.of(), "Ungültige Item-Suche.");
             case UNAVAILABLE -> new CatalogResultState<>(
                     CatalogResultState.Status.UNAVAILABLE, List.of(), "Noch kein Item-Katalog importiert.");
+            case INCOMPATIBLE -> CatalogResultState.failed("Item-Katalog ist nicht kompatibel.");
             case NOT_FOUND -> CatalogResultState.ready(List.of());
             case STORAGE_ERROR -> CatalogResultState.failed("Item-Katalog konnte nicht gelesen werden.");
             case EXECUTION_ERROR -> CatalogResultState.failed("Item-Suche konnte nicht ausgeführt werden.");
@@ -319,6 +320,7 @@ public final class ItemsCatalogController implements CatalogLifecycle {
             case SUCCESS -> "";
             case INVALID_QUERY -> "Ungültige Item-Suche.";
             case UNAVAILABLE -> "Noch kein Item-Katalog importiert.";
+            case INCOMPATIBLE -> "Item-Katalog ist nicht kompatibel.";
             case NOT_FOUND -> "Item nicht gefunden.";
             case STORAGE_ERROR -> "Item-Katalog konnte nicht gelesen werden.";
             case EXECUTION_ERROR -> "Item-Suche konnte nicht ausgeführt werden.";

--- a/features/items/adapter/sqlite/ItemsSchema.java
+++ b/features/items/adapter/sqlite/ItemsSchema.java
@@ -1,12 +1,38 @@
 package features.items.adapter.sqlite;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 final class ItemsSchema {
 
-    void migrate(Connection connection) throws SQLException {
+    static final String ENTRIES_TABLE = "items_catalog_entries";
+    static final String TAGS_TABLE = "items_catalog_tags";
+
+    private static final String PREDECESSOR_ENTRIES_TABLE = "items";
+    private static final String PREDECESSOR_TAGS_TABLE = "item_tags";
+
+    private static final List<String> LEGACY_ENTRY_COLUMNS = List.of(
+            "id", "name", "slug", "category", "subcategory", "is_magic", "rarity",
+            "requires_attunement", "attunement_condition", "cost", "cost_cp", "weight",
+            "damage", "properties", "armor_class", "description", "source", "tags");
+    private static final List<String> LEGACY_TAG_COLUMNS = List.of("item_id", "tag");
+    private static final List<String> INTERMEDIATE_ENTRY_COLUMNS = List.of(
+            "source_key", "name", "category", "subcategory", "magic", "rarity", "attunement",
+            "cost_cp", "cost_display", "weight", "damage", "armor_class", "description",
+            "source_version", "source_url");
+    private static final List<String> INTERMEDIATE_TAG_COLUMNS = List.of("item_source_key", "tag");
+    private static final List<String> TARGET_ENTRY_COLUMNS = List.of(
+            "source_key", "legacy_id", "name", "category", "subcategory", "magic", "rarity",
+            "attunement", "attunement_condition", "cost_cp", "cost_display", "weight", "damage",
+            "armor_class", "description", "source_version", "source_url", "source_properties_text",
+            "source_tags_text");
+    private static final List<String> TARGET_TAG_COLUMNS = List.of("item_source_key", "tag");
+
+    void migrateV1(Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
             statement.execute("""
                     CREATE TABLE IF NOT EXISTS items (
@@ -41,4 +67,351 @@ final class ItemsSchema {
             statement.execute("CREATE INDEX IF NOT EXISTS idx_items_cost ON items(cost_cp)");
         }
     }
+
+    void migrateV2(Connection connection) throws SQLException {
+        SourceShape shape = classify(connection);
+        if (shape == SourceShape.TARGET) {
+            validateTarget(connection);
+            return;
+        }
+        validatePredecessor(connection, shape);
+        int expectedEntries = count(connection, "SELECT COUNT(*) FROM " + PREDECESSOR_ENTRIES_TABLE);
+        int expectedTags = count(connection, "SELECT COUNT(*) FROM " + PREDECESSOR_TAGS_TABLE);
+
+        createTarget(connection);
+        if (shape == SourceShape.LEGACY) {
+            copyLegacy(connection);
+        } else {
+            copyIntermediate(connection);
+        }
+        assertCount(connection, ENTRIES_TABLE, expectedEntries);
+        assertCount(connection, TAGS_TABLE, expectedTags);
+        validateTargetRows(connection);
+        dropPredecessor(connection);
+        validateTarget(connection);
+    }
+
+    void validateTarget(Connection connection) throws SQLException {
+        if (!tableExists(connection, ENTRIES_TABLE) || !tableExists(connection, TAGS_TABLE)
+                || tableExists(connection, PREDECESSOR_ENTRIES_TABLE)
+                || tableExists(connection, PREDECESSOR_TAGS_TABLE)) {
+            throw incompatible();
+        }
+        requireColumns(connection, ENTRIES_TABLE, TARGET_ENTRY_COLUMNS);
+        requireColumns(connection, TAGS_TABLE, TARGET_TAG_COLUMNS);
+        requirePrimaryKey(connection, ENTRIES_TABLE, List.of("source_key"));
+        requirePrimaryKey(connection, TAGS_TABLE, List.of("item_source_key", "tag"));
+        requireForeignKey(connection, TAGS_TABLE, ENTRIES_TABLE, "item_source_key", "source_key");
+        if (!hasUniqueIndex(connection, ENTRIES_TABLE, List.of("legacy_id"))) {
+            throw incompatible();
+        }
+        validateTargetRows(connection);
+    }
+
+    private static SourceShape classify(Connection connection) throws SQLException {
+        boolean predecessorEntries = tableExists(connection, PREDECESSOR_ENTRIES_TABLE);
+        boolean predecessorTags = tableExists(connection, PREDECESSOR_TAGS_TABLE);
+        boolean targetEntries = tableExists(connection, ENTRIES_TABLE);
+        boolean targetTags = tableExists(connection, TAGS_TABLE);
+        if (targetEntries && targetTags && !predecessorEntries && !predecessorTags) {
+            requireColumns(connection, ENTRIES_TABLE, TARGET_ENTRY_COLUMNS);
+            requireColumns(connection, TAGS_TABLE, TARGET_TAG_COLUMNS);
+            return SourceShape.TARGET;
+        }
+        if (!targetEntries && !targetTags && predecessorEntries && predecessorTags) {
+            List<String> entries = columns(connection, PREDECESSOR_ENTRIES_TABLE);
+            List<String> tags = columns(connection, PREDECESSOR_TAGS_TABLE);
+            if (entries.equals(LEGACY_ENTRY_COLUMNS) && tags.equals(LEGACY_TAG_COLUMNS)) {
+                requirePrimaryKey(connection, PREDECESSOR_ENTRIES_TABLE, List.of("id"));
+                requirePrimaryKey(connection, PREDECESSOR_TAGS_TABLE, List.of("item_id", "tag"));
+                requireForeignKey(
+                        connection, PREDECESSOR_TAGS_TABLE, PREDECESSOR_ENTRIES_TABLE, "item_id", "id");
+                return SourceShape.LEGACY;
+            }
+            if (entries.equals(INTERMEDIATE_ENTRY_COLUMNS) && tags.equals(INTERMEDIATE_TAG_COLUMNS)) {
+                requirePrimaryKey(connection, PREDECESSOR_ENTRIES_TABLE, List.of("source_key"));
+                requirePrimaryKey(
+                        connection, PREDECESSOR_TAGS_TABLE, List.of("item_source_key", "tag"));
+                requireForeignKey(
+                        connection,
+                        PREDECESSOR_TAGS_TABLE,
+                        PREDECESSOR_ENTRIES_TABLE,
+                        "item_source_key",
+                        "source_key");
+                return SourceShape.INTERMEDIATE;
+            }
+        }
+        throw incompatible();
+    }
+
+    private static void validatePredecessor(Connection connection, SourceShape shape) throws SQLException {
+        if (shape == SourceShape.LEGACY) {
+            requireNoRows(connection, """
+                    SELECT 1 FROM items
+                    WHERE slug IS NULL OR TRIM(slug) = ''
+                       OR name IS NULL OR TRIM(name) = ''
+                       OR is_magic NOT IN (0, 1)
+                       OR requires_attunement NOT IN (0, 1)
+                    LIMIT 1
+                    """);
+            requireNoRows(connection, """
+                    SELECT 1 FROM items GROUP BY slug HAVING COUNT(*) > 1 LIMIT 1
+                    """);
+            requireNoRows(connection, """
+                    SELECT 1 FROM item_tags tag
+                    LEFT JOIN items item ON item.id = tag.item_id
+                    WHERE item.id IS NULL LIMIT 1
+                    """);
+            return;
+        }
+        requireNoRows(connection, """
+                SELECT 1 FROM items
+                WHERE source_key IS NULL OR TRIM(source_key) = ''
+                   OR name IS NULL OR TRIM(name) = ''
+                   OR category IS NULL OR magic NOT IN (0, 1) OR attunement NOT IN (0, 1)
+                LIMIT 1
+                """);
+        requireNoRows(connection, """
+                SELECT 1 FROM item_tags tag
+                LEFT JOIN items item ON item.source_key = tag.item_source_key
+                WHERE item.source_key IS NULL LIMIT 1
+                """);
+    }
+
+    private static void createTarget(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    CREATE TABLE items_catalog_entries (
+                        source_key TEXT PRIMARY KEY,
+                        legacy_id INTEGER UNIQUE,
+                        name TEXT NOT NULL,
+                        category TEXT NOT NULL,
+                        subcategory TEXT NOT NULL DEFAULT '',
+                        magic INTEGER NOT NULL CHECK (magic IN (0, 1)),
+                        rarity TEXT NOT NULL DEFAULT '',
+                        attunement INTEGER NOT NULL CHECK (attunement IN (0, 1)),
+                        attunement_condition TEXT NOT NULL DEFAULT '',
+                        cost_cp INTEGER,
+                        cost_display TEXT NOT NULL DEFAULT '',
+                        weight REAL,
+                        damage TEXT NOT NULL DEFAULT '',
+                        armor_class TEXT NOT NULL DEFAULT '',
+                        description TEXT NOT NULL DEFAULT '',
+                        source_version TEXT NOT NULL DEFAULT '',
+                        source_url TEXT NOT NULL DEFAULT '',
+                        source_properties_text TEXT NOT NULL DEFAULT '',
+                        source_tags_text TEXT NOT NULL DEFAULT ''
+                    )
+                    """);
+            statement.execute("""
+                    CREATE TABLE items_catalog_tags (
+                        item_source_key TEXT NOT NULL,
+                        tag TEXT NOT NULL,
+                        PRIMARY KEY (item_source_key, tag),
+                        FOREIGN KEY (item_source_key)
+                            REFERENCES items_catalog_entries(source_key) ON DELETE CASCADE
+                    )
+                    """);
+            statement.execute("CREATE INDEX idx_items_catalog_name ON items_catalog_entries(name)");
+            statement.execute("CREATE INDEX idx_items_catalog_category "
+                    + "ON items_catalog_entries(category, subcategory)");
+            statement.execute("CREATE INDEX idx_items_catalog_rarity ON items_catalog_entries(rarity)");
+            statement.execute("CREATE INDEX idx_items_catalog_cost ON items_catalog_entries(cost_cp)");
+            statement.execute("CREATE INDEX idx_items_catalog_tag ON items_catalog_tags(tag)");
+        }
+    }
+
+    private static void copyLegacy(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO items_catalog_entries(
+                        source_key, legacy_id, name, category, subcategory, magic, rarity, attunement,
+                        attunement_condition, cost_cp, cost_display, weight, damage, armor_class,
+                        description, source_version, source_url, source_properties_text, source_tags_text)
+                    SELECT 'legacy:' || slug, id, name, COALESCE(category, ''), COALESCE(subcategory, ''),
+                        COALESCE(is_magic, 0), COALESCE(rarity, ''), COALESCE(requires_attunement, 0),
+                        COALESCE(attunement_condition, ''), cost_cp, COALESCE(cost, ''), weight,
+                        COALESCE(damage, ''), COALESCE(armor_class, ''), COALESCE(description, ''),
+                        COALESCE(source, ''), '', COALESCE(properties, ''), COALESCE(tags, '')
+                    FROM items
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO items_catalog_tags(item_source_key, tag)
+                    SELECT 'legacy:' || item.slug, tag.tag
+                    FROM item_tags tag JOIN items item ON item.id = tag.item_id
+                    """);
+        }
+    }
+
+    private static void copyIntermediate(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO items_catalog_entries(
+                        source_key, legacy_id, name, category, subcategory, magic, rarity, attunement,
+                        attunement_condition, cost_cp, cost_display, weight, damage, armor_class,
+                        description, source_version, source_url, source_properties_text, source_tags_text)
+                    SELECT source_key, NULL, name, category, subcategory, magic, rarity, attunement,
+                        '', cost_cp, cost_display, weight, damage, armor_class, description,
+                        source_version, source_url, '', ''
+                    FROM items
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO items_catalog_tags(item_source_key, tag)
+                    SELECT item_source_key, tag FROM item_tags
+                    """);
+        }
+    }
+
+    private static void dropPredecessor(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE item_tags");
+            statement.execute("DROP TABLE items");
+        }
+    }
+
+    private static void validateTargetRows(Connection connection) throws SQLException {
+        requireNoRows(connection, """
+                SELECT 1 FROM items_catalog_entries
+                WHERE source_key IS NULL OR TRIM(source_key) = ''
+                   OR name IS NULL OR TRIM(name) = '' OR category IS NULL
+                   OR magic NOT IN (0, 1) OR attunement NOT IN (0, 1)
+                LIMIT 1
+                """);
+        requireNoRows(connection, """
+                SELECT 1 FROM items_catalog_tags tag
+                LEFT JOIN items_catalog_entries item ON item.source_key = tag.item_source_key
+                WHERE item.source_key IS NULL LIMIT 1
+                """);
+    }
+
+    private static void requireColumns(Connection connection, String table, List<String> expected)
+            throws SQLException {
+        if (!columns(connection, table).equals(expected)) {
+            throw incompatible();
+        }
+    }
+
+    private static List<String> columns(Connection connection, String table) throws SQLException {
+        List<String> names = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+            while (result.next()) {
+                names.add(result.getString("name"));
+            }
+        }
+        return List.copyOf(names);
+    }
+
+    private static void requirePrimaryKey(Connection connection, String table, List<String> expected)
+            throws SQLException {
+        List<PrimaryKeyColumn> columns = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("PRAGMA table_info(" + table + ")")) {
+            while (result.next()) {
+                int position = result.getInt("pk");
+                if (position > 0) {
+                    columns.add(new PrimaryKeyColumn(position, result.getString("name")));
+                }
+            }
+        }
+        columns.sort(java.util.Comparator.comparingInt(PrimaryKeyColumn::position));
+        if (!columns.stream().map(PrimaryKeyColumn::name).toList().equals(expected)) {
+            throw incompatible();
+        }
+    }
+
+    private static void requireForeignKey(
+            Connection connection,
+            String table,
+            String targetTable,
+            String sourceColumn,
+            String targetColumn
+    ) throws SQLException {
+        List<ForeignKey> keys = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("PRAGMA foreign_key_list(" + table + ")")) {
+            while (result.next()) {
+                keys.add(new ForeignKey(
+                        result.getString("table"),
+                        result.getString("from"),
+                        result.getString("to"),
+                        result.getString("on_delete")));
+            }
+        }
+        if (!keys.equals(List.of(new ForeignKey(targetTable, sourceColumn, targetColumn, "CASCADE")))) {
+            throw incompatible();
+        }
+    }
+
+    private static boolean hasUniqueIndex(Connection connection, String table, List<String> expectedColumns)
+            throws SQLException {
+        List<String> uniqueIndexes = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("PRAGMA index_list(" + table + ")")) {
+            while (result.next()) {
+                if (result.getInt("unique") == 1) {
+                    uniqueIndexes.add(result.getString("name"));
+                }
+            }
+        }
+        for (String index : uniqueIndexes) {
+            List<String> indexedColumns = new ArrayList<>();
+            try (Statement statement = connection.createStatement();
+                 ResultSet result = statement.executeQuery("PRAGMA index_info('" + index + "')")) {
+                while (result.next()) {
+                    indexedColumns.add(result.getString("name"));
+                }
+            }
+            if (indexedColumns.equals(expectedColumns)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean tableExists(Connection connection, String table) throws SQLException {
+        try (var statement = connection.prepareStatement(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")) {
+            statement.setString(1, table);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
+    private static void requireNoRows(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            if (result.next()) {
+                throw incompatible();
+            }
+        }
+    }
+
+    private static int count(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            return result.next() ? result.getInt(1) : 0;
+        }
+    }
+
+    private static void assertCount(Connection connection, String table, int expected) throws SQLException {
+        if (count(connection, "SELECT COUNT(*) FROM " + table) != expected) {
+            throw incompatible();
+        }
+    }
+
+    private static SQLException incompatible() {
+        return new SQLException("Unsupported Items schema signature.");
+    }
+
+    private enum SourceShape {
+        LEGACY,
+        INTERMEDIATE,
+        TARGET
+    }
+
+    private record PrimaryKeyColumn(int position, String name) { }
+
+    private record ForeignKey(String table, String sourceColumn, String targetColumn, String onDelete) { }
 }

--- a/features/items/adapter/sqlite/SqliteItemCatalogAdapter.java
+++ b/features/items/adapter/sqlite/SqliteItemCatalogAdapter.java
@@ -2,6 +2,7 @@ package features.items.adapter.sqlite;
 
 import features.items.domain.catalog.ItemCatalogData;
 import features.items.domain.catalog.ItemCatalogData.Detail;
+import features.items.domain.catalog.ItemCatalogAccessException;
 import features.items.domain.catalog.ItemCatalogPort;
 import features.items.domain.importing.ImportedItem;
 import features.items.domain.importing.ItemImportBatch;
@@ -17,6 +18,8 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import platform.persistence.FeatureStoreDefinition;
 import platform.persistence.FeatureStoreHandle;
+import platform.persistence.FeatureStoreReadiness;
+import platform.persistence.FeatureStoreUnavailableException;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
 
@@ -24,7 +27,7 @@ import platform.persistence.SqliteMigration;
 public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImportStore {
 
     public static final String OWNER = "items";
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     private static final String FILTERS = " WHERE "
             + "(? IS NULL OR LOWER(name) LIKE LOWER(?)) "
@@ -42,15 +45,18 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     public SqliteItemCatalogAdapter(SqliteDatabase database) {
         this.database = Objects.requireNonNull(database, "database");
         ItemsSchema schema = new ItemsSchema();
-        connections = database.featureStore(FeatureStoreDefinition.of(
+        connections = database.featureStore(FeatureStoreDefinition.validated(
                 OWNER,
-                new SqliteMigration(SCHEMA_VERSION, schema::migrate)));
+                schema::validateTarget,
+                new SqliteMigration(1, schema::migrateV1),
+                new SqliteMigration(SCHEMA_VERSION, schema::migrateV2)));
     }
 
     @Override
     public boolean isAvailable() {
         try (Connection connection = connections.openConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM items");
+             PreparedStatement statement = connection.prepareStatement(
+                     "SELECT COUNT(*) FROM " + ItemsSchema.ENTRIES_TABLE);
              ResultSet result = statement.executeQuery()) {
             return result.next() && result.getInt(1) > 0;
         } catch (SQLException exception) {
@@ -74,9 +80,10 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     public ItemCatalogData.CatalogPage search(ItemCatalogData.SearchSpec spec) {
         Objects.requireNonNull(spec, "spec");
         String rowSql = "SELECT source_key, name, category, subcategory, magic, rarity, attunement, "
-                + "cost_cp, cost_display FROM items" + FILTERS + orderBy(spec.sortField(), spec.ascending())
+                + "cost_cp, cost_display FROM " + ItemsSchema.ENTRIES_TABLE
+                + FILTERS + orderBy(spec.sortField(), spec.ascending())
                 + " LIMIT ? OFFSET ?";
-        String countSql = "SELECT COUNT(*) FROM items" + FILTERS;
+        String countSql = "SELECT COUNT(*) FROM " + ItemsSchema.ENTRIES_TABLE + FILTERS;
         try (Connection connection = connections.openConnection();
              PreparedStatement count = connection.prepareStatement(countSql);
              PreparedStatement rows = connection.prepareStatement(rowSql)) {
@@ -98,7 +105,7 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     public @Nullable Detail loadDetail(String sourceKey) {
         String sql = "SELECT source_key, name, category, subcategory, magic, rarity, attunement, cost_cp, "
                 + "cost_display, weight, damage, armor_class, description, source_version, source_url "
-                + "FROM items WHERE source_key = ?";
+                + "FROM " + ItemsSchema.ENTRIES_TABLE + " WHERE source_key = ?";
         try (Connection connection = connections.openConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, sourceKey);
@@ -156,8 +163,8 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
         connection.setAutoCommit(false);
         try {
             try (var statement = connection.createStatement()) {
-                statement.executeUpdate("DELETE FROM item_tags");
-                statement.executeUpdate("DELETE FROM items");
+                statement.executeUpdate("DELETE FROM " + ItemsSchema.TAGS_TABLE);
+                statement.executeUpdate("DELETE FROM " + ItemsSchema.ENTRIES_TABLE);
             }
             insert(connection, items);
             connection.commit();
@@ -170,10 +177,11 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     }
 
     private static void insert(Connection connection, List<ImportedItem> items) throws SQLException {
-        String itemSql = "INSERT INTO items(source_key, name, category, subcategory, magic, rarity, attunement, "
+        String itemSql = "INSERT INTO " + ItemsSchema.ENTRIES_TABLE
+                + "(source_key, name, category, subcategory, magic, rarity, attunement, "
                 + "cost_cp, cost_display, weight, damage, armor_class, description, source_version, source_url) "
                 + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-        String tagSql = "INSERT INTO item_tags(item_source_key, tag) VALUES (?, ?)";
+        String tagSql = "INSERT INTO " + ItemsSchema.TAGS_TABLE + "(item_source_key, tag) VALUES (?, ?)";
         try (PreparedStatement item = connection.prepareStatement(itemSql);
              PreparedStatement tag = connection.prepareStatement(tagSql)) {
             for (ImportedItem imported : items) {
@@ -210,7 +218,8 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
 
     private static List<String> distinct(Connection connection, String column) throws SQLException {
         List<String> values = new ArrayList<>();
-        String sql = "SELECT DISTINCT " + column + " FROM items WHERE " + column + " <> '' ORDER BY " + column;
+        String sql = "SELECT DISTINCT " + column + " FROM " + ItemsSchema.ENTRIES_TABLE
+                + " WHERE " + column + " <> '' ORDER BY " + column;
         try (PreparedStatement statement = connection.prepareStatement(sql);
              ResultSet result = statement.executeQuery()) {
             while (result.next()) {
@@ -252,7 +261,7 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     private static List<String> tags(Connection connection, String sourceKey) throws SQLException {
         List<String> values = new ArrayList<>();
         try (PreparedStatement statement = connection.prepareStatement(
-                "SELECT tag FROM item_tags WHERE item_source_key = ? ORDER BY tag")) {
+                "SELECT tag FROM " + ItemsSchema.TAGS_TABLE + " WHERE item_source_key = ? ORDER BY tag")) {
             statement.setString(1, sourceKey);
             try (ResultSet result = statement.executeQuery()) {
                 while (result.next()) {
@@ -351,6 +360,11 @@ public final class SqliteItemCatalogAdapter implements ItemCatalogPort, ItemImpo
     }
 
     private static IllegalStateException failure(String action, SQLException exception) {
-        return new IllegalStateException("Could not " + action + " in SQLite.", exception);
+        ItemCatalogAccessException.Reason reason = exception instanceof FeatureStoreUnavailableException unavailable
+                && (unavailable.readiness() == FeatureStoreReadiness.MIGRATION_FAILED
+                    || unavailable.readiness() == FeatureStoreReadiness.NEWER_SCHEMA)
+                ? ItemCatalogAccessException.Reason.INCOMPATIBLE
+                : ItemCatalogAccessException.Reason.STORAGE;
+        return new ItemCatalogAccessException(reason, exception);
     }
 }

--- a/features/items/api/ItemsCatalogApi.java
+++ b/features/items/api/ItemsCatalogApi.java
@@ -17,6 +17,7 @@ public interface ItemsCatalogApi {
         SUCCESS,
         INVALID_QUERY,
         UNAVAILABLE,
+        INCOMPATIBLE,
         NOT_FOUND,
         STORAGE_ERROR,
         EXECUTION_ERROR

--- a/features/items/application/ItemsApplicationService.java
+++ b/features/items/application/ItemsApplicationService.java
@@ -4,6 +4,7 @@ import features.items.api.ItemsCatalogApi;
 import features.items.api.ItemsImportApi;
 import features.items.domain.catalog.ItemCatalogData;
 import features.items.domain.catalog.ItemCatalogData.Detail;
+import features.items.domain.catalog.ItemCatalogAccessException;
 import features.items.domain.catalog.ItemCatalogPort;
 import features.items.domain.importing.ImportedItem;
 import features.items.domain.importing.ItemImportBatch;
@@ -83,6 +84,9 @@ public final class ItemsApplicationService implements ItemsCatalogApi, ItemsImpo
                     values.categories(),
                     values.subcategories(),
                     values.rarities());
+        } catch (ItemCatalogAccessException exception) {
+            diagnostics.failure(READ_FAILURE, exception.getClass());
+            return new FilterOptionsResult(status(exception), List.of(), List.of(), List.of());
         } catch (IllegalStateException exception) {
             diagnostics.failure(READ_FAILURE, exception.getClass());
             return new FilterOptionsResult(CatalogStatus.STORAGE_ERROR, List.of(), List.of(), List.of());
@@ -104,6 +108,9 @@ public final class ItemsApplicationService implements ItemsCatalogApi, ItemsImpo
                     page.totalCount(),
                     page.pageSize(),
                     page.pageOffset());
+        } catch (ItemCatalogAccessException exception) {
+            diagnostics.failure(READ_FAILURE, exception.getClass());
+            return empty(status(exception), query);
         } catch (IllegalStateException exception) {
             diagnostics.failure(READ_FAILURE, exception.getClass());
             return empty(CatalogStatus.STORAGE_ERROR, query);
@@ -122,6 +129,9 @@ public final class ItemsApplicationService implements ItemsCatalogApi, ItemsImpo
             return new DetailResult(
                     detail == null ? CatalogStatus.NOT_FOUND : CatalogStatus.SUCCESS,
                     toDetail(detail));
+        } catch (ItemCatalogAccessException exception) {
+            diagnostics.failure(READ_FAILURE, exception.getClass());
+            return new DetailResult(status(exception), null);
         } catch (IllegalStateException exception) {
             diagnostics.failure(READ_FAILURE, exception.getClass());
             return new DetailResult(CatalogStatus.STORAGE_ERROR, null);
@@ -183,6 +193,12 @@ public final class ItemsApplicationService implements ItemsCatalogApi, ItemsImpo
 
     private FilterOptionsResult filterExecutionFailure() {
         return new FilterOptionsResult(CatalogStatus.EXECUTION_ERROR, List.of(), List.of(), List.of());
+    }
+
+    private static CatalogStatus status(ItemCatalogAccessException exception) {
+        return exception.reason() == ItemCatalogAccessException.Reason.INCOMPATIBLE
+                ? CatalogStatus.INCOMPATIBLE
+                : CatalogStatus.STORAGE_ERROR;
     }
 
     private static ItemQuery normalize(@Nullable ItemQuery query) {

--- a/features/items/domain/catalog/ItemCatalogAccessException.java
+++ b/features/items/domain/catalog/ItemCatalogAccessException.java
@@ -1,0 +1,23 @@
+package features.items.domain.catalog;
+
+import java.util.Objects;
+
+/** Typed provider failure that keeps persistence implementation details below Items. */
+public final class ItemCatalogAccessException extends IllegalStateException {
+
+    private final Reason reason;
+
+    public ItemCatalogAccessException(Reason reason, Throwable cause) {
+        super("Item catalog access failed: " + Objects.requireNonNull(reason, "reason"), cause);
+        this.reason = reason;
+    }
+
+    public Reason reason() {
+        return reason;
+    }
+
+    public enum Reason {
+        INCOMPATIBLE,
+        STORAGE
+    }
+}

--- a/test/features/items/adapter/sqlite/SqliteItemCatalogAdapterTest.java
+++ b/test/features/items/adapter/sqlite/SqliteItemCatalogAdapterTest.java
@@ -7,13 +7,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import features.items.domain.catalog.ItemCatalogData;
+import features.items.domain.catalog.ItemCatalogAccessException;
 import features.items.domain.importing.ImportedItem;
 import features.items.domain.importing.ItemImportBatch;
+import features.items.application.ItemsApplicationService;
+import features.items.api.ItemsCatalogApi;
+import features.creatures.adapter.sqlite.query.SqliteCreatureCatalogQueryAdapter;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.persistence.FeatureStoreReadiness;
 import platform.persistence.SqliteDatabase;
 
 class SqliteItemCatalogAdapterTest {
@@ -51,6 +59,132 @@ class SqliteItemCatalogAdapterTest {
         }
     }
 
+    @Test
+    void migratesLegacyNumericShapeAndRetainsIdentityDetailsTagsAndProvenance() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("legacy.db");
+        seedLegacy(databasePath);
+
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteItemCatalogAdapter adapter = new SqliteItemCatalogAdapter(database);
+            assertEquals(FeatureStoreReadiness.READY, database.prepareRegisteredStores().get("items"));
+
+            ItemCatalogData.Detail detail = adapter.loadDetail("legacy:moon-blade");
+            assertNotNull(detail);
+            assertEquals("Moon Blade", detail.row().name());
+            assertTrue(detail.row().magic());
+            assertEquals("25 gp", detail.row().costDisplay());
+            assertEquals(List.of("Finesse", "Silvered"), detail.properties());
+            assertEquals("Legacy SRD", detail.sourceVersion());
+            assertEquals("", detail.sourceUrl());
+            ItemCatalogData.Detail unattributed = adapter.loadDetail("legacy:plain-rope");
+            assertNotNull(unattributed);
+            assertEquals("", unattributed.sourceVersion());
+            assertEquals("", unattributed.sourceUrl());
+        }
+
+        try (Connection connection = open(databasePath)) {
+            assertFalse(tableExists(connection, "items"));
+            assertFalse(tableExists(connection, "item_tags"));
+            assertTrue(tableExists(connection, ItemsSchema.ENTRIES_TABLE));
+            assertEquals(2, ownerVersion(connection));
+            try (var result = connection.createStatement().executeQuery("""
+                    SELECT legacy_id, attunement_condition, source_properties_text, source_tags_text
+                    FROM items_catalog_entries WHERE source_key='legacy:moon-blade'
+                    """)) {
+                assertTrue(result.next());
+                assertEquals(7L, result.getLong("legacy_id"));
+                assertEquals("by a good creature", result.getString("attunement_condition"));
+                assertEquals("Finesse, Silvered", result.getString("source_properties_text"));
+                assertEquals("legacy-tag-text", result.getString("source_tags_text"));
+            }
+        }
+
+        try (SqliteDatabase reopened = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteItemCatalogAdapter adapter = new SqliteItemCatalogAdapter(reopened);
+            assertEquals("Moon Blade", adapter.loadDetail("legacy:moon-blade").row().name());
+        }
+        try (Connection connection = open(databasePath)) {
+            assertEquals(2, ownerVersion(connection));
+            assertEquals(2, count(connection, "SELECT COUNT(*) FROM items_catalog_entries"));
+            assertEquals(2, count(connection, "SELECT COUNT(*) FROM items_catalog_tags"));
+        }
+    }
+
+    @Test
+    void migratesIntermediateSourceKeyShapeExactlyOnce() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("intermediate.db");
+        seedIntermediate(databasePath);
+
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteItemCatalogAdapter adapter = new SqliteItemCatalogAdapter(database);
+            ItemCatalogData.Detail detail = adapter.loadDetail("equipment:shield");
+            assertNotNull(detail);
+            assertEquals("Shield", detail.row().name());
+            assertEquals(List.of("Armor"), detail.properties());
+            assertEquals("2014 SRD", detail.sourceVersion());
+            assertEquals("https://example.invalid/shield", detail.sourceUrl());
+        }
+
+        try (SqliteDatabase reopened = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteItemCatalogAdapter adapter = new SqliteItemCatalogAdapter(reopened);
+            assertEquals(1, adapter.search(new ItemCatalogData.SearchSpec(
+                    null, null, null, null, null, null, null, null,
+                    ItemCatalogData.SortField.NAME, true, 50, 0)).totalCount());
+        }
+        try (Connection connection = open(databasePath)) {
+            assertEquals(2, ownerVersion(connection));
+            assertFalse(tableExists(connection, "items"));
+            assertEquals(1, count(connection, "SELECT COUNT(*) FROM items_catalog_entries"));
+        }
+    }
+
+    @Test
+    void unknownSignatureRollsBackAndDoesNotBlockCreatureProvider() throws Exception {
+        Path databasePath = temporaryDirectory.resolve("unknown.db");
+        seedUnknown(databasePath);
+        String beforeSchema;
+        try (Connection connection = open(databasePath)) {
+            beforeSchema = tableSql(connection, "items");
+        }
+
+        try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+            SqliteItemCatalogAdapter items = new SqliteItemCatalogAdapter(database);
+            SqliteCreatureCatalogQueryAdapter creatures = new SqliteCreatureCatalogQueryAdapter(database);
+
+            var readiness = database.prepareRegisteredStores();
+
+            assertEquals(FeatureStoreReadiness.MIGRATION_FAILED, readiness.get("items"));
+            assertEquals(FeatureStoreReadiness.READY, readiness.get("creatures"));
+            assertTrue(creatures.loadFilterValues().types().isEmpty());
+            ItemCatalogAccessException failure = assertThrows(
+                    ItemCatalogAccessException.class,
+                    items::isAvailable);
+            assertEquals(ItemCatalogAccessException.Reason.INCOMPATIBLE, failure.reason());
+
+            ItemsApplicationService application = new ItemsApplicationService(
+                    items,
+                    List::of,
+                    items,
+                    DirectExecutionLane.INSTANCE,
+                    NoopDiagnostics.INSTANCE);
+            assertEquals(
+                    ItemsCatalogApi.CatalogStatus.INCOMPATIBLE,
+                    application.search(ItemsCatalogApi.ItemQuery.firstPage())
+                            .toCompletableFuture().join().status());
+        }
+
+        try (Connection connection = open(databasePath)) {
+            assertEquals(beforeSchema, tableSql(connection, "items"));
+            try (var result = connection.createStatement()
+                    .executeQuery("SELECT note FROM items WHERE id=1")) {
+                assertTrue(result.next());
+                assertEquals("kept", result.getString(1));
+            }
+            assertFalse(tableExists(connection, ItemsSchema.ENTRIES_TABLE));
+            assertEquals(1, ownerVersion(connection));
+        }
+    }
+
     private static ItemImportBatch validBatch(List<String> equipmentProperties) {
         return new ItemImportBatch(List.of(
                 new ImportedItem(
@@ -63,5 +197,120 @@ class SqliteItemCatalogAdapterTest {
                         "Rare", true, null, "", null, "", "", List.of(),
                         "Requires attunement.", "2014 SRD",
                         "https://www.dnd5eapi.co/api/2014/magic-items/ring")));
+    }
+
+    private static void seedLegacy(Path databasePath) throws Exception {
+        try (Connection connection = open(databasePath); var statement = connection.createStatement()) {
+            createLedger(statement);
+            statement.execute("""
+                    CREATE TABLE items (
+                        id INTEGER PRIMARY KEY, name TEXT NOT NULL, slug TEXT, category TEXT,
+                        subcategory TEXT, is_magic INTEGER DEFAULT 0, rarity TEXT,
+                        requires_attunement INTEGER DEFAULT 0, attunement_condition TEXT,
+                        cost TEXT, cost_cp INTEGER DEFAULT 0, weight REAL DEFAULT 0.0,
+                        damage TEXT, properties TEXT, armor_class TEXT, description TEXT,
+                        source TEXT, tags TEXT DEFAULT '')
+                    """);
+            statement.execute("""
+                    CREATE TABLE item_tags (
+                        item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+                        tag TEXT NOT NULL, PRIMARY KEY (item_id, tag))
+                    """);
+            statement.execute("""
+                    INSERT INTO items VALUES(
+                        7, 'Moon Blade', 'moon-blade', 'Weapon', 'Sword', 1, 'Rare', 1,
+                        'by a good creature', '25 gp', 2500, 3.0, '1d8', 'Finesse, Silvered', '',
+                        'A pale blade.', 'Legacy SRD', 'legacy-tag-text')
+                    """);
+            statement.execute("""
+                    INSERT INTO items VALUES(
+                        8, 'Plain Rope', 'plain-rope', 'Gear', NULL, 0, NULL, 0,
+                        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+                    """);
+            statement.execute("INSERT INTO item_tags VALUES(7, 'Finesse')");
+            statement.execute("INSERT INTO item_tags VALUES(7, 'Silvered')");
+        }
+    }
+
+    private static void seedIntermediate(Path databasePath) throws Exception {
+        try (Connection connection = open(databasePath); var statement = connection.createStatement()) {
+            createLedger(statement);
+            statement.execute("""
+                    CREATE TABLE items (
+                        source_key TEXT PRIMARY KEY, name TEXT NOT NULL, category TEXT NOT NULL,
+                        subcategory TEXT NOT NULL DEFAULT '', magic INTEGER NOT NULL,
+                        rarity TEXT NOT NULL DEFAULT '', attunement INTEGER NOT NULL, cost_cp INTEGER,
+                        cost_display TEXT NOT NULL DEFAULT '', weight REAL, damage TEXT NOT NULL DEFAULT '',
+                        armor_class TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '',
+                        source_version TEXT NOT NULL, source_url TEXT NOT NULL)
+                    """);
+            statement.execute("""
+                    CREATE TABLE item_tags (
+                        item_source_key TEXT NOT NULL REFERENCES items(source_key) ON DELETE CASCADE,
+                        tag TEXT NOT NULL, PRIMARY KEY (item_source_key, tag))
+                    """);
+            statement.execute("""
+                    INSERT INTO items VALUES(
+                        'equipment:shield', 'Shield', 'Armor', 'Shield', 0, '', 0, 1000,
+                        '10 gp', 6.0, '', 'AC 2', 'A shield.', '2014 SRD',
+                        'https://example.invalid/shield')
+                    """);
+            statement.execute("INSERT INTO item_tags VALUES('equipment:shield', 'Armor')");
+        }
+    }
+
+    private static void seedUnknown(Path databasePath) throws Exception {
+        try (Connection connection = open(databasePath); var statement = connection.createStatement()) {
+            createLedger(statement);
+            statement.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, note TEXT NOT NULL)");
+            statement.execute("CREATE TABLE item_tags(item_id INTEGER, tag TEXT)");
+            statement.execute("INSERT INTO items VALUES(1, 'kept')");
+        }
+    }
+
+    private static void createLedger(java.sql.Statement statement) throws Exception {
+        statement.execute("PRAGMA user_version=1");
+        statement.execute("CREATE TABLE sm_schema_versions(owner TEXT PRIMARY KEY, version INTEGER NOT NULL)");
+        statement.execute("INSERT INTO sm_schema_versions VALUES('items', 1)");
+    }
+
+    private static Connection open(Path databasePath) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        Connection connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+        connection.createStatement().execute("PRAGMA foreign_keys=ON");
+        return connection;
+    }
+
+    private static boolean tableExists(Connection connection, String table) throws Exception {
+        try (var statement = connection.prepareStatement(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")) {
+            statement.setString(1, table);
+            try (var result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
+    private static String tableSql(Connection connection, String table) throws Exception {
+        try (var statement = connection.prepareStatement(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?")) {
+            statement.setString(1, table);
+            try (var result = statement.executeQuery()) {
+                return result.next() ? result.getString(1) : "";
+            }
+        }
+    }
+
+    private static int ownerVersion(Connection connection) throws Exception {
+        try (var result = connection.createStatement().executeQuery(
+                "SELECT version FROM sm_schema_versions WHERE owner='items'")) {
+            return result.next() ? result.getInt(1) : 0;
+        }
+    }
+
+    private static int count(Connection connection, String sql) throws Exception {
+        try (var result = connection.createStatement().executeQuery(sql)) {
+            return result.next() ? result.getInt(1) : 0;
+        }
     }
 }


### PR DESCRIPTION
## Ziel

Schließt Katalog-Roadmap M2 ab: beide historisch als Items-v1 gespeicherten Formen werden transaktional in ein eindeutiges v2-Ziel überführt.

## Umsetzung

- neue Zieltabellen `items_catalog_entries` und `items_catalog_tags`
- Owner-Zielversion 2 mit unverändertem historischen v1-Schritt
- Signaturklassifikation vor jeder Mutation: Legacy, Zwischenform oder Ziel
- Legacy-Identität `legacy:<slug>` plus nullable numerische Provenienz
- Erhalt von Details, normalisierten Tags, Attunement-Bedingung, Rohquellfeldern und nullable Attribution
- Zeilen-/Taganzahl, PK, FK, Unique-Provenienz und Owner-Daten vor Commit validiert
- unbekannte oder gemischte Signaturen rollen vollständig zurück
- typisierter Items-Status `INCOMPATIBLE` ohne JDBC-Leak
- Items-Inkompatibilität blockiert den Creature-Provider nicht
- Items-Vertrag, Anforderungen und Roadmap auf v2 ausgerichtet

## Nachweis

- synthetische Legacy-Fixture: migriert und wiederöffnet auf v2
- synthetische Zwischenform-Fixture: migriert und wiederöffnet auf v2
- unbekannte Fixture: Schema, Row und Owner-Version bleiben erhalten
- Creature-Produktionsadapter bleibt im selben Prozess `READY`
- gesamte Items-Testfläche: grün
- `git diff --check`: grün
- `./gradlew check --console=plain`: `BUILD SUCCESSFUL in 5m 43s`
