### PR TITLE
M5.2: Dungeon-Fenster pro Chunk cachen

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -106,10 +106,74 @@ and commit boundaries. M7 starts only after both are complete.
   local identity derivation, compatibility writer, and full-record fixture
   families are deleted.
 - M4.6 delivery proof is literal green `./gradlew check` plus
-  `./gradlew installDesktopApp`. M5.1 is complete in this change with the same
-  literal green proof; M5.2 is next. No intermediate review panel runs; the
-  single independent cross-roadmap review runs only after all M7 implementation
-  is complete.
+  `./gradlew installDesktopApp`. M5.1 is complete through PR #536. M5.2 is
+  complete in this change with the same literal green proof; M5.3 is next. No
+  intermediate review panel runs; the single independent cross-roadmap review
+  runs only after all M7 implementation is complete.
+
+### Completed Slice Contract: M5.2 Per-Chunk Cache And Touched Invalidation
+
+#### Goal And Ownership
+
+- Add one feature-lifetime `DungeonCachedWindowStore` between all Authored,
+  command-workset, and Travel consumers and the SQLite window source. JavaFX,
+  static state, and per-session cache instances are forbidden.
+- Cache immutable chunk content by `(DungeonChunkKey, contentRevision)`. Map
+  revision and viewport rectangles are not cache keys, so unchanged content is
+  reusable across map revisions.
+- Split the persistence boundary into an exact requested-chunk index read and a
+  content read for explicit cache misses. Both are revision-bound; a change
+  between reads yields stale/retry rather than mixed-revision facts. I/O never
+  runs while the cache monitor is held.
+- Assemble cache hits and misses deterministically into the existing
+  `DungeonWindow`. A cache value owns one chunk's bounded fragments,
+  dependencies, and entity extents; it never owns `DungeonMap`, a complete
+  window, or map-wide collections. M5.3 will extend extents into indexed bounds
+  and paged continuations without changing the cache key.
+
+#### Capacity, Protection, And Invalidation
+
+- Extend `WeightedViewportCache` with atomic batch lookup/put, protected-key
+  replacement, targeted invalidation, and eviction immediately after protection
+  is released. Use an access-ordered maximum of 262,144 fact weights; weight is
+  the saturating sum of one plus contained atomic spatial facts, dependency
+  refs, and extent refs.
+- Protect the chunks of the latest accepted visible viewport, excluding its
+  prefetch-only ring. Change that protected set only after M5.1 latest-request
+  acceptance. Protect command workset chunks through a scoped edit lease from
+  load/preview until commit, cancel, or context change.
+- After a successful commit, undo, redo, or compound commit, invalidate exactly
+  the chunk identities named by committed `chunkRevisions()` before refresh and
+  publication. Reject/rollback and rename invalidate nothing; map deletion
+  removes only that map; read-only Travel refresh invalidates nothing.
+
+#### Implementation Order And Proof
+
+1. Extend the generic weighted cache and focused platform tests for batches,
+   leases/protection, temporary overweight, release eviction, and targeted
+   invalidation.
+2. Add the typed index/content/extent port values, cached store and deterministic
+   window assembler; compose exactly one shared instance in `DungeonFeature`.
+3. Split SQLite header/index and miss-content queries. Every content query must
+   carry explicit chunk identities plus expected map/content revisions; no
+   authored query may scan unrequested content.
+4. Bind visible protection after accepted viewport publication, edit protection
+   to command worksets, and touched-only invalidation to successful UoW results.
+5. Prove with counting production-route fakes and SQLite integration: cold nine
+   chunks load nine contents; identical warm reads load zero; a one-chunk pan or
+   successful touch loads only the entering/touched chunk; undo, redo and
+   compound commits behave likewise; rename/reject load or invalidate none;
+   negative chunks and stale two-phase reads remain correct; 100k off-window
+   cells do not change statement or loaded-fact counts.
+
+#### Delete Gate
+
+- Delete direct injection of the uncached SQLite window store into Authored or
+  Travel, revision-wide/full-map invalidation, whole-window cache values, and
+  content reads without explicit miss chunks and expected revisions.
+- Literal green focused tests, `./gradlew check`, and
+  `./gradlew installDesktopApp` are required before the M5.2 PR merges. M5.3
+  starts from that merge without a review cycle.
 
 ### Completed Slice Contract: M5.1 Viewport Dispatch And Latest Acceptance
 

--- a/features/dungeon/DungeonFeature.java
+++ b/features/dungeon/DungeonFeature.java
@@ -18,6 +18,7 @@ import features.dungeon.api.authored.DungeonAuthoredApi;
 import features.dungeon.api.editor.DungeonEditorApi;
 import features.dungeon.api.travel.DungeonTravelApi;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.dungeon.application.authored.DungeonAuthoredPublishedState;
 import features.dungeon.application.authored.port.DungeonCatalogStore;
 import features.dungeon.application.authored.port.DungeonIdentityAllocator;
@@ -64,7 +65,8 @@ public final class DungeonFeature {
         UiDispatcher dispatcher = Objects.requireNonNull(uiDispatcher, "uiDispatcher");
         SqliteDungeonCatalogStore catalogStore =
                 new SqliteDungeonCatalogStore(Objects.requireNonNull(database, "database"));
-        SqliteDungeonWindowStore windowStore = new SqliteDungeonWindowStore(database);
+        DungeonCachedWindowStore windowStore = new DungeonCachedWindowStore(
+                new SqliteDungeonWindowStore(database));
         SqliteDungeonUnitOfWork unitOfWork = new SqliteDungeonUnitOfWork(database);
         SqliteDungeonIdentityAllocator identityAllocator = new SqliteDungeonIdentityAllocator(database);
         Runtime runtime = createRuntime(

--- a/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
+++ b/features/dungeon/adapter/javafx/editor/DungeonEditorViewModel.java
@@ -996,7 +996,7 @@ final class DungeonEditorViewModel {
         long noSelectedMapId = 0L;
         if (selectedMapIdValue > noSelectedMapId) {
             mapContentModel.clearHoverTarget();
-            editorApi.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(selectedMapIdValue)));
+            editorApi.dispatch(new DungeonEditorIntent.ReloadMap(new DungeonMapId(selectedMapIdValue)));
         }
     }
 

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteWindowGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteWindowGateway.java
@@ -15,6 +15,8 @@ import features.dungeon.application.authored.port.DungeonTravelChunkKeysResult;
 import features.dungeon.application.authored.port.DungeonTravelStartRequest;
 import features.dungeon.application.authored.port.DungeonTravelStartResult;
 import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
 import features.dungeon.application.authored.port.DungeonWindowChunkHeader;
 import features.dungeon.application.authored.port.DungeonWindowContinuation;
 import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
@@ -72,15 +74,47 @@ public final class DungeonSqliteWindowGateway {
         this.afterHeaderRead = Objects.requireNonNull(afterHeaderRead, "afterHeaderRead");
     }
 
-    public Optional<DungeonWindow> loadWindow(DungeonWindowRequest request) {
+    public Optional<DungeonWindowIndex> loadIndex(DungeonWindowRequest request) {
         DungeonWindowRequest safeRequest = Objects.requireNonNull(request, "request");
         DungeonSqliteQueryCounter queries = new DungeonSqliteQueryCounter();
         try (Connection connection = connectionSupport.openReadyConnection()) {
-            return DungeonSqliteReadSnapshot.read(
-                    connection,
-                    () -> loadWindowSnapshot(connection, safeRequest, queries));
+            return DungeonSqliteReadSnapshot.read(connection, () -> {
+                Optional<DungeonMapHeader> header = loadMapHeader(
+                        connection, safeRequest.mapId().value(), queries);
+                if (header.isEmpty()) {
+                    return Optional.empty();
+                }
+                afterHeaderRead.run();
+                return Optional.of(new DungeonWindowIndex(
+                        header.get(), safeRequest.requestGeneration(),
+                        loadChunkHeaders(connection, safeRequest, queries)));
+            });
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to load Dungeon window from SQLite.", exception);
+            throw new IllegalStateException("Failed to load Dungeon window index from SQLite.", exception);
+        } finally {
+            lastStatementCount.set(queries.statements());
+            lastStatementSql.set(queries.preparedSql());
+        }
+    }
+
+    public Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request) {
+        DungeonWindowContentRequest safeRequest = Objects.requireNonNull(request, "request");
+        DungeonSqliteQueryCounter queries = new DungeonSqliteQueryCounter();
+        DungeonWindowRequest windowRequest = new DungeonWindowRequest(
+                safeRequest.mapId(), safeRequest.requestGeneration(),
+                safeRequest.chunks().stream().map(DungeonWindowChunkHeader::key).toList());
+        try (Connection connection = connectionSupport.openReadyConnection()) {
+            return DungeonSqliteReadSnapshot.read(connection, () -> {
+                Optional<DungeonWindow> loaded = loadWindowSnapshot(connection, windowRequest, queries);
+                if (loaded.isEmpty()
+                        || loaded.get().mapHeader().revision() != safeRequest.expectedMapRevision()
+                        || !loaded.get().chunkHeaders().equals(safeRequest.chunks())) {
+                    return Optional.empty();
+                }
+                return loaded;
+            });
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to load Dungeon window content from SQLite.", exception);
         } finally {
             lastStatementCount.set(queries.statements());
             lastStatementSql.set(queries.preparedSql());

--- a/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStore.java
+++ b/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStore.java
@@ -10,14 +10,16 @@ import features.dungeon.application.authored.port.DungeonTravelChunkKeysResult;
 import features.dungeon.application.authored.port.DungeonTravelStartRequest;
 import features.dungeon.application.authored.port.DungeonTravelStartResult;
 import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowContentSource;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
-import features.dungeon.application.authored.port.DungeonWindowStore;
 import java.util.Objects;
 import java.util.Optional;
 import platform.persistence.SqliteDatabase;
 
 /** Dedicated SQLite adapter for sparse windows and exact identity closure. */
-public final class SqliteDungeonWindowStore implements DungeonWindowStore {
+public final class SqliteDungeonWindowStore implements DungeonWindowContentSource {
 
     private final DungeonSqliteWindowGateway gateway;
 
@@ -34,8 +36,13 @@ public final class SqliteDungeonWindowStore implements DungeonWindowStore {
     }
 
     @Override
-    public Optional<DungeonWindow> loadWindow(DungeonWindowRequest request) {
-        return gateway.loadWindow(request);
+    public Optional<DungeonWindowIndex> loadIndex(DungeonWindowRequest request) {
+        return gateway.loadIndex(request);
+    }
+
+    @Override
+    public Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request) {
+        return gateway.loadContent(request);
     }
 
     @Override

--- a/features/dungeon/api/editor/DungeonEditorIntent.java
+++ b/features/dungeon/api/editor/DungeonEditorIntent.java
@@ -24,6 +24,14 @@ public sealed interface DungeonEditorIntent {
         }
     }
 
+    record ReloadMap(DungeonMapId mapId) implements DungeonEditorIntent {
+        public ReloadMap {
+            if (mapId == null) {
+                throw new IllegalArgumentException("mapId is required");
+            }
+        }
+    }
+
     record CreateMap(String mapName) implements DungeonEditorIntent {
         public CreateMap {
             mapName = cleanName(mapName);

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -270,6 +270,16 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         return acceptedWindowRequestGeneration;
     }
 
+    public void invalidateAcceptedWindow(MapId mapId) {
+        if (mapId == null) {
+            return;
+        }
+        DungeonCommandReadSpecs.AcceptedViewport accepted = acceptedViewports.get(mapId.value());
+        if (accepted != null) {
+            windowStore.invalidateChunks(accepted.chunkKeys());
+        }
+    }
+
     private static void validateWindowResult(DungeonWindowRequest request, DungeonWindow window) {
         if (!request.mapId().equals(window.mapHeader().mapId())) {
             throw new IllegalStateException("Dungeon window returned a different map identity.");
@@ -423,6 +433,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     session.dungeonState());
             return;
         }
+        List<DungeonWindowStore.Lease> editLeases = new ArrayList<>();
+        try {
         Map<Long, HistoryLoadedMap> loadedMaps = new LinkedHashMap<>();
         Map<Long, DungeonMap> currentMaps = new LinkedHashMap<>();
         for (DungeonPatch selectedPatch : step.selectedPatches()) {
@@ -435,6 +447,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                         session.dungeonState());
                 return;
             }
+            editLeases.add(windowStore.protectEditChunks(readSpec.chunkKeys()));
             DungeonCommandWorksetResult loaded = commandWorksetLoader.load(readSpec);
             if (!(loaded instanceof DungeonCommandWorksetResult.Complete complete)
                     || !complete.workset().containsComplete(readSpec)) {
@@ -463,6 +476,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             DungeonUnitOfWorkResult.Committed committed = (DungeonUnitOfWorkResult.Committed) commit;
             validateCommittedPatch(patch, committed);
+            windowStore.invalidateChunks(committed.chunkRevisions().keySet());
             completeHistoryStep(step, loadedMaps, List.of(patch), selectedMapId, session, undo);
             return;
         }
@@ -479,7 +493,11 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         DungeonCompoundUnitOfWorkResult.Committed committed =
                 (DungeonCompoundUnitOfWorkResult.Committed) commit;
         validateCommittedCompoundPatch(patch, committed);
+        invalidateCommittedChunks(committed);
         completeHistoryStep(step, loadedMaps, patch.patches(), selectedMapId, session, undo);
+        } finally {
+            closeLeases(editLeases);
+        }
     }
 
     private void completeHistoryStep(
@@ -938,12 +956,14 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             DungeonCommandReadSpec spec = DungeonCommandReadSpecs.forViewport(
                     viewport, commandChunks, seedRefs, expansion, intent);
-            DungeonCommandWorksetResult loaded = commandWorksetLoader.load(spec);
-            if (!(loaded instanceof DungeonCommandWorksetResult.Complete complete)
-                    || !complete.workset().containsComplete(spec)) {
-                return fallback;
+            try (DungeonWindowStore.Lease editLease = windowStore.protectEditChunks(spec.chunkKeys())) {
+                DungeonCommandWorksetResult loaded = commandWorksetLoader.load(spec);
+                if (!(loaded instanceof DungeonCommandWorksetResult.Complete complete)
+                        || !complete.workset().containsComplete(spec)) {
+                    return fallback;
+                }
+                return reader.apply(complete.workset().aggregateFor(spec));
             }
-            return reader.apply(complete.workset().aggregateFor(spec));
         }
 
         private OperationResultData executePatchCommand(
@@ -964,6 +984,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     seedRefs,
                     expansion,
                     DungeonCommandReadSpec.CommandIntent.AUTHORED_MUTATION);
+            try (DungeonWindowStore.Lease editLease = windowStore.protectEditChunks(spec.chunkKeys())) {
             DungeonCommandWorksetResult loaded = commandWorksetLoader.load(spec);
             if (loaded instanceof DungeonCommandWorksetResult.Rejected rejected) {
                 return rejectedResult(worksetRejection(rejected.reason()));
@@ -1017,6 +1038,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             }
             DungeonUnitOfWorkResult.Committed committed = (DungeonUnitOfWorkResult.Committed) commit;
             validateCommittedPatch(patch, committed);
+            windowStore.invalidateChunks(committed.chunkRevisions().keySet());
             acceptedViewports.computeIfPresent(
                     mapId.value(),
                     (ignored, acceptedViewport) -> acceptedViewport.committed(committed.committedRevision()));
@@ -1027,6 +1049,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     OPERATION_FEEDBACK_POLICY.validationMessages(current, candidate),
                     OPERATION_FEEDBACK_POLICY.reactionMessages(current, candidate),
                     DungeonEditorCommandOutcome.accepted(committed.committedRevision()));
+            }
         }
 
         private LoadDungeonSnapshotUseCase.DungeonSnapshotData snapshotData(
@@ -1278,6 +1301,18 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
         }
     }
 
+    private void invalidateCommittedChunks(DungeonCompoundUnitOfWorkResult.Committed committed) {
+        for (DungeonUnitOfWorkResult.Committed mapCommit : committed.committedMaps()) {
+            windowStore.invalidateChunks(mapCommit.chunkRevisions().keySet());
+        }
+    }
+
+    private static void closeLeases(List<DungeonWindowStore.Lease> leases) {
+        for (int index = leases.size() - 1; index >= 0; index--) {
+            leases.get(index).close();
+        }
+    }
+
     private final class PublicationOperations {
         private final PublicationAssembler assembler = new PublicationAssembler();
 
@@ -1453,6 +1488,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                             maximumQ,
                             maximumR,
                             request.chunkKeys()));
+            windowStore.protectVisibleChunks(viewport.visibleChunks());
             acceptedWindowRequestGeneration = generation;
             return ViewportLoadResult.ACCEPTED;
         }
@@ -2065,6 +2101,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
         private DungeonMapIdentity deleteMap(DungeonMapIdentity mapIdentity) {
             catalogStore.delete(mapIdentity);
+            windowStore.invalidateMap(mapIdentity.value());
             acceptedViewports.remove(mapIdentity.value());
             editHistory.remove(mapIdentity);
             return mapIdentity;
@@ -2138,6 +2175,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (sourceViewport == null) {
                 return rejectedResult(DungeonEditorCommandOutcome.RejectionReason.STALE_REVISION);
             }
+            List<DungeonWindowStore.Lease> editLeases = new ArrayList<>();
+            try {
             Map<Long, List<DungeonPatchEntityRef>> initialSeeds = new LinkedHashMap<>();
             initialSeeds.computeIfAbsent(sourceMapId.value(), ignored -> new ArrayList<>())
                     .add(transitionRef(sourceTransitionId));
@@ -2150,7 +2189,8 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 LinkLoadResult load = loadLinkMap(
                         mapId,
                         entry.getValue(),
-                        mapId.equals(sourceMapId) ? sourceViewport : null);
+                        mapId.equals(sourceMapId) ? sourceViewport : null,
+                        editLeases);
                 if (load.rejectionReason() != null) {
                     return rejectedResult(load.rejectionReason());
                 }
@@ -2182,7 +2222,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                         return rejectedResult(
                                 DungeonEditorCommandOutcome.RejectionReason.INSUFFICIENT_LOADED_CLOSURE);
                     }
-                    LinkLoadResult load = loadLinkMap(requiredIdentity, priorLinkSeeds, null);
+                    LinkLoadResult load = loadLinkMap(requiredIdentity, priorLinkSeeds, null, editLeases);
                     if (load.rejectionReason() != null) {
                         return rejectedResult(load.rejectionReason());
                     }
@@ -2215,9 +2255,10 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
             if (commit instanceof DungeonCompoundUnitOfWorkResult.Rejected rejected) {
                 return rejectedCommit(rejected.reason());
             }
-            validateCommittedCompoundPatch(
-                    patch,
-                    (DungeonCompoundUnitOfWorkResult.Committed) commit);
+            DungeonCompoundUnitOfWorkResult.Committed committed =
+                    (DungeonCompoundUnitOfWorkResult.Committed) commit;
+            validateCommittedCompoundPatch(patch, committed);
+            invalidateCommittedChunks(committed);
             for (DungeonPatch mapPatch : patch.patches()) {
                 acceptedViewports.computeIfPresent(
                         mapPatch.mapId().value(),
@@ -2239,12 +2280,16 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     List.of(),
                     List.of("transition link saved"),
                     DungeonEditorCommandOutcome.accepted(sourcePatch.committedRevision()));
+            } finally {
+                closeLeases(editLeases);
+            }
         }
 
         private LinkLoadResult loadLinkMap(
                 DungeonMapIdentity mapId,
                 List<DungeonPatchEntityRef> seedRefs,
-                DungeonCommandReadSpecs.AcceptedViewport viewport
+                DungeonCommandReadSpecs.AcceptedViewport viewport,
+                List<DungeonWindowStore.Lease> editLeases
         ) {
             DungeonCommandReadSpec spec;
             if (viewport != null) {
@@ -2268,6 +2313,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                         DungeonCommandReadSpec.DependencyExpansion.OUTBOUND_AND_INBOUND,
                         DungeonCommandReadSpec.CommandIntent.TRANSITION_LINK);
             }
+            editLeases.add(windowStore.protectEditChunks(spec.chunkKeys()));
             DungeonCommandWorksetResult result = commandWorksetLoader.load(spec);
             if (result instanceof DungeonCommandWorksetResult.Rejected rejected) {
                 return LinkLoadResult.rejected(transitionLinkWorksetRejection(rejected.reason()));

--- a/features/dungeon/application/authored/DungeonCachedWindowStore.java
+++ b/features/dungeon/application/authored/DungeonCachedWindowStore.java
@@ -1,0 +1,333 @@
+package features.dungeon.application.authored;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.command.DungeonPatchEntityRef;
+import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
+import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
+import features.dungeon.application.authored.port.DungeonInboundReferenceRequest;
+import features.dungeon.application.authored.port.DungeonInboundReferenceResult;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysRequest;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysResult;
+import features.dungeon.application.authored.port.DungeonTravelStartRequest;
+import features.dungeon.application.authored.port.DungeonTravelStartResult;
+import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowChunkHeader;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowContentSource;
+import features.dungeon.application.authored.port.DungeonWindowContinuation;
+import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.application.authored.port.DungeonWindowStore;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import platform.ui.mapcanvas.WeightedViewportCache;
+
+/** One feature-lifetime, revision-keyed cache shared by every Dungeon window consumer. */
+public final class DungeonCachedWindowStore implements DungeonWindowStore {
+    static final long MAXIMUM_FACT_WEIGHT = 262_144L;
+
+    private final DungeonWindowContentSource source;
+    private final WeightedViewportCache<ChunkVersion, ChunkContent> cache =
+            new WeightedViewportCache<>(MAXIMUM_FACT_WEIGHT, ChunkContent::weight);
+    private final Map<DungeonChunkKey, ChunkVersion> currentVersions = new LinkedHashMap<>();
+
+    public DungeonCachedWindowStore(DungeonWindowContentSource source) {
+        this.source = Objects.requireNonNull(source, "source");
+    }
+
+    @Override
+    public Optional<DungeonWindow> loadWindow(DungeonWindowRequest request) {
+        DungeonWindowRequest safeRequest = Objects.requireNonNull(request, "request");
+        Optional<DungeonWindowIndex> indexed = source.loadIndex(safeRequest);
+        if (indexed.isEmpty()) {
+            return Optional.empty();
+        }
+        DungeonWindowIndex index = indexed.get();
+        if (!sameRequest(safeRequest, index)) {
+            return Optional.empty();
+        }
+        List<ChunkVersion> versions = index.chunkHeaders().stream()
+                .map(header -> new ChunkVersion(header.key(), header.contentRevision()))
+                .toList();
+        remember(versions);
+        Map<ChunkVersion, ChunkContent> contents = new LinkedHashMap<>(cache.getAll(versions));
+        Map<ChunkVersion, ChunkContent> loadedMisses = new LinkedHashMap<>();
+        for (int indexPosition = 0; indexPosition < versions.size(); indexPosition++) {
+            ChunkVersion version = versions.get(indexPosition);
+            if (contents.containsKey(version)) {
+                continue;
+            }
+            DungeonWindowChunkHeader expectedChunk = index.chunkHeaders().get(indexPosition);
+            Optional<DungeonWindow> loaded = source.loadContent(new DungeonWindowContentRequest(
+                    index.mapHeader().mapId(), index.mapHeader().revision(), index.requestGeneration(),
+                    List.of(expectedChunk)));
+            if (loaded.isEmpty() || !validSingleChunk(index, expectedChunk, loaded.get())) {
+                return Optional.empty();
+            }
+            ChunkContent content = ChunkContent.from(loaded.get());
+            loadedMisses.put(version, content);
+            contents.put(version, content);
+        }
+        if (!loadedMisses.isEmpty()) {
+            Optional<DungeonWindowIndex> confirmed = source.loadIndex(safeRequest);
+            if (confirmed.isEmpty() || !sameIndex(index, confirmed.get())) {
+                return Optional.empty();
+            }
+            cache.putAll(loadedMisses);
+        }
+        return Optional.of(assemble(index, versions, contents));
+    }
+
+    @Override
+    public synchronized void protectVisibleChunks(Collection<DungeonChunkKey> chunks) {
+        Set<ChunkVersion> protectedVersions = new LinkedHashSet<>();
+        for (DungeonChunkKey chunk : chunks == null ? List.<DungeonChunkKey>of() : chunks) {
+            ChunkVersion version = currentVersions.get(chunk);
+            if (version != null) {
+                protectedVersions.add(version);
+            }
+        }
+        cache.replaceProtectedKeys(protectedVersions);
+    }
+
+    @Override
+    public synchronized Lease protectEditChunks(Collection<DungeonChunkKey> chunks) {
+        Set<ChunkVersion> protectedVersions = new LinkedHashSet<>();
+        for (DungeonChunkKey chunk : chunks == null ? List.<DungeonChunkKey>of() : chunks) {
+            ChunkVersion version = currentVersions.get(chunk);
+            if (version != null) {
+                protectedVersions.add(version);
+            }
+        }
+        WeightedViewportCache.Lease lease = cache.protect(protectedVersions);
+        return lease::close;
+    }
+
+    @Override
+    public synchronized void invalidateChunks(Collection<DungeonChunkKey> chunks) {
+        Set<DungeonChunkKey> identities = Set.copyOf(
+                chunks == null ? List.<DungeonChunkKey>of() : chunks);
+        cache.invalidateIf(version -> identities.contains(version.key()));
+        identities.forEach(currentVersions::remove);
+    }
+
+    @Override
+    public synchronized void invalidateMap(long mapId) {
+        cache.invalidateIf(version -> version.key().mapId() == mapId);
+        currentVersions.keySet().removeIf(key -> key.mapId() == mapId);
+    }
+
+    @Override
+    public DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request) {
+        return source.loadIdentityClosure(request);
+    }
+
+    @Override
+    public DungeonTravelStartResult locateTravelStart(DungeonTravelStartRequest request) {
+        return source.locateTravelStart(request);
+    }
+
+    @Override
+    public DungeonTravelChunkKeysResult discoverTravelChunkKeys(DungeonTravelChunkKeysRequest request) {
+        return source.discoverTravelChunkKeys(request);
+    }
+
+    @Override
+    public DungeonInboundReferenceResult discoverInboundReferences(DungeonInboundReferenceRequest request) {
+        return source.discoverInboundReferences(request);
+    }
+
+    private synchronized void remember(List<ChunkVersion> versions) {
+        versions.forEach(version -> currentVersions.put(version.key(), version));
+    }
+
+    private static boolean sameRequest(DungeonWindowRequest request, DungeonWindowIndex index) {
+        return request.mapId().equals(index.mapHeader().mapId())
+                && request.requestGeneration() == index.requestGeneration()
+                && request.chunkKeys().equals(index.chunkHeaders().stream()
+                        .map(DungeonWindowChunkHeader::key).toList());
+    }
+
+    private static boolean sameIndex(DungeonWindowIndex left, DungeonWindowIndex right) {
+        return left.mapHeader().equals(right.mapHeader())
+                && left.requestGeneration() == right.requestGeneration()
+                && left.chunkHeaders().equals(right.chunkHeaders());
+    }
+
+    private static boolean validSingleChunk(
+            DungeonWindowIndex index,
+            DungeonWindowChunkHeader expected,
+            DungeonWindow window
+    ) {
+        return window.mapHeader().equals(index.mapHeader())
+                && window.requestGeneration() == index.requestGeneration()
+                && window.chunkHeaders().equals(List.of(expected));
+    }
+
+    private static DungeonWindow assemble(
+            DungeonWindowIndex index,
+            List<ChunkVersion> versions,
+            Map<ChunkVersion, ChunkContent> contents
+    ) {
+        Map<DungeonPatchEntityRef, DungeonWindowEntityFragment> fragments = new LinkedHashMap<>();
+        Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> offWindow = new LinkedHashMap<>();
+        for (ChunkVersion version : versions) {
+            ChunkContent content = Objects.requireNonNull(contents.get(version), "indexed chunk content");
+            for (DungeonWindowEntityFragment fragment : content.fragments()) {
+                fragments.merge(fragment.entityRef(), fragment, DungeonCachedWindowStore::merge);
+            }
+            for (DungeonWindowContinuation continuation : content.continuations()) {
+                offWindow.computeIfAbsent(continuation.entityRef(), ignored -> new LinkedHashSet<>())
+                        .addAll(continuation.offWindowChunks());
+            }
+        }
+        Set<DungeonChunkKey> requested = new LinkedHashSet<>(
+                index.chunkHeaders().stream().map(DungeonWindowChunkHeader::key).toList());
+        List<DungeonWindowContinuation> continuations = new ArrayList<>();
+        for (Map.Entry<DungeonPatchEntityRef, Set<DungeonChunkKey>> entry : offWindow.entrySet()) {
+            entry.getValue().removeAll(requested);
+            if (!entry.getValue().isEmpty()) {
+                continuations.add(new DungeonWindowContinuation(entry.getKey(), List.copyOf(entry.getValue())));
+            }
+        }
+        return new DungeonWindow(index.mapHeader(), index.requestGeneration(), index.chunkHeaders(),
+                List.copyOf(fragments.values()), continuations);
+    }
+
+    private static DungeonWindowEntityFragment merge(
+            DungeonWindowEntityFragment left,
+            DungeonWindowEntityFragment right
+    ) {
+        if (!left.entityRef().equals(right.entityRef()) || left.getClass() != right.getClass()) {
+            throw new IllegalStateException("incompatible cached Dungeon fragments");
+        }
+        List<DungeonChunkKey> chunks = union(left.intersectingRequestedChunks(), right.intersectingRequestedChunks());
+        List<DungeonPatchEntityRef> dependencies = union(left.dependencyHeaders(), right.dependencyHeaders());
+        if (left instanceof DungeonWindowEntityFragment.Room a
+                && right instanceof DungeonWindowEntityFragment.Room b) {
+            requireEqual(a.clusterId(), b.clusterId()); requireEqual(a.name(), b.name());
+            requireEqual(a.visualDescription(), b.visualDescription());
+            return new DungeonWindowEntityFragment.Room(a.entityRef(), a.clusterId(), a.name(),
+                    a.visualDescription(), union(a.floorCells(), b.floorCells()),
+                    union(a.exitDescriptions(), b.exitDescriptions()), chunks, dependencies);
+        }
+        if (left instanceof DungeonWindowEntityFragment.RoomCluster a
+                && right instanceof DungeonWindowEntityFragment.RoomCluster b) {
+            requireEqual(a.name(), b.name());
+            return new DungeonWindowEntityFragment.RoomCluster(a.entityRef(), a.name(),
+                    union(a.memberCells(), b.memberCells()), union(a.boundaries(), b.boundaries()),
+                    chunks, dependencies);
+        }
+        if (left instanceof DungeonWindowEntityFragment.Corridor a
+                && right instanceof DungeonWindowEntityFragment.Corridor b) {
+            requireEqual(a.level(), b.level()); requireEqual(a.roomIds(), b.roomIds());
+            return new DungeonWindowEntityFragment.Corridor(a.entityRef(), a.level(), a.roomIds(),
+                    union(a.waypoints(), b.waypoints()), union(a.doorBindings(), b.doorBindings()),
+                    union(a.anchorBindings(), b.anchorBindings()), union(a.anchorRefs(), b.anchorRefs()),
+                    union(a.routeCells(), b.routeCells()), chunks, dependencies);
+        }
+        if (left instanceof DungeonWindowEntityFragment.Stair a
+                && right instanceof DungeonWindowEntityFragment.Stair b) {
+            requireEqual(a.name(), b.name()); requireEqual(a.shape(), b.shape());
+            requireEqual(a.direction(), b.direction()); requireEqual(a.dimension1(), b.dimension1());
+            requireEqual(a.dimension2(), b.dimension2()); requireEqual(a.corridorId(), b.corridorId());
+            return new DungeonWindowEntityFragment.Stair(a.entityRef(), a.name(), a.shape(), a.direction(),
+                    a.dimension1(), a.dimension2(), a.corridorId(), union(a.path(), b.path()),
+                    union(a.exits(), b.exits()), chunks, dependencies);
+        }
+        if (left instanceof DungeonWindowEntityFragment.Transition a
+                && right instanceof DungeonWindowEntityFragment.Transition b) {
+            requireEqual(a.description(), b.description()); requireEqual(a.anchor(), b.anchor());
+            requireEqual(a.destination(), b.destination()); requireEqual(a.linkedTransitionId(), b.linkedTransitionId());
+            return new DungeonWindowEntityFragment.Transition(a.entityRef(), a.description(), a.anchor(),
+                    a.destination(), a.linkedTransitionId(), chunks, dependencies);
+        }
+        if (left instanceof DungeonWindowEntityFragment.FeatureMarker a
+                && right instanceof DungeonWindowEntityFragment.FeatureMarker b) {
+            requireEqual(a.kind(), b.kind()); requireEqual(a.anchor(), b.anchor());
+            requireEqual(a.label(), b.label()); requireEqual(a.description(), b.description());
+            return new DungeonWindowEntityFragment.FeatureMarker(a.entityRef(), a.kind(), a.anchor(),
+                    a.label(), a.description(), chunks, dependencies);
+        }
+        throw new IllegalStateException("unsupported cached Dungeon fragment");
+    }
+
+    private static <T> List<T> union(Collection<T> left, Collection<T> right) {
+        LinkedHashSet<T> values = new LinkedHashSet<>(left);
+        values.addAll(right);
+        return List.copyOf(values);
+    }
+
+    private static void requireEqual(Object left, Object right) {
+        if (!Objects.equals(left, right)) {
+            throw new IllegalStateException("cached Dungeon fragment metadata changed without revision change");
+        }
+    }
+
+    private record ChunkVersion(DungeonChunkKey key, long contentRevision) {
+        private ChunkVersion {
+            key = Objects.requireNonNull(key, "key");
+            if (contentRevision < 0L) {
+                throw new IllegalArgumentException("content revision must not be negative");
+            }
+        }
+    }
+
+    private record ChunkContent(
+            DungeonWindowChunkHeader header,
+            List<DungeonWindowEntityFragment> fragments,
+            List<DungeonWindowContinuation> continuations
+    ) {
+        private ChunkContent {
+            header = Objects.requireNonNull(header, "header");
+            fragments = List.copyOf(fragments);
+            continuations = List.copyOf(continuations);
+        }
+
+        static ChunkContent from(DungeonWindow window) {
+            return new ChunkContent(window.chunkHeaders().get(0), window.fragments(), window.continuations());
+        }
+
+        long weight() {
+            long result = 1L;
+            for (DungeonWindowEntityFragment fragment : fragments) {
+                result = add(result, atomicFactCount(fragment));
+                result = add(result, fragment.dependencyHeaders().size());
+                result = add(result, fragment.intersectingRequestedChunks().size());
+            }
+            for (DungeonWindowContinuation continuation : continuations) {
+                result = add(result, continuation.offWindowChunks().size());
+            }
+            return result;
+        }
+
+        private static long atomicFactCount(DungeonWindowEntityFragment fragment) {
+            if (fragment instanceof DungeonWindowEntityFragment.Room value) {
+                return value.floorCells().size() + value.exitDescriptions().size();
+            }
+            if (fragment instanceof DungeonWindowEntityFragment.RoomCluster value) {
+                return value.memberCells().size() + value.boundaries().size();
+            }
+            if (fragment instanceof DungeonWindowEntityFragment.Corridor value) {
+                return value.roomIds().size() + value.waypoints().size() + value.doorBindings().size()
+                        + value.anchorBindings().size() + value.anchorRefs().size() + value.routeCells().size();
+            }
+            if (fragment instanceof DungeonWindowEntityFragment.Stair value) {
+                return value.path().size() + value.exits().size();
+            }
+            return 1L;
+        }
+
+        private static long add(long left, long right) {
+            return Long.MAX_VALUE - left < right ? Long.MAX_VALUE : left + right;
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonWindowContentRequest.java
+++ b/features/dungeon/application/authored/port/DungeonWindowContentRequest.java
@@ -1,0 +1,29 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/** Exact cache-miss content request bound to map and per-chunk revisions. */
+public record DungeonWindowContentRequest(
+        DungeonMapIdentity mapId,
+        long expectedMapRevision,
+        long requestGeneration,
+        List<DungeonWindowChunkHeader> chunks
+) {
+    public DungeonWindowContentRequest {
+        mapId = Objects.requireNonNull(mapId, "mapId");
+        if (expectedMapRevision < 1L || requestGeneration < 0L) {
+            throw new IllegalArgumentException("content request revisions must be valid");
+        }
+        long requestedMapId = mapId.value();
+        List<DungeonWindowChunkHeader> ordered = new ArrayList<>(chunks == null ? List.of() : chunks);
+        ordered.sort(Comparator.comparing(DungeonWindowChunkHeader::key, DungeonWindowRequest.CHUNK_ORDER));
+        if (ordered.isEmpty() || ordered.stream().anyMatch(chunk -> chunk.key().mapId() != requestedMapId)) {
+            throw new IllegalArgumentException("content request must name chunks of the requested map");
+        }
+        chunks = List.copyOf(ordered);
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonWindowContentSource.java
+++ b/features/dungeon/application/authored/port/DungeonWindowContentSource.java
@@ -1,0 +1,19 @@
+package features.dungeon.application.authored.port;
+
+import java.util.Optional;
+
+/** Two-phase sparse source used beneath the feature-lifetime window cache. */
+public interface DungeonWindowContentSource {
+    Optional<DungeonWindowIndex> loadIndex(DungeonWindowRequest request);
+
+    /** Returns empty when map or any expected revision changed between index and content reads. */
+    Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request);
+
+    DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request);
+
+    DungeonTravelStartResult locateTravelStart(DungeonTravelStartRequest request);
+
+    DungeonTravelChunkKeysResult discoverTravelChunkKeys(DungeonTravelChunkKeysRequest request);
+
+    DungeonInboundReferenceResult discoverInboundReferences(DungeonInboundReferenceRequest request);
+}

--- a/features/dungeon/application/authored/port/DungeonWindowIndex.java
+++ b/features/dungeon/application/authored/port/DungeonWindowIndex.java
@@ -1,0 +1,24 @@
+package features.dungeon.application.authored.port;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/** Revision-bound metadata for exactly the requested sparse chunks. */
+public record DungeonWindowIndex(
+        DungeonMapHeader mapHeader,
+        long requestGeneration,
+        List<DungeonWindowChunkHeader> chunkHeaders
+) {
+    public DungeonWindowIndex {
+        mapHeader = Objects.requireNonNull(mapHeader, "mapHeader");
+        if (requestGeneration < 0L) {
+            throw new IllegalArgumentException("requestGeneration must not be negative");
+        }
+        List<DungeonWindowChunkHeader> ordered = new ArrayList<>(
+                chunkHeaders == null ? List.of() : chunkHeaders);
+        ordered.sort(Comparator.comparing(DungeonWindowChunkHeader::key, DungeonWindowRequest.CHUNK_ORDER));
+        chunkHeaders = List.copyOf(ordered);
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonWindowStore.java
+++ b/features/dungeon/application/authored/port/DungeonWindowStore.java
@@ -1,11 +1,30 @@
 package features.dungeon.application.authored.port;
 
+import features.dungeon.api.DungeonChunkKey;
+import java.util.Collection;
 import java.util.Optional;
 
 /** Sparse authored read port for explicit chunk windows and exact identity closure. */
 public interface DungeonWindowStore {
 
     Optional<DungeonWindow> loadWindow(DungeonWindowRequest request);
+
+    /** Replaces cache protection with the latest accepted visible chunks. */
+    default void protectVisibleChunks(Collection<DungeonChunkKey> chunks) {
+    }
+
+    /** Protects loaded workset chunks for the lifetime of one edit operation. */
+    default Lease protectEditChunks(Collection<DungeonChunkKey> chunks) {
+        return () -> { };
+    }
+
+    /** Invalidates exactly the identities touched by a successful commit. */
+    default void invalidateChunks(Collection<DungeonChunkKey> chunks) {
+    }
+
+    /** Removes cached content only for the deleted map. */
+    default void invalidateMap(long mapId) {
+    }
 
     DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request);
 
@@ -29,5 +48,11 @@ public interface DungeonWindowStore {
         return new DungeonInboundReferenceResult.Rejected(
                 DungeonIdentityClosureResult.Reason.INCOMPLETE_ENTITY,
                 request == null ? java.util.List.of() : request.targetRefs());
+    }
+
+    @FunctionalInterface
+    interface Lease extends AutoCloseable {
+        @Override
+        void close();
     }
 }

--- a/features/dungeon/application/editor/DungeonEditorApiFacade.java
+++ b/features/dungeon/application/editor/DungeonEditorApiFacade.java
@@ -54,6 +54,8 @@ public final class DungeonEditorApiFacade implements DungeonEditorApi {
             runtimeRoot.setViewport(setViewport.viewport());
         } else if (safeIntent instanceof DungeonEditorIntent.SelectMap selectMap) {
             runtimeRoot.selectMap(selectMap.mapId().value());
+        } else if (safeIntent instanceof DungeonEditorIntent.ReloadMap reloadMap) {
+            runtimeRoot.reloadMap(reloadMap.mapId().value());
         } else if (safeIntent instanceof DungeonEditorIntent.CreateMap createMap) {
             runtimeRoot.createMap(createMap.mapName());
         } else if (safeIntent instanceof DungeonEditorIntent.RenameMap renameMap) {

--- a/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
+++ b/features/dungeon/application/editor/DungeonEditorFeatureRuntimeRoot.java
@@ -128,6 +128,11 @@ public final class DungeonEditorFeatureRuntimeRoot
     }
 
     @Override
+    public void reloadMap(long mapIdValue) {
+        commands.reloadMap(mapIdValue);
+    }
+
+    @Override
     public void createMap(String mapName) {
         commands.createMap(mapName);
     }

--- a/features/dungeon/application/editor/DungeonEditorMapCatalogOperations.java
+++ b/features/dungeon/application/editor/DungeonEditorMapCatalogOperations.java
@@ -3,6 +3,8 @@ package features.dungeon.application.editor;
 public interface DungeonEditorMapCatalogOperations {
     void selectMap(long mapIdValue);
 
+    void reloadMap(long mapIdValue);
+
     void createMap(String mapName);
 
     void renameMap(long mapIdValue, String mapName);

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -147,6 +147,12 @@ public final class DungeonEditorRuntimeApplicationService {
             return snapshot;
         }
 
+        public DungeonEditorSessionSnapshot.SnapshotData reloadMap(long mapId) {
+            MapId selectedMap = new MapId(mapId);
+            authoredService.invalidateAcceptedWindow(selectedMap);
+            return selectMap(mapId);
+        }
+
         public DungeonEditorSessionSnapshot.@Nullable SnapshotData setViewport(
                 DungeonEditorViewportInput viewport
         ) {

--- a/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeCommands.java
@@ -77,6 +77,17 @@ final class DungeonEditorRuntimeCommands
     }
 
     @Override
+    public void reloadMap(long mapIdValue) {
+        execute(() -> {
+            interactionState.clear();
+            draftSession.clearInlineLabelEditSession();
+            statePublisher.markDraftSessionChanged();
+            stairDraftOperation.clear();
+            applyInExecutionLane(() -> context.reloadMap(mapIdValue));
+        });
+    }
+
+    @Override
     public void createMap(String mapName) {
         execute(() -> {
             interactionState.clear();

--- a/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeContext.java
@@ -114,6 +114,10 @@ final class DungeonEditorRuntimeContext {
         return fromSnapshot(session.selectMap(mapIdValue));
     }
 
+    Result reloadMap(long mapIdValue) {
+        return fromSnapshot(session.reloadMap(mapIdValue));
+    }
+
     Result setViewport(DungeonEditorViewportInput viewport) {
         return fromSnapshot(session.setViewport(viewport));
     }

--- a/platform/ui/mapcanvas/WeightedViewportCache.java
+++ b/platform/ui/mapcanvas/WeightedViewportCache.java
@@ -1,10 +1,13 @@
 package platform.ui.mapcanvas;
 
 import java.util.Iterator;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 
 /** Access-ordered viewport cache that never evicts currently protected keys. */
@@ -12,6 +15,8 @@ public final class WeightedViewportCache<K, V> {
     private final long maximumWeight;
     private final ToLongFunction<V> weightOf;
     private final Map<K, Entry<V>> entries = new LinkedHashMap<>(16, 0.75f, true);
+    private final Map<K, Integer> leasedKeys = new LinkedHashMap<>();
+    private Set<K> protectedKeys = Set.of();
     private long weight;
 
     public WeightedViewportCache(long maximumWeight, ToLongFunction<V> weightOf) {
@@ -27,17 +32,77 @@ public final class WeightedViewportCache<K, V> {
         return entry == null ? null : entry.value();
     }
 
-    public synchronized void put(K key, V value, Set<K> protectedKeys) {
-        K safeKey = Objects.requireNonNull(key, "key");
-        V safeValue = Objects.requireNonNull(value, "value");
-        Entry<V> previous = entries.remove(safeKey);
-        if (previous != null) {
-            weight -= previous.weight();
+    /** Returns all present values in caller order as one synchronized access. */
+    public synchronized Map<K, V> getAll(Collection<K> keys) {
+        Map<K, V> result = new LinkedHashMap<>();
+        for (K key : keys == null ? Set.<K>of() : keys) {
+            Entry<V> entry = entries.get(key);
+            if (entry != null) {
+                result.put(key, entry.value());
+            }
         }
-        long entryWeight = Math.max(1L, weightOf.applyAsLong(safeValue));
-        entries.put(safeKey, new Entry<>(safeValue, entryWeight));
-        weight += entryWeight;
-        evict(protectedKeys == null ? Set.of() : Set.copyOf(protectedKeys));
+        return Map.copyOf(result);
+    }
+
+    public synchronized void put(K key, V value, Set<K> protectedKeys) {
+        putWithoutEviction(key, value);
+        evict(combinedProtection(protectedKeys));
+    }
+
+    /** Adds a batch atomically and applies eviction only after the entire batch is visible. */
+    public synchronized void putAll(Map<K, V> values) {
+        for (Map.Entry<K, V> value : values == null
+                ? Map.<K, V>of().entrySet() : values.entrySet()) {
+            putWithoutEviction(value.getKey(), value.getValue());
+        }
+        evict(combinedProtection(null));
+    }
+
+    /** Replaces the long-lived protected set, then immediately evicts newly unprotected excess. */
+    public synchronized void replaceProtectedKeys(Set<K> keys) {
+        protectedKeys = keys == null ? Set.of() : Set.copyOf(keys);
+        evict(combinedProtection(null));
+    }
+
+    /** Temporarily protects keys. Nested leases are reference counted. */
+    public synchronized Lease protect(Set<K> keys) {
+        Set<K> safeKeys = keys == null ? Set.of() : Set.copyOf(keys);
+        safeKeys.forEach(key -> leasedKeys.merge(key, 1, Integer::sum));
+        return new Lease() {
+            private boolean closed;
+
+            @Override
+            public void close() {
+                synchronized (WeightedViewportCache.this) {
+                    if (closed) {
+                        return;
+                    }
+                    closed = true;
+                    for (K key : safeKeys) {
+                        leasedKeys.computeIfPresent(key, (ignored, count) -> count == 1 ? null : count - 1);
+                    }
+                    evict(combinedProtection(null));
+                }
+            }
+        };
+    }
+
+    public synchronized void invalidateAll(Collection<K> keys) {
+        for (K key : keys == null ? Set.<K>of() : keys) {
+            remove(key);
+        }
+    }
+
+    public synchronized void invalidateIf(Predicate<K> predicate) {
+        Objects.requireNonNull(predicate, "predicate");
+        Iterator<Map.Entry<K, Entry<V>>> iterator = entries.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<K, Entry<V>> entry = iterator.next();
+            if (predicate.test(entry.getKey())) {
+                weight -= entry.getValue().weight();
+                iterator.remove();
+            }
+        }
     }
 
     public synchronized int size() {
@@ -46,6 +111,38 @@ public final class WeightedViewportCache<K, V> {
 
     public synchronized long weight() {
         return weight;
+    }
+
+    private void putWithoutEviction(K key, V value) {
+        K safeKey = Objects.requireNonNull(key, "key");
+        V safeValue = Objects.requireNonNull(value, "value");
+        Entry<V> previous = entries.remove(safeKey);
+        if (previous != null) {
+            weight -= previous.weight();
+        }
+        long entryWeight = Math.max(1L, weightOf.applyAsLong(safeValue));
+        entries.put(safeKey, new Entry<>(safeValue, entryWeight));
+        weight = saturatedAdd(weight, entryWeight);
+    }
+
+    private void remove(K key) {
+        Entry<V> removed = entries.remove(key);
+        if (removed != null) {
+            weight -= removed.weight();
+        }
+    }
+
+    private Set<K> combinedProtection(Set<K> additional) {
+        Set<K> result = new LinkedHashSet<>(protectedKeys);
+        result.addAll(leasedKeys.keySet());
+        if (additional != null) {
+            result.addAll(additional);
+        }
+        return Set.copyOf(result);
+    }
+
+    private static long saturatedAdd(long left, long right) {
+        return Long.MAX_VALUE - left < right ? Long.MAX_VALUE : left + right;
     }
 
     private void evict(Set<K> protectedKeys) {
@@ -67,5 +164,11 @@ public final class WeightedViewportCache<K, V> {
     }
 
     private record Entry<V>(V value, long weight) {
+    }
+
+    @FunctionalInterface
+    public interface Lease extends AutoCloseable {
+        @Override
+        void close();
     }
 }

--- a/test/architecture/dungeon/DungeonStoragePortArchitectureTest.java
+++ b/test/architecture/dungeon/DungeonStoragePortArchitectureTest.java
@@ -19,6 +19,7 @@ public final class DungeonStoragePortArchitectureTest {
     private static final String PORTS = "features.dungeon.application.authored.port.";
     private static final String CATALOG_STORE = PORTS + "DungeonCatalogStore";
     private static final String WINDOW_STORE = PORTS + "DungeonWindowStore";
+    private static final String WINDOW_CONTENT_SOURCE = PORTS + "DungeonWindowContentSource";
     private static final String UNIT_OF_WORK = PORTS + "DungeonUnitOfWork";
     private static final String IDENTITY_ALLOCATOR = PORTS + "DungeonIdentityAllocator";
     private static final String SQLITE_REPOSITORY = "features.dungeon.adapter.sqlite.repository.";
@@ -72,9 +73,9 @@ public final class DungeonStoragePortArchitectureTest {
                     .should(directlyImplementOnly(CATALOG_STORE)).allowEmptyShould(false);
 
     @ArchTest
-    static final ArchRule sqliteWindowDirectlyImplementsOnlyWindow =
+    static final ArchRule sqliteWindowDirectlyImplementsOnlyContentSource =
             classes().that().haveFullyQualifiedName(SQLITE_WINDOW_STORE)
-                    .should(directlyImplementOnly(WINDOW_STORE)).allowEmptyShould(false);
+                    .should(directlyImplementOnly(WINDOW_CONTENT_SOURCE)).allowEmptyShould(false);
 
     @ArchTest
     static final ArchRule sqliteUnitOfWorkDirectlyImplementsOnlyUnitOfWork =

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestPersistence.java
@@ -21,6 +21,7 @@ import features.dungeon.adapter.sqlite.repository.SqliteDungeonCatalogStore;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonIdentityAllocator;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonUnitOfWork;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonWindowStore;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.party.adapter.sqlite.model.PartyPersistenceSchema;
 import features.dungeon.DungeonTestAssembly;
 import features.dungeon.domain.core.geometry.Cell;
@@ -105,7 +106,7 @@ class DungeonEditorTestPersistence {
             SqliteDungeonCatalogStore catalog = new SqliteDungeonCatalogStore(sqliteDatabase);
             DungeonTestAssembly.Component dungeon = createDungeonServices(
                     catalog,
-                    new SqliteDungeonWindowStore(sqliteDatabase),
+                    new DungeonCachedWindowStore(new SqliteDungeonWindowStore(sqliteDatabase)),
                     new SqliteDungeonUnitOfWork(sqliteDatabase),
                     new SqliteDungeonIdentityAllocator(sqliteDatabase));
             DungeonEditorRuntimeDependencies dependencies =

--- a/test/features/dungeon/adapter/javafx/editor/DungeonTravelProjectionLevelTest.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonTravelProjectionLevelTest.java
@@ -11,6 +11,7 @@ import shell.api.ShellSlot;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonCatalogStore;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonUnitOfWork;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonWindowStore;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.party.adapter.sqlite.repository.SqlitePartyRosterRepository;
 import features.dungeon.DungeonTestAssembly;
 import features.dungeon.application.travel.DungeonTravelRuntimeApplicationService;
@@ -452,7 +453,7 @@ public final class DungeonTravelProjectionLevelTest {
             SqliteDungeonCatalogStore dungeonCatalog = new SqliteDungeonCatalogStore(dungeonDatabase);
             DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
                     dungeonCatalog,
-                    new SqliteDungeonWindowStore(dungeonDatabase),
+                    new DungeonCachedWindowStore(new SqliteDungeonWindowStore(dungeonDatabase)),
                     new SqliteDungeonUnitOfWork(dungeonDatabase),
                     party.activeParty(),
                     party.travelPositions(),

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSpatialIndexTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSpatialIndexTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonWindowStore;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.dungeon.application.authored.command.CorridorChange;
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
@@ -63,7 +64,9 @@ final class DungeonCanonicalSpatialIndexTest {
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
             seedAuthoredMap(database);
 
-            DungeonWindow window = new SqliteDungeonWindowStore(database).loadWindow(new DungeonWindowRequest(
+            DungeonCachedWindowStore windows = new DungeonCachedWindowStore(
+                    new SqliteDungeonWindowStore(database));
+            DungeonWindow window = windows.loadWindow(new DungeonWindowRequest(
                     new DungeonMapIdentity(41L),
                     1L,
                     List.of(new DungeonChunkKey(41L, 5, -1, -2))))
@@ -78,7 +81,7 @@ final class DungeonCanonicalSpatialIndexTest {
             assertEquals(new Cell(1, 0, 5), door.relativeCell());
             assertEquals(new Cell(-64, -65, 5), door.absoluteCell());
 
-            DungeonWindow interiorWindow = new SqliteDungeonWindowStore(database).loadWindow(
+            DungeonWindow interiorWindow = windows.loadWindow(
                     new DungeonWindowRequest(
                             new DungeonMapIdentity(41L),
                             2L,

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonSqliteReadSnapshotTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonSqliteReadSnapshotTest.java
@@ -3,6 +3,7 @@ package features.dungeon.adapter.sqlite.gateway;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
@@ -11,7 +12,9 @@ import features.dungeon.application.authored.port.DungeonEntitySnapshot;
 import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
 import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
 import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
 import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
@@ -40,7 +43,7 @@ final class DungeonSqliteReadSnapshotTest {
     private static final long OLD_REVISION = 9L;
 
     @Test
-    void windowCannotCombineOldHeaderWithConcurrentNewEntityFacts(@TempDir Path tempDir) throws Exception {
+    void twoPhaseWindowRejectsConcurrentRevisionInsteadOfCombiningFacts(@TempDir Path tempDir) throws Exception {
         Path path = tempDir.resolve("window-snapshot.db");
         try (SqliteDatabase database = savedDatabase(path)) {
             enableWal(path);
@@ -48,18 +51,17 @@ final class DungeonSqliteReadSnapshotTest {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database, update::afterHeaderRead);
             update.start();
 
-            DungeonWindow window = gateway.loadWindow(new DungeonWindowRequest(
+            DungeonWindowRequest request = new DungeonWindowRequest(
                     new DungeonMapIdentity(MAP_ID),
                     4L,
-                    List.of(new DungeonChunkKey(MAP_ID, 0, 1, 0))))
-                    .orElseThrow();
+                    List.of(new DungeonChunkKey(MAP_ID, 0, 1, 0)));
+            DungeonWindowIndex index = gateway.loadIndex(request).orElseThrow();
             update.joinAndAssert();
 
-            assertEquals(OLD_REVISION, window.mapHeader().revision());
-            DungeonWindowEntityFragment.FeatureMarker marker = assertInstanceOf(
-                    DungeonWindowEntityFragment.FeatureMarker.class,
-                    window.fragments().getFirst());
-            assertEquals("old marker", marker.label());
+            assertEquals(OLD_REVISION, index.mapHeader().revision());
+            assertTrue(gateway.loadContent(new DungeonWindowContentRequest(
+                    index.mapHeader().mapId(), index.mapHeader().revision(),
+                    index.requestGeneration(), index.chunkHeaders())).isEmpty());
             assertCommittedNewState(path);
         }
     }

--- a/test/features/dungeon/adapter/sqlite/repository/SqliteDungeonUnitOfWorkTest.java
+++ b/test/features/dungeon/adapter/sqlite/repository/SqliteDungeonUnitOfWorkTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import features.dungeon.adapter.sqlite.gateway.DungeonSqliteFixtureSeeder;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.dungeon.application.authored.command.CorridorChange;
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.application.authored.command.DungeonPatchChange;
@@ -19,6 +20,7 @@ import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
 import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
 import features.dungeon.application.authored.port.DungeonWindow;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.application.authored.port.DungeonWindowStore;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.component.CorridorWaypoint;
 import features.dungeon.domain.core.component.StairExit;
@@ -60,7 +62,8 @@ final class SqliteDungeonUnitOfWorkTest {
         try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
             DungeonSqliteFixtureSeeder.insertHeader(database, MAP_ID, "Patch map", 1L);
             SqliteDungeonUnitOfWork unitOfWork = new SqliteDungeonUnitOfWork(database);
-            SqliteDungeonWindowStore readStore = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore readStore = new DungeonCachedWindowStore(
+                    new SqliteDungeonWindowStore(database));
 
             Facts first = facts("first", false);
             DungeonUnitOfWorkResult.Committed inserted = committed(unitOfWork.commit(
@@ -119,7 +122,7 @@ final class SqliteDungeonUnitOfWorkTest {
     }
 
     private static void assertExactProductionRead(
-            SqliteDungeonWindowStore readStore,
+            DungeonWindowStore readStore,
             long revision,
             Facts expected
     ) {

--- a/test/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStoreTest.java
+++ b/test/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStoreTest.java
@@ -10,6 +10,7 @@ import features.dungeon.adapter.sqlite.gateway.DungeonSqliteFixtureSeeder;
 import features.dungeon.adapter.sqlite.gateway.DungeonSqliteWindowGateway;
 import features.dungeon.adapter.sqlite.model.DungeonPersistenceSchema;
 import features.dungeon.application.authored.command.CorridorChange;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
 import features.dungeon.application.authored.command.DungeonPatchResultFacts;
@@ -21,8 +22,11 @@ import features.dungeon.application.authored.command.TransitionChange;
 import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
 import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
 import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
 import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.application.authored.port.DungeonWindowStore;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.component.CorridorAnchor;
 import features.dungeon.domain.core.component.CorridorAnchorRef;
@@ -68,12 +72,37 @@ final class SqliteDungeonWindowStoreTest {
     private static final long REVISION = 9L;
 
     @Test
+    void cachedSingleChunkReadsReassembleTheExactSQLiteWindow(@TempDir Path tempDir) {
+        try (SqliteDatabase database = savedDatabase(tempDir.resolve("cached-window.db"))) {
+            DungeonCachedWindowStore cached = new DungeonCachedWindowStore(
+                    new SqliteDungeonWindowStore(database));
+            DungeonWindowRequest request = new DungeonWindowRequest(
+                    new DungeonMapIdentity(MAP_ID), 41L,
+                    List.of(key(0, -1, -1), key(0, 0, -1), key(0, 1, 0), key(1, 0, 1)));
+
+            DungeonWindow first = cached.loadWindow(request).orElseThrow();
+            DungeonWindow warm = cached.loadWindow(new DungeonWindowRequest(
+                    request.mapId(), 42L, request.chunkKeys())).orElseThrow();
+
+            assertEquals(request.chunkKeys(), first.chunkHeaders().stream()
+                    .map(header -> header.key()).toList());
+            assertEquals(first.fragments().stream().map(DungeonWindowEntityFragment::entityRef).toList(),
+                    warm.fragments().stream().map(DungeonWindowEntityFragment::entityRef).toList());
+            assertEquals(42L, warm.requestGeneration());
+            assertTypedAuthoredSemantics(warm);
+            assertTrue(warm.fragments().stream()
+                    .flatMap(fragment -> fragmentCells(fragment).stream())
+                    .allMatch(cell -> requestedFact(cell, warm)));
+        }
+    }
+
+    @Test
     void loadsExactNonRectangularWindowWithSixKindsStableHeadersAndContinuations(@TempDir Path tempDir)
             throws Exception {
         Path path = tempDir.resolve("window.db");
         try (SqliteDatabase database = savedDatabase(path)) {
             insertUnindexedMalformedTransition(path);
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             DungeonWindow window = store.loadWindow(new DungeonWindowRequest(
                     new DungeonMapIdentity(MAP_ID),
                     42L,
@@ -140,7 +169,7 @@ final class SqliteDungeonWindowStoreTest {
         int singleClosureStatements;
         try (SqliteDatabase database = savedDatabase(tempDir.resolve("single-count.db"), 1)) {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            gateway.loadWindow(markerWindow()).orElseThrow();
+            loadWindow(gateway, markerWindow()).orElseThrow();
             singleWindowStatements = gateway.lastStatementCount();
             gateway.loadIdentityClosure(markerClosure(1));
             singleClosureStatements = gateway.lastStatementCount();
@@ -148,7 +177,7 @@ final class SqliteDungeonWindowStoreTest {
 
         try (SqliteDatabase database = savedDatabase(tempDir.resolve("many-count.db"), 25)) {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            DungeonWindow window = gateway.loadWindow(markerWindow()).orElseThrow();
+            DungeonWindow window = loadWindow(gateway, markerWindow()).orElseThrow();
             assertEquals(25L, window.fragments().stream()
                     .filter(DungeonWindowEntityFragment.FeatureMarker.class::isInstance)
                     .count());
@@ -170,14 +199,14 @@ final class SqliteDungeonWindowStoreTest {
         int singleClosureStatements;
         try (SqliteDatabase database = savedGraphDatabase(tempDir.resolve("single-graph.db"), 1)) {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            gateway.loadWindow(corridorWindow()).orElseThrow();
+            loadWindow(gateway, corridorWindow()).orElseThrow();
             singleWindowStatements = gateway.lastStatementCount();
             gateway.loadIdentityClosure(corridorClosure(1));
             singleClosureStatements = gateway.lastStatementCount();
         }
         try (SqliteDatabase database = savedGraphDatabase(tempDir.resolve("many-graphs.db"), 20)) {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            DungeonWindow window = gateway.loadWindow(corridorWindow()).orElseThrow();
+            DungeonWindow window = loadWindow(gateway, corridorWindow()).orElseThrow();
             assertEquals(21L, window.fragments().stream()
                     .filter(DungeonWindowEntityFragment.Corridor.class::isInstance)
                     .count());
@@ -193,7 +222,7 @@ final class SqliteDungeonWindowStoreTest {
     @Test
     void corridorWindowPublishesCanonicalInteriorRouteWithoutOmittedControlPoints(@TempDir Path tempDir) {
         try (SqliteDatabase database = savedGraphDatabase(tempDir.resolve("interior-route.db"), 2)) {
-            DungeonWindow window = new SqliteDungeonWindowStore(database).loadWindow(new DungeonWindowRequest(
+            DungeonWindow window = cachedStore(database).loadWindow(new DungeonWindowRequest(
                     new DungeonMapIdentity(MAP_ID),
                     19L,
                     List.of(key(0, 0, -1), key(0, -3, 4))))
@@ -230,7 +259,7 @@ final class SqliteDungeonWindowStoreTest {
         corruptPreDependencySchemaVersion(path);
 
         try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
-            assertTrue(new SqliteDungeonWindowStore(database).loadWindow(new DungeonWindowRequest(
+            assertTrue(cachedStore(database).loadWindow(new DungeonWindowRequest(
                     new DungeonMapIdentity(MAP_ID),
                     23L,
                     List.of(key(0, 0, -1))))
@@ -261,7 +290,7 @@ final class SqliteDungeonWindowStoreTest {
                     new DungeonMapIdentity(MAP_ID),
                     REVISION - 1L,
                     List.of(new CorridorChange(null, corridor, Set.of(key(0, 0, 0))))));
-            DungeonWindow window = new SqliteDungeonWindowStore(database).loadWindow(new DungeonWindowRequest(
+            DungeonWindow window = cachedStore(database).loadWindow(new DungeonWindowRequest(
                     new DungeonMapIdentity(MAP_ID), 20L, List.of(key(0, 0, 0))))
                     .orElseThrow();
             DungeonWindowEntityFragment.Corridor fragment = fragment(
@@ -291,7 +320,7 @@ final class SqliteDungeonWindowStoreTest {
         List<String> baselineSql;
         try (SqliteDatabase database = savedGraphDatabase(tempDir.resolve("bounded-baseline.db"), 1)) {
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            gateway.loadWindow(request).orElseThrow();
+            loadWindow(gateway, request).orElseThrow();
             baselineStatements = gateway.lastStatementCount();
             baselineSql = gateway.lastStatementSql();
         }
@@ -300,7 +329,7 @@ final class SqliteDungeonWindowStoreTest {
         try (SqliteDatabase database = savedGraphDatabase(path, 1)) {
             insertLargeOffWindowRoomPopulation(database, 4_096);
             DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
-            DungeonWindow window = gateway.loadWindow(request).orElseThrow();
+            DungeonWindow window = loadWindow(gateway, request).orElseThrow();
             DungeonWindowEntityFragment.Corridor corridor = fragment(
                     window, DungeonPatchEntityRef.corridor(302L),
                     DungeonWindowEntityFragment.Corridor.class);
@@ -333,7 +362,7 @@ final class SqliteDungeonWindowStoreTest {
     void exactClosureCompletesAllSixFamiliesInStableOrder(@TempDir Path tempDir) throws Exception {
         Path path = tempDir.resolve("closure.db");
         try (SqliteDatabase database = savedDatabase(path)) {
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             DungeonIdentityClosureResult.Complete complete = assertInstanceOf(
                     DungeonIdentityClosureResult.Complete.class,
                     store.loadIdentityClosure(new DungeonIdentityClosureRequest(
@@ -470,7 +499,7 @@ final class SqliteDungeonWindowStoreTest {
                     new DungeonMapIdentity(MAP_ID),
                     REVISION,
                     List.of(new StairChange(windowStair(null), windowStair(302L)))));
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             DungeonWindowEntityFragment.Stair stair = fragment(
                     store.loadWindow(stairWindow()).orElseThrow(),
                     DungeonPatchEntityRef.stair(401L),
@@ -607,7 +636,7 @@ final class SqliteDungeonWindowStoreTest {
              Connection connection = open(path);
              Statement statement = connection.createStatement()) {
             applyTargetedCorruption(statement, corruptionSql);
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             assertThrows(RuntimeException.class, () -> store.loadWindow(request));
         }
     }
@@ -659,7 +688,7 @@ final class SqliteDungeonWindowStoreTest {
                     applyTargetedCorruption(statement, statementSql);
                 }
             }
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             assertThrows(RuntimeException.class, () -> store.loadWindow(stairWindow()));
             DungeonIdentityClosureResult.Rejected rejected = assertInstanceOf(
                     DungeonIdentityClosureResult.Rejected.class,
@@ -677,7 +706,7 @@ final class SqliteDungeonWindowStoreTest {
                     "UPDATE dungeon_transitions SET linked_transition_id=" + linkedTransitionId
                             + " WHERE transition_id=501");
 
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             assertThrows(RuntimeException.class, () -> store.loadWindow(transitionWindow()));
             DungeonIdentityClosureResult.Rejected rejected = assertInstanceOf(
                     DungeonIdentityClosureResult.Rejected.class,
@@ -702,7 +731,7 @@ final class SqliteDungeonWindowStoreTest {
                         REVISION + 1L,
                         List.of(new TransitionChange(before, windowTransition(linkedTransitionId)))));
             }
-            SqliteDungeonWindowStore store = new SqliteDungeonWindowStore(database);
+            DungeonWindowStore store = cachedStore(database);
             DungeonWindowEntityFragment.Transition transition = fragment(
                     store.loadWindow(transitionWindow()).orElseThrow(),
                     DungeonPatchEntityRef.transition(501L),
@@ -729,6 +758,28 @@ final class SqliteDungeonWindowStoreTest {
 
     private static SqliteDatabase savedDatabase(Path path) {
         return savedDatabase(path, 1);
+    }
+
+    private static DungeonWindowStore cachedStore(SqliteDatabase database) {
+        return new DungeonCachedWindowStore(new SqliteDungeonWindowStore(database));
+    }
+
+    private static java.util.Optional<DungeonWindow> loadWindow(
+            DungeonSqliteWindowGateway gateway,
+            DungeonWindowRequest request
+    ) {
+        java.util.Optional<DungeonWindowIndex> indexed = gateway.loadIndex(request);
+        if (indexed.isEmpty()) {
+            return java.util.Optional.empty();
+        }
+        DungeonWindowIndex index = indexed.get();
+        if (index.chunkHeaders().isEmpty()) {
+            return java.util.Optional.of(new DungeonWindow(
+                    index.mapHeader(), index.requestGeneration(), List.of(), List.of(), List.of()));
+        }
+        return gateway.loadContent(new DungeonWindowContentRequest(
+                index.mapHeader().mapId(), index.mapHeader().revision(),
+                index.requestGeneration(), index.chunkHeaders()));
     }
 
     private static SqliteDatabase savedDatabase(Path path, int markerCount) {

--- a/test/features/dungeon/application/authored/DungeonCachedWindowStoreTest.java
+++ b/test/features/dungeon/application/authored/DungeonCachedWindowStoreTest.java
@@ -1,0 +1,146 @@
+package features.dungeon.application.authored;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
+import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
+import features.dungeon.application.authored.port.DungeonInboundReferenceRequest;
+import features.dungeon.application.authored.port.DungeonInboundReferenceResult;
+import features.dungeon.application.authored.port.DungeonMapHeader;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysRequest;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysResult;
+import features.dungeon.application.authored.port.DungeonTravelStartRequest;
+import features.dungeon.application.authored.port.DungeonTravelStartResult;
+import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowChunkHeader;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowContentSource;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class DungeonCachedWindowStoreTest {
+    private static final DungeonMapIdentity MAP_ID = new DungeonMapIdentity(7L);
+
+    @Test
+    void coldWarmPanAndTouchedInvalidationLoadOnlyRequiredChunkContents() {
+        CountingSource source = new CountingSource();
+        DungeonCachedWindowStore store = new DungeonCachedWindowStore(source);
+        List<DungeonChunkKey> nine = square(-1, -1, 3);
+
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 1L, nine)).isPresent());
+        assertEquals(9, source.contentReads);
+
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 2L, nine)).isPresent());
+        assertEquals(9, source.contentReads, "map request generations do not fragment the content cache");
+
+        List<DungeonChunkKey> panned = new ArrayList<>(nine);
+        panned.remove(0);
+        panned.add(chunk(9, -4));
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 3L, panned)).isPresent());
+        assertEquals(10, source.contentReads, "only the entering chunk is a miss");
+
+        DungeonChunkKey touched = panned.get(4);
+        source.revisions.put(touched, 2L);
+        store.invalidateChunks(List.of(touched));
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 4L, panned)).isPresent());
+        assertEquals(11, source.contentReads, "a successful touch reloads only the touched chunk");
+    }
+
+    @Test
+    void negativeChunksAndStaleTwoPhaseReadNeverPublishMixedContent() {
+        CountingSource source = new CountingSource();
+        DungeonCachedWindowStore store = new DungeonCachedWindowStore(source);
+        DungeonChunkKey negative = chunk(-12, -8);
+        source.changeRevisionDuringNextContent = negative;
+
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 1L, List.of(negative))).isEmpty());
+        assertEquals(1, source.contentReads);
+
+        assertTrue(store.loadWindow(new DungeonWindowRequest(MAP_ID, 2L, List.of(negative))).isPresent());
+        assertEquals(2, source.contentReads, "stale content was not inserted into the cache");
+        assertEquals(negative, store.loadWindow(new DungeonWindowRequest(MAP_ID, 3L, List.of(negative)))
+                .orElseThrow().chunkHeaders().get(0).key());
+        assertEquals(2, source.contentReads);
+    }
+
+    private static List<DungeonChunkKey> square(int minimumQ, int minimumR, int side) {
+        List<DungeonChunkKey> result = new ArrayList<>();
+        for (int r = minimumR; r < minimumR + side; r++) {
+            for (int q = minimumQ; q < minimumQ + side; q++) {
+                result.add(chunk(q, r));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static DungeonChunkKey chunk(int q, int r) {
+        return new DungeonChunkKey(MAP_ID.value(), 0, q, r);
+    }
+
+    private static final class CountingSource implements DungeonWindowContentSource {
+        private final Map<DungeonChunkKey, Long> revisions = new LinkedHashMap<>();
+        private int contentReads;
+        private DungeonChunkKey changeRevisionDuringNextContent;
+
+        @Override
+        public Optional<DungeonWindowIndex> loadIndex(DungeonWindowRequest request) {
+            return Optional.of(new DungeonWindowIndex(
+                    header(), request.requestGeneration(), request.chunkKeys().stream()
+                            .map(key -> new DungeonWindowChunkHeader(key, revisions.getOrDefault(key, 1L)))
+                            .toList()));
+        }
+
+        @Override
+        public Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request) {
+            contentReads++;
+            DungeonWindowChunkHeader expected = request.chunks().get(0);
+            if (changeRevisionDuringNextContent != null
+                    && changeRevisionDuringNextContent.equals(expected.key())) {
+                revisions.put(expected.key(), expected.contentRevision() + 1L);
+                changeRevisionDuringNextContent = null;
+                return Optional.empty();
+            }
+            if (request.expectedMapRevision() != 1L
+                    || expected.contentRevision() != revisions.getOrDefault(expected.key(), 1L)) {
+                return Optional.empty();
+            }
+            return Optional.of(new DungeonWindow(
+                    header(), request.requestGeneration(), request.chunks(), List.of(), List.of()));
+        }
+
+        private static DungeonMapHeader header() {
+            return new DungeonMapHeader(MAP_ID, "Cached", 1L);
+        }
+
+        @Override
+        public DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request) {
+            return new DungeonIdentityClosureResult.Rejected(
+                    DungeonIdentityClosureResult.Reason.ENTITY_MISSING, request.entityRefs());
+        }
+
+        @Override
+        public DungeonTravelStartResult locateTravelStart(DungeonTravelStartRequest request) {
+            return new DungeonTravelStartResult.Rejected(DungeonIdentityClosureResult.Reason.ENTITY_MISSING);
+        }
+
+        @Override
+        public DungeonTravelChunkKeysResult discoverTravelChunkKeys(DungeonTravelChunkKeysRequest request) {
+            return new DungeonTravelChunkKeysResult.Rejected(DungeonIdentityClosureResult.Reason.ENTITY_MISSING);
+        }
+
+        @Override
+        public DungeonInboundReferenceResult discoverInboundReferences(DungeonInboundReferenceRequest request) {
+            return new DungeonInboundReferenceResult.Rejected(
+                    DungeonIdentityClosureResult.Reason.ENTITY_MISSING, request.targetRefs());
+        }
+    }
+}

--- a/test/platform/ui/mapcanvas/WeightedViewportCacheTest.java
+++ b/test/platform/ui/mapcanvas/WeightedViewportCacheTest.java
@@ -3,6 +3,9 @@ package platform.ui.mapcanvas;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -17,5 +20,43 @@ final class WeightedViewportCacheTest {
         assertEquals("1234", cache.get("visible"));
         assertNull(cache.get("old"));
         assertEquals("12", cache.get("new"));
+    }
+
+    @Test
+    void batchAccessProtectionLeaseAndTargetedInvalidationAreAtomic() {
+        WeightedViewportCache<String, String> cache = new WeightedViewportCache<>(4L, String::length);
+        Map<String, String> initial = new LinkedHashMap<>();
+        initial.put("visible", "1234");
+        initial.put("edit", "12");
+        cache.replaceProtectedKeys(Set.of("visible"));
+        WeightedViewportCache.Lease editLease = cache.protect(Set.of("edit"));
+        cache.putAll(initial);
+
+        assertEquals(Map.of("visible", "1234", "edit", "12"),
+                cache.getAll(List.of("visible", "edit", "missing")));
+        assertEquals(6L, cache.weight(), "protected entries may be temporarily overweight");
+
+        editLease.close();
+        assertNull(cache.get("edit"), "release immediately evicts newly unprotected excess");
+        assertEquals("1234", cache.get("visible"));
+
+        cache.invalidateAll(Set.of("visible"));
+        assertEquals(0, cache.size());
+        assertEquals(0L, cache.weight());
+    }
+
+    @Test
+    void replacingProtectionEvictsExcessAndPredicateInvalidationIsTargeted() {
+        WeightedViewportCache<String, String> cache = new WeightedViewportCache<>(2L, ignored -> 2L);
+        cache.replaceProtectedKeys(Set.of("a", "b"));
+        cache.putAll(Map.of("a", "A", "b", "B"));
+        assertEquals(4L, cache.weight());
+
+        cache.replaceProtectedKeys(Set.of("b"));
+        assertNull(cache.get("a"));
+        assertEquals("B", cache.get("b"));
+
+        cache.invalidateIf(key -> key.startsWith("b"));
+        assertEquals(0, cache.size());
     }
 }

--- a/test/shell/host/SessionPlannerShellLayoutTest.java
+++ b/test/shell/host/SessionPlannerShellLayoutTest.java
@@ -43,6 +43,7 @@ import features.creatures.adapter.sqlite.query.SqliteCreatureCatalogQueryAdapter
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonCatalogStore;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonUnitOfWork;
 import features.dungeon.adapter.sqlite.repository.SqliteDungeonWindowStore;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
 import features.dungeon.adapter.sqlite.model.DungeonPersistenceSchema;
 import features.encounter.adapter.sqlite.repository.SqliteEncounterPlanRepository;
 import features.encountertable.adapter.sqlite.query.SqliteEncounterTableCatalogAdapter;
@@ -241,7 +242,7 @@ public final class SessionPlannerShellLayoutTest {
         SqliteDungeonCatalogStore dungeonCatalog = new SqliteDungeonCatalogStore(dungeonDatabase);
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
                 dungeonCatalog,
-                new SqliteDungeonWindowStore(dungeonDatabase),
+                new DungeonCachedWindowStore(new SqliteDungeonWindowStore(dungeonDatabase)),
                 new SqliteDungeonUnitOfWork(dungeonDatabase),
                 party.activeParty(),
                 party.travelPositions(),


### PR DESCRIPTION
Summary:
- share one feature-lifetime window cache across Editor worksets and Travel
- key immutable content by chunk and content revision, with visible and edit protection
- read SQLite indexes first and load only explicit revision-bound cache misses
- invalidate only committed touched chunks; keep rename, rejection and read-only refresh warm
- remove uncached whole-window SQLite conveniences and add targeted explicit reload

Proof:
- ./gradlew check --no-daemon --console=plain: BUILD SUCCESSFUL in 9m 58s
- ./gradlew installDesktopApp --no-daemon --console=plain: BUILD SUCCESSFUL in 41s
- architectureTest and focused cache/SQLite/application suites: green
- git diff --check: clean