### PR TITLE
M5.1: Dungeon-Viewport an sichtbare Fenster binden

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -99,16 +99,75 @@ and commit boundaries. M7 starts only after both are complete.
 
 - Current foundation: M0 through M3 are complete through PR #508; M4.1 is
   complete through PR #509, M4.2 through PR #510, and M4.3 through PR #518.
-  M4.4 is complete through PR #526, M4.5 through PR #527, and M4.6 is complete
-  in this change. Production Editor commands, inspectors, history, transition
+  M4.4 is complete through PR #526, M4.5 through PR #527, and M4.6 through
+  PR #534. Production Editor commands, inspectors, history, transition
   linking, and Dungeon Travel now use revision-bound Catalog, Window, identity
   closure, and incremental UoW routes. The whole-map repository/record/loader,
   local identity derivation, compatibility writer, and full-record fixture
   families are deleted.
 - M4.6 delivery proof is literal green `./gradlew check` plus
-  `./gradlew installDesktopApp`. M5 is the next slice. No M4.6 review panel ran;
-  the single independent cross-roadmap review runs only after all M7
-  implementation is complete.
+  `./gradlew installDesktopApp`. M5.1 is complete in this change with the same
+  literal green proof; M5.2 is next. No intermediate review panel runs; the
+  single independent cross-roadmap review runs only after all M7 implementation
+  is complete.
+
+### Completed Slice Contract: M5.1 Viewport Dispatch And Latest Acceptance
+
+#### Goal And Decisions
+
+- Replace the Editor's fixed `0..63` authored load with a real visible-cell
+  viewport request emitted on initial binding, canvas resize, camera pan or
+  zoom, selected map change, and projection-level change.
+- JavaFX supplies only ordered visible cell bounds and the active level. The
+  application binds the selected map, expected catalog revision, and a strictly
+  increasing request generation; JavaFX must not manufacture authoritative
+  identity or revision state.
+- Load exactly the visible chunk set plus one ring through
+  `DungeonWindowStore`. Accept a result only when map identity, expected map
+  revision, and request generation still match the latest application request.
+  Late, stale, malformed, or superseded results publish nothing and never clear
+  a newer accepted surface.
+- Camera state remains presentation-local. Viewport dispatch may coalesce
+  duplicate cell bounds, but it must not turn pan or zoom into domain state.
+  M5.2 owns weighted caching and touched-chunk invalidation; M5.3 owns indexed
+  bounds and continuations; M5.4 owns physical paint layers and qualification.
+
+#### Implementation And Ownership
+
+1. Add one typed Editor API viewport input/intent and route it through
+   `DungeonEditorApiFacade`, `DungeonEditorFeatureRuntimeRoot`, runtime commands,
+   context, and session without exposing authored internals to JavaFX.
+2. Derive ordered integer cell bounds from the current map-canvas viewport and
+   actual canvas dimensions. Bind a dedicated viewport-change callback in
+   `DungeonEditorBinder`; emit after initial layout, resize, completed camera
+   movement, zoom, selected-map publication, and projection-level publication.
+3. Replace `LoadOperations.loadInitialWindow(...0, 0, 63, 63...)` with the
+   application-owned viewport request path. Preserve the last accepted viewport
+   per map/level for command worksets and make selection/commit refresh reuse
+   the latest visible bounds rather than restore a fixed window.
+4. Prove exact negative and positive chunk requests, one-ring loading, resize,
+   pan, zoom and level redispatch, duplicate coalescing, and rejection of late
+   generation, wrong-map, and stale-revision results on production routes.
+
+#### Delete Gate And Proof
+
+- Delete the fixed `0..63` Editor request and every `loadInitialWindow` name or
+  fallback that recreates it. No production Editor refresh may choose authored
+  bounds independently of the latest visible-cell input.
+- Focused API/application/JavaFX behavior tests, then literal green
+  `./gradlew check` and `./gradlew installDesktopApp` are required before the
+  M5.1 PR is merged. The next slice starts from that merge without a review
+  cycle.
+
+### Planned M5 Slice Order
+
+1. M5.1 viewport dispatch and latest-result acceptance.
+2. M5.2 bounded per-chunk-revision cache with visible/active protection and
+   touched-only invalidation.
+3. M5.3 indexed authored bounds and off-window continuations without map-wide
+   scans.
+4. M5.4 independent base/interaction/actor paint invalidation plus deterministic
+   operation-count and p95 qualification on 1k/10k/100k sparse datasets.
 
 ### Completed Slice Contract: M4.6 Read-Path Closure
 

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorBinder.java
@@ -41,6 +41,7 @@ final class DungeonEditorBinder {
         mapCatalog.bind(mapCatalogContentModel);
         state.bind(statePanelModel);
         main.onViewInputEvent(viewModel::consume);
+        main.onVisibleCellBoundsChanged(viewModel::consumeViewport);
         controls.onControlsInput(viewModel::consume);
         mapCatalog.onViewInputEvent(viewModel::consume);
         state.onStateInput(viewModel::consume);

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -22,6 +22,8 @@ import features.dungeon.adapter.javafx.map.DungeonMapContentModel.InlineLabelEdi
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.InlineLabelEditState;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.PointerTarget;
 import features.dungeon.adapter.javafx.map.DungeonMapViewInputEvent;
+import features.dungeon.adapter.javafx.map.DungeonMapVisibleCellBounds;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 
 final class DungeonEditorViewModel {
     private static final long NO_TRANSITION_ID = 0L;
@@ -41,6 +43,7 @@ final class DungeonEditorViewModel {
     private boolean inlineEditOutsidePressActive;
     private DungeonEditorState latestEditorState = DungeonEditorState.empty();
     private InteractionState interactionState = InteractionState.empty();
+    private DungeonMapVisibleCellBounds latestVisibleCellBounds;
 
     DungeonEditorViewModel(
             DungeonEditorControlsPanelModel controlsPanelModel,
@@ -87,6 +90,26 @@ final class DungeonEditorViewModel {
         controlsProjection.set(ControlsProjection.from(safeState));
         statePanelModel.apply(safeState);
         mapContentModel.applyEditorState(safeState);
+        dispatchLatestViewport();
+    }
+
+    void consumeViewport(DungeonMapVisibleCellBounds bounds) {
+        latestVisibleCellBounds = Objects.requireNonNull(bounds, "bounds");
+        if (!cameraDragActive) {
+            dispatchLatestViewport();
+        }
+    }
+
+    private void dispatchLatestViewport() {
+        if (latestVisibleCellBounds == null) {
+            return;
+        }
+        editorApi.dispatch(new DungeonEditorIntent.SetViewport(new DungeonEditorViewportInput(
+                latestEditorState.projectionLevel(),
+                latestVisibleCellBounds.minimumQ(),
+                latestVisibleCellBounds.minimumR(),
+                latestVisibleCellBounds.maximumQ(),
+                latestVisibleCellBounds.maximumR())));
     }
 
     private InteractionState currentInteractionState() {
@@ -851,6 +874,7 @@ final class DungeonEditorViewModel {
         }
         if (event.input().mouseReleased() && event.buttons().middleButtonDown()) {
             cameraDragActive = false;
+            dispatchLatestViewport();
             return true;
         }
         if (event.input().scrolled() && !event.modifiers().controlDown()) {

--- a/features/dungeon/adapter/javafx/map/DungeonMapView.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapView.java
@@ -83,7 +83,10 @@ public class DungeonMapView extends BorderPane {
     private final ChangeListener<String> inlineLabelEditorTextListener =
             (ignored, before, after) -> InputSnapshots.emitLabelEditEvent(this, LABEL_EDIT_TEXT_CHANGED_INPUT, after);
     private Consumer<DungeonMapViewInputEvent> viewInputEventHandler = ignored -> {};
+    private Consumer<DungeonMapVisibleCellBounds> visibleCellBoundsHandler = ignored -> {};
     private Runnable removeCanvasBinding = NO_CANVAS_BINDING;
+    private DungeonMapContentModel boundPresentationModel;
+    private DungeonMapVisibleCellBounds lastPublishedVisibleBounds;
     private double[] polygonXBuffer = new double[0];
     private double[] polygonYBuffer = new double[0];
     private RenderScene lastRenderedScene;
@@ -103,6 +106,8 @@ public class DungeonMapView extends BorderPane {
 
     public void bind(DungeonMapContentModel presentationModel) {
         removeCurrentCanvasListeners();
+        boundPresentationModel = presentationModel;
+        lastPublishedVisibleBounds = null;
         if (presentationModel == null) {
             return;
         }
@@ -110,6 +115,7 @@ public class DungeonMapView extends BorderPane {
                 (ignored, before, after) -> {
                     redraw(after, presentationModel);
                     showInlineLabelEditor(presentationModel.currentInlineLabelEditorPresentation(), true);
+                    publishVisibleCellBounds(after == null ? null : after.viewport());
                 };
         ChangeListener<InlineLabelEditState> inlineLabelEditListener =
                 (ignored, before, after) -> {
@@ -123,6 +129,7 @@ public class DungeonMapView extends BorderPane {
         InvalidationListener canvasSizeListener = ignored -> {
             redraw(presentationModel.currentCanvasState(), presentationModel);
             showInlineLabelEditor(presentationModel.currentInlineLabelEditorPresentation(), true);
+            publishVisibleCellBounds(presentationModel.currentCanvasState().viewport());
         };
         presentationModel.canvasStateProperty().addListener(canvasStateListener);
         presentationModel.inlineLabelEditStateProperty().addListener(inlineLabelEditListener);
@@ -136,10 +143,67 @@ public class DungeonMapView extends BorderPane {
         };
         redraw(presentationModel.currentCanvasState(), presentationModel);
         showInlineLabelEditor(presentationModel.currentInlineLabelEditorPresentation(), false);
+        publishVisibleCellBounds(presentationModel.currentCanvasState().viewport());
     }
 
     public void onViewInputEvent(Consumer<DungeonMapViewInputEvent> handler) {
         viewInputEventHandler = handler == null ? ignored -> {} : handler;
+    }
+
+    public void onVisibleCellBoundsChanged(Consumer<DungeonMapVisibleCellBounds> handler) {
+        visibleCellBoundsHandler = handler == null ? ignored -> {} : handler;
+        if (boundPresentationModel != null) {
+            publishVisibleCellBounds(boundPresentationModel.currentCanvasState().viewport());
+        }
+    }
+
+    private void publishVisibleCellBounds(Viewport viewport) {
+        double width = canvas.getWidth();
+        double height = canvas.getHeight();
+        if (viewport == null || width <= 1.0 || height <= 1.0) {
+            return;
+        }
+        DungeonMapVisibleCellBounds bounds = visibleCellBounds(viewport, width, height);
+        if (!bounds.equals(lastPublishedVisibleBounds)) {
+            lastPublishedVisibleBounds = bounds;
+            visibleCellBoundsHandler.accept(bounds);
+        }
+    }
+
+    static DungeonMapVisibleCellBounds visibleCellBounds(Viewport viewport, double width, double height) {
+        Viewport safeViewport = Objects.requireNonNull(viewport, "viewport");
+        MapCanvasWindow window = MapCanvasWindow.visible(
+                new MapCanvasViewport(
+                        safeViewport.panX(),
+                        safeViewport.panY(),
+                        safeViewport.zoom(),
+                        DungeonMapViewportScale.baseGrid()),
+                width,
+                height,
+                0.0);
+        return new DungeonMapVisibleCellBounds(
+                floorCell(window.minX()),
+                floorCell(window.minY()),
+                ceilingCell(window.maxX()),
+                ceilingCell(window.maxY()));
+    }
+
+    private static int floorCell(double coordinate) {
+        return saturatingInt(Math.floor(coordinate));
+    }
+
+    private static int ceilingCell(double coordinate) {
+        return saturatingInt(Math.ceil(coordinate) - 1.0);
+    }
+
+    private static int saturatingInt(double value) {
+        if (value <= Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        if (value >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) value;
     }
 
     private void redraw(
@@ -207,6 +271,7 @@ public class DungeonMapView extends BorderPane {
     private void removeCurrentCanvasListeners() {
         removeCanvasBinding.run();
         removeCanvasBinding = NO_CANVAS_BINDING;
+        boundPresentationModel = null;
     }
 
     private void requestCanvasFocus() {

--- a/features/dungeon/adapter/javafx/map/DungeonMapVisibleCellBounds.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapVisibleCellBounds.java
@@ -1,0 +1,15 @@
+package features.dungeon.adapter.javafx.map;
+
+/** Integer Dungeon cells intersecting the current JavaFX canvas viewport. */
+public record DungeonMapVisibleCellBounds(
+        int minimumQ,
+        int minimumR,
+        int maximumQ,
+        int maximumR
+) {
+    public DungeonMapVisibleCellBounds {
+        if (maximumQ < minimumQ || maximumR < minimumR) {
+            throw new IllegalArgumentException("visible cell bounds must be ordered");
+        }
+    }
+}

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -8,6 +8,14 @@ import java.util.List;
 /** Typed editor inputs introduced ahead of the JavaFX consumer migration. */
 public sealed interface DungeonEditorIntent {
 
+    record SetViewport(DungeonEditorViewportInput viewport) implements DungeonEditorIntent {
+        public SetViewport {
+            if (viewport == null) {
+                throw new IllegalArgumentException("viewport is required");
+            }
+        }
+    }
+
     record SelectMap(DungeonMapId mapId) implements DungeonEditorIntent {
         public SelectMap {
             if (mapId == null) {

--- a/features/dungeon/api/editor/DungeonEditorViewportInput.java
+++ b/features/dungeon/api/editor/DungeonEditorViewportInput.java
@@ -1,0 +1,21 @@
+package features.dungeon.api.editor;
+
+/** Presentation-owned visible cell bounds for one Dungeon Editor level. */
+public record DungeonEditorViewportInput(
+        int level,
+        int minimumQ,
+        int minimumR,
+        int maximumQ,
+        int maximumR
+) {
+    public DungeonEditorViewportInput {
+        if (maximumQ < minimumQ || maximumR < minimumR) {
+            throw new IllegalArgumentException("viewport bounds must be ordered");
+        }
+    }
+
+    public DungeonEditorViewportInput atLevel(int nextLevel) {
+        return new DungeonEditorViewportInput(
+                nextLevel, minimumQ, minimumR, maximumQ, maximumR);
+    }
+}

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -1381,35 +1381,65 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
     private final class LoadOperations {
 
-        private boolean loadInitialWindow(
+        private ViewportLoadResult loadViewportWindow(
                 MapId mapId,
                 int projectionLevel,
+                int minimumQ,
+                int minimumR,
+                int maximumQ,
+                int maximumR,
+                boolean coalesce,
                 DungeonEditorDungeonState state
         ) {
+            if (mapId == null || maximumQ < minimumQ || maximumR < minimumR) {
+                return ViewportLoadResult.REJECTED;
+            }
+            DungeonMapHeader expectedHeader = catalogStore.find(domainMapId(mapId)).orElse(null);
+            if (expectedHeader == null) {
+                return ViewportLoadResult.REJECTED;
+            }
+            DungeonCommandReadSpecs.AcceptedViewport current = acceptedViewports.get(mapId.value());
+            if (coalesce
+                    && current != null
+                    && state.committedFacts(mapId).committedSnapshot() != null
+                    && current.matches(
+                            expectedHeader.revision(),
+                            projectionLevel,
+                            minimumQ,
+                            minimumR,
+                            maximumQ,
+                            maximumR)) {
+                return ViewportLoadResult.COALESCED;
+            }
             long generation = windowRequestGeneration.incrementAndGet();
             DungeonViewportRequest viewport = new DungeonViewportRequest(
-                    mapId.value(), generation, projectionLevel, 0, 0, 63, 63);
+                    mapId.value(),
+                    generation,
+                    projectionLevel,
+                    minimumQ,
+                    minimumR,
+                    maximumQ,
+                    maximumR);
             DungeonWindowRequest request = new DungeonWindowRequest(
                     domainMapId(mapId), generation, List.copyOf(viewport.loadingChunks()));
             DungeonWindow window = windowStore.loadWindow(request).orElse(null);
             if (window == null) {
-                rejectLatestWindow(generation, state);
-                return false;
+                return ViewportLoadResult.REJECTED;
             }
             try {
                 validateWindowResult(request, window);
             } catch (IllegalStateException invalidWindow) {
-                rejectLatestWindow(generation, state);
-                return false;
+                return ViewportLoadResult.REJECTED;
             }
             long mapIdValue = mapId.value();
             if (generation != windowRequestGeneration.get()
-                    || generation <= acceptedWindowRequestGeneration) {
-                return false;
+                    || generation <= acceptedWindowRequestGeneration
+                    || window.mapHeader().revision() != expectedHeader.revision()) {
+                return ViewportLoadResult.REJECTED;
             }
             if (!publicationOperations.publishWindowSnapshot(
                     windowProjection.editorSnapshot(window, projectionLevel), state)) {
-                return false;
+                return ViewportLoadResult.REJECTED;
             }
             acceptedViewports.put(
                     mapIdValue,
@@ -1418,26 +1448,13 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                             window.mapHeader().revision(),
                             window.requestGeneration(),
                             projectionLevel,
+                            minimumQ,
+                            minimumR,
+                            maximumQ,
+                            maximumR,
                             request.chunkKeys()));
             acceptedWindowRequestGeneration = generation;
-            return true;
-        }
-
-        private void rejectLatestWindow(long generation, DungeonEditorDungeonState state) {
-            if (generation == windowRequestGeneration.get()) {
-                state.replaceSnapshot(null);
-                state.replaceInspector(null);
-                state.replacePreview(null);
-            }
-        }
-
-        private void loadAuthoredMap(
-                MapId mapId,
-                DungeonEditorDungeonState state
-        ) {
-            DungeonCommandReadSpecs.AcceptedViewport accepted =
-                    mapId == null ? null : acceptedViewports.get(mapId.value());
-            loadInitialWindow(mapId, accepted == null ? 0 : accepted.projectionLevel(), state);
+            return ViewportLoadResult.ACCEPTED;
         }
 
         private LoadDungeonSnapshotUseCase.@Nullable InspectorSnapshotData loadInspectorWithSelection(
@@ -1521,6 +1538,12 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     clusterRef(handleRef.clusterId()),
                     roomRef(handleRef.roomId()));
         }
+    }
+
+    private enum ViewportLoadResult {
+        ACCEPTED,
+        COALESCED,
+        REJECTED
     }
 
     private final class CorridorFeatureOperations {
@@ -2613,12 +2636,42 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             catalogOperations.searchMaps(query, dungeonState);
         }
 
-        public void loadMap(MapId mapId) {
-            loadOperations.loadAuthoredMap(mapId, dungeonState);
+        public boolean loadViewport(
+                MapId mapId,
+                int projectionLevel,
+                int minimumQ,
+                int minimumR,
+                int maximumQ,
+                int maximumR
+        ) {
+            return loadOperations.loadViewportWindow(
+                    mapId,
+                    projectionLevel,
+                    minimumQ,
+                    minimumR,
+                    maximumQ,
+                    maximumR,
+                    true,
+                    dungeonState) == ViewportLoadResult.ACCEPTED;
         }
 
-        public boolean loadInitialWindow(MapId mapId, int projectionLevel) {
-            return loadOperations.loadInitialWindow(mapId, projectionLevel, dungeonState);
+        public boolean refreshViewport(
+                MapId mapId,
+                int projectionLevel,
+                int minimumQ,
+                int minimumR,
+                int maximumQ,
+                int maximumR
+        ) {
+            return loadOperations.loadViewportWindow(
+                    mapId,
+                    projectionLevel,
+                    minimumQ,
+                    minimumR,
+                    maximumQ,
+                    maximumR,
+                    false,
+                    dungeonState) == ViewportLoadResult.ACCEPTED;
         }
 
         public void loadInspectorWithSelection(

--- a/features/dungeon/application/authored/DungeonCommandReadSpecs.java
+++ b/features/dungeon/application/authored/DungeonCommandReadSpecs.java
@@ -195,6 +195,10 @@ final class DungeonCommandReadSpecs {
             long revision,
             long requestGeneration,
             int projectionLevel,
+            int minimumQ,
+            int minimumR,
+            int maximumQ,
+            int maximumR,
             List<DungeonChunkKey> chunkKeys
     ) {
         AcceptedViewport {
@@ -202,7 +206,25 @@ final class DungeonCommandReadSpecs {
         }
 
         AcceptedViewport committed(long committedRevision) {
-            return new AcceptedViewport(mapId, committedRevision, requestGeneration, projectionLevel, chunkKeys);
+            return new AcceptedViewport(
+                    mapId,
+                    committedRevision,
+                    requestGeneration,
+                    projectionLevel,
+                    minimumQ,
+                    minimumR,
+                    maximumQ,
+                    maximumR,
+                    chunkKeys);
+        }
+
+        boolean matches(long expectedRevision, int level, int minQ, int minR, int maxQ, int maxR) {
+            return revision == expectedRevision
+                    && projectionLevel == level
+                    && minimumQ == minQ
+                    && minimumR == minR
+                    && maximumQ == maxQ
+                    && maximumR == maxR;
         }
     }
 }

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -50,7 +50,9 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
     @Override
     public void dispatch(DungeonEditorIntent intent) {
         DungeonEditorIntent safeIntent = Objects.requireNonNull(intent, "intent");
-        if (safeIntent instanceof DungeonEditorIntent.SelectMap selectMap) {
+        if (safeIntent instanceof DungeonEditorIntent.SetViewport setViewport) {
+            runtimeRoot.setViewport(setViewport.viewport());
+        } else if (safeIntent instanceof DungeonEditorIntent.SelectMap selectMap) {
             runtimeRoot.selectMap(selectMap.mapId().value());
         } else if (safeIntent instanceof DungeonEditorIntent.CreateMap createMap) {
             runtimeRoot.createMap(createMap.mapName());

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -7,6 +7,7 @@ import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 
 public final class DungeonEditorFeatureRuntimeRoot
         implements DungeonEditorMapCatalogOperations,
@@ -107,6 +108,10 @@ public final class DungeonEditorFeatureRuntimeRoot
         if (initializationRequested.compareAndSet(false, true)) {
             commands.apply(context::publishCurrent);
         }
+    }
+
+    public void setViewport(DungeonEditorViewportInput viewport) {
+        commands.setViewport(viewport);
     }
 
     public features.dungeon.api.editor.DungeonEditorState currentState() {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -26,6 +26,7 @@ import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.application.editor.session.DungeonEditorSessionWorkflow;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceGeometry;
 import features.dungeon.application.editor.session.DungeonEditorWorkspaceValues.MapId;
@@ -140,6 +141,24 @@ public final class DungeonEditorRuntimeApplicationService {
         public DungeonEditorSessionSnapshot.SnapshotData selectMap(long mapId) {
             workflow.selectMap(mapId);
             snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+            DungeonEditorSessionSnapshot.SnapshotData snapshot =
+                    workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
+            editorPublishedState.publishEditorSnapshot(snapshot);
+            return snapshot;
+        }
+
+        public DungeonEditorSessionSnapshot.@Nullable SnapshotData setViewport(
+                DungeonEditorViewportInput viewport
+        ) {
+            DungeonEditorViewportInput safeViewport = Objects.requireNonNull(viewport, "viewport");
+            if (safeViewport.level() != workflow.session().projectionLevel()) {
+                return null;
+            }
+            snapshotBuilder.setViewport(safeViewport);
+            MapId mapId = workflow.session().selectedMapId();
+            if (mapId == null || !snapshotBuilder.requestAuthoredSurface(mapId, workflow.session())) {
+                return null;
+            }
             DungeonEditorSessionSnapshot.SnapshotData snapshot =
                     workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
             editorPublishedState.publishEditorSnapshot(snapshot);
@@ -792,6 +811,7 @@ public final class DungeonEditorRuntimeApplicationService {
     private static final class SnapshotBuilder {
         private final DungeonAuthoredApplicationService.Session authored;
         private final DungeonEditorDungeonState dungeonState;
+        private DungeonEditorViewportInput latestViewport;
 
         private SnapshotBuilder(
                 DungeonAuthoredApplicationService.Session authored,
@@ -818,6 +838,10 @@ public final class DungeonEditorRuntimeApplicationService {
                     .maps();
             @Nullable MapId resolvedMapId = resolveSelectedMapId(safeState, maps);
             refreshAuthoredSurface(resolvedMapId, safeState);
+        }
+
+        private void setViewport(DungeonEditorViewportInput viewport) {
+            latestViewport = Objects.requireNonNull(viewport, "viewport");
         }
 
         private void refreshSelectionInspector(@Nullable DungeonEditorSession state) {
@@ -848,14 +872,7 @@ public final class DungeonEditorRuntimeApplicationService {
 
         private @Nullable MapSnapshot loadCommittedSnapshot(@Nullable MapId mapId) {
             @Nullable MapSnapshot committed = dungeonState.committedFacts(mapId).committedSnapshot();
-            if (committed != null) {
-                return committed;
-            }
-            if (mapId == null) {
-                return null;
-            }
-            authored.loadMap(mapId);
-            return dungeonState.committedFacts(mapId).committedSnapshot();
+            return committed;
         }
 
         private DungeonEditorSessionSnapshot.SnapshotData snapshotData(
@@ -885,18 +902,52 @@ public final class DungeonEditorRuntimeApplicationService {
                     safeState.commandOutcome());
         }
 
-        private void refreshAuthoredSurface(
+        private boolean refreshAuthoredSurface(
                 @Nullable MapId readbackMapId,
                 DungeonEditorSession state
         ) {
-            if (readbackMapId == null) {
-                return;
+            if (readbackMapId == null || latestViewport == null) {
+                return false;
             }
-            authored.loadInitialWindow(readbackMapId, state.projectionLevel());
+            DungeonEditorViewportInput viewport = latestViewport.atLevel(state.projectionLevel());
+            latestViewport = viewport;
+            boolean accepted = authored.refreshViewport(
+                    readbackMapId,
+                    viewport.level(),
+                    viewport.minimumQ(),
+                    viewport.minimumR(),
+                    viewport.maximumQ(),
+                    viewport.maximumR());
+            if (!accepted) {
+                return false;
+            }
             DungeonEditorSessionValues.Selection selection = state.selection();
             if (hasSelectionForInspector(selection)) {
                 loadSelectionInspector(readbackMapId, selection);
             }
+            return true;
+        }
+
+        private boolean requestAuthoredSurface(
+                @Nullable MapId mapId,
+                DungeonEditorSession state
+        ) {
+            if (mapId == null || latestViewport == null) {
+                return false;
+            }
+            DungeonEditorViewportInput viewport = latestViewport.atLevel(state.projectionLevel());
+            latestViewport = viewport;
+            boolean accepted = authored.loadViewport(
+                    mapId,
+                    viewport.level(),
+                    viewport.minimumQ(),
+                    viewport.minimumR(),
+                    viewport.maximumQ(),
+                    viewport.maximumR());
+            if (accepted && hasSelectionForInspector(state.selection())) {
+                loadSelectionInspector(mapId, state.selection());
+            }
+            return accepted;
         }
 
         private static boolean hasSelectionForInspector(DungeonEditorSessionValues.Selection selection) {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -13,6 +13,7 @@ import features.dungeon.api.DungeonEditorStateSnapshot;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 
 final class DungeonEditorRuntimeCommands
         implements DungeonEditorMapCatalogOperations,
@@ -58,6 +59,10 @@ final class DungeonEditorRuntimeCommands
 
     void bindPointerOperations(DungeonEditorPointerInteractionOperations pointerOperations) {
         this.pointerOperations = Objects.requireNonNull(pointerOperations, "pointerOperations");
+    }
+
+    void setViewport(DungeonEditorViewportInput viewport) {
+        apply(() -> context.setViewport(viewport));
     }
 
     @Override

--- a/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
@@ -20,6 +20,7 @@ import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonOverlaySettings;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.api.editor.DungeonEditorCommandOutcome;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 
 final class DungeonEditorRuntimeContext {
     private final DungeonEditorRuntimeApplicationService.RuntimeSession session;
@@ -111,6 +112,10 @@ final class DungeonEditorRuntimeContext {
 
     Result selectMap(long mapIdValue) {
         return fromSnapshot(session.selectMap(mapIdValue));
+    }
+
+    Result setViewport(DungeonEditorViewportInput viewport) {
+        return fromSnapshot(session.setViewport(viewport));
     }
 
     Result publishCurrent() {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorMapControlsScenarios.java
@@ -187,8 +187,8 @@ final class DungeonEditorMapControlsScenarios {
         assertEquals(0L, canvasStateChanges.get(),
                 "DE-CAM-007 resetCamera at initial viewport does not notify unchanged canvas state");
         dragMap(mapView, MouseButton.MIDDLE, 300, 300, 420, 300);
-        assertEquals(surfaceBefore, runtime.mapSurfaceModel().current(),
-                "DE-CAM-001 pan right leaves published map surface unchanged");
+        assertEquals(surfaceBefore.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-001 pan right preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport afterRightViewport = mapContentModel.currentViewport();
         assertDoubleEquals(initialViewport.panX() + 120.0, afterRightViewport.panX(),
                 "DE-CAM-001 viewport panX increases by 120px");
@@ -203,8 +203,8 @@ final class DungeonEditorMapControlsScenarios {
 
         DungeonEditorMapSurfaceSnapshot afterRightSurface = runtime.mapSurfaceModel().current();
         dragMap(mapView, MouseButton.MIDDLE, 420, 300, 300, 300);
-        assertEquals(afterRightSurface, runtime.mapSurfaceModel().current(),
-                "DE-CAM-002 pan left leaves published map surface unchanged");
+        assertEquals(afterRightSurface.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-002 pan left preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport afterLeftViewport = mapContentModel.currentViewport();
         assertDoubleEquals(afterRightViewport.panX() - 120.0, afterLeftViewport.panX(),
                 "DE-CAM-002 viewport panX decreases by 120px");
@@ -219,8 +219,8 @@ final class DungeonEditorMapControlsScenarios {
 
         DungeonEditorMapSurfaceSnapshot beforeDownSurface = runtime.mapSurfaceModel().current();
         dragMap(mapView, MouseButton.MIDDLE, 300, 300, 300, 420);
-        assertEquals(beforeDownSurface, runtime.mapSurfaceModel().current(),
-                "DE-CAM-003 pan down leaves published map surface unchanged");
+        assertEquals(beforeDownSurface.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-003 pan down preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport afterDownViewport = mapContentModel.currentViewport();
         assertDoubleEquals(afterLeftViewport.panX(), afterDownViewport.panX(),
                 "DE-CAM-003 viewport panX unchanged");
@@ -235,8 +235,8 @@ final class DungeonEditorMapControlsScenarios {
 
         DungeonEditorMapSurfaceSnapshot beforeUpSurface = runtime.mapSurfaceModel().current();
         dragMap(mapView, MouseButton.MIDDLE, 300, 420, 300, 300);
-        assertEquals(beforeUpSurface, runtime.mapSurfaceModel().current(),
-                "DE-CAM-004 pan up leaves published map surface unchanged");
+        assertEquals(beforeUpSurface.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-004 pan up preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport afterUpViewport = mapContentModel.currentViewport();
         assertDoubleEquals(afterDownViewport.panX(), afterUpViewport.panX(),
                 "DE-CAM-004 viewport panX unchanged");
@@ -266,8 +266,8 @@ final class DungeonEditorMapControlsScenarios {
 
         DungeonMapContentModel.Viewport initialViewport = mapContentModel.currentViewport();
         fireMapScroll(mapView, 80, 80, 120);
-        assertEquals(surfaceBefore, runtime.mapSurfaceModel().current(),
-                "DE-CAM-005 zoom in leaves published map surface unchanged");
+        assertEquals(surfaceBefore.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-005 zoom in preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport zoomedInViewport = mapContentModel.currentViewport();
         assertTrue(zoomedInViewport.zoom() > initialViewport.zoom(),
                 "DE-CAM-005 viewport zoom increases");
@@ -286,8 +286,8 @@ final class DungeonEditorMapControlsScenarios {
 
         DungeonEditorMapSurfaceSnapshot afterZoomInSurface = runtime.mapSurfaceModel().current();
         fireMapScroll(mapView, 80, 80, -120);
-        assertEquals(afterZoomInSurface, runtime.mapSurfaceModel().current(),
-                "DE-CAM-006 zoom out leaves published map surface unchanged");
+        assertEquals(afterZoomInSurface.surface().revision(), runtime.mapSurfaceModel().current().surface().revision(),
+                "DE-CAM-006 zoom out preserves the authored revision while refreshing the viewport");
         DungeonMapContentModel.Viewport zoomedOutViewport = mapContentModel.currentViewport();
         assertTrue(zoomedOutViewport.zoom() < zoomedInViewport.zoom(),
                 "DE-CAM-006 viewport zoom decreases");

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTransitionInvariantScenarios.java
@@ -218,7 +218,7 @@ final class DungeonTransitionInvariantScenarios {
                 repository.unitOfWork());
         DungeonEditorDungeonState dungeonState = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService.Session initialSession = services.authored().openSession(dungeonState);
-        assertTrue(initialSession.loadInitialWindow(new MapId(sourceMapId), 0),
+        assertTrue(initialSession.loadViewport(new MapId(sourceMapId), 0, 0, 0, 63, 63),
                 "transition link use case starts from an accepted source window");
         DungeonAuthoredApplicationService.OperationResult result = services
                 .editor()
@@ -261,7 +261,7 @@ final class DungeonTransitionInvariantScenarios {
                 "compound undo restores the target reverse link atomically");
         assertTrue(services.authored().canRedo(new MapId(targetMapId)),
                 "compound transition link is available as one target-map redo step");
-        assertTrue(authoredSession.loadInitialWindow(new MapId(targetMapId), 0),
+        assertTrue(authoredSession.loadViewport(new MapId(targetMapId), 0, 0, 0, 63, 63),
                 "compound redo loads the current post-undo target-map window");
         services.authored().redo(new MapId(targetMapId), authoredSession);
         assertEquals(

--- a/test/features/dungeon/adapter/javafx/map/DungeonMapViewportDispatchTest.java
+++ b/test/features/dungeon/adapter/javafx/map/DungeonMapViewportDispatchTest.java
@@ -1,0 +1,31 @@
+package features.dungeon.adapter.javafx.map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import features.dungeon.adapter.javafx.map.DungeonMapContentModel.Viewport;
+import org.junit.jupiter.api.Test;
+
+final class DungeonMapViewportDispatchTest {
+
+    @Test
+    void visibleBoundsFollowActualCanvasResizePanAndZoomAcrossNegativeCells() {
+        Viewport initial = new Viewport(0.0, 0.0, 1.0);
+        assertEquals(
+                new DungeonMapVisibleCellBounds(0, 0, 9, 4),
+                DungeonMapView.visibleCellBounds(initial, 320.0, 160.0));
+
+        DungeonMapVisibleCellBounds resized =
+                DungeonMapView.visibleCellBounds(initial, 640.0, 320.0);
+        assertEquals(new DungeonMapVisibleCellBounds(0, 0, 19, 9), resized);
+
+        DungeonMapVisibleCellBounds panned = DungeonMapView.visibleCellBounds(
+                new Viewport(64.0, 32.0, 1.0), 640.0, 320.0);
+        assertEquals(new DungeonMapVisibleCellBounds(-2, -1, 17, 8), panned);
+
+        DungeonMapVisibleCellBounds zoomed = DungeonMapView.visibleCellBounds(
+                new Viewport(64.0, 32.0, 2.0), 640.0, 320.0);
+        assertEquals(new DungeonMapVisibleCellBounds(-1, -1, 8, 4), zoomed);
+        assertNotEquals(panned, zoomed);
+    }
+}

--- a/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
+++ b/test/features/dungeon/application/authored/DungeonAuthoredPreviewWorksetTest.java
@@ -51,7 +51,7 @@ final class DungeonAuthoredPreviewWorksetTest {
         DungeonEditorDungeonState dungeonState = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService.Session session = service.openSession(dungeonState);
         DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
-        session.loadInitialWindow(mapId, 0);
+        session.loadViewport(mapId, 0, 0, 0, 63, 63);
         var surface = dungeonState.committedFacts(mapId).surface();
         var handle = surface.map().editorHandles().stream()
                 .filter(candidate -> candidate.ref().kind() == DungeonEditorHandleKind.CLUSTER_LABEL)
@@ -169,7 +169,7 @@ final class DungeonAuthoredPreviewWorksetTest {
         DungeonEditorDungeonState state = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
-        session.loadInitialWindow(mapId, 0);
+        session.loadViewport(mapId, 0, 0, 0, 63, 63);
         return new Workset(windowStore, state, session, mapId);
     }
 

--- a/test/features/dungeon/application/authored/DungeonCompoundUnitOfWorkApplicationTest.java
+++ b/test/features/dungeon/application/authored/DungeonCompoundUnitOfWorkApplicationTest.java
@@ -39,7 +39,7 @@ final class DungeonCompoundUnitOfWorkApplicationTest {
         DungeonEditorDungeonState state = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(new MapId(11L), 0));
+        assertTrue(session.loadViewport(new MapId(11L), 0, 0, 0, 63, 63));
         long initialRevision = store.revision(11L);
 
         assertTrue(session.saveAuthoredTransitionLink(new MapId(11L), 1L, 12L, 2L, true));
@@ -79,7 +79,7 @@ final class DungeonCompoundUnitOfWorkApplicationTest {
         DungeonEditorDungeonState state = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(new MapId(11L), 0));
+        assertTrue(session.loadViewport(new MapId(11L), 0, 0, 0, 63, 63));
         long initialRevision = store.revision(11L);
         assertTrue(session.saveAuthoredTransitionLink(new MapId(11L), 1L, 12L, 2L, true));
         var beforeRejection = state.committedFacts(new MapId(11L));
@@ -122,7 +122,7 @@ final class DungeonCompoundUnitOfWorkApplicationTest {
         DungeonEditorDungeonState state = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(new MapId(11L), 0));
+        assertTrue(session.loadViewport(new MapId(11L), 0, 0, 0, 63, 63));
         long initialRevision = store.revision(11L);
 
         unitOfWork.failNext(new IllegalStateException("injected compound storage failure"));
@@ -160,7 +160,7 @@ final class DungeonCompoundUnitOfWorkApplicationTest {
         DungeonEditorDungeonState state = new DungeonEditorDungeonState();
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(new MapId(11L), 0));
+        assertTrue(session.loadViewport(new MapId(11L), 0, 0, 0, 63, 63));
 
         assertTrue(session.saveAuthoredTransitionLink(new MapId(11L), 1L, 12L, 2L, false));
         assertEquals(1, unitOfWork.compoundPatches.getFirst().patches().size());
@@ -180,7 +180,7 @@ final class DungeonCompoundUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId sourceMapId = new MapId(11L);
-        assertTrue(session.loadInitialWindow(sourceMapId, 0));
+        assertTrue(session.loadViewport(sourceMapId, 0, 0, 0, 63, 63));
         assertTrue(session.saveAuthoredTransitionLink(sourceMapId, 1L, 12L, 2L, true));
         var committedBeforeFailure = state.committedFacts(sourceMapId).committedSnapshot();
         int commitsBeforeFailure = unitOfWork.compoundPatches.size();

--- a/test/features/dungeon/application/authored/DungeonUnitOfWorkApplicationTest.java
+++ b/test/features/dungeon/application/authored/DungeonUnitOfWorkApplicationTest.java
@@ -47,7 +47,7 @@ final class DungeonUnitOfWorkApplicationTest {
 
         MapId mapId = new MapId(1L);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         service.applyRoomRectangle(
                 mapId,
                 new Cell(3, 1, 0),
@@ -73,7 +73,7 @@ final class DungeonUnitOfWorkApplicationTest {
 
         MapId mapId = new MapId(1L);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         service.applyRoomRectangle(
                 mapId,
                 new Cell(3, 1, 0),
@@ -97,7 +97,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
 
         long markerId = service.createFeatureMarker(
                 mapId, FeatureMarkerKind.POI, new Cell(4, 5, 0), session);
@@ -134,7 +134,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
 
         assertEquals(0L, service.createFeatureMarker(
                 mapId, FeatureMarkerKind.POI, new Cell(4, 5, 0), session));
@@ -164,7 +164,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         var beforeFailure = state.committedFacts(mapId);
 
         assertThrows(IllegalStateException.class, () -> service.createFeatureMarker(
@@ -191,7 +191,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         assertEquals(10_000L, service.createFeatureMarker(
                 mapId, FeatureMarkerKind.POI, new Cell(4, 5, 0), session));
 
@@ -234,7 +234,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
 
         assertEquals(0L, service.createFeatureMarker(
                 mapId, FeatureMarkerKind.POI, new Cell(4, 5, 0), session));
@@ -262,7 +262,7 @@ final class DungeonUnitOfWorkApplicationTest {
         DungeonAuthoredApplicationService service = service(store, unitOfWork);
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         MapId mapId = new MapId(1L);
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         assertEquals(10_000L, service.createFeatureMarker(
                 mapId, FeatureMarkerKind.POI, new Cell(4, 5, 0), session));
         var committedBeforeFailure = state.committedFacts(mapId).committedSnapshot();

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -37,6 +37,7 @@ import features.dungeon.api.editor.DungeonEditorState;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
 import features.dungeon.api.editor.DungeonEditorToolOptions;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 import features.party.PartyServiceAssembly;
 import features.party.domain.roster.PartyRoster;
 import features.party.domain.roster.repository.PartyRosterRepository;
@@ -104,6 +105,8 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
         DungeonEditorFeatureRuntimeRoot runtime = createRuntimeDirect(repository);
         QueuedUiDispatcher dispatcher = new QueuedUiDispatcher();
         DungeonEditorApi api = new DungeonEditorApiFacade(runtime, dispatcher);
+        api.dispatch(new DungeonEditorIntent.SetViewport(
+                new DungeonEditorViewportInput(0, -8, -8, 8, 8)));
         List<DungeonEditorState> delivered = new ArrayList<>();
         api.subscribe(delivered::add);
 

--- a/test/features/dungeon/application/editor/DungeonEditorWindowLoadIntegrationTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorWindowLoadIntegrationTest.java
@@ -20,6 +20,7 @@ import features.dungeon.api.editor.DungeonEditorPointerGesture;
 import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorViewportInput;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
 import features.dungeon.application.authored.DungeonAuthoredPublishedState;
@@ -97,6 +98,51 @@ final class DungeonEditorWindowLoadIntegrationTest {
     }
 
     @Test
+    void editorViewportIntentLoadsExactNegativeChunksAndCoalescesDuplicates() {
+        Catalog catalog = new Catalog();
+        RecordingWindowStore windows = new RecordingWindowStore();
+        DungeonEditorApi editor = editor(component(catalog, windows));
+        editor.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(1L)));
+        windows.requests.clear();
+
+        DungeonEditorViewportInput negative = new DungeonEditorViewportInput(
+                0, -65, -1, -1, 1);
+        editor.dispatch(new DungeonEditorIntent.SetViewport(negative));
+
+        assertEquals(1, windows.requests.size());
+        DungeonWindowRequest request = windows.requests.getFirst();
+        assertEquals(16, request.chunkKeys().size());
+        assertTrue(request.chunkKeys().contains(new DungeonChunkKey(1L, 0, -3, -2)));
+        assertTrue(request.chunkKeys().contains(new DungeonChunkKey(1L, 0, 0, 1)));
+        assertFalse(request.chunkKeys().contains(new DungeonChunkKey(1L, 0, 1, 1)));
+
+        editor.dispatch(new DungeonEditorIntent.SetViewport(negative));
+
+        assertEquals(1, windows.requests.size(), "an exact duplicate viewport is coalesced");
+    }
+
+    @Test
+    void projectionLevelRedispatchReusesLatestVisibleBounds() {
+        Catalog catalog = new Catalog();
+        RecordingWindowStore windows = new RecordingWindowStore();
+        DungeonEditorApi editor = editor(component(catalog, windows));
+        editor.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(1L)));
+        editor.dispatch(new DungeonEditorIntent.SetViewport(
+                new DungeonEditorViewportInput(0, -12, 70, 12, 90)));
+        windows.requests.clear();
+
+        editor.dispatch(new DungeonEditorIntent.ShiftProjectionLevel(1));
+
+        assertEquals(1, windows.requests.size());
+        assertTrue(windows.requests.getFirst().chunkKeys().stream()
+                .allMatch(chunk -> chunk.level() == 1));
+        assertTrue(windows.requests.getFirst().chunkKeys()
+                .contains(new DungeonChunkKey(1L, 1, -2, 0)));
+        assertTrue(windows.requests.getFirst().chunkKeys()
+                .contains(new DungeonChunkKey(1L, 1, 1, 2)));
+    }
+
+    @Test
     void missingSecondMapWindowNeverRelabelsThePreviouslyAcceptedSurface() {
         assertRejectedSecondWindow(SecondWindowMode.MISSING);
     }
@@ -129,7 +175,7 @@ final class DungeonEditorWindowLoadIntegrationTest {
         DungeonAuthoredApplicationService.Session session = service.openSession(state);
         DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
 
-        assertTrue(session.loadInitialWindow(mapId, 0));
+        assertTrue(session.loadViewport(mapId, 0, 0, 0, 63, 63));
         var initial = state.committedFacts(mapId).surface();
         assertNotNull(initial);
         assertEquals(1L, initial.requestGeneration());
@@ -154,7 +200,7 @@ final class DungeonEditorWindowLoadIntegrationTest {
                 .flatMap(area -> area.cells().stream())
                 .anyMatch(new Cell(10, 10, 0)::equals));
 
-        assertFalse(session.loadInitialWindow(mapId, 0),
+        assertFalse(session.loadViewport(mapId, 0, 0, 0, 63, 63),
                 "the later generation cannot publish an older map revision");
 
         var retained = state.committedFacts(mapId).surface();
@@ -350,9 +396,12 @@ final class DungeonEditorWindowLoadIntegrationTest {
                 component.authored()::currentWindowRequestGeneration,
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE);
-        return new DungeonEditorApiFacade(
+        DungeonEditorApi editor = new DungeonEditorApiFacade(
                 DungeonEditorFeatureRuntimeRoot.create(dependencies),
                 DirectUiDispatcher.INSTANCE);
+        editor.dispatch(new DungeonEditorIntent.SetViewport(
+                new DungeonEditorViewportInput(0, 0, 0, 63, 63)));
+        return editor;
     }
 
     private static void assertSemanticSurface(features.dungeon.api.DungeonEditorMapSnapshot map) {


### PR DESCRIPTION
Summary:
- dispatch visible cell bounds from initial layout, resize, pan, zoom, map and level changes
- keep map identity, expected revision and request generation application-owned
- load exact visible chunks plus one ring and reject stale or superseded results
- remove the fixed 0..63 Editor load and reuse the accepted viewport for refreshes

Proof:
- ./gradlew check --no-daemon --console=plain: BUILD SUCCESSFUL in 9m 37s
- ./gradlew installDesktopApp --no-daemon --console=plain: BUILD SUCCESSFUL in 1m 2s
- git diff --check: clean