### PR TITLE
perf: Session-Vorbereitung qualifizieren

### DIFF
--- a/app/AppBootstrap.java
+++ b/app/AppBootstrap.java
@@ -50,6 +50,8 @@ public final class AppBootstrap implements AutoCloseable {
     private final ExecutionLane sessionGenerationIoLane;
     private final ExecutionLane encounterGeneratedCpuLane;
     private final ExecutionLane encounterGeneratedIoLane;
+    private final ExecutionLane sessionPreparationCpuLane;
+    private final ExecutionLane sessionPreparationIoLane;
     private final UiDispatcher uiDispatcher;
     private final SqliteDatabase database;
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -73,44 +75,10 @@ public final class AppBootstrap implements AutoCloseable {
                         "encounter-generated-cpu",
                         Math.max(2, Runtime.getRuntime().availableProcessors() - 1)),
                 new BoundedExecutionLane(diagnostics, "encounter-generated-io", 2),
+                new BoundedExecutionLane(diagnostics, "session-preparation-cpu", 2),
+                new BoundedExecutionLane(diagnostics, "session-preparation-io", 2),
                 new JavaFxUiDispatcher(),
                 SqliteDatabase.defaultDatabase(SqliteDatabase.DEFAULT_DATABASE_FILE_NAME, diagnostics));
-    }
-
-    AppBootstrap(
-            Diagnostics diagnostics,
-            ExecutionLane executionLane,
-            UiDispatcher uiDispatcher,
-            SqliteDatabase database
-    ) {
-        this(
-                diagnostics,
-                executionLane,
-                new BoundedExecutionLane(diagnostics, "session-generation-cpu", 2),
-                new BoundedExecutionLane(diagnostics, "session-generation-io", 2),
-                new BoundedExecutionLane(diagnostics, "encounter-generated-cpu", 2),
-                new BoundedExecutionLane(diagnostics, "encounter-generated-io", 2),
-                uiDispatcher,
-                database);
-    }
-
-    AppBootstrap(
-            Diagnostics diagnostics,
-            ExecutionLane executionLane,
-            ExecutionLane sessionGenerationCpuLane,
-            ExecutionLane sessionGenerationIoLane,
-            UiDispatcher uiDispatcher,
-            SqliteDatabase database
-    ) {
-        this(
-                diagnostics,
-                executionLane,
-                sessionGenerationCpuLane,
-                sessionGenerationIoLane,
-                new BoundedExecutionLane(diagnostics, "encounter-generated-cpu", 2),
-                new BoundedExecutionLane(diagnostics, "encounter-generated-io", 2),
-                uiDispatcher,
-                database);
     }
 
     AppBootstrap(
@@ -120,6 +88,8 @@ public final class AppBootstrap implements AutoCloseable {
             ExecutionLane sessionGenerationIoLane,
             ExecutionLane encounterGeneratedCpuLane,
             ExecutionLane encounterGeneratedIoLane,
+            ExecutionLane sessionPreparationCpuLane,
+            ExecutionLane sessionPreparationIoLane,
             UiDispatcher uiDispatcher,
             SqliteDatabase database
     ) {
@@ -133,6 +103,10 @@ public final class AppBootstrap implements AutoCloseable {
                 encounterGeneratedCpuLane, "encounterGeneratedCpuLane");
         this.encounterGeneratedIoLane = java.util.Objects.requireNonNull(
                 encounterGeneratedIoLane, "encounterGeneratedIoLane");
+        this.sessionPreparationCpuLane = java.util.Objects.requireNonNull(
+                sessionPreparationCpuLane, "sessionPreparationCpuLane");
+        this.sessionPreparationIoLane = java.util.Objects.requireNonNull(
+                sessionPreparationIoLane, "sessionPreparationIoLane");
         this.uiDispatcher = java.util.Objects.requireNonNull(uiDispatcher, "uiDispatcher");
         this.database = java.util.Objects.requireNonNull(database, "database");
     }
@@ -155,12 +129,12 @@ public final class AppBootstrap implements AutoCloseable {
 
     private Components createComponents() {
         CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(
-                database, executionLane, uiDispatcher, diagnostics);
+                database, executionLane, sessionPreparationIoLane, uiDispatcher, diagnostics);
         EncounterTableServiceAssembly.Component encounterTables =
                 EncounterTableServiceAssembly.create(
                         database, executionLane, uiDispatcher, diagnostics);
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                database, executionLane, uiDispatcher, diagnostics);
+                database, executionLane, sessionPreparationIoLane, uiDispatcher, diagnostics);
         ItemsServiceAssembly.Component items = ItemsServiceAssembly.create(
                 database, executionLane, diagnostics);
 
@@ -210,6 +184,8 @@ public final class AppBootstrap implements AutoCloseable {
                 world.snapshot(),
                 generation,
                 executionLane,
+                sessionPreparationCpuLane,
+                sessionPreparationIoLane,
                 uiDispatcher,
                 diagnostics);
         SceneFeature.Component scene = SceneFeature.create(
@@ -506,6 +482,8 @@ public final class AppBootstrap implements AutoCloseable {
         sessionGenerationIoLane.close();
         encounterGeneratedCpuLane.close();
         encounterGeneratedIoLane.close();
+        sessionPreparationCpuLane.close();
+        sessionPreparationIoLane.close();
         executionLane.close();
         database.close();
     }

--- a/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
+++ b/docs/sessionplanner/delivery/roadmap-session-planner-greenfield.md
@@ -197,13 +197,13 @@ acceptance after the last UI diff.
 
 ## Current Migration Position
 
-- Current foundation: M0 through M4 are complete. Session Generation publishes
+- Current foundation: M0 through M5 are complete. Session Generation publishes
   the typed draft/commit/load/reward-read boundary, Encounter owns concrete
   deterministic roster batches and summary hydration, and Session Planner owns
   one confirmed preparation route, one revision-guarded final transaction, and
   one coherent revisioned workspace publication with typed foreign facts.
-- Current milestone: M5 enforces the delivered boundaries, removes remaining
-  migration compatibility, and proves production-route performance.
+- Current milestone: M6 compacts the passive frontend on the enforced workspace
+  boundary and closes owner-visible acceptance.
 - M0 closure: documentation whitespace, required `check`, and desktop install
   proof are green after the final owner-language diff.
 - M1 closure: the Golden fixture uses two level-3 and two level-4 characters,
@@ -244,6 +244,28 @@ acceptance after the last UI diff.
   child family. The final Session Planner and shell focused suite (`49s`),
   `git diff --check`, required `check` (`7m 27s`), and desktop install (`25s`)
   are green after the final M4 code diff.
+- M5 closure: Session preparation now owns bounded two-worker
+  `session-preparation-cpu` and `session-preparation-io` lanes; authored commands
+  alone retain the global serial lane. Party and Creature preparation reads use
+  the preparation I/O lane, while JDBC-observed diagnostics report two prepared
+  statement families for each owner read and seven for one complete planner
+  workspace capture. Architecture gates enforce passive JavaFX, the sole
+  workspace publication, dependency direction, and absence of the retired
+  preview, slot-import, and old publication types. The retire audit and runtime
+  composition proof close the compatibility-constructor and same-lane seams.
+  The real SQLite production route proves cancellation/latest-wins and
+  idempotent retry after a foreign storage failure, including one generation
+  run and three Encounter origins after retry. The final canonical fixture
+  recorded cold catalog `86043904ns`, cold store initialization `50522527ns`,
+  warm sorted
+  durations `[84420110, 85829566, 86106004, 87027889, 87097314, 87303342,
+  87359192, 88492792, 89082199, 92037925, 92670368, 93201598, 93448440,
+  93698531, 94468680, 96211973, 97054078, 97203380, 98094012, 101839373]ns`,
+  and p95 `98094012ns` over 20 runs. Focused production/cardinality proof (`21s`),
+  JavaFX next-turn Generate-to-Cancel proof (`22s`), architecture proof (`36s`),
+  the full M5 focused suite (`33s`), `git diff --check`, and required `check`
+  (`8m 6s`) are green after the final M5 backend diff; final roadmap whitespace,
+  `check` (`47s`), and desktop install (`8s`) are green.
 
 ## Delivery Rules
 

--- a/features/creatures/CreaturesServiceAssembly.java
+++ b/features/creatures/CreaturesServiceAssembly.java
@@ -35,6 +35,7 @@ public final class CreaturesServiceAssembly {
         return create(
                 catalogPort,
                 DirectExecutionLane.INSTANCE,
+                DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
     }
@@ -42,12 +43,16 @@ public final class CreaturesServiceAssembly {
     public static Component create(
             SqliteDatabase database,
             ExecutionLane executionLane,
+            ExecutionLane factsLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
         return create(
-                new SqliteCreatureCatalogQueryAdapter(Objects.requireNonNull(database, "database")),
+                new SqliteCreatureCatalogQueryAdapter(
+                        Objects.requireNonNull(database, "database"),
+                        Objects.requireNonNull(diagnostics, "diagnostics")),
                 executionLane,
+                factsLane,
                 uiDispatcher,
                 diagnostics);
     }
@@ -55,6 +60,7 @@ public final class CreaturesServiceAssembly {
     public static Component create(
             CreatureCatalogPort catalogPort,
             ExecutionLane executionLane,
+            ExecutionLane factsLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
@@ -81,6 +87,7 @@ public final class CreaturesServiceAssembly {
                 safeCatalogPort,
                 publishedState,
                 safeExecutionLane,
+                Objects.requireNonNull(factsLane, "factsLane"),
                 safeDiagnostics);
         CreatureReferenceApi references = creatureId -> {
             if (creatureId <= 0L) {

--- a/features/creatures/adapter/sqlite/gateway/local/SqliteCreatureCatalogLocalGateway.java
+++ b/features/creatures/adapter/sqlite/gateway/local/SqliteCreatureCatalogLocalGateway.java
@@ -1,10 +1,14 @@
 package features.creatures.adapter.sqlite.gateway.local;
 
 import platform.diagnostics.NoopDiagnostics;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 import platform.persistence.FeatureStoreDefinition;
 import platform.persistence.FeatureStoreHandle;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
+import platform.persistence.SqliteQueryCounter;
 import org.jspecify.annotations.Nullable;
 import features.creatures.adapter.sqlite.model.CreatureCatalogPageRecord;
 import features.creatures.adapter.sqlite.model.CreatureCatalogSearchCriteriaRecord;
@@ -23,12 +27,15 @@ import java.util.Objects;
  */
 public final class SqliteCreatureCatalogLocalGateway {
 
+    private static final DiagnosticId FACTS_READ = new DiagnosticId("creatures.sqlite.facts-read");
+
     private final FeatureStoreHandle connections;
     private final CreatureCatalogFilterValuesSqliteStore filterValuesStore = new CreatureCatalogFilterValuesSqliteStore();
     private final CreatureCatalogSearchSqliteStore catalogSearchStore = new CreatureCatalogSearchSqliteStore();
     private final CreatureDetailSqliteStore creatureDetailStore = new CreatureDetailSqliteStore();
     private final EncounterCandidateSqliteStore encounterCandidateStore = new EncounterCandidateSqliteStore();
     private final CreatureFactsSqliteStore creatureFactsStore = new CreatureFactsSqliteStore();
+    private final Diagnostics diagnostics;
 
     public SqliteCreatureCatalogLocalGateway() {
         this(SqliteDatabase.defaultDatabase(
@@ -37,11 +44,16 @@ public final class SqliteCreatureCatalogLocalGateway {
     }
 
     public SqliteCreatureCatalogLocalGateway(SqliteDatabase database) {
+        this(database, NoopDiagnostics.INSTANCE);
+    }
+
+    public SqliteCreatureCatalogLocalGateway(SqliteDatabase database, Diagnostics diagnostics) {
         CreaturesSchemaMigrator schemaMigrator = new CreaturesSchemaMigrator();
         this.connections = Objects.requireNonNull(database, "database").featureStore(
                 FeatureStoreDefinition.of(
                         "creatures",
                         new SqliteMigration(1, schemaMigrator::ensureSchema)));
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public CreatureFilterValuesRecord loadFilterValues() {
@@ -85,8 +97,19 @@ public final class SqliteCreatureCatalogLocalGateway {
             features.creatures.domain.catalog.CreatureCatalogData.CreatureFactsSpec spec
     ) {
         Objects.requireNonNull(spec, "spec");
-        try (Connection connection = openReadyConnection()) {
-            return creatureFactsStore.load(connection, spec);
+        long startedNanos = System.nanoTime();
+        try {
+            SqliteQueryCounter counted = new SqliteQueryCounter(openReadyConnection());
+            try (Connection connection = counted.connection()) {
+                List<EncounterCandidateRecord> facts = creatureFactsStore.load(connection, spec);
+                diagnostics.measurement(new Measurement(
+                        FACTS_READ,
+                        0L,
+                        Math.max(0L, System.nanoTime() - startedNanos),
+                        facts.size(),
+                        counted.queryCount()));
+                return facts;
+            }
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to load requested creature facts from SQLite.", exception);
         }

--- a/features/creatures/adapter/sqlite/query/SqliteCreatureCatalogQueryAdapter.java
+++ b/features/creatures/adapter/sqlite/query/SqliteCreatureCatalogQueryAdapter.java
@@ -2,6 +2,7 @@ package features.creatures.adapter.sqlite.query;
 
 import org.jspecify.annotations.Nullable;
 import platform.persistence.SqliteDatabase;
+import platform.diagnostics.Diagnostics;
 import features.creatures.adapter.sqlite.gateway.local.SqliteCreatureCatalogLocalGateway;
 import features.creatures.adapter.sqlite.mapper.CreatureCatalogQueryMappingFacade;
 import features.creatures.domain.catalog.CreatureCatalogData.CatalogPageData;
@@ -24,6 +25,10 @@ public final class SqliteCreatureCatalogQueryAdapter implements CreatureCatalogP
 
     public SqliteCreatureCatalogQueryAdapter(SqliteDatabase database) {
         this(new SqliteCreatureCatalogLocalGateway(database));
+    }
+
+    public SqliteCreatureCatalogQueryAdapter(SqliteDatabase database, Diagnostics diagnostics) {
+        this(new SqliteCreatureCatalogLocalGateway(database, diagnostics));
     }
 
     SqliteCreatureCatalogQueryAdapter(SqliteCreatureCatalogLocalGateway gateway) {

--- a/features/creatures/application/CreaturesApplicationService.java
+++ b/features/creatures/application/CreaturesApplicationService.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
 import platform.diagnostics.DiagnosticId;
 import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 import platform.diagnostics.NoopDiagnostics;
 import platform.execution.DirectExecutionLane;
 import platform.execution.ExecutionLane;
@@ -56,6 +57,7 @@ public final class CreaturesApplicationService
     private static final DiagnosticId DETAIL_FAILURE = new DiagnosticId("creatures.detail.storage-failure");
     private static final DiagnosticId ENCOUNTER_CANDIDATES_FAILURE =
             new DiagnosticId("creatures.encounter-candidates.storage-failure");
+    private static final DiagnosticId FACTS_READ = new DiagnosticId("creatures.facts.read");
 
     private static final List<String> CHALLENGE_RATINGS = List.of(
             "0", "1/8", "1/4", "1/2",
@@ -102,6 +104,7 @@ public final class CreaturesApplicationService
     private final CreatureCatalogPort lookup;
     private final CreaturesPublishedState publishedState;
     private final ExecutionLane executionLane;
+    private final ExecutionLane factsLane;
     private final Diagnostics diagnostics;
     private final Object referenceIndexLock = new Object();
     private long referenceIndexRevision;
@@ -114,6 +117,7 @@ public final class CreaturesApplicationService
                 lookup,
                 publishedState,
                 DirectExecutionLane.INSTANCE,
+                DirectExecutionLane.INSTANCE,
                 NoopDiagnostics.INSTANCE);
     }
 
@@ -121,11 +125,13 @@ public final class CreaturesApplicationService
             CreatureCatalogPort lookup,
             CreaturesPublishedState publishedState,
             ExecutionLane executionLane,
+            ExecutionLane factsLane,
             Diagnostics diagnostics
     ) {
         this.lookup = Objects.requireNonNull(lookup, "lookup");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
         this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.factsLane = Objects.requireNonNull(factsLane, "factsLane");
         this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
@@ -277,7 +283,7 @@ public final class CreaturesApplicationService
             return completion;
         }
         try {
-            executionLane.execute(() -> completion.complete(loadFactsInLane(query)));
+            factsLane.execute(() -> completion.complete(loadFactsInLane(query)));
         } catch (RuntimeException exception) {
             diagnostics.failure(ENCOUNTER_CANDIDATES_FAILURE, exception.getClass());
             completion.complete(CreatureFactsSnapshotResult.storageFailure());
@@ -286,14 +292,22 @@ public final class CreaturesApplicationService
     }
 
     private CreatureFactsSnapshotResult loadFactsInLane(CreatureFactsQuery query) {
+        long startedNanos = System.nanoTime();
         try {
             var mode = query.mode() == CreatureFactsQuery.Mode.XP_VALUES
                     ? CreatureCatalogData.CreatureFactsSpec.FactsMode.XP_VALUES
                     : CreatureCatalogData.CreatureFactsSpec.FactsMode.CREATURE_IDS;
-            return CreatureFactsSnapshotResult.success(lookup.loadCreatureFacts(
+            CreatureFactsSnapshotResult result = CreatureFactsSnapshotResult.success(lookup.loadCreatureFacts(
                     new CreatureCatalogData.CreatureFactsSpec(mode, query.values())).stream()
                     .map(CreatureCatalogProjection::encounterCandidate)
                     .toList());
+            diagnostics.measurement(new Measurement(
+                    FACTS_READ,
+                    0L,
+                    Math.max(0L, System.nanoTime() - startedNanos),
+                    query.values().size(),
+                    0));
+            return result;
         } catch (IllegalArgumentException exception) {
             return CreatureFactsSnapshotResult.invalidRequest();
         } catch (IllegalStateException exception) {

--- a/features/party/PartyServiceAssembly.java
+++ b/features/party/PartyServiceAssembly.java
@@ -33,6 +33,7 @@ public final class PartyServiceAssembly {
         Component component = assemble(
                 repository,
                 DirectExecutionLane.INSTANCE,
+                DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
         start(component);
@@ -42,12 +43,16 @@ public final class PartyServiceAssembly {
     public static Component create(
             SqliteDatabase database,
             ExecutionLane executionLane,
+            ExecutionLane planningFactsLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
         return assemble(
-                new SqlitePartyRosterRepository(Objects.requireNonNull(database, "database")),
+                new SqlitePartyRosterRepository(
+                        Objects.requireNonNull(database, "database"),
+                        Objects.requireNonNull(diagnostics, "diagnostics")),
                 executionLane,
+                planningFactsLane,
                 uiDispatcher,
                 diagnostics);
     }
@@ -55,10 +60,11 @@ public final class PartyServiceAssembly {
     public static Component create(
             PartyRosterRepository repository,
             ExecutionLane executionLane,
+            ExecutionLane planningFactsLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
-        Component component = assemble(repository, executionLane, uiDispatcher, diagnostics);
+        Component component = assemble(repository, executionLane, planningFactsLane, uiDispatcher, diagnostics);
         start(component);
         return component;
     }
@@ -66,6 +72,7 @@ public final class PartyServiceAssembly {
     private static Component assemble(
             PartyRosterRepository repository,
             ExecutionLane executionLane,
+            ExecutionLane planningFactsLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
@@ -82,6 +89,7 @@ public final class PartyServiceAssembly {
                 Objects.requireNonNull(repository, "repository"),
                 publishedState,
                 Objects.requireNonNull(executionLane, "executionLane"),
+                Objects.requireNonNull(planningFactsLane, "planningFactsLane"),
                 Objects.requireNonNull(diagnostics, "diagnostics"));
         return new Component(
                 application,

--- a/features/party/adapter/sqlite/gateway/local/SqlitePartyLocalGateway.java
+++ b/features/party/adapter/sqlite/gateway/local/SqlitePartyLocalGateway.java
@@ -1,9 +1,13 @@
 package features.party.adapter.sqlite.gateway.local;
 
 import platform.diagnostics.NoopDiagnostics;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 import platform.persistence.SqliteConnectionSource;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
+import platform.persistence.SqliteQueryCounter;
 import features.party.adapter.sqlite.model.PartyRosterRecord;
 
 import java.sql.Connection;
@@ -15,8 +19,11 @@ import java.util.Objects;
  */
 public final class SqlitePartyLocalGateway {
 
+    private static final DiagnosticId ROSTER_READ = new DiagnosticId("party.sqlite.roster-read");
+
     private final SqliteConnectionSource connections;
     private final PartyRosterSqliteStore store;
+    private final Diagnostics diagnostics;
 
     public SqlitePartyLocalGateway() {
         this(SqliteDatabase.defaultDatabase(
@@ -25,16 +32,32 @@ public final class SqlitePartyLocalGateway {
     }
 
     public SqlitePartyLocalGateway(SqliteDatabase database) {
+        this(database, NoopDiagnostics.INSTANCE);
+    }
+
+    public SqlitePartyLocalGateway(SqliteDatabase database, Diagnostics diagnostics) {
         PartyRosterSchemaMigrator schemaMigrator = new PartyRosterSchemaMigrator();
         this.connections = Objects.requireNonNull(database, "database").connections(
                 "party",
                 new SqliteMigration(1, schemaMigrator::ensureSchema));
         this.store = new PartyRosterSqliteStore();
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public PartyRosterRecord load() {
-        try (Connection connection = connections.openConnection()) {
-            return store.load(connection);
+        long startedNanos = System.nanoTime();
+        try {
+            SqliteQueryCounter counted = new SqliteQueryCounter(connections.openConnection());
+            try (Connection connection = counted.connection()) {
+                PartyRosterRecord roster = store.load(connection);
+                diagnostics.measurement(new Measurement(
+                        ROSTER_READ,
+                        0L,
+                        Math.max(0L, System.nanoTime() - startedNanos),
+                        roster.characters().size(),
+                        counted.queryCount()));
+                return roster;
+            }
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to load party roster from SQLite.", exception);
         }

--- a/features/party/adapter/sqlite/repository/SqlitePartyRosterRepository.java
+++ b/features/party/adapter/sqlite/repository/SqlitePartyRosterRepository.java
@@ -1,6 +1,7 @@
 package features.party.adapter.sqlite.repository;
 
 import platform.persistence.SqliteDatabase;
+import platform.diagnostics.Diagnostics;
 import features.party.adapter.sqlite.gateway.local.SqlitePartyLocalGateway;
 
 import java.util.Objects;
@@ -13,6 +14,10 @@ public final class SqlitePartyRosterRepository extends AbstractPartyRosterReposi
 
     public SqlitePartyRosterRepository(SqliteDatabase database) {
         this(new SqlitePartyLocalGateway(database));
+    }
+
+    public SqlitePartyRosterRepository(SqliteDatabase database, Diagnostics diagnostics) {
+        this(new SqlitePartyLocalGateway(database, diagnostics));
     }
 
     SqlitePartyRosterRepository(SqlitePartyLocalGateway gateway) {

--- a/features/party/application/PartyApplicationService.java
+++ b/features/party/application/PartyApplicationService.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import platform.diagnostics.DiagnosticId;
 import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 import platform.execution.ExecutionLane;
 import features.party.domain.roster.PartyCharacterDraft;
 import features.party.domain.roster.PartyDungeonTravelLocationKind;
@@ -55,10 +56,12 @@ import features.party.api.UpdateCharacterCommand;
 public final class PartyApplicationService implements features.party.api.PartyApi {
 
     private static final DiagnosticId STORAGE_FAILURE = new DiagnosticId("party.storage-failure");
+    private static final DiagnosticId PLANNING_FACTS_READ = new DiagnosticId("party.planning-facts.read");
 
     private final PartyRosterRepository repository;
     private final PartyPublishedState publishedState;
     private final ExecutionLane executionLane;
+    private final ExecutionLane planningFactsLane;
     private final Diagnostics diagnostics;
     private final AdventuringDayProgressCalculationHelper adventuringDayProgress =
             new AdventuringDayProgressCalculationHelper();
@@ -67,11 +70,13 @@ public final class PartyApplicationService implements features.party.api.PartyAp
             PartyRosterRepository repository,
             PartyPublishedState publishedState,
             ExecutionLane executionLane,
+            ExecutionLane planningFactsLane,
             Diagnostics diagnostics
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
         this.publishedState = Objects.requireNonNull(publishedState, "publishedState");
         this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.planningFactsLane = Objects.requireNonNull(planningFactsLane, "planningFactsLane");
         this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
@@ -148,7 +153,7 @@ public final class PartyApplicationService implements features.party.api.PartyAp
             return result;
         }
         try {
-            executionLane.execute(() -> completePlanningFacts(query, result));
+            planningFactsLane.execute(() -> completePlanningFacts(query, result));
         } catch (RuntimeException exception) {
             diagnostics.failure(STORAGE_FAILURE, exception.getClass());
             result.complete(PartyPlanningFactsResponse.failure(
@@ -161,6 +166,7 @@ public final class PartyApplicationService implements features.party.api.PartyAp
             PartyPlanningFactsQuery query,
             CompletableFuture<PartyPlanningFactsResponse> result
     ) {
+        long startedNanos = System.nanoTime();
         try {
             PartyRoster roster = repository.load();
             List<PartyMemberSummary> active = PartyPublishedProjection.activePartyResult(roster).members();
@@ -180,6 +186,12 @@ public final class PartyApplicationService implements features.party.api.PartyAp
                     PartyPublishedProjection.adventuringDayCalculationResult(
                             levels, query.plannedGroupXp(), adventuringDayProgress).planningSummary(),
                     ""));
+            diagnostics.measurement(new Measurement(
+                    PLANNING_FACTS_READ,
+                    0L,
+                    Math.max(0L, System.nanoTime() - startedNanos),
+                    query.participantIds().size(),
+                    0));
         } catch (RuntimeException exception) {
             diagnostics.failure(STORAGE_FAILURE, exception.getClass());
             result.complete(PartyPlanningFactsResponse.failure(

--- a/features/sessionplanner/SessionPlannerServiceAssembly.java
+++ b/features/sessionplanner/SessionPlannerServiceAssembly.java
@@ -20,6 +20,8 @@ import features.worldplanner.api.WorldPlannerSnapshotModel;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import platform.diagnostics.Diagnostics;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Measurement;
 import platform.execution.ExecutionLane;
 import platform.persistence.SqliteDatabase;
 import platform.ui.UiDispatcher;
@@ -27,7 +29,11 @@ import shell.api.ShellContribution;
 
 public final class SessionPlannerServiceAssembly {
 
+    private static final DiagnosticId JAVAFX_APPLY =
+            new DiagnosticId("sessionplanner.javafx.workspace-apply");
+
     private final Runtime runtime;
+    private final Diagnostics diagnostics;
 
     public static SessionPlannerServiceAssembly create(
             SqliteDatabase database,
@@ -36,7 +42,9 @@ public final class SessionPlannerServiceAssembly {
             SavedEncounterPlanListModel savedPlans,
             @Nullable WorldPlannerSnapshotModel worldPlanner,
             SessionGenerationApi generation,
-            ExecutionLane executionLane,
+            ExecutionLane authoredExecutionLane,
+            ExecutionLane preparationCpuLane,
+            ExecutionLane preparationIoLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
@@ -44,7 +52,8 @@ public final class SessionPlannerServiceAssembly {
                 Objects.requireNonNull(database, "database"));
         return new SessionPlannerServiceAssembly(
                 repository, repository, repository, party, encounters, savedPlans, worldPlanner,
-                generation, executionLane, uiDispatcher, diagnostics);
+                generation, authoredExecutionLane, preparationCpuLane, preparationIoLane,
+                uiDispatcher, diagnostics);
     }
 
     public SessionPlannerServiceAssembly(
@@ -56,7 +65,9 @@ public final class SessionPlannerServiceAssembly {
             SavedEncounterPlanListModel savedPlans,
             @Nullable WorldPlannerSnapshotModel worldPlanner,
             SessionGenerationApi generation,
-            ExecutionLane executionLane,
+            ExecutionLane authoredExecutionLane,
+            ExecutionLane preparationCpuLane,
+            ExecutionLane preparationIoLane,
             UiDispatcher uiDispatcher,
             Diagnostics diagnostics
     ) {
@@ -64,14 +75,17 @@ public final class SessionPlannerServiceAssembly {
         PartyApi safeParty = Objects.requireNonNull(party, "party");
         EncounterApi safeEncounters = Objects.requireNonNull(encounters, "encounters");
         SavedEncounterPlanListModel safeSavedPlans = Objects.requireNonNull(savedPlans, "savedPlans");
-        ExecutionLane lane = Objects.requireNonNull(executionLane, "executionLane");
+        ExecutionLane authoredLane = Objects.requireNonNull(authoredExecutionLane, "authoredExecutionLane");
+        ExecutionLane cpuLane = Objects.requireNonNull(preparationCpuLane, "preparationCpuLane");
+        ExecutionLane ioLane = Objects.requireNonNull(preparationIoLane, "preparationIoLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
         SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
                 Objects.requireNonNull(workspaceSource, "workspaceSource"), safeParty, safeEncounters,
-                safeSavedPlans, Objects.requireNonNull(generation, "generation"), worldPlanner, lane);
+                safeSavedPlans, Objects.requireNonNull(generation, "generation"), worldPlanner, ioLane, diagnostics);
         SessionPlannerWorkspacePublicationCoordinator publication =
                 new SessionPlannerWorkspacePublicationCoordinator(
                         assembler, Objects.requireNonNull(uiDispatcher, "uiDispatcher"),
-                        Objects.requireNonNull(diagnostics, "diagnostics"));
+                        diagnostics);
         SessionPreparationCoordinator preparation = new SessionPreparationCoordinator(
                 safeRepository,
                 Objects.requireNonNull(preparedSessions, "preparedSessions"),
@@ -79,10 +93,11 @@ public final class SessionPlannerServiceAssembly {
                 publication,
                 generation,
                 safeEncounters,
-                lane,
-                Objects.requireNonNull(diagnostics, "diagnostics"));
+                cpuLane,
+                ioLane,
+                diagnostics);
         SessionPlannerApplicationService application = new SessionPlannerApplicationService(
-                safeRepository, publication, preparation, lane, diagnostics);
+                safeRepository, publication, preparation, authoredLane, diagnostics);
         safeParty.activeParty().subscribe(ignored -> application.refreshPartyFacts());
         safeSavedPlans.subscribe(ignored -> application.refreshForeignFacts());
         if (worldPlanner != null) {
@@ -104,7 +119,13 @@ public final class SessionPlannerServiceAssembly {
     }
 
     public ShellContribution contribution() {
-        return new SessionPlannerContribution(runtime.applicationService(), workspaceModel());
+        return new SessionPlannerContribution(runtime.applicationService(), workspaceModel(), durationNanos ->
+                diagnostics.measurement(new Measurement(
+                        JAVAFX_APPLY,
+                        runtime.publication().current().preparation().attemptId(),
+                        durationNanos,
+                        1,
+                        0)));
     }
 
     private record Runtime(

--- a/features/sessionplanner/adapter/javafx/SessionPlannerBinder.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerBinder.java
@@ -36,13 +36,16 @@ final class SessionPlannerBinder {
 
     private final SessionPlannerApi planner;
     private final SessionPlannerWorkspaceModel workspace;
+    private final java.util.function.LongConsumer workspaceApplied;
 
     SessionPlannerBinder(
             SessionPlannerApi planner,
-            SessionPlannerWorkspaceModel workspace
+            SessionPlannerWorkspaceModel workspace,
+            java.util.function.LongConsumer workspaceApplied
     ) {
         this.planner = Objects.requireNonNull(planner, "planner");
         this.workspace = Objects.requireNonNull(workspace, "workspace");
+        this.workspaceApplied = Objects.requireNonNull(workspaceApplied, "workspaceApplied");
     }
 
     ShellBinding bind() {
@@ -129,12 +132,16 @@ final class SessionPlannerBinder {
         }));
 
         workspace.subscribe(snapshot -> {
+            long startedNanos = System.nanoTime();
             viewModel.applyWorkspace(snapshot);
             generationPanel.show(snapshot.preparation());
+            workspaceApplied.accept(Math.max(0L, System.nanoTime() - startedNanos));
         });
         SessionPlannerWorkspaceSnapshot initial = workspace.current();
+        long initialApplyStartedNanos = System.nanoTime();
         viewModel.applyWorkspace(initial);
         generationPanel.show(initial.preparation());
+        workspaceApplied.accept(Math.max(0L, System.nanoTime() - initialApplyStartedNanos));
         planner.initialize();
         return new Binding(ShellControls.stack(catalogView, controlsView), timelineView, summaryView);
     }

--- a/features/sessionplanner/adapter/javafx/SessionPlannerContribution.java
+++ b/features/sessionplanner/adapter/javafx/SessionPlannerContribution.java
@@ -16,10 +16,16 @@ public final class SessionPlannerContribution implements ShellContribution {
 
     private final SessionPlannerApi planner;
     private final SessionPlannerWorkspaceModel workspace;
+    private final java.util.function.LongConsumer workspaceApplied;
 
-    public SessionPlannerContribution(SessionPlannerApi planner, SessionPlannerWorkspaceModel workspace) {
+    public SessionPlannerContribution(
+            SessionPlannerApi planner,
+            SessionPlannerWorkspaceModel workspace,
+            java.util.function.LongConsumer workspaceApplied
+    ) {
         this.planner = Objects.requireNonNull(planner, "planner");
         this.workspace = Objects.requireNonNull(workspace, "workspace");
+        this.workspaceApplied = Objects.requireNonNull(workspaceApplied, "workspaceApplied");
     }
 
     @Override
@@ -35,6 +41,6 @@ public final class SessionPlannerContribution implements ShellContribution {
 
     @Override
     public ShellBinding bind() {
-        return new SessionPlannerBinder(planner, workspace).bind();
+        return new SessionPlannerBinder(planner, workspace, workspaceApplied).bind();
     }
 }

--- a/features/sessionplanner/adapter/sqlite/gateway/local/SessionPlanSqliteReads.java
+++ b/features/sessionplanner/adapter/sqlite/gateway/local/SessionPlanSqliteReads.java
@@ -59,7 +59,7 @@ final class SessionPlanSqliteReads {
         if (selectedId > 0L && plans.stream().noneMatch(plan -> plan.sessionId() == selectedId)) {
             currentSessionId = 0L;
         }
-        return new SqliteSessionPlannerLocalGateway.WorkspaceRead(currentSessionId, sessions);
+        return new SqliteSessionPlannerLocalGateway.WorkspaceRead(currentSessionId, sessions, 0);
     }
 
     Optional<SessionPlanSnapshotRecord> loadSession(Connection connection, long sessionId) throws SQLException {

--- a/features/sessionplanner/adapter/sqlite/gateway/local/SqliteSessionPlannerLocalGateway.java
+++ b/features/sessionplanner/adapter/sqlite/gateway/local/SqliteSessionPlannerLocalGateway.java
@@ -9,6 +9,7 @@ import platform.diagnostics.NoopDiagnostics;
 import platform.persistence.SqliteConnectionSource;
 import platform.persistence.SqliteDatabase;
 import platform.persistence.SqliteMigration;
+import platform.persistence.SqliteQueryCounter;
 import features.sessionplanner.adapter.sqlite.model.SessionPlanRecord;
 import features.sessionplanner.adapter.sqlite.model.SessionPlanSnapshotRecord;
 import features.sessionplanner.adapter.sqlite.model.SessionPlannerPersistenceSchema;
@@ -69,13 +70,19 @@ public final class SqliteSessionPlannerLocalGateway {
     }
 
     public WorkspaceRead loadWorkspace() {
-        try (Connection connection = openReadyConnection()) {
+        SqliteQueryCounter counted;
+        try {
+            counted = new SqliteQueryCounter(openReadyConnection());
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to load session planner workspace from SQLite.", exception);
+        }
+        try (Connection connection = counted.connection()) {
             boolean previousAutoCommit = connection.getAutoCommit();
             connection.setAutoCommit(false);
             try {
                 WorkspaceRead result = reads.loadWorkspace(connection);
                 connection.commit();
-                return result;
+                return new WorkspaceRead(result.currentSessionId(), result.sessions(), counted.queryCount());
             } catch (SQLException | RuntimeException exception) {
                 connection.rollback();
                 throw exception;
@@ -236,10 +243,13 @@ public final class SqliteSessionPlannerLocalGateway {
         ALREADY_EXISTS
     }
 
-    public record WorkspaceRead(long currentSessionId, List<SessionPlanSnapshotRecord> sessions) {
+    public record WorkspaceRead(long currentSessionId, List<SessionPlanSnapshotRecord> sessions, int queryCount) {
         public WorkspaceRead {
             currentSessionId = Math.max(0L, currentSessionId);
             sessions = sessions == null ? List.of() : List.copyOf(sessions);
+            if (queryCount < 0) {
+                throw new IllegalArgumentException("query count must not be negative");
+            }
         }
     }
 }

--- a/features/sessionplanner/adapter/sqlite/repository/SqliteSessionPlanRepository.java
+++ b/features/sessionplanner/adapter/sqlite/repository/SqliteSessionPlanRepository.java
@@ -67,7 +67,8 @@ public final class SqliteSessionPlanRepository
         SqliteSessionPlannerLocalGateway.WorkspaceRead read = gateway.loadWorkspace();
         return new SessionPlannerReadCapture(
                 read.currentSessionId(),
-                read.sessions().stream().map(SessionPlanMapper::toDomain).toList());
+                read.sessions().stream().map(SessionPlanMapper::toDomain).toList(),
+                read.queryCount());
     }
 
     @Override

--- a/features/sessionplanner/application/SessionPlannerReadCapture.java
+++ b/features/sessionplanner/application/SessionPlannerReadCapture.java
@@ -5,11 +5,14 @@ import java.util.List;
 import java.util.Optional;
 
 /** Complete Session Planner-owned read captured at one storage instant. */
-public record SessionPlannerReadCapture(long currentSessionId, List<SessionPlan> sessions) {
+public record SessionPlannerReadCapture(long currentSessionId, List<SessionPlan> sessions, int queryCount) {
 
     public SessionPlannerReadCapture {
         currentSessionId = Math.max(0L, currentSessionId);
         sessions = sessions == null ? List.of() : List.copyOf(sessions);
+        if (queryCount < 0) {
+            throw new IllegalArgumentException("query count must not be negative");
+        }
         if (sessions.stream().map(SessionPlan::sessionId).distinct().count() != sessions.size()) {
             throw new IllegalArgumentException("session ids must be unique");
         }

--- a/features/sessionplanner/application/SessionPlannerWorkspaceAssembler.java
+++ b/features/sessionplanner/application/SessionPlannerWorkspaceAssembler.java
@@ -54,6 +54,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.jspecify.annotations.Nullable;
 import platform.execution.ExecutionLane;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 
 /** Assembles one coherent workspace from one planner capture and bounded owner reads. */
 public final class SessionPlannerWorkspaceAssembler {
@@ -61,6 +64,8 @@ public final class SessionPlannerWorkspaceAssembler {
     private static final BigDecimal HUNDRED = new BigDecimal("100");
     private static final String ENCOUNTER_FAILURE = "Encounter-Details konnten nicht geladen werden.";
     private static final String REWARD_FAILURE = "Generierte Belohnungen konnten nicht geladen werden.";
+    private static final DiagnosticId WORKSPACE_ASSEMBLY =
+            new DiagnosticId("sessionplanner.workspace.assembly");
 
     private final SessionPlannerWorkspaceSource source;
     private final PartyApi party;
@@ -69,6 +74,7 @@ public final class SessionPlannerWorkspaceAssembler {
     private final SessionGenerationApi generation;
     private final @Nullable WorldPlannerSnapshotModel worldPlanner;
     private final ExecutionLane executionLane;
+    private final Diagnostics diagnostics;
 
     public SessionPlannerWorkspaceAssembler(
             SessionPlannerWorkspaceSource source,
@@ -77,7 +83,8 @@ public final class SessionPlannerWorkspaceAssembler {
             SavedEncounterPlanListModel savedPlans,
             SessionGenerationApi generation,
             @Nullable WorldPlannerSnapshotModel worldPlanner,
-            ExecutionLane executionLane
+            ExecutionLane executionLane,
+            Diagnostics diagnostics
     ) {
         this.source = Objects.requireNonNull(source, "source");
         this.party = Objects.requireNonNull(party, "party");
@@ -86,9 +93,11 @@ public final class SessionPlannerWorkspaceAssembler {
         this.generation = Objects.requireNonNull(generation, "generation");
         this.worldPlanner = worldPlanner;
         this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
     public CompletionStage<SessionPlannerWorkspaceAssembly> assemble(SessionPreparationSnapshot preparation) {
+        long startedNanos = System.nanoTime();
         CompletableFuture<SessionPlannerReadCapture> plannerRead = new CompletableFuture<>();
         try {
             executionLane.execute(() -> {
@@ -103,7 +112,15 @@ public final class SessionPlannerWorkspaceAssembler {
         }
         SessionPreparationSnapshot safePreparation = preparation == null
                 ? SessionPreparationSnapshot.idle() : preparation;
-        return plannerRead.thenCompose(capture -> hydrate(capture, safePreparation));
+        return plannerRead.thenCompose(capture -> hydrate(capture, safePreparation).thenApply(result -> {
+            diagnostics.measurement(new Measurement(
+                    WORKSPACE_ASSEMBLY,
+                    safePreparation.attemptId(),
+                    Math.max(0L, System.nanoTime() - startedNanos),
+                    result.workspace().sceneTimeline().sessionScenes().size(),
+                    capture.queryCount()));
+            return result;
+        }));
     }
 
     private CompletionStage<SessionPlannerWorkspaceAssembly> hydrate(

--- a/features/sessionplanner/application/SessionPreparationCoordinator.java
+++ b/features/sessionplanner/application/SessionPreparationCoordinator.java
@@ -40,12 +40,25 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import platform.diagnostics.DiagnosticId;
 import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 import platform.execution.ExecutionLane;
 
 public final class SessionPreparationCoordinator {
 
     private static final DiagnosticId PREPARATION_FAILURE =
             new DiagnosticId("sessionplanner.preparation-failure");
+    private static final DiagnosticId PARTY_READ =
+            new DiagnosticId("sessionplanner.preparation.party-read");
+    private static final DiagnosticId GENERATION_DRAFT =
+            new DiagnosticId("sessionplanner.preparation.generation-draft");
+    private static final DiagnosticId ENCOUNTER_PREPARE =
+            new DiagnosticId("sessionplanner.preparation.encounter-prepare");
+    private static final DiagnosticId PREPARED_ASSEMBLY =
+            new DiagnosticId("sessionplanner.preparation.prepared-assembly");
+    private static final DiagnosticId FOREIGN_COMMITS =
+            new DiagnosticId("sessionplanner.preparation.foreign-commits");
+    private static final DiagnosticId PLANNER_COMMIT =
+            new DiagnosticId("sessionplanner.preparation.planner-commit");
 
     private final SessionPlanRepository repository;
     private final SessionPreparedSessionStore preparedSessions;
@@ -53,7 +66,8 @@ public final class SessionPreparationCoordinator {
     private final SessionPlannerWorkspacePublicationCoordinator workspace;
     private final SessionGenerationApi generation;
     private final EncounterApi encounters;
-    private final ExecutionLane executionLane;
+    private final ExecutionLane cpuLane;
+    private final ExecutionLane ioLane;
     private final Diagnostics diagnostics;
     private long attemptSequence;
     private Attempt active;
@@ -65,7 +79,8 @@ public final class SessionPreparationCoordinator {
             SessionPlannerWorkspacePublicationCoordinator workspace,
             SessionGenerationApi generation,
             EncounterApi encounters,
-            ExecutionLane executionLane,
+            ExecutionLane cpuLane,
+            ExecutionLane ioLane,
             Diagnostics diagnostics
     ) {
         this.repository = Objects.requireNonNull(repository, "repository");
@@ -74,112 +89,99 @@ public final class SessionPreparationCoordinator {
         this.workspace = Objects.requireNonNull(workspace, "workspace");
         this.generation = Objects.requireNonNull(generation, "generation");
         this.encounters = Objects.requireNonNull(encounters, "encounters");
-        this.executionLane = Objects.requireNonNull(executionLane, "executionLane");
+        this.cpuLane = Objects.requireNonNull(cpuLane, "cpuLane");
+        this.ioLane = Objects.requireNonNull(ioLane, "ioLane");
         this.diagnostics = Objects.requireNonNull(diagnostics, "diagnostics");
     }
 
-    void prepare(PrepareSessionCommand command) {
+    synchronized void prepare(PrepareSessionCommand command) {
         Objects.requireNonNull(command, "command");
-        executionLane.execute(() -> prepareOnLane(command));
+        Attempt attempt = new Attempt(++attemptSequence, command);
+        active = attempt;
+        publish(SessionPreparationStatus.GENERATING, "Session wird vorbereitet …",
+                workspace.current().sourceSessionId(), attempt.id, true);
+        dispatchIo(attempt, () -> loadSession(attempt), "Session konnte nicht geladen werden.");
     }
 
-    void cancel() {
-        executionLane.execute(() -> invalidateOnLane(
-                SessionPreparationStatus.CANCELLED, "Vorbereitung abgebrochen."));
+    synchronized void cancel() {
+        invalidateNow(SessionPreparationStatus.CANCELLED, "Vorbereitung abgebrochen.");
     }
 
-    void invalidate() {
-        executionLane.execute(() -> invalidateOnLane(SessionPreparationStatus.IDLE, ""));
+    synchronized void invalidate() {
+        invalidateNow(SessionPreparationStatus.IDLE, "");
     }
 
-    private void prepareOnLane(PrepareSessionCommand command) {
-        long attemptId = ++attemptSequence;
-        active = null;
+    private void loadSession(Attempt attempt) {
         Optional<SessionPlan> loaded;
         try {
             loaded = repository.loadCurrent();
         } catch (IllegalStateException exception) {
-            diagnostics.failure(PREPARATION_FAILURE, exception.getClass());
-            publish(SessionPreparationStatus.FAILED, "Session konnte nicht geladen werden.", 0L, attemptId, false);
+            scheduleCpu(attempt, () -> fail(attempt, "Session konnte nicht geladen werden.", exception),
+                    "Session konnte nicht geladen werden.");
+            return;
+        }
+        scheduleCpu(attempt, () -> completeSessionLoad(attempt, loaded), "Session konnte nicht geladen werden.");
+    }
+
+    private synchronized void completeSessionLoad(Attempt attempt, Optional<SessionPlan> loaded) {
+        if (!isActive(attempt)) {
             return;
         }
         if (loaded.isEmpty()) {
-            publish(SessionPreparationStatus.INVALID, "Keine Session verfügbar.", 0L, attemptId, false);
+            invalid(attempt, "Keine Session verfügbar.");
             return;
         }
         SessionPlan session = loaded.orElseThrow();
-        if (replacesAuthoredContent(session) && !command.replacementConfirmed()) {
+        attempt.session = session;
+        if (replacesAuthoredContent(session) && !attempt.command.replacementConfirmed()) {
+            active = null;
             publish(
                     SessionPreparationStatus.CONFIRMING_REPLACEMENT,
                     "Vorhandene Szenen, Rasten und Beutenotizen werden ersetzt.",
-                    session.sessionId(), attemptId, false);
+                    session.sessionId(), attempt.id, false);
             return;
         }
         publish(SessionPreparationStatus.GENERATING, "Session wird generiert …",
-                session.sessionId(), attemptId, true);
+                session.sessionId(), attempt.id, true);
         CompletionStage<PartyPlanningFactsResponse> planningStage;
+        attempt.partyReadStartedNanos = System.nanoTime();
         try {
             planningStage = party.loadPlanningFacts(new PartyPlanningFactsQuery(session.participantRefs(), 0));
         } catch (RuntimeException exception) {
-            diagnostics.failure(PREPARATION_FAILURE, exception.getClass());
-            publish(SessionPreparationStatus.FAILED, "Party-Planungsdaten konnten nicht geladen werden.",
-                    session.sessionId(), attemptId, false);
+            fail(attempt, "Party-Planungsdaten konnten nicht geladen werden.", exception);
             return;
         }
         if (planningStage == null) {
-            publish(SessionPreparationStatus.FAILED, "Party-Planungsdaten konnten nicht geladen werden.",
-                    session.sessionId(), attemptId, false);
+            fail(attempt, "Party-Planungsdaten konnten nicht geladen werden.", null);
             return;
         }
-        try {
-            planningStage.whenComplete((response, failure) -> {
-                try {
-                    executionLane.execute(() ->
-                            completePlanningFacts(attemptId, session, command, response, failure));
-                } catch (RuntimeException schedulingFailure) {
-                    diagnostics.failure(PREPARATION_FAILURE, schedulingFailure.getClass());
-                    if (attemptSequence == attemptId) {
-                        publish(SessionPreparationStatus.FAILED,
-                                "Party-Planungsdaten konnten nicht abgeschlossen werden.",
-                                session.sessionId(), attemptId, false);
-                    }
-                }
-            });
-        } catch (RuntimeException exception) {
-            diagnostics.failure(PREPARATION_FAILURE, exception.getClass());
-            publish(SessionPreparationStatus.FAILED, "Party-Planungsdaten konnten nicht geladen werden.",
-                    session.sessionId(), attemptId, false);
-        }
+        observe(planningStage, (response, failure) -> completePlanningFacts(attempt, response, failure), attempt,
+                "Party-Planungsdaten konnten nicht geladen werden.");
     }
 
-    private void completePlanningFacts(
-            long attemptId,
-            SessionPlan session,
-            PrepareSessionCommand command,
+    private synchronized void completePlanningFacts(
+            Attempt attempt,
             PartyPlanningFactsResponse facts,
             Throwable failure
     ) {
-        if (attemptSequence != attemptId) {
+        if (!isActive(attempt)) {
             return;
         }
+        measure(PARTY_READ, attempt, attempt.partyReadStartedNanos,
+                attempt.session.participantRefs().size(), 0);
         if (failure != null) {
-            diagnostics.failure(PREPARATION_FAILURE, failure.getClass());
-            publish(SessionPreparationStatus.FAILED, "Party-Planungsdaten konnten nicht geladen werden.",
-                    session.sessionId(), attemptId, false);
+            fail(attempt, "Party-Planungsdaten konnten nicht geladen werden.", failure);
             return;
         }
         Optional<SessionPreparationFingerprint> captured = SessionPreparationFingerprint.capture(
-                session, facts, command.encounterCount(), command.seed());
+                attempt.session, facts, attempt.command.encounterCount(), attempt.command.seed());
         if (captured.isEmpty()) {
-            publish(
-                    SessionPreparationStatus.INVALID,
-                    "Alle Session-Teilnehmer müssen mit gültigem Level verfügbar sein.",
-                    session.sessionId(), attemptId, false);
+            invalid(attempt, "Alle Session-Teilnehmer müssen mit gültigem Level verfügbar sein.");
             return;
         }
-        Attempt attempt = new Attempt(attemptId, captured.orElseThrow());
-        active = attempt;
+        attempt.fingerprint = captured.orElseThrow();
         CompletionStage<GenerationDraftResponse> stage;
+        attempt.generationDraftStartedNanos = System.nanoTime();
         try {
             stage = generation.draft(attempt.fingerprint.toGenerationRequest());
         } catch (RuntimeException exception) {
@@ -194,7 +196,7 @@ public final class SessionPreparationCoordinator {
                 "Session konnte nicht generiert werden.");
     }
 
-    private void completeGenerationDraft(
+    private synchronized void completeGenerationDraft(
             Attempt attempt,
             GenerationDraftResponse response,
             Throwable failure
@@ -202,6 +204,9 @@ public final class SessionPreparationCoordinator {
         if (!isLive(attempt)) {
             return;
         }
+        int encounterCount = response == null || response.draft().isEmpty()
+                ? 0 : response.draft().orElseThrow().result().encounters().size();
+        measure(GENERATION_DRAFT, attempt, attempt.generationDraftStartedNanos, encounterCount, 0);
         if (failure != null) {
             fail(attempt, "Session konnte nicht generiert werden.", failure);
             return;
@@ -226,6 +231,7 @@ public final class SessionPreparationCoordinator {
         publish(SessionPreparationStatus.RESOLVING_ENCOUNTERS, "Encounter werden aufgelöst …",
                 attempt.fingerprint.sessionId(), attempt.id, true);
         CompletionStage<PreparedGeneratedEncounterBatchResult> stage;
+        attempt.encounterPrepareStartedNanos = System.nanoTime();
         try {
             stage = encounters.prepareGeneratedBatch(command);
         } catch (RuntimeException exception) {
@@ -241,7 +247,7 @@ public final class SessionPreparationCoordinator {
                 attempt, "Encounter konnten nicht vorbereitet werden.");
     }
 
-    private void completeEncounterPrepare(
+    private synchronized void completeEncounterPrepare(
             Attempt attempt,
             PreparedGeneratedEncounterBatchResult response,
             Throwable failure
@@ -249,6 +255,9 @@ public final class SessionPreparationCoordinator {
         if (!isLive(attempt)) {
             return;
         }
+        int rosterCount = response == null || response.batch().isEmpty()
+                ? 0 : response.batch().orElseThrow().rosters().size();
+        measure(ENCOUNTER_PREPARE, attempt, attempt.encounterPrepareStartedNanos, rosterCount, 0);
         if (failure != null) {
             fail(attempt, "Encounter konnten nicht vorbereitet werden.", failure);
             return;
@@ -264,6 +273,7 @@ public final class SessionPreparationCoordinator {
             return;
         }
         PreparedSessionDraft prepared;
+        long assemblyStarted = System.nanoTime();
         try {
             prepared = PreparedSessionDraft.assemble(
                     attempt.fingerprint,
@@ -273,6 +283,7 @@ public final class SessionPreparationCoordinator {
             invalid(attempt, "Vorbereitete Session ist unvollständig oder widersprüchlich.");
             return;
         }
+        measure(PREPARED_ASSEMBLY, attempt, assemblyStarted, prepared.scenes().size(), 0);
         if (!isLive(attempt)) {
             return;
         }
@@ -282,9 +293,10 @@ public final class SessionPreparationCoordinator {
         startForeignCommits(attempt);
     }
 
-    private void startForeignCommits(Attempt attempt) {
+    private synchronized void startForeignCommits(Attempt attempt) {
         CompletionStage<GenerationRunResponse> generationStage;
         CompletionStage<CommittedGeneratedEncounterBatchResult> encounterStage;
+        attempt.foreignCommitsStartedNanos = System.nanoTime();
         try {
             generationStage = generation.commit(new CommitGenerationRunCommand(attempt.prepared.generationDraft()));
             if (generationStage == null) {
@@ -309,16 +321,24 @@ public final class SessionPreparationCoordinator {
         try {
             stage.whenComplete((result, failure) -> scheduleCallback(
                     attempt,
-                    () -> {
-                        attempt.generationCommit = result;
-                        attempt.generationCommitFailure = failure;
-                        completeForeignCommits(attempt);
-                    },
+                    () -> completeForeignGeneration(attempt, result, failure),
                     "Generierte Session konnte nicht abgeschlossen werden."));
         } catch (RuntimeException exception) {
-            attempt.generationCommitFailure = exception;
-            completeForeignCommits(attempt);
+            completeForeignGeneration(attempt, null, exception);
         }
+    }
+
+    private synchronized void completeForeignGeneration(
+            Attempt attempt,
+            GenerationRunResponse result,
+            Throwable failure
+    ) {
+        if (!isActive(attempt)) {
+            return;
+        }
+        attempt.generationCommit = result;
+        attempt.generationCommitFailure = failure;
+        completeForeignCommits(attempt);
     }
 
     private void observeForeignEncounters(
@@ -328,23 +348,32 @@ public final class SessionPreparationCoordinator {
         try {
             stage.whenComplete((result, failure) -> scheduleCallback(
                     attempt,
-                    () -> {
-                        attempt.encounterCommit = result;
-                        attempt.encounterCommitFailure = failure;
-                        completeForeignCommits(attempt);
-                    },
+                    () -> completeForeignEncounters(attempt, result, failure),
                     "Encounter-Speicherung konnte nicht abgeschlossen werden."));
         } catch (RuntimeException exception) {
-            attempt.encounterCommitFailure = exception;
-            completeForeignCommits(attempt);
+            completeForeignEncounters(attempt, null, exception);
         }
     }
 
-    private void completeForeignCommits(Attempt attempt) {
+    private synchronized void completeForeignEncounters(
+            Attempt attempt,
+            CommittedGeneratedEncounterBatchResult result,
+            Throwable failure
+    ) {
+        if (!isActive(attempt)) {
+            return;
+        }
+        attempt.encounterCommit = result;
+        attempt.encounterCommitFailure = failure;
+        completeForeignCommits(attempt);
+    }
+
+    private synchronized void completeForeignCommits(Attempt attempt) {
         attempt.foreignCompletions++;
         if (attempt.foreignCompletions < 2) {
             return;
         }
+        measure(FOREIGN_COMMITS, attempt, attempt.foreignCommitsStartedNanos, 2, 0);
         if (!isLive(attempt)) {
             return;
         }
@@ -366,13 +395,37 @@ public final class SessionPreparationCoordinator {
         if (!isLive(attempt)) {
             return;
         }
+        attempt.plannerCommitStartedNanos = System.nanoTime();
+        dispatchIo(attempt, () -> commitPlanner(attempt, command), "Session konnte nicht gespeichert werden.");
+    }
+
+    private void commitPlanner(Attempt attempt, CommitPreparedSessionCommand command) {
         CommitPreparedSessionResult result;
         try {
+            Optional<SessionPlan> current = repository.loadCurrent();
+            if (current.isEmpty()
+                    || current.orElseThrow().sessionId() != attempt.fingerprint.sessionId()
+                    || !current.orElseThrow().revision().equals(attempt.fingerprint.sourceRevision())) {
+                scheduleCpu(attempt, () -> invalid(
+                                attempt, "Session wurde geändert; die Vorbereitung wurde nicht übernommen."),
+                        "Session konnte nicht auf Änderungen geprüft werden.");
+                return;
+            }
             result = preparedSessions.commitPreparedSession(command);
         } catch (RuntimeException exception) {
-            fail(attempt, "Session konnte nicht gespeichert werden.", exception);
+            scheduleCpu(attempt, () -> fail(attempt, "Session konnte nicht gespeichert werden.", exception),
+                    "Session konnte nicht gespeichert werden.");
             return;
         }
+        scheduleCpu(attempt, () -> completePlannerCommit(attempt, result), "Session konnte nicht gespeichert werden.");
+    }
+
+    private synchronized void completePlannerCommit(Attempt attempt, CommitPreparedSessionResult result) {
+        if (!isActive(attempt)) {
+            return;
+        }
+        measure(PLANNER_COMMIT, attempt, attempt.plannerCommitStartedNanos,
+                attempt.prepared.scenes().size(), 0);
         if (result == null) {
             fail(attempt, "Session konnte nicht gespeichert werden.", null);
             return;
@@ -551,30 +604,10 @@ public final class SessionPreparationCoordinator {
     }
 
     private boolean isLive(Attempt attempt) {
-        if (!isActive(attempt)) {
-            return false;
-        }
-        Optional<SessionPlan> current;
-        try {
-            current = repository.loadCurrent();
-        } catch (IllegalStateException exception) {
-            fail(attempt, "Session konnte nicht auf Änderungen geprüft werden.", exception);
-            return false;
-        }
-        if (current.isEmpty()
-                || current.orElseThrow().sessionId() != attempt.fingerprint.sessionId()
-                || !current.orElseThrow().revision().equals(attempt.fingerprint.sourceRevision())) {
-            active = null;
-            attemptSequence++;
-            publish(SessionPreparationStatus.INVALID,
-                    "Session wurde geändert; die ältere Vorbereitung wurde verworfen.",
-                    attempt.fingerprint.sessionId(), attempt.id, false);
-            return false;
-        }
-        return true;
+        return isActive(attempt);
     }
 
-    private boolean isActive(Attempt attempt) {
+    private synchronized boolean isActive(Attempt attempt) {
         return active == attempt && attemptSequence == attempt.id;
     }
 
@@ -584,29 +617,60 @@ public final class SessionPreparationCoordinator {
             String failureMessage
     ) {
         try {
-            executionLane.execute(callback);
+            cpuLane.execute(callback);
         } catch (RuntimeException exception) {
             fail(attempt, failureMessage, exception);
         }
     }
 
-    private void invalidateOnLane(SessionPreparationStatus status, String message) {
+    private void invalidateNow(SessionPreparationStatus status, String message) {
         long sessionId = workspace.current().preparation().sessionId();
         long attemptId = ++attemptSequence;
         active = null;
         publish(status, message, sessionId, attemptId, false);
     }
 
-    private void invalid(Attempt attempt, String message) {
+    private void dispatchIo(Attempt attempt, Runnable work, String failureMessage) {
+        try {
+            ioLane.execute(work);
+        } catch (RuntimeException exception) {
+            fail(attempt, failureMessage, exception);
+        }
+    }
+
+    private void scheduleCpu(Attempt attempt, Runnable work, String failureMessage) {
+        try {
+            cpuLane.execute(work);
+        } catch (RuntimeException exception) {
+            fail(attempt, failureMessage, exception);
+        }
+    }
+
+    private void measure(
+            DiagnosticId id,
+            Attempt attempt,
+            long startedNanos,
+            int cardinality,
+            int queryCount
+    ) {
+        diagnostics.measurement(new Measurement(
+                id,
+                attempt.id,
+                Math.max(0L, System.nanoTime() - startedNanos),
+                cardinality,
+                queryCount));
+    }
+
+    private synchronized void invalid(Attempt attempt, String message) {
         if (active != attempt) {
             return;
         }
         active = null;
         publish(SessionPreparationStatus.INVALID, message,
-                attempt.fingerprint.sessionId(), attempt.id, false);
+                sessionId(attempt), attempt.id, false);
     }
 
-    private void fail(Attempt attempt, String message, Throwable failure) {
+    private synchronized void fail(Attempt attempt, String message, Throwable failure) {
         if (failure != null) {
             diagnostics.failure(PREPARATION_FAILURE, failure.getClass());
         }
@@ -615,7 +679,17 @@ public final class SessionPreparationCoordinator {
         }
         active = null;
         publish(SessionPreparationStatus.FAILED, message,
-                attempt.fingerprint.sessionId(), attempt.id, false);
+                sessionId(attempt), attempt.id, false);
+    }
+
+    private long sessionId(Attempt attempt) {
+        if (attempt.fingerprint != null) {
+            return attempt.fingerprint.sessionId();
+        }
+        if (attempt.session != null) {
+            return attempt.session.sessionId();
+        }
+        return workspace.current().sourceSessionId();
     }
 
     private void publish(
@@ -643,18 +717,25 @@ public final class SessionPreparationCoordinator {
 
     private static final class Attempt {
         private final long id;
-        private final SessionPreparationFingerprint fingerprint;
+        private final PrepareSessionCommand command;
+        private SessionPlan session;
+        private SessionPreparationFingerprint fingerprint;
         private GenerationDraft generationDraft;
         private PreparedSessionDraft prepared;
+        private long partyReadStartedNanos;
+        private long generationDraftStartedNanos;
+        private long encounterPrepareStartedNanos;
+        private long foreignCommitsStartedNanos;
+        private long plannerCommitStartedNanos;
         private int foreignCompletions;
         private GenerationRunResponse generationCommit;
         private Throwable generationCommitFailure;
         private CommittedGeneratedEncounterBatchResult encounterCommit;
         private Throwable encounterCommitFailure;
 
-        private Attempt(long id, SessionPreparationFingerprint fingerprint) {
+        private Attempt(long id, PrepareSessionCommand command) {
             this.id = id;
-            this.fingerprint = fingerprint;
+            this.command = Objects.requireNonNull(command, "command");
         }
     }
 }

--- a/platform/diagnostics/Diagnostics.java
+++ b/platform/diagnostics/Diagnostics.java
@@ -3,4 +3,7 @@ package platform.diagnostics;
 public interface Diagnostics {
 
     void failure(DiagnosticId id, Class<? extends Throwable> failureType);
+
+    default void measurement(Measurement measurement) {
+    }
 }

--- a/platform/diagnostics/Measurement.java
+++ b/platform/diagnostics/Measurement.java
@@ -1,0 +1,33 @@
+package platform.diagnostics;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** Payload-free local timing and cardinality measurement for one bounded operation. */
+public record Measurement(
+        DiagnosticId id,
+        long operationId,
+        long durationNanos,
+        int cardinality,
+        int queryCount
+) {
+
+    private static final long MAX_DURATION_NANOS = Duration.ofHours(1).toNanos();
+    private static final int MAX_COUNT = 1_000_000;
+
+    public Measurement {
+        id = Objects.requireNonNull(id, "id");
+        if (operationId < 0L) {
+            throw new IllegalArgumentException("operation id must be nonnegative");
+        }
+        if (durationNanos < 0L || durationNanos > MAX_DURATION_NANOS) {
+            throw new IllegalArgumentException("duration must be between zero and one hour");
+        }
+        if (cardinality < 0 || cardinality > MAX_COUNT) {
+            throw new IllegalArgumentException("cardinality is outside the supported range");
+        }
+        if (queryCount < 0 || queryCount > MAX_COUNT) {
+            throw new IllegalArgumentException("query count is outside the supported range");
+        }
+    }
+}

--- a/platform/diagnostics/NoopDiagnostics.java
+++ b/platform/diagnostics/NoopDiagnostics.java
@@ -6,4 +6,8 @@ public enum NoopDiagnostics implements Diagnostics {
     @Override
     public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
     }
+
+    @Override
+    public void measurement(Measurement measurement) {
+    }
 }

--- a/platform/diagnostics/SystemLoggerDiagnostics.java
+++ b/platform/diagnostics/SystemLoggerDiagnostics.java
@@ -6,14 +6,19 @@ import java.util.function.Consumer;
 public final class SystemLoggerDiagnostics implements Diagnostics {
 
     private final Consumer<String> warningSink;
+    private final Consumer<String> measurementSink;
 
     public SystemLoggerDiagnostics() {
-        this(message -> System.getLogger(SystemLoggerDiagnostics.class.getName())
-                .log(System.Logger.Level.WARNING, message));
+        this(
+                message -> System.getLogger(SystemLoggerDiagnostics.class.getName())
+                        .log(System.Logger.Level.WARNING, message),
+                message -> System.getLogger(SystemLoggerDiagnostics.class.getName())
+                        .log(System.Logger.Level.INFO, message));
     }
 
-    SystemLoggerDiagnostics(Consumer<String> warningSink) {
+    SystemLoggerDiagnostics(Consumer<String> warningSink, Consumer<String> measurementSink) {
         this.warningSink = Objects.requireNonNull(warningSink, "warningSink");
+        this.measurementSink = Objects.requireNonNull(measurementSink, "measurementSink");
     }
 
     @Override
@@ -21,5 +26,15 @@ public final class SystemLoggerDiagnostics implements Diagnostics {
         warningSink.accept(Objects.requireNonNull(id, "id").value()
                 + " failure="
                 + Objects.requireNonNull(failureType, "failureType").getName());
+    }
+
+    @Override
+    public void measurement(Measurement measurement) {
+        Measurement safe = Objects.requireNonNull(measurement, "measurement");
+        measurementSink.accept(safe.id().value()
+                + " operation=" + safe.operationId()
+                + " durationNanos=" + safe.durationNanos()
+                + " cardinality=" + safe.cardinality()
+                + " queryCount=" + safe.queryCount());
     }
 }

--- a/platform/persistence/SqliteQueryCounter.java
+++ b/platform/persistence/SqliteQueryCounter.java
@@ -1,0 +1,39 @@
+package platform.persistence;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Counts the actual prepared statements created through one SQLite connection. */
+public final class SqliteQueryCounter {
+
+    private final AtomicInteger queries = new AtomicInteger();
+    private final Connection connection;
+
+    public SqliteQueryCounter(Connection delegate) {
+        Connection safeDelegate = Objects.requireNonNull(delegate, "delegate");
+        connection = (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[] {Connection.class},
+                (proxy, method, arguments) -> {
+                    if (method.getName().equals("prepareStatement")) {
+                        queries.incrementAndGet();
+                    }
+                    try {
+                        return method.invoke(safeDelegate, arguments);
+                    } catch (InvocationTargetException failure) {
+                        throw failure.getCause();
+                    }
+                });
+    }
+
+    public Connection connection() {
+        return connection;
+    }
+
+    public int queryCount() {
+        return queries.get();
+    }
+}

--- a/test/app/AppBootstrapLifecycleTest.java
+++ b/test/app/AppBootstrapLifecycleTest.java
@@ -21,6 +21,8 @@ final class AppBootstrapLifecycleTest {
         RecordingLane generationIo = new RecordingLane();
         RecordingLane encounterCpu = new RecordingLane();
         RecordingLane encounterIo = new RecordingLane();
+        RecordingLane preparationCpu = new RecordingLane();
+        RecordingLane preparationIo = new RecordingLane();
         AppBootstrap bootstrap = new AppBootstrap(
                 NoopDiagnostics.INSTANCE,
                 shared,
@@ -28,6 +30,8 @@ final class AppBootstrapLifecycleTest {
                 generationIo,
                 encounterCpu,
                 encounterIo,
+                preparationCpu,
+                preparationIo,
                 DirectUiDispatcher.INSTANCE,
                 new SqliteDatabase(temporaryDirectory.resolve("lifecycle.sqlite"), NoopDiagnostics.INSTANCE));
 
@@ -38,6 +42,8 @@ final class AppBootstrapLifecycleTest {
         assertEquals(1, generationIo.closes);
         assertEquals(1, encounterCpu.closes);
         assertEquals(1, encounterIo.closes);
+        assertEquals(1, preparationCpu.closes);
+        assertEquals(1, preparationIo.closes);
         assertEquals(1, shared.closes);
     }
 

--- a/test/app/SmokeStartupTest.java
+++ b/test/app/SmokeStartupTest.java
@@ -100,6 +100,12 @@ public final class SmokeStartupTest {
                 try (AppBootstrap bootstrap = new AppBootstrap(
                         NoopDiagnostics.INSTANCE,
                         lane,
+                        lane,
+                        lane,
+                        lane,
+                        lane,
+                        lane,
+                        lane,
                         DirectUiDispatcher.INSTANCE,
                         database)) {
                     bootstrap.createShell();

--- a/test/architecture/sessionplanner/SessionPlannerTargetArchitectureTest.java
+++ b/test/architecture/sessionplanner/SessionPlannerTargetArchitectureTest.java
@@ -1,0 +1,191 @@
+package architecture.sessionplanner;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import architecture.AnalyzeMainClasses;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.Set;
+
+@AnalyzeMainClasses
+public final class SessionPlannerTargetArchitectureTest {
+
+    private static final Set<String> RETIRED_TYPES = Set.of(
+            "features.sessionplanner.api.ApplyGeneratedSessionCommand",
+            "features.sessionplanner.api.PreviewGeneratedSessionCommand",
+            "features.sessionplanner.api.SessionGenerationDraftChangedCommand",
+            "features.sessionplanner.api.SessionGenerationPreviewModel",
+            "features.sessionplanner.api.SessionGenerationPreviewSnapshot",
+            "features.sessionplanner.api.SessionGenerationPreviewStatus",
+            "features.sessionplanner.api.SessionPreparationModel",
+            "features.sessionplanner.application.GeneratedSessionAssembly",
+            "features.sessionplanner.application.SessionGenerationCoordinator",
+            "features.sessionplanner.application.SessionGenerationPreviewProjection",
+            "features.sessionplanner.application.SessionGenerationPublishedState",
+            "features.sessionplanner.application.SessionGenerationRequestFingerprint",
+            "features.sessionplanner.application.SessionPreparationPublishedState",
+            "features.sessionplanner.api.SessionPlannerCatalogModel",
+            "features.sessionplanner.api.SessionPlannerCurrentSessionModel",
+            "features.sessionplanner.api.SessionPlannerParticipantsModel",
+            "features.sessionplanner.api.SessionPlannerSceneTimelineModel",
+            "features.sessionplanner.api.SessionPlannerStatePanelModel",
+            "features.encounter.api.GeneratedEncounterPlanImportApi",
+            "features.encounter.api.GeneratedEncounterPlanImportCommand",
+            "features.encounter.api.GeneratedEncounterPlanImportResult",
+            "features.encounter.api.GeneratedEncounterPlanRole",
+            "features.encounter.api.GeneratedEncounterPlanSlotSpec",
+            "features.encounter.api.GeneratedEncounterPlanSource",
+            "features.encounter.api.GeneratedEncounterPlanSpec",
+            "features.encounter.application.GeneratedEncounterPlanBatchRepository",
+            "features.encounter.application.GeneratedEncounterPlanCandidateSource",
+            "features.encounter.application.GeneratedEncounterPlanImportService");
+
+    private SessionPlannerTargetArchitectureTest() {
+    }
+
+    @ArchTest
+    static final ArchRule sessionPlannerJavaFxIsPassive =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner.adapter.javafx..")
+                    .should(avoidBackendAndForeignImplementationDependencies());
+
+    @ArchTest
+    static final ArchRule onlyTheWorkspaceCoordinatorOwnsPlannerPublishedState =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner..")
+                    .should(allowPublishedStateOnlyInTheWorkspaceCoordinator());
+
+    @ArchTest
+    static final ArchRule plannerApiHasOnlyTheTwoTargetModelTypes =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner.api..")
+                    .and()
+                    .haveSimpleNameEndingWith("Model")
+                    .should(haveOneOfSimpleNames("SessionPlannerWorkspaceModel", "PreparedSceneCatalogModel"));
+
+    @ArchTest
+    static final ArchRule javaFxConsumesOnlyTheWorkspaceViewModel =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner.adapter.javafx..")
+                    .should(consumeNoPlannerModelExceptWorkspace());
+
+    @ArchTest
+    static final ArchRule plannerHasOnlyTheTargetBinder =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner..")
+                    .and()
+                    .haveSimpleNameEndingWith("Binder")
+                    .should()
+                    .haveSimpleName("SessionPlannerBinder");
+
+    @ArchTest
+    static final ArchRule plannerHasOnlyTheTargetPublicationCoordinator =
+            classes()
+                    .that()
+                    .resideInAPackage("features.sessionplanner..")
+                    .and()
+                    .haveSimpleNameEndingWith("PublicationCoordinator")
+                    .should()
+                    .haveSimpleName("SessionPlannerWorkspacePublicationCoordinator");
+
+    @ArchTest
+    static final ArchRule preparationNeverUsesTheGlobalSerialLane =
+            noClasses()
+                    .that()
+                    .resideInAPackage("features.sessionplanner.application..")
+                    .and()
+                    .haveSimpleNameContaining("Preparation")
+                    .should()
+                    .dependOnClassesThat()
+                    .haveFullyQualifiedName("platform.execution.SerialExecutionLane");
+
+    @ArchTest
+    static void oneWorkspaceViewPublicationAndNoRetiredSymbols(JavaClasses classes) {
+        Set<String> present = classes.stream().map(JavaClass::getFullName).collect(java.util.stream.Collectors.toSet());
+        RETIRED_TYPES.forEach(type -> assertFalse(present.contains(type), () -> type + " is a retired M2-M4 symbol"));
+    }
+
+    private static ArchCondition<JavaClass> allowPublishedStateOnlyInTheWorkspaceCoordinator() {
+        return new ArchCondition<>("use PublishedState only from SessionPlannerWorkspacePublicationCoordinator") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean dependsOnPublishedState = item.getDirectDependenciesFromSelf().stream()
+                        .anyMatch(dependency -> dependency.getTargetClass().getFullName()
+                                .equals("platform.state.PublishedState"));
+                if (dependsOnPublishedState
+                        && !item.getSimpleName().equals("SessionPlannerWorkspacePublicationCoordinator")) {
+                    events.add(SimpleConditionEvent.violated(
+                            item, item.getName() + " creates a second Session Planner publication owner"));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> consumeNoPlannerModelExceptWorkspace() {
+        return new ArchCondition<>("consume only SessionPlannerWorkspaceModel from Session Planner API models") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                item.getDirectDependenciesFromSelf().stream()
+                        .map(Dependency::getTargetClass)
+                        .filter(target -> target.getPackageName().equals("features.sessionplanner.api"))
+                        .filter(target -> target.getSimpleName().endsWith("Model"))
+                        .filter(target -> !target.getSimpleName().equals("SessionPlannerWorkspaceModel"))
+                        .forEach(target -> events.add(SimpleConditionEvent.violated(
+                                item, item.getName() + " consumes duplicate view model " + target.getName())));
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> haveOneOfSimpleNames(String... allowedNames) {
+        Set<String> allowed = Set.of(allowedNames);
+        return new ArchCondition<>("have one of the target names " + allowed) {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                if (!allowed.contains(item.getSimpleName())) {
+                    events.add(SimpleConditionEvent.violated(
+                            item, item.getName() + " is outside the target allowlist " + allowed));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> avoidBackendAndForeignImplementationDependencies() {
+        return new ArchCondition<>("depend only on Session Planner API, JavaFX, shell API, and platform UI") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (Dependency dependency : item.getDirectDependenciesFromSelf()) {
+                    String target = dependency.getTargetClass().getPackageName();
+                    boolean ownBackend = in(target, "features.sessionplanner.application")
+                            || in(target, "features.sessionplanner.adapter.sqlite");
+                    boolean platformBackend = in(target, "platform.execution")
+                            || in(target, "platform.persistence");
+                    boolean foreignImplementation = in(target, "features")
+                            && !in(target, "features.sessionplanner")
+                            && !target.matches("features\\.[^.]+\\.api(?:\\..*)?");
+                    if (ownBackend || platformBackend || foreignImplementation) {
+                        events.add(SimpleConditionEvent.violated(
+                                item,
+                                item.getName() + " must not depend on " + dependency.getTargetClass().getName()));
+                    }
+                }
+            }
+        };
+    }
+
+    private static boolean in(String actual, String expected) {
+        return actual.equals(expected) || actual.startsWith(expected + ".");
+    }
+}

--- a/test/architecture/system/PlatformDiagnosticsArchitectureTest.java
+++ b/test/architecture/system/PlatformDiagnosticsArchitectureTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
 
 @AnalyzeMainClasses
 public final class PlatformDiagnosticsArchitectureTest {
@@ -42,5 +43,12 @@ public final class PlatformDiagnosticsArchitectureTest {
                                     || Throwable.class.isAssignableFrom(type)),
                     () -> method + " must accept only stable diagnostic ids and failure types");
         }
+        assertFalse(Arrays.stream(Measurement.class.getRecordComponents()).anyMatch(component -> {
+                    Class<?> type = component.getType();
+                    return type == String.class
+                            || type == Object.class
+                            || type == Map.class
+                            || Throwable.class.isAssignableFrom(type);
+                }), "measurements must contain only stable ids and bounded numeric facts");
     }
 }

--- a/test/features/creatures/adapter/sqlite/query/CreatureFactsSqliteTest.java
+++ b/test/features/creatures/adapter/sqlite/query/CreatureFactsSqliteTest.java
@@ -25,7 +25,8 @@ final class CreatureFactsSqliteTest {
         Path path = directory.resolve("creature-facts.sqlite");
         try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
             CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(
-                    database, DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE,
+                    database, DirectExecutionLane.INSTANCE, DirectExecutionLane.INSTANCE,
+                    DirectUiDispatcher.INSTANCE,
                     NoopDiagnostics.INSTANCE);
             creatures.catalogQueries().loadFilterOptions().toCompletableFuture().join();
             insert(path, 31L, "Third", "1/2", 100);

--- a/test/features/creatures/application/CreaturesRuntimeBoundaryTest.java
+++ b/test/features/creatures/application/CreaturesRuntimeBoundaryTest.java
@@ -29,7 +29,7 @@ final class CreaturesRuntimeBoundaryTest {
         RecordingDiagnostics diagnostics = new RecordingDiagnostics();
         RecordingPort port = new RecordingPort();
         CreaturesServiceAssembly.Component component =
-                CreaturesServiceAssembly.create(port, lane, ui, diagnostics);
+                CreaturesServiceAssembly.create(port, lane, lane, ui, diagnostics);
         CompletionStage<CreatureCatalogPageResult> older = component.catalogQueries().search(command("older"));
         CompletionStage<CreatureCatalogPageResult> newer = component.catalogQueries().search(command("newer"));
 

--- a/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorRuntimeThreadOwnershipTest.java
@@ -261,7 +261,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
             UiDispatcher dispatcher
     ) {
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                new InMemoryPartyRepository(), lane, dispatcher, (id, type) -> { });
+                new InMemoryPartyRepository(), lane, lane, dispatcher, (id, type) -> { });
         lane.runAll();
         DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
                 repository,
@@ -283,6 +283,7 @@ final class DungeonEditorRuntimeThreadOwnershipTest {
     private static DungeonEditorFeatureRuntimeRoot createRuntimeDirect(InMemoryDungeonRepository repository) {
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
                 new InMemoryPartyRepository(),
+                DirectExecutionLane.INSTANCE,
                 DirectExecutionLane.INSTANCE,
                 DirectUiDispatcher.INSTANCE,
                 (id, type) -> { });

--- a/test/features/party/application/PartyRuntimeMechanismsTest.java
+++ b/test/features/party/application/PartyRuntimeMechanismsTest.java
@@ -35,7 +35,7 @@ final class PartyRuntimeMechanismsTest {
         repository.seedOverworldTravel();
 
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                repository, lane, dispatcher, new RecordingDiagnostics());
+                repository, lane, lane, dispatcher, new RecordingDiagnostics());
         List<Integer> observedActiveCounts = new ArrayList<>();
         List<PartyTravelPositionsResult> observedTravel = new ArrayList<>();
         party.snapshot().subscribe(result -> observedActiveCounts.add(
@@ -74,7 +74,7 @@ final class PartyRuntimeMechanismsTest {
         repository.failLoads = true;
 
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                repository, lane, dispatcher, diagnostics);
+                repository, lane, lane, dispatcher, diagnostics);
         List<ReadStatus> snapshotStatuses = new ArrayList<>();
         List<ReadStatus> travelStatuses = new ArrayList<>();
         party.snapshot().subscribe(result -> snapshotStatuses.add(result.status()));
@@ -99,7 +99,7 @@ final class PartyRuntimeMechanismsTest {
         RecordingRepository repository = new RecordingRepository();
 
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                repository, lane, dispatcher, diagnostics);
+                repository, lane, lane, dispatcher, diagnostics);
 
         assertEquals(0, repository.loads);
         assertEquals(1, lane.pending());
@@ -133,7 +133,7 @@ final class PartyRuntimeMechanismsTest {
         RecordingDiagnostics diagnostics = new RecordingDiagnostics();
         RecordingRepository repository = new RecordingRepository();
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                repository, lane, update -> update.run(), diagnostics);
+                repository, lane, lane, update -> update.run(), diagnostics);
         lane.runNext();
         repository.failLoads = true;
 

--- a/test/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepositoryTest.java
+++ b/test/features/sessiongeneration/adapter/sqlite/persistence/SqliteGenerationRunRepositoryTest.java
@@ -230,7 +230,11 @@ final class SqliteGenerationRunRepositoryTest {
         java.nio.file.Path databasePath = temporaryDirectory.resolve("load-query-bound.sqlite");
         GeneratedRunDraft draft = GeneratedRunDraft.from(generate(179974L));
         try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
-            new SqliteGenerationRunRepository(database).commit(draft);
+            SqliteGenerationRunRepository writer = new SqliteGenerationRunRepository(database);
+            writer.commit(draft);
+            for (long seed = 200_000L; seed < 200_032L; seed++) {
+                writer.commit(GeneratedRunDraft.from(generate(seed)));
+            }
             AtomicInteger queries = new AtomicInteger();
             SqliteGenerationRunRepository counted = new SqliteGenerationRunRepository(
                     () -> countingConnection(databasePath, queries));

--- a/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
+++ b/test/features/sessionplanner/adapter/javafx/SessionPlannerCatalogTest.java
@@ -125,7 +125,22 @@ public final class SessionPlannerCatalogTest {
             }
 
         };
-        runOnFxThread(() -> assertPendingDraftCancellation(delayedGeneration));
+        java.util.concurrent.atomic.AtomicReference<PendingPreparationUi> pendingUi =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        runOnFxThread(() -> pendingUi.set(openPendingDraft(delayedGeneration)));
+        runOnFxThread(() -> {
+            PendingPreparationUi ui = pendingUi.get();
+            layout(ui.controls());
+            assertTrue(button(ui.controls(), "Session generieren").isDisabled(),
+                    "next JavaFX turn keeps duplicate generation disabled");
+            assertTrue(isEffectivelyVisible(button(ui.controls(), "Abbrechen")),
+                    "next JavaFX turn exposes cancellation while the provider remains pending");
+            button(ui.controls(), "Abbrechen").fire();
+        });
+        runOnFxThread(() -> assertEquals(
+                SessionPreparationStatus.CANCELLED,
+                pendingUi.get().planner().workspaceModel().current().preparation().status(),
+                "cancel intent is visible on the following JavaFX turn"));
     }
 
     @Test
@@ -145,7 +160,7 @@ public final class SessionPlannerCatalogTest {
                         return planner.workspaceModel().subscribe(listener);
                     });
 
-            new SessionPlannerContribution(planner.application(), counted).bind();
+            new SessionPlannerContribution(planner.application(), counted, ignored -> { }).bind();
 
             assertEquals(1, subscriptions[0],
                     "catalog, controls, timeline, summary, and preparation share one workspace subscription");
@@ -168,12 +183,12 @@ public final class SessionPlannerCatalogTest {
                 "saving state keeps cancellation visible");
     }
 
-    private static void assertPendingDraftCancellation(SessionGenerationApi generation) {
+    private static PendingPreparationUi openPendingDraft(SessionGenerationApi generation) {
         SessionPlannerTestServices services = services(generation);
         seedActiveParty(services);
         SessionPlannerServiceAssembly planner = services.planner();
         ShellBinding binding = new SessionPlannerContribution(
-                planner.application(), planner.workspaceModel()).bind();
+                planner.application(), planner.workspaceModel(), ignored -> { }).bind();
         Parent controls = slot(binding, ShellSlot.COCKPIT_CONTROLS, Parent.class);
         Stage stage = new Stage();
         stage.setScene(new Scene(controls, 420.0, 720.0));
@@ -188,11 +203,10 @@ public final class SessionPlannerCatalogTest {
         assertTrue(button(controls, "Session generieren").isDisabled(),
                 "pending generation prevents duplicate submission");
 
-        button(controls, "Abbrechen").fire();
+        return new PendingPreparationUi(controls, planner);
+    }
 
-        assertEquals(SessionPreparationStatus.CANCELLED,
-                planner.workspaceModel().current().preparation().status(),
-                "cancel invalidates the pending preparation attempt");
+    private record PendingPreparationUi(Parent controls, SessionPlannerServiceAssembly planner) {
     }
 
     private static void runTest() {
@@ -200,7 +214,7 @@ public final class SessionPlannerCatalogTest {
         long locationId = seedLocation(services);
         SessionPlannerServiceAssembly planner = services.planner();
         ShellBinding binding = new SessionPlannerContribution(
-                planner.application(), planner.workspaceModel()).bind();
+                planner.application(), planner.workspaceModel(), ignored -> { }).bind();
         Parent controls = slot(binding, ShellSlot.COCKPIT_CONTROLS, Parent.class);
         Parent main = slot(binding, ShellSlot.COCKPIT_MAIN, Parent.class);
         Parent state = slot(binding, ShellSlot.COCKPIT_STATE, Parent.class);
@@ -702,6 +716,8 @@ public final class SessionPlannerCatalogTest {
         SessionPlannerServiceAssembly planner = new SessionPlannerServiceAssembly(
                 sessionRepository, sessionRepository, sessionRepository, party.application(),
                 generatedEncounterApi(), savedPlans, world.snapshotModel(), generation,
+                platform.execution.DirectExecutionLane.INSTANCE,
+                platform.execution.DirectExecutionLane.INSTANCE,
                 platform.execution.DirectExecutionLane.INSTANCE,
                 platform.ui.DirectUiDispatcher.INSTANCE,
                 platform.diagnostics.NoopDiagnostics.INSTANCE);

--- a/test/features/sessionplanner/adapter/sqlite/gateway/local/SessionPlannerWorkspaceSqliteReadTest.java
+++ b/test/features/sessionplanner/adapter/sqlite/gateway/local/SessionPlannerWorkspaceSqliteReadTest.java
@@ -45,20 +45,22 @@ final class SessionPlannerWorkspaceSqliteReadTest {
     }
 
     @Test
-    void populatedV3WorkspaceReadsEveryChildFamilyWithCardinalityIndependentStatements() throws Exception {
+    void highCardinalityV3WorkspaceReadsEveryChildFamilyWithCardinalityIndependentStatements() throws Exception {
         Path path = temporaryDirectory.resolve("populated-workspace.db");
         try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
             SqliteSessionPlanRepository repository = new SqliteSessionPlanRepository(database);
-            repository.insert(completePlan(7L, 1L, 11L, "run-7"));
-            repository.insert(completePlan(8L, 2L, 21L, "run-8"));
-            repository.setCurrentSessionId(8L);
+            for (long sessionId = 1L; sessionId <= 64L; sessionId++) {
+                repository.insert(completePlan(
+                        sessionId, sessionId * 100L, sessionId * 10L, "run-" + sessionId));
+            }
+            repository.setCurrentSessionId(64L);
 
             CountedRead counted = loadCounted(path);
 
             assertEquals(WORKSPACE_STATEMENT_FAMILIES, counted.statements(),
                     "pointer, roots, participants, scenes, rests, notes, and generated rewards");
-            assertEquals(8L, counted.workspace().currentSessionId());
-            assertEquals(2, counted.workspace().sessions().size());
+            assertEquals(64L, counted.workspace().currentSessionId());
+            assertEquals(64, counted.workspace().sessions().size());
             counted.workspace().sessions().forEach(snapshot -> {
                 assertEquals(2, snapshot.participants().size());
                 assertEquals(2, snapshot.encounters().size());

--- a/test/features/sessionplanner/application/SessionPlannerRuntimeMechanismsTest.java
+++ b/test/features/sessionplanner/application/SessionPlannerRuntimeMechanismsTest.java
@@ -287,7 +287,7 @@ final class SessionPlannerRuntimeMechanismsTest {
             RecordingDispatcher dispatcher
     ) {
         PartyServiceAssembly.Component party = PartyServiceAssembly.create(
-                new InMemoryPartyRepository(), lane, dispatcher, (id, type) -> { });
+                new InMemoryPartyRepository(), lane, lane, dispatcher, (id, type) -> { });
         lane.runAll();
         party.application().createCharacter(new CreateCharacterCommand(
                 new CharacterDraft("Aria", "Mira", 3, 14, 16), MembershipState.ACTIVE));
@@ -319,6 +319,8 @@ final class SessionPlannerRuntimeMechanismsTest {
                 savedPlans,
                 null,
                 unavailableGeneration(),
+                lane,
+                lane,
                 lane,
                 dispatcher,
                 diagnostics);
@@ -413,8 +415,8 @@ final class SessionPlannerRuntimeMechanismsTest {
             SessionPlan captured = staleWorkspaceReads > 0 ? previous : current;
             staleWorkspaceReads = Math.max(0, staleWorkspaceReads - 1);
             return captured == null
-                    ? new SessionPlannerReadCapture(0L, List.of())
-                    : new SessionPlannerReadCapture(captured.sessionId(), List.of(captured));
+                    ? new SessionPlannerReadCapture(0L, List.of(), 0)
+                    : new SessionPlannerReadCapture(captured.sessionId(), List.of(captured), 0);
         }
 
         @Override

--- a/test/features/sessionplanner/application/SessionPlannerWorkspaceAssemblerTest.java
+++ b/test/features/sessionplanner/application/SessionPlannerWorkspaceAssemblerTest.java
@@ -84,7 +84,7 @@ final class SessionPlannerWorkspaceAssemblerTest {
                 .attachEncounter(11L)
                 .attachEncounter(12L);
         SessionPlan other = SessionPlan.seeded(8L, List.of(1L), EncounterDays.one()).addScene();
-        CountingSource source = new CountingSource(new SessionPlannerReadCapture(7L, List.of(current, other)));
+        CountingSource source = new CountingSource(new SessionPlannerReadCapture(7L, List.of(current, other), 0));
         CountingParty party = new CountingParty();
         CountingEncounter encounters = new CountingEncounter(false);
         int[] savedPlanReads = {0};
@@ -94,7 +94,8 @@ final class SessionPlannerWorkspaceAssemblerTest {
                     return new SavedEncounterPlanListResult(SavedEncounterPlanStatus.SUCCESS, List.of(), "");
                 }, listener -> () -> { }, listener -> () -> { });
         SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
-                source, party, encounters, savedPlans, unavailableGeneration(), null, directLane());
+                source, party, encounters, savedPlans, unavailableGeneration(), null, directLane(),
+                NoopDiagnostics.INSTANCE);
 
         SessionPlannerWorkspaceAssembly result = assembler.assemble(SessionPreparationSnapshot.idle())
                 .toCompletableFuture().join();
@@ -119,8 +120,9 @@ final class SessionPlannerWorkspaceAssemblerTest {
                 .attachEncounter(12L);
         CountingEncounter encounters = new CountingEncounter(true);
         SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
-                new CountingSource(new SessionPlannerReadCapture(7L, List.of(current))),
-                new CountingParty(), encounters, emptySavedPlans(), unavailableGeneration(), null, directLane());
+                new CountingSource(new SessionPlannerReadCapture(7L, List.of(current), 0)),
+                new CountingParty(), encounters, emptySavedPlans(), unavailableGeneration(), null, directLane(),
+                NoopDiagnostics.INSTANCE);
 
         SessionPlannerWorkspaceSnapshot workspace = assembler.assemble(SessionPreparationSnapshot.idle())
                 .toCompletableFuture().join().workspace();
@@ -145,9 +147,9 @@ final class SessionPlannerWorkspaceAssemblerTest {
                                 1L, "run-7", 3L, "STALE FALLBACK LABEL")));
         RewardGeneration generation = new RewardGeneration();
         SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
-                new CountingSource(new SessionPlannerReadCapture(7L, List.of(current))),
+                new CountingSource(new SessionPlannerReadCapture(7L, List.of(current), 0)),
                 new CountingParty(), new CountingEncounter(false), emptySavedPlans(), generation, null,
-                directLane());
+                directLane(), NoopDiagnostics.INSTANCE);
 
         SessionPlannerSceneTimelineProjection.GeneratedReward reward = assembler
                 .assemble(SessionPreparationSnapshot.idle()).toCompletableFuture().join()
@@ -167,11 +169,11 @@ final class SessionPlannerWorkspaceAssemblerTest {
         SessionPlan initial = SessionPlan.seeded(7L, List.of(1L), EncounterDays.one()).attachEncounter(11L);
         SessionPlan newer = withRevision(initial.setEncounterDays(new EncounterDays(new BigDecimal("2"))),
                 initial.revision().next());
-        CountingSource source = new CountingSource(new SessionPlannerReadCapture(7L, List.of(initial)));
+        CountingSource source = new CountingSource(new SessionPlannerReadCapture(7L, List.of(initial), 0));
         CountingEncounter encounters = new CountingEncounter(false, true);
         SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
                 source, new CountingParty(), encounters, emptySavedPlans(), unavailableGeneration(), null,
-                directLane());
+                directLane(), NoopDiagnostics.INSTANCE);
         SessionPlannerWorkspacePublicationCoordinator publications =
                 new SessionPlannerWorkspacePublicationCoordinator(
                         assembler, DirectUiDispatcher.INSTANCE, NoopDiagnostics.INSTANCE);
@@ -179,7 +181,7 @@ final class SessionPlannerWorkspaceAssemblerTest {
         publications.model().subscribe(snapshot -> publishedSourceRevisions.add(snapshot.sourceSessionRevision()));
 
         publications.initialize();
-        source.capture = new SessionPlannerReadCapture(7L, List.of(newer));
+        source.capture = new SessionPlannerReadCapture(7L, List.of(newer), 0);
         publications.providerRefresh();
         publications.providerRefresh();
         publications.authoredMutation(newer);
@@ -204,9 +206,9 @@ final class SessionPlannerWorkspaceAssemblerTest {
                             List.of(new SessionGeneratedRewardReference(
                                     1L, "run-7", 3L, "Last known reward")));
             SessionPlannerWorkspaceAssembler assembler = new SessionPlannerWorkspaceAssembler(
-                    new CountingSource(new SessionPlannerReadCapture(7L, List.of(current))),
+                    new CountingSource(new SessionPlannerReadCapture(7L, List.of(current), 0)),
                     new CountingParty(), new CountingEncounter(false), emptySavedPlans(),
-                    new RewardGeneration(mode), null, directLane());
+                    new RewardGeneration(mode), null, directLane(), NoopDiagnostics.INSTANCE);
 
             SessionPlannerWorkspaceSnapshot workspace = assembler.assemble(SessionPreparationSnapshot.idle())
                     .toCompletableFuture().join().workspace();

--- a/test/features/sessionplanner/application/SessionPreparationCoordinatorTest.java
+++ b/test/features/sessionplanner/application/SessionPreparationCoordinatorTest.java
@@ -369,6 +369,8 @@ final class SessionPreparationCoordinatorTest {
                 null,
                 generation,
                 lane,
+                lane,
+                lane,
                 DirectUiDispatcher.INSTANCE,
                 NoopDiagnostics.INSTANCE);
         planner.application().initialize();

--- a/test/features/sessionplanner/qualification/SessionPreparationProductionRouteTest.java
+++ b/test/features/sessionplanner/qualification/SessionPreparationProductionRouteTest.java
@@ -1,0 +1,603 @@
+package features.sessionplanner.qualification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.creatures.CreaturesServiceAssembly;
+import features.encounter.EncounterServiceAssembly;
+import features.encountertable.EncounterTableServiceAssembly;
+import features.party.PartyServiceAssembly;
+import features.party.api.CharacterDraft;
+import features.party.api.CreateCharacterCommand;
+import features.party.api.MembershipState;
+import features.sessiongeneration.SessionGenerationServiceAssembly;
+import features.sessiongeneration.api.GenerationPreparationIdentity;
+import features.sessiongeneration.api.GenerationRequest;
+import features.sessiongeneration.api.GenerationResult;
+import features.sessiongeneration.api.GenerationStatus;
+import features.sessiongeneration.api.SessionGenerationApi;
+import features.sessionplanner.SessionPlannerServiceAssembly;
+import features.sessionplanner.api.PrepareSessionCommand;
+import features.sessionplanner.api.SessionPlannerCatalogCommand;
+import features.sessionplanner.api.SessionPlannerParticipantCommand;
+import features.sessionplanner.api.SessionPlannerWorkspaceModel;
+import features.sessionplanner.api.SessionPlannerWorkspaceSnapshot;
+import features.sessionplanner.api.SessionPreparationStatus;
+import features.sessionplanner.api.SetSessionEncounterDaysCommand;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.DiagnosticId;
+import platform.diagnostics.Diagnostics;
+import platform.diagnostics.Measurement;
+import platform.execution.BoundedExecutionLane;
+import platform.execution.SerialExecutionLane;
+import platform.persistence.SqliteDatabase;
+import platform.ui.DirectUiDispatcher;
+
+final class SessionPreparationProductionRouteTest {
+
+    private static final Duration DEADLOCK_TIMEOUT = Duration.ofSeconds(30);
+    private static final int QUALIFICATION_RUNS = 20;
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void canonicalProductionRouteStaysBoundedAcrossTwentyWarmRuns() throws Exception {
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        Path path = temporaryDirectory.resolve("session-preparation-production.sqlite");
+        try (ProductionFixture fixture = ProductionFixture.open(path, diagnostics)) {
+            awaitPreparation(fixture.planner, fixture.canonical, 0L, false);
+            List<Measurement> smallCardinalityMeasurements = List.copyOf(diagnostics.measurements);
+            List<Long> warmDurations = new ArrayList<>();
+            for (int run = 0; run < QUALIFICATION_RUNS; run++) {
+                long priorAttempt = fixture.planner.workspaceModel().current().preparation().attemptId();
+                long started = System.nanoTime();
+                awaitPreparation(fixture.planner, fixture.canonical, priorAttempt, true);
+                warmDurations.add(Long.valueOf(System.nanoTime() - started));
+            }
+
+            List<Long> sorted = warmDurations.stream().sorted().toList();
+            long p95Nanos = sorted.get((int) Math.ceil(QUALIFICATION_RUNS * 0.95d) - 1).longValue();
+            System.out.println("SESSION_PREPARATION_QUALIFICATION coldCatalogNanos=" + fixture.coldCatalogNanos
+                    + " coldStoreNanos=" + fixture.coldStoreNanos
+                    + " warmSortedNanos=" + sorted
+                    + " p95Nanos=" + p95Nanos);
+            assertTrue(p95Nanos < Duration.ofSeconds(2).toNanos(), () ->
+                    "warm p95 exceeded 2s; coldCatalogNanos=" + fixture.coldCatalogNanos
+                            + ", coldStoreNanos=" + fixture.coldStoreNanos
+                            + ", warmNanos=" + warmDurations
+                            + ", measurements=" + diagnostics.measurements);
+            assertTrue(diagnostics.failures.isEmpty(), () -> "diagnostic failures=" + diagnostics.failures);
+            assertBoundedQueryCounts(smallCardinalityMeasurements, diagnostics.measurements);
+        }
+    }
+
+    @Test
+    void cancellationAndLatestAttemptWinOnProductionRoute() throws Exception {
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        HoldingFirstDraft delayed = new HoldingFirstDraft();
+        Path path = temporaryDirectory.resolve("session-preparation-latest-wins.sqlite");
+        try (ProductionFixture fixture = ProductionFixture.open(path, diagnostics, delayed::wrap)) {
+            long initialRevision = fixture.planner.workspaceModel().current().publicationRevision();
+            fixture.planner.application().prepareSession(new PrepareSessionCommand(
+                    OptionalInt.of(3), 179974L, false));
+            delayed.captured.get(DEADLOCK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            SessionPlannerWorkspaceSnapshot first = awaitWorkspace(
+                    fixture.planner.workspaceModel(), initialRevision,
+                    workspace -> workspace.preparation().status() == SessionPreparationStatus.GENERATING);
+            long firstAttempt = first.preparation().attemptId();
+
+            fixture.planner.application().cancelPreparation();
+            SessionPlannerWorkspaceSnapshot cancelled = awaitWorkspace(
+                    fixture.planner.workspaceModel(), first.publicationRevision(),
+                    workspace -> workspace.preparation().attemptId() > firstAttempt
+                            && workspace.preparation().status() == SessionPreparationStatus.CANCELLED);
+            assertFalse(cancelled.preparation().cancelEnabled());
+
+            awaitPreparation(fixture.planner, fixture.canonical, cancelled.preparation().attemptId(), false);
+            long winningAttempt = fixture.planner.workspaceModel().current().preparation().attemptId();
+            delayed.release.complete(null);
+            delayed.finished.get(DEADLOCK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            fixture.preparationCpu.close();
+            fixture.preparationIo.close();
+
+            assertEquals(SessionPreparationStatus.READY,
+                    fixture.planner.workspaceModel().current().preparation().status());
+            assertEquals(winningAttempt, fixture.planner.workspaceModel().current().preparation().attemptId());
+            assertEquals(1L, rowCount(path, "session_generation_runs"));
+            assertEquals(3L, rowCount(path, "generated_encounter_plan_origins"));
+            assertTrue(diagnostics.failures.isEmpty(), () -> "diagnostic failures=" + diagnostics.failures);
+        }
+    }
+
+    @Test
+    void foreignStorageFailureRetriesIdempotentlyOnProductionRoute() throws Exception {
+        RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+        FailFirstGenerationCommit generationFailure = new FailFirstGenerationCommit();
+        Path path = temporaryDirectory.resolve("session-preparation-retry.sqlite");
+        try (ProductionFixture fixture = ProductionFixture.open(path, diagnostics, generationFailure::wrap)) {
+            long firstAttempt = prepareUntilTerminal(fixture.planner, 0L, false, SessionPreparationStatus.FAILED);
+
+            awaitPreparation(fixture.planner, fixture.canonical, firstAttempt, false);
+
+            assertEquals(2, generationFailure.commitCalls);
+            assertEquals(1L, rowCount(path, "session_generation_runs"),
+                    "retry stores one canonical generation run");
+            assertEquals(3L, rowCount(path, "generated_encounter_plan_origins"),
+                    "retry reuses the first committed encounter batch");
+            assertEquals(
+                    fixture.planner.workspaceModel().current().sceneTimeline().sessionScenes().size(),
+                    rowCount(path, "session_planner_encounters"),
+                    "planner CAS publishes one prepared scene set");
+        }
+    }
+
+    private static BoundedExecutionLane lane(Diagnostics diagnostics, String name) {
+        return new BoundedExecutionLane(diagnostics, name, 2);
+    }
+
+    private static long prepareUntilTerminal(
+            SessionPlannerServiceAssembly planner,
+            long priorAttempt,
+            boolean replacementConfirmed,
+            SessionPreparationStatus expected
+    ) throws Exception {
+        long revision = planner.workspaceModel().current().publicationRevision();
+        planner.application().prepareSession(new PrepareSessionCommand(
+                OptionalInt.of(3), 179974L, replacementConfirmed));
+        SessionPlannerWorkspaceSnapshot terminal = awaitWorkspace(planner.workspaceModel(), revision, workspace ->
+                workspace.preparation().attemptId() > priorAttempt
+                        && terminal(workspace.preparation().status()));
+        assertEquals(expected, terminal.preparation().status(), () ->
+                "unexpected production terminal: " + terminal.preparation());
+        return terminal.preparation().attemptId();
+    }
+
+    private static long rowCount(Path path, String table) throws Exception {
+        if (!table.matches("[a-z_]+")) {
+            throw new IllegalArgumentException("unsafe table name");
+        }
+        try (var connection = DriverManager.getConnection("jdbc:sqlite:" + path);
+                var statement = connection.createStatement();
+                var rows = statement.executeQuery("SELECT COUNT(*) FROM " + table)) {
+            return rows.getLong(1);
+        }
+    }
+
+    private static GenerationResult canonicalDraft(SessionGenerationApi generation) throws Exception {
+        var response = generation.draft(new GenerationRequest(
+                new GenerationPreparationIdentity("qualification:canonical-cold"),
+                List.of(new GenerationRequest.PartyLevel(3, 2), new GenerationRequest.PartyLevel(4, 2)),
+                new BigDecimal("0.6"), OptionalInt.of(3), 179974L))
+                .toCompletableFuture().get(DEADLOCK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        assertEquals(GenerationStatus.SUCCESS, response.status());
+        return response.draft().orElseThrow().result();
+    }
+
+    private static void seedCreatures(Path path, GenerationResult generated) throws Exception {
+        record Candidate(String challengeRating, long xp) {
+        }
+        Set<Candidate> required = generated.encounters().stream()
+                .flatMap(encounter -> encounter.blocks().stream())
+                .map(block -> new Candidate(block.challengeLabel(), block.monsterXp()))
+                .collect(java.util.stream.Collectors.toSet());
+        try (var connection = DriverManager.getConnection("jdbc:sqlite:" + path);
+                var statement = connection.prepareStatement(
+                        "INSERT INTO creatures (id,name,size,creature_type,alignment,cr,xp,hp,ac) "
+                                + "VALUES (?,?,?,?,?,?,?,?,?)")) {
+            long id = 1L;
+            for (Candidate candidate : required.stream()
+                    .sorted(Comparator.comparingLong(Candidate::xp).thenComparing(Candidate::challengeRating))
+                    .toList()) {
+                for (int variant = 0; variant < 5; variant++) {
+                    statement.setLong(1, id);
+                    statement.setString(2, "Qualification creature " + id);
+                    statement.setString(3, "Medium");
+                    statement.setString(4, "humanoid");
+                    statement.setString(5, "neutral");
+                    statement.setString(6, candidate.challengeRating());
+                    statement.setLong(7, candidate.xp());
+                    statement.setInt(8, 10 + variant);
+                    statement.setInt(9, 12 + variant);
+                    statement.addBatch();
+                    id++;
+                }
+            }
+            statement.executeBatch();
+        }
+    }
+
+    private static void createCanonicalParty(PartyServiceAssembly.Component party) throws Exception {
+        createCharacter(party, "Aria", 3, 1);
+        createCharacter(party, "Borin", 3, 2);
+        createCharacter(party, "Cyra", 4, 3);
+        createCharacter(party, "Dain", 4, 4);
+    }
+
+    private static void createCharacter(
+            PartyServiceAssembly.Component party,
+            String name,
+            int level,
+            int expectedSize
+    ) throws Exception {
+        CompletableFuture<Void> published = new CompletableFuture<>();
+        Runnable unsubscribe = party.activeParty().subscribe(result -> {
+            if (result.members().size() == expectedSize) {
+                published.complete(null);
+            }
+        });
+        try {
+            party.application().createCharacter(new CreateCharacterCommand(
+                    new CharacterDraft(name, "Qualification", level, 12, 14), MembershipState.ACTIVE));
+            published.get(DEADLOCK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        } finally {
+            unsubscribe.run();
+        }
+    }
+
+    private static void initializeCanonicalSession(
+            SessionPlannerServiceAssembly planner,
+            List<Long> participantIds
+    ) throws Exception {
+        planner.application().initialize();
+        awaitWorkspace(planner.workspaceModel(), 0L, workspace -> workspace.publicationRevision() > 0L);
+
+        long revision = planner.workspaceModel().current().publicationRevision();
+        planner.application().createSession(new SessionPlannerCatalogCommand.CreateSessionCommand(
+                "Canonical qualification"));
+        SessionPlannerWorkspaceSnapshot created = awaitWorkspace(
+                planner.workspaceModel(), revision, workspace -> workspace.catalog().selectedSessionId() > 0L);
+
+        for (long participantId : participantIds) {
+            if (created.participants().participants().stream()
+                    .anyMatch(participant -> participant.characterId() == participantId)) {
+                continue;
+            }
+            revision = created.publicationRevision();
+            planner.application().addParticipant(SessionPlannerParticipantCommand.add(participantId));
+            int expected = created.participants().participants().size() + 1;
+            created = awaitWorkspace(planner.workspaceModel(), revision,
+                    workspace -> workspace.participants().participants().size() == expected);
+        }
+        revision = created.publicationRevision();
+        planner.application().setEncounterDays(new SetSessionEncounterDaysCommand(new BigDecimal("0.6")));
+        awaitWorkspace(planner.workspaceModel(), revision, workspace ->
+                workspace.currentSession().session().encounterDays().compareTo(new BigDecimal("0.6")) == 0);
+    }
+
+    private static void awaitPreparation(
+            SessionPlannerServiceAssembly planner,
+            GenerationResult canonical,
+            long priorAttempt,
+            boolean replacementConfirmed
+    ) throws Exception {
+        long revision = planner.workspaceModel().current().publicationRevision();
+        planner.application().prepareSession(new PrepareSessionCommand(
+                OptionalInt.of(3), 179974L, replacementConfirmed));
+        SessionPlannerWorkspaceSnapshot ready = awaitWorkspace(planner.workspaceModel(), revision, workspace ->
+                workspace.preparation().attemptId() > priorAttempt
+                        && terminal(workspace.preparation().status()));
+        assertEquals(SessionPreparationStatus.READY, ready.preparation().status(), () ->
+                "production preparation did not reach READY: " + ready.preparation()
+                        + ", issues=" + ready.issues());
+        assertFalse(ready.preparation().cancelEnabled());
+        var encounterScenes = ready.sceneTimeline().sessionScenes().stream()
+                .filter(SessionPlannerWorkspaceSnapshotTestSupport::linkedEncounter)
+                .toList();
+        assertEquals(canonical.encounters().size(), encounterScenes.size());
+        assertTrue(encounterScenes.stream().allMatch(scene ->
+                scene.linkedEncounterPlanId() > 0L
+                        && scene.linkedEncounterCreatureCount() > 0
+                        && scene.linkedEncounterAdjustedXp() > 0));
+        var rewards = ready.sceneTimeline().sessionScenes().stream()
+                .flatMap(scene -> scene.generatedRewards().stream())
+                .toList();
+        assertEquals(canonical.treasures().size(), rewards.size());
+        assertTrue(rewards.stream().allMatch(reward ->
+                reward.availability()
+                        == features.sessionplanner.api.SessionPlannerSceneTimelineProjection.Availability.AVAILABLE
+                        && !reward.generationRunId().isBlank()
+                        && !reward.itemLines().isEmpty()));
+    }
+
+    private static boolean terminal(SessionPreparationStatus status) {
+        return switch (status) {
+            case READY, INVALID, FAILED, CANCELLED, CONFIRMING_REPLACEMENT -> true;
+            default -> false;
+        };
+    }
+
+    private static SessionPlannerWorkspaceSnapshot awaitWorkspace(
+            SessionPlannerWorkspaceModel model,
+            long priorRevision,
+            Predicate<SessionPlannerWorkspaceSnapshot> condition
+    ) throws Exception {
+        CompletableFuture<SessionPlannerWorkspaceSnapshot> completion = new CompletableFuture<>();
+        Runnable unsubscribe = model.subscribe(workspace -> {
+            if (workspace.publicationRevision() > priorRevision && condition.test(workspace)) {
+                completion.complete(workspace);
+            }
+        });
+        try {
+            SessionPlannerWorkspaceSnapshot current = model.current();
+            if (current.publicationRevision() > priorRevision && condition.test(current)) {
+                completion.complete(current);
+            }
+            return completion.get(DEADLOCK_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        } finally {
+            unsubscribe.run();
+        }
+    }
+
+    private static void assertBoundedQueryCounts(
+            List<Measurement> smallCardinality,
+            List<Measurement> highCardinality
+    ) {
+        assertTrue(smallCardinality.stream().anyMatch(measurement ->
+                measurement.id().value().equals("sessionplanner.workspace.assembly")
+                        && measurement.queryCount() == 7));
+        assertTrue(highCardinality.stream().filter(measurement ->
+                        measurement.id().value().equals("sessionplanner.workspace.assembly"))
+                .allMatch(measurement -> measurement.queryCount() == 7));
+        assertTrue(highCardinality.stream().filter(measurement ->
+                        measurement.id().value().equals("party.planning-facts.read"))
+                .allMatch(measurement -> measurement.queryCount() == 0));
+        assertTrue(highCardinality.stream().filter(measurement ->
+                        measurement.id().value().equals("creatures.facts.read"))
+                .allMatch(measurement -> measurement.queryCount() == 0));
+        assertTrue(highCardinality.stream().filter(measurement ->
+                        measurement.id().value().equals("party.sqlite.roster-read"))
+                .allMatch(measurement -> measurement.queryCount() == 2));
+        assertTrue(highCardinality.stream().filter(measurement ->
+                        measurement.id().value().equals("creatures.sqlite.facts-read"))
+                .allMatch(measurement -> measurement.queryCount() == 2));
+        assertTrue(highCardinality.stream().anyMatch(measurement ->
+                measurement.id().value().equals("party.sqlite.roster-read")));
+        assertTrue(highCardinality.stream().anyMatch(measurement ->
+                measurement.id().value().equals("creatures.sqlite.facts-read")));
+    }
+
+    private static final class SessionPlannerWorkspaceSnapshotTestSupport {
+        private SessionPlannerWorkspaceSnapshotTestSupport() {
+        }
+
+        private static boolean linkedEncounter(
+                features.sessionplanner.api.SessionPlannerSceneTimelineProjection.SessionScene scene
+        ) {
+            return scene.linkedEncounterPlan();
+        }
+    }
+
+    private static final class ProductionFixture implements AutoCloseable {
+        private final SqliteDatabase database;
+        private final SerialExecutionLane authored;
+        private final BoundedExecutionLane generationCpu;
+        private final BoundedExecutionLane generationIo;
+        private final BoundedExecutionLane encounterCpu;
+        private final BoundedExecutionLane encounterIo;
+        private final BoundedExecutionLane preparationCpu;
+        private final BoundedExecutionLane preparationIo;
+        private final GenerationResult canonical;
+        private final SessionPlannerServiceAssembly planner;
+        private final long coldCatalogNanos;
+        private final long coldStoreNanos;
+
+        private ProductionFixture(
+                SqliteDatabase database,
+                SerialExecutionLane authored,
+                BoundedExecutionLane generationCpu,
+                BoundedExecutionLane generationIo,
+                BoundedExecutionLane encounterCpu,
+                BoundedExecutionLane encounterIo,
+                BoundedExecutionLane preparationCpu,
+                BoundedExecutionLane preparationIo,
+                GenerationResult canonical,
+                SessionPlannerServiceAssembly planner,
+                long coldCatalogNanos,
+                long coldStoreNanos
+        ) {
+            this.database = database;
+            this.authored = authored;
+            this.generationCpu = generationCpu;
+            this.generationIo = generationIo;
+            this.encounterCpu = encounterCpu;
+            this.encounterIo = encounterIo;
+            this.preparationCpu = preparationCpu;
+            this.preparationIo = preparationIo;
+            this.canonical = canonical;
+            this.planner = planner;
+            this.coldCatalogNanos = coldCatalogNanos;
+            this.coldStoreNanos = coldStoreNanos;
+        }
+
+        private static ProductionFixture open(Path path, RecordingDiagnostics diagnostics) throws Exception {
+            return open(path, diagnostics, UnaryOperator.identity());
+        }
+
+        private static ProductionFixture open(
+                Path path,
+                RecordingDiagnostics diagnostics,
+                UnaryOperator<SessionGenerationApi> generationDecorator
+        ) throws Exception {
+            SqliteDatabase database = new SqliteDatabase(path, diagnostics);
+            SerialExecutionLane authored = new SerialExecutionLane(diagnostics);
+            BoundedExecutionLane generationCpu = lane(diagnostics, "qualification-generation-cpu");
+            BoundedExecutionLane generationIo = lane(diagnostics, "qualification-generation-io");
+            BoundedExecutionLane encounterCpu = lane(diagnostics, "qualification-encounter-cpu");
+            BoundedExecutionLane encounterIo = lane(diagnostics, "qualification-encounter-io");
+            BoundedExecutionLane preparationCpu = lane(diagnostics, "session-preparation-cpu");
+            BoundedExecutionLane preparationIo = lane(diagnostics, "session-preparation-io");
+            SessionGenerationApi generation = SessionGenerationServiceAssembly.create(
+                    database, generationCpu, generationIo);
+            long coldCatalogStarted = System.nanoTime();
+            GenerationResult canonical = canonicalDraft(generation);
+            long coldCatalogNanos = System.nanoTime() - coldCatalogStarted;
+
+            CreaturesServiceAssembly.Component creatures = CreaturesServiceAssembly.create(
+                    database, authored, preparationIo, DirectUiDispatcher.INSTANCE, diagnostics);
+            EncounterTableServiceAssembly.Component tables = EncounterTableServiceAssembly.create(
+                    database, authored, DirectUiDispatcher.INSTANCE, diagnostics);
+            PartyServiceAssembly.Component party = PartyServiceAssembly.create(
+                    database, authored, preparationIo, DirectUiDispatcher.INSTANCE, diagnostics);
+            EncounterServiceAssembly.Component encounters = EncounterServiceAssembly.create(
+                    database,
+                    creatures.application(), creatures.detail(), creatures.encounterCandidates(),
+                    tables.application(), tables.candidates(), null,
+                    party.application(), party.activeParty(), party.activeComposition(),
+                    party.adventuringDaySummary(), party.mutation(),
+                    authored, encounterCpu, encounterIo, DirectUiDispatcher.INSTANCE, diagnostics);
+            SessionPlannerServiceAssembly planner = SessionPlannerServiceAssembly.create(
+                    database, party.application(), encounters.application(), encounters.savedPlans(), null,
+                    generationDecorator.apply(generation), authored, preparationCpu, preparationIo,
+                    DirectUiDispatcher.INSTANCE, diagnostics);
+
+            long coldStoreStarted = System.nanoTime();
+            database.prepareRegisteredStores();
+            long coldStoreNanos = System.nanoTime() - coldStoreStarted;
+            seedCreatures(path, canonical);
+            PartyServiceAssembly.start(party);
+            encounters.start();
+            createCanonicalParty(party);
+            initializeCanonicalSession(planner, party.activeParty().current().memberIds());
+            return new ProductionFixture(
+                    database, authored, generationCpu, generationIo, encounterCpu, encounterIo,
+                    preparationCpu, preparationIo, canonical, planner, coldCatalogNanos, coldStoreNanos);
+        }
+
+        @Override
+        public void close() {
+            preparationIo.close();
+            preparationCpu.close();
+            encounterIo.close();
+            encounterCpu.close();
+            generationIo.close();
+            generationCpu.close();
+            authored.close();
+            database.close();
+        }
+    }
+
+    private static final class HoldingFirstDraft {
+        private final CompletableFuture<Void> captured = new CompletableFuture<>();
+        private final CompletableFuture<Void> release = new CompletableFuture<>();
+        private final CompletableFuture<Void> finished = new CompletableFuture<>();
+        private final AtomicBoolean first = new AtomicBoolean(true);
+
+        private SessionGenerationApi wrap(SessionGenerationApi delegate) {
+            return new ForwardingGenerationApi(delegate) {
+                @Override
+                public CompletionStage<features.sessiongeneration.api.GenerationDraftResponse> draft(
+                        GenerationRequest request
+                ) {
+                    if (!first.compareAndSet(true, false)) {
+                        return delegate.draft(request);
+                    }
+                    captured.complete(null);
+                    CompletableFuture<features.sessiongeneration.api.GenerationDraftResponse> delayed = release
+                            .thenCompose(ignored -> delegate.draft(request))
+                            .toCompletableFuture();
+                    delayed.whenComplete((ignored, failure) -> {
+                        if (failure == null) {
+                            finished.complete(null);
+                        } else {
+                            finished.completeExceptionally(failure);
+                        }
+                    });
+                    return delayed;
+                }
+            };
+        }
+    }
+
+    private static final class FailFirstGenerationCommit {
+        private final AtomicBoolean first = new AtomicBoolean(true);
+        private int commitCalls;
+
+        private SessionGenerationApi wrap(SessionGenerationApi delegate) {
+            return new ForwardingGenerationApi(delegate) {
+                @Override
+                public CompletionStage<features.sessiongeneration.api.GenerationRunResponse> commit(
+                        features.sessiongeneration.api.CommitGenerationRunCommand command
+                ) {
+                    commitCalls++;
+                    if (first.compareAndSet(true, false)) {
+                        return CompletableFuture.completedFuture(
+                                features.sessiongeneration.api.GenerationRunResponse.failure(
+                                        GenerationStatus.STORAGE_FAILURE,
+                                        "qualification injected generation storage failure"));
+                    }
+                    return delegate.commit(command);
+                }
+            };
+        }
+    }
+
+    private static class ForwardingGenerationApi implements SessionGenerationApi {
+        protected final SessionGenerationApi delegate;
+
+        private ForwardingGenerationApi(SessionGenerationApi delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationDraftResponse> draft(
+                GenerationRequest request
+        ) {
+            return delegate.draft(request);
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRunResponse> commit(
+                features.sessiongeneration.api.CommitGenerationRunCommand command
+        ) {
+            return delegate.commit(command);
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRunResponse> load(
+                features.sessiongeneration.api.GenerationRunId runId
+        ) {
+            return delegate.load(runId);
+        }
+
+        @Override
+        public CompletionStage<features.sessiongeneration.api.GenerationRewardBatchResponse> loadRewards(
+                features.sessiongeneration.api.GenerationRewardBatchQuery query
+        ) {
+            return delegate.loadRewards(query);
+        }
+    }
+
+    private static final class RecordingDiagnostics implements Diagnostics {
+        private final List<String> failures = new CopyOnWriteArrayList<>();
+        private final List<Measurement> measurements = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void failure(DiagnosticId id, Class<? extends Throwable> failureType) {
+            failures.add(id.value() + ":" + failureType.getName());
+        }
+
+        @Override
+        public void measurement(Measurement measurement) {
+            measurements.add(measurement);
+        }
+    }
+}

--- a/test/platform/diagnostics/SystemLoggerDiagnosticsTest.java
+++ b/test/platform/diagnostics/SystemLoggerDiagnosticsTest.java
@@ -2,6 +2,8 @@ package platform.diagnostics;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +14,8 @@ final class SystemLoggerDiagnosticsTest {
     @Test
     void emitsOnlyStableIdAndFailureType() {
         List<String> messages = new ArrayList<>();
-        SystemLoggerDiagnostics diagnostics = new SystemLoggerDiagnostics(messages::add);
+        List<String> measurements = new ArrayList<>();
+        SystemLoggerDiagnostics diagnostics = new SystemLoggerDiagnostics(messages::add, measurements::add);
         String sensitive = "/home/user/game.db secret authored SQL";
 
         diagnostics.failure(new DiagnosticId("worldplanner.load-failure"),
@@ -21,5 +24,34 @@ final class SystemLoggerDiagnosticsTest {
         assertTrue(messages.getFirst().contains("worldplanner.load-failure"));
         assertTrue(messages.getFirst().contains(IllegalStateException.class.getName()));
         assertFalse(messages.getFirst().contains(sensitive));
+        assertTrue(measurements.isEmpty(), "failures must not enter the measurement sink");
+    }
+
+    @Test
+    void emitsMeasurementsAtTheSeparateNonWarningSink() {
+        List<String> warnings = new ArrayList<>();
+        List<String> measurements = new ArrayList<>();
+        SystemLoggerDiagnostics diagnostics = new SystemLoggerDiagnostics(warnings::add, measurements::add);
+
+        diagnostics.measurement(new Measurement(
+                new DiagnosticId("sessionplanner.preparation.party-read"), 7L, 42L, 4, 1));
+
+        assertTrue(warnings.isEmpty(), "normal stage measurements must not flood warning logs");
+        assertEquals(1, measurements.size());
+        assertTrue(measurements.getFirst().contains("sessionplanner.preparation.party-read"));
+        assertTrue(measurements.getFirst().contains("operation=7"));
+        assertTrue(measurements.getFirst().contains("durationNanos=42"));
+        assertTrue(measurements.getFirst().contains("cardinality=4"));
+        assertTrue(measurements.getFirst().contains("queryCount=1"));
+    }
+
+    @Test
+    void measurementRejectsNegativeOrUnboundedValues() {
+        DiagnosticId id = new DiagnosticId("sessionplanner.workspace.assembly");
+        assertThrows(IllegalArgumentException.class, () -> new Measurement(id, -1L, 0L, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> new Measurement(id, 1L, -1L, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> new Measurement(id, 1L, 0L, -1, 0));
+        assertThrows(IllegalArgumentException.class, () -> new Measurement(id, 1L, 0L, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new Measurement(id, 1L, 0L, 1_000_001, 0));
     }
 }

--- a/test/shell/host/SessionPlannerShellLayoutTest.java
+++ b/test/shell/host/SessionPlannerShellLayoutTest.java
@@ -233,7 +233,8 @@ public final class SessionPlannerShellLayoutTest {
         SessionPlannerServiceAssembly session = new SessionPlannerServiceAssembly(
                 sessionRepository, sessionRepository, sessionRepository, party.application(),
                 encounter.application(), encounter.savedPlans(), null, unsupportedGeneration(),
-                DirectExecutionLane.INSTANCE, DirectUiDispatcher.INSTANCE, NoopDiagnostics.INSTANCE);
+                DirectExecutionLane.INSTANCE, DirectExecutionLane.INSTANCE, DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE, NoopDiagnostics.INSTANCE);
         HexServiceAssembly hex = new HexServiceAssembly(
                 new SqliteHexMapRepository(), party.travelPositions(), party.application());
         SqliteDatabase dungeonDatabase = SqliteDatabase.defaultDatabase(
@@ -296,7 +297,7 @@ public final class SessionPlannerShellLayoutTest {
 
     private static SessionPlannerContribution sessionPlanner(LayoutServices services) {
         return new SessionPlannerContribution(
-                services.session().application(), services.session().workspaceModel());
+                services.session().application(), services.session().workspaceModel(), ignored -> { });
     }
 
     private static SessionGenerationApi unsupportedGeneration() {


### PR DESCRIPTION
## Zusammenfassung
- trennt die Session-Vorbereitung von der globalen Serial-Lane auf bounded CPU-/I/O-Lanes
- ergänzt payload-freie Stage-Messungen und echte JDBC-Query-Zähler
- erzwingt passive JavaFX-, Workspace- und Retire-Grenzen mechanisch
- qualifiziert Cancellation/latest-wins, Storage-Retry, Query-Bounds und die kanonische Production-Route

## Nachweis
- canonical warm p95: 98.094.012 ns über 20 Runs (Ziel <2s)
- reale Queryfamilien: Workspace 7, Party 2, Creature Facts 2
- echte Cancellation/latest-wins und idempotenter Foreign-Storage-Retry: grün
- `git diff --check origin/main...HEAD`: grün
- `./gradlew check --console=plain`: grün (7m 58s auf aktuellem `origin/main`)
- `./gradlew installDesktopApp --console=plain`: grün (15s)
