### PR TITLE
M5.4: Dungeon-Runtime proportional qualifizieren

### DIFF
--- a/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
+++ b/docs/dungeon/delivery/roadmap-dungeon-greenfield.md
@@ -106,10 +106,69 @@ and commit boundaries. M7 starts only after both are complete.
   local identity derivation, compatibility writer, and full-record fixture
   families are deleted.
 - M4.6 delivery proof is literal green `./gradlew check` plus
-  `./gradlew installDesktopApp`. M5.1 is complete through PR #536 and M5.2
-  through PR #538. M5.3 is complete in this change with the same literal green
-  proof; M5.4 is next. No intermediate review panel runs; the single independent
-  cross-roadmap review runs only after all M7 implementation is complete.
+  `./gradlew installDesktopApp`. M5.1 is complete through PR #536, M5.2 through
+  PR #538, and M5.3 through PR #540. M5.4 is complete in this change with
+  literal green `./gradlew check` and `./gradlew installDesktopApp`; M6 is next
+  and begins from the M5.4 merge. No intermediate review panel runs; the single
+  independent cross-roadmap review runs only after all M7 implementation is
+  complete.
+
+### Completed Slice Contract: M5.4 Layered Canvas And Runtime Qualification
+
+#### Physical Layers And Invalidation
+
+- `MapCanvasPane` owns three distinct size-bound canvases in fixed z-order:
+  `BASE`, `INTERACTION`, and `ACTOR`. Only `BASE` receives pointer/focus input;
+  the other layers are mouse-transparent.
+- Stable grid/authored geometry/relations/labels paint on `BASE`; selection,
+  preview, handles, and hover on `INTERACTION`; Party/Travel and other moving
+  runtime actors on `ACTOR`.
+- `CanvasState` carries independent layer revisions. Hover invalidates only
+  interaction, actor movement only actor, and authored publication only the
+  projections that changed. Camera and resize invalidate all physical layers.
+  Hit-index rebuilding is forbidden for hover-only or actor-only changes.
+- Delete canvas aliasing, the shared-surface fallback, Base redraw on hover,
+  actor paint on interaction, and the no-op aggregate redraw hook.
+
+#### Measurement And Sample Protocol
+
+- Add feature-neutral `MapCanvasPaintSample` and `MapCanvasPaintObserver`. Every
+  executed layer paint emits exactly one sample containing layer, operation id,
+  duration, visited primitives, and painted primitives; a non-invalidated layer
+  emits none. Production defaults to a passive observer.
+- Qualify through fresh schema-v6 SQLite plus real Dungeon feature, public
+  Editor/Travel API, JavaFX binding, and paint routes. Counting decorators record
+  index, content, closure, continuation, UoW, and Travel operations; fixture
+  self-tests and timing-only proof are insufficient.
+- For each 1k/10k/100k sparse dataset use the same visible authored subset,
+  at most nine visible-plus-ring chunks, and off-window-only growth. Camera,
+  hover, preview, commit, undo, and Travel refresh use 20 fixed warmups followed
+  by exactly 100 measured alternating real inputs. Cold load uses one sample.
+- Record all measured samples and nearest-rank min/p50/p95/max. Do not retry,
+  trim outliers, adapt warmups, raise budgets, or skip for environment noise.
+  Camera and hover p95 must be at most 16 ms; preview p95 at most 50 ms with
+  exactly zero repository I/O.
+
+#### Deterministic Work Proof
+
+- Hover paints neither Base nor Actor and performs zero repository I/O;
+  preview paints neither Base nor Actor and performs zero repository I/O;
+  actor-only refresh paints neither Base nor Interaction.
+- Encode fixed upper bounds for port calls, hydrated entities, visited/painted
+  primitives, and touched/reloaded chunks for cold load, camera, commit, undo,
+  and Travel refresh. Counts must be identical across 1k/10k/100k while only
+  off-window content grows.
+- Run at least 100 bind/resize/camera/hover/preview/actor cycles and prove exactly
+  three canvases, stable z-order, no listener or paint multiplication, and
+  pointer/focus ownership on Base.
+
+#### Delete Gate And Proof
+
+- Delete aggregate-only/no-op measurement, dynamic count budgets derived from
+  observed results, and any timing pass based on retry, trimming, or skip.
+- Focused layer, stability, work-bound, and p95 qualification tests followed by
+  literal green `./gradlew check` and `./gradlew installDesktopApp` are required
+  before the M5.4 PR merges. M6 starts from that merge without a review cycle.
 
 ### Completed Slice Contract: M5.3 Indexed Bounds And Paged Continuations
 

--- a/features/dungeon/adapter/javafx/map/DungeonMapContentModel.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapContentModel.java
@@ -232,10 +232,6 @@ public final class DungeonMapContentModel {
                 safeTarget.topologyId());
     }
 
-    void recordCanvasRedraw(long elapsedNanos) {
-        // Retained as the canvas redraw hook; Wave 08 removed the unused local accumulator.
-    }
-
     private void showRenderState(DungeonMapRenderState nextRenderState) {
         renderState = nextRenderState == null ? renderState : nextRenderState;
         frameConsumption.clearHoverTarget();
@@ -334,24 +330,36 @@ public final class DungeonMapContentModel {
         private final RenderScene renderScene;
         private final DungeonMapSceneAssembler.SceneBuckets hoverOverlay;
         private final Viewport viewport;
+        private final long baseRevision;
+        private final long interactionRevision;
+        private final long actorRevision;
 
-        private static CanvasState initial(RenderScene renderScene, Viewport viewport) {
+        static CanvasState initial(RenderScene renderScene, Viewport viewport) {
             return new CanvasState(
                 renderScene,
                     DungeonMapSceneAssembler.SceneBuckets.empty(),
-                    viewport);
+                    viewport,
+                    1L,
+                    1L,
+                    1L);
         }
 
         private CanvasState(
                 RenderScene renderScene,
                 DungeonMapSceneAssembler.SceneBuckets hoverOverlay,
-                Viewport viewport
+                Viewport viewport,
+                long baseRevision,
+                long interactionRevision,
+                long actorRevision
         ) {
             this.renderScene = renderScene == null ? RenderScene.empty(defaultTitle()) : renderScene;
             this.hoverOverlay = hoverOverlay == null
                     ? DungeonMapSceneAssembler.SceneBuckets.empty()
                     : hoverOverlay;
             this.viewport = viewport == null ? Viewport.initial() : viewport;
+            this.baseRevision = Math.max(0L, baseRevision);
+            this.interactionRevision = Math.max(0L, interactionRevision);
+            this.actorRevision = Math.max(0L, actorRevision);
         }
 
         public RenderScene baseRenderScene() {
@@ -382,36 +390,75 @@ public final class DungeonMapContentModel {
             return viewport;
         }
 
-        private CanvasState withRenderScene(RenderScene nextRenderScene, Viewport nextViewport) {
-            return new CanvasState(
-                    nextRenderScene,
-                    DungeonMapSceneAssembler.SceneBuckets.empty(),
-                    nextViewport);
+        public long baseRevision() {
+            return baseRevision;
         }
 
-        private CanvasState withHoverOverlay(
+        public long interactionRevision() {
+            return interactionRevision;
+        }
+
+        public long actorRevision() {
+            return actorRevision;
+        }
+
+        CanvasState withRenderScene(RenderScene nextRenderScene, Viewport nextViewport) {
+            RenderScene safeNext = nextRenderScene == null ? RenderScene.empty(defaultTitle()) : nextRenderScene;
+            boolean viewportChanged = !Objects.equals(viewport, nextViewport);
+            return new CanvasState(
+                    safeNext,
+                    DungeonMapSceneAssembler.SceneBuckets.empty(),
+                    nextViewport,
+                    incrementIf(baseRevision, viewportChanged || !renderScene.sameBasePaint(safeNext)),
+                    incrementIf(interactionRevision,
+                            viewportChanged
+                                    || !renderScene.sameInteractionPaint(safeNext)
+                                    || !hoverOverlay.equals(DungeonMapSceneAssembler.SceneBuckets.empty())),
+                    incrementIf(actorRevision, viewportChanged || !renderScene.sameActorPaint(safeNext)));
+        }
+
+        CanvasState withHoverOverlay(
                 DungeonMapSceneAssembler.SceneBuckets nextHoverOverlay,
                 Viewport nextViewport
         ) {
             return new CanvasState(
                     renderScene,
                     nextHoverOverlay,
-                    nextViewport);
+                    nextViewport,
+                    incrementIf(baseRevision, !Objects.equals(viewport, nextViewport)),
+                    incrementIf(interactionRevision,
+                            !Objects.equals(viewport, nextViewport)
+                                    || !Objects.equals(hoverOverlay, nextHoverOverlay)),
+                    incrementIf(actorRevision, !Objects.equals(viewport, nextViewport)));
         }
 
         private CanvasState withRenderSceneMetadata(RenderScene nextRenderScene, Viewport nextViewport) {
-            return new CanvasState(nextRenderScene, hoverOverlay, nextViewport);
+            return withRenderScene(nextRenderScene, nextViewport);
         }
 
-        private CanvasState withViewport(Viewport nextViewport) {
-            return new CanvasState(renderScene, hoverOverlay, nextViewport);
+        CanvasState withViewport(Viewport nextViewport) {
+            boolean changed = !Objects.equals(viewport, nextViewport);
+            return new CanvasState(
+                    renderScene,
+                    hoverOverlay,
+                    nextViewport,
+                    incrementIf(baseRevision, changed),
+                    incrementIf(interactionRevision, changed),
+                    incrementIf(actorRevision, changed));
         }
 
         private boolean sameAs(CanvasState other) {
             return other != null
                     && Objects.equals(renderScene, other.renderScene)
                     && Objects.equals(hoverOverlay, other.hoverOverlay)
-                    && Objects.equals(viewport, other.viewport);
+                    && Objects.equals(viewport, other.viewport)
+                    && baseRevision == other.baseRevision
+                    && interactionRevision == other.interactionRevision
+                    && actorRevision == other.actorRevision;
+        }
+
+        private static long incrementIf(long revision, boolean changed) {
+            return changed ? revision + 1L : revision;
         }
     }
 
@@ -694,6 +741,10 @@ public final class DungeonMapContentModel {
             List<GlyphPrimitive> glyphs,
             List<TextPrimitive> texts,
             List<RelationPrimitive> relations,
+            List<MapCanvasPolygonPrimitive> interactionSurfaces,
+            List<BoundaryPrimitive> interactionBoundaries,
+            List<GlyphPrimitive> interactionGlyphs,
+            List<TextPrimitive> interactionTexts,
             List<MapCanvasPolygonPrimitive> actors,
             List<MapCanvasPolygonPrimitive> hoverSurfaces,
             List<BoundaryPrimitive> hoverBoundaries,
@@ -713,6 +764,10 @@ public final class DungeonMapContentModel {
             glyphs = copyOf(glyphs);
             texts = copyOf(texts);
             relations = copyOf(relations);
+            interactionSurfaces = copyOf(interactionSurfaces);
+            interactionBoundaries = copyOf(interactionBoundaries);
+            interactionGlyphs = copyOf(interactionGlyphs);
+            interactionTexts = copyOf(interactionTexts);
             actors = copyOf(actors);
             hoverSurfaces = copyOf(hoverSurfaces);
             hoverBoundaries = copyOf(hoverBoundaries);
@@ -730,6 +785,10 @@ public final class DungeonMapContentModel {
                     false,
                     "No map scene loaded.",
                     true,
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
                     List.of(),
                     List.of(),
                     List.of(),
@@ -760,6 +819,10 @@ public final class DungeonMapContentModel {
                     glyphs,
                     texts,
                     relations,
+                    interactionSurfaces,
+                    interactionBoundaries,
+                    interactionGlyphs,
+                    interactionTexts,
                     actors,
                     safeOverlay.surfaces(),
                     safeOverlay.boundaries(),
@@ -782,6 +845,10 @@ public final class DungeonMapContentModel {
                     glyphs,
                     texts,
                     relations,
+                    interactionSurfaces,
+                    interactionBoundaries,
+                    interactionGlyphs,
+                    interactionTexts,
                     actors,
                     hoverSurfaces,
                     hoverBoundaries,
@@ -802,19 +869,43 @@ public final class DungeonMapContentModel {
             return !surfaces.isEmpty()
                     || !boundaries.isEmpty()
                     || !glyphs.isEmpty()
+                    || !interactionSurfaces.isEmpty()
+                    || !interactionBoundaries.isEmpty()
+                    || !interactionGlyphs.isEmpty()
                     || !actors.isEmpty();
         }
 
         private boolean containsAnnotationPrimitives() {
-            return !texts.isEmpty() || !relations.isEmpty();
+            return !texts.isEmpty() || !interactionTexts.isEmpty() || !relations.isEmpty();
+        }
+
+        boolean sameBasePaint(RenderScene other) {
+            return other != null
+                    && gridView == other.gridView
+                    && Objects.equals(surfaces, other.surfaces)
+                    && Objects.equals(boundaries, other.boundaries)
+                    && Objects.equals(glyphs, other.glyphs)
+                    && Objects.equals(texts, other.texts)
+                    && Objects.equals(relations, other.relations);
+        }
+
+        boolean sameInteractionPaint(RenderScene other) {
+            return other != null
+                    && Objects.equals(interactionSurfaces, other.interactionSurfaces)
+                    && Objects.equals(interactionBoundaries, other.interactionBoundaries)
+                    && Objects.equals(interactionGlyphs, other.interactionGlyphs)
+                    && Objects.equals(interactionTexts, other.interactionTexts);
+        }
+
+        boolean sameActorPaint(RenderScene other) {
+            return other != null && Objects.equals(actors, other.actors);
         }
 
         @Override
         public List<MapCanvasPolygonPrimitive> surfaces() {
-            if (hoverSurfaces.isEmpty()) {
-                return copyOf(surfaces);
-            }
-            List<MapCanvasPolygonPrimitive> combined = new java.util.ArrayList<>(surfaces.size() + hoverSurfaces.size());
+            List<MapCanvasPolygonPrimitive> combined = new java.util.ArrayList<>(
+                    surfaces.size() + interactionSurfaces.size() + hoverSurfaces.size());
+            combined.addAll(interactionSurfaces);
             combined.addAll(surfaces);
             combined.addAll(hoverSurfaces);
             return List.copyOf(combined);
@@ -822,10 +913,9 @@ public final class DungeonMapContentModel {
 
         @Override
         public List<BoundaryPrimitive> boundaries() {
-            if (hoverBoundaries.isEmpty()) {
-                return copyOf(boundaries);
-            }
-            List<BoundaryPrimitive> combined = new java.util.ArrayList<>(boundaries.size() + hoverBoundaries.size());
+            List<BoundaryPrimitive> combined = new java.util.ArrayList<>(
+                    boundaries.size() + interactionBoundaries.size() + hoverBoundaries.size());
+            combined.addAll(interactionBoundaries);
             combined.addAll(boundaries);
             combined.addAll(hoverBoundaries);
             return List.copyOf(combined);
@@ -833,10 +923,9 @@ public final class DungeonMapContentModel {
 
         @Override
         public List<GlyphPrimitive> glyphs() {
-            if (hoverGlyphs.isEmpty()) {
-                return copyOf(glyphs);
-            }
-            List<GlyphPrimitive> combined = new java.util.ArrayList<>(glyphs.size() + hoverGlyphs.size());
+            List<GlyphPrimitive> combined = new java.util.ArrayList<>(
+                    glyphs.size() + interactionGlyphs.size() + hoverGlyphs.size());
+            combined.addAll(interactionGlyphs);
             combined.addAll(glyphs);
             combined.addAll(hoverGlyphs);
             return List.copyOf(combined);
@@ -844,10 +933,9 @@ public final class DungeonMapContentModel {
 
         @Override
         public List<TextPrimitive> texts() {
-            if (hoverTexts.isEmpty()) {
-                return copyOf(texts);
-            }
-            List<TextPrimitive> combined = new java.util.ArrayList<>(texts.size() + hoverTexts.size());
+            List<TextPrimitive> combined = new java.util.ArrayList<>(
+                    texts.size() + interactionTexts.size() + hoverTexts.size());
+            combined.addAll(interactionTexts);
             combined.addAll(texts);
             combined.addAll(hoverTexts);
             return List.copyOf(combined);
@@ -877,6 +965,26 @@ public final class DungeonMapContentModel {
 
         List<TextPrimitive> baseTexts() {
             return copyOf(texts);
+        }
+
+        @Override
+        public List<MapCanvasPolygonPrimitive> interactionSurfaces() {
+            return copyOf(interactionSurfaces);
+        }
+
+        @Override
+        public List<BoundaryPrimitive> interactionBoundaries() {
+            return copyOf(interactionBoundaries);
+        }
+
+        @Override
+        public List<GlyphPrimitive> interactionGlyphs() {
+            return copyOf(interactionGlyphs);
+        }
+
+        @Override
+        public List<TextPrimitive> interactionTexts() {
+            return copyOf(interactionTexts);
         }
 
         @Override

--- a/features/dungeon/adapter/javafx/map/DungeonMapRenderState.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapRenderState.java
@@ -178,6 +178,82 @@ DungeonMapRenderState withSelectedTool(String nextSelectedTool) {
             partyToken);
 }
 
+DungeonMapRenderState baseLayerProjection() {
+    return withLayerPrimitives(
+            cells.stream().filter(cell -> !cell.preview()).map(DungeonMapRenderState::unselected).toList(),
+            edges.stream().filter(edge -> !edge.preview()).map(DungeonMapRenderState::unselected).toList(),
+            labels.stream().filter(label -> !label.preview()).map(DungeonMapRenderState::unselected).toList(),
+            markers.stream()
+                    .filter(marker -> !marker.preview() && marker.handle().ref() == null)
+                    .map(DungeonMapRenderState::unselected)
+                    .toList(),
+            graphNodes.stream().map(DungeonMapRenderState::unselected).toList(),
+            graphLinks.stream().map(DungeonMapRenderState::unselected).toList(),
+            null);
+}
+
+DungeonMapRenderState interactionLayerProjection() {
+    return withLayerPrimitives(
+            cells.stream().filter(cell -> cell.preview() || cell.selected()).toList(),
+            edges.stream().filter(edge -> edge.preview() || edge.selected()).toList(),
+            labels.stream().filter(label -> label.preview() || label.selected()).toList(),
+            markers.stream()
+                    .filter(marker -> marker.preview() || marker.selected() || marker.handle().ref() != null)
+                    .toList(),
+            graphNodes.stream().filter(GraphNode::selected).toList(),
+            graphLinks.stream().filter(GraphLink::selected).toList(),
+            null);
+}
+
+DungeonMapRenderState actorLayerProjection() {
+    return withLayerPrimitives(
+            List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), partyToken);
+}
+
+private DungeonMapRenderState withLayerPrimitives(
+        List<Cell> layerCells,
+        List<Edge> layerEdges,
+        List<Label> layerLabels,
+        List<Marker> layerMarkers,
+        List<GraphNode> layerGraphNodes,
+        List<GraphLink> layerGraphLinks,
+        PartyToken layerPartyToken
+) {
+    return new DungeonMapRenderState(
+            title, projectionAvailable, width, height, topology, viewMode, overlaySettings,
+            projectionLevel, editorMode, selectedTool, emptyMessage, layerCells, layerEdges,
+            layerLabels, layerMarkers, layerGraphNodes, layerGraphLinks, layerPartyToken);
+}
+
+private static Cell unselected(Cell cell) {
+    return new Cell(cell.q(), cell.r(), cell.z(), cell.label(), cell.kind(), cell.ownerId(),
+            cell.clusterId(), cell.topologyRef(), false, cell.overlay(), false, false);
+}
+
+private static Edge unselected(Edge edge) {
+    return new Edge(edge.startQ(), edge.startR(), edge.endQ(), edge.endR(), edge.z(), edge.kind(),
+            edge.label(), edge.ownerId(), edge.topologyRef(), false, false);
+}
+
+private static Label unselected(Label label) {
+    return new Label(label.label(), label.q(), label.r(), label.z(), label.ownerId(), label.clusterId(),
+            label.topologyRef(), label.labelKind(), false, false, label.availableWidthScene(),
+            label.rotationDegrees());
+}
+
+private static Marker unselected(Marker marker) {
+    return new Marker(marker.label(), marker.q(), marker.r(), marker.z(), marker.kind(), false,
+            marker.handle(), false, marker.sourceEdge(), marker.hoverLabel());
+}
+
+private static GraphNode unselected(GraphNode node) {
+    return new GraphNode(node.id(), node.clusterId(), node.label(), node.q(), node.r(), false);
+}
+
+private static GraphLink unselected(GraphLink link) {
+    return new GraphLink(link.fromId(), link.toId(), false);
+}
+
 static DungeonMapRenderState empty(String title, boolean editorMode) {
     return new DungeonMapRenderState(
             title,

--- a/features/dungeon/adapter/javafx/map/DungeonMapSceneAssembler.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapSceneAssembler.java
@@ -19,9 +19,10 @@ final class DungeonMapSceneAssembler {
                     RenderScene.empty(DungeonMapContentModel.defaultTitle()),
                     SceneBuckets.empty());
         }
-        SceneBuckets buckets = displayModel.isGraphView()
-                ? graphSceneAssembler.assemble(displayModel, hoverTarget)
-                : gridSceneAssembler.assemble(displayModel, hoverTarget);
+        SceneBuckets base = assemble(displayModel.baseLayerProjection(), PointerTarget.empty());
+        SceneBuckets interaction = assemble(displayModel.interactionLayerProjection(), PointerTarget.empty());
+        SceneBuckets actor = assemble(displayModel.actorLayerProjection(), PointerTarget.empty());
+        SceneBuckets buckets = assemble(displayModel, PointerTarget.empty());
         return new RenderSceneProjection(
                 new RenderScene(
                         displayModel.title(),
@@ -32,17 +33,27 @@ final class DungeonMapSceneAssembler {
                         displayModel.mapLoaded(),
                         displayModel.overlayMessage(),
                         !displayModel.isGraphView(),
-                        buckets.surfaces(),
-                        buckets.boundaries(),
-                        buckets.glyphs(),
-                        buckets.texts(),
-                        buckets.relations(),
-                        buckets.actors(),
+                        base.surfaces(),
+                        base.boundaries(),
+                        base.glyphs(),
+                        base.texts(),
+                        base.relations(),
+                        interaction.surfaces(),
+                        interaction.boundaries(),
+                        interaction.glyphs(),
+                        interaction.texts(),
+                        actor.actors(),
                         List.of(),
                         List.of(),
                         List.of(),
                         List.of()),
                 buckets);
+    }
+
+    private SceneBuckets assemble(DungeonMapRenderState displayModel, PointerTarget hoverTarget) {
+        return displayModel.isGraphView()
+                ? graphSceneAssembler.assemble(displayModel, hoverTarget)
+                : gridSceneAssembler.assemble(displayModel, hoverTarget);
     }
 
     SceneBuckets toHoverOverlay(DungeonMapRenderState displayModel, PointerTarget hoverTarget) {

--- a/features/dungeon/adapter/javafx/map/DungeonMapView.java
+++ b/features/dungeon/adapter/javafx/map/DungeonMapView.java
@@ -35,6 +35,8 @@ import features.dungeon.adapter.javafx.map.DungeonMapContentModel.RelationPrimit
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.RenderScene;
 import features.dungeon.adapter.javafx.map.DungeonMapContentModel.Viewport;
 import platform.ui.mapcanvas.MapCanvasLayer;
+import platform.ui.mapcanvas.MapCanvasPaintObserver;
+import platform.ui.mapcanvas.MapCanvasPaintSample;
 import platform.ui.mapcanvas.MapCanvasPane;
 import platform.ui.mapcanvas.MapCanvasViewport;
 import platform.ui.mapcanvas.MapCanvasWindow;
@@ -78,6 +80,7 @@ public class DungeonMapView extends BorderPane {
     private final MapCanvasPane canvasLayer = ViewChrome.createCanvasLayer();
     private final Canvas canvas = canvasLayer.canvas(MapCanvasLayer.BASE);
     private final Canvas interactionCanvas = canvasLayer.canvas(MapCanvasLayer.INTERACTION);
+    private final Canvas actorCanvas = canvasLayer.canvas(MapCanvasLayer.ACTOR);
     private final TextField inlineLabelEditor = ViewChrome.createInlineLabelEditor();
     private final Label overlayMessage = ViewChrome.createOverlayMessage();
     private final ChangeListener<String> inlineLabelEditorTextListener =
@@ -89,12 +92,13 @@ public class DungeonMapView extends BorderPane {
     private DungeonMapVisibleCellBounds lastPublishedVisibleBounds;
     private double[] polygonXBuffer = new double[0];
     private double[] polygonYBuffer = new double[0];
-    private RenderScene lastRenderedScene;
-    private Viewport lastRenderedViewport;
-    private List<MapCanvasPolygonPrimitive> lastHoverSurfaces = List.of();
-    private List<BoundaryPrimitive> lastHoverBoundaries = List.of();
-    private List<GlyphPrimitive> lastHoverGlyphs = List.of();
-    private List<DungeonMapContentModel.TextPrimitive> lastHoverTexts = List.of();
+    private MapCanvasPaintObserver paintObserver = MapCanvasPaintObserver.passive();
+    private long paintOperationId;
+    private long lastBaseRevision = -1L;
+    private long lastInteractionRevision = -1L;
+    private long lastActorRevision = -1L;
+    private double lastPaintWidth = -1.0;
+    private double lastPaintHeight = -1.0;
 
     public DungeonMapView() {
         getStyleClass().addAll("surface-root", "dungeon-map-surface");
@@ -157,6 +161,18 @@ public class DungeonMapView extends BorderPane {
         }
     }
 
+    public void onPaintSample(MapCanvasPaintObserver observer) {
+        paintObserver = observer == null ? MapCanvasPaintObserver.passive() : observer;
+    }
+
+    int physicalCanvasCount() {
+        return canvasLayer.canvasCount();
+    }
+
+    Canvas physicalCanvas(MapCanvasLayer layer) {
+        return canvasLayer.canvas(layer);
+    }
+
     private void publishVisibleCellBounds(Viewport viewport) {
         double width = canvas.getWidth();
         double height = canvas.getHeight();
@@ -208,19 +224,12 @@ public class DungeonMapView extends BorderPane {
 
     private void redraw(
             DungeonMapContentModel.CanvasState canvasState,
-            DungeonMapContentModel measurementSink
+            DungeonMapContentModel ignoredMeasurementSink
     ) {
         if (canvasState == null) {
             return;
         }
-        long startedNanos = System.nanoTime();
-        try {
-            redrawChangedLayers(canvasState);
-        } finally {
-            if (measurementSink != null) {
-                measurementSink.recordCanvasRedraw(System.nanoTime() - startedNanos);
-            }
-        }
+        redrawChangedLayers(canvasState);
         ViewChrome.showOverlay(overlayMessage, canvasState);
     }
 
@@ -229,43 +238,41 @@ public class DungeonMapView extends BorderPane {
         Viewport viewport = canvasState.viewport();
         double width = CanvasSurface.renderWidth(canvas);
         double height = CanvasSurface.renderHeight(canvas);
-        boolean cameraOrBaseChanged = !Objects.equals(lastRenderedScene, scene)
-                || !Objects.equals(lastRenderedViewport, viewport);
-        if (cameraOrBaseChanged) {
-            CanvasRenderer.renderBase(this, CanvasSurface.graphicsContext(canvas), scene, viewport, width, height);
-            lastRenderedScene = scene;
+        boolean sizeChanged = Double.compare(lastPaintWidth, width) != 0
+                || Double.compare(lastPaintHeight, height) != 0;
+        long operationId = ++paintOperationId;
+        if (sizeChanged || lastBaseRevision != canvasState.baseRevision()) {
+            observePaint(MapCanvasLayer.BASE, operationId,
+                    () -> CanvasRenderer.renderBase(this, CanvasSurface.graphicsContext(canvas),
+                            scene, viewport, width, height));
+            lastBaseRevision = canvasState.baseRevision();
         }
-        boolean hoverChanged = cameraOrBaseChanged
-                || !Objects.equals(lastHoverSurfaces, canvasState.hoverSurfaces())
-                || !Objects.equals(lastHoverBoundaries, canvasState.hoverBoundaries())
-                || !Objects.equals(lastHoverGlyphs, canvasState.hoverGlyphs())
-                || !Objects.equals(lastHoverTexts, canvasState.hoverTexts());
-        if (hoverChanged) {
-            boolean sharedSurface = interactionCanvas == canvas;
-            if (sharedSurface && !cameraOrBaseChanged) {
-                CanvasRenderer.renderBase(
-                        this,
-                        CanvasSurface.graphicsContext(canvas),
-                        scene,
-                        viewport,
-                        width,
-                        height);
-            }
-            CanvasRenderer.renderDynamic(
-                    this,
-                    CanvasSurface.graphicsContext(interactionCanvas),
-                    canvasState,
-                    scene,
-                    viewport,
-                    width,
-                    height,
-                    !sharedSurface);
-            lastHoverSurfaces = canvasState.hoverSurfaces();
-            lastHoverBoundaries = canvasState.hoverBoundaries();
-            lastHoverGlyphs = canvasState.hoverGlyphs();
-            lastHoverTexts = canvasState.hoverTexts();
+        if (sizeChanged || lastInteractionRevision != canvasState.interactionRevision()) {
+            observePaint(MapCanvasLayer.INTERACTION, operationId,
+                    () -> CanvasRenderer.renderInteraction(this,
+                            CanvasSurface.graphicsContext(interactionCanvas), canvasState, scene,
+                            viewport, width, height));
+            lastInteractionRevision = canvasState.interactionRevision();
         }
-        lastRenderedViewport = viewport;
+        if (sizeChanged || lastActorRevision != canvasState.actorRevision()) {
+            observePaint(MapCanvasLayer.ACTOR, operationId,
+                    () -> CanvasRenderer.renderActor(this, CanvasSurface.graphicsContext(actorCanvas),
+                            scene, viewport, width, height));
+            lastActorRevision = canvasState.actorRevision();
+        }
+        lastPaintWidth = width;
+        lastPaintHeight = height;
+    }
+
+    private void observePaint(MapCanvasLayer layer, long operationId, LayerPainter painter) {
+        long startedNanos = System.nanoTime();
+        PaintCounts counts = painter.paint();
+        paintObserver.onPaint(new MapCanvasPaintSample(
+                layer,
+                operationId,
+                System.nanoTime() - startedNanos,
+                counts.visited(),
+                counts.painted()));
     }
 
     private void removeCurrentCanvasListeners() {
@@ -275,7 +282,7 @@ public class DungeonMapView extends BorderPane {
     }
 
     private void requestCanvasFocus() {
-        canvasLayer.requestFocus();
+        canvas.requestFocus();
     }
 
     private void emitInput(DungeonMapViewInputEvent inputEvent) {
@@ -776,7 +783,7 @@ public class DungeonMapView extends BorderPane {
 
     private interface CanvasRenderer {
 
-        static void renderBase(
+        static PaintCounts renderBase(
                 DungeonMapView view,
                 GraphicsContext gc,
                 RenderScene renderScene,
@@ -787,32 +794,45 @@ public class DungeonMapView extends BorderPane {
             clear(gc, width, height);
             drawGrid(gc, renderScene, viewport, width, height);
             MapCanvasWindow visibleWindow = visibleWindow(viewport, width, height);
-            drawRelations(gc, renderScene.relations(), viewport, visibleWindow);
-            drawSurfaces(view, gc, renderScene.baseSurfaces(), viewport, visibleWindow);
-            drawBoundaries(gc, renderScene.baseBoundaries(), viewport, visibleWindow);
-            drawGlyphs(view, gc, renderScene.baseGlyphs(), viewport, visibleWindow);
-            drawTexts(gc, renderScene.baseTexts(), viewport, visibleWindow);
+            return drawRelations(gc, renderScene.relations(), viewport, visibleWindow)
+                    .plus(drawSurfaces(view, gc, renderScene.baseSurfaces(), viewport, visibleWindow))
+                    .plus(drawBoundaries(gc, renderScene.baseBoundaries(), viewport, visibleWindow))
+                    .plus(drawGlyphs(view, gc, renderScene.baseGlyphs(), viewport, visibleWindow))
+                    .plus(drawTexts(gc, renderScene.baseTexts(), viewport, visibleWindow));
         }
 
-        static void renderDynamic(
+        static PaintCounts renderInteraction(
                 DungeonMapView view,
                 GraphicsContext gc,
                 DungeonMapContentModel.CanvasState canvasState,
                 RenderScene renderScene,
                 Viewport viewport,
                 double width,
-                double height,
-                boolean clearSurface
+                double height
         ) {
-            if (clearSurface) {
-                clearTransparent(gc, width, height);
-            }
+            clearTransparent(gc, width, height);
             MapCanvasWindow visibleWindow = visibleWindow(viewport, width, height);
-            drawSurfaces(view, gc, canvasState.hoverSurfaces(), viewport, visibleWindow);
-            drawBoundaries(gc, canvasState.hoverBoundaries(), viewport, visibleWindow);
-            drawGlyphs(view, gc, canvasState.hoverGlyphs(), viewport, visibleWindow);
-            drawTexts(gc, canvasState.hoverTexts(), viewport, visibleWindow);
-            drawSurfaces(view, gc, renderScene.actors(), viewport, visibleWindow);
+            return drawSurfaces(view, gc, renderScene.interactionSurfaces(), viewport, visibleWindow)
+                    .plus(drawBoundaries(gc, renderScene.interactionBoundaries(), viewport, visibleWindow))
+                    .plus(drawGlyphs(view, gc, renderScene.interactionGlyphs(), viewport, visibleWindow))
+                    .plus(drawTexts(gc, renderScene.interactionTexts(), viewport, visibleWindow))
+                    .plus(drawSurfaces(view, gc, canvasState.hoverSurfaces(), viewport, visibleWindow))
+                    .plus(drawBoundaries(gc, canvasState.hoverBoundaries(), viewport, visibleWindow))
+                    .plus(drawGlyphs(view, gc, canvasState.hoverGlyphs(), viewport, visibleWindow))
+                    .plus(drawTexts(gc, canvasState.hoverTexts(), viewport, visibleWindow));
+        }
+
+        static PaintCounts renderActor(
+                DungeonMapView view,
+                GraphicsContext gc,
+                RenderScene renderScene,
+                Viewport viewport,
+                double width,
+                double height
+        ) {
+            clearTransparent(gc, width, height);
+            return drawSurfaces(view, gc, renderScene.actors(), viewport,
+                    visibleWindow(viewport, width, height));
         }
 
         static void clear(GraphicsContext gc, double width, double height) {
@@ -857,47 +877,56 @@ public class DungeonMapView extends BorderPane {
             return spacing >= 10.0;
         }
 
-        static void drawSurfaces(
+        static PaintCounts drawSurfaces(
                 DungeonMapView view,
                 GraphicsContext gc,
                 List<MapCanvasPolygonPrimitive> surfaces,
                 Viewport viewport,
                 MapCanvasWindow visibleWindow
         ) {
+            long painted = 0L;
             for (MapCanvasPolygonPrimitive surface : surfaces) {
                 if (PrimitivePainter.visible(surface.polygon(), visibleWindow)) {
                     PrimitivePainter.drawPolygon(view, gc, surface.polygon(), surface.style(), viewport);
+                    painted++;
                 }
             }
+            return new PaintCounts(surfaces.size(), painted);
         }
 
-        static void drawBoundaries(
+        static PaintCounts drawBoundaries(
                 GraphicsContext gc,
                 List<BoundaryPrimitive> boundaries,
                 Viewport viewport,
                 MapCanvasWindow visibleWindow
         ) {
+            long painted = 0L;
             for (BoundaryPrimitive boundary : boundaries) {
                 if (PrimitivePainter.visible(boundary.polyline(), visibleWindow)) {
                     PrimitivePainter.drawPolyline(gc, boundary.polyline(), boundary.style(), viewport);
+                    painted++;
                 }
             }
+            return new PaintCounts(boundaries.size(), painted);
         }
 
-        static void drawRelations(
+        static PaintCounts drawRelations(
                 GraphicsContext gc,
                 List<RelationPrimitive> relations,
                 Viewport viewport,
                 MapCanvasWindow visibleWindow
         ) {
+            long painted = 0L;
             for (RelationPrimitive relation : relations) {
                 if (PrimitivePainter.visible(relation.polyline(), visibleWindow)) {
                     PrimitivePainter.drawPolyline(gc, relation.polyline(), relation.style(), viewport);
+                    painted++;
                 }
             }
+            return new PaintCounts(relations.size(), painted);
         }
 
-        static void drawGlyphs(
+        static PaintCounts drawGlyphs(
                 DungeonMapView view,
                 GraphicsContext gc,
                 List<GlyphPrimitive> glyphs,
@@ -905,11 +934,13 @@ public class DungeonMapView extends BorderPane {
                 MapCanvasWindow visibleWindow
         ) {
             gc.setTextAlign(TextAlignment.CENTER);
+            long painted = 0L;
             for (GlyphPrimitive glyph : glyphs) {
                 if (!PrimitivePainter.visible(glyph.polygon(), visibleWindow)) {
                     continue;
                 }
                 PrimitivePainter.drawPolygon(view, gc, glyph.polygon(), glyph.style(), viewport);
+                painted++;
                 String label = glyph.label();
                 if (!label.isBlank()) {
                     gc.setFill(PaintPalette.defaultTextColor(glyph.labelColor()));
@@ -920,15 +951,17 @@ public class DungeonMapView extends BorderPane {
                 }
             }
             gc.setTextAlign(TextAlignment.LEFT);
+            return new PaintCounts(glyphs.size(), painted);
         }
 
-        static void drawTexts(
+        static PaintCounts drawTexts(
                 GraphicsContext gc,
                 List<DungeonMapContentModel.TextPrimitive> texts,
                 Viewport viewport,
                 MapCanvasWindow visibleWindow
         ) {
             gc.setTextAlign(TextAlignment.CENTER);
+            long painted = 0L;
             for (DungeonMapContentModel.TextPrimitive text : texts) {
                 double halfWidth = Math.max(0.0, text.width()) / 2.0;
                 double halfHeight = Math.max(0.0, text.height()) / 2.0;
@@ -962,8 +995,10 @@ public class DungeonMapView extends BorderPane {
                 gc.setFont(PaintPalette.fxFont(text.typography()));
                 gc.fillText(text.text(), centerX, y + height * 0.69, Math.max(1.0, width * 0.92));
                 gc.restore();
+                painted++;
             }
             gc.setTextAlign(TextAlignment.LEFT);
+            return new PaintCounts(texts.size(), painted);
         }
 
         private static MapCanvasWindow visibleWindow(Viewport viewport, double width, double height) {
@@ -978,6 +1013,17 @@ public class DungeonMapView extends BorderPane {
                     2.0);
         }
 
+    }
+
+    @FunctionalInterface
+    private interface LayerPainter {
+        PaintCounts paint();
+    }
+
+    private record PaintCounts(long visited, long painted) {
+        private PaintCounts plus(PaintCounts other) {
+            return new PaintCounts(visited + other.visited, painted + other.painted);
+        }
     }
 
     private interface PrimitivePainter {

--- a/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
+++ b/features/dungeon/application/authored/DungeonAuthoredApplicationService.java
@@ -1423,28 +1423,23 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                 int minimumR,
                 int maximumQ,
                 int maximumR,
-                boolean coalesce,
                 DungeonEditorDungeonState state
         ) {
             if (mapId == null || maximumQ < minimumQ || maximumR < minimumR) {
                 return ViewportLoadResult.REJECTED;
             }
+            DungeonViewportRequest requestedViewport = new DungeonViewportRequest(
+                    mapId.value(),
+                    0L,
+                    projectionLevel,
+                    minimumQ,
+                    minimumR,
+                    maximumQ,
+                    maximumR);
+            var requestedChunks = List.copyOf(requestedViewport.loadingChunks());
             DungeonMapHeader expectedHeader = catalogStore.find(domainMapId(mapId)).orElse(null);
             if (expectedHeader == null) {
                 return ViewportLoadResult.REJECTED;
-            }
-            DungeonCommandReadSpecs.AcceptedViewport current = acceptedViewports.get(mapId.value());
-            if (coalesce
-                    && current != null
-                    && state.committedFacts(mapId).committedSnapshot() != null
-                    && current.matches(
-                            expectedHeader.revision(),
-                            projectionLevel,
-                            minimumQ,
-                            minimumR,
-                            maximumQ,
-                            maximumR)) {
-                return ViewportLoadResult.COALESCED;
             }
             long generation = windowRequestGeneration.incrementAndGet();
             DungeonViewportRequest viewport = new DungeonViewportRequest(
@@ -1456,7 +1451,7 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     maximumQ,
                     maximumR);
             DungeonWindowRequest request = new DungeonWindowRequest(
-                    domainMapId(mapId), generation, List.copyOf(viewport.loadingChunks()));
+                    domainMapId(mapId), generation, requestedChunks);
             DungeonWindow window = windowStore.loadWindow(request).orElse(null);
             if (window == null) {
                 return ViewportLoadResult.REJECTED;
@@ -1578,7 +1573,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
 
     private enum ViewportLoadResult {
         ACCEPTED,
-        COALESCED,
         REJECTED
     }
 
@@ -2697,7 +2691,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     minimumR,
                     maximumQ,
                     maximumR,
-                    true,
                     dungeonState) == ViewportLoadResult.ACCEPTED;
         }
 
@@ -2716,7 +2709,6 @@ public final class DungeonAuthoredApplicationService implements DungeonAuthoredA
                     minimumR,
                     maximumQ,
                     maximumR,
-                    false,
                     dungeonState) == ViewportLoadResult.ACCEPTED;
         }
 

--- a/features/dungeon/application/authored/DungeonCommandReadSpecs.java
+++ b/features/dungeon/application/authored/DungeonCommandReadSpecs.java
@@ -218,13 +218,5 @@ final class DungeonCommandReadSpecs {
                     chunkKeys);
         }
 
-        boolean matches(long expectedRevision, int level, int minQ, int minR, int maxQ, int maxR) {
-            return revision == expectedRevision
-                    && projectionLevel == level
-                    && minimumQ == minQ
-                    && minimumR == minR
-                    && maximumQ == maxQ
-                    && maximumR == maxR;
-        }
     }
 }

--- a/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
+++ b/features/dungeon/application/editor/DungeonEditorRuntimeApplicationService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import features.dungeon.application.authored.DungeonAuthoredApplicationService;
 import features.dungeon.domain.core.geometry.Cell;
@@ -21,8 +22,10 @@ import features.dungeon.application.editor.session.DungeonEditorSession;
 import features.dungeon.application.editor.session.DungeonEditorSessionEffect;
 import features.dungeon.application.editor.session.DungeonEditorSessionSnapshot;
 import features.dungeon.application.editor.session.DungeonEditorSessionValues;
+import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.api.DungeonEditorViewMode;
 import features.dungeon.api.DungeonOverlaySettings;
+import features.dungeon.api.DungeonViewportRequest;
 import features.dungeon.application.editor.session.DungeonEditorSessionWorkflow;
 import features.dungeon.api.editor.DungeonEditorToolSelection;
 import features.dungeon.api.editor.DungeonEditorCommandOutcome;
@@ -71,6 +74,7 @@ public final class DungeonEditorRuntimeApplicationService {
         private final DungeonEditorSessionWorkflow workflow = new DungeonEditorSessionWorkflow();
         private final SnapshotBuilder snapshotBuilder;
         private final PreviewLifecycle previewLifecycle;
+        private AcceptedRuntimeViewport acceptedViewport;
 
         private RuntimeSession(
                 DungeonAuthoredApplicationService authoredService,
@@ -140,7 +144,7 @@ public final class DungeonEditorRuntimeApplicationService {
 
         public DungeonEditorSessionSnapshot.SnapshotData selectMap(long mapId) {
             workflow.selectMap(mapId);
-            snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+            refreshAndAcceptAuthoredSurface();
             DungeonEditorSessionSnapshot.SnapshotData snapshot =
                     workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
             editorPublishedState.publishEditorSnapshot(snapshot);
@@ -162,13 +166,106 @@ public final class DungeonEditorRuntimeApplicationService {
             }
             snapshotBuilder.setViewport(safeViewport);
             MapId mapId = workflow.session().selectedMapId();
-            if (mapId == null || !snapshotBuilder.requestAuthoredSurface(mapId, workflow.session())) {
+            if (mapId == null) {
                 return null;
             }
+            AcceptedRuntimeViewport requested = acceptedViewport(mapId, safeViewport);
+            if (requested.equals(acceptedViewport)) {
+                return null;
+            }
+            acceptedViewport = requested;
+            if (!snapshotBuilder.requestAuthoredSurface(mapId, workflow.session())) {
+                acceptedViewport = null;
+                return null;
+            }
+            acceptedViewport = acceptedViewport(mapId, safeViewport);
             DungeonEditorSessionSnapshot.SnapshotData snapshot =
                     workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
             editorPublishedState.publishEditorSnapshot(snapshot);
             return snapshot;
+        }
+
+        private AcceptedRuntimeViewport acceptedViewport(
+                MapId mapId,
+                DungeonEditorViewportInput viewport
+        ) {
+            DungeonEditorSessionSnapshot.SurfaceData surface = dungeonState.committedFacts(mapId).surface();
+            long revision = surface == null ? 0L : surface.acceptedRevision();
+            return new AcceptedRuntimeViewport(
+                    mapId.value(),
+                    revision,
+                    viewport.level(),
+                    loadingChunks(mapId, viewport));
+        }
+
+        private void acceptPublishedMutationRevision() {
+            if (acceptedViewport == null
+                    || !(currentFacts().commandOutcome() instanceof DungeonEditorCommandOutcome.Accepted accepted)) {
+                return;
+            }
+            MapId mapId = workflow.session().selectedMapId();
+            if (mapId == null || acceptedViewport.mapId() != mapId.value()) {
+                return;
+            }
+            DungeonEditorSessionSnapshot.SurfaceData surface = dungeonState.committedFacts(mapId).surface();
+            if (surface == null
+                    || surface.mapId() == null
+                    || surface.mapId().value() != mapId.value()
+                    || surface.acceptedRevision() != accepted.authoredRevision()
+                    || surface.acceptedRevision() < acceptedViewport.revision()) {
+                return;
+            }
+            acceptedViewport = acceptedViewport.atRevision(surface.acceptedRevision());
+        }
+
+        private void refreshAndAcceptAuthoredSurface() {
+            SnapshotBuilder.AcceptedSurfaceRefresh refresh =
+                    snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+            if (refresh == null) {
+                return;
+            }
+            DungeonEditorSessionSnapshot.SurfaceData surface =
+                    dungeonState.committedFacts(refresh.mapId()).surface();
+            if (surface == null
+                    || surface.mapId() == null
+                    || surface.mapId().value() != refresh.mapId().value()) {
+                return;
+            }
+            DungeonEditorViewportInput viewport = refresh.viewport();
+            acceptedViewport = new AcceptedRuntimeViewport(
+                    refresh.mapId().value(),
+                    surface.acceptedRevision(),
+                    viewport.level(),
+                    loadingChunks(refresh.mapId(), viewport));
+        }
+
+        private static Set<DungeonChunkKey> loadingChunks(
+                MapId mapId,
+                DungeonEditorViewportInput viewport
+        ) {
+            return new DungeonViewportRequest(
+                    mapId.value(),
+                    0L,
+                    viewport.level(),
+                    viewport.minimumQ(),
+                    viewport.minimumR(),
+                    viewport.maximumQ(),
+                    viewport.maximumR()).loadingChunks();
+        }
+
+        private record AcceptedRuntimeViewport(
+                long mapId,
+                long revision,
+                int level,
+                Set<DungeonChunkKey> loadingChunks
+        ) {
+            private AcceptedRuntimeViewport {
+                loadingChunks = Set.copyOf(loadingChunks);
+            }
+
+            private AcceptedRuntimeViewport atRevision(long acceptedRevision) {
+                return new AcceptedRuntimeViewport(mapId, acceptedRevision, level, loadingChunks);
+            }
         }
 
         public DungeonEditorSessionSnapshot.SnapshotData createMap(String mapName) {
@@ -556,14 +653,16 @@ public final class DungeonEditorRuntimeApplicationService {
             }
             DungeonEditorSessionSnapshot.SnapshotData snapshot =
                     workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
+            acceptPublishedMutationRevision();
             editorPublishedState.publishEditorSnapshot(snapshot);
             return PublicationResult.full(snapshot);
         }
 
         private DungeonEditorSessionSnapshot.SnapshotData refreshAuthoredSnapshot() {
-            snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+            refreshAndAcceptAuthoredSurface();
             DungeonEditorSessionSnapshot.SnapshotData snapshot =
                     workflow.reconcileSnapshot(snapshotBuilder.execute(workflow.session()));
+            acceptPublishedMutationRevision();
             editorPublishedState.publishEditorSnapshot(snapshot);
             return snapshot;
         }
@@ -603,7 +702,7 @@ public final class DungeonEditorRuntimeApplicationService {
 
         private final class PreviewLifecycle {
             PublicationOutcome preparePublishCurrent() {
-                snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+                refreshAndAcceptAuthoredSurface();
                 return PublicationOutcome.PUBLISH_CURRENT;
             }
 
@@ -667,12 +766,12 @@ public final class DungeonEditorRuntimeApplicationService {
             }
 
             private PublicationOutcome prepareCurrentReadback() {
-                snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+                refreshAndAcceptAuthoredSurface();
                 return PublicationOutcome.CURRENT_READBACK_PUBLISHED;
             }
 
             private PublicationOutcome prepareAuthoredPreviewApplied() {
-                snapshotBuilder.refreshAuthoredSnapshot(workflow.session());
+                refreshAndAcceptAuthoredSurface();
                 return PublicationOutcome.AUTHORED_PREVIEW_APPLIED;
             }
 
@@ -836,14 +935,16 @@ public final class DungeonEditorRuntimeApplicationService {
             return snapshotData(safeState, maps, resolvedMapId);
         }
 
-        private void refreshAuthoredSnapshot(@Nullable DungeonEditorSession state) {
+        private @Nullable AcceptedSurfaceRefresh refreshAuthoredSnapshot(
+                @Nullable DungeonEditorSession state
+        ) {
             DungeonEditorSession safeState = DungeonEditorSnapshotStateProjectionHelper.safeState(state);
             refreshCatalog();
             List<MapSummary> maps = dungeonState
                     .currentFacts(null, safeState.selection(), safeState.preview())
                     .maps();
             @Nullable MapId resolvedMapId = resolveSelectedMapId(safeState, maps);
-            refreshAuthoredSurface(resolvedMapId, safeState);
+            return refreshAuthoredSurface(resolvedMapId, safeState);
         }
 
         private void setViewport(DungeonEditorViewportInput viewport) {
@@ -908,12 +1009,12 @@ public final class DungeonEditorRuntimeApplicationService {
                     safeState.commandOutcome());
         }
 
-        private boolean refreshAuthoredSurface(
+        private @Nullable AcceptedSurfaceRefresh refreshAuthoredSurface(
                 @Nullable MapId readbackMapId,
                 DungeonEditorSession state
         ) {
             if (readbackMapId == null || latestViewport == null) {
-                return false;
+                return null;
             }
             DungeonEditorViewportInput viewport = latestViewport.atLevel(state.projectionLevel());
             latestViewport = viewport;
@@ -925,13 +1026,13 @@ public final class DungeonEditorRuntimeApplicationService {
                     viewport.maximumQ(),
                     viewport.maximumR());
             if (!accepted) {
-                return false;
+                return null;
             }
             DungeonEditorSessionValues.Selection selection = state.selection();
             if (hasSelectionForInspector(selection)) {
                 loadSelectionInspector(readbackMapId, selection);
             }
-            return true;
+            return new AcceptedSurfaceRefresh(readbackMapId, viewport);
         }
 
         private boolean requestAuthoredSurface(
@@ -995,6 +1096,9 @@ public final class DungeonEditorRuntimeApplicationService {
                 }
             }
             return maps.isEmpty() ? null : maps.getFirst().mapId();
+        }
+
+        private record AcceptedSurfaceRefresh(MapId mapId, DungeonEditorViewportInput viewport) {
         }
 
     }

--- a/platform/ui/mapcanvas/MapCanvasPaintObserver.java
+++ b/platform/ui/mapcanvas/MapCanvasPaintObserver.java
@@ -1,0 +1,11 @@
+package platform.ui.mapcanvas;
+
+/** Feature-neutral sink for deterministic physical-layer paint evidence. */
+@FunctionalInterface
+public interface MapCanvasPaintObserver {
+    void onPaint(MapCanvasPaintSample sample);
+
+    static MapCanvasPaintObserver passive() {
+        return ignored -> { };
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasPaintSample.java
+++ b/platform/ui/mapcanvas/MapCanvasPaintSample.java
@@ -1,0 +1,21 @@
+package platform.ui.mapcanvas;
+
+/** One executed physical-layer paint, emitted after the paint completes. */
+public record MapCanvasPaintSample(
+        MapCanvasLayer layer,
+        long operationId,
+        long durationNanos,
+        long visitedPrimitives,
+        long paintedPrimitives
+) {
+    public MapCanvasPaintSample {
+        layer = layer == null ? MapCanvasLayer.BASE : layer;
+        operationId = Math.max(0L, operationId);
+        durationNanos = Math.max(0L, durationNanos);
+        visitedPrimitives = Math.max(0L, visitedPrimitives);
+        paintedPrimitives = Math.max(0L, paintedPrimitives);
+        if (paintedPrimitives > visitedPrimitives) {
+            throw new IllegalArgumentException("painted primitives cannot exceed visited primitives");
+        }
+    }
+}

--- a/platform/ui/mapcanvas/MapCanvasPane.java
+++ b/platform/ui/mapcanvas/MapCanvasPane.java
@@ -5,18 +5,18 @@ import java.util.Map;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.layout.Pane;
 
-/** JavaFX host for logical map paint layers on one bounded backing surface. */
+/** JavaFX host for three independently painted map layers. */
 public final class MapCanvasPane extends Pane {
     private final Map<MapCanvasLayer, Canvas> canvases = new EnumMap<>(MapCanvasLayer.class);
 
     public MapCanvasPane() {
-        setFocusTraversable(true);
+        setFocusTraversable(false);
         setMinSize(0.0, 0.0);
-        Canvas base = createCanvas(false);
-        canvases.put(MapCanvasLayer.BASE, base);
-        canvases.put(MapCanvasLayer.INTERACTION, base);
-        canvases.put(MapCanvasLayer.ACTOR, base);
-        getChildren().add(base);
+        for (MapCanvasLayer layer : MapCanvasLayer.values()) {
+            Canvas canvas = createCanvas(layer != MapCanvasLayer.BASE);
+            canvases.put(layer, canvas);
+            getChildren().add(canvas);
+        }
     }
 
     public Canvas canvas(MapCanvasLayer layer) {
@@ -24,9 +24,14 @@ public final class MapCanvasPane extends Pane {
         return canvases.get(safeLayer);
     }
 
+    public int canvasCount() {
+        return canvases.size();
+    }
+
     private Canvas createCanvas(boolean mouseTransparent) {
         Canvas canvas = new Canvas();
         canvas.setMouseTransparent(mouseTransparent);
+        canvas.setFocusTraversable(!mouseTransparent);
         canvas.widthProperty().bind(widthProperty());
         canvas.heightProperty().bind(heightProperty());
         return canvas;

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestRuntime.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestRuntime.java
@@ -5,7 +5,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.stage.Stage;
 import javafx.stage.Window;
+import features.dungeon.adapter.javafx.map.DungeonMapView;
+import platform.ui.mapcanvas.MapCanvasLayer;
+import platform.ui.mapcanvas.MapCanvasPane;
 
 class DungeonEditorTestRuntime extends DungeonEditorTestPersistence {
 
@@ -54,11 +62,48 @@ class DungeonEditorTestRuntime extends DungeonEditorTestPersistence {
         runOnFxThread(DungeonEditorTestRuntime::hideWindowsWithoutImplicitExit);
     }
 
+    static void releaseProofWindowsBeforeBinding() {
+        hideWindowsWithoutImplicitExit();
+    }
+
     private static void hideWindowsWithoutImplicitExit() {
         Platform.setImplicitExit(false);
         for (Window window : List.copyOf(Window.getWindows())) {
-            window.hide();
+            Scene scene = window.getScene();
+            if (scene != null) {
+                releaseNode(scene.getRoot());
+            }
+            if (window instanceof Stage stage) {
+                stage.hide();
+                stage.setScene(null);
+                stage.close();
+            } else {
+                window.hide();
+            }
         }
+    }
+
+    private static void releaseNode(Node node) {
+        if (node instanceof DungeonMapView mapView) {
+            mapView.bind(null);
+        }
+        if (node instanceof MapCanvasPane pane) {
+            releaseCanvas(pane.canvas(MapCanvasLayer.BASE));
+            releaseCanvas(pane.canvas(MapCanvasLayer.INTERACTION));
+            releaseCanvas(pane.canvas(MapCanvasLayer.ACTOR));
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : List.copyOf(parent.getChildrenUnmodifiable())) {
+                releaseNode(child);
+            }
+        }
+    }
+
+    private static void releaseCanvas(Canvas canvas) {
+        canvas.widthProperty().unbind();
+        canvas.heightProperty().unbind();
+        canvas.setWidth(0.0);
+        canvas.setHeight(0.0);
     }
 
     static void runRoute(ThrowingRunnable action) throws Exception {

--- a/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestSupport.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonEditorTestSupport.java
@@ -31,12 +31,12 @@ import features.dungeon.adapter.javafx.map.DungeonMapContentModel.PointerTarget;
 import features.dungeon.api.editor.DungeonEditorPointerInput;
 import features.dungeon.adapter.javafx.map.DungeonMapView;
 import platform.ui.catalogcrud.CatalogCrudControlsView;
+import platform.ui.mapcanvas.MapCanvasPane;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.canvas.Canvas;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.CheckBox;
@@ -1917,10 +1917,10 @@ final class DungeonEditorTestSupport extends DungeonEditorTestRuntime {
         assertTrue(paintedPixels > 0, message);
     }
 
-    static Canvas mapCanvas(DungeonMapView mapView) {
+    static MapCanvasPane mapCanvas(DungeonMapView mapView) {
         return descendants(mapView).stream()
-                .filter(Canvas.class::isInstance)
-                .map(Canvas.class::cast)
+                .filter(MapCanvasPane.class::isInstance)
+                .map(MapCanvasPane.class::cast)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Dungeon map canvas not found."));
     }
@@ -2307,6 +2307,7 @@ final class DungeonEditorTestSupport extends DungeonEditorTestRuntime {
     }
 
     static TestBinding bindTest(TestRuntime runtime, double width, double height) {
+        releaseProofWindowsBeforeBinding();
         ShellBinding shellBinding = new DungeonEditorContribution(runtime.editorApi()).bind();
         Parent controlsRoot = slot(shellBinding, ShellSlot.COCKPIT_CONTROLS, Parent.class);
         DungeonEditorControlsView controls = descendant(controlsRoot, DungeonEditorControlsView.class);
@@ -2324,6 +2325,7 @@ final class DungeonEditorTestSupport extends DungeonEditorTestRuntime {
     }
 
     static TestBinding bindShellTest(TestRuntime runtime, double width, double height) {
+        releaseProofWindowsBeforeBinding();
         AppShell shell = new AppShell();
         DungeonEditorContribution contribution = new DungeonEditorContribution(runtime.editorApi());
         ShellBinding shellBinding = contribution.bind();

--- a/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProductionQualificationTest.java
+++ b/test/features/dungeon/adapter/javafx/editor/DungeonRuntimeProductionQualificationTest.java
@@ -1,0 +1,507 @@
+package features.dungeon.adapter.javafx.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.DungeonTestAssembly;
+import features.dungeon.adapter.javafx.map.DungeonMapContentModel;
+import features.dungeon.adapter.javafx.map.DungeonMapView;
+import features.dungeon.adapter.javafx.travel.DungeonTravelContribution;
+import features.dungeon.adapter.sqlite.gateway.DungeonSparseQualificationFixture;
+import features.dungeon.adapter.sqlite.repository.SqliteDungeonCatalogStore;
+import features.dungeon.adapter.sqlite.repository.SqliteDungeonIdentityAllocator;
+import features.dungeon.adapter.sqlite.repository.SqliteDungeonUnitOfWork;
+import features.dungeon.adapter.sqlite.repository.SqliteDungeonWindowStore;
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.editor.DungeonEditorApi;
+import features.dungeon.api.editor.DungeonEditorIntent;
+import features.dungeon.api.editor.DungeonEditorToolFamily;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.api.travel.DungeonTravelApi;
+import features.dungeon.application.authored.DungeonCachedWindowStore;
+import features.dungeon.application.editor.DungeonEditorApiFacade;
+import features.dungeon.application.editor.DungeonEditorFeatureRuntimeRoot;
+import features.dungeon.application.editor.DungeonEditorRuntimeDependencies;
+import features.dungeon.qualification.DungeonQualificationDataset;
+import features.dungeon.qualification.DungeonRuntimeQualificationProtocol;
+import features.dungeon.qualification.DungeonRuntimeQualificationProtocol.Histogram;
+import features.dungeon.qualification.DungeonRuntimeWorkProbe;
+import features.dungeon.qualification.DungeonRuntimeWorkProbe.Snapshot;
+import features.party.PartyServiceAssembly;
+import features.party.domain.roster.PartyRoster;
+import features.party.domain.roster.repository.PartyRosterRepository;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import platform.diagnostics.NoopDiagnostics;
+import platform.execution.DirectExecutionLane;
+import platform.persistence.SqliteDatabase;
+import platform.ui.DirectUiDispatcher;
+import platform.ui.mapcanvas.MapCanvasLayer;
+import platform.ui.mapcanvas.MapCanvasPaintSample;
+import shell.api.ShellBinding;
+import shell.api.ShellSlot;
+
+/** M5.4 production-route qualification over equal visible work and growing off-window truth. */
+final class DungeonRuntimeProductionQualificationTest {
+    private static final int MAX_VISIBLE_PLUS_RING_CHUNKS = 9;
+    private static final long MAX_COLD_INDEX_CALLS = 8L;
+    private static final long MAX_COLD_CONTENT_CALLS = 9L;
+    private static final long MAX_COLD_HYDRATED_ENTITIES = 18L;
+    private static final long MAX_COLD_REQUESTED_CHUNKS = 72L;
+    private static final long MAX_OPERATION_INDEX_CALLS = 4L;
+    private static final long MAX_OPERATION_CONTENT_CALLS = 2L;
+    private static final long MAX_OPERATION_CLOSURE_CALLS = 2L;
+    private static final long MAX_OPERATION_UOW_CALLS = 1L;
+    private static final long MAX_OPERATION_HYDRATED_ENTITIES = 12L;
+    private static final long MAX_OPERATION_REQUESTED_CHUNKS = 36L;
+    private static final long MAX_OPERATION_RELOADED_CHUNKS = 9L;
+    private static final long MAX_OPERATION_TOUCHED_CHUNKS = 9L;
+
+    @Test
+    void runtimeWorkAndPaintRemainBoundedAcrossSparse1k10k100k(@TempDir Path tempDir) throws Exception {
+        Map<DungeonQualificationDataset, QualificationEvidence> evidence =
+                new EnumMap<>(DungeonQualificationDataset.class);
+        for (DungeonQualificationDataset dataset : DungeonQualificationDataset.values()) {
+            Path databasePath = tempDir.resolve(dataset.name().toLowerCase() + ".db");
+            try (SqliteDatabase database = new SqliteDatabase(databasePath, NoopDiagnostics.INSTANCE)) {
+                DungeonSparseQualificationFixture.seedRuntime(database, databasePath, dataset);
+                evidence.put(dataset, runOnFxThread(() -> qualify(database, dataset)));
+            }
+        }
+
+        List<WorkEnvelope> comparableWork = evidence.values().stream()
+                .map(QualificationEvidence::work)
+                .toList();
+        assertEquals(1L, comparableWork.stream().distinct().count(),
+                "1k, 10k and 100k must execute identical visible production-route work");
+        List<PaintEnvelope> comparablePaint = evidence.values().stream()
+                .map(QualificationEvidence::paint)
+                .toList();
+        assertEquals(1L, comparablePaint.stream().distinct().count(),
+                "1k, 10k and 100k must visit and paint identical visible primitives");
+    }
+
+    private static QualificationEvidence qualify(
+            SqliteDatabase database,
+            DungeonQualificationDataset dataset
+    ) {
+        DungeonRuntimeWorkProbe probe = new DungeonRuntimeWorkProbe();
+        Snapshot beforeCold = probe.snapshot();
+        long coldStarted = System.nanoTime();
+        DungeonCachedWindowStore windowStore = new DungeonCachedWindowStore(
+                probe.count(new SqliteDungeonWindowStore(database)));
+        PartyServiceAssembly.Component party = PartyServiceAssembly.create(new EmptyPartyRosterRepository());
+        DungeonTestAssembly.Component dungeon = DungeonTestAssembly.create(
+                new SqliteDungeonCatalogStore(database),
+                windowStore,
+                probe.count(new SqliteDungeonUnitOfWork(database)),
+                new SqliteDungeonIdentityAllocator(database),
+                party.activeParty(),
+                party.travelPositions(),
+                party.application(),
+                party.mutation(),
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE,
+                NoopDiagnostics.INSTANCE);
+        DungeonEditorRuntimeDependencies dependencies = new DungeonEditorRuntimeDependencies(
+                dungeon.editorControls(), dungeon.editorMapSurface(), dungeon.editorState(), dungeon.editor(),
+                new features.dungeon.domain.core.structure.corridor.OrthogonalCorridorRoutingPolicy(),
+                dungeon.authored()::currentWindowRequestGeneration,
+                DirectExecutionLane.INSTANCE,
+                DirectUiDispatcher.INSTANCE);
+        DungeonEditorApi editorApi = new DungeonEditorApiFacade(
+                DungeonEditorFeatureRuntimeRoot.create(dependencies),
+                DirectUiDispatcher.INSTANCE);
+        ShellBinding editorBinding = new DungeonEditorContribution(editorApi).bind();
+        DungeonMapView editorView = DungeonEditorTestSupport.slot(
+                editorBinding, ShellSlot.COCKPIT_MAIN, DungeonMapView.class);
+        DungeonMapContentModel editorModel = DungeonEditorTestSupport.boundContentModel(editorBinding);
+        List<MapCanvasPaintSample> editorPaint = new ArrayList<>();
+        editorView.onPaintSample(editorPaint::add);
+        Stage editorStage = mount(editorBinding, 960.0, 640.0);
+        editorModel.panByPixels(-512.0, -512.0);
+        editorApi.dispatch(new DungeonEditorIntent.SelectMap(
+                new DungeonMapId(DungeonQualificationDataset.MAP_ID)));
+        long coldNanos = System.nanoTime() - coldStarted;
+        System.out.println("M5.4 " + dataset + " cold samples=[" + coldNanos + "]"
+                + " min=" + coldNanos + " p50=" + coldNanos
+                + " p95=" + coldNanos + " max=" + coldNanos);
+        Snapshot cold = probe.snapshot().subtract(beforeCold);
+        assertColdBounds(cold);
+
+        List<Snapshot> cameraWork = new ArrayList<>();
+        editorModel.panByPixels(16.0, 16.0);
+        editorPaint.clear();
+        Histogram camera = DungeonRuntimeQualificationProtocol.measureAlternating(index -> {
+            Snapshot before = probe.snapshot();
+            double startX = 480.0;
+            double endX = startX + ((index & 1) == 0 ? 1.0 : -1.0);
+            DungeonEditorTestSupport.fireMapMouse(
+                    editorView, MouseEvent.MOUSE_PRESSED, MouseButton.MIDDLE, startX, 320.0, false);
+            DungeonEditorTestSupport.fireMapMouse(
+                    editorView, MouseEvent.MOUSE_DRAGGED, MouseButton.MIDDLE, endX, 320.0, false);
+            DungeonEditorTestSupport.fireMapMouse(
+                    editorView, MouseEvent.MOUSE_RELEASED, MouseButton.MIDDLE, endX, 320.0, false);
+            cameraWork.add(probe.snapshot().subtract(before));
+        });
+        record(dataset, "camera", camera);
+        PaintWork cameraPaint = PaintWork.from(editorPaint);
+        System.out.println("M5.4 " + dataset + " camera paint=" + cameraPaint);
+        System.out.println("M5.4 " + dataset + " camera work=" + WorkMaximum.from(cameraWork));
+        assertTrue(camera.p95() <= DungeonRuntimeQualificationProtocol.CAMERA_P95_NANOS,
+                dataset + " camera p95=" + camera.p95());
+
+        List<Snapshot> hoverWork = new ArrayList<>();
+        editorPaint.clear();
+        for (int index = 0; index < DungeonRuntimeQualificationProtocol.WARMUP_SAMPLES
+                + DungeonRuntimeQualificationProtocol.MEASURED_SAMPLES; index++) {
+            Snapshot before = probe.snapshot();
+            DungeonMapContentModel.Viewport viewport = editorModel.currentViewport();
+            double scene = (index & 1) == 0 ? 2.5 : 1.5;
+            DungeonEditorTestSupport.fireMapMouse(
+                    editorView, MouseEvent.MOUSE_MOVED, MouseButton.NONE,
+                    viewport.sceneToScreenX(scene), viewport.sceneToScreenY(scene), false);
+            Snapshot work = probe.snapshot().subtract(before);
+            assertEquals(0L, work.repositoryCalls(), dataset + " hover repository I/O");
+            hoverWork.add(work);
+        }
+        assertOnlyLayer(editorPaint, MapCanvasLayer.INTERACTION, "hover");
+        PaintWork hoverPaint = PaintWork.from(editorPaint);
+
+        editorApi.dispatch(new DungeonEditorIntent.SetTool(
+                DungeonEditorToolSelection.family(DungeonEditorToolFamily.ROOM)));
+        DungeonMapContentModel.Viewport previewViewport = editorModel.currentViewport();
+        DungeonEditorTestSupport.fireMapMouse(
+                editorView, MouseEvent.MOUSE_PRESSED, MouseButton.PRIMARY,
+                previewViewport.sceneToScreenX(3.1), previewViewport.sceneToScreenY(3.1), false);
+        List<Snapshot> previewWork = new ArrayList<>();
+        editorPaint.clear();
+        Histogram preview = DungeonRuntimeQualificationProtocol.measureAlternating(index -> {
+            Snapshot before = probe.snapshot();
+            DungeonMapContentModel.Viewport viewport = editorModel.currentViewport();
+            double scene = (index & 1) == 0 ? 4.9 : 5.9;
+            DungeonEditorTestSupport.fireMapMouse(
+                    editorView, MouseEvent.MOUSE_DRAGGED, MouseButton.PRIMARY,
+                    viewport.sceneToScreenX(scene), viewport.sceneToScreenY(scene), false);
+            if (index == 0) {
+                assertTrue(editorApi.current().preview()
+                                instanceof features.dungeon.api.DungeonEditorPreview.RoomRectanglePreview,
+                        dataset + " public preview route state=" + editorApi.current());
+            }
+            Snapshot work = probe.snapshot().subtract(before);
+            assertEquals(0L, work.repositoryCalls(), dataset + " preview repository I/O");
+            previewWork.add(work);
+        });
+        record(dataset, "preview", preview);
+        assertTrue(preview.p95() <= DungeonRuntimeQualificationProtocol.PREVIEW_P95_NANOS,
+                dataset + " preview p95=" + preview.p95());
+        assertExactlyOneLayerPerInput(editorPaint, MapCanvasLayer.INTERACTION, "preview");
+        PaintWork previewPaint = PaintWork.from(editorPaint);
+        editorApi.dispatch(DungeonEditorIntent.CancelPreview.INSTANCE);
+
+        List<Snapshot> commitWork = new ArrayList<>();
+        Histogram commit = DungeonRuntimeQualificationProtocol.measureAlternating(index -> {
+            Snapshot before = probe.snapshot();
+            commitAlternating(editorApi, editorView, editorModel, index);
+            commitWork.add(probe.snapshot().subtract(before));
+        });
+        record(dataset, "commit", commit);
+
+        List<Snapshot> undoWork = new ArrayList<>();
+        Histogram undo = DungeonRuntimeQualificationProtocol.measureAlternating(
+                index -> createFeatureMarker(editorApi, editorView, editorModel),
+                index -> {
+                    Snapshot before = probe.snapshot();
+                    editorApi.dispatch(DungeonEditorIntent.Undo.INSTANCE);
+                    undoWork.add(probe.snapshot().subtract(before));
+                });
+        record(dataset, "undo", undo);
+
+        DungeonTravelApi travelApi = probe.count(dungeon.travel());
+        ShellBinding travelBinding = new DungeonTravelContribution(
+                travelApi, dungeon.mapCatalog(), dungeon.travelModel()).bind();
+        DungeonMapView travelView = DungeonEditorTestSupport.slot(
+                travelBinding, ShellSlot.COCKPIT_MAIN, DungeonMapView.class);
+        Stage travelStage = mount(travelBinding, 960.0, 640.0);
+        travelApi.selectMap(DungeonQualificationDataset.MAP_ID);
+        List<Snapshot> travelWork = new ArrayList<>();
+        Histogram travel = DungeonRuntimeQualificationProtocol.measureAlternating(index -> {
+            Snapshot before = probe.snapshot();
+            travelApi.refresh();
+            travelWork.add(probe.snapshot().subtract(before));
+        });
+        record(dataset, "travel-refresh", travel);
+
+        WorkEnvelope work = new WorkEnvelope(
+                cold,
+                WorkMaximum.from(cameraWork),
+                WorkMaximum.from(hoverWork),
+                WorkMaximum.from(previewWork),
+                WorkMaximum.from(commitWork),
+                WorkMaximum.from(undoWork),
+                WorkMaximum.from(travelWork));
+        List.of(cameraWork, hoverWork, previewWork, commitWork, undoWork, travelWork).stream()
+                .flatMap(List::stream)
+                .forEach(DungeonRuntimeProductionQualificationTest::assertChunkWorkBound);
+        assertOperationBounds(work);
+        PaintEnvelope paint = new PaintEnvelope(cameraPaint, hoverPaint, previewPaint);
+        assertTrue(dataset.qualificationViewport(1L).loadingChunks().size() <= MAX_VISIBLE_PLUS_RING_CHUNKS,
+                dataset + " visible-plus-ring chunk count");
+        assertEquals(120, camera.samples().size() + DungeonRuntimeQualificationProtocol.WARMUP_SAMPLES);
+        assertEquals(120, preview.samples().size() + DungeonRuntimeQualificationProtocol.WARMUP_SAMPLES);
+        editorStage.close();
+        travelStage.close();
+        return new QualificationEvidence(work, paint);
+    }
+
+    private static void commitAlternating(
+            DungeonEditorApi api,
+            DungeonMapView view,
+            DungeonMapContentModel model,
+            int index
+    ) {
+        if ((index & 1) == 0) {
+            createFeatureMarker(api, view, model);
+            return;
+        }
+        api.dispatch(new DungeonEditorIntent.SetTool(
+                DungeonEditorToolSelection.family(DungeonEditorToolFamily.FEATURE)));
+        DungeonMapContentModel.Viewport viewport = model.currentViewport();
+        DungeonEditorTestSupport.fireMapMouse(
+                view, MouseEvent.MOUSE_PRESSED, MouseButton.SECONDARY,
+                viewport.sceneToScreenX(6.5), viewport.sceneToScreenY(6.5), false);
+    }
+
+    private static void createFeatureMarker(
+            DungeonEditorApi api,
+            DungeonMapView view,
+            DungeonMapContentModel model
+    ) {
+        api.dispatch(new DungeonEditorIntent.SetTool(
+                DungeonEditorToolSelection.family(DungeonEditorToolFamily.FEATURE)));
+        DungeonMapContentModel.Viewport viewport = model.currentViewport();
+        DungeonEditorTestSupport.fireMapMouse(
+                view, MouseEvent.MOUSE_PRESSED, MouseButton.PRIMARY,
+                viewport.sceneToScreenX(6.5), viewport.sceneToScreenY(6.5), false);
+    }
+
+    private static Stage mount(ShellBinding binding, double width, double height) {
+        Node controls = binding.slotContent().get(ShellSlot.COCKPIT_CONTROLS);
+        Node main = binding.slotContent().get(ShellSlot.COCKPIT_MAIN);
+        Node state = binding.slotContent().get(ShellSlot.COCKPIT_STATE);
+        Stage stage = new Stage();
+        HBox root = new HBox(controls, main, state);
+        stage.setScene(new Scene(root, width, height));
+        stage.show();
+        root.applyCss();
+        root.layout();
+        return stage;
+    }
+
+    private static void assertColdBounds(Snapshot cold) {
+        assertTrue(cold.indexCalls() <= MAX_COLD_INDEX_CALLS, "cold index calls=" + cold.indexCalls());
+        assertTrue(cold.contentCalls() <= MAX_COLD_CONTENT_CALLS, "cold content calls=" + cold.contentCalls());
+        assertTrue(cold.hydratedEntities() <= MAX_COLD_HYDRATED_ENTITIES,
+                "cold hydrated entities=" + cold.hydratedEntities());
+        assertTrue(cold.requestedChunks() <= MAX_COLD_REQUESTED_CHUNKS,
+                "cold requested chunks=" + cold.requestedChunks());
+        assertTrue(cold.reloadedChunks() <= MAX_VISIBLE_PLUS_RING_CHUNKS,
+                "cold reloaded chunks=" + cold.reloadedChunks());
+        assertChunkWorkBound(cold);
+    }
+
+    private static void assertChunkWorkBound(Snapshot work) {
+        assertTrue(work.requestedChunks()
+                        <= (work.indexCalls() + work.travelChunkReads()) * MAX_VISIBLE_PLUS_RING_CHUNKS,
+                "one index/Travel read may request at most nine chunks: " + work);
+    }
+
+    private static void assertOperationBounds(WorkEnvelope work) {
+        for (WorkMaximum maximum : List.of(
+                work.camera(), work.hover(), work.preview(), work.commit(), work.undo(), work.travelRefresh())) {
+            assertTrue(maximum.indexCalls() <= MAX_OPERATION_INDEX_CALLS, "index calls=" + maximum);
+            assertTrue(maximum.contentCalls() <= MAX_OPERATION_CONTENT_CALLS, "content calls=" + maximum);
+            assertTrue(maximum.closureCalls() <= MAX_OPERATION_CLOSURE_CALLS, "closure calls=" + maximum);
+            assertTrue(maximum.unitOfWorkCalls() <= MAX_OPERATION_UOW_CALLS, "UoW calls=" + maximum);
+            assertTrue(maximum.hydratedEntities() <= MAX_OPERATION_HYDRATED_ENTITIES,
+                    "hydrated entities=" + maximum);
+            assertTrue(maximum.requestedChunks() <= MAX_OPERATION_REQUESTED_CHUNKS,
+                    "requested chunks=" + maximum);
+            assertTrue(maximum.reloadedChunks() <= MAX_OPERATION_RELOADED_CHUNKS,
+                    "reloaded chunks=" + maximum);
+            assertTrue(maximum.touchedChunks() <= MAX_OPERATION_TOUCHED_CHUNKS,
+                    "touched chunks=" + maximum);
+        }
+        assertEquals(0L, work.hover().repositoryCalls());
+        assertEquals(0L, work.preview().repositoryCalls());
+        assertEquals(1L, work.travelRefresh().travelRefreshes());
+    }
+
+    private static void assertOnlyLayer(
+            List<MapCanvasPaintSample> samples,
+            MapCanvasLayer expected,
+            String scenario
+    ) {
+        assertTrue(samples.stream().allMatch(sample -> sample.layer() == expected),
+                scenario + " paints only " + expected);
+    }
+
+    private static void assertExactlyOneLayerPerInput(
+            List<MapCanvasPaintSample> samples,
+            MapCanvasLayer expected,
+            String scenario
+    ) {
+        assertEquals(DungeonRuntimeQualificationProtocol.WARMUP_SAMPLES
+                        + DungeonRuntimeQualificationProtocol.MEASURED_SAMPLES,
+                samples.size(), scenario + " emits exactly one paint per input");
+        assertOnlyLayer(samples, expected, scenario);
+    }
+
+    private static void record(
+            DungeonQualificationDataset dataset,
+            String scenario,
+            Histogram histogram
+    ) {
+        System.out.println("M5.4 " + dataset + " " + scenario
+                + " samples=" + histogram.samples()
+                + " min=" + histogram.minimum()
+                + " p50=" + histogram.p50()
+                + " p95=" + histogram.p95()
+                + " max=" + histogram.maximum());
+    }
+
+    private static <T> T runOnFxThread(ThrowingSupplier<T> action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Object[] result = new Object[1];
+        Throwable[] failure = new Throwable[1];
+        testsupport.JavaFxRuntime.startup(() -> {
+            try {
+                Platform.setImplicitExit(false);
+                result[0] = action.get();
+            } catch (Throwable throwable) {
+                failure[0] = throwable;
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(10, TimeUnit.MINUTES), "M5.4 qualification timed out");
+        if (failure[0] != null) {
+            throw new AssertionError(failure[0]);
+        }
+        @SuppressWarnings("unchecked")
+        T typed = (T) result[0];
+        return typed;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private static final class EmptyPartyRosterRepository implements PartyRosterRepository {
+        private PartyRoster roster = new PartyRoster(1L, List.of());
+
+        @Override
+        public PartyRoster load() {
+            return roster;
+        }
+
+        @Override
+        public void save(PartyRoster roster) {
+            this.roster = Objects.requireNonNull(roster, "roster");
+        }
+    }
+
+    private record QualificationEvidence(WorkEnvelope work, PaintEnvelope paint) {
+    }
+
+    private record WorkEnvelope(
+            Snapshot cold,
+            WorkMaximum camera,
+            WorkMaximum hover,
+            WorkMaximum preview,
+            WorkMaximum commit,
+            WorkMaximum undo,
+            WorkMaximum travelRefresh
+    ) {
+    }
+
+    private record WorkMaximum(
+            long indexCalls,
+            long contentCalls,
+            long closureCalls,
+            long continuationCalls,
+            long unitOfWorkCalls,
+            long travelStartReads,
+            long travelChunkReads,
+            long travelRefreshes,
+            long hydratedEntities,
+            long requestedChunks,
+            long reloadedChunks,
+            long touchedChunks
+    ) {
+        static WorkMaximum from(List<Snapshot> samples) {
+            return new WorkMaximum(
+                    maximum(samples, Snapshot::indexCalls),
+                    maximum(samples, Snapshot::contentCalls),
+                    maximum(samples, Snapshot::closureCalls),
+                    maximum(samples, Snapshot::continuationCalls),
+                    maximum(samples, Snapshot::unitOfWorkCalls),
+                    maximum(samples, Snapshot::travelStartReads),
+                    maximum(samples, Snapshot::travelChunkReads),
+                    maximum(samples, Snapshot::travelRefreshes),
+                    maximum(samples, Snapshot::hydratedEntities),
+                    maximum(samples, Snapshot::requestedChunks),
+                    maximum(samples, Snapshot::reloadedChunks),
+                    maximum(samples, Snapshot::touchedChunks));
+        }
+
+        long repositoryCalls() {
+            return indexCalls + contentCalls + closureCalls + continuationCalls
+                    + unitOfWorkCalls + travelStartReads + travelChunkReads;
+        }
+
+        private static long maximum(List<Snapshot> samples, java.util.function.ToLongFunction<Snapshot> value) {
+            return samples.stream().mapToLong(value).max().orElse(0L);
+        }
+    }
+
+    private record PaintEnvelope(PaintWork camera, PaintWork hover, PaintWork preview) {
+    }
+
+    private record PaintWork(
+            long baseSamples,
+            long interactionSamples,
+            long actorSamples,
+            long maximumVisited,
+            long maximumPainted
+    ) {
+        static PaintWork from(List<MapCanvasPaintSample> samples) {
+            return new PaintWork(
+                    count(samples, MapCanvasLayer.BASE),
+                    count(samples, MapCanvasLayer.INTERACTION),
+                    count(samples, MapCanvasLayer.ACTOR),
+                    samples.stream().mapToLong(MapCanvasPaintSample::visitedPrimitives).max().orElse(0L),
+                    samples.stream().mapToLong(MapCanvasPaintSample::paintedPrimitives).max().orElse(0L));
+        }
+
+        private static long count(List<MapCanvasPaintSample> samples, MapCanvasLayer layer) {
+            return samples.stream().filter(sample -> sample.layer() == layer).count();
+        }
+    }
+}

--- a/test/features/dungeon/adapter/javafx/map/DungeonMapLayerQualificationTest.java
+++ b/test/features/dungeon/adapter/javafx/map/DungeonMapLayerQualificationTest.java
@@ -1,0 +1,198 @@
+package features.dungeon.adapter.javafx.map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonEditorMapSnapshot;
+import features.dungeon.api.DungeonEditorPreview;
+import features.dungeon.api.DungeonEditorStateSnapshot;
+import features.dungeon.api.DungeonEditorSurface;
+import features.dungeon.api.DungeonMapId;
+import features.dungeon.api.DungeonMapSnapshot;
+import features.dungeon.api.DungeonMapSummary;
+import features.dungeon.api.DungeonOverlaySettings;
+import features.dungeon.api.DungeonTopologyElementKind;
+import features.dungeon.api.DungeonTopologyElementRef;
+import features.dungeon.api.DungeonTravelContextKind;
+import features.dungeon.api.DungeonTravelHeading;
+import features.dungeon.api.DungeonTravelLocationKind;
+import features.dungeon.api.DungeonTravelPosition;
+import features.dungeon.api.DungeonTravelSurfaceSnapshot;
+import features.dungeon.api.DungeonEditorViewMode;
+import features.dungeon.api.TravelDungeonSnapshot;
+import features.dungeon.api.editor.DungeonEditorDraftState;
+import features.dungeon.api.editor.DungeonEditorState;
+import features.dungeon.api.editor.DungeonEditorToolSelection;
+import features.dungeon.qualification.DungeonRuntimeQualificationProtocol;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import org.junit.jupiter.api.Test;
+import platform.ui.mapcanvas.MapCanvasLayer;
+import platform.ui.mapcanvas.MapCanvasPaintSample;
+
+final class DungeonMapLayerQualificationTest {
+
+    @Test
+    void cameraHoverPreviewAndActorUseIndependentPhysicalPaintRoutes() throws Exception {
+        runOnFxThread(() -> {
+            List<MapCanvasPaintSample> samples = new ArrayList<>();
+            DungeonMapContentModel editorModel = new DungeonMapContentModel("Qualification", true);
+            DungeonMapView editorView = mountedView(editorModel, samples);
+            DungeonEditorState stable = editorState(DungeonEditorPreview.none(), 1L);
+            editorModel.applyEditorState(stable);
+            samples.clear();
+
+            var camera = DungeonRuntimeQualificationProtocol.measureAlternating(index ->
+                    editorModel.panByPixels((index & 1) == 0 ? 1.0 : -1.0, 0.0));
+            record("camera", camera);
+            assertTrue(camera.p95() <= DungeonRuntimeQualificationProtocol.CAMERA_P95_NANOS,
+                    "camera p95=" + camera.p95());
+            assertLayerCount(samples, MapCanvasLayer.BASE, 120);
+            assertLayerCount(samples, MapCanvasLayer.INTERACTION, 120);
+            assertLayerCount(samples, MapCanvasLayer.ACTOR, 120);
+
+            var roomTarget = editorModel.pointerTargetsAt(0.5, 0.5).getFirst();
+            samples.clear();
+            var hover = DungeonRuntimeQualificationProtocol.measureAlternating(index -> {
+                if ((index & 1) == 0) {
+                    editorModel.updateHoverTarget(roomTarget);
+                } else {
+                    editorModel.clearHoverTarget();
+                }
+            });
+            record("hover", hover);
+            assertTrue(hover.p95() <= DungeonRuntimeQualificationProtocol.HOVER_P95_NANOS,
+                    "hover p95=" + hover.p95());
+            assertOnlyLayer(samples, MapCanvasLayer.INTERACTION, 120);
+
+            samples.clear();
+            var preview = DungeonRuntimeQualificationProtocol.measureAlternating(index ->
+                    editorModel.applyEditorState(editorState(
+                            new DungeonEditorPreview.StairCreatePreview(
+                                    new DungeonCellRef(2, 2, 0),
+                                    new DungeonCellRef((index & 1) == 0 ? 2 : 3, 2, 0),
+                                    "STRAIGHT",
+                                    false,
+                                    "preview"),
+                            index + 2L)));
+            record("preview", preview);
+            assertTrue(preview.p95() <= DungeonRuntimeQualificationProtocol.PREVIEW_P95_NANOS,
+                    "preview p95=" + preview.p95());
+            assertOnlyLayer(samples, MapCanvasLayer.INTERACTION, 120);
+
+            List<MapCanvasPaintSample> actorSamples = new ArrayList<>();
+            DungeonMapContentModel travelModel = new DungeonMapContentModel("Travel", false);
+            DungeonMapView travelView = mountedView(travelModel, actorSamples);
+            travelModel.applyTravelSnapshot(travelSnapshot(0));
+            actorSamples.clear();
+            DungeonRuntimeQualificationProtocol.measureAlternating(index ->
+                    travelModel.applyTravelSnapshot(travelSnapshot((index & 1) == 0 ? 1 : 0)));
+            assertOnlyLayer(actorSamples, MapCanvasLayer.ACTOR, 120);
+
+            assertStablePhysicalLayers(editorView);
+            assertStablePhysicalLayers(travelView);
+        });
+    }
+
+    private static DungeonMapView mountedView(
+            DungeonMapContentModel model,
+            List<MapCanvasPaintSample> samples
+    ) {
+        DungeonMapView view = new DungeonMapView();
+        view.onPaintSample(samples::add);
+        view.bind(model);
+        new Scene(view, 960.0, 640.0);
+        view.applyCss();
+        view.layout();
+        return view;
+    }
+
+    private static DungeonEditorState editorState(DungeonEditorPreview preview, long revision) {
+        DungeonMapId mapId = new DungeonMapId(1L);
+        DungeonTopologyElementRef roomRef = new DungeonTopologyElementRef(
+                DungeonTopologyElementKind.ROOM, 1L);
+        DungeonEditorMapSnapshot map = new DungeonEditorMapSnapshot(
+                "SQUARE", 1, 1,
+                List.of(new DungeonEditorMapSnapshot.Area(
+                        "ROOM", 1L, 1L, "Room", List.of(new DungeonCellRef(0, 0, 0)), roomRef)),
+                List.of(), List.of(), List.of());
+        return new DungeonEditorState(
+                revision, revision, List.of(new DungeonMapSummary(mapId, "Qualification", revision)),
+                mapId, new DungeonEditorSurface("Qualification", (int) revision, map, null, null),
+                DungeonEditorViewMode.GRID, DungeonEditorToolSelection.select(),
+                DungeonOverlaySettings.defaults(), 0, List.of(0),
+                DungeonEditorStateSnapshot.Selection.empty(), DungeonEditorDraftState.empty(),
+                preview, null, DungeonEditorState.CommandStatus.idle());
+    }
+
+    private static TravelDungeonSnapshot travelSnapshot(int q) {
+        DungeonTravelSurfaceSnapshot surface = new DungeonTravelSurfaceSnapshot(
+                DungeonTravelContextKind.DUNGEON, "Travel", 1, DungeonMapSnapshot.empty(),
+                new DungeonTravelPosition(new DungeonMapId(1L), DungeonTravelLocationKind.TILE, 0L,
+                        new DungeonCellRef(q, 0, 0), DungeonTravelHeading.defaultHeading()),
+                "Travel", "Area", "Tile", "", "", "", List.of());
+        return new TravelDungeonSnapshot(null, surface, DungeonOverlaySettings.defaults(), 0);
+    }
+
+    private static void assertOnlyLayer(
+            List<MapCanvasPaintSample> samples,
+            MapCanvasLayer layer,
+            int count
+    ) {
+        assertEquals(count, samples.size());
+        assertTrue(samples.stream().allMatch(sample -> sample.layer() == layer));
+    }
+
+    private static void assertLayerCount(
+            List<MapCanvasPaintSample> samples,
+            MapCanvasLayer layer,
+            int count
+    ) {
+        assertEquals(count, samples.stream().filter(sample -> sample.layer() == layer).count());
+    }
+
+    private static void assertStablePhysicalLayers(DungeonMapView view) {
+        assertEquals(3, view.physicalCanvasCount());
+        assertFalse(view.physicalCanvas(MapCanvasLayer.BASE).isMouseTransparent());
+        assertTrue(view.physicalCanvas(MapCanvasLayer.BASE).isFocusTraversable());
+        assertTrue(view.physicalCanvas(MapCanvasLayer.INTERACTION).isMouseTransparent());
+        assertTrue(view.physicalCanvas(MapCanvasLayer.ACTOR).isMouseTransparent());
+    }
+
+    private static void record(
+            String scenario,
+            DungeonRuntimeQualificationProtocol.Histogram histogram
+    ) {
+        System.out.println("M5.4 layer " + scenario
+                + " samples=" + histogram.samples()
+                + " min=" + histogram.minimum()
+                + " p50=" + histogram.p50()
+                + " p95=" + histogram.p95()
+                + " max=" + histogram.maximum());
+    }
+
+    private static void runOnFxThread(Runnable action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Throwable[] failure = new Throwable[1];
+        testsupport.JavaFxRuntime.startup(() -> {
+            try {
+                Platform.setImplicitExit(false);
+                action.run();
+            } catch (Throwable throwable) {
+                failure[0] = throwable;
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(60, TimeUnit.SECONDS));
+        if (failure[0] != null) {
+            throw new AssertionError(failure[0]);
+        }
+    }
+}

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseQualificationFixture.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseQualificationFixture.java
@@ -1,0 +1,171 @@
+package features.dungeon.adapter.sqlite.gateway;
+
+import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonChunkKey;
+import features.dungeon.qualification.DungeonQualificationDataset;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import platform.persistence.SqliteDatabase;
+
+/** Shared fresh-schema sparse setup for the M5 read and runtime qualification routes. */
+public final class DungeonSparseQualificationFixture {
+
+    private DungeonSparseQualificationFixture() {
+    }
+
+    public static void seed(SqliteDatabase database, Path path, DungeonQualificationDataset dataset)
+            throws Exception {
+        seed(database, path, dataset, true);
+    }
+
+    public static void seedRuntime(SqliteDatabase database, Path path, DungeonQualificationDataset dataset)
+            throws Exception {
+        seed(database, path, dataset, false);
+    }
+
+    private static void seed(
+            SqliteDatabase database,
+            Path path,
+            DungeonQualificationDataset dataset,
+            boolean spanVisibleChunk
+    ) throws Exception {
+        DungeonSqliteFixtureSeeder.insertHeader(database, DungeonQualificationDataset.MAP_ID, "Sparse", 2L);
+        List<DungeonCellRef> cells = dataset.authoredCells().toList();
+        List<DungeonCellRef> visibleCells = List.of(
+                new DungeonCellRef(2, 2, DungeonQualificationDataset.LEVEL));
+        List<DungeonCellRef> offWindowCells = spanVisibleChunk
+                ? List.copyOf(cells.subList(0, cells.size() - 1))
+                : List.copyOf(cells.subList(1, cells.size()));
+        List<DungeonCellRef> persistedCells = new ArrayList<>(offWindowCells);
+        persistedCells.addAll(visibleCells);
+        Map<DungeonChunkKey, Extent> visibleExtents = extents(visibleCells);
+        Map<DungeonChunkKey, Extent> offWindowExtents = extents(offWindowCells);
+        int minimumQ = persistedCells.stream().mapToInt(DungeonCellRef::q).min().orElseThrow();
+        int minimumR = persistedCells.stream().mapToInt(DungeonCellRef::r).min().orElseThrow();
+        int maximumQ = persistedCells.stream().mapToInt(DungeonCellRef::q).max().orElseThrow();
+        int maximumR = persistedCells.stream().mapToInt(DungeonCellRef::r).max().orElseThrow();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath());
+             Statement statement = connection.createStatement()) {
+            connection.setAutoCommit(false);
+            statement.executeUpdate("INSERT INTO dungeon_room_clusters(cluster_id,dungeon_map_id,name)"
+                    + " VALUES(11,1,'Visible cluster'),(21,1,'Off-window cluster')");
+            statement.executeUpdate("INSERT INTO dungeon_rooms(room_id,dungeon_map_id,cluster_id,name,visual_description)"
+                    + " VALUES(12,1,11,'Visible room',''),(22,1,21,'Off-window room','')");
+            insertCells(connection, 12L, visibleCells);
+            insertCells(connection, 22L, offWindowCells);
+            insertChunkExtents(connection, 12L, visibleExtents);
+            insertChunkExtents(connection, 22L, offWindowExtents);
+            try (PreparedStatement bounds = connection.prepareStatement(
+                    "INSERT INTO dungeon_authored_level_bounds"
+                            + "(dungeon_map_id,level_z,minimum_q,minimum_r,maximum_q,maximum_r)"
+                            + " VALUES(1,0,?,?,?,?)")) {
+                bounds.setInt(1, minimumQ);
+                bounds.setInt(2, minimumR);
+                bounds.setInt(3, maximumQ);
+                bounds.setInt(4, maximumR);
+                bounds.executeUpdate();
+            }
+            connection.commit();
+        }
+    }
+
+    private static Map<DungeonChunkKey, Extent> extents(List<DungeonCellRef> cells) {
+        Map<DungeonChunkKey, Extent> result = new LinkedHashMap<>();
+        for (DungeonCellRef cell : cells) {
+            DungeonChunkKey chunk = new DungeonChunkKey(
+                    DungeonQualificationDataset.MAP_ID, cell.level(),
+                    Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
+                    Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE));
+            result.compute(chunk, (ignored, extent) -> extent == null
+                    ? Extent.at(cell.q(), cell.r()) : extent.include(cell.q(), cell.r()));
+        }
+        return result;
+    }
+
+    private static void insertCells(
+            Connection connection,
+            long roomId,
+            List<DungeonCellRef> cells
+    ) throws Exception {
+        try (PreparedStatement insert = connection.prepareStatement(
+                "INSERT INTO dungeon_room_cells(room_id,level_z,cell_x,cell_y) VALUES(?,?,?,?)")) {
+            int pending = 0;
+            for (DungeonCellRef cell : cells) {
+                insert.setLong(1, roomId);
+                insert.setInt(2, cell.level());
+                insert.setInt(3, cell.q());
+                insert.setInt(4, cell.r());
+                insert.addBatch();
+                if (++pending == 5_000) {
+                    insert.executeBatch();
+                    pending = 0;
+                }
+            }
+            if (pending > 0) {
+                insert.executeBatch();
+            }
+        }
+    }
+
+    private static void insertChunkExtents(
+            Connection connection,
+            long roomId,
+            Map<DungeonChunkKey, Extent> extents
+    ) throws Exception {
+        try (PreparedStatement chunk = connection.prepareStatement(
+                    "INSERT OR IGNORE INTO dungeon_chunks(dungeon_map_id,level_z,chunk_q,chunk_r,content_revision)"
+                            + " VALUES(1,?,?,?,2)");
+             PreparedStatement extent = connection.prepareStatement(
+                    "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r,"
+                            + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count)"
+                            + " VALUES(1,'ROOM',?,?,?,?,?,?,?,?,?)")) {
+            int pending = 0;
+            for (Map.Entry<DungeonChunkKey, Extent> entry : extents.entrySet()) {
+                DungeonChunkKey key = entry.getKey();
+                Extent value = entry.getValue();
+                chunk.setInt(1, key.level());
+                chunk.setInt(2, key.chunkQ());
+                chunk.setInt(3, key.chunkR());
+                chunk.addBatch();
+                extent.setLong(1, roomId);
+                extent.setInt(2, key.level());
+                extent.setInt(3, key.chunkQ());
+                extent.setInt(4, key.chunkR());
+                extent.setInt(5, value.minimumQ());
+                extent.setInt(6, value.minimumR());
+                extent.setInt(7, value.maximumQ());
+                extent.setInt(8, value.maximumR());
+                extent.setInt(9, extents.size());
+                extent.addBatch();
+                if (++pending == 5_000) {
+                    chunk.executeBatch();
+                    extent.executeBatch();
+                    pending = 0;
+                }
+            }
+            if (pending > 0) {
+                chunk.executeBatch();
+                extent.executeBatch();
+            }
+        }
+    }
+
+    private record Extent(int minimumQ, int minimumR, int maximumQ, int maximumR) {
+        static Extent at(int q, int r) {
+            return new Extent(q, r, q, r);
+        }
+
+        Extent include(int q, int r) {
+            return new Extent(Math.min(minimumQ, q), Math.min(minimumR, r),
+                    Math.max(maximumQ, q), Math.max(maximumR, r));
+        }
+    }
+}

--- a/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseReadQualificationTest.java
+++ b/test/features/dungeon/adapter/sqlite/gateway/DungeonSparseReadQualificationTest.java
@@ -3,8 +3,6 @@ package features.dungeon.adapter.sqlite.gateway;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import features.dungeon.api.DungeonCellRef;
-import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.application.authored.port.DungeonWindow;
 import features.dungeon.application.authored.port.DungeonWindowContentRequest;
 import features.dungeon.application.authored.port.DungeonWindowEntityFragment;
@@ -13,14 +11,8 @@ import features.dungeon.application.authored.port.DungeonWindowRequest;
 import features.dungeon.domain.core.structure.DungeonMapIdentity;
 import features.dungeon.qualification.DungeonQualificationDataset;
 import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import platform.diagnostics.NoopDiagnostics;
@@ -37,7 +29,7 @@ final class DungeonSparseReadQualificationTest {
                 DungeonSqliteWindowGateway gateway = new DungeonSqliteWindowGateway(database);
                 gateway.loadIndex(new DungeonWindowRequest(
                         new DungeonMapIdentity(DungeonQualificationDataset.MAP_ID), 0L, List.of()));
-                seedSparseRoom(path, dataset);
+                DungeonSparseQualificationFixture.seed(database, path, dataset);
 
                 var viewport = dataset.qualificationViewport(dataset.ordinal() + 1L);
                 DungeonWindowRequest request = new DungeonWindowRequest(
@@ -76,74 +68,6 @@ final class DungeonSparseReadQualificationTest {
                 "1k, 10k and 100k authored cells must perform identical requested-window work");
     }
 
-    private static void seedSparseRoom(Path path, DungeonQualificationDataset dataset) throws Exception {
-        List<DungeonCellRef> cells = dataset.authoredCells().toList();
-        Map<DungeonChunkKey, Extent> extents = new LinkedHashMap<>();
-        for (DungeonCellRef cell : cells) {
-            DungeonChunkKey chunk = new DungeonChunkKey(
-                    DungeonQualificationDataset.MAP_ID, cell.level(),
-                    Math.floorDiv(cell.q(), DungeonChunkKey.CHUNK_SIZE),
-                    Math.floorDiv(cell.r(), DungeonChunkKey.CHUNK_SIZE));
-            extents.compute(chunk, (ignored, extent) -> extent == null
-                    ? Extent.at(cell.q(), cell.r()) : extent.include(cell.q(), cell.r()));
-        }
-        int minimumQ = cells.stream().mapToInt(DungeonCellRef::q).min().orElseThrow();
-        int minimumR = cells.stream().mapToInt(DungeonCellRef::r).min().orElseThrow();
-        int maximumQ = cells.stream().mapToInt(DungeonCellRef::q).max().orElseThrow();
-        int maximumR = cells.stream().mapToInt(DungeonCellRef::r).max().orElseThrow();
-
-        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + path.toAbsolutePath());
-             Statement statement = connection.createStatement()) {
-            connection.setAutoCommit(false);
-            statement.executeUpdate("INSERT INTO dungeon_maps(dungeon_map_id,name,revision) VALUES(1,'Sparse',2)");
-            statement.executeUpdate("INSERT INTO dungeon_room_clusters(cluster_id,dungeon_map_id,name)"
-                    + " VALUES(11,1,'Sparse cluster')");
-            statement.executeUpdate("INSERT INTO dungeon_rooms(room_id,dungeon_map_id,cluster_id,name,visual_description)"
-                    + " VALUES(12,1,11,'Sparse room','')");
-            try (PreparedStatement insert = connection.prepareStatement(
-                    "INSERT INTO dungeon_room_cells(room_id,level_z,cell_x,cell_y) VALUES(12,?,?,?)")) {
-                int pending = 0;
-                for (DungeonCellRef cell : cells) {
-                    insert.setInt(1, cell.level()); insert.setInt(2, cell.q()); insert.setInt(3, cell.r());
-                    insert.addBatch();
-                    if (++pending == 5_000) {
-                        insert.executeBatch(); pending = 0;
-                    }
-                }
-                if (pending > 0) insert.executeBatch();
-            }
-            try (PreparedStatement chunk = connection.prepareStatement(
-                        "INSERT INTO dungeon_chunks(dungeon_map_id,level_z,chunk_q,chunk_r,content_revision)"
-                                + " VALUES(1,?,?,?,2)");
-                 PreparedStatement extent = connection.prepareStatement(
-                        "INSERT INTO dungeon_entity_chunks(dungeon_map_id,entity_kind,entity_id,level_z,chunk_q,chunk_r,"
-                                + "minimum_q,minimum_r,maximum_q,maximum_r,entity_chunk_count)"
-                                + " VALUES(1,'ROOM',12,?,?,?,?,?,?,?,?)")) {
-                int pending = 0;
-                for (Map.Entry<DungeonChunkKey, Extent> entry : extents.entrySet()) {
-                    DungeonChunkKey key = entry.getKey(); Extent value = entry.getValue();
-                    chunk.setInt(1, key.level()); chunk.setInt(2, key.chunkQ()); chunk.setInt(3, key.chunkR());
-                    chunk.addBatch();
-                    extent.setInt(1, key.level()); extent.setInt(2, key.chunkQ()); extent.setInt(3, key.chunkR());
-                    extent.setInt(4, value.minimumQ()); extent.setInt(5, value.minimumR());
-                    extent.setInt(6, value.maximumQ()); extent.setInt(7, value.maximumR());
-                    extent.setInt(8, extents.size()); extent.addBatch();
-                    if (++pending == 5_000) {
-                        chunk.executeBatch(); extent.executeBatch(); pending = 0;
-                    }
-                }
-                if (pending > 0) { chunk.executeBatch(); extent.executeBatch(); }
-            }
-            try (PreparedStatement bounds = connection.prepareStatement(
-                    "INSERT INTO dungeon_authored_level_bounds"
-                            + "(dungeon_map_id,level_z,minimum_q,minimum_r,maximum_q,maximum_r) VALUES(1,0,?,?,?,?)")) {
-                bounds.setInt(1, minimumQ); bounds.setInt(2, minimumR);
-                bounds.setInt(3, maximumQ); bounds.setInt(4, maximumR); bounds.executeUpdate();
-            }
-            connection.commit();
-        }
-    }
-
     private record ReadWork(
             int indexStatements,
             int boundsStatements,
@@ -154,11 +78,4 @@ final class DungeonSparseReadQualificationTest {
             int cells
     ) { }
 
-    private record Extent(int minimumQ, int minimumR, int maximumQ, int maximumR) {
-        static Extent at(int q, int r) { return new Extent(q, r, q, r); }
-        Extent include(int q, int r) {
-            return new Extent(Math.min(minimumQ, q), Math.min(minimumR, r),
-                    Math.max(maximumQ, q), Math.max(maximumR, r));
-        }
-    }
 }

--- a/test/features/dungeon/application/editor/DungeonEditorWindowLoadIntegrationTest.java
+++ b/test/features/dungeon/application/editor/DungeonEditorWindowLoadIntegrationTest.java
@@ -122,13 +122,72 @@ final class DungeonEditorWindowLoadIntegrationTest {
     }
 
     @Test
-    void projectionLevelRedispatchReusesLatestVisibleBounds() {
+    void sameRevisionAndLoadingChunksCoalesceEvenWhenCellBoundsMove() {
         Catalog catalog = new Catalog();
         RecordingWindowStore windows = new RecordingWindowStore();
         DungeonEditorApi editor = editor(component(catalog, windows));
         editor.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(1L)));
         editor.dispatch(new DungeonEditorIntent.SetViewport(
-                new DungeonEditorViewportInput(0, -12, 70, 12, 90)));
+                new DungeonEditorViewportInput(0, 1, 1, 30, 30)));
+        windows.requests.clear();
+
+        editor.dispatch(new DungeonEditorIntent.SetViewport(
+                new DungeonEditorViewportInput(0, 2, 2, 29, 29)));
+
+        assertTrue(windows.requests.isEmpty(),
+                "same revision, level and loading chunks coalesce without repository I/O");
+    }
+
+    @Test
+    void mutationRevisionCoalescesTheFollowingVisibleViewportPublication() {
+        Catalog catalog = new Catalog();
+        TestDungeonCommandStore windows = new TestDungeonCommandStore(
+                DungeonMapAuthoring.committedContent(
+                        DungeonMapAuthoring.empty(new DungeonMapIdentity(1L), "Alpha"),
+                        7L));
+        DungeonAuthoredApplicationService service = new DungeonAuthoredApplicationService(
+                catalog,
+                windows,
+                features.dungeon.DungeonTestAssembly.inMemoryUnitOfWork(),
+                new TestDungeonIdentityAllocator(),
+                DirectExecutionLane.INSTANCE,
+                new DungeonAuthoredPublishedState(DirectUiDispatcher.INSTANCE));
+        DungeonEditorRuntimeApplicationService application = new DungeonEditorRuntimeApplicationService(
+                service,
+                new DungeonEditorPublishedState(DirectUiDispatcher.INSTANCE));
+        DungeonEditorDungeonState state = new DungeonEditorDungeonState();
+        DungeonEditorViewportInput viewport = new DungeonEditorViewportInput(0, 0, 0, 63, 63);
+        application.openSession(state, runtime -> {
+            runtime.setViewport(viewport);
+            runtime.selectMap(1L);
+            runtime.setViewport(viewport);
+            DungeonEditorWorkspaceValues.MapId mapId = new DungeonEditorWorkspaceValues.MapId(1L);
+
+            runtime.applyRoomRectangle(mapId, new Cell(10, 10, 0), new Cell(10, 10, 0), false);
+            runtime.publishCurrent();
+
+            assertInstanceOf(
+                    DungeonEditorCommandOutcome.Accepted.class,
+                    state.committedFacts(mapId).commandOutcome());
+            assertEquals(8L, state.committedFacts(mapId).surface().acceptedRevision());
+            int requestsAfterMutation = windows.windowRequests().size();
+
+            assertNull(runtime.setViewport(viewport));
+            assertEquals(requestsAfterMutation, windows.windowRequests().size(),
+                    "the mutation publication already makes the same visible chunks current at its new revision");
+            return null;
+        });
+    }
+
+    @Test
+    void projectionLevelRedispatchReusesLatestVisibleBounds() {
+        Catalog catalog = new Catalog();
+        RecordingWindowStore windows = new RecordingWindowStore();
+        DungeonEditorApi editor = editor(component(catalog, windows));
+        editor.dispatch(new DungeonEditorIntent.SelectMap(new DungeonMapId(1L)));
+        DungeonEditorViewportInput levelZeroViewport =
+                new DungeonEditorViewportInput(0, -12, 70, 12, 90);
+        editor.dispatch(new DungeonEditorIntent.SetViewport(levelZeroViewport));
         windows.requests.clear();
 
         editor.dispatch(new DungeonEditorIntent.ShiftProjectionLevel(1));
@@ -140,6 +199,14 @@ final class DungeonEditorWindowLoadIntegrationTest {
                 .contains(new DungeonChunkKey(1L, 1, -2, 0)));
         assertTrue(windows.requests.getFirst().chunkKeys()
                 .contains(new DungeonChunkKey(1L, 1, 1, 2)));
+
+        long refreshedGeneration = editor.current().requestGeneration();
+        editor.dispatch(new DungeonEditorIntent.SetViewport(levelZeroViewport.atLevel(1)));
+
+        assertEquals(1, windows.requests.size(),
+                "the projection refresh already accepted the identical level-one viewport");
+        assertEquals(refreshedGeneration, editor.current().requestGeneration(),
+                "coalescing the identical viewport must keep the accepted refresh generation stable");
     }
 
     @Test

--- a/test/features/dungeon/qualification/DungeonQualificationDataset.java
+++ b/test/features/dungeon/qualification/DungeonQualificationDataset.java
@@ -1,6 +1,7 @@
 package features.dungeon.qualification;
 
 import features.dungeon.api.DungeonCellRef;
+import features.dungeon.api.DungeonChunkKey;
 import features.dungeon.api.DungeonViewportRequest;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -13,6 +14,7 @@ public enum DungeonQualificationDataset {
 
     public static final long MAP_ID = 1L;
     public static final int LEVEL = 0;
+    private static final int OFF_WINDOW_CHUNKS = 300;
 
     private final int authoredCellCount;
 
@@ -30,14 +32,23 @@ public enum DungeonQualificationDataset {
 
     public Stream<DungeonCellRef> authoredCells() {
         return IntStream.range(0, authoredCellCount)
-                .mapToObj(index -> new DungeonCellRef(
-                        sparseCoordinate(index, 67),
-                        sparseCoordinate(index, 131),
-                        LEVEL));
+                .mapToObj(DungeonQualificationDataset::sparseCell);
     }
 
-    private static int sparseCoordinate(int index, int stride) {
-        int magnitude = Math.multiplyExact(index, stride);
-        return (index & 1) == 0 ? magnitude : -magnitude;
+    private static DungeonCellRef sparseCell(int index) {
+        if (index == 0) {
+            return new DungeonCellRef(0, 0, LEVEL);
+        }
+        int position = index - 1;
+        int slot = position % OFF_WINDOW_CHUNKS;
+        int inChunk = position / OFF_WINDOW_CHUNKS;
+        int magnitude = 10 + slot / 2;
+        int chunk = (slot & 1) == 0 ? magnitude : -magnitude;
+        int localQ = inChunk % DungeonChunkKey.CHUNK_SIZE;
+        int localR = inChunk / DungeonChunkKey.CHUNK_SIZE;
+        return new DungeonCellRef(
+                chunk * DungeonChunkKey.CHUNK_SIZE + localQ,
+                chunk * DungeonChunkKey.CHUNK_SIZE + localR,
+                LEVEL);
     }
 }

--- a/test/features/dungeon/qualification/DungeonRuntimeQualificationProtocol.java
+++ b/test/features/dungeon/qualification/DungeonRuntimeQualificationProtocol.java
@@ -1,0 +1,62 @@
+package features.dungeon.qualification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Fixed M5 runtime protocol. It has no retry, trimming, skipping, or adaptive budget path. */
+public final class DungeonRuntimeQualificationProtocol {
+    public static final int WARMUP_SAMPLES = 20;
+    public static final int MEASURED_SAMPLES = 100;
+    public static final long CAMERA_P95_NANOS = 16_000_000L;
+    public static final long HOVER_P95_NANOS = 16_000_000L;
+    public static final long PREVIEW_P95_NANOS = 50_000_000L;
+
+    private DungeonRuntimeQualificationProtocol() {
+    }
+
+    public static Histogram measureAlternating(AlternatingInput input) {
+        return measureAlternating(index -> { }, input);
+    }
+
+    public static Histogram measureAlternating(AlternatingInput prepare, AlternatingInput input) {
+        for (int index = 0; index < WARMUP_SAMPLES; index++) {
+            prepare.run(index);
+            input.run(index);
+        }
+        List<Long> measured = new ArrayList<>(MEASURED_SAMPLES);
+        for (int index = 0; index < MEASURED_SAMPLES; index++) {
+            prepare.run(index);
+            long started = System.nanoTime();
+            input.run(index);
+            measured.add(System.nanoTime() - started);
+        }
+        return Histogram.of(measured);
+    }
+
+    @FunctionalInterface
+    public interface AlternatingInput {
+        void run(int index);
+    }
+
+    public record Histogram(List<Long> samples, long minimum, long p50, long p95, long maximum) {
+        public Histogram {
+            samples = List.copyOf(samples);
+        }
+
+        static Histogram of(List<Long> measured) {
+            if (measured == null || measured.size() != MEASURED_SAMPLES) {
+                throw new IllegalArgumentException("qualification requires exactly 100 measured samples");
+            }
+            List<Long> sorted = new ArrayList<>(measured);
+            Collections.sort(sorted);
+            return new Histogram(measured, sorted.get(0), nearestRank(sorted, 50),
+                    nearestRank(sorted, 95), sorted.get(sorted.size() - 1));
+        }
+
+        private static long nearestRank(List<Long> sorted, int percentile) {
+            int rank = (int) Math.ceil(percentile / 100.0 * sorted.size());
+            return sorted.get(Math.max(0, rank - 1));
+        }
+    }
+}

--- a/test/features/dungeon/qualification/DungeonRuntimeQualificationProtocolTest.java
+++ b/test/features/dungeon/qualification/DungeonRuntimeQualificationProtocolTest.java
@@ -1,0 +1,39 @@
+package features.dungeon.qualification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class DungeonRuntimeQualificationProtocolTest {
+
+    @Test
+    void usesFixedTwentyPlusOneHundredAlternatingInputsAndNearestRankHistogram() {
+        List<Integer> inputs = new ArrayList<>();
+        var histogram = DungeonRuntimeQualificationProtocol.measureAlternating(inputs::add);
+
+        assertEquals(120, inputs.size());
+        assertEquals(100, histogram.samples().size());
+        for (int index = 0; index < inputs.size(); index++) {
+            assertEquals(index < 20 ? index : index - 20, inputs.get(index));
+        }
+    }
+
+    @Test
+    void runsPreparationOutsideEveryMeasuredSample() {
+        List<String> events = new ArrayList<>();
+        var histogram = DungeonRuntimeQualificationProtocol.measureAlternating(
+                index -> events.add("prepare-" + index),
+                index -> events.add("input-" + index));
+
+        assertEquals(240, events.size());
+        assertEquals(100, histogram.samples().size());
+        for (int index = 0; index < events.size(); index += 2) {
+            int invocation = index / 2;
+            int sample = invocation < 20 ? invocation : invocation - 20;
+            assertEquals("prepare-" + sample, events.get(index));
+            assertEquals("input-" + sample, events.get(index + 1));
+        }
+    }
+}

--- a/test/features/dungeon/qualification/DungeonRuntimeWorkProbe.java
+++ b/test/features/dungeon/qualification/DungeonRuntimeWorkProbe.java
@@ -1,0 +1,232 @@
+package features.dungeon.qualification;
+
+import features.dungeon.api.DungeonOverlaySettings;
+import features.dungeon.api.travel.DungeonTravelApi;
+import features.dungeon.application.authored.command.DungeonCompoundPatch;
+import features.dungeon.application.authored.command.DungeonPatch;
+import features.dungeon.application.authored.port.DungeonCompoundUnitOfWorkResult;
+import features.dungeon.application.authored.port.DungeonContinuationPage;
+import features.dungeon.application.authored.port.DungeonContinuationPageRequest;
+import features.dungeon.application.authored.port.DungeonIdentityClosureRequest;
+import features.dungeon.application.authored.port.DungeonIdentityClosureResult;
+import features.dungeon.application.authored.port.DungeonInboundReferenceRequest;
+import features.dungeon.application.authored.port.DungeonInboundReferenceResult;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysRequest;
+import features.dungeon.application.authored.port.DungeonTravelChunkKeysResult;
+import features.dungeon.application.authored.port.DungeonTravelStartRequest;
+import features.dungeon.application.authored.port.DungeonTravelStartResult;
+import features.dungeon.application.authored.port.DungeonUnitOfWork;
+import features.dungeon.application.authored.port.DungeonUnitOfWorkResult;
+import features.dungeon.application.authored.port.DungeonWindow;
+import features.dungeon.application.authored.port.DungeonWindowContentRequest;
+import features.dungeon.application.authored.port.DungeonWindowContentSource;
+import features.dungeon.application.authored.port.DungeonWindowIndex;
+import features.dungeon.application.authored.port.DungeonWindowRequest;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Narrow cumulative counters around the production ports used by M5 qualification. */
+public final class DungeonRuntimeWorkProbe {
+    private long indexCalls;
+    private long contentCalls;
+    private long closureCalls;
+    private long continuationCalls;
+    private long unitOfWorkCalls;
+    private long travelStartReads;
+    private long travelChunkReads;
+    private long travelRefreshes;
+    private long hydratedEntities;
+    private long requestedChunks;
+    private long reloadedChunks;
+    private long touchedChunks;
+
+    public DungeonWindowContentSource count(DungeonWindowContentSource delegate) {
+        return new CountingContentSource(Objects.requireNonNull(delegate, "delegate"));
+    }
+
+    public DungeonUnitOfWork count(DungeonUnitOfWork delegate) {
+        return new CountingUnitOfWork(Objects.requireNonNull(delegate, "delegate"));
+    }
+
+    public DungeonTravelApi count(DungeonTravelApi delegate) {
+        return new CountingTravelApi(Objects.requireNonNull(delegate, "delegate"));
+    }
+
+    public synchronized Snapshot snapshot() {
+        return new Snapshot(indexCalls, contentCalls, closureCalls, continuationCalls,
+                unitOfWorkCalls, travelStartReads, travelChunkReads, travelRefreshes,
+                hydratedEntities, requestedChunks, reloadedChunks, touchedChunks);
+    }
+
+    public record Snapshot(
+            long indexCalls,
+            long contentCalls,
+            long closureCalls,
+            long continuationCalls,
+            long unitOfWorkCalls,
+            long travelStartReads,
+            long travelChunkReads,
+            long travelRefreshes,
+            long hydratedEntities,
+            long requestedChunks,
+            long reloadedChunks,
+            long touchedChunks
+    ) {
+        public Snapshot subtract(Snapshot before) {
+            Objects.requireNonNull(before, "before");
+            return new Snapshot(
+                    indexCalls - before.indexCalls,
+                    contentCalls - before.contentCalls,
+                    closureCalls - before.closureCalls,
+                    continuationCalls - before.continuationCalls,
+                    unitOfWorkCalls - before.unitOfWorkCalls,
+                    travelStartReads - before.travelStartReads,
+                    travelChunkReads - before.travelChunkReads,
+                    travelRefreshes - before.travelRefreshes,
+                    hydratedEntities - before.hydratedEntities,
+                    requestedChunks - before.requestedChunks,
+                    reloadedChunks - before.reloadedChunks,
+                    touchedChunks - before.touchedChunks);
+        }
+
+        public long repositoryCalls() {
+            return indexCalls + contentCalls + closureCalls + continuationCalls
+                    + unitOfWorkCalls + travelStartReads + travelChunkReads;
+        }
+    }
+
+    private final class CountingContentSource implements DungeonWindowContentSource {
+        private final DungeonWindowContentSource delegate;
+
+        private CountingContentSource(DungeonWindowContentSource delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Optional<DungeonWindowIndex> loadIndex(DungeonWindowRequest request) {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                indexCalls++;
+                requestedChunks += request.chunkKeys().size();
+            }
+            return delegate.loadIndex(request);
+        }
+
+        @Override
+        public Optional<DungeonWindow> loadContent(DungeonWindowContentRequest request) {
+            Optional<DungeonWindow> result = delegate.loadContent(request);
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                contentCalls++;
+                reloadedChunks += request.chunks().size();
+                result.ifPresent(window -> hydratedEntities += window.fragments().size());
+            }
+            return result;
+        }
+
+        @Override
+        public Optional<DungeonContinuationPage> loadContinuationPage(DungeonContinuationPageRequest request) {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                continuationCalls++;
+            }
+            return delegate.loadContinuationPage(request);
+        }
+
+        @Override
+        public DungeonIdentityClosureResult loadIdentityClosure(DungeonIdentityClosureRequest request) {
+            DungeonIdentityClosureResult result = delegate.loadIdentityClosure(request);
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                closureCalls++;
+                if (result instanceof DungeonIdentityClosureResult.Complete complete) {
+                    hydratedEntities += complete.entities().size();
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public DungeonTravelStartResult locateTravelStart(DungeonTravelStartRequest request) {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                travelStartReads++;
+            }
+            return delegate.locateTravelStart(request);
+        }
+
+        @Override
+        public DungeonTravelChunkKeysResult discoverTravelChunkKeys(DungeonTravelChunkKeysRequest request) {
+            DungeonTravelChunkKeysResult result = delegate.discoverTravelChunkKeys(request);
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                travelChunkReads++;
+                if (result instanceof DungeonTravelChunkKeysResult.Complete complete) {
+                    requestedChunks += complete.chunkKeys().size();
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public DungeonInboundReferenceResult discoverInboundReferences(DungeonInboundReferenceRequest request) {
+            return delegate.discoverInboundReferences(request);
+        }
+    }
+
+    private final class CountingUnitOfWork implements DungeonUnitOfWork {
+        private final DungeonUnitOfWork delegate;
+
+        private CountingUnitOfWork(DungeonUnitOfWork delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public DungeonUnitOfWorkResult commit(DungeonPatch patch) {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                unitOfWorkCalls++;
+                touchedChunks += patch.touchedChunks().size();
+            }
+            return delegate.commit(patch);
+        }
+
+        @Override
+        public DungeonCompoundUnitOfWorkResult commit(DungeonCompoundPatch patch) {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                unitOfWorkCalls++;
+                touchedChunks += patch.touchedChunks().size();
+            }
+            return delegate.commit(patch);
+        }
+    }
+
+    private final class CountingTravelApi implements DungeonTravelApi {
+        private final DungeonTravelApi delegate;
+
+        private CountingTravelApi(DungeonTravelApi delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void refresh() {
+            synchronized (DungeonRuntimeWorkProbe.this) {
+                travelRefreshes++;
+            }
+            delegate.refresh();
+        }
+
+        @Override
+        public void performAction(int selectedActionRowIndex) {
+            delegate.performAction(selectedActionRowIndex);
+        }
+
+        @Override
+        public void selectMap(long mapId) {
+            delegate.selectMap(mapId);
+        }
+
+        @Override
+        public void shiftProjectionLevel(int projectionLevelShift) {
+            delegate.shiftProjectionLevel(projectionLevelShift);
+        }
+
+        @Override
+        public void setOverlay(DungeonOverlaySettings overlaySettings) {
+            delegate.setOverlay(overlaySettings);
+        }
+    }
+}

--- a/test/platform/ui/mapcanvas/MapCanvasPaintSampleTest.java
+++ b/test/platform/ui/mapcanvas/MapCanvasPaintSampleTest.java
@@ -1,0 +1,27 @@
+package platform.ui.mapcanvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+final class MapCanvasPaintSampleTest {
+
+    @Test
+    void preservesOneLayerPaintWorkSample() {
+        MapCanvasPaintSample sample = new MapCanvasPaintSample(
+                MapCanvasLayer.INTERACTION, 7L, 19L, 11L, 3L);
+
+        assertEquals(MapCanvasLayer.INTERACTION, sample.layer());
+        assertEquals(7L, sample.operationId());
+        assertEquals(19L, sample.durationNanos());
+        assertEquals(11L, sample.visitedPrimitives());
+        assertEquals(3L, sample.paintedPrimitives());
+    }
+
+    @Test
+    void rejectsImpossiblePaintCounts() {
+        assertThrows(IllegalArgumentException.class, () -> new MapCanvasPaintSample(
+                MapCanvasLayer.BASE, 1L, 1L, 1L, 2L));
+    }
+}

--- a/test/platform/ui/mapcanvas/MapCanvasPaneTest.java
+++ b/test/platform/ui/mapcanvas/MapCanvasPaneTest.java
@@ -1,0 +1,44 @@
+package platform.ui.mapcanvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.scene.canvas.Canvas;
+import org.junit.jupiter.api.Test;
+
+final class MapCanvasPaneTest {
+
+    @Test
+    void ownsThreeDistinctSizeBoundCanvasesInStableLayerOrder() {
+        MapCanvasPane pane = new MapCanvasPane();
+        Canvas base = pane.canvas(MapCanvasLayer.BASE);
+        Canvas interaction = pane.canvas(MapCanvasLayer.INTERACTION);
+        Canvas actor = pane.canvas(MapCanvasLayer.ACTOR);
+
+        assertEquals(3, pane.canvasCount());
+        assertEquals(3, pane.getChildren().size());
+        assertSame(base, pane.getChildren().get(0));
+        assertSame(interaction, pane.getChildren().get(1));
+        assertSame(actor, pane.getChildren().get(2));
+        assertNotSame(base, interaction);
+        assertNotSame(base, actor);
+        assertNotSame(interaction, actor);
+
+        assertFalse(base.isMouseTransparent());
+        assertTrue(base.isFocusTraversable());
+        assertTrue(interaction.isMouseTransparent());
+        assertFalse(interaction.isFocusTraversable());
+        assertTrue(actor.isMouseTransparent());
+        assertFalse(actor.isFocusTraversable());
+
+        assertTrue(base.widthProperty().isBound());
+        assertTrue(base.heightProperty().isBound());
+        assertTrue(interaction.widthProperty().isBound());
+        assertTrue(interaction.heightProperty().isBound());
+        assertTrue(actor.widthProperty().isBound());
+        assertTrue(actor.heightProperty().isBound());
+    }
+}


### PR DESCRIPTION
## Was sich ändert

- trennt die Dungeon-Karte in physische Base-, Interaction- und Actor-Canvas-Layer mit unabhängiger Invalidierung
- erfasst pro ausgeführtem Layer-Paint feste Samples für Dauer sowie besuchte und gezeichnete Primitive
- qualifiziert reale Editor-, Travel-, SQLite- und JavaFX-Routen auf 1k/10k/100k Sparse-Datensätzen mit festen 20 Warmups und 100 Messungen
- hält Viewport-Arbeit über Chunk-/Revision-Coalescing proportional und bewahrt Generation-/Race-Akzeptanz
- entfernt Shared-Surface-, Alias- und No-op-Messpfade

## Warum

M5.4 schließt die Runtime- und Performance-Qualifikation der Dungeon-Greenfield-Roadmap ab. Passive Interaktionen dürfen weder stabile Layer neu zeichnen noch Repository-I/O auslösen; Arbeit und p95 müssen unabhängig von Off-Window-Wachstum bleiben.

## Proof

- `./gradlew check --no-daemon --console=plain` — `BUILD SUCCESSFUL in 7m 2s`
- `./gradlew installDesktopApp --no-daemon --console=plain` — `BUILD SUCCESSFUL in 38s`
- fokussiert: Window-Integration 12/12, Runtime-Qualifikation 1/1, komplette Dungeon-Editor-Behavior-Suite grün
- `git diff --check` — grün

Kein Zwischenreview: Der einmalige cross-roadmap Review bleibt gemäß Roadmap bis nach der vollständigen M7-Implementation verschoben.
