### PR TITLE
M5.3: Dungeon-Bounds und Continuations indizieren

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -106,10 +106,72 @@ and commit boundaries. M7 starts only after both are complete.
   local identity derivation, compatibility writer, and full-record fixture
   families are deleted.
 - M4.6 delivery proof is literal green `./gradlew check` plus
-  `./gradlew installDesktopApp`. M5.1 is complete through PR #536. M5.2 is
-  complete in this change with the same literal green proof; M5.3 is next. No
-  intermediate review panel runs; the single independent cross-roadmap review
-  runs only after all M7 implementation is complete.
+  `./gradlew installDesktopApp`. M5.1 is complete through PR #536 and M5.2
+  through PR #538. M5.3 is complete in this change with the same literal green
+  proof; M5.4 is next. No intermediate review panel runs; the single independent
+  cross-roadmap review runs only after all M7 implementation is complete.
+
+### Completed Slice Contract: M5.3 Indexed Bounds And Paged Continuations
+
+#### Goal And Authoritative Index
+
+- Extend the fresh destructive schema-v6 `dungeon_entity_chunks` index with the
+  exact cell extent contributed by one stable entity inside one chunk and its
+  total entity chunk count. Add level-keyed `dungeon_authored_level_bounds` as
+  the sole public authored-bounds source. There is no v5 translation, backfill,
+  preservation path, or schema v7.
+- Maintain entity extents, level bounds, chunk revisions, and map revision in
+  the same patch/UoW transaction. Normal and compound rollback must restore all
+  of them. Bounds are recomputed only for old/new affected levels through
+  indexed ordered extrema, never through authored hydration or map scans.
+- Preserve the M5.2 cache key `(DungeonChunkKey, contentRevision)`, protection,
+  and touched-only invalidation. Per-chunk cached content may carry immutable
+  entity extents; it must not carry global bounds or viewport-specific pages.
+
+#### Typed Reads And Paging
+
+- Add typed per-chunk entity extent, authored level bounds, continuation cursor,
+  page, and page-request values. `DungeonWindowIndex` and `DungeonWindow` carry
+  indexed bounds and the first continuation page; the public viewport snapshot
+  publishes only the active level's indexed bounds plus that typed page.
+- A continuation candidate is a stable entity intersecting at least one of the
+  exact requested chunks. Exclude the complete requested chunk set, deduplicate
+  by `(entityRef, offWindowChunk)`, and order by
+  `(entityKind, entityId, level, chunkR, chunkQ)`.
+- Page size is 256; SQLite reads at most 257 ordered rows to determine an
+  exclusive next cursor. A cursor is valid only for the same map, expected map
+  revision, request generation, and exact ordered requested-chunk set. Stale,
+  superseded, or mismatched requests publish nothing and do not mutate cache.
+- Command completeness never depends on paging through every continuation.
+  When the number of requested extents is below `entityChunkCount`, the command
+  loader resolves the stable entity through revision-bound identity closure.
+
+#### Implementation And Proof
+
+1. Change only the fresh v6 schema/create-drop ownership and constraints; add
+   extent/extrema indexes and level-bounds storage with cascade deletion.
+2. Derive old/new per-chunk extents from the complete patch-bound entity closure
+   in `DungeonSqlitePatchSpatialWriter`; update extent rows and affected level
+   bounds atomically before committing chunk/map revisions.
+3. Add exact indexed bounds and cursor-page queries to the SQLite window source,
+   then thread typed values through cached assembly, command completeness, and
+   viewport projection without changing M5.2 cache semantics.
+4. Prove empty maps/levels, negative coordinates, multiple levels, moving or
+   deleting an extremum, compound commit/rollback, multi-chunk stitching, and
+   0/1/256/257/>512 continuation rows with no gaps or duplicates. Stale revision,
+   generation, and changed chunk sets must reject.
+5. On 1k/10k/100k sparse datasets, bounds statement count is constant per
+   requested level, continuation results are capped at 257 rows, and content
+   work remains proportional to requested chunks.
+
+#### Delete Gate
+
+- Delete full off-window membership materialization, unpaged continuation
+  lists, public bounds derived from `workspaceBounds` or loaded render facts,
+  and any authored-table/map-wide scan used for bounds or continuations.
+- Literal green focused tests, `./gradlew check`, and
+  `./gradlew installDesktopApp` are required before the M5.3 PR merges. M5.4
+  starts from that merge without a review cycle.
 
 ### Completed Slice Contract: M5.2 Per-Chunk Cache And Touched Invalidation
 

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqlitePatchSpatialWriter.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqlitePatchSpatialWriter.java
@@ -68,17 +68,20 @@ final class DungeonSqlitePatchSpatialWriter {
             preliminaryMemberships.put(ref, record == null
                     ? Set.of()
                     : memberships(connection, patch.mapId().value(), record, Set.of(),
-                            preliminaryRoutes, preliminaryDependencies));
+                            preliminaryRoutes, preliminaryDependencies, new LinkedHashMap<>()));
         }
         Set<DungeonChunkKey> blockerChunks = blockerChunks(oldMemberships, preliminaryMemberships);
         Set<Cell> blockers = loadRoomCells(connection, patch.mapId().value(), blockerChunks);
         Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> nextMemberships = new LinkedHashMap<>();
+        Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> nextExtents = new LinkedHashMap<>();
         for (DungeonPatchEntityRef ref : refs) {
             DungeonWindowEntityRecord record = closure.records().get(ref);
+            Map<DungeonChunkKey, CellExtent> extents = new LinkedHashMap<>();
             nextMemberships.put(ref, record == null
                     ? Set.of()
                     : memberships(connection, patch.mapId().value(), record, blockers,
-                            nextRoutes, nextDependencies));
+                            nextRoutes, nextDependencies, extents));
+            nextExtents.put(ref, Map.copyOf(extents));
         }
 
         List<DungeonPatchEntityRef> affected = affectedRefs(
@@ -86,6 +89,7 @@ final class DungeonSqlitePatchSpatialWriter {
         assertDeclaredEntities(patch, affected);
         oldMemberships = membershipsFor(oldMemberships, affected);
         nextMemberships = membershipsFor(nextMemberships, affected);
+        nextExtents = extentsFor(nextExtents, affected);
         Set<Long> affectedCorridors = corridorIds(affected);
         oldRoutes = routesFor(oldRoutes, affectedCorridors);
         nextRoutes = routesFor(nextRoutes, affectedCorridors);
@@ -93,9 +97,11 @@ final class DungeonSqlitePatchSpatialWriter {
         nextDependencies = dependenciesFor(nextDependencies, affectedCorridors);
         assertExactChunks(patch, oldMemberships, nextMemberships, oldRoutes, nextRoutes);
         upsertTouchedChunks(connection, patch);
-        reconcileMembershipRows(connection, oldMemberships, nextMemberships);
+        Set<Integer> affectedLevels = affectedLevels(oldMemberships, nextExtents);
+        reconcileMembershipRows(connection, patch.mapId().value(), oldMemberships, nextExtents);
         reconcileRouteRows(connection, oldRoutes, nextRoutes);
         reconcileDependencyRows(connection, oldDependencies, nextDependencies);
+        recomputeLevelBounds(connection, patch.mapId().value(), affectedLevels);
         Map<DungeonChunkKey, Long> result = new LinkedHashMap<>();
         patch.touchedChunks().stream().sorted(DungeonChunkKeyOrder.ORDER)
                 .forEach(key -> result.put(key, patch.committedRevision()));
@@ -434,33 +440,35 @@ final class DungeonSqlitePatchSpatialWriter {
 
     private static Set<DungeonChunkKey> memberships(Connection connection, long mapId,
             DungeonWindowEntityRecord record, Set<Cell> blockers, Map<RouteKey, RouteRow> routes,
-            Map<DependencyKey, DependencyRow> dependencies)
+            Map<DependencyKey, DependencyRow> dependencies,
+            Map<DungeonChunkKey, CellExtent> extents)
             throws SQLException {
         Set<DungeonChunkKey> result = new LinkedHashSet<>();
         if (record instanceof DungeonWindowEntityRecord.Room room) {
-            room.value().floorCells().forEach(cell -> add(result, mapId, cell.levelZ(), cell.cellX(), cell.cellY()));
+            room.value().floorCells().forEach(cell -> add(result, extents, mapId, cell.levelZ(), cell.cellX(), cell.cellY()));
         } else if (record instanceof DungeonWindowEntityRecord.RoomCluster cluster) {
             cluster.memberRooms().forEach(room -> room.floorCells()
-                    .forEach(cell -> add(result, mapId, cell.levelZ(), cell.cellX(), cell.cellY())));
+                    .forEach(cell -> add(result, extents, mapId, cell.levelZ(), cell.cellX(), cell.cellY())));
             cluster.value().boundaries().forEach(boundary -> add(
-                    result, mapId, boundary.levelZ(), boundary.cellX(), boundary.cellY()));
+                    result, extents, mapId, boundary.levelZ(), boundary.cellX(), boundary.cellY()));
         } else if (record instanceof DungeonWindowEntityRecord.Corridor corridor) {
-            corridorMembership(connection, result, routes, dependencies, mapId, corridor, blockers);
+            corridorMembership(connection, result, extents, routes, dependencies, mapId, corridor, blockers);
         } else if (record instanceof DungeonWindowEntityRecord.Stair stair) {
-            stair.value().pathNodes().forEach(node -> add(result, mapId, node.cellZ(), node.cellX(), node.cellY()));
-            stair.value().exits().forEach(exit -> add(result, mapId, exit.cellZ(), exit.cellX(), exit.cellY()));
+            stair.value().pathNodes().forEach(node -> add(result, extents, mapId, node.cellZ(), node.cellX(), node.cellY()));
+            stair.value().exits().forEach(exit -> add(result, extents, mapId, exit.cellZ(), exit.cellX(), exit.cellY()));
         } else if (record instanceof DungeonWindowEntityRecord.Transition transition) {
             if (transition.value().cellX() != null && transition.value().cellY() != null
                     && transition.value().levelZ() != null) {
-                add(result, mapId, transition.value().levelZ(), transition.value().cellX(), transition.value().cellY());
+                add(result, extents, mapId, transition.value().levelZ(), transition.value().cellX(), transition.value().cellY());
             }
         } else if (record instanceof DungeonWindowEntityRecord.FeatureMarker marker) {
-            add(result, mapId, marker.value().levelZ(), marker.value().cellX(), marker.value().cellY());
+            add(result, extents, mapId, marker.value().levelZ(), marker.value().cellX(), marker.value().cellY());
         }
         return Set.copyOf(result);
     }
 
     private static void corridorMembership(Connection connection, Set<DungeonChunkKey> membership,
+            Map<DungeonChunkKey, CellExtent> extents,
             Map<RouteKey, RouteRow> routeRows, Map<DependencyKey, DependencyRow> dependencyRows,
             long mapId, DungeonWindowEntityRecord.Corridor graph,
             Set<Cell> blockers) throws SQLException {
@@ -472,7 +480,7 @@ final class DungeonSqlitePatchSpatialWriter {
             if (center != null) {
                 Cell cell = new Cell(center.q() + waypoint.relativeX(), center.r() + waypoint.relativeY(),
                         waypoint.relativeZ());
-                waypoints.add(cell); add(membership, mapId, cell.level(), cell.q(), cell.r());
+                waypoints.add(cell); add(membership, extents, mapId, cell.level(), cell.q(), cell.r());
             }
         });
         List<Cell> doors = new ArrayList<>();
@@ -481,7 +489,7 @@ final class DungeonSqlitePatchSpatialWriter {
             if (center != null) {
                 Cell cell = new Cell(center.q() + door.relativeCellX(), center.r() + door.relativeCellY(),
                         door.relativeCellZ());
-                add(membership, mapId, cell.level(), cell.q(), cell.r());
+                add(membership, extents, mapId, cell.level(), cell.q(), cell.r());
                 doors.add(Direction.parse(door.edgeDirection()).neighborOf(cell));
             }
         });
@@ -492,7 +500,7 @@ final class DungeonSqlitePatchSpatialWriter {
                     new AnchorTopologyKey(anchor.hostCorridorId(), anchor.topologyElementId()), anchor);
         }));
         corridor.anchorBindings().forEach(anchor -> add(
-                membership, mapId, anchor.cellZ(), anchor.cellX(), anchor.cellY()));
+                membership, extents, mapId, anchor.cellZ(), anchor.cellX(), anchor.cellY()));
         List<Cell> anchorEndpoints = new ArrayList<>();
         for (DungeonCorridorAnchorRefRecord ref : corridor.anchorRefs()) {
             if (ref.topologyElementId() == null) continue;
@@ -500,7 +508,7 @@ final class DungeonSqlitePatchSpatialWriter {
                     new AnchorTopologyKey(ref.hostCorridorId(), ref.topologyElementId()));
             if (anchor != null) {
                 Cell cell = new Cell(anchor.cellX(), anchor.cellY(), anchor.cellZ());
-                anchorEndpoints.add(cell); add(membership, mapId, cell.level(), cell.q(), cell.r());
+                anchorEndpoints.add(cell); add(membership, extents, mapId, cell.level(), cell.q(), cell.r());
             }
         }
         for (Cell cell : DungeonSqliteCorridorRouteFacts.dependencyCells(waypoints, doors, anchorEndpoints)) {
@@ -511,7 +519,7 @@ final class DungeonSqlitePatchSpatialWriter {
         for (DungeonSqliteCorridorRouteFacts.RouteCell route
                 : DungeonSqliteCorridorRouteFacts.routeCells(waypoints, doors, anchorEndpoints, blockers)) {
             Cell cell = route.cell(); DungeonChunkKey chunk = containing(mapId, cell.level(), cell.q(), cell.r());
-            membership.add(chunk);
+            add(membership, extents, mapId, cell.level(), cell.q(), cell.r());
             RouteRow row = new RouteRow(mapId, corridor.corridorId(), route.segmentOrder(), route.cellOrder(),
                     cell.level(), cell.q(), cell.r(), chunk.chunkQ(), chunk.chunkR());
             routeRows.put(row.key(), row);
@@ -558,6 +566,17 @@ final class DungeonSqlitePatchSpatialWriter {
         Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> result = new LinkedHashMap<>();
         for (DungeonPatchEntityRef ref : refs) {
             result.put(ref, source.getOrDefault(ref, Set.of()));
+        }
+        return result;
+    }
+
+    private static Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> extentsFor(
+            Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> source,
+            List<DungeonPatchEntityRef> refs
+    ) {
+        Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> result = new LinkedHashMap<>();
+        for (DungeonPatchEntityRef ref : refs) {
+            result.put(ref, source.getOrDefault(ref, Map.of()));
         }
         return result;
     }
@@ -620,29 +639,73 @@ final class DungeonSqlitePatchSpatialWriter {
         }
     }
 
-    private static void reconcileMembershipRows(Connection connection,
+    private static void reconcileMembershipRows(Connection connection, long mapId,
             Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> oldRows,
-            Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> nextRows) throws SQLException {
+            Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> nextRows) throws SQLException {
         try (PreparedStatement delete = connection.prepareStatement(
-                "DELETE FROM dungeon_entity_chunks WHERE dungeon_map_id=? AND entity_kind=? AND entity_id=? "
-                        + "AND level_z=? AND chunk_q=? AND chunk_r=?");
+                "DELETE FROM dungeon_entity_chunks WHERE dungeon_map_id=? AND entity_kind=? AND entity_id=?");
              PreparedStatement insert = connection.prepareStatement(
-                     "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r) "
-                             + "VALUES(?,?,?,?,?,?)")) {
+                     "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r,"
+                             + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count) "
+                             + "VALUES(?,?,?,?,?,?,?,?,?,?,?)")) {
             for (DungeonPatchEntityRef ref : oldRows.keySet()) {
-                Set<DungeonChunkKey> old = oldRows.getOrDefault(ref, Set.of());
-                Set<DungeonChunkKey> next = nextRows.getOrDefault(ref, Set.of());
-                for (DungeonChunkKey key : difference(old, next)) { bindMembership(delete, ref, key); delete.addBatch(); }
-                for (DungeonChunkKey key : difference(next, old)) { bindMembership(insert, ref, key); insert.addBatch(); }
+                delete.setLong(1, mapId);
+                delete.setString(2, ref.kind().name());
+                delete.setLong(3, ref.id());
+                delete.addBatch();
+                Map<DungeonChunkKey, CellExtent> next = nextRows.getOrDefault(ref, Map.of());
+                for (Map.Entry<DungeonChunkKey, CellExtent> entry : next.entrySet()) {
+                    bindMembership(insert, ref, entry.getKey(), entry.getValue(), next.size());
+                    insert.addBatch();
+                }
             }
             delete.executeBatch(); insert.executeBatch();
         }
     }
 
-    private static void bindMembership(PreparedStatement statement, DungeonPatchEntityRef ref, DungeonChunkKey key)
+    private static void bindMembership(PreparedStatement statement, DungeonPatchEntityRef ref, DungeonChunkKey key,
+            CellExtent extent, int entityChunkCount)
             throws SQLException {
         statement.setLong(1, key.mapId()); statement.setString(2, ref.kind().name()); statement.setLong(3, ref.id());
         statement.setInt(4, key.level()); statement.setInt(5, key.chunkQ()); statement.setInt(6, key.chunkR());
+        statement.setInt(7, extent.minimumQ()); statement.setInt(8, extent.minimumR());
+        statement.setInt(9, extent.maximumQ()); statement.setInt(10, extent.maximumR());
+        statement.setInt(11, entityChunkCount);
+    }
+
+    private static Set<Integer> affectedLevels(
+            Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> oldRows,
+            Map<DungeonPatchEntityRef, Map<DungeonChunkKey, CellExtent>> nextRows
+    ) {
+        Set<Integer> levels = new LinkedHashSet<>();
+        oldRows.values().forEach(chunks -> chunks.forEach(chunk -> levels.add(chunk.level())));
+        nextRows.values().forEach(chunks -> chunks.keySet().forEach(chunk -> levels.add(chunk.level())));
+        return Set.copyOf(levels);
+    }
+
+    private static void recomputeLevelBounds(Connection connection, long mapId, Set<Integer> levels)
+            throws SQLException {
+        try (PreparedStatement delete = connection.prepareStatement(
+                    "DELETE FROM dungeon_authored_level_bounds WHERE dungeon_map_id=? AND level_z=?");
+             PreparedStatement extrema = connection.prepareStatement(
+                    "SELECT MIN(minimum_q),MIN(minimum_r),MAX(maximum_q),MAX(maximum_r) "
+                            + "FROM dungeon_entity_chunks WHERE dungeon_map_id=? AND level_z=?");
+             PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO dungeon_authored_level_bounds(dungeon_map_id,level_z,minimum_q,minimum_r,maximum_q,maximum_r) "
+                            + "VALUES(?,?,?,?,?,?)")) {
+            for (int level : levels) {
+                delete.setLong(1, mapId); delete.setInt(2, level); delete.executeUpdate();
+                extrema.setLong(1, mapId); extrema.setInt(2, level);
+                try (ResultSet row = extrema.executeQuery()) {
+                    if (row.next() && row.getObject(1) != null) {
+                        insert.setLong(1, mapId); insert.setInt(2, level);
+                        insert.setInt(3, row.getInt(1)); insert.setInt(4, row.getInt(2));
+                        insert.setInt(5, row.getInt(3)); insert.setInt(6, row.getInt(4));
+                        insert.executeUpdate();
+                    }
+                }
+            }
+        }
     }
 
     private static void reconcileRouteRows(Connection connection, Map<RouteKey, RouteRow> oldRows,
@@ -718,8 +781,12 @@ final class DungeonSqlitePatchSpatialWriter {
         Set<T> result = new LinkedHashSet<>(left); result.removeAll(right); return result;
     }
 
-    private static void add(Set<DungeonChunkKey> result, long mapId, int level, int x, int y) {
-        result.add(containing(mapId, level, x, y));
+    private static void add(Set<DungeonChunkKey> result, Map<DungeonChunkKey, CellExtent> extents,
+            long mapId, int level, int x, int y) {
+        DungeonChunkKey chunk = containing(mapId, level, x, y);
+        result.add(chunk);
+        extents.compute(chunk, (ignored, extent) -> extent == null
+                ? CellExtent.at(x, y) : extent.include(x, y));
     }
 
     private static DungeonChunkKey containing(long mapId, int level, int x, int y) {
@@ -767,6 +834,16 @@ final class DungeonSqlitePatchSpatialWriter {
                     target.add(new DungeonChunkKey(mapId, level, q, r));
                 }
             }
+        }
+    }
+    private record CellExtent(int minimumQ, int minimumR, int maximumQ, int maximumR) {
+        static CellExtent at(int q, int r) {
+            return new CellExtent(q, r, q, r);
+        }
+
+        CellExtent include(int q, int r) {
+            return new CellExtent(Math.min(minimumQ, q), Math.min(minimumR, r),
+                    Math.max(maximumQ, q), Math.max(maximumR, r));
         }
     }
     private record RouteKey(long mapId, long corridorId, int segment, int order) { }

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteSchemaManager.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteSchemaManager.java
@@ -17,6 +17,7 @@ final class DungeonSqliteSchemaManager {
             DungeonPersistenceSchema.IDENTITY_SEQUENCES_TABLE,
             DungeonPersistenceSchema.CORRIDOR_ROUTE_CELLS_TABLE,
             DungeonPersistenceSchema.CORRIDOR_ROUTE_DEPENDENCIES_TABLE,
+            DungeonPersistenceSchema.AUTHORED_LEVEL_BOUNDS_TABLE,
             DungeonPersistenceSchema.ENTITY_CHUNKS_TABLE,
             DungeonPersistenceSchema.CHUNKS_TABLE,
             DungeonPersistenceSchema.CORRIDOR_ANCHOR_REFS_TABLE,

--- a/features/dungeon/adapter/sqlite/gateway/DungeonSqliteWindowGateway.java
+++ b/features/dungeon/adapter/sqlite/gateway/DungeonSqliteWindowGateway.java
@@ -21,6 +21,11 @@ import features.dungeon.application.authored.port.DungeonWindowChunkHeader;
 import features.dungeon.application.authored.port.DungeonWindowContinuation;
 import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.application.authored.port.DungeonAuthoredLevelBounds;
+import features.dungeon.application.authored.port.DungeonContinuationCursor;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonContinuationPageRequest;
+import features.dungeon.application.authored.port.DungeonEntityChunkExtent;
 import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import java.sql.Connection;
@@ -47,6 +52,7 @@ public final class DungeonSqliteWindowGateway {
 
     private final DungeonSqliteConnectionSupport connectionSupport;
     private final AtomicInteger lastStatementCount = new AtomicInteger();
+    private final AtomicInteger lastContinuationRowsRead = new AtomicInteger();
     private final AtomicReference<List<String>> lastStatementSql = new AtomicReference<>(List.of());
     private final Runnable afterHeaderRead;
 
@@ -85,9 +91,17 @@ public final class DungeonSqliteWindowGateway {
                     return Optional.empty();
                 }
                 afterHeaderRead.run();
+                List<DungeonAuthoredLevelBounds> bounds = loadLevelBounds(
+                        connection, safeRequest.mapId().value(), safeRequest.chunkKeys(), queries);
+                DungeonContinuationPage page = loadContinuationPageSnapshot(
+                        connection,
+                        new DungeonContinuationPageRequest(
+                                safeRequest.mapId(), header.get().revision(), safeRequest.requestGeneration(),
+                                safeRequest.chunkKeys(), Optional.empty()),
+                        queries);
                 return Optional.of(new DungeonWindowIndex(
                         header.get(), safeRequest.requestGeneration(),
-                        loadChunkHeaders(connection, safeRequest, queries)));
+                        loadChunkHeaders(connection, safeRequest, queries), bounds, page));
             });
         } catch (SQLException exception) {
             throw new IllegalStateException("Failed to load Dungeon window index from SQLite.", exception);
@@ -121,6 +135,27 @@ public final class DungeonSqliteWindowGateway {
         }
     }
 
+    public Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+        DungeonContinuationPageRequest safeRequest = Objects.requireNonNull(request, "request");
+        DungeonSqliteQueryCounter queries = new DungeonSqliteQueryCounter();
+        try (Connection connection = connectionSupport.openReadyConnection()) {
+            return DungeonSqliteReadSnapshot.read(connection, () -> {
+                Optional<DungeonMapHeader> header = loadMapHeader(
+                        connection, safeRequest.mapId().value(), queries);
+                if (header.isEmpty() || header.get().revision() != safeRequest.expectedMapRevision()) {
+                    return Optional.empty();
+                }
+                afterHeaderRead.run();
+                return Optional.of(loadContinuationPageSnapshot(connection, safeRequest, queries));
+            });
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to load Dungeon continuation page from SQLite.", exception);
+        } finally {
+            lastStatementCount.set(queries.statements());
+            lastStatementSql.set(queries.preparedSql());
+        }
+    }
+
     /** Last sparse-read statement count, excluding connection setup and migrations. */
     public int lastStatementCount() {
         return lastStatementCount.get();
@@ -129,6 +164,11 @@ public final class DungeonSqliteWindowGateway {
     /** Last sparse-read SQL shapes for bounded-query diagnostics. */
     public List<String> lastStatementSql() {
         return lastStatementSql.get();
+    }
+
+    /** Rows consumed by the last continuation query, including its one-row lookahead. */
+    public int lastContinuationRowsRead() {
+        return lastContinuationRowsRead.get();
     }
 
     public DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request) {
@@ -360,30 +400,16 @@ public final class DungeonSqliteWindowGateway {
         List<DungeonWindowChunkHeader> chunkHeaders = loadChunkHeaders(connection, request, queries);
         Map<DungeonPatchEntityRef, List<DungeonChunkKey>> requestedMemberships =
                 loadRequestedMemberships(connection, request, queries);
+        List<DungeonEntityChunkExtent> extents = loadRequestedExtents(connection, request, queries);
         List<DungeonWindowEntityFragment> fragments = DungeonSqliteWindowFragmentLoader.loadAll(
                 connection,
                 request.mapId().value(),
                 request.chunkKeys(),
                 requestedMemberships,
                 queries);
-        Map<DungeonPatchEntityRef, List<DungeonChunkKey>> allMemberships = loadAllMemberships(
-                connection,
-                request.mapId().value(),
-                requestedMemberships.keySet(),
-                queries);
-        List<DungeonWindowContinuation> continuations = new ArrayList<>();
-        Set<DungeonChunkKey> requestedKeys = Set.copyOf(request.chunkKeys());
-        for (Map.Entry<DungeonPatchEntityRef, List<DungeonChunkKey>> entry : requestedMemberships.entrySet()) {
-            List<DungeonChunkKey> offWindow = allMemberships.getOrDefault(entry.getKey(), List.of())
-                    .stream()
-                    .filter(key -> !requestedKeys.contains(key))
-                    .toList();
-            if (!offWindow.isEmpty()) {
-                continuations.add(new DungeonWindowContinuation(entry.getKey(), offWindow));
-            }
-        }
         return Optional.of(new DungeonWindow(
-                header.get(), request.requestGeneration(), chunkHeaders, fragments, continuations));
+                header.get(), request.requestGeneration(), chunkHeaders, fragments,
+                extents, List.of(), DungeonContinuationPage.empty()));
     }
 
     private DungeonIdentityClosureResult loadClosureSnapshot(
@@ -552,52 +578,140 @@ public final class DungeonSqliteWindowGateway {
         }
     }
 
-    private static Map<DungeonPatchEntityRef, List<DungeonChunkKey>> loadAllMemberships(
+    private static List<DungeonEntityChunkExtent> loadRequestedExtents(
             Connection connection,
-            long mapId,
-            Set<DungeonPatchEntityRef> refs,
+            DungeonWindowRequest request,
             DungeonSqliteQueryCounter queries
     ) throws SQLException {
-        if (refs.isEmpty()) {
-            return Map.of();
+        if (request.chunkKeys().isEmpty()) {
+            return List.of();
         }
-        Map<DungeonPatchEntityRef.Kind, List<Long>> idsByKind = new java.util.EnumMap<>(
-                DungeonPatchEntityRef.Kind.class);
-        for (DungeonPatchEntityRef ref : refs) {
-            idsByKind.computeIfAbsent(ref.kind(), ignored -> new ArrayList<>()).add(ref.id());
-        }
-        String predicate = idsByKind.entrySet().stream()
-                .map(entry -> "(entity_kind=? AND entity_id IN (" + String.join(",",
-                        java.util.Collections.nCopies(entry.getValue().size(), "?")) + "))")
-                .collect(java.util.stream.Collectors.joining(" OR "));
-        try (PreparedStatement statement = queries.prepare(connection,
-                "SELECT entity_kind, entity_id, level_z, chunk_q, chunk_r FROM "
-                        + DungeonPersistenceSchema.ENTITY_CHUNKS_TABLE
-                        + " WHERE dungeon_map_id=? AND (" + predicate + ")"
-                        + " ORDER BY entity_kind, entity_id, level_z, chunk_r, chunk_q")) {
-            int parameter = 1;
-            statement.setLong(parameter++, mapId);
-            for (Map.Entry<DungeonPatchEntityRef.Kind, List<Long>> entry : idsByKind.entrySet()) {
-                statement.setString(parameter++, entry.getKey().name());
-                for (Long id : entry.getValue()) {
-                    statement.setLong(parameter++, id);
+        String sql = "SELECT entity_kind,entity_id,level_z,chunk_q,chunk_r,"
+                + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count FROM "
+                + DungeonPersistenceSchema.ENTITY_CHUNKS_TABLE
+                + " WHERE dungeon_map_id=? AND (" + exactChunkPredicate(request.chunkKeys().size()) + ")"
+                + " ORDER BY entity_kind,entity_id,level_z,chunk_r,chunk_q";
+        try (PreparedStatement statement = queries.prepare(connection, sql)) {
+            bindExactChunks(statement, request.mapId().value(), request.chunkKeys());
+            try (ResultSet rows = statement.executeQuery()) {
+                List<DungeonEntityChunkExtent> result = new ArrayList<>();
+                while (rows.next()) {
+                    DungeonChunkKey chunk = new DungeonChunkKey(request.mapId().value(),
+                            rows.getInt("level_z"), rows.getInt("chunk_q"), rows.getInt("chunk_r"));
+                    result.add(new DungeonEntityChunkExtent(
+                            ref(rows.getString("entity_kind"), rows.getLong("entity_id")), chunk,
+                            rows.getInt("minimum_q"), rows.getInt("minimum_r"),
+                            rows.getInt("maximum_q"), rows.getInt("maximum_r"),
+                            rows.getInt("entity_chunk_count")));
                 }
+                return List.copyOf(result);
+            }
+        }
+    }
+
+    private static List<DungeonAuthoredLevelBounds> loadLevelBounds(
+            Connection connection,
+            long mapId,
+            List<DungeonChunkKey> requestedChunks,
+            DungeonSqliteQueryCounter queries
+    ) throws SQLException {
+        List<Integer> levels = requestedChunks.stream().map(DungeonChunkKey::level).distinct().sorted().toList();
+        if (levels.isEmpty()) {
+            return List.of();
+        }
+        String sql = "SELECT level_z,minimum_q,minimum_r,maximum_q,maximum_r FROM "
+                + DungeonPersistenceSchema.AUTHORED_LEVEL_BOUNDS_TABLE
+                + " WHERE dungeon_map_id=? AND level_z IN ("
+                + String.join(",", java.util.Collections.nCopies(levels.size(), "?")) + ") ORDER BY level_z";
+        Map<Integer, DungeonAuthoredLevelBounds> loaded = new LinkedHashMap<>();
+        try (PreparedStatement statement = queries.prepare(connection, sql)) {
+            statement.setLong(1, mapId);
+            for (int index = 0; index < levels.size(); index++) {
+                statement.setInt(index + 2, levels.get(index));
             }
             try (ResultSet rows = statement.executeQuery()) {
-                Map<DungeonPatchEntityRef, List<DungeonChunkKey>> mutable = new LinkedHashMap<>();
                 while (rows.next()) {
-                    DungeonPatchEntityRef ref = ref(rows.getString("entity_kind"), rows.getLong("entity_id"));
-                    mutable.computeIfAbsent(ref, ignored -> new ArrayList<>()).add(new DungeonChunkKey(
-                            mapId,
-                            rows.getInt("level_z"),
-                            rows.getInt("chunk_q"),
-                            rows.getInt("chunk_r")));
+                    int level = rows.getInt("level_z");
+                    loaded.put(level, new DungeonAuthoredLevelBounds(level, true,
+                            rows.getInt("minimum_q"), rows.getInt("minimum_r"),
+                            rows.getInt("maximum_q"), rows.getInt("maximum_r")));
                 }
-                Map<DungeonPatchEntityRef, List<DungeonChunkKey>> result = new LinkedHashMap<>();
-                mutable.forEach((ref, values) -> result.put(ref, List.copyOf(values)));
-                return Map.copyOf(result);
             }
         }
+        return levels.stream().map(level -> loaded.getOrDefault(level, DungeonAuthoredLevelBounds.empty(level)))
+                .toList();
+    }
+
+    private DungeonContinuationPage loadContinuationPageSnapshot(
+            Connection connection,
+            DungeonContinuationPageRequest request,
+            DungeonSqliteQueryCounter queries
+    ) throws SQLException {
+        if (request.requestedChunks().isEmpty()) {
+            lastContinuationRowsRead.set(0);
+            return DungeonContinuationPage.empty();
+        }
+        String requestedPredicate = exactChunkPredicate("seed", request.requestedChunks().size());
+        String excludedPredicate = exactChunkPredicate("off", request.requestedChunks().size());
+        String cursorPredicate = request.after().isPresent()
+                ? " AND (off.entity_kind,off.entity_id,off.level_z,off.chunk_r,off.chunk_q) > (?,?,?,?,?)"
+                : "";
+        String sql = "WITH requested_entities AS MATERIALIZED ("
+                + "SELECT DISTINCT seed.entity_kind,seed.entity_id FROM "
+                + DungeonPersistenceSchema.ENTITY_CHUNKS_TABLE + " seed WHERE seed.dungeon_map_id=? AND ("
+                + requestedPredicate + ")) SELECT DISTINCT off.entity_kind,off.entity_id,off.level_z,off.chunk_q,off.chunk_r"
+                + " FROM " + DungeonPersistenceSchema.ENTITY_CHUNKS_TABLE + " off"
+                + " JOIN requested_entities requested ON requested.entity_kind=off.entity_kind"
+                + " AND requested.entity_id=off.entity_id WHERE off.dungeon_map_id=?"
+                + " AND NOT (" + excludedPredicate + ")" + cursorPredicate
+                + " ORDER BY off.entity_kind,off.entity_id,off.level_z,off.chunk_r,off.chunk_q LIMIT 257";
+        try (PreparedStatement statement = queries.prepare(connection, sql)) {
+            int parameter = bindExactChunks(statement, request.mapId().value(), request.requestedChunks());
+            statement.setLong(parameter++, request.mapId().value());
+            parameter = bindExactChunks(statement, parameter, request.requestedChunks());
+            if (request.after().isPresent()) {
+                DungeonContinuationCursor cursor = request.after().get();
+                statement.setString(parameter++, cursor.entityRef().kind().name());
+                statement.setLong(parameter++, cursor.entityRef().id());
+                statement.setInt(parameter++, cursor.offWindowChunk().level());
+                statement.setInt(parameter++, cursor.offWindowChunk().chunkR());
+                statement.setInt(parameter, cursor.offWindowChunk().chunkQ());
+            }
+            List<ContinuationRow> rowsRead = new ArrayList<>();
+            try (ResultSet rows = statement.executeQuery()) {
+                while (rows.next()) {
+                    rowsRead.add(new ContinuationRow(
+                            ref(rows.getString("entity_kind"), rows.getLong("entity_id")),
+                            new DungeonChunkKey(request.mapId().value(), rows.getInt("level_z"),
+                                    rows.getInt("chunk_q"), rows.getInt("chunk_r"))));
+                }
+            }
+            lastContinuationRowsRead.set(rowsRead.size());
+            boolean hasMore = rowsRead.size() > DungeonContinuationPageRequest.PAGE_SIZE;
+            List<ContinuationRow> pageRows = hasMore
+                    ? List.copyOf(rowsRead.subList(0, DungeonContinuationPageRequest.PAGE_SIZE))
+                    : List.copyOf(rowsRead);
+            Map<DungeonPatchEntityRef, List<DungeonChunkKey>> grouped = new LinkedHashMap<>();
+            pageRows.forEach(row -> grouped.computeIfAbsent(row.entityRef(), ignored -> new ArrayList<>())
+                    .add(row.offWindowChunk()));
+            List<DungeonWindowContinuation> entries = grouped.entrySet().stream()
+                    .map(entry -> new DungeonWindowContinuation(entry.getKey(), entry.getValue()))
+                    .toList();
+            Optional<DungeonContinuationCursor> next = Optional.empty();
+            if (hasMore) {
+                ContinuationRow last = pageRows.get(pageRows.size() - 1);
+                next = Optional.of(new DungeonContinuationCursor(
+                        request.mapId(), request.expectedMapRevision(), request.requestGeneration(),
+                        request.requestedChunks(), last.entityRef(), last.offWindowChunk()));
+            }
+            return new DungeonContinuationPage(entries, next);
+        }
+    }
+
+    private static String exactChunkPredicate(String alias, int chunkCount) {
+        return String.join(" OR ", java.util.Collections.nCopies(
+                chunkCount,
+                "(" + alias + ".level_z=? AND " + alias + ".chunk_q=? AND " + alias + ".chunk_r=?)"));
     }
 
     private static String exactChunkPredicate(int chunkCount) {
@@ -621,6 +735,19 @@ public final class DungeonSqliteWindowGateway {
         return parameter;
     }
 
+    private static int bindExactChunks(
+            PreparedStatement statement,
+            int parameter,
+            List<DungeonChunkKey> chunks
+    ) throws SQLException {
+        for (DungeonChunkKey chunk : chunks) {
+            statement.setInt(parameter++, chunk.level());
+            statement.setInt(parameter++, chunk.chunkQ());
+            statement.setInt(parameter++, chunk.chunkR());
+        }
+        return parameter;
+    }
+
     private static DungeonPatchEntityRef ref(String kind, long id) {
         try {
             return switch (DungeonPatchEntityRef.Kind.valueOf(kind)) {
@@ -635,4 +762,6 @@ public final class DungeonSqliteWindowGateway {
             throw new IllegalStateException("Unknown Dungeon entity membership kind: " + kind, exception);
         }
     }
+
+    private record ContinuationRow(DungeonPatchEntityRef entityRef, DungeonChunkKey offWindowChunk) { }
 }

--- a/features/dungeon/adapter/sqlite/model/DungeonPersistenceSchema.java
+++ b/features/dungeon/adapter/sqlite/model/DungeonPersistenceSchema.java
@@ -25,6 +25,7 @@ public final class DungeonPersistenceSchema {
     public static final String FEATURE_MARKERS_TABLE = "dungeon_feature_markers";
     public static final String CHUNKS_TABLE = "dungeon_chunks";
     public static final String ENTITY_CHUNKS_TABLE = "dungeon_entity_chunks";
+    public static final String AUTHORED_LEVEL_BOUNDS_TABLE = "dungeon_authored_level_bounds";
     public static final String CORRIDOR_ROUTE_CELLS_TABLE = "dungeon_corridor_route_cells";
     public static final String CORRIDOR_ROUTE_DEPENDENCIES_TABLE = "dungeon_corridor_route_dependencies";
     public static final String IDENTITY_SEQUENCES_TABLE = "dungeon_identity_sequences";
@@ -60,6 +61,14 @@ public final class DungeonPersistenceSchema {
                     + "level_z        INTEGER NOT NULL,"
                     + "chunk_q        INTEGER NOT NULL,"
                     + "chunk_r        INTEGER NOT NULL,"
+                    + "minimum_q      INTEGER NOT NULL,"
+                    + "minimum_r      INTEGER NOT NULL,"
+                    + "maximum_q      INTEGER NOT NULL,"
+                    + "maximum_r      INTEGER NOT NULL,"
+                    + "entity_chunk_count INTEGER NOT NULL CHECK(entity_chunk_count > 0),"
+                    + "CHECK(maximum_q >= minimum_q AND maximum_r >= minimum_r),"
+                    + "CHECK(minimum_q >= chunk_q * 64 AND maximum_q < (chunk_q + 1) * 64),"
+                    + "CHECK(minimum_r >= chunk_r * 64 AND maximum_r < (chunk_r + 1) * 64),"
                     + "PRIMARY KEY (dungeon_map_id, entity_kind, entity_id, level_z, chunk_q, chunk_r),"
                     + "FOREIGN KEY (dungeon_map_id, level_z, chunk_q, chunk_r)"
                     + " REFERENCES dungeon_chunks(dungeon_map_id, level_z, chunk_q, chunk_r) ON DELETE CASCADE"
@@ -68,6 +77,27 @@ public final class DungeonPersistenceSchema {
     public static final String CREATE_DUNGEON_ENTITY_CHUNKS_LOOKUP_INDEX_SQL =
             "CREATE INDEX IF NOT EXISTS idx_dungeon_entity_chunks_by_chunk "
                     + "ON dungeon_entity_chunks(dungeon_map_id, level_z, chunk_q, chunk_r, entity_kind, entity_id)";
+
+    public static final String CREATE_DUNGEON_ENTITY_CHUNKS_EXTREMA_INDEX_SQL =
+            "CREATE INDEX IF NOT EXISTS idx_dungeon_entity_chunks_level_extrema "
+                    + "ON dungeon_entity_chunks(dungeon_map_id, level_z, minimum_q, maximum_q, minimum_r, maximum_r)";
+
+    public static final String CREATE_DUNGEON_ENTITY_CHUNKS_CONTINUATION_INDEX_SQL =
+            "CREATE INDEX IF NOT EXISTS idx_dungeon_entity_chunks_continuation "
+                    + "ON dungeon_entity_chunks("
+                    + "dungeon_map_id, entity_kind, entity_id, level_z, chunk_r, chunk_q)";
+
+    public static final String CREATE_DUNGEON_AUTHORED_LEVEL_BOUNDS_TABLE_SQL =
+            "CREATE TABLE IF NOT EXISTS dungeon_authored_level_bounds ("
+                    + "dungeon_map_id INTEGER NOT NULL REFERENCES dungeon_maps(dungeon_map_id) ON DELETE CASCADE,"
+                    + "level_z        INTEGER NOT NULL,"
+                    + "minimum_q      INTEGER NOT NULL,"
+                    + "minimum_r      INTEGER NOT NULL,"
+                    + "maximum_q      INTEGER NOT NULL,"
+                    + "maximum_r      INTEGER NOT NULL,"
+                    + "CHECK(maximum_q >= minimum_q AND maximum_r >= minimum_r),"
+                    + "PRIMARY KEY (dungeon_map_id, level_z)"
+                    + ")";
 
     public static final String CREATE_DUNGEON_CHUNKS_HORIZONTAL_LOOKUP_INDEX_SQL =
             "CREATE INDEX IF NOT EXISTS idx_dungeon_chunks_by_horizontal_window "
@@ -306,6 +336,7 @@ public final class DungeonPersistenceSchema {
             CREATE_DUNGEON_IDENTITY_SEQUENCES_TABLE_SQL,
             CREATE_DUNGEON_CHUNKS_TABLE_SQL,
             CREATE_DUNGEON_ENTITY_CHUNKS_TABLE_SQL,
+            CREATE_DUNGEON_AUTHORED_LEVEL_BOUNDS_TABLE_SQL,
             CREATE_DUNGEON_CORRIDOR_ROUTE_CELLS_TABLE_SQL,
             CREATE_DUNGEON_CORRIDOR_ROUTE_DEPENDENCIES_TABLE_SQL,
             CREATE_DUNGEON_ROOM_CLUSTERS_TABLE_SQL,
@@ -330,6 +361,8 @@ public final class DungeonPersistenceSchema {
     public static final List<String> CREATE_INDEX_SQL = List.of(
             CREATE_DUNGEON_CHUNKS_HORIZONTAL_LOOKUP_INDEX_SQL,
             CREATE_DUNGEON_ENTITY_CHUNKS_LOOKUP_INDEX_SQL,
+            CREATE_DUNGEON_ENTITY_CHUNKS_EXTREMA_INDEX_SQL,
+            CREATE_DUNGEON_ENTITY_CHUNKS_CONTINUATION_INDEX_SQL,
             CREATE_DUNGEON_CORRIDOR_ROUTE_CELLS_LOOKUP_INDEX_SQL,
             CREATE_DUNGEON_CORRIDOR_ROUTE_DEPENDENCIES_LOOKUP_INDEX_SQL,
             CREATE_DUNGEON_ROOMS_CLUSTER_LOOKUP_INDEX_SQL

--- a/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStore.java
+++ b/features/dungeon/adapter/sqlite/repository/SqliteDungeonWindowStore.java
@@ -14,6 +14,8 @@ import features.dungeon.application.authored.port.DungeonWindowContentRequest;
 import features.dungeon.application.authored.port.DungeonWindowContentSource;
 import features.dungeon.application.authored.port.DungeonWindowIndex;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonContinuationPageRequest;
 import java.util.Objects;
 import java.util.Optional;
 import platform.persistence.SqliteDatabase;
@@ -43,6 +45,11 @@ public final class SqliteDungeonWindowStore implements DungeonWindowContentSourc
     @Override
     public Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request) {
         return gateway.loadContent(request);
+    }
+
+    @Override
+    public Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+        return gateway.loadContinuationPage(request);
     }
 
     @Override

--- a/features/dungeon/api/DungeonViewportContinuationCursor.java
+++ b/features/dungeon/api/DungeonViewportContinuationCursor.java
@@ -1,0 +1,24 @@
+package features.dungeon.api;
+
+import java.util.List;
+
+/** Exclusive public cursor bound to one accepted viewport identity. */
+public record DungeonViewportContinuationCursor(
+        long mapId,
+        long mapRevision,
+        long requestGeneration,
+        List<DungeonChunkKey> requestedChunks,
+        String ownerKind,
+        long ownerId,
+        DungeonChunkKey offWindowChunk
+) {
+    public DungeonViewportContinuationCursor {
+        if (mapId < 1L || mapRevision < 1L || requestGeneration < 0L
+                || ownerKind == null || ownerKind.isBlank() || ownerId < 1L
+                || offWindowChunk == null || offWindowChunk.mapId() != mapId) {
+            throw new IllegalArgumentException("viewport continuation cursor must be complete");
+        }
+        requestedChunks = requestedChunks == null ? List.of() : List.copyOf(requestedChunks);
+        ownerKind = ownerKind.trim();
+    }
+}

--- a/features/dungeon/api/DungeonViewportContinuationPage.java
+++ b/features/dungeon/api/DungeonViewportContinuationPage.java
@@ -1,0 +1,22 @@
+package features.dungeon.api;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Public bounded continuation page for the active viewport. */
+public record DungeonViewportContinuationPage(
+        List<DungeonViewportContinuation> entries,
+        Optional<DungeonViewportContinuationCursor> nextCursor
+) {
+    public DungeonViewportContinuationPage {
+        entries = entries == null ? List.of() : List.copyOf(entries);
+        nextCursor = nextCursor == null ? Optional.empty() : nextCursor;
+        if (entries.size() > 256) {
+            throw new IllegalArgumentException("viewport continuation page exceeds 256 entries");
+        }
+    }
+
+    public static DungeonViewportContinuationPage empty() {
+        return new DungeonViewportContinuationPage(List.of(), Optional.empty());
+    }
+}

--- a/features/dungeon/api/DungeonViewportSnapshot.java
+++ b/features/dungeon/api/DungeonViewportSnapshot.java
@@ -20,7 +20,7 @@ public record DungeonViewportSnapshot(
         List<DungeonBoundarySnapshot> boundaries,
         List<DungeonFeatureSnapshot> features,
         List<DungeonEditorHandleSnapshot> editorHandles,
-        List<DungeonViewportContinuation> continuations,
+        DungeonViewportContinuationPage continuationPage,
         AuthoredBounds authoredBounds
 ) {
     public DungeonViewportSnapshot {
@@ -40,8 +40,12 @@ public record DungeonViewportSnapshot(
         boundaries = boundaries == null ? List.of() : List.copyOf(boundaries);
         features = features == null ? List.of() : List.copyOf(features);
         editorHandles = editorHandles == null ? List.of() : List.copyOf(editorHandles);
-        continuations = continuations == null ? List.of() : List.copyOf(continuations);
+        continuationPage = continuationPage == null ? DungeonViewportContinuationPage.empty() : continuationPage;
         authoredBounds = authoredBounds == null ? AuthoredBounds.empty() : authoredBounds;
+    }
+
+    public List<DungeonViewportContinuation> continuations() {
+        return continuationPage.entries();
     }
 
     public record AuthoredBounds(boolean present, int minimumQ, int minimumR, int maximumQ, int maximumR) {

--- a/features/dungeon/application/authored/DungeonCachedWindowStore.java
+++ b/features/dungeon/application/authored/DungeonCachedWindowStore.java
@@ -4,6 +4,10 @@ import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
 import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
 import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
+import features.dungeon.application.authored.port.DungeonAuthoredLevelBounds;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonContinuationPageRequest;
+import features.dungeon.application.authored.port.DungeonEntityChunkExtent;
 import features.dungeon.application.authored.port.DungeonInboundReferenceRequest;
 import features.dungeon.application.authored.port.DungeonInboundReferenceResult;
 import features.dungeon.application.authored.port.DungeonTravelChunkKeysRequest;
@@ -87,6 +91,11 @@ public final class DungeonCachedWindowStore implements DungeonWindowStore {
     }
 
     @Override
+    public Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+        return source.loadContinuationPage(Objects.requireNonNull(request, "request"));
+    }
+
+    @Override
     public synchronized void protectVisibleChunks(Collection<DungeonChunkKey> chunks) {
         Set<ChunkVersion> protectedVersions = new LinkedHashSet<>();
         for (DungeonChunkKey chunk : chunks == null ? List.<DungeonChunkKey>of() : chunks) {
@@ -159,7 +168,9 @@ public final class DungeonCachedWindowStore implements DungeonWindowStore {
     private static boolean sameIndex(DungeonWindowIndex left, DungeonWindowIndex right) {
         return left.mapHeader().equals(right.mapHeader())
                 && left.requestGeneration() == right.requestGeneration()
-                && left.chunkHeaders().equals(right.chunkHeaders());
+                && left.chunkHeaders().equals(right.chunkHeaders())
+                && left.authoredBounds().equals(right.authoredBounds())
+                && left.continuationPage().equals(right.continuationPage());
     }
 
     private static boolean validSingleChunk(
@@ -178,28 +189,16 @@ public final class DungeonCachedWindowStore implements DungeonWindowStore {
             Map<ChunkVersion, ChunkContent> contents
     ) {
         Map<DungeonPatchEntityRef, DungeonWindowEntityFragment> fragments = new LinkedHashMap<>();
-        Map<DungeonPatchEntityRef, Set<DungeonChunkKey>> offWindow = new LinkedHashMap<>();
+        List<DungeonEntityChunkExtent> extents = new ArrayList<>();
         for (ChunkVersion version : versions) {
             ChunkContent content = Objects.requireNonNull(contents.get(version), "indexed chunk content");
             for (DungeonWindowEntityFragment fragment : content.fragments()) {
                 fragments.merge(fragment.entityRef(), fragment, DungeonCachedWindowStore::merge);
             }
-            for (DungeonWindowContinuation continuation : content.continuations()) {
-                offWindow.computeIfAbsent(continuation.entityRef(), ignored -> new LinkedHashSet<>())
-                        .addAll(continuation.offWindowChunks());
-            }
-        }
-        Set<DungeonChunkKey> requested = new LinkedHashSet<>(
-                index.chunkHeaders().stream().map(DungeonWindowChunkHeader::key).toList());
-        List<DungeonWindowContinuation> continuations = new ArrayList<>();
-        for (Map.Entry<DungeonPatchEntityRef, Set<DungeonChunkKey>> entry : offWindow.entrySet()) {
-            entry.getValue().removeAll(requested);
-            if (!entry.getValue().isEmpty()) {
-                continuations.add(new DungeonWindowContinuation(entry.getKey(), List.copyOf(entry.getValue())));
-            }
+            extents.addAll(content.entityExtents());
         }
         return new DungeonWindow(index.mapHeader(), index.requestGeneration(), index.chunkHeaders(),
-                List.copyOf(fragments.values()), continuations);
+                List.copyOf(fragments.values()), extents, index.authoredBounds(), index.continuationPage());
     }
 
     private static DungeonWindowEntityFragment merge(
@@ -284,16 +283,16 @@ public final class DungeonCachedWindowStore implements DungeonWindowStore {
     private record ChunkContent(
             DungeonWindowChunkHeader header,
             List<DungeonWindowEntityFragment> fragments,
-            List<DungeonWindowContinuation> continuations
+            List<DungeonEntityChunkExtent> entityExtents
     ) {
         private ChunkContent {
             header = Objects.requireNonNull(header, "header");
             fragments = List.copyOf(fragments);
-            continuations = List.copyOf(continuations);
+            entityExtents = List.copyOf(entityExtents);
         }
 
         static ChunkContent from(DungeonWindow window) {
-            return new ChunkContent(window.chunkHeaders().get(0), window.fragments(), window.continuations());
+            return new ChunkContent(window.chunkHeaders().get(0), window.fragments(), window.entityExtents());
         }
 
         long weight() {
@@ -303,9 +302,7 @@ public final class DungeonCachedWindowStore implements DungeonWindowStore {
                 result = add(result, fragment.dependencyHeaders().size());
                 result = add(result, fragment.intersectingRequestedChunks().size());
             }
-            for (DungeonWindowContinuation continuation : continuations) {
-                result = add(result, continuation.offWindowChunks().size());
-            }
+            result = add(result, entityExtents.size());
             return result;
         }
 

--- a/features/dungeon/application/authored/DungeonCommandWorksetLoader.java
+++ b/features/dungeon/application/authored/DungeonCommandWorksetLoader.java
@@ -57,7 +57,13 @@ public final class DungeonCommandWorksetLoader {
             required.add(fragment.entityRef());
             required.addAll(fragment.dependencyHeaders());
         });
-        window.continuations().forEach(continuation -> required.add(continuation.entityRef()));
+        Map<DungeonPatchEntityRef, Integer> requestedExtentCounts = new LinkedHashMap<>();
+        window.entityExtents().forEach(extent -> requestedExtentCounts.merge(
+                extent.entityRef(), 1, Integer::sum));
+        window.entityExtents().stream()
+                .filter(extent -> requestedExtentCounts.getOrDefault(extent.entityRef(), 0)
+                        < extent.entityChunkCount())
+                .forEach(extent -> required.add(extent.entityRef()));
 
         Map<DungeonPatchEntityRef, DungeonEntitySnapshot> loaded = new LinkedHashMap<>();
         Set<DungeonPatchEntityRef> inboundExpanded = new LinkedHashSet<>();

--- a/features/dungeon/application/authored/DungeonWindowProjection.java
+++ b/features/dungeon/application/authored/DungeonWindowProjection.java
@@ -15,6 +15,8 @@ import features.dungeon.api.DungeonTopologyElementKind;
 import features.dungeon.api.DungeonTopologyElementRef;
 import features.dungeon.api.DungeonTopologyKind;
 import features.dungeon.api.DungeonViewportContinuation;
+import features.dungeon.api.DungeonViewportContinuationCursor;
+import features.dungeon.api.DungeonViewportContinuationPage;
 import features.dungeon.api.DungeonViewportRequest;
 import features.dungeon.api.DungeonViewportSnapshot;
 import features.dungeon.application.authored.port.DungeonWindow;
@@ -76,8 +78,8 @@ final class DungeonWindowProjection {
                 projection.publicBoundaries(),
                 projection.publicFeatures(),
                 projection.publicHandles(),
-                continuations(window),
-                projection.bounds());
+                continuationPage(window),
+                indexedBounds(window, request.level()));
     }
 
     private Projection project(DungeonWindow window, int level) {
@@ -128,8 +130,7 @@ final class DungeonWindowProjection {
                 publicAreas(areas),
                 publicBoundaries(boundaries),
                 publicFeatures(features),
-                publicHandles(handles),
-                dimensions.publicBounds());
+                publicHandles(handles));
     }
 
     private static List<DungeonEditorWorkspaceValues.Area> mergeClusterMemberCells(
@@ -699,6 +700,24 @@ final class DungeonWindowProjection {
         return List.copyOf(result);
     }
 
+    private static DungeonViewportContinuationPage continuationPage(DungeonWindow window) {
+        var cursor = window.continuationPage().nextCursor().map(value ->
+                new DungeonViewportContinuationCursor(
+                        value.mapId().value(), value.expectedMapRevision(), value.requestGeneration(),
+                        value.requestedChunks(), value.entityRef().kind().name(), value.entityRef().id(),
+                        value.offWindowChunk()));
+        return new DungeonViewportContinuationPage(continuations(window), cursor);
+    }
+
+    private static DungeonViewportSnapshot.AuthoredBounds indexedBounds(DungeonWindow window, int level) {
+        return window.authoredBounds().stream()
+                .filter(bounds -> bounds.level() == level && bounds.present())
+                .findFirst()
+                .map(bounds -> new DungeonViewportSnapshot.AuthoredBounds(
+                        true, bounds.minimumQ(), bounds.minimumR(), bounds.maximumQ(), bounds.maximumR()))
+                .orElseGet(DungeonViewportSnapshot.AuthoredBounds::empty);
+    }
+
     private static DungeonTopologyElementRef topologyRef(
             features.dungeon.application.authored.command.DungeonPatchEntityRef.Kind kind,
             long id
@@ -758,8 +777,7 @@ final class DungeonWindowProjection {
             List<DungeonAreaSnapshot> publicAreas,
             List<DungeonBoundarySnapshot> publicBoundaries,
             List<DungeonFeatureSnapshot> publicFeatures,
-            List<DungeonEditorHandleSnapshot> publicHandles,
-            DungeonViewportSnapshot.AuthoredBounds bounds
+            List<DungeonEditorHandleSnapshot> publicHandles
     ) {
     }
 

--- a/features/dungeon/application/authored/port/DungeonAuthoredLevelBounds.java
+++ b/features/dungeon/application/authored/port/DungeonAuthoredLevelBounds.java
@@ -1,0 +1,24 @@
+package features.dungeon.application.authored.port;
+
+/** Exact indexed authored cell bounds for one map level. */
+public record DungeonAuthoredLevelBounds(
+        int level,
+        boolean present,
+        int minimumQ,
+        int minimumR,
+        int maximumQ,
+        int maximumR
+) {
+    public DungeonAuthoredLevelBounds {
+        if (present && (maximumQ < minimumQ || maximumR < minimumR)) {
+            throw new IllegalArgumentException("present authored bounds must be ordered");
+        }
+        if (!present) {
+            minimumQ = minimumR = maximumQ = maximumR = 0;
+        }
+    }
+
+    public static DungeonAuthoredLevelBounds empty(int level) {
+        return new DungeonAuthoredLevelBounds(level, false, 0, 0, 0, 0);
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonContinuationCursor.java
+++ b/features/dungeon/application/authored/port/DungeonContinuationCursor.java
@@ -1,0 +1,30 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.command.DungeonPatchEntityRef;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.List;
+import java.util.Objects;
+
+/** Exclusive continuation cursor bound to the exact immutable window request. */
+public record DungeonContinuationCursor(
+        DungeonMapIdentity mapId,
+        long expectedMapRevision,
+        long requestGeneration,
+        List<DungeonChunkKey> requestedChunks,
+        DungeonPatchEntityRef entityRef,
+        DungeonChunkKey offWindowChunk
+) {
+    public DungeonContinuationCursor {
+        mapId = Objects.requireNonNull(mapId, "mapId");
+        if (expectedMapRevision < 1L || requestGeneration < 0L) {
+            throw new IllegalArgumentException("cursor revisions must be valid");
+        }
+        requestedChunks = new DungeonWindowRequest(mapId, requestGeneration, requestedChunks).chunkKeys();
+        entityRef = Objects.requireNonNull(entityRef, "entityRef");
+        offWindowChunk = Objects.requireNonNull(offWindowChunk, "offWindowChunk");
+        if (offWindowChunk.mapId() != mapId.value()) {
+            throw new IllegalArgumentException("cursor chunk must identify the requested map");
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonContinuationPage.java
+++ b/features/dungeon/application/authored/port/DungeonContinuationPage.java
@@ -1,0 +1,22 @@
+package features.dungeon.application.authored.port;
+
+import java.util.List;
+import java.util.Optional;
+
+/** At most 256 ordered continuation rows plus an exclusive cursor. */
+public record DungeonContinuationPage(
+        List<DungeonWindowContinuation> entries,
+        Optional<DungeonContinuationCursor> nextCursor
+) {
+    public DungeonContinuationPage {
+        entries = entries == null ? List.of() : List.copyOf(entries);
+        nextCursor = nextCursor == null ? Optional.empty() : nextCursor;
+        if (entries.size() > DungeonContinuationPageRequest.PAGE_SIZE) {
+            throw new IllegalArgumentException("continuation page exceeds its fixed size");
+        }
+    }
+
+    public static DungeonContinuationPage empty() {
+        return new DungeonContinuationPage(List.of(), Optional.empty());
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonContinuationPageRequest.java
+++ b/features/dungeon/application/authored/port/DungeonContinuationPageRequest.java
@@ -1,0 +1,36 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** One revision- and generation-bound continuation page request. */
+public record DungeonContinuationPageRequest(
+        DungeonMapIdentity mapId,
+        long expectedMapRevision,
+        long requestGeneration,
+        List<DungeonChunkKey> requestedChunks,
+        Optional<DungeonContinuationCursor> after
+) {
+    public static final int PAGE_SIZE = 256;
+
+    public DungeonContinuationPageRequest {
+        mapId = Objects.requireNonNull(mapId, "mapId");
+        if (expectedMapRevision < 1L || requestGeneration < 0L) {
+            throw new IllegalArgumentException("page request revisions must be valid");
+        }
+        requestedChunks = new DungeonWindowRequest(mapId, requestGeneration, requestedChunks).chunkKeys();
+        after = after == null ? Optional.empty() : after;
+        if (after.isPresent()) {
+            DungeonContinuationCursor cursor = after.get();
+            if (!mapId.equals(cursor.mapId())
+                    || expectedMapRevision != cursor.expectedMapRevision()
+                    || requestGeneration != cursor.requestGeneration()
+                    || !requestedChunks.equals(cursor.requestedChunks())) {
+                throw new IllegalArgumentException("continuation cursor does not belong to this request");
+            }
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonEntityChunkExtent.java
+++ b/features/dungeon/application/authored/port/DungeonEntityChunkExtent.java
@@ -1,0 +1,26 @@
+package features.dungeon.application.authored.port;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.command.DungeonPatchEntityRef;
+import java.util.Objects;
+
+/** Exact cell extent contributed by one stable entity inside one spatial chunk. */
+public record DungeonEntityChunkExtent(
+        DungeonPatchEntityRef entityRef,
+        DungeonChunkKey chunk,
+        int minimumQ,
+        int minimumR,
+        int maximumQ,
+        int maximumR,
+        int entityChunkCount
+) {
+    public DungeonEntityChunkExtent {
+        entityRef = Objects.requireNonNull(entityRef, "entityRef");
+        chunk = Objects.requireNonNull(chunk, "chunk");
+        if (maximumQ < minimumQ || maximumR < minimumR || entityChunkCount < 1
+                || minimumQ < chunk.minimumQ() || maximumQ > chunk.maximumQ()
+                || minimumR < chunk.minimumR() || maximumR > chunk.maximumR()) {
+            throw new IllegalArgumentException("entity extent must be non-empty and contained by its chunk");
+        }
+    }
+}

--- a/features/dungeon/application/authored/port/DungeonWindow.java
+++ b/features/dungeon/application/authored/port/DungeonWindow.java
@@ -12,11 +12,24 @@ public record DungeonWindow(
         long requestGeneration,
         List<DungeonWindowChunkHeader> chunkHeaders,
         List<DungeonWindowEntityFragment> fragments,
-        List<DungeonWindowContinuation> continuations
+        List<DungeonEntityChunkExtent> entityExtents,
+        List<DungeonAuthoredLevelBounds> authoredBounds,
+        DungeonContinuationPage continuationPage
 ) {
     public static final Comparator<DungeonPatchEntityRef> ENTITY_ORDER = Comparator
             .comparing(DungeonPatchEntityRef::kind)
             .thenComparingLong(DungeonPatchEntityRef::id);
+
+    public DungeonWindow(
+            DungeonMapHeader mapHeader,
+            long requestGeneration,
+            List<DungeonWindowChunkHeader> chunkHeaders,
+            List<DungeonWindowEntityFragment> fragments,
+            List<DungeonWindowContinuation> continuations
+    ) {
+        this(mapHeader, requestGeneration, chunkHeaders, fragments, List.of(), List.of(),
+                new DungeonContinuationPage(continuations, java.util.Optional.empty()));
+    }
 
     public DungeonWindow {
         mapHeader = Objects.requireNonNull(mapHeader, "mapHeader");
@@ -34,9 +47,20 @@ public record DungeonWindow(
                 DungeonWindowEntityFragment::entityRef, ENTITY_ORDER));
         fragments = List.copyOf(orderedFragments);
 
-        List<DungeonWindowContinuation> orderedContinuations = new ArrayList<>(
-                continuations == null ? List.of() : continuations);
-        orderedContinuations.sort(Comparator.comparing(DungeonWindowContinuation::entityRef, ENTITY_ORDER));
-        continuations = List.copyOf(orderedContinuations);
+        List<DungeonEntityChunkExtent> orderedExtents = new ArrayList<>(
+                entityExtents == null ? List.of() : entityExtents);
+        orderedExtents.sort(Comparator.comparing(DungeonEntityChunkExtent::entityRef, ENTITY_ORDER)
+                .thenComparing(DungeonEntityChunkExtent::chunk, DungeonWindowRequest.CHUNK_ORDER));
+        entityExtents = List.copyOf(orderedExtents);
+        List<DungeonAuthoredLevelBounds> orderedBounds = new ArrayList<>(
+                authoredBounds == null ? List.of() : authoredBounds);
+        orderedBounds.sort(Comparator.comparingInt(DungeonAuthoredLevelBounds::level));
+        authoredBounds = List.copyOf(orderedBounds);
+        continuationPage = continuationPage == null ? DungeonContinuationPage.empty() : continuationPage;
+    }
+
+    /** Compatibility projection for consumers that only need the current typed page entries. */
+    public List<DungeonWindowContinuation> continuations() {
+        return continuationPage.entries();
     }
 }

--- a/features/dungeon/application/authored/port/DungeonWindowContentSource.java
+++ b/features/dungeon/application/authored/port/DungeonWindowContentSource.java
@@ -9,6 +9,10 @@ public interface DungeonWindowContentSource {
     /** Returns empty when map or any expected revision changed between index and content reads. */
     Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request);
 
+    default Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+        return Optional.empty();
+    }
+
     DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request);
 
     DungeonTravelStartResult locateTravelStart(DungeonTravelStartRequest request);

--- a/features/dungeon/application/authored/port/DungeonWindowIndex.java
+++ b/features/dungeon/application/authored/port/DungeonWindowIndex.java
@@ -9,8 +9,18 @@ import java.util.Objects;
 public record DungeonWindowIndex(
         DungeonMapHeader mapHeader,
         long requestGeneration,
-        List<DungeonWindowChunkHeader> chunkHeaders
+        List<DungeonWindowChunkHeader> chunkHeaders,
+        List<DungeonAuthoredLevelBounds> authoredBounds,
+        DungeonContinuationPage continuationPage
 ) {
+    public DungeonWindowIndex(
+            DungeonMapHeader mapHeader,
+            long requestGeneration,
+            List<DungeonWindowChunkHeader> chunkHeaders
+    ) {
+        this(mapHeader, requestGeneration, chunkHeaders, List.of(), DungeonContinuationPage.empty());
+    }
+
     public DungeonWindowIndex {
         mapHeader = Objects.requireNonNull(mapHeader, "mapHeader");
         if (requestGeneration < 0L) {
@@ -20,5 +30,10 @@ public record DungeonWindowIndex(
                 chunkHeaders == null ? List.of() : chunkHeaders);
         ordered.sort(Comparator.comparing(DungeonWindowChunkHeader::key, DungeonWindowRequest.CHUNK_ORDER));
         chunkHeaders = List.copyOf(ordered);
+        List<DungeonAuthoredLevelBounds> orderedBounds = new ArrayList<>(
+                authoredBounds == null ? List.of() : authoredBounds);
+        orderedBounds.sort(Comparator.comparingInt(DungeonAuthoredLevelBounds::level));
+        authoredBounds = List.copyOf(orderedBounds);
+        continuationPage = continuationPage == null ? DungeonContinuationPage.empty() : continuationPage;
     }
 }

--- a/features/dungeon/application/authored/port/DungeonWindowStore.java
+++ b/features/dungeon/application/authored/port/DungeonWindowStore.java
@@ -9,6 +9,10 @@ public interface DungeonWindowStore {
 
     Optional<DungeonWindow> loadWindow(DungeonWindowRequest request);
 
+    default Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+        return Optional.empty();
+    }
+
     /** Replaces cache protection with the latest accepted visible chunks. */
     default void protectVisibleChunks(Collection<DungeonChunkKey> chunks) {
     }

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonAuthoredLevelBoundsPatchTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonAuthoredLevelBoundsPatchTest.java
@@ -1,0 +1,82 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.command.DungeonPatch;
+import features.dungeon.application.authored.command.FeatureMarkerChange;
+import features.dungeon.application.authored.port.DungeonAuthoredLevelBounds;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.domain.core.geometry.Cell;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.domain.core.structure.feature.FeatureMarker;
+import features.dungeon.domain.core.structure.feature.FeatureMarkerKind;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.persistence.SqliteDatabase;
+
+final class DungeonAuthoredLevelBoundsPatchTest {
+
+    @Test
+    void realPatchesMoveAndDeleteExtremaWithoutChangingOtherLevels(@TempDir Path tempDir) {
+        DungeonMapIdentity mapId = new DungeonMapIdentity(41L);
+        FeatureMarker minimum = marker(mapId, 101L, new Cell(-130, -70, 0));
+        FeatureMarker maximum = marker(mapId, 102L, new Cell(140, 90, 0));
+        FeatureMarker otherLevel = marker(mapId, 103L, new Cell(-999, 999, 1));
+        FeatureMarker movedMinimum = marker(mapId, 101L, new Cell(-20, -10, 0));
+
+        try (SqliteDatabase database = new SqliteDatabase(
+                tempDir.resolve("level-bounds.db"), NoopDiagnostics.INSTANCE)) {
+            DungeonSqliteFixtureSeeder.insertHeader(database, mapId.value(), "Bounds", 1L);
+            DungeonSqliteFixtureSeeder.commit(database, DungeonPatch.of(mapId, 1L, List.of(
+                    new FeatureMarkerChange(null, minimum),
+                    new FeatureMarkerChange(null, maximum),
+                    new FeatureMarkerChange(null, otherLevel))));
+            DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
+
+            assertEquals(new DungeonAuthoredLevelBounds(0, true, -130, -70, 140, 90),
+                    bounds(gateway, mapId, 2L, 0));
+            assertEquals(new DungeonAuthoredLevelBounds(1, true, -999, 999, -999, 999),
+                    bounds(gateway, mapId, 2L, 1));
+
+            DungeonSqliteFixtureSeeder.commit(database, DungeonPatch.of(mapId, 2L,
+                    List.of(new FeatureMarkerChange(minimum, movedMinimum))));
+            assertEquals(new DungeonAuthoredLevelBounds(0, true, -20, -10, 140, 90),
+                    bounds(gateway, mapId, 3L, 0));
+            assertEquals(new DungeonAuthoredLevelBounds(1, true, -999, 999, -999, 999),
+                    bounds(gateway, mapId, 3L, 1));
+
+            DungeonSqliteFixtureSeeder.commit(database, DungeonPatch.of(mapId, 3L,
+                    List.of(new FeatureMarkerChange(maximum, null))));
+            assertEquals(new DungeonAuthoredLevelBounds(0, true, -20, -10, -20, -10),
+                    bounds(gateway, mapId, 4L, 0));
+
+            DungeonSqliteFixtureSeeder.commit(database, DungeonPatch.of(mapId, 4L,
+                    List.of(new FeatureMarkerChange(movedMinimum, null))));
+            DungeonAuthoredLevelBounds empty = bounds(gateway, mapId, 5L, 0);
+            assertFalse(empty.present());
+            assertEquals(DungeonAuthoredLevelBounds.empty(0), empty);
+            assertEquals(new DungeonAuthoredLevelBounds(1, true, -999, 999, -999, 999),
+                    bounds(gateway, mapId, 5L, 1));
+        }
+    }
+
+    private static DungeonAuthoredLevelBounds bounds(
+            DungeonSqliteWindowGateway gateway,
+            DungeonMapIdentity mapId,
+            long generation,
+            int level
+    ) {
+        return gateway.loadIndex(new DungeonWindowRequest(
+                        mapId, generation, List.of(new DungeonChunkKey(mapId.value(), level, 0, 0))))
+                .orElseThrow().authoredBounds().getFirst();
+    }
+
+    private static FeatureMarker marker(DungeonMapIdentity mapId, long id, Cell cell) {
+        return new FeatureMarker(id, mapId, FeatureMarkerKind.OBJECT, cell, "Marker " + id, "");
+    }
+}

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSchemaMigrationTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSchemaMigrationTest.java
@@ -43,6 +43,11 @@ final class DungeonCanonicalSchemaMigrationTest {
             assertFalse(tableExists(connection, "dungeon_room_cluster_vertices"));
             assertTrue(tableExists(connection, "dungeon_room_cells"));
             assertTrue(tableExists(connection, "dungeon_entity_chunks"));
+            assertTrue(tableExists(connection, "dungeon_authored_level_bounds"));
+            assertTrue(indexExists(connection, "idx_dungeon_entity_chunks_continuation"));
+            assertEquals(Set.of("dungeon_map_id", "entity_kind", "entity_id", "level_z", "chunk_q", "chunk_r",
+                            "minimum_q", "minimum_r", "maximum_q", "maximum_r", "entity_chunk_count"),
+                    columns(connection, "dungeon_entity_chunks"));
             assertTrue(tableExists(connection, "dungeon_corridor_route_cells"));
             assertTrue(tableExists(connection, "dungeon_corridor_route_dependencies"));
             assertEquals(

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSpatialIndexTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonCanonicalSpatialIndexTest.java
@@ -142,6 +142,17 @@ final class DungeonCanonicalSpatialIndexTest {
                     "SELECT COUNT(*) FROM dungeon_chunks"));
             assertEquals(List.of("17"), rows(connection,
                     "SELECT COUNT(*) FROM dungeon_entity_chunks"));
+            assertEquals(List.of("7"), rows(connection,
+                    "SELECT DISTINCT entity_chunk_count FROM dungeon_entity_chunks"
+                            + " WHERE entity_kind='CORRIDOR' AND entity_id=301"));
+            assertEquals(List.of(
+                    "-1|-1|-1|-1|-1",
+                    "0|-65|-65|129|63",
+                    "1|-1|64|-1|64",
+                    "2|128|-129|128|-129",
+                    "5|-64|-65|-63|-64"), rows(connection,
+                    "SELECT level_z,minimum_q,minimum_r,maximum_q,maximum_r"
+                            + " FROM dungeon_authored_level_bounds ORDER BY level_z"));
             assertEquals(List.of("261|261"), rows(connection,
                     "SELECT COUNT(*), COUNT(DISTINCT level_z || '|' || cell_x || '|' || cell_y)"
                             + " FROM dungeon_corridor_route_cells"

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonContinuationPagingTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonContinuationPagingTest.java
@@ -1,0 +1,90 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonContinuationPageRequest;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.persistence.SqliteDatabase;
+
+final class DungeonContinuationPagingTest {
+
+    @Test
+    void pagesAtMost257RowsWithoutGapsAndBindsCursorToWindowIdentity(@TempDir Path tempDir) throws Exception {
+        Path path = tempDir.resolve("continuations.db");
+        try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
+            DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
+            gateway.loadIndex(new DungeonWindowRequest(new DungeonMapIdentity(77L), 1L, List.of()));
+            seed(path, 513);
+
+            DungeonChunkKey requested = new DungeonChunkKey(77L, 0, 0, 0);
+            DungeonChunkKey offWindow = new DungeonChunkKey(77L, 0, 1, 0);
+            var index = gateway.loadIndex(new DungeonWindowRequest(
+                    new DungeonMapIdentity(77L), 19L, List.of(requested))).orElseThrow();
+            DungeonContinuationPage first = index.continuationPage();
+            assertEquals(256, first.entries().size());
+            assertTrue(first.nextCursor().isPresent());
+
+            DungeonContinuationPage second = gateway.loadContinuationPage(new DungeonContinuationPageRequest(
+                    new DungeonMapIdentity(77L), 7L, 19L, List.of(requested), first.nextCursor()))
+                    .orElseThrow();
+            assertEquals(256, second.entries().size());
+            DungeonContinuationPage third = gateway.loadContinuationPage(new DungeonContinuationPageRequest(
+                    new DungeonMapIdentity(77L), 7L, 19L, List.of(requested), second.nextCursor()))
+                    .orElseThrow();
+            assertEquals(1, third.entries().size());
+            assertFalse(third.nextCursor().isPresent());
+
+            Set<Long> ids = new LinkedHashSet<>();
+            List.of(first, second, third).forEach(page -> page.entries().forEach(
+                    entry -> ids.add(entry.entityRef().id())));
+            assertEquals(513, ids.size());
+            assertTrue(gateway.loadContinuationPage(new DungeonContinuationPageRequest(
+                    new DungeonMapIdentity(77L), 6L, 19L, List.of(requested), java.util.Optional.empty())).isEmpty());
+            assertThrows(IllegalArgumentException.class, () -> new DungeonContinuationPageRequest(
+                    new DungeonMapIdentity(77L), 7L, 20L, List.of(offWindow), first.nextCursor()));
+        }
+    }
+
+    private static void seed(Path path, int entities) throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath());
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("INSERT INTO dungeon_maps(dungeon_map_id,name,revision) VALUES(77,'Paged',7)");
+            statement.executeUpdate("INSERT INTO dungeon_chunks(dungeon_map_id,level_z,chunk_q,chunk_r,content_revision)"
+                    + " VALUES(77,0,0,0,7),(77,0,1,0,7)");
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r,"
+                            + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count) VALUES(77,'FEATURE_MARKER',?,?,?,?,?,?,?,?,2)")) {
+                for (long id = 1; id <= entities; id++) {
+                    insert.setLong(1, id);
+                    insert.setInt(2, 0); insert.setInt(3, 0); insert.setInt(4, 0);
+                    insert.setInt(5, 0); insert.setInt(6, 0); insert.setInt(7, 0); insert.setInt(8, 0);
+                    insert.addBatch();
+                    insert.setLong(1, id);
+                    insert.setInt(2, 0); insert.setInt(3, 1); insert.setInt(4, 0);
+                    insert.setInt(5, 64); insert.setInt(6, 0); insert.setInt(7, 64); insert.setInt(8, 0);
+                    insert.addBatch();
+                }
+                insert.executeBatch();
+            }
+            statement.executeUpdate("INSERT INTO dungeon_authored_level_bounds"
+                    + "(dungeon_map_id,level_z,minimum_q,minimum_r,maximum_q,maximum_r) VALUES(77,0,0,0,64,0)");
+        }
+    }
+}

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseReadQualificationTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseReadQualificationTest.java
@@ -1,0 +1,164 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import features.dungeon.domain.core.structure.DungeonMapIdentity;
+import features.dungeon.qualification.DungeonQualificationDataset;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.persistence.SqliteDatabase;
+
+final class DungeonSparseReadQualificationTest {
+
+    @Test
+    void sparse1k10k100kReadsKeepBoundsPagingAndContentWorkBounded(@TempDir Path tempDir) throws Exception {
+        List<ReadWork> work = new ArrayList<>();
+        for (DungeonQualificationDataset dataset : DungeonQualificationDataset.values()) {
+            Path path = tempDir.resolve(dataset.name().toLowerCase() + ".db");
+            try (SqliteDatabase database = new SqliteDatabase(path, NoopDiagnostics.INSTANCE)) {
+                DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
+                gateway.loadIndex(new DungeonWindowRequest(
+                        new DungeonMapIdentity(DungeonQualificationDataset.MAP_ID), 0L, List.of()));
+                seedSparseRoom(path, dataset);
+
+                var viewport = dataset.qualificationViewport(dataset.ordinal() + 1L);
+                DungeonWindowRequest request = new DungeonWindowRequest(
+                        new DungeonMapIdentity(DungeonQualificationDataset.MAP_ID),
+                        viewport.requestGeneration(), List.copyOf(viewport.loadingChunks()));
+                DungeonWindowIndex index = gateway.loadIndex(request).orElseThrow();
+                int indexStatements = gateway.lastStatementCount();
+                int boundsStatements = (int) gateway.lastStatementSql().stream()
+                        .filter(sql -> sql.contains("dungeon_authored_level_bounds"))
+                        .count();
+                int continuationRows = gateway.lastContinuationRowsRead();
+                int publishedContinuationRows = index.continuationPage().entries().stream()
+                        .mapToInt(entry -> entry.offWindowChunks().size()).sum();
+
+                DungeonWindow content = gateway.loadContent(new DungeonWindowContentRequest(
+                        request.mapId(), index.mapHeader().revision(), request.requestGeneration(),
+                        index.chunkHeaders())).orElseThrow();
+                int contentStatements = gateway.lastStatementCount();
+                int contentCells = content.fragments().stream()
+                        .filter(DungeonWindowEntityFragment.Room.class::isInstance)
+                        .map(DungeonWindowEntityFragment.Room.class::cast)
+                        .mapToInt(room -> room.floorCells().size()).sum();
+
+                assertEquals(1, boundsStatements);
+                assertEquals(257, continuationRows);
+                assertEquals(256, publishedContinuationRows);
+                assertTrue(index.continuationPage().nextCursor().isPresent());
+                assertTrue(content.fragments().size() <= request.chunkKeys().size());
+                assertTrue(content.entityExtents().size() <= request.chunkKeys().size());
+                assertTrue(contentCells <= request.chunkKeys().size());
+                work.add(new ReadWork(indexStatements, boundsStatements, continuationRows,
+                        contentStatements, content.fragments().size(), content.entityExtents().size(), contentCells));
+            }
+        }
+        assertEquals(1L, work.stream().distinct().count(),
+                "1k, 10k and 100k authored cells must perform identical requested-window work");
+    }
+
+    private static void seedSparseRoom(Path path, DungeonQualificationDataset dataset) throws Exception {
+        List<DungeonCellRef> cells = dataset.authoredCells().toList();
+        Map<DungeonChunkKey, Extent> extents = new LinkedHashMap<>();
+        for (DungeonCellRef cell : cells) {
+            DungeonChunkKey chunk = new DungeonChunkKey(
+                    DungeonQualificationDataset.MAP_ID, cell.level(),
+                    Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                    Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE));
+            extents.compute(chunk, (ignored, extent) -> extent == null
+                    ? Extent.at(cell.q(), cell.r()) : extent.include(cell.q(), cell.r()));
+        }
+        int minimumQ = cells.stream().mapToInt(DungeonCellRef::q).min().orElseThrow();
+        int minimumR = cells.stream().mapToInt(DungeonCellRef::r).min().orElseThrow();
+        int maximumQ = cells.stream().mapToInt(DungeonCellRef::q).max().orElseThrow();
+        int maximumR = cells.stream().mapToInt(DungeonCellRef::r).max().orElseThrow();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath());
+             Statement statement = connection.createStatement()) {
+            connection.setAutoCommit(false);
+            statement.executeUpdate("INSERT INTO dungeon_maps(dungeon_map_id,name,revision) VALUES(1,'Sparse',2)");
+            statement.executeUpdate("INSERT INTO dungeon_room_clusters(cluster_id,dungeon_map_id,name)"
+                    + " VALUES(11,1,'Sparse cluster')");
+            statement.executeUpdate("INSERT INTO dungeon_rooms(room_id,dungeon_map_id,cluster_id,name,visual_description)"
+                    + " VALUES(12,1,11,'Sparse room','')");
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO dungeon_room_cells(room_id,level_z,cell_x,cell_y) VALUES(12,?,?,?)")) {
+                int pending = 0;
+                for (DungeonCellRef cell : cells) {
+                    insert.setInt(1, cell.level()); insert.setInt(2, cell.q()); insert.setInt(3, cell.r());
+                    insert.addBatch();
+                    if (++pending == 5_000) {
+                        insert.executeBatch(); pending = 0;
+                    }
+                }
+                if (pending > 0) insert.executeBatch();
+            }
+            try (PreparedStatement chunk = connection.prepareStatement(
+                        "INSERT INTO dungeon_chunks(dungeon_map_id,level_z,chunk_q,chunk_r,content_revision)"
+                                + " VALUES(1,?,?,?,2)");
+                 PreparedStatement extent = connection.prepareStatement(
+                        "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r,"
+                                + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count)"
+                                + " VALUES(1,'ROOM',12,?,?,?,?,?,?,?,?)")) {
+                int pending = 0;
+                for (Map.Entry<DungeonChunkKey, Extent> entry : extents.entrySet()) {
+                    DungeonChunkKey key = entry.getKey(); Extent value = entry.getValue();
+                    chunk.setInt(1, key.level()); chunk.setInt(2, key.chunkQ()); chunk.setInt(3, key.chunkR());
+                    chunk.addBatch();
+                    extent.setInt(1, key.level()); extent.setInt(2, key.chunkQ()); extent.setInt(3, key.chunkR());
+                    extent.setInt(4, value.minimumQ()); extent.setInt(5, value.minimumR());
+                    extent.setInt(6, value.maximumQ()); extent.setInt(7, value.maximumR());
+                    extent.setInt(8, extents.size()); extent.addBatch();
+                    if (++pending == 5_000) {
+                        chunk.executeBatch(); extent.executeBatch(); pending = 0;
+                    }
+                }
+                if (pending > 0) { chunk.executeBatch(); extent.executeBatch(); }
+            }
+            try (PreparedStatement bounds = connection.prepareStatement(
+                    "INSERT INTO dungeon_authored_level_bounds"
+                            + "(dungeon_map_id,level_z,minimum_q,minimum_r,maximum_q,maximum_r) VALUES(1,0,?,?,?,?)")) {
+                bounds.setInt(1, minimumQ); bounds.setInt(2, minimumR);
+                bounds.setInt(3, maximumQ); bounds.setInt(4, maximumR); bounds.executeUpdate();
+            }
+            connection.commit();
+        }
+    }
+
+    private record ReadWork(
+            int indexStatements,
+            int boundsStatements,
+            int continuationRows,
+            int contentStatements,
+            int fragments,
+            int extents,
+            int cells
+    ) { }
+
+    private record Extent(int minimumQ, int minimumR, int maximumQ, int maximumR) {
+        static Extent at(int q, int r) { return new Extent(q, r, q, r); }
+        Extent include(int q, int r) {
+            return new Extent(Math.min(minimumQ, q), Math.min(minimumR, r),
+                    Math.max(maximumQ, q), Math.max(maximumR, r));
+        }
+    }
+}

--- a/test/features/dungeon/application/authored/TestDungeonCommandStore.java
+++ b/test/features/dungeon/application/authored/TestDungeonCommandStore.java
@@ -5,6 +5,8 @@ import features.dungeon.application.authored.command.DungeonCompoundPatch;
 import features.dungeon.application.authored.command.DungeonPatch;
 import features.dungeon.application.authored.command.DungeonPatchEntityRef;
 import features.dungeon.application.authored.port.DungeonCatalogStore;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonEntityChunkExtent;
 import features.dungeon.application.authored.port.DungeonEntitySnapshot;
 import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
 import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
@@ -13,7 +15,6 @@ import features.dungeon.application.authored.port.DungeonInboundReferenceResult;
 import features.dungeon.application.authored.port.DungeonMapHeader;
 import features.dungeon.application.authored.port.DungeonWindow;
 import features.dungeon.application.authored.port.DungeonWindowChunkHeader;
-import features.dungeon.application.authored.port.DungeonWindowContinuation;
 import features.dungeon.application.authored.port.DungeonWindowRequest;
 import features.dungeon.application.authored.port.DungeonWindowStore;
 import features.dungeon.domain.core.structure.DungeonMap;
@@ -70,7 +71,9 @@ public final class TestDungeonCommandStore implements DungeonCatalogStore, Dunge
             return Optional.empty();
         }
         List<DungeonEntitySnapshot> snapshots = snapshots(map);
-        DungeonChunkKey offWindow = new DungeonChunkKey(request.mapId().value(), 0, 1_000_000, 1_000_000);
+        List<DungeonEntityChunkExtent> extents = request.chunkKeys().isEmpty()
+                ? List.of()
+                : snapshots.stream().map(snapshot -> extent(snapshot.ref(), request.chunkKeys().getFirst())).toList();
         return Optional.of(new DungeonWindow(
                 header(map),
                 request.requestGeneration(),
@@ -78,9 +81,9 @@ public final class TestDungeonCommandStore implements DungeonCatalogStore, Dunge
                         .map(key -> new DungeonWindowChunkHeader(key, map.revision()))
                         .toList(),
                 List.of(),
-                snapshots.stream()
-                        .map(snapshot -> new DungeonWindowContinuation(snapshot.ref(), List.of(offWindow)))
-                        .toList()));
+                extents,
+                List.of(),
+                DungeonContinuationPage.empty()));
     }
 
     @Override
@@ -163,6 +166,12 @@ public final class TestDungeonCommandStore implements DungeonCatalogStore, Dunge
 
     private static DungeonMapHeader header(DungeonMap map) {
         return new DungeonMapHeader(map.metadata().mapId(), map.metadata().mapName(), map.revision());
+    }
+
+    private static DungeonEntityChunkExtent extent(DungeonPatchEntityRef ref, DungeonChunkKey chunk) {
+        return new DungeonEntityChunkExtent(
+                ref, chunk,
+                chunk.minimumQ(), chunk.minimumR(), chunk.minimumQ(), chunk.minimumR(), 2);
     }
 
     private static List<DungeonEntitySnapshot> snapshots(DungeonMap map) {


### PR DESCRIPTION
Summary:
- maintain exact per-chunk entity extents and level bounds atomically in schema v6 UoWs
- publish indexed active-level bounds instead of deriving public bounds from loaded facts
- replace full off-window materialization with revision-bound 256-row cursor pages
- preserve per-chunk cache semantics and use extent counts for command completeness
- qualify constant requested-window work on 1k, 10k and 100k sparse datasets
- fix the discovered quadratic continuation query with a materialized entity set and covering index

Proof:
- ./gradlew check --no-daemon --console=plain: BUILD SUCCESSFUL in 8m 56s
- ./gradlew installDesktopApp --no-daemon --console=plain: BUILD SUCCESSFUL in 36s
- focused schema, UoW bounds, paging, cache and sparse qualification suites: green
- git diff --check: clean