### PR TITLE
Establish program-wide needs baseline

### DIFF
--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -53,6 +53,7 @@ lives under `docs/<feature>/`; see [docs/README.md](../README.md).
 
 Behavior owned centrally rather than by one feature:
 [anchored popup](requirements/requirements-anchored-popup.md),
+[program capabilities](requirements/requirements-program-capabilities.md),
 [dialog surface](requirements/requirements-dialog-surface.md),
 [dropdown popup](requirements/requirements-dropdown-popup.md),
 [progress meter](requirements/requirements-progress-meter.md),

--- a/docs/project/interviews/README.md
+++ b/docs/project/interviews/README.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Aaron
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-22
 Source of Truth: Index for German owner-interview transcripts used as source
 material for SaltMarcher vision, roadmap, acceptance criteria, and Definition
 of Done documents.
@@ -18,6 +18,7 @@ marked interpretation.
 
 - [Goal Interview 2026-07-10](2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](2026-07-20-dungeon-needs-interview.md)
+- [Program Needs Interview Series](program-needs/README.md)
 
 Interview transcripts are evidence only and do not schedule delivery. No owner
 answer is interpreted or copied into repo-facing documents before explicit

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -346,8 +346,8 @@ established as a need.
 
 1. Enthält das Charakter-Inventar nur Rewards, die über SaltMarcher verteilt
    wurden, oder kann der GM dort jederzeit manuell ein Item hinzufügen,
-   entfernen oder korrigieren? Braucht ein manuell hinzugefügtes Item zwingend
-   eine Herkunft?
+   entfernen oder korrigieren, auch ohne Reward-Quelle? Ist eine Herkunft für
+   einen manuellen Eintrag optional?
 2. Wenn ein Item als `abgegeben` oder `verkauft` markiert wird, verschwindet es
    aus dem aktuellen Charakter-Inventar und bleibt nur in der History? Ist die
    Gegenpartei freier Text, ein Link auf einen vorhandenen NPC oder beides?
@@ -360,6 +360,69 @@ established as a need.
 5. Welche Herkunft soll SaltMarcher automatisch am Item festhalten: Treasure,
    Encounter oder Quest, Scene oder Ort, In-World-Zeit und Vergabezeit? Reicht
    zusätzlich ein freies Herkunfts-Notizfeld für manuelle Fälle?
+
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ja.
+
+The GM may add, remove, or correct an Item in a character's ledger manually,
+including without a Reward source. Provenance is optional for a manual entry.
+
+> [Owner, wörtlich zu 2] bleibt im inventar.
+
+An Item marked as given away or sold remains visible in the character's
+inventory ledger with that reminder. The ledger therefore records awarded Item
+history rather than asserting current physical possession. Whether a
+counterparty is free text, a linked existing object, or both remains open.
+
+> [Owner, wörtlich zu 3] Ja.
+
+Coins, trade goods, and equivalent Items support quantity stacks which the GM
+may split and merge.
+
+> [Owner, wörtlich zu 4] Ja. per default sind alle encounter teilnehmer
+> ausgewählt.
+
+For a narrative XP reward, the GM chooses recipients and SaltMarcher divides
+XP equally and rounds each share up. Every Encounter participant is selected by
+default when an Encounter participant set is available. The default outside an
+Encounter context remains to be clarified.
+
+> [Owner, wörtlich zu 5] ja
+
+SaltMarcher records available source Treasure, Encounter or Quest, Scene or
+place, in-world time, and actual award time as Item provenance. A free-form
+source note supports manual or exceptional cases.
+
+### Literal Evidence So Far
+
+- The GM may manually add, remove, and correct ledger Items; manual provenance
+  is optional.
+- Sold and given-away Items remain visible as marked historical awards rather
+  than disappearing from the character ledger.
+- Quantity stacks can be split and merged.
+- Narrative XP uses a GM-adjustable recipient set, equal rounded-up shares, and
+  defaults to all Encounter participants when that context exists.
+- Item provenance captures its available source and both fictional and award
+  timing, with a free-form fallback.
+
+## Final Gap Block: Ledger Presentation And Defaults
+
+1. Weil verkaufte und abgegebene Items im Charakter-Ledger bleiben: Soll die
+   Standardansicht alle Einträge gemeinsam zeigen, oder aktive, verkaufte und
+   abgegebene Einträge getrennt beziehungsweise filterbar darstellen?
+2. Soll die Gegenpartei bei Verkauf oder Abgabe freier Text, ein Link auf einen
+   vorhandenen NPC, Ort oder eine Fraktion, oder wahlweise beides sein?
+3. Welche XP-Empfänger sind bei einer Quest-Auflösung vorausgewählt, wenn kein
+   Encounter-Kontext existiert: die Charaktere der fokussierten Scene, die
+   gesamte aktive Party oder niemand, bis der GM auswählt?
+4. Wie ordnet SaltMarcher tatsächlich erhaltenen Loot einem Adventure Day für
+   den Soll/Ist-Vergleich zu: automatisch anhand In-World-Zeit, über den
+   aktuellen Plan oder durch eine ausdrückliche GM-Auswahl beziehungsweise
+   Korrektur?
+5. Welcher Wert zählt für Loot-Budget und Ledger: der Standardwert der
+   Item-Definition, ein pro konkretem Item überschreibbarer Wert und bei
+   Verkauf zusätzlich ein separater tatsächlicher Preis?
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -60,6 +60,79 @@ scope.
    history keeps the original plus a linked correction? What must happen when
    the corrected fact has already influenced later progression or history?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Gm verteilt items
+
+The GM, not SaltMarcher, chooses every Item recipient. No automatic recipient
+selection is required. Whether distribution may target only individual
+characters or also shared storage and locations remains to be clarified.
+
+> [Owner, wörtlich zu 2] XP wird immer gleichmäßig aufgeteilt. "Level Up" sind
+> einfach "Charakter hat XP Schwelle überschritten" der GM muss da nichts
+> bestätigen.
+
+Encounter XP is always divided equally among the applicable characters and is
+not individually adjusted. Crossing an XP threshold is itself the level-up
+state and requires no GM confirmation. The exact recipient set and handling of
+fractions remain to be clarified.
+
+> [Owner, wörtlich zu 3] HP und Tod. Alles andere ist GM sache.
+
+The direct Encounter-completion consequences for characters and NPCs are HP
+and death. Conditions, capture, location, consumed resources, possessions, and
+notes are ordinary GM-managed state rather than inferred or proposed
+completion consequences. Whether death is derived automatically or explicitly
+chosen by the GM remains to be clarified.
+
+> [Owner, wörtlich zu 4] Was? Wie? Warum?
+
+The abstract question did not describe a recognizable GM task and establishes
+no product behavior. It must be replaced with a concrete table-play scenario
+rather than interpreted.
+
+> [Owner, wörtlich zu 5] Ja. Wird sie nicht? Ich wüsste nicht wie.
+
+A later correction immediately updates current Campaign state while history
+keeps the original fact plus a linked correction. The owner did not recognize
+the proposed downstream-dependency case, so no automatic dependent-state
+reversal or conflict behavior is established here. Concrete examples are
+needed to determine whether any such case matters.
+
+### Literal Evidence So Far
+
+- The GM distributes Items; SaltMarcher does not choose recipients.
+- Encounter XP is always divided equally among its applicable recipients.
+- Crossing an XP threshold needs no separate GM confirmation.
+- Encounter completion directly carries HP and death; other consequences remain
+  ordinary GM work.
+- Corrections update current truth immediately and append linked history.
+- No behavior has yet been established for narrative World consequences or for
+  corrections which might affect later derived state.
+
+## Second Breadth Block: Concrete Recipients And Corrections
+
+1. Wohin genau darf der GM ein gefundenes Item verteilen: nur an einzelne
+   Charaktere, auch in ein gemeinsames Party-Inventar, oder zurück an einen
+   Treasure beziehungsweise Ort? Kann er einen Treasure teilweise verteilen
+   und den Rest dort lassen?
+2. Wer erhält den gleichmäßigen XP-Anteil: nur PCs, die am Encounter
+   teilgenommen haben, alle Charaktere der betroffenen Scene oder die gesamte
+   aktuelle Party einschließlich Charakteren in anderen Scenes? Wie werden
+   nicht glatt teilbare XP behandelt?
+3. Soll SaltMarcher HP aus dem laufenden Encounter beim Abschluss einfach
+   übernehmen und der GM markiert Tod ausdrücklich, oder darf das Programm Tod
+   aus den verfolgten Kampfregeln selbst ableiten?
+4. Konkretes Beispiel zur vorigen Frage 4: Nach dem Sieg über Banditen möchte
+   der GM die Quest `Banditenlager` als abgeschlossen markieren und das Ansehen
+   beim Dorf erhöhen. Soll der Encounter-Abschluss dafür direkte Felder oder
+   Aktionen anbieten, oder beendet der GM zuerst den Encounter und bearbeitet
+   Quest und Dorf danach ganz normal an ihren jeweiligen Stellen?
+5. Konkretes Korrekturbeispiel: Der GM korrigiert später die XP nach unten und
+   ein Charakter liegt dadurch wieder unter seiner letzten Level-Schwelle.
+   Soll sich der abgeleitete Level-Status sofort mitkorrigieren, während die
+   ursprüngliche Vergabe und Korrektur in der History bleiben?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -424,6 +424,77 @@ source note supports manual or exceptional cases.
    Item-Definition, ein pro konkretem Item überschreibbarer Wert und bei
    Verkauf zusätzlich ein separater tatsächlicher Preis?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] inventar sollte durchsucht und gefiltert werden
+> können.
+
+The character loot ledger is searchable and filterable. The exact default
+grouping is an interaction-design choice as long as the GM can isolate active,
+sold, given-away, and other relevant entries.
+
+> [Owner, wörtlich zu 2] automatisch letzteres, mit verkaufswert, freitext ist
+> optional.
+
+A sale or handoff records a structured link to an existing NPC, place, or
+faction when available, its sale value where applicable, and optional free
+text. This provides both structured provenance and an escape hatch for an
+unmodelled or exceptional counterparty.
+
+> [Owner, wörtlich zu 3] Quests bekommen noch ein strukturiertes Datenfeld:
+> Mitwirkende. GM kann hier charaktere hinzufügen, welche an der quest
+> mitgewirkt haben. fyi: Wenn inaktive charaktere XP erhalten dann wird der GM
+> informiert wenn sie das nächste mal aktiviert werden.
+
+Quests have a structured contributor set to which the GM adds participating
+characters. Those contributors supply the default XP recipient set when the
+Quest is resolved, independent of Encounter context, and remain GM-adjustable
+in the shared reward dialog. If an inactive character receives XP, SaltMarcher
+notifies the GM the next time that character is activated.
+
+> [Owner, wörtlich zu 4] Beim session planing. erhaltenes loot wird mit dem
+> soll-wert verglichen und rewards werden entsprechend angepasst.
+
+Loot sufficiency is evaluated during Session planning. SaltMarcher compares
+already received loot with the DMG-derived expected value and adjusts proposed
+new rewards to compensate. The comparison window and the GM's control over the
+adjustment remain to be clarified.
+
+> [Owner, wörtlich zu 5] Was meinst du mit "Zählt"? Bei was?
+
+The value question was too abstract and establishes no behavior. It is replaced
+below with a concrete budget example.
+
+### Literal Evidence So Far
+
+- The character ledger can be searched and filtered by relevant reminder
+  state and content.
+- Sale and handoff history supports a structured counterparty link, applicable
+  sale value, and optional free text.
+- Quests keep structured contributors which default their XP recipients.
+- Inactive XP recipients produce a notification on their next activation.
+- Session planning compares received loot to the expected target and adjusts
+  proposed rewards to compensate.
+
+## Final Targeted Clarifications
+
+1. Konkretes Wertbeispiel: Ein Item hat laut Definition 100 GP Wert, der GM
+   überschreibt dieses konkrete Exemplar auf 80 GP und die Party verkauft es
+   später für 50 GP. Zählen für die Loot-Soll/Ist-Bilanz die 80 GP, während die
+   50 GP nur als tatsächlicher Verkaufspreis in der History stehen?
+2. Zählt ein einmal erhaltenes Item weiterhin vollständig als erhaltenes Loot,
+   nachdem es verkauft oder abgegeben wurde?
+3. Vergleicht die Session-Planung den gesamten bisher erwarteten Loot aus allen
+   von den Charakteren erhaltenen XP mit ihrem gesamten bisher erhaltenen Loot,
+   oder nur einen begrenzten Zeitraum seit der letzten Planung?
+4. Wenn die Party über oder unter dem Soll liegt: Passt die Generation die
+   vorgeschlagenen Rewards automatisch an, zeigt dem GM die Abweichung und
+   erlaubt ihm trotzdem, die Anpassung zu überschreiben?
+5. Beginnt eine neu erstellte Quest ohne Mitwirkende, außer sie wird aus einem
+   Kontext mit ausgewählten Charakteren erstellt? Soll die Aktivierungswarnung
+   für zwischenzeitlich erhaltene XP nach einmaligem Anzeigen als erledigt
+   gelten?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
@@ -560,12 +560,11 @@ unless creation context supplies selected characters. An inactive character's
 XP information appears once on next activation and then clears automatically.
 No manual dismissal is required.
 
-## Proposed Consolidated Interpretation For Owner Confirmation
+## Confirmed Consolidated Interpretation
 
-This interpretation is not yet canonical program truth. It consolidates the
-complete follow-up, progression, reward, ledger, narrative-note, history, and
-correction workflow without selecting architecture, persistence, or transaction
-boundaries.
+The owner confirmed this complete interpretation on 2026-07-23. It is the
+evidence promoted into the draft Program Capability Requirements without
+selecting architecture, persistence, or transaction boundaries.
 
 1. Ending an Encounter carries forward its tracked HP, rule-derived deaths, and
    XP consequences while the Running Scene continues. Conditions, capture,
@@ -626,10 +625,9 @@ boundaries.
     for the cumulative loot surplus or deficit. The GM retains the previously
     confirmed ability to inspect and edit each proposed Reward independently.
 
-If the owner confirms this interpretation, Workflow 5 can enter the draft
-Program Capability Requirements and the interview can continue with Workflow
-6: Campaign switching, restart, import, export, reference refresh, backup,
-restore, recovery, and local data lifecycle.
+Workflow 5 is confirmed. The interview continues with Workflow 6: Campaign
+switching, restart, import, export, reference refresh, backup, restore,
+recovery, and local data lifecycle.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -65,8 +65,8 @@ scope.
 > [Owner, wörtlich zu 1] Gm verteilt items
 
 The GM, not SaltMarcher, chooses every Item recipient. No automatic recipient
-selection is required. Whether distribution may target only individual
-characters or also shared storage and locations remains to be clarified.
+selection is required. Later answers below clarify partial distribution,
+character-specific ledger recipients, and Items left at Treasures or places.
 
 > [Owner, wörtlich zu 2] XP wird immer gleichmäßig aufgeteilt. "Level Up" sind
 > einfach "Charakter hat XP Schwelle überschritten" der GM muss da nichts
@@ -75,15 +75,14 @@ characters or also shared storage and locations remains to be clarified.
 Encounter XP is always divided equally among the applicable characters and is
 not individually adjusted. Crossing an XP threshold is itself the level-up
 state and requires no GM confirmation. The exact recipient set and handling of
-fractions remain to be clarified.
+fractions are clarified in later answers below.
 
 > [Owner, wörtlich zu 3] HP und Tod. Alles andere ist GM sache.
 
 The direct Encounter-completion consequences for characters and NPCs are HP
 and death. Conditions, capture, location, consumed resources, possessions, and
 notes are ordinary GM-managed state rather than inferred or proposed
-completion consequences. Whether death is derived automatically or explicitly
-chosen by the GM remains to be clarified.
+completion consequences. Later answers below establish rule-derived death.
 
 > [Owner, wörtlich zu 4] Was? Wie? Warum?
 
@@ -137,17 +136,18 @@ needed to determine whether any such case matters.
 
 > [Owner, wörtlich zu 1] ja.
 
-The GM may distribute part or all of a Treasure among individual characters, a
-shared Party inventory, another Treasure, or a place and leave any remainder
-undistributed. Item distribution remains entirely GM-chosen.
+The GM may distribute part or all of a Treasure among individual characters or
+leave Items with another Treasure or place. Item distribution remains entirely
+GM-chosen. Later answers clarify that the durable character view is a GM loot
+ledger rather than a shared or rules-complete inventory.
 
 > [Owner, wörtlich zu 2] Teilnehmende PCs, welche in der initiative order
 > waren. GM kann pcs hinzufügen oder entfernen.
 
 Encounter XP is divided equally among participating PCs represented in the
 initiative order. Before distribution, the GM may add or remove PCs from that
-recipient set; the equal shares are then recalculated. Handling of indivisible
-remainders remains open.
+recipient set; the equal shares are then recalculated. A later answer below
+establishes rounded-up shares for indivisible totals.
 
 > [Owner, wörtlich zu 3] ersteres.
 
@@ -319,8 +319,8 @@ inventory simulation.
 
 Structured narrative rewards are XP and Items. `Item` includes coins,
 equipment, trade goods, magic Items, and other concrete reward goods. The XP
-recipient default for a narrative reward remains to be clarified because no
-initiative order necessarily exists.
+recipient default for a narrative reward is later established through Quest
+contributors.
 
 > [Owner, wörtlich zu 5] Aktuelles inventar per charakter mit remindern zu
 > herkunft.
@@ -372,8 +372,8 @@ including without a Reward source. Provenance is optional for a manual entry.
 
 An Item marked as given away or sold remains visible in the character's
 inventory ledger with that reminder. The ledger therefore records awarded Item
-history rather than asserting current physical possession. Whether a
-counterparty is free text, a linked existing object, or both remains open.
+history rather than asserting current physical possession. Later answers below
+establish a structured counterparty link plus optional free text.
 
 > [Owner, wörtlich zu 3] Ja.
 
@@ -385,8 +385,8 @@ may split and merge.
 
 For a narrative XP reward, the GM chooses recipients and SaltMarcher divides
 XP equally and rounds each share up. Every Encounter participant is selected by
-default when an Encounter participant set is available. The default outside an
-Encounter context remains to be clarified.
+default when an Encounter participant set is available. Later answers establish
+Quest contributors as the default outside Encounter context.
 
 > [Owner, wörtlich zu 5] ja
 
@@ -457,8 +457,8 @@ notifies the GM the next time that character is activated.
 
 Loot sufficiency is evaluated during Session planning. SaltMarcher compares
 already received loot with the DMG-derived expected value and adjusts proposed
-new rewards to compensate. The comparison window and the GM's control over the
-adjustment remain to be clarified.
+new rewards to compensate. Later answers establish a cumulative comparison
+across all received XP and preserve ordinary editing of generated Rewards.
 
 > [Owner, wörtlich zu 5] Was meinst du mit "Zählt"? Bei was?
 
@@ -549,6 +549,87 @@ You previously added that when an inactive character receives XP, the GM is
 informed the next time that character is activated. Should this information be
 shown once and then clear automatically, or remain visible until the GM
 explicitly dismisses it?
+
+### Owner Answer 2026-07-23
+
+> [Owner, wörtlich] Ah, ich war verwirrt, ich dacht die beiden punkt 5 fragen
+> hätten irgend einen Zusammenhang. 5.1 ja. 5.2. ja
+
+The two questions were independent. A new Quest begins without contributors
+unless creation context supplies selected characters. An inactive character's
+XP information appears once on next activation and then clears automatically.
+No manual dismissal is required.
+
+## Proposed Consolidated Interpretation For Owner Confirmation
+
+This interpretation is not yet canonical program truth. It consolidates the
+complete follow-up, progression, reward, ledger, narrative-note, history, and
+correction workflow without selecting architecture, persistence, or transaction
+boundaries.
+
+1. Ending an Encounter carries forward its tracked HP, rule-derived deaths, and
+   XP consequences while the Running Scene continues. Conditions, capture,
+   location, resource use, notes, and other narrative consequences remain
+   ordinary GM-managed edits rather than inferred completion results.
+2. A dead PC or NPC remains as a dead character in the Roster or at its place,
+   may be revived by the GM, and is never automatically deleted.
+3. Encounter XP defaults to participating PCs in the initiative order. The GM
+   may add or remove recipients before distribution. SaltMarcher divides XP
+   equally and rounds each individual share up.
+4. Crossing an XP threshold immediately changes the character's derived level
+   state without GM confirmation. An XP correction immediately recalculates
+   that state while history retains the original award and linked correction.
+5. If an inactive character receives XP, the GM is informed once when that
+   character is next activated; the information then clears automatically.
+6. Encounter and manually resolved Quest rewards use one GM-facing distribution
+   dialog. Whether reward application shares a technical transaction with
+   Encounter completion is not a product requirement.
+7. A Treasure may be distributed partially or completely, and undistributed
+   Items may remain with the Treasure or at its place. The GM chooses every
+   Item recipient; SaltMarcher never chooses one automatically.
+8. Awarded Items are recorded in a searchable and filterable character-specific
+   loot ledger. This is a GM reminder and reward-accounting surface, not a
+   player-operated or rules-complete inventory simulation.
+9. The GM may manually add, remove, or correct ledger Items without a Reward
+   source. Coins, trade goods, and equivalent Items support quantity stacks
+   which may be split and merged.
+10. `Received`, `given away`, and `sold` are non-mechanical reminders. Sold or
+    given-away Items remain visible and continue to count as received loot.
+11. A sale or handoff records a structured counterparty link to an existing
+    NPC, place, or faction when available, plus optional free text. A sale also
+    records its actual price.
+12. The actual sale price becomes authoritative for final loot valuation of a
+    sold Item. A separate per-instance value override is not required.
+13. Item provenance records available Treasure, Encounter or Quest, Scene or
+    place, in-world time, and award time, with optional free-form provenance for
+    manual and exceptional cases.
+14. Quests, rumours, and similarly complex narrative concepts remain
+    lightweight records attached to places, factions, or NPCs. They contain an
+    open-or-closed state, free text, optional structured Rewards, and, for a
+    Quest, a structured contributor set.
+15. SaltMarcher does not model Quest completion conditions, NPC trigger graphs,
+    or automatic narrative resolution. The GM resolves the note manually. A
+    new Quest begins without contributors unless its creation context supplies
+    selected characters.
+16. Structured narrative Rewards are XP and Items, where Items include coins,
+    equipment, trade goods, magic Items, and other concrete goods. Quest
+    contributors default the XP recipient set, which remains GM-adjustable;
+    XP uses the same equal rounded-up distribution rule as Encounter XP.
+17. Later corrections immediately update current Item, XP, HP, death, or other
+    corrected truth while explanatory history retains the original fact and a
+    linked correction. Existing explicit-deletion and travel-undo exceptions
+    remain governed by their previously confirmed behavior.
+18. Expected loot derives from DMG guidance by character level through a
+    loot-per-XP value. Session planning compares cumulative received loot with
+    cumulative expected loot for all XP the characters have received so far.
+19. Session generation automatically adjusts proposed Rewards to compensate
+    for the cumulative loot surplus or deficit. The GM retains the previously
+    confirmed ability to inspect and edit each proposed Reward independently.
+
+If the owner confirms this interpretation, Workflow 5 can enter the draft
+Program Capability Requirements and the interview can continue with Workflow
+6: Campaign switching, restart, import, export, reference refresh, backup,
+restore, recovery, and local data lifecycle.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -1,0 +1,69 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Verbatim owner answers and confirmed interpretations for
+post-Encounter follow-up, possessions, progression, World consequences,
+history, and correction needs.
+
+# Follow-Up, Progression, And History Interview 2026-07-22
+
+## Scope
+
+This workflow begins when a live Encounter, Chase, discovery, or other Scene
+event produces consequences which the GM may carry into possessions,
+characters, NPCs, factions, quests, locations, World state, and Campaign
+history. It asks what the GM must accomplish without assuming that today's
+feature boundaries, persistence, screens, or update mechanisms are the right
+solution.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture, contracts, persistence, APIs, and delivery order remain out of
+scope.
+
+## Carried-Forward Confirmed Evidence
+
+- The GM confirms one complete Encounter outcome. Completion, calculated Party
+  XP, selected named-NPC lifecycle changes, and selected finite-stock effects
+  become effective together or remain unchanged.
+- The Running Scene continues after an Encounter or another runtime mask ends.
+- Treasures and their Items are persistent editable World content before they
+  are awarded. Reaching them never awards them automatically.
+- Confirmed Campaign consequences ordinarily remain in explanatory history.
+  Later table focus may use an earlier in-world time without rolling them back.
+- Explicit deletion and travel undo have already confirmed exceptional
+  behavior; conflicting later history is exposed for manual GM resolution.
+
+## First Breadth Block: From Scene Outcome To Durable Campaign State
+
+1. When the Party obtains a treasure, what must the GM be able to do in one
+   operation: award the whole treasure to the Party, distribute individual
+   Items to characters, leave some Items at the location, move them into a
+   shared Party inventory, or any combination? Must SaltMarcher ever choose
+   recipients automatically?
+2. How should Encounter XP work after the already confirmed calculation: is it
+   divided equally among participating PCs, assigned only when the GM confirms
+   the outcome, individually adjustable before confirmation, and immediately
+   reflected in progression? Does SaltMarcher perform level-up changes or only
+   tell the GM when a threshold is reached?
+3. Which other PC or NPC consequences must the completion workflow support
+   directly—HP, conditions, death, capture, location, consumed resources,
+   possessions, or arbitrary notes—and which of those should be automatic
+   proposals versus explicit GM-entered choices?
+4. When an outcome changes a faction, quest, rumour, place, or other World
+   object, should the GM select and edit those consequences as part of the same
+   completion operation, or finish the Encounter first and perform ordinary
+   World edits afterward? Should any such narrative consequence be inferred
+   automatically?
+5. If the GM later corrects an awarded Item, XP amount, character consequence,
+   or World change, should the current Campaign state update immediately while
+   history keeps the original plus a linked correction? What must happen when
+   the corrected fact has already influenced later progression or history?
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Session And Scene Preparation](2026-07-22-session-and-scene-preparation.md)
+- [Confirmed Running Scene And Live Play](2026-07-22-running-scene-and-live-play.md)
+- [Confirmed Spatial Travel And Progression](2026-07-22-spatial-travel-and-progression.md)
+- [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -133,6 +133,85 @@ needed to determine whether any such case matters.
    Soll sich der abgeleitete Level-Status sofort mitkorrigieren, während die
    ursprüngliche Vergabe und Korrektur in der History bleiben?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] ja.
+
+The GM may distribute part or all of a Treasure among individual characters, a
+shared Party inventory, another Treasure, or a place and leave any remainder
+undistributed. Item distribution remains entirely GM-chosen.
+
+> [Owner, wörtlich zu 2] Teilnehmende PCs, welche in der initiative order
+> waren. GM kann pcs hinzufügen oder entfernen.
+
+Encounter XP is divided equally among participating PCs represented in the
+initiative order. Before distribution, the GM may add or remove PCs from that
+recipient set; the equal shares are then recalculated. Handling of indivisible
+remainders remains open.
+
+> [Owner, wörtlich zu 3] ersteres.
+
+Encounter completion carries forward tracked HP and derives death from the
+applicable tracked combat rules. The GM need not mark death separately.
+
+> [Owner, wörtlich zu 4] Seit wann modellieren wir quests in SaltMarcher? Wäre
+> mir neu.
+
+This rejects the question's assumed RPG-style Quest workflow. The owner then
+clarified the intended, much smaller capability:
+
+> [Owner, ergänzend wörtlich] Quests können erstellt werden, indem Sinne, dass
+> sie als reine text ontizen an ORte oder Fraktionen oder NPCs gehangen werden,
+> vielleicht mit strukturierten reward feldern. Aber der GM muss nicht wie in
+> einem RPG completion bedingungen mit bestimmten NPCs verknüpfen oder so einen
+> mist, er kann die quest einfach später manuell resolven. Gleiches gillt auch
+> für rumors und andere ähnlich komplexe nicht einfach mechanisierbare Konzepte.
+
+Quests, rumours, and comparable narrative concepts are note-first records
+attached to places, factions, or NPCs. They do not model completion conditions,
+NPC-linked triggers, or automatic resolution; the GM resolves them manually.
+Structured reward fields are still only a possibility to clarify. Encounter
+completion does not infer or apply narrative consequences.
+
+> [Owner, wörtlich zu 5] Ja.
+
+If an XP correction moves a character below a threshold, the derived level
+state updates immediately. History retains both the original award and its
+linked correction.
+
+### Literal Evidence So Far
+
+- A Treasure may be distributed partially or completely among characters,
+  shared Party inventory, other Treasures, and places.
+- Encounter XP is always shared equally among GM-adjustable participating PCs
+  from the initiative order.
+- Tracked HP and rule-derived death carry forward at Encounter completion.
+- Quests, rumours, and comparable narrative concepts remain lightweight notes
+  with manual resolution, not automated RPG workflows.
+- Corrected XP immediately corrects derived level state while preserving the
+  original award and linked correction in history.
+
+## Third Breadth Block: Inventory, Rewards, And Death Lifecycle
+
+1. Wenn Encounter-XP nicht glatt durch die Empfängerzahl teilbar ist: Werden
+   Bruchteile gespeichert, wird abgerundet und ein Rest verworfen, oder darf
+   der GM den Rest verteilen?
+2. Welche normalen Besitzaktionen braucht der GM nach der Verteilung: Items
+   zwischen Charakteren, Party-Inventar, Treasures und Orten verschieben;
+   ausrüsten oder ablegen; verbrauchen; sowie Mengenstapel teilen und
+   zusammenführen?
+3. Welche minimale Zustandsangabe brauchen Quests, Rumours und ähnliche
+   Notizen: nur frei editierbarer Text, oder zusätzlich beispielsweise `offen`,
+   `resolved` und `verworfen`? Soll das manuelle Resolven einer Quest ihre
+   strukturierten Rewards über denselben XP- und Item-Verteilungsdialog
+   anbieten?
+4. Was geschieht mit einem regelbasiert gestorbenen PC oder NPC: Bleibt er als
+   toter Charakter im Roster beziehungsweise am Ort, kann der GM ihn später
+   wiederbeleben, und darf Tod niemals den Datensatz automatisch löschen?
+5. Gehört Item-Verteilung zur selben atomaren Bestätigung wie Encounter-Ende,
+   HP, Tod und XP, oder bleibt das Awarden eines Treasures eine unabhängige
+   Aktion, die der GM vor oder nach dem Encounter-Abschluss ausführen kann?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -182,8 +182,8 @@ linked correction.
 ### Literal Evidence So Far
 
 - A Treasure may be distributed partially or completely or left at its source;
-  later evidence below clarifies that distribution feeds GM loot accounting,
-  not durable player inventories.
+  later evidence below clarifies that distribution feeds a durable GM reminder
+  ledger rather than a rules-complete player inventory simulation.
 - Encounter XP is always shared equally among GM-adjustable participating PCs
   from the initiative order.
 - Tracked HP and rule-derived death carry forward at Encounter completion.
@@ -226,12 +226,14 @@ GM to allocate a remainder.
 > loot erhalten haben, wieviel besagter loot wert war und ob er schon verkauft
 > wurde.
 
-SaltMarcher does not track player inventories, equipment, consumption, or
-transfers between PCs. The GM-facing need is loot accounting: whether loot was
-received or given away, its value, whether it was sold, and whether the Party
-has received enough loot. This supersedes the earlier interpretation of
-character and shared Party inventories as durable product-managed destinations.
-The precise accounting scope and sale-value behavior remain to be clarified.
+SaltMarcher does not aim to simulate the players' complete rules-facing
+inventory, equipment, consumption, or table decisions. The GM-facing need is
+loot accounting: whether loot was received or given away, its value, whether it
+was sold, and whether the Party has received enough loot. Later evidence below
+clarifies that this accounting still includes a current Item list per character
+and therefore supersedes the earlier, overly absolute wording that no player
+inventory is tracked. The precise reminder and sale-value behavior remains to
+be clarified.
 
 > [Owner, wörtlich zu 3] Offen oder nicht offen. Rest ist freitext und rewards.
 > Verteilung im selben verteilungsdialog wie encounter.
@@ -259,7 +261,8 @@ with Encounter completion is deferred to technical-needs and architecture work.
 
 - Uneven equal XP shares are rounded up per participating PC.
 - SaltMarcher tracks loot sufficiency, value, received or given-away state, and
-  sale state for the GM; it does not track player inventories.
+  sale state for the GM; later evidence below confirms a lightweight current
+  inventory per character but no rules-complete inventory simulation.
 - Narrative notes have only open or closed state, free text, and optional
   rewards distributed through the same interaction as Encounter rewards.
 - Dead characters persist, may be revived, and are never automatically deleted.
@@ -286,6 +289,77 @@ with Encounter completion is deferred to technical-needs and architecture work.
 5. Muss der GM Loot-Bilanz und Reward-History nach Zeitraum, Adventure Day,
    Scene, Quelle und Empfänger filtern können, oder reicht zunächst eine
    chronologische Gesamtliste mit aktuellem Soll/Ist-Vergleich?
+
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] DMG loot guidelines pro level, aus welchem sich pro XP
+> ableitet, aus welchem sich pro adventure day ableitet.
+
+Loot sufficiency is measured from DMG loot guidance by character level. That
+guidance yields a loot value per XP, which in turn yields the expected loot for
+one Adventure Day. The later rule work must establish the exact versioned
+derivation; this interview establishes the GM-visible comparison target.
+
+> [Owner, wörtlich zu 2] Nichts. Es sind lediglich reminder für den GM. Die
+> History kann gerne auch speichern, an wen sie verkauft oder abgegeben wurden.
+
+`Received`, `given away`, and `sold` are non-mechanical GM reminders. Changing
+one does not trigger rules or inferred consequences. History may record the
+person or other recipient to whom an Item was sold or given.
+
+> [Owner, wörtlich zu 3] Ersteres.
+
+SaltMarcher durably records which PC received each Item. Together with the
+later inventory answer, this provides a current Item list per character while
+remaining a GM reminder rather than a player-operated or rules-complete
+inventory simulation.
+
+> [Owner, wörtlich zu 4] XP und Items, wobei Items alles von Münzen über
+> equipment und handelswaren bis magic items sind.
+
+Structured narrative rewards are XP and Items. `Item` includes coins,
+equipment, trade goods, magic Items, and other concrete reward goods. The XP
+recipient default for a narrative reward remains to be clarified because no
+initiative order necessarily exists.
+
+> [Owner, wörtlich zu 5] Aktuelles inventar per charakter mit remindern zu
+> herkunft.
+
+The required follow-up view is the current Item inventory per character with
+reminders showing where each Item came from. Broad analytical filtering is not
+established as a need.
+
+### Literal Evidence So Far
+
+- The expected loot target for an Adventure Day derives from versioned DMG
+  level guidance through a loot-per-XP value.
+- Received, given-away, and sold states are reminders only; history may record
+  the receiving counterparty.
+- The GM can see each character's current Item inventory and the source of each
+  Item.
+- This inventory is a GM loot ledger, not a player-operated or rules-complete
+  inventory simulation.
+- Narrative rewards contain XP and Items, including coins, equipment, trade
+  goods, and magic Items.
+
+## Fifth Breadth Block: Ledger Boundaries And Narrative XP
+
+1. Enthält das Charakter-Inventar nur Rewards, die über SaltMarcher verteilt
+   wurden, oder kann der GM dort jederzeit manuell ein Item hinzufügen,
+   entfernen oder korrigieren? Braucht ein manuell hinzugefügtes Item zwingend
+   eine Herkunft?
+2. Wenn ein Item als `abgegeben` oder `verkauft` markiert wird, verschwindet es
+   aus dem aktuellen Charakter-Inventar und bleibt nur in der History? Ist die
+   Gegenpartei freier Text, ein Link auf einen vorhandenen NPC oder beides?
+3. Wie werden Mengen behandelt: Sind Münzen, Handelswaren und gleiche Items
+   Mengenstapel, die der GM teilen und zusammenführen kann, oder genügt je
+   Reward eine Menge plus Gesamtwert ohne weitere Bestandsoperationen?
+4. Wer erhält XP aus einer manuell aufgelösten Quest oder ähnlichen Notiz?
+   Wählt der GM einen Empfängerkreis aus dem Roster, worauf SaltMarcher die XP
+   gleichmäßig und aufgerundet verteilt?
+5. Welche Herkunft soll SaltMarcher automatisch am Item festhalten: Treasure,
+   Encounter oder Quest, Scene oder Ort, In-World-Zeit und Vergabezeit? Reicht
+   zusätzlich ein freies Herkunfts-Notizfeld für manuelle Fälle?
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -495,6 +495,61 @@ below with a concrete budget example.
    für zwischenzeitlich erhaltene XP nach einmaligem Anzeigen als erledigt
    gelten?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] Verkaufspreis ist was am Ende zählt. Preis muss nicht
+> überschrieben werden können.
+
+The actual sale price is authoritative for the final loot-value accounting of
+a sold Item. A concrete Item does not need a separate value override. This
+keeps definition value and actual sale value distinct without introducing a
+third mutable valuation.
+
+> [Owner, wörtlich zu 2] ja.
+
+An Item continues to count as received loot after being sold or given away. Its
+reminder state and, for a sale, authoritative sale price change how it is
+described and valued, not whether the Party received it.
+
+> [Owner, wörtlich zu 3] gesammten erhaltenen loot für bisher erhaltene XP.
+
+Session planning compares total received loot with the total expected loot for
+all XP the characters have received so far. The comparison is cumulative rather
+than limited to the previous Session or planning interval.
+
+> [Owner, wörtlich zu 4] passt automatisch an.
+
+Session generation automatically adjusts proposed rewards to compensate for
+the cumulative loot surplus or deficit. Previously confirmed generation
+behavior still lets the GM inspect and edit each proposed reward independently.
+
+> [Owner, wörtlich zu 5] ja. XP-Aktivierungswarnung?
+
+A new Quest begins without contributors unless its creation context supplies
+selected characters. The second part was not understood. `XP activation
+notification` refers only to the owner's earlier statement that an inactive
+character who receives XP should notify the GM when next activated. Its
+dismissal lifetime remains the only open point in this workflow.
+
+### Literal Evidence So Far
+
+- Actual sale price is final for a sold Item's loot value; per-instance value
+  overrides are not required.
+- Sold or given-away Items continue to count as received loot.
+- Loot sufficiency compares cumulative received loot against expected loot for
+  all XP received so far.
+- Session generation automatically compensates proposed rewards for cumulative
+  loot surplus or deficit while preserving normal reward editing.
+- Quests begin without contributors unless creation context supplies selected
+  characters.
+
+## Remaining Clarification
+
+You previously added that when an inactive character receives XP, the GM is
+informed the next time that character is activated. Should this information be
+shown once and then clear automatically, or remain visible until the GM
+explicitly dismisses it?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
+++ b/docs/project/interviews/program-needs/2026-07-22-follow-up-progression-and-history.md
@@ -1,6 +1,6 @@
 Status: Active Evidence
 Owner: Aaron
-Last Reviewed: 2026-07-22
+Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
 post-Encounter follow-up, possessions, progression, World consequences,
 history, and correction needs.
@@ -181,8 +181,9 @@ linked correction.
 
 ### Literal Evidence So Far
 
-- A Treasure may be distributed partially or completely among characters,
-  shared Party inventory, other Treasures, and places.
+- A Treasure may be distributed partially or completely or left at its source;
+  later evidence below clarifies that distribution feeds GM loot accounting,
+  not durable player inventories.
 - Encounter XP is always shared equally among GM-adjustable participating PCs
   from the initiative order.
 - Tracked HP and rule-derived death carry forward at Encounter completion.
@@ -211,6 +212,80 @@ linked correction.
 5. Gehört Item-Verteilung zur selben atomaren Bestätigung wie Encounter-Ende,
    HP, Tod und XP, oder bleibt das Awarden eines Treasures eine unabhängige
    Aktion, die der GM vor oder nach dem Encounter-Abschluss ausführen kann?
+
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] aufrunden
+
+Each participating PC's equal Encounter-XP share is rounded up when the total
+is not evenly divisible. SaltMarcher does not preserve fractions or require the
+GM to allocate a remainder.
+
+> [Owner, wörtlich zu 2] "erhalten" und "abgegeben." Wir nutzen das nicht um
+> für Spieler inventar zu tracken, sondern um als GM zu tracken, ob sie genug
+> loot erhalten haben, wieviel besagter loot wert war und ob er schon verkauft
+> wurde.
+
+SaltMarcher does not track player inventories, equipment, consumption, or
+transfers between PCs. The GM-facing need is loot accounting: whether loot was
+received or given away, its value, whether it was sold, and whether the Party
+has received enough loot. This supersedes the earlier interpretation of
+character and shared Party inventories as durable product-managed destinations.
+The precise accounting scope and sale-value behavior remain to be clarified.
+
+> [Owner, wörtlich zu 3] Offen oder nicht offen. Rest ist freitext und rewards.
+> Verteilung im selben verteilungsdialog wie encounter.
+
+A Quest, rumour, or comparable narrative note has only a Boolean open state,
+free text, and optional structured rewards. Manual resolution closes the note
+and offers those rewards through the same GM-facing distribution dialog used
+for Encounter rewards. No additional workflow states or completion mechanics
+are required.
+
+> [Owner, wörtlich zu 4] ja.
+
+A rule-derived dead PC or NPC remains as a dead character in the Roster or at
+its place, may later be revived by the GM, and is never automatically deleted.
+
+> [Owner, wörtlich zu 5] Das klingt nach technischem detail und interessiert
+> mich entsprechend nicht.
+
+Transaction composition is not an owner-level product decision. The observable
+need established here is that Encounter rewards and manually resolved narrative
+rewards use the same distribution dialog. Whether awarding shares a transaction
+with Encounter completion is deferred to technical-needs and architecture work.
+
+### Literal Evidence So Far
+
+- Uneven equal XP shares are rounded up per participating PC.
+- SaltMarcher tracks loot sufficiency, value, received or given-away state, and
+  sale state for the GM; it does not track player inventories.
+- Narrative notes have only open or closed state, free text, and optional
+  rewards distributed through the same interaction as Encounter rewards.
+- Dead characters persist, may be revived, and are never automatically deleted.
+- Encounter and narrative rewards use the same distribution dialog; its
+  transaction boundary remains a later technical decision.
+
+## Fourth Breadth Block: Loot Accounting And Reward Sources
+
+1. Gegen welches Ziel entscheidet SaltMarcher, ob die Party „genug Loot“
+   erhalten hat: gegen das für den Adventure Day berechnete DMG-Lootbudget,
+   gegen einen vom GM gewählten Zeitraum oder gegen etwas anderes? Welche
+   Zusammenfassung soll der GM sehen?
+2. Was unterscheiden `erhalten`, `abgegeben` und `verkauft` genau? Soll ein
+   Verkauf zusätzlich den tatsächlichen Verkaufspreis speichern, damit die
+   Bilanz Item-Wert und real erhaltenes Geld getrennt zeigt?
+3. Soll nach einer Verteilung dauerhaft gespeichert werden, welcher PC welchen
+   Gegenstand bekam, oder zählt SaltMarcher bewusst nur den aggregierten
+   Loot-Wert der Party und überlässt jede individuelle Zuordnung vollständig
+   dem Tisch?
+4. Welche strukturierten Rewards kann eine Quest oder ähnliche Notiz anbieten:
+   XP, vorhandene oder neu erstellte Items, Treasures, Münzwert und freie
+   Notizen? Werden XP daraus über denselben GM-anpassbaren Empfängerkreis
+   gleichmäßig verteilt wie Encounter-XP?
+5. Muss der GM Loot-Bilanz und Reward-History nach Zeitraum, Adventure Day,
+   Scene, Quelle und Empfänger filtern können, oder reicht zunächst eine
+   chronologische Gesamtliste mit aktuellem Soll/Ist-Vergleich?
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-22
 Source of Truth: Confirmed scope, method, carried-forward owner answers, and

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -315,6 +315,23 @@ the interpretation as one complete workflow.
 The proposed Campaign-foundation interpretation is confirmed in full on
 2026-07-22 and may enter the draft program requirements.
 
+## Later Owner Clarification: Narrative Notes
+
+> [Owner, wörtlich am 2026-07-22] Quests können erstellt werden, indem Sinne,
+> dass sie als reine text ontizen an ORte oder Fraktionen oder NPCs gehangen
+> werden, vielleicht mit strukturierten reward feldern. Aber der GM muss nicht
+> wie in einem RPG completion bedingungen mit bestimmten NPCs verknüpfen oder
+> so einen mist, er kann die quest einfach später manuell resolven. Gleiches
+> gillt auch für rumors und andere ähnlich komplexe nicht einfach
+> mechanisierbare Konzepte.
+
+This narrows the previously confirmed generic Campaign-object wording. Quests,
+rumours, and similarly complex narrative concepts are lightweight, note-first
+GM records attached to places, factions, or NPCs. SaltMarcher does not require
+authored completion conditions, NPC trigger graphs, or automatic resolution.
+The GM resolves these records manually. Structured reward fields remain a
+possibility to clarify rather than confirmed behavior.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -112,6 +112,52 @@ The next owner-answer block must clarify:
 4. how quickly the GM can create an intentionally incomplete NPC, place, item,
    faction, quest, rumour, or similar fact during play and complete it later
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ein name reicht. Sesions können auch ohne Party
+> vorbereitet, aber nicht generiert werden.
+
+> [Owner, wörtlich zu 2] korrekt
+
+This confirms the proposed split in the question: rules, general Creature data,
+and Item definitions are reusable across Campaigns; PCs, NPCs, places,
+factions, quests, rumours, possessions, and concrete Item instances belong to
+one Campaign.
+
+> [Owner, wörtlich zu 3] Ja, wechsel passiert über ein
+> optionen/einstellungen menü
+
+> [Owner, wörtlich zu 4] Ein Name, alles andere ist optional
+
+### Literal Evidence So Far
+
+- A Campaign requires only a name.
+- A Session may be authored without a Party. Session generation requires a
+  Party.
+- SaltMarcher keeps multiple Campaigns and exposes Campaign switching through
+  options or settings.
+- A spontaneous Campaign object requires only a name; every other property is
+  optional and may be completed later.
+
+These are evidence, not yet the confirmed interpretation of the complete
+Campaign-foundation workflow.
+
+## Second Breadth Block: Campaign Switching And Immediate Use
+
+The next owner-answer block must clarify:
+
+1. whether Running Scene, Encounter, and travel state in Campaign A remains
+   exactly preserved and resumes when the GM returns after switching to
+   Campaign B
+2. whether switching with running table state happens immediately, requires a
+   warning or confirmation, or is unavailable until that state is closed
+3. whether refreshing a reusable Creature, Item, or rule definition changes
+   Campaign-specific uses automatically or must preserve the version and
+   overrides already used in that Campaign
+4. whether a name-only NPC, place, item, quest, or rumour created from a Running
+   Scene is attached to that Scene immediately or is merely created for later
+   selection
+
 No interpretation of these four questions is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -250,7 +250,63 @@ The next owner-answer block must resolve:
 4. whether deleting an NPC, Item, or other object that is already used by a
    Running Encounter removes it from that Encounter immediately
 
-No consolidated Campaign-foundation interpretation is confirmed yet.
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ja
+
+> [Owner, wörtlich zu 2] Der GM kann eine angenommene Party in der Session aus
+> dem Roster auswählen. Das ist nicht die aktive Party, sie dient nur zur
+> Planung.
+
+The Session therefore owns a planning-only expected Party selection from the
+Roster. It enables generation without changing the current table Party.
+
+> [Owner, wörtlich zu 3] Nein, wenn ich aus irgend einem Grund Hans lösche,
+> dann traf ie Party [UNKOWN] ggf. mit einem link zum papierkorb falls Hans noch
+> dort liegt.
+
+The completed historical fact remains, resolving the contradiction. Its deleted
+object reference is shown as unknown rather than retaining the former live
+identity. If the deleted object is still recoverable from a trash surface, the
+history may link there.
+
+> [Owner, wörtlich zu 4] Ja, wenn ich das Ding löschen will (warum auch immer
+> ich das machen wollen sollte) dann sollte es gelöscht werden.
+
+Explicit deletion also removes the object from a Running Encounter and discards
+runtime state that depended on that object.
+
+## Proposed Campaign-Foundation Interpretation
+
+The following compact interpretation awaits explicit owner confirmation:
+
+- A new Campaign requires only a name. SaltMarcher stores several Campaigns;
+  the GM switches immediately through options or settings. Every Running Scene,
+  Encounter, and travel state in the previous Campaign remains preserved and
+  resumes when the GM returns.
+- Rules, general Creature data, and Item definitions are reusable references
+  across Campaigns. PCs, NPCs, places, factions, quests, rumours, possessions,
+  and concrete Item instances belong to one Campaign. A Campaign-specific object
+  may be copied to another Campaign as a fully independent object.
+- Current and future play reads the current referenced definition. Completed
+  Scenes and their historical facts are not retroactively recalculated when a
+  reusable definition changes.
+- Every Campaign has one `Roster` containing all of its PCs and at most one
+  current `Party` containing the PCs whose players currently participate. Scene
+  groups are subdivisions of that Party, not separate Parties.
+- A Session may be authored without any Party. For generation, the GM selects a
+  planning-only expected Party from the Roster; it neither is nor changes the
+  current table Party.
+- Any Campaign object may begin with only a name, every other property is
+  optional, and same-kind objects may share names. Creation from a Running Scene
+  attaches the object there by default, while the dialog lets the GM opt out.
+- Explicit deletion removes the object from preparation, Running Scenes, and
+  Running Encounters, including dependent runtime state. Completed history keeps
+  the historical fact but displays the missing identity as `[UNKNOWN]`, with a
+  link to the trash when the object remains recoverable there.
+
+None of these bullets enters the program requirements until the owner confirms
+the interpretation as one complete workflow.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -158,6 +158,52 @@ The next owner-answer block must clarify:
    Scene is attached to that Scene immediately or is merely created for later
    selection
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ja
+
+> [Owner, wörtlich zu 2] Sofort
+
+Together these answers confirm that switching Campaigns immediately preserves
+the complete Running Scene, Encounter, and travel state of the previous
+Campaign for direct continuation after switching back. No warning, confirmation,
+or prerequisite closure is needed.
+
+> [Owner, wörtlich zu 3] Diese Dinge "Verwenden" den Gegenstand nicht, sie
+> referenzieren ihn allerhöchstens. Wenn sie aus irgend einem Grund doch auf die
+> Inhalte des Gegenstands zugreifen müsssen (z.b. wieviel licht eine Laterne
+> während exploration spenden kann) muss dass nicht in bereits vergangenen
+> Szenen retroaktiv korrigiert werden, aber in jetzt laufenden und zukünftigen.
+
+This corrects the question's premise: Campaign content references reusable
+definitions rather than embedding or consuming copies of them. A changed
+definition affects facts read in current and future play. It does not
+retroactively rewrite already completed Scenes or their historical account.
+
+> [Owner, wörtlich zu 4] Wenn das scene feature mir die Option anbietet, direkt
+> dort Inhalte zu erstellen, sollte das der default sein, weil ich davon ausgehe
+> dass ich das für diese aktuelle Szene mache. Der Dialog sollte mir aber die
+> Option bieten, das selbst zu entscheiden.
+
+A name-only object created from a Running Scene is therefore attached to that
+Scene by default. The creation dialog lets the GM opt out before confirming.
+
+These are evidence, not yet the confirmed interpretation of the complete
+Campaign-foundation workflow.
+
+## Third Breadth Block: Party And Campaign-Object Lifecycle
+
+The next owner-answer block must clarify:
+
+1. whether one Campaign has exactly one Party with active and reserve characters
+   or may contain several separately selectable Parties
+2. whether a Campaign-specific NPC, place, faction, quest, rumour, or concrete
+   Item instance can be copied into another Campaign and, if so, whether the copy
+   becomes fully independent
+3. whether two Campaign objects of the same kind may have the same name
+4. what happens when the GM deletes an object that current preparation, a
+   Running Scene, or completed history still references
+
 No interpretation of these four questions is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -1,0 +1,122 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Confirmed scope, method, carried-forward owner answers, and
+discovery prompts for the program-wide SaltMarcher needs interview.
+
+# Program Needs Foundation And Coverage 2026-07-22
+
+## Owner Motivation
+
+> [Owner, wörtlich] Ich glaube ein grundlegendes Problem ist, dass bisher alle
+> Features des Programms in Isolation geplant und umgesetzt wurden, und diesen
+> Fehler wiederholen wir grade. Wir sollten das Bedürfniss Interview erstmal auf
+> alle Features erweitern, die das Programm am Ende haben soll. Modularität ist
+> trotzdem ein wichtiges feature, damit wir einzelne Aspekte ohne große Probleme
+> bearbeiten können, aber für etwas wie grundlegende Architektur und Technologie
+> Entscheidungen wäre ein gesammtbild der Ziele wahrscheinlich wichtig.
+
+## Confirmed Analysis Boundary
+
+The owner selected and confirmed:
+
+- `GM-Kernprodukt`: the complete local GM tool is binding; player-operated and
+  remote-play extensions remain parked separately
+- `Bestätigtes behalten`: confirmed vision and owner answers remain valid;
+  feature requirements, architecture, and code serve only as prompts and
+  counterexamples
+- `Als verfrüht schließen`: architecture PR #547 must not become target truth
+- `Erst Breite, dann Tiefe`: establish the complete GM lifecycle and capability
+  map before deepening only gaps and architecture-significant interactions
+- `Kleine Themenblöcke`: ask three to five closely related concrete questions
+  per interview turn
+- `Pro Workflow bestätigen`: confirm one compact interpretation after each
+  coherent GM workflow and perform one final overall confirmation
+
+## Carried-Forward Confirmed Cross-Workflow Answers
+
+The following owner-confirmed answers were produced after the Dungeon-focused
+interview. They remain product evidence but prescribe no root, storage, module,
+transaction, or integration technology.
+
+### Encounter Outcome
+
+One explicit overall confirmation applies Encounter result and completion,
+calculated Party XP, and selected named-NPC lifecycle or finite-stock
+consequences together or applies none of them. The associated Running Scene
+continues. Loot persistence is not part of this confirmation.
+
+### Scene And Encounter Reconciliation
+
+A valid Scene change is saved first and remains usable. Failed Encounter
+synchronization is visibly pending; stale Encounter context is never presented
+as synchronized. Initialization, refresh, or explicit retry resumes the saved
+reconciliation.
+
+### Party Membership Reconciliation
+
+Party activation, deactivation, or deletion becomes authoritative immediately.
+Activation assigns no Running Scene automatically. After deactivation or
+deletion, only Running Scenes that reference that character and their Encounters
+reconcile to the accepted Party state. Failure does not roll back Party and does
+not change unaffected running contexts.
+
+### Campaign History
+
+The GM needs an immutable chronological journal of meaningful confirmed World
+consequences such as time, travel, Encounter completion, XP, membership,
+NPC/stock consequences, and GM corrections. Corrections append linked entries.
+A whole-campaign historical snapshot, event replay, or arbitrary past restore
+is not required.
+
+## Breadth-First Discovery Prompts
+
+The following census prevents omissions. It is not a confirmed feature list and
+does not imply separate modules.
+
+### Already Represented In Current Product Documents
+
+- Party and adventuring-day information
+- Creatures, Items, Encounter Tables, saved Encounters, World records, and the
+  shared Catalog workspace
+- Session planning, deterministic session generation, runtime Scenes, Encounter
+  building/combat/resolution, and generated rewards
+- Dungeon and Hex authoring, travel, shared map presentation, global travel
+  context, perception, and optional Actor Autonomy
+
+### Vision And Inventory Gaps Requiring Program-Level Confirmation
+
+- multiple Campaigns and the boundary between reusable reference knowledge and
+  Campaign-specific authored facts
+- calendar, campaign time, events, weather generation and override
+- music library, tags, automatic ambience choice, and manual table control
+- loot generation, actual possession or award, finite resources, and later
+  correction
+- fast rules/reference lookup beyond the current Creature and Item subsets
+- campaign notes, rumours, quests, changing relationships, and improvised
+  content created during play
+- cross-feature history and session follow-up
+- local import/export, reference refresh, backup, restore, and failure recovery
+- passive second-monitor presentation without player input
+
+## First Breadth Block: Campaign Foundation And Knowledge
+
+The next owner-answer block must clarify:
+
+1. what the GM creates or selects when beginning a new Campaign and what minimum
+   information must exist before preparation or play can start
+2. which information is reusable reference knowledge across Campaigns and which
+   information belongs to exactly one Campaign
+3. whether and how the GM keeps multiple Campaigns, switches between them, and
+   avoids accidental cross-Campaign changes
+4. how quickly the GM can create an intentionally incomplete NPC, place, item,
+   faction, quest, rumour, or similar fact during play and complete it later
+
+No interpretation of these four questions is confirmed yet.
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Project Vision](../../vision.md)
+- [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
+- [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -204,7 +204,53 @@ The next owner-answer block must clarify:
 4. what happens when the GM deletes an object that current preparation, a
    Running Scene, or completed history still references
 
-No interpretation of these four questions is confirmed yet.
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Hier sollten wir zwischen Roster und Party trennen.
+> Roster ist die gesammtheit aller PCs in der Kampagne, ob grade aktiv ode
+> rnicht. Party sind jene Charaktere, deren Spieler grade mit dem GM am
+> Spieltisch sitzen. Die party kann in mehrere Szenen aufgeteilt werden und
+> oswas, was halt im Spiel passieren kann, das Roster ist aber nur zum managen
+> da.
+
+This introduces two distinct user concepts. `Roster` is the complete managed
+set of Campaign PCs independent of current participation. `Party` is the subset
+whose players currently participate at the table. Splitting those characters
+across Running Scenes does not split the Roster.
+
+> [Owner, wörtlich zu 2] Ja und ja
+
+A Campaign-specific object may be copied to another Campaign and becomes an
+independent object there.
+
+> [Owner, wörtlich zu 3] Ja
+
+Campaign objects of the same kind may share a name.
+
+> [Owner, wörtlich zu 4] es wird aus diesen Dingen entfernt.
+
+This answer confirms removal from current preparation and Running Scene
+references. Its literal inclusion of completed history conflicts with the
+previously confirmed immutable-history rule, under which corrections append and
+past entries are not rewritten. Neither answer is reinterpreted until the owner
+resolves that concrete conflict.
+
+## Required Clarification Before Workflow Confirmation
+
+The next owner-answer block must resolve:
+
+1. whether each Campaign has exactly one Roster and at most one current Party
+   subset, with Scene groups being subdivisions of that Party rather than
+   separate Parties
+2. which PCs Session generation uses before the players physically sit at the
+   table: the whole Roster or an expected-attendance Party selected by the GM
+3. whether deleting an object from completed history means removing only its
+   live link while retaining the historical text/fact, or deleting the
+   historical entry itself despite the earlier immutable-history answer
+4. whether deleting an NPC, Item, or other object that is already used by a
+   Running Encounter removes it from that Encounter immediately
+
+No consolidated Campaign-foundation interpretation is confirmed yet.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
+++ b/docs/project/interviews/program-needs/2026-07-22-foundation-and-coverage.md
@@ -308,6 +308,13 @@ The following compact interpretation awaits explicit owner confirmation:
 None of these bullets enters the program requirements until the owner confirms
 the interpretation as one complete workflow.
 
+## Owner Confirmation
+
+> [Owner, wörtlich] passt
+
+The proposed Campaign-foundation interpretation is confirmed in full on
+2026-07-22 and may enter the draft program requirements.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -418,6 +418,71 @@ whether it exposes any mechanical text remain unanswered.
    textual information such as names, weather, initiative, or HP, and must
    private GM notes always be excluded?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] History wird entfernt
+
+Moving Scene time backward removes history. The exact history entries and
+whether their World consequences are also reversed remain unresolved. This
+conflicts with the earlier confirmed requirement that Campaign history is
+immutable and corrections only append linked entries.
+
+> [Owner, wörtlich zu 2] Kann vergangene Zeit wählen, wird aber informiert das
+> etwas gelöscht werden würde.
+
+When reuniting Scenes, the GM may choose a past resulting time. Before applying
+it, SaltMarcher informs the GM that doing so would delete something. What is
+deleted and whether the GM explicitly confirms or cancels still need
+clarification.
+
+> [Owner, wörtlich zu 3] ja.
+
+The second display follows the currently focused Scene and switches immediately
+when the GM focuses another Scene.
+
+> [Owner, wörtlich zu 4] ja.
+
+The second-display map shows the union of everything at least one character in
+the focused Scene can currently perceive and updates immediately when position,
+line of sight, lighting, or hidden state changes.
+
+> [Owner, wörtlich zu 5] Die Anzeitge enthält nur npc/location artwork und map
+> visuals.
+
+The second display contains only NPC or location artwork and map visuals. It
+never exposes mechanical or textual state such as names, weather, initiative,
+HP, or private GM notes. Whether the GM may blank or manually replace automatic
+visuals remains unanswered.
+
+### Literal Evidence So Far
+
+- Rewinding Scene time deletes history, but the deletion boundary and effect on
+  World state conflict with the earlier immutable-history requirement and are
+  not yet defined.
+- Reuniting Scenes at a past time warns the GM that content would be deleted.
+- The second display immediately follows the focused Scene.
+- Its map uses the union of the focused Scene's character visibility and updates
+  with visibility changes.
+- The display is visual-only: maps and NPC or location artwork, never mechanics,
+  text, or private notes.
+
+## Seventh Breadth Block: Rewind Deletion Boundary And Display Control
+
+1. When a Scene is rewound to time `T`, which history is deleted: every action
+   and event recorded by that Scene after `T`, or only time-progression entries?
+2. Are the deleted events' current World consequences also reversed—for example
+   travel location, Encounter results, XP, NPC death, consumed stock, awarded
+   Items, and possession changes—or does only their history disappear?
+3. If a deleted Scene event affected another Scene or shared Campaign content,
+   does rewind reverse that shared effect too, leave it untouched, or prevent
+   the rewind until the GM resolves the conflict?
+4. Is rewind an intentional exception to immutable Campaign history, so the
+   deleted events vanish even from the audit trail after a warning and explicit
+   confirmation? Or should the audit retain the deletion itself as a correction
+   while hiding the removed events from ordinary history?
+5. Can the GM blank the second display or manually replace its automatic map or
+   background visual at any time?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -274,6 +274,75 @@ of the same type may coexist remain unanswered.
    immediately for that Scene? May the GM override the calculated weather, and
    if so, for how long or until what event?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] ja
+
+Several Encounter masks, several Chase masks, and different mask types may
+coexist for one Scene. The same PC, NPC, or monster may participate in several
+active masks at the same time.
+
+> [Owner, wörtlich zu 2] wird aus der maske entfernt.
+
+Moving a character to another Scene removes that character from every mask the
+character participated in; the masks do not move with the character and do not
+block the Scene move.
+
+> [Owner, wörtlich zu 3] suchen: alle. erstellen: alles, was in erster linie
+> aus notizen besteht: npcs, orte, fraktionen und so. nicht aber komplee
+> datenträger wie items, monstrt o.ä.
+
+The GM can search all content without leaving the Scene. The GM can create
+lightweight, primarily note-based Campaign content there, including NPCs,
+locations, factions, and similar objects. Complete data records such as Items
+or monsters are not created through the Scene. The immediate actions offered by
+a search result remain unanswered.
+
+> [Owner, wörtlich zu 4] szenen können unabhängig voneinander fortschreiten.
+> zeit schreitet voran durch reisen, durch initiative runden in encounter,
+> combat, exploretion etc.
+
+Each Running Scene has an independently advancing time. Travel, initiative
+rounds, combat, exploration, and other time-consuming live actions advance that
+Scene's time. Manual time adjustment and reunification of Scenes with different
+times still need clarification.
+
+> [Owner, wörtlich zu 5] wetter chreitet mit zeit fort. der gm kann es wie
+> musik übersteuern.
+
+Weather advances with Scene time. The GM may override autonomous weather in the
+same manner as automatic music; the scope and release of that override remain
+unanswered.
+
+### Literal Evidence So Far
+
+- Multiple masks of the same or different types may coexist, and one actor may
+  participate in several. A Scene move removes that actor from every mask.
+- Live Scene search covers all content. Scene-local creation is limited to
+  lightweight, note-first Campaign content rather than complete Item or monster
+  records.
+- Split Scenes advance time independently through their actual live actions.
+- Autonomous weather follows Scene time and remains manually overridable.
+
+## Fifth Breadth Block: Search Actions, Time Reconciliation, And Presentation
+
+1. What immediate actions should a Scene search result offer: inspect details,
+   add the content to the Scene, make it travel with the Party, pin it to the
+   Scene, add it to a mask, or something else?
+2. Besides action-driven advancement, can the GM add an arbitrary duration or
+   set an exact Scene time? Are automatically calculated travel, round, combat,
+   and exploration durations editable before they advance time?
+3. When split groups reunite while their Scene times differ, does the earlier
+   group advance to the later time, does the GM choose a shared time, or may the
+   reunited Scene retain some other explicit result?
+4. Is weather calculated separately for every Scene from its local time and
+   location? Does a manual override remain until the GM releases it, after which
+   autonomous weather resumes like music autoplay?
+5. What may the passive second-monitor presentation show during live play, and
+   does it always follow the focused Scene? Must every displayed map, image,
+   handout, combat state, weather state, or other content be explicitly revealed
+   by the GM so private notes can never appear automatically?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -483,7 +483,114 @@ visuals remains unanswered.
 5. Can the GM blank the second display or manually replace its automatic map or
    background visual at any time?
 
-No consolidated interpretation of this workflow is confirmed yet.
+### Owner Correction And Answer 2026-07-22
+
+> [Owner, wörtlich zu 1/2/3/4] Okay, nein, warte, das machen wir nicht.
+> Einträge werden nicht gelöscht, es kann ja auch einfach sein, dass wir nun
+> dinge verfolgen, die "schon passiert sind" (in spiel-logik) aber wir uns am
+> Tisch jetzt erst darauf fokussieren. Wenn wir uns in der Zeit zurück bewegen,
+> und dann andere Dinge passieren, tuen wir einfach so als wäre das schon
+> passiert gewesen. Das ist alles table-talk, wichtig is, es wird nichts
+> gelöscht oder rückgägig gemacht, außer der GM nutz explizit dafür
+> bereitgestellte Löschvoräge.
+
+The owner withdraws the preceding deletion model completely. Moving Scene time
+backward or choosing a past time while reuniting Scenes never deletes history,
+reverses World consequences, or rolls back any other Scene. An event recorded
+later at the table may have an earlier in-world time and is treated as having
+already happened then. Only a GM-invoked operation explicitly provided for
+deletion removes anything. The earlier proposed deletion warning therefore has
+no applicable deletion to warn about.
+
+This correction restores consistency with the confirmed immutable Campaign
+history: temporal focus may move backward, while recorded facts remain and new
+facts may be added at an earlier in-world time.
+
+> [Owner, wörtlich zu 5] ja
+
+The GM can blank the second display or manually replace its automatic map or
+background visual at any time.
+
+## Proposed Consolidated Interpretation For Confirmation
+
+### Continuous Scene State And Party Splits
+
+- The primary Scene is always present as mutable runtime state in the Scene tab;
+  the GM neither creates nor completes it. It may have zero or one location;
+  split Scenes need no name or label.
+- Every active Party character belongs to exactly one Scene. Activating a Roster
+  character assigns that character to the GM-focused Scene. Inactive Roster
+  characters belong to no Scene and retain their last location and other state.
+- The GM moves selected characters into a new or existing Scene through the
+  same action. Empty Scenes are removed and a remaining populated Scene becomes
+  primary. With no active Party, one empty primary Scene remains.
+- A location change replaces the Scene's location-derived content. Any
+  Scene-capable content may instead be pinned to the Scene or assigned to travel
+  with exactly one Party subgroup. Content that leaves or outlives a Scene
+  remains at its location and is never implicitly deleted.
+
+### Masks And Prepared Monster Groups
+
+- Persistent preparation creates editable monster groups at locations, not
+  Encounters. At the current Scene location, the GM selects individual monsters
+  or groups and Scene participants to start an Encounter.
+- Encounter, Chase, and possible future masks add focused runtime behavior over
+  the continuously visible Scene. The Scene remains in the main panel and mask
+  state remains in the adjacent state panel.
+- Several masks of the same or different types may coexist, and one PC, NPC, or
+  monster may participate in several masks. Moving a character to another Scene
+  removes that character from every mask without blocking the move.
+- The GM can end an Encounter through the already confirmed completion
+  workflow; its confirmed consequences apply while the Scene continues.
+
+### Live Search, Creation, Notes, And Music
+
+- The GM can search all content without leaving the Scene and add a result
+  directly to it.
+- The Scene can create lightweight, note-first Campaign content such as NPCs,
+  locations, and factions. Complete data records such as Items and monsters are
+  managed outside Scene-local creation.
+- Relevant object notes remain visible and editable in the Scene, while notes
+  across every object kind remain searchable.
+- The focused Scene drives optional music autoplay. Scene changes update the
+  queue, obsolete songs fade out, and the GM's manual player actions take
+  precedence.
+
+### Independent Time And Weather
+
+- Every Scene advances its own time through travel, exploration, and mask
+  activity. Encounter and Chase rounds last six seconds. Travel duration is
+  calculated and initially not overridable; the GM chooses exploration
+  duration.
+- The GM may increment Scene time forward or backward. When groups with
+  different times reunite, the GM manually chooses their temporal resolution.
+- Moving temporal focus backward never deletes history or reverses World state.
+  Facts entered later with an earlier in-world time are treated as having
+  happened then. Only explicit deletion operations remove anything.
+- Weather advances independently from each Scene's time, location, terrain, and
+  climate data. A GM override remains until the GM disables it, after which
+  autonomous weather resumes.
+
+### Passive Second Display
+
+- The second display immediately follows the focused Scene. During travel it
+  automatically shows the map; at a location it automatically shows background
+  art.
+- Map visibility is the union of what at least one character in the focused
+  Scene can perceive and updates with position, line of sight, light, hidden
+  state, and similar visibility changes.
+- NPC artwork appears only when highlighted by the GM. During Encounter or
+  Chase masks, the GM may enable automatic artwork for the current actor.
+- The display contains only maps and NPC or location artwork. It never exposes
+  mechanics, text, or private notes. The GM can blank it or manually replace its
+  automatic visual at any time.
+
+## Confirmation Requested
+
+This interpretation is ready for owner confirmation. Only after confirmation
+will the complete live-play workflow enter the draft Program Capability
+Requirements and the interview move to spatial travel and campaign-time
+progression.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-22
 Source of Truth: Verbatim owner answers and confirmed interpretations for the
@@ -511,7 +511,7 @@ facts may be added at an earlier in-world time.
 The GM can blank the second display or manually replace its automatic map or
 background visual at any time.
 
-## Proposed Consolidated Interpretation For Confirmation
+## Confirmed Consolidated Interpretation
 
 ### Continuous Scene State And Party Splits
 
@@ -585,12 +585,14 @@ background visual at any time.
   mechanics, text, or private notes. The GM can blank it or manually replace its
   automatic visual at any time.
 
-## Confirmation Requested
+## Owner Confirmation
 
-This interpretation is ready for owner confirmation. Only after confirmation
-will the complete live-play workflow enter the draft Program Capability
-Requirements and the interview move to spatial travel and campaign-time
-progression.
+> [Owner, wörtlich] passt
+
+The owner confirmed the complete consolidated interpretation on 2026-07-22.
+The live-play workflow may therefore enter the draft Program Capability
+Requirements, and the program interview may continue with spatial travel and
+campaign-time progression.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -205,6 +205,75 @@ an Encounter mask with them.
    ends, does the GM return to the same continuously updated Scene with the
    mask's confirmed consequences applied?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Der fokussierten
+
+Activating a Roster character into the current Party assigns that character to
+the currently focused Running Scene.
+
+> [Owner, wörtlich zu 2] Wenn eine Szene leer ist, wird sie entfernt. Die
+> verbleibende Szene ist dann die primäre. Gibt es keine aktive Party werden alle
+> bis auf die primäre szene entfernt.
+
+An empty Scene is removed. When only one populated Scene remains, it becomes the
+primary Scene. If there is no active Party, every Scene except the primary Scene
+is removed and the empty primary Scene remains available.
+
+> [Owner, wörtlich zu 3] Charaktere könen nicht nur in neue, sondern auch in
+> bestehende szenen geschoben werden über das selbe ui element. Verbleibende
+> inhalte bleiben einfach an dem Ort.
+
+The same Scene action moves selected characters either into a new Scene or an
+existing Scene. When the source Scene becomes empty and is removed, its other
+content remains at that Scene's location.
+
+> [Owner, wörtlich zu 4] Der split gruppe, der sie hinzugefügt wurde. es kann
+> nur einer gruppe Folgen.
+
+Content travelling with the Party follows the one split group to which the GM
+assigned it. The same concrete content cannot follow several groups at once.
+
+> [Owner, wörtlich zu 5] Es kann mehrere masken geben, I guess. Der GM muss
+> nicht "zurückkehren," die Szene bleibt unverändet im main panel, die Masken
+> bleiben im state panel neben der Szene.
+
+Several masks may coexist beside one Scene. The Scene remains continuously
+visible and unchanged as the main panel while its masks remain available in the
+adjacent state panel. Ending a mask therefore does not navigate back to the
+Scene. Whether actors may participate in several masks and whether several masks
+of the same type may coexist remain unanswered.
+
+### Literal Evidence So Far
+
+- Party activation assigns the character to the GM-focused Scene.
+- Empty Scenes are removed and a remaining populated Scene becomes primary. If
+  the Party is empty, one empty primary Scene remains available.
+- The same character-move action creates splits and reunites groups. Content
+  from a removed Scene remains at its location.
+- Travelling content follows exactly one split group.
+- The Scene remains the main live workspace while several focused workflow
+  masks can remain beside it in the state panel.
+
+## Fourth Breadth Block: Mask Participation, Lookup, Time, And Weather
+
+1. May several Encounter masks, several Chase masks, and different mask types
+   coexist for one Scene? May the same PC, NPC, or monster participate in more
+   than one active mask at the same time?
+2. If a character moves to another Scene while participating in a mask, is the
+   character removed from that mask, does the mask move with the character, or
+   must the GM resolve the mask first?
+3. During play, what must the GM be able to find or create without leaving the
+   Scene: any Campaign object, reusable rules and definitions, local monster
+   groups and treasures, or something else? Which immediate actions should a
+   search result offer?
+4. How does campaign time advance during live play: does the GM enter an amount,
+   choose common actions or durations, run a clock, or use a combination? With
+   split Scenes, may their local times differ?
+5. When Scene time or location changes, does autonomous weather update
+   immediately for that Scene? May the GM override the calculated weather, and
+   if so, for how long or until what event?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -28,8 +28,9 @@ scope.
 - Current Party membership is authoritative. A character may remain unassigned
   after activation; affected Running Scenes and Encounters reconcile visibly
   without rolling the Party change back.
-- Entering a prepared location exposes its accepted Encounters and treasures in
-  the Running Scene UI without starting or awarding them automatically.
+- Entering a prepared location exposes its accepted monster groups and
+  treasures in the Running Scene UI without starting combat or awarding them
+  automatically.
 - Scene saves remain authoritative when Encounter synchronization is pending.
 - Notes relevant to a Scene are visible and editable there. Weather develops
   autonomously from terrain and climate data.
@@ -50,6 +51,80 @@ scope.
    Encounter directly during play?
 5. What can the GM do with a Running Scene besides continuing it: pause it,
    close it, mark it completed, or discard it? What remains visible afterward?
+
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Die Szene ist immer da. Sie ist runtime zustand und
+> kann imer befüllt werden. Sie ist im Szene Tab immer bereit. Der Gm kann iene
+> zweite szene "starten" indem er die Party aus der eigentlichen szene aufteilt.
+
+The primary Running Scene always exists as mutable runtime state and is always
+ready in the Scene tab. The GM does not create or start it. A second Running
+Scene arises only when the GM splits characters out of the primary Scene.
+
+> [Owner, wörtlich zu 2] Der Gm kann in der Szene charaktere wählen und "in
+> neue szene verschieben" auswählen.
+
+The GM creates a split Scene by selecting characters in the current Scene and
+choosing `move to new Scene`. Whether a character may belong to several Scenes
+or none remains unanswered.
+
+> [Owner, wörtlich zu 3] eine Szene hat null oder einen Ort. Wird der ort
+> gewechselt, dann ähndern sich anwesende NPCs, Features, Treasures etc, es sei
+> denn der Gm schiebt sie in die Party damit sie sich mitbewegen oder fixiert sie
+> an der Szene.
+
+A Running Scene has zero or one current location. Changing that location
+changes its present NPCs, Features, treasures, and other location content. The
+GM can instead make content travel with the Party or pin it to the Scene. The
+exact eligible content and default movement behavior still need clarification.
+
+> [Owner, wörtlich zu 4] Encounter sind eine Maske über der Szene. Sie nehmen
+> PCs und ausgewählte NPCs aus der Szene und fügen HP tracking, initiative etc
+> hinzu. Es gibt in dem Sinne keine "persistierten encounter" sondern nur
+> gruppen von Monstern an Orten oder ohne Ortszuordnung.
+
+An Encounter is a temporary combat mask over a Running Scene. It selects PCs
+and NPCs already present in that Scene and adds combat behavior such as HP
+tracking and initiative. There are no persistent Encounter objects. Prepared
+World content consists of monster groups with or without a location. This
+clarifies and supersedes the earlier preparation wording that called those
+groups persistent Encounters.
+
+> [Owner, wörtlich zu 5] nicht möglich. Die Szene endet nicht, sie verändert
+> sich nur.
+
+A Running Scene cannot be paused, closed, completed, or discarded. It never
+ends; its runtime content only changes.
+
+### Literal Evidence So Far
+
+- The primary Scene is an always-present runtime workspace in the Scene tab.
+  Additional Scenes arise from splitting characters out of it.
+- A Scene has zero or one location. Location changes replace location-derived
+  content unless the GM makes content travel with the Party or pins it to the
+  Scene.
+- An Encounter is a temporary combat mask over Scene participants, not a
+  persistent object. Monster groups are the prepared and placed World content.
+- A Scene has no end or closed state; it changes continuously.
+
+## Second Breadth Block: Split Scenes, Travelling Content, And Combat Masks
+
+1. May a current Party character belong to exactly one Running Scene or none,
+   but never several? When all characters move out of a split Scene, does that
+   empty split Scene disappear, while the primary Scene always remains?
+2. Do split Scenes need a GM-visible name or label, or are their participants
+   and current location enough to distinguish them?
+3. Which content may the GM move with the Party or pin to a Scene: NPCs,
+   monster groups, Features, treasures, individual Items, or all of them? On a
+   location change, does every unpinned and non-travelling object immediately
+   leave the Scene?
+4. May one Scene have only one active Encounter mask at a time? How does the GM
+   leave that mask, and which combat changes remain on the PCs and NPCs after
+   the mask is removed?
+5. To confirm the preparation correction: does Session generation create
+   editable monster groups rather than Encounters, after which the GM selects
+   Scene PCs and NPCs or monsters to enter the temporary Encounter mask?
 
 No consolidated interpretation of this workflow is confirmed yet.
 

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -1,0 +1,61 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Verbatim owner answers and confirmed interpretations for the
+program-wide Running Scene and live table workflow.
+
+# Running Scene And Live Play Interview 2026-07-22
+
+## Scope
+
+This workflow covers what the GM does during table play: starting and resuming
+Running Scenes, assigning and splitting the current Party, changing locations,
+running Encounters and combat, looking up or improvising content, managing
+notes and campaign time, observing autonomous weather, controlling music, and
+using passive presentation. It does not assume today's screens, features, or
+runtime boundaries are the correct target decomposition.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture, contracts, persistence, APIs, and delivery order remain out of
+scope.
+
+## Carried-Forward Evidence
+
+- A Scene is resumable runtime state, not preparation. A split Party may have
+  several distinct Running Scenes, and the GM-focused Scene controls automatic
+  music.
+- Current Party membership is authoritative. A character may remain unassigned
+  after activation; affected Running Scenes and Encounters reconcile visibly
+  without rolling the Party change back.
+- Entering a prepared location exposes its accepted Encounters and treasures in
+  the Running Scene UI without starting or awarding them automatically.
+- Scene saves remain authoritative when Encounter synchronization is pending.
+- Notes relevant to a Scene are visible and editable there. Weather develops
+  autonomously from terrain and climate data.
+
+## First Breadth Block: Running Scene Lifecycle And Encounter Shape
+
+1. How does the GM start the first Running Scene? Must the GM select a location
+   and Party members, or may a Scene start without either? Does a Running Scene
+   need a name?
+2. When the Party splits or reunites, does the GM assign characters manually?
+   May one current Party member belong to more than one Running Scene at once,
+   and may a member remain unassigned?
+3. May a Running Scene have no location or exactly one current location? Can the
+   GM move the same Running Scene to another location without ending it, and
+   should the displayed prepared content change immediately with the location?
+4. How many Encounters may be running inside one Scene at once? May an
+   Encounter span several Running Scenes, and can the GM start an unprepared
+   Encounter directly during play?
+5. What can the GM do with a Running Scene besides continuing it: pause it,
+   close it, mark it completed, or discard it? What remains visible afterward?
+
+No consolidated interpretation of this workflow is confirmed yet.
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Session And Scene Preparation](2026-07-22-session-and-scene-preparation.md)
+- [Confirmed Campaign Foundation](2026-07-22-foundation-and-coverage.md)
+- [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -25,9 +25,10 @@ scope.
 - A Scene is resumable runtime state, not preparation. A split Party may have
   several distinct Running Scenes, and the GM-focused Scene controls automatic
   music.
-- Current Party membership is authoritative. A character may remain unassigned
-  after activation; affected Running Scenes and Encounters reconcile visibly
-  without rolling the Party change back.
+- Current Party membership is authoritative. Earlier evidence allowed an
+  activated character to remain unassigned, but the current live-workflow answer
+  says every active Party character is assigned to exactly one Scene. Which
+  Scene receives a newly activated character remains to be reconciled.
 - Entering a prepared location exposes its accepted monster groups and
   treasures in the Running Scene UI without starting combat or awarding them
   automatically.
@@ -125,6 +126,84 @@ ends; its runtime content only changes.
 5. To confirm the preparation correction: does Session generation create
    editable monster groups rather than Encounters, after which the GM selects
    Scene PCs and NPCs or monsters to enter the temporary Encounter mask?
+
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] charaktere sind immer einer szene zugeordnet. Eine
+> Szene ohne Charaktere verschwindet.
+
+> [Owner, spätere Korrektur zu 1] aktive charaktere in der Party sind immer
+> einer Szene zugeordnet. NIcht aktive roster charaktere snd keiner Szene
+> zugeordnet, bewahren aber ihre letzte location und anderen zustand.
+
+Every active Party character belongs to exactly one Running Scene. An inactive
+Roster character belongs to no Scene but retains the character's last location
+and other state. A Scene with no characters disappears. How this applies to the
+always-available primary Scene, and which Scene receives a newly activated
+character, remain unresolved.
+
+> [Owner, wörtlich zu 2] Nein.
+
+Split Scenes have no names or labels.
+
+> [Owner, wörtlich zu 3] Alles ,was in einer szene sein kann. Inhalte
+> "Verschwinden" nicht. Sie sind nichtmehr in der Szene, aber sie bleiben an dem
+> Ort.
+
+Anything capable of being in a Scene may be made to travel with the Party or be
+pinned to the Scene. On a location change, other location-derived content
+leaves the Scene but remains at its previous location; it is never deleted.
+
+> [Owner, wörtlich zu 4] Ja. Alternativ gibt es auch chase masken und, falls
+> später nötig, andere. Encounter kann vom GM beendet werden, der Workflow
+> existiert bereits und ist richtig so.
+
+A Scene has at most one active Encounter mask. A Chase mask and future mask
+types provide alternative focused workflows over the Scene. The GM can end an
+Encounter using the already accepted Encounter-completion workflow. Whether
+different mask types are mutually exclusive still needs explicit confirmation.
+
+> [Owner, wörtlich zu 5] Ja, monstergruppen werden erstellt und an Orten
+> platziert, ist die Party an diesen Orten (oder verschiebt der GM die Gruppe an
+> den aktuellen szenen Ort) kann er monster oder Gruppen auswählen und einen
+> encounter starten.
+
+Session generation creates monster groups and places them at locations. When
+the Party is at such a location, or after the GM moves a group to the current
+Scene location, the GM can select individual monsters or whole groups and start
+an Encounter mask with them.
+
+### Literal Evidence So Far
+
+- Every active Party character belongs to exactly one Scene. Inactive Roster
+  characters belong to none and retain their last location and other state.
+- Empty Scenes disappear and split Scenes need no name or label. The special
+  case of the primary Scene is still unresolved.
+- Any Scene-capable content may travel with the Party or be pinned to a Scene.
+  Content left behind remains at its location.
+- Encounter, Chase, and possible future masks provide temporary focused
+  workflows over Scene state. The GM can end an Encounter; the Scene continues.
+- Prepared monster groups become eligible for an Encounter only at the current
+  Scene location.
+
+## Third Breadth Block: Assignment, Reunification, And Mask Exclusivity
+
+1. When the GM activates a Roster character into the current Party, does the
+   character enter the primary Scene, the currently focused Scene, or a Scene
+   the GM chooses during activation?
+2. Does `an empty Scene disappears` apply only to split Scenes, so the primary
+   Scene remains available even when the current Party is empty? If the primary
+   Scene is emptied while another Scene has characters, which one is primary?
+3. How does the GM reunite split groups: by moving selected characters into an
+   existing Scene? When the source Scene becomes empty, what happens to content
+   pinned specifically to that disappearing Scene?
+4. When the Party splits, which new Scene receives content currently travelling
+   with the Party? Does the GM choose one Scene for each piece of content, and
+   can the same concrete content ever appear in both?
+5. May a Scene have only one active mask of any type, so starting a Chase or
+   another mask requires ending the current Encounter mask first? When a mask
+   ends, does the GM return to the same continuously updated Scene with the
+   mask's confirmed consequences applied?
 
 No consolidated interpretation of this workflow is confirmed yet.
 

--- a/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
+++ b/docs/project/interviews/program-needs/2026-07-22-running-scene-and-live-play.md
@@ -343,6 +343,81 @@ unanswered.
    handout, combat state, weather state, or other content be explicitly revealed
    by the GM so private notes can never appear automatically?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] zur szene hinzufügen.
+
+A Scene search result offers the immediate action to add that content to the
+current Scene.
+
+> [Owner, wörtlich zu 2] zeit kann inkrementell vor oder urückggedreht werden.
+> automatisch berechnete reisezeiten können erstmals nicht überschrieben werden,
+> das wäre ein low priority qol feature. Encounter und chase runden sind immer 6
+> Sekunden. Exploration wird vom Gm gewählt.
+
+The GM can incrementally move Scene time forward or backward. Automatically
+calculated travel duration is initially binding; overriding it is only a
+low-priority quality-of-life extension. Encounter and Chase rounds always
+advance time by six seconds. The GM chooses the duration of exploration.
+
+> [Owner, wörtlich zu 3] Der Gm wählt resolved das manuell.
+
+The GM manually resolves differing Scene times when groups reunite. The exact
+effect of that resolution on the resulting time and already completed events
+still needs clarification.
+
+> [Owner, wörtlich zu 4] ja. override gillt, bis der Gm ihn abschaltet.
+
+Weather is calculated independently for each Scene from its local time and
+location. A manual override remains in force until the GM disables it, after
+which autonomous weather resumes.
+
+> [Owner, wörtlich zu 5] Die zweitanzeige zeigt die Karte beim reisen, sie kann
+> NPC illustrationen aneigen, wenn der Gm sie highlighted, oder hintergrund art
+> für Orte an denen sich die Charaktere befinden. Hintergrund und map werden
+> automatisch angezeigt, aber begrenzt auf das was Charaktere tatsächlich sehen
+> können (line of sight, licht, verstecktes etc.) illustrationen müssen vom GM
+> gehighlighted werden, im Kampf oder während Chases kann der Gm aber automatisch
+> das artwork des NPCs/PCs der grade dran ist anzeigen.
+
+During travel, the passive second display shows the map. At a location it shows
+background art. Both appear automatically but reveal only what the characters
+can actually perceive after line of sight, lighting, hidden-content, and similar
+visibility rules. NPC illustrations appear only when the GM highlights them.
+During an Encounter or Chase, the GM may enable automatic artwork for the NPC or
+PC whose turn is current. Whether the display follows the focused Scene and
+whether it exposes any mechanical text remain unanswered.
+
+### Literal Evidence So Far
+
+- Search results can be added directly to the current Scene.
+- The GM can increment Scene time forward or backward. Travel duration is
+  initially fixed, Encounter and Chase rounds last six seconds, and exploration
+  duration is chosen by the GM.
+- The GM manually resolves differing Scene times during reunification.
+- Weather is local to each Scene and a manual override persists until disabled.
+- The second display automatically presents visibility-filtered travel maps and
+  location art. Illustrations require a GM highlight, except for optional
+  automatic current-turn artwork in Encounters and Chases.
+
+## Sixth Breadth Block: Time Correction And Presentation Safety
+
+1. When the GM moves Scene time backward, does only the Scene clock and derived
+   state such as weather change, while completed travel, Encounter outcomes,
+   awarded Items, and Campaign history remain untouched?
+2. When the GM manually resolves different Scene times during reunification,
+   can the GM choose the resulting Scene time freely? Does this resolution avoid
+   rewriting either Scene's already completed events and history?
+3. Does the second display always follow the currently focused Scene and switch
+   immediately when the GM focuses another split Scene?
+4. If characters in the focused Scene have different perception, does the map
+   show the union of everything at least one of them can currently see, updating
+   immediately as position, line of sight, light, or hidden state changes?
+5. Can the GM blank, hide, or manually replace the automatic second-display
+   content at any time? Besides artwork and maps, may it show mechanical or
+   textual information such as names, weather, initiative, or HP, and must
+   private GM notes always be excluded?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -1,0 +1,48 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Verbatim owner answers and confirmed interpretations for the
+program-wide Session and Scene preparation workflow.
+
+# Session And Scene Preparation Interview 2026-07-22
+
+## Scope
+
+This workflow covers what the GM prepares before table play: Sessions, planned
+Scenes, expected participants, linked Campaign knowledge, Encounter and reward
+preparation, weather, music, and notes. It does not assume today's Session
+Planner, Scene, Encounter, or generation boundaries are the correct target
+decomposition.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture, contracts, persistence, APIs, and delivery order remain out of
+scope.
+
+## Carried-Forward Evidence
+
+The confirmed project vision already requires the GM to prepare Sessions with
+Scenes, linked places, NPCs, and factions, and to request adjustable Encounter
+or loot suggestions that fit that preparation. The earlier goal interview also
+establishes that current implementation details are too compressed to complete
+the program-level need.
+
+## First Breadth Block: Session And Planned Scene Shape
+
+1. When the GM creates a Session, what minimum information is required? Is a
+   name enough, and is a date optional?
+2. Does one Session represent one expected table sitting, or may one Session
+   intentionally span several real play dates?
+3. How are planned Scenes organized: an ordered sequence, an unordered set,
+   optional alternatives, or a mixture that the GM can rearrange?
+4. When table play begins, do all planned Scenes become Running Scenes, or only
+   the Scenes the GM explicitly starts? May several of them run at once?
+
+No interpretation of this workflow is confirmed yet.
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Campaign Foundation](2026-07-22-foundation-and-coverage.md)
+- [Project Vision](../../vision.md)
+- [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -518,6 +518,17 @@ The owner confirmed the complete consolidated interpretation on 2026-07-22. It
 is therefore eligible to enter the draft Program Capability Requirements. This
 confirmation does not approve any architecture, technology, or delivery plan.
 
+## Later Terminology Clarification 2026-07-22
+
+The subsequent live-play interview clarified that an `Encounter` is a temporary
+combat mask over a Running Scene and is never persistent World content. Every
+reference above to a generated, accepted, or placed Encounter therefore means
+the editable monster group that preparation creates and places. The Encounter
+itself exists only when the GM applies combat tracking to selected Scene
+participants. The current
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md)
+use the corrected terms.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-22
 Source of Truth: Verbatim owner answers and confirmed interpretations for the
@@ -443,7 +443,7 @@ the GM efficiently prepare content and create it as persistent World state. The
 GM can build the same content entirely manually without a planning Party,
 Adventure Day, date, name, or generation.
 
-## Proposed Consolidated Interpretation For Confirmation
+## Confirmed Consolidated Interpretation
 
 ### Planning Workspace And Timeline
 
@@ -510,11 +510,13 @@ Adventure Day, date, name, or generation.
   notes are visible and editable in the Running Scene, and the GM can search
   notes across every kind of object.
 
-## Confirmation Requested
+## Owner Confirmation
 
-This interpretation is ready for owner confirmation. Only after confirmation
-will it enter the draft Program Capability Requirements and let the interview
-move to the live table workflow.
+> [Owner, wörtlich] passt
+
+The owner confirmed the complete consolidated interpretation on 2026-07-22. It
+is therefore eligible to enter the draft Program Capability Requirements. This
+confirmation does not approve any architecture, technology, or delivery plan.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -38,6 +38,55 @@ the program-level need.
 4. When table play begins, do all planned Scenes become Running Scenes, or only
    the Scenes the GM explicitly starts? May several of them run at once?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1, 3 und 4] Es gibt nur eine aktuelle Session. Diese kann
+> im Session Planer überschrieben werden. Dort werden Encounter und treasures
+> erstellt und dann auf Orten platziert. Die Session ist danach nurnoch die
+> Timeline aller geplanten Szenen (wobei es auch nur eine aktuelle Szene gibt.
+> Die vorbereiteten Szenen sind danach nurnoch da, vorbereitet. Wenn die Party
+> den Ort betritt wird es wie in der geplanten Szene sein, aber es gibt keine
+> gespeicherten, vorbereiteten Szenen zwischen denen man wechseln kann.
+
+> [Owner, wörtlich zu 2] Nein das Programm soll die session verweigern, wenn sie
+> nicht mit dem angegebenen Spieltermin übereinstimmt :) Natürlich soll ich sie
+> wiederverwenden können wenn ich will du trottel. Wieso sollten wir dem User
+> solche unnötigen Steine in den Weg legen?
+
+This rejects the question's artificial date restriction. A Session is reusable
+across as many real play dates as the GM wants.
+
+### Literal Evidence So Far
+
+- SaltMarcher has one current Session, which Session preparation may overwrite.
+- Preparation creates Encounters and treasures and places them on locations.
+- The prepared Session becomes a timeline of planned Scene occurrences.
+- Prepared Scenes are not stored workspaces that the GM opens or switches
+  between. Their preparation becomes relevant when the Party enters the
+  corresponding location.
+- There is one current Scene.
+- A Session is not constrained to one date or one real table sitting.
+
+The original question block incorrectly offered unnecessary restrictions. The
+remaining interview uses concrete behavior that follows from this corrected
+shape rather than asking whether SaltMarcher should obstruct reuse.
+
+## Corrected Clarification Block
+
+1. Earlier evidence says the current Party may split across Scenes. Does “one
+   current Scene” mean one focused Scene while other split groups retain
+   background Scene state, or literally one Scene state for the whole Party?
+2. Is one Session-timeline entry primarily an expected visit to a location whose
+   prepared content supplies the Scene, or does the timeline entry also own
+   preparation such as notes, participants, and ordering independently of that
+   location?
+3. When Session preparation overwrites the current Session, should it replace
+   the previous plan immediately or first ask before discarding manual timeline,
+   Encounter, or treasure changes?
+4. When the Party enters a prepared location, do all placed Encounters and
+   treasures enter the current Scene automatically, or do they become prepared
+   options that the GM explicitly activates or awards?
+
 No interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -166,6 +166,57 @@ of the new Session plan.
    Encounter or treasure independently, or is the generated result handled only
    as one complete plan?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] ja
+
+A timeline entry may reference zero or one location, never several. The same
+location may appear in several timeline entries.
+
+> [Owner, wörtlich zu 2] ersteres.
+
+Session generation produces a timeline containing concrete Encounters and
+treasures rather than only a collection for the GM to arrange afterward.
+
+> [Owner, wörtlich zu 3] adventure day, gewünschte Szenen, gewünschte Orte,
+> Fraktionen, NPCs, Items etc. Außer adventure day sind alle optional.
+
+The required generation input is the Adventure Day. The GM may additionally
+specify desired Scenes, locations, factions, NPCs, Items, and further optional
+context.
+
+> [Owner, wörtlich zu 4] ersteres.
+
+The GM controls every generated Encounter and treasure independently: each can
+be edited, regenerated, rejected, accepted, and placed without treating the
+generated Session as one indivisible plan.
+
+### Literal Evidence So Far
+
+- Each timeline entry may reference no location or exactly one location. A
+  location may occur in several entries.
+- Generation creates a Session timeline with concrete Encounters and treasures.
+- Adventure Day is the only required generation input. Desired Scenes,
+  locations, factions, NPCs, Items, and other context are optional inputs.
+- Each generated Encounter and treasure has an independent review, editing,
+  regeneration, acceptance, rejection, and placement lifecycle.
+
+## Fourth Breadth Block: Generation Semantics
+
+1. What does the required `Adventure Day` input tell SaltMarcher in observable
+   terms: a desired total challenge or resource budget, an amount of in-world
+   time, a predefined rules concept, or something else?
+2. What may the GM provide as `desired Scenes`: only a desired count, brief
+   descriptions or goals, already authored timeline entries, or any mixture of
+   these?
+3. Are optional locations, factions, NPCs, Items, and other context binding
+   constraints for generation, or preferences that the result may ignore? May
+   generation create new Campaign content when the supplied Campaign content
+   is insufficient?
+4. When the GM regenerates one generated Encounter or treasure, must all other
+   generated results, manual edits, accepted placements, and timeline changes
+   remain unchanged?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -351,6 +351,68 @@ explicit answer.
    content? Can each contained reward be edited independently before and after
    World placement?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Sogs werden lokal gespeichert und beim einpflegen vom
+> GM kategorisiert.
+
+Songs are stored locally. When the GM adds a song, the GM assigns its music
+categories. Whether those categories remain editable afterward is not yet
+explicitly answered.
+
+> [Owner, wörtlich zu 2] Der GM kann autoplay aktivieren oder deaktivieren.
+> Unterbrechungen an der Szene ändern die automatsch generierte Wateschlange und
+> songs faden langsam aus wenn sie nichtmehr zur aktuellen Situation passen.
+
+The GM can enable or disable autoplay. Scene changes update the automatically
+generated queue. A currently playing song that no longer fits the situation
+fades out gradually rather than stopping abruptly.
+
+> [Owner, wörtlich zu 3] Die aktuell vom GM fokussierte.
+
+When several Running Scenes exist, the Scene currently focused by the GM alone
+drives automatic music selection.
+
+> [Owner, wörtlich zu 4] ja.
+
+Notes for content present in a Running Scene are visible and editable there.
+The GM also has a searchable view across notes attached to every kind of
+object.
+
+> [Owner, wörtlich zu 5] Treasures können Items enthalten. Items können alles
+> von Handelswaren über Münzen bis magic items und equipment sein.
+
+A treasure may contain Items. The Item concept covers trade goods, coins,
+magic Items, equipment, and other kinds of possession. Independent editing of
+the Items inside a treasure remains unanswered.
+
+### Literal Evidence So Far
+
+- The music library and its audio files are local; the GM categorizes songs
+  when adding them.
+- Autoplay is optional. Scene changes recalculate its queue and obsolete music
+  fades out gradually.
+- Only the GM-focused Running Scene drives automatic music when Scenes are
+  split.
+- Object notes are editable in their Running Scene context and searchable
+  across object kinds.
+- A treasure is capable of containing Items, and Items encompass currency,
+  trade goods, magic Items, equipment, and other possessions.
+
+## Seventh Breadth Block: Manual Overrides And Treasure Editing
+
+1. Can the GM change a song's mood, intensity, vibe tags, and genre after
+   adding it to the local library?
+2. While autoplay is enabled, do manually selected, queued, or looped songs
+   take precedence until the GM's manual selection, queue, or loop ends, after
+   which automatic selection resumes?
+3. Can the GM add, remove, replace, and edit every Item within a treasure
+   independently both before and after placement? Can individual Items be moved
+   out of one placed treasure into another treasure or location?
+4. Can the GM create an empty current Session and manually build its timeline,
+   Encounters, treasures, and World placements without a planning Party,
+   Adventure Day, date, name, or any use of generation?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -126,6 +126,46 @@ decides what to do there.
    timeline, its notes, and any unaccepted drafts while leaving every already
    accepted World placement untouched?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] ja ja und ja
+
+The first two literal answers conflict: an entry cannot both require exactly one
+location and allow no location. Repeated use of the same location is confirmed;
+the per-entry location cardinality remains open.
+
+> [Owner, wörtlich zu 2] ja
+
+The GM may manually add, remove, reorder, and annotate timeline entries at any
+time, including after generation.
+
+> [Owner, wörtlich zu 3] Sie sind auch danach weiterhin bearbeitbar, aber ja.
+
+Generated Encounters and treasures remain adjustable before placement. Explicit
+placement accepts them as persistent World state, but acceptance does not make
+them immutable; the GM may continue editing them afterward.
+
+> [Owner, wörtlich zu 4] ja.
+
+Overwriting the current Session replaces its timeline, timeline notes, and
+unaccepted drafts. Accepted World placements remain untouched and independent
+of the new Session plan.
+
+## Third Breadth Block: Generation Result And Control
+
+1. Is the location rule `zero or one location per timeline entry`: an entry may
+   have no location, never several locations, and the same location may appear
+   in several entries?
+2. When the GM generates a Session, does the result contain the timeline plus
+   concrete Encounters and treasures, or does generation create only Encounters
+   and treasures for the GM to arrange into the timeline?
+3. Besides the planning Party, which generation inputs does the GM deliberately
+   choose: session duration or Encounter count, difficulty, locations,
+   factions, reward amount, or something else? Which of them are required?
+4. Can the GM edit, regenerate, accept, reject, and place each generated
+   Encounter or treasure independently, or is the generated result handled only
+   as one complete plan?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -87,7 +87,46 @@ shape rather than asking whether SaltMarcher should obstruct reuse.
    treasures enter the current Scene automatically, or do they become prepared
    options that the GM explicitly activates or awards?
 
-No interpretation of this workflow is confirmed yet.
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] split scenes sind zwei verschiedne. es gibt in dem
+> fall doch mehrere. szenen sind dennoch nuur resumable runtime zustand
+
+This corrects the earlier “one current Scene” statement. Ordinarily there is one
+Running Scene; a split Party creates several distinct Running Scenes. Every
+Scene is resumable runtime state, never a stored preparation workspace.
+
+> [Owner, wörtlich zu 2] er kann notizen enthalten
+
+A Session-timeline entry may contain its own notes. Its remaining relationship
+to location preparation is not yet interpreted.
+
+> [Owner, wörtlich zu 3] Platzierungen bleiben erhalten, die sind jetzt ja
+> einfach prsidtierter welt-zustand ohne weiteren panner-bezug.
+
+Encounter and treasure placements survive Session overwrite because accepted
+placement is persistent World state with no remaining Planner ownership.
+
+> [Owner, wörtlich zu 4] die stehen dann einfach in der szenen ui wo der GM
+> machen kann was er will.
+
+Entering a prepared location exposes its placed Encounters and treasures in the
+Running Scene UI. Nothing starts, resolves, or awards automatically; the GM
+decides what to do there.
+
+## Second Breadth Block: Timeline And Placement Lifecycle
+
+1. Does every Session-timeline entry reference exactly one location, or may an
+   entry have no location and may the same location appear several times?
+2. Can the GM add, remove, reorder, and annotate timeline entries manually at
+   any time, including after generation?
+3. Do generated Encounters and treasures remain adjustable draft suggestions
+   until the GM explicitly accepts their placement as persistent World state?
+4. When the Session Planner overwrites the current Session, does it replace the
+   timeline, its notes, and any unaccepted drafts while leaving every already
+   accepted World placement untouched?
+
+No consolidated interpretation of this workflow is confirmed yet.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -217,6 +217,63 @@ generated Session as one indivisible plan.
    generated results, manual edits, accepted placements, and timeline changes
    remain unchanged?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Aus DMG kann abgeleitet werden, wieviel encounter, xp
+> budget und loot pro adventuring day für x charaktere mit y level eingeplant
+> werden müssten. Das wird für session generation verwendet um encounter und
+> loot zu erstellen.
+
+For the selected planning Party, the Adventure Day derives the expected
+Encounter amount, XP budget, and loot from the DMG guidance using character
+count and levels. Session generation uses that result to create Encounters and
+loot.
+
+> [Owner, wörtlich zu 2] anzahl.
+
+`Desired Scenes` specifies only how many Scenes the generated Session should
+suggest.
+
+> [Owner, wörtlich zu 3] Verbindliche Vorgaben. Sie müssen in den
+> vogeschlagenene Szenen vorkommen.
+
+Every location, faction, NPC, Item, or other context the GM supplies is a
+binding generation constraint and must occur in the suggested Scenes. Whether
+generation may additionally invent new Campaign content remains unanswered.
+
+> [Owner, wörtlich zu 4] ja.
+
+Regenerating one Encounter or treasure leaves every other generated result,
+manual edit, accepted placement, and timeline change untouched.
+
+### Literal Evidence So Far
+
+- Adventure Day generation derives Encounter amount, XP budget, and loot from
+  DMG guidance for the planning Party's character count and levels.
+- The optional desired-Scenes input is a count, not authored Scene content.
+- Every optional Campaign object supplied to generation is mandatory content
+  for the suggested Scenes, not an ignorable preference.
+- Individual regeneration is isolated from all other generated and manually
+  changed preparation.
+
+## Fifth Breadth Block: Additional Content, Weather, Music, And Notes
+
+1. May generation use additional existing Campaign content or create new NPCs,
+   Items, factions, or locations alongside the GM's binding selections? If the
+   selections cannot fit the Adventure Day budget, should generation return no
+   result, return a visibly warned best effort, or ask the GM to change them?
+2. Where does the GM prepare weather: as starting World weather, on individual
+   timeline entries, on locations, or in some combination? When its moment
+   arrives, does it become active automatically or appear as a suggestion for
+   the GM?
+3. What should music preparation provide: playable audio inside SaltMarcher,
+   references to tracks or playlists, or only written cues? What may music be
+   attached to, and does playback ever start automatically?
+4. Which prepared objects need free-form GM notes: the Session, timeline
+   entries, locations, Encounters, treasures, or all of them? When prepared
+   content appears in a Running Scene, should its notes appear there and remain
+   editable?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -413,7 +413,108 @@ the Items inside a treasure remains unanswered.
    Encounters, treasures, and World placements without a planning Party,
    Adventure Day, date, name, or any use of generation?
 
-No consolidated interpretation of this workflow is confirmed yet.
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Der Gm kann songs nachträgich onch über die Dtenbasis
+> verwalten.
+
+After adding songs, the GM can continue managing their categories through the
+local data collection.
+
+> [Owner, wörtlich zu 2] Ja.
+
+Manual selection, queueing, and looping take precedence over autoplay until the
+manual choice ends. Automatic selection then resumes while autoplay remains
+enabled.
+
+> [Owner, wörtlich zu 3] Ja.
+
+The GM can add, remove, replace, and edit every Item inside a treasure before
+and after placement. Individual Items can move from a placed treasure into
+another treasure or location.
+
+> [Owner, wörtlich zu 4] Sessions haben, wie gesagt, keine Namen. Session ist
+> eine Planungsmaske, welche hilft effizient content vorzubereiten und als
+> persistierten Welt-zustand zu erstellen. Aber ja, content kann auch komplett
+> manuell aufgebaut werden.
+
+A Session is not a named content object. It is a planning workspace that helps
+the GM efficiently prepare content and create it as persistent World state. The
+GM can build the same content entirely manually without a planning Party,
+Adventure Day, date, name, or generation.
+
+## Proposed Consolidated Interpretation For Confirmation
+
+### Planning Workspace And Timeline
+
+- `Session` means the planning workspace, not a named or date-bound content
+  object. It exposes one current plan that the GM may reuse or overwrite.
+- The plan becomes an ordered timeline of expected Scene occurrences. Each
+  entry may have notes and zero or one location; one location may occur in
+  several entries. The GM may add, remove, reorder, and annotate entries at any
+  time.
+- Timeline entries are not saved Scene workspaces. A Scene exists only as
+  resumable runtime state. Ordinarily one Running Scene exists; splitting the
+  Party creates several distinct Running Scenes.
+- The GM may prepare every supported content type and World placement manually
+  without a planning Party, Adventure Day, name, date, or generation.
+
+### Assisted Generation
+
+- Generation uses an expected planning Party selected from the Roster without
+  changing the current table Party. It also requires an Adventure Day, from
+  which DMG guidance supplies an Encounter amount, XP budget, and loot budget
+  for the Party's character count and levels.
+- The desired Scene count and selected locations, factions, NPCs, Items, and
+  other Campaign content are optional inputs. Every supplied object is a
+  binding constraint and must occur in the suggested Scenes.
+- SaltMarcher may supplement those constraints with other existing or newly
+  created Campaign content. It validates the constraints before generation. If
+  they cannot fit the Adventure Day, it explains why and disables generation.
+- A generated result includes the timeline plus concrete Encounters and
+  treasures. The GM can independently edit, regenerate, reject, accept, and
+  place each generated Encounter or treasure. Regenerating one result preserves
+  every other result and all manual edits, placements, and timeline changes.
+
+### Persistent World Content And Treasures
+
+- Accepting an Encounter or treasure placement turns it into persistent World
+  state and ends Planner ownership. It remains editable and survives replacing
+  the current plan.
+- Replacing the plan discards its timeline, timeline notes, and unaccepted
+  drafts, but does not change accepted World placements.
+- Entering a prepared location exposes its placed Encounters and treasures in
+  the Running Scene UI. Nothing starts, resolves, or awards automatically; the
+  GM decides what happens.
+- A treasure may contain Items, including coins, trade goods, magic Items,
+  equipment, and other possessions. Each Item remains independently editable
+  before and after placement and may move between treasures and locations.
+
+### Weather, Music, And Notes
+
+- Weather is not prepared in the Session workspace. It develops autonomously
+  from location terrain and other climate data; its live behavior belongs to a
+  later workflow.
+- Songs are stored locally and remain manageable by the GM. The GM categorizes
+  them by mood, intensity, vibe tags, and genre when adding them and may change
+  that data later.
+- Scene sliders provide mood and intensity input; Scene content such as
+  locations, NPCs, factions, and monsters contributes vibe tags and genres.
+  The exact mood axes and categorization model remain subject to product
+  testing.
+- With autoplay enabled, the GM-focused Running Scene drives an automatically
+  generated queue. Scene changes update the queue, and songs that no longer fit
+  fade out gradually. Manual stop, skip, back, selection, queue, and loop
+  controls take precedence; automation resumes when the manual choice ends.
+- Every authored or generated object may carry free-form GM notes. Relevant
+  notes are visible and editable in the Running Scene, and the GM can search
+  notes across every kind of object.
+
+## Confirmation Requested
+
+This interpretation is ready for owner confirmation. Only after confirmation
+will it enter the draft Program Capability Requirements and let the interview
+move to the live table workflow.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
+++ b/docs/project/interviews/program-needs/2026-07-22-session-and-scene-preparation.md
@@ -274,6 +274,83 @@ manual edit, accepted placement, and timeline change untouched.
    content appears in a Running Scene, should its notes appear there and remain
    editable?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ja, wenn es nicht passt wird das vor dem generieren
+> gesagt und der generieren button gesperrt.
+
+Generation may supplement the GM's binding selections with additional existing
+or newly created Campaign content. SaltMarcher validates the binding selections
+against the Adventure Day before generation. If they cannot fit, it explains
+that before generation and disables the generate action; it does not produce a
+partial or best-effort result.
+
+> [Owner, wörtlich zu 2] Garnicht, wetter passiert autonom. Es entsteht
+> basierend auf location terrain und ggf. anderer klima daten.
+
+Weather is not Session or Scene preparation. It develops autonomously from the
+location's terrain and any other available climate data. Its live behavior will
+be clarified in the Running Scene and campaign-time workflows.
+
+> [Owner, wörtlich zu 3] Musik wird autonatisch ausgewählt. Musik wird
+> kategorisiert basierend auf: Mood, Intensität, vibe-tags und genre. Mood und
+> Intensität entstehen aus szene input (GM hat mehrere Slider wie komödie zu
+> tragödie, romanze oder so, das muss später noch getestet werden, wie das am
+> besten zu kategorisieren ist, intensität ist ein eigenen Slider) und Orten,
+> NPCs, Fraktionen, Monstern etc, welche ebenfalls vibe tags und genres
+> zugeordnet sind. Musikauswahl basiert dann also auf Szenen Inhalt, der GM kann
+> aber auch über ein player dropdown im topbar selbst musik stoppen,
+> überspringen, zurückspringen, auswählen, in die Warteschlange setzen oder
+> einen oder mehrere Songs loopen.
+
+SaltMarcher selects music automatically from Scene content. Songs are
+categorized by mood, intensity, vibe tags, and genre. Scene input supplies mood
+and intensity: the GM controls several mood-axis sliders and a separate
+intensity slider. Locations, NPCs, factions, monsters, and other Scene content
+also contribute assigned vibe tags and genres. The exact mood axes and best
+classification model require later product testing and are not fixed yet.
+
+A player dropdown in the top bar lets the GM override automation by stopping,
+skipping, going back, selecting, queueing, or looping one or several songs.
+
+> [Owner, wörtlich zu 4] Alles sollte erstmal potentiell Notizen tragen können,
+> für den Fall dass der GM das braucht.
+
+Every authored or generated object may carry free-form GM notes. Whether notes
+surface automatically and remain editable in Running Scenes still needs an
+explicit answer.
+
+### Literal Evidence So Far
+
+- Binding generation inputs are validated before generation. An impossible
+  combination is explained and disables generation.
+- Weather has no preparation lifecycle; it develops autonomously from terrain
+  and climate data.
+- Music selection is automatic and responds to Scene input and categorized
+  Scene content, while the GM retains the listed top-bar player controls.
+- The concrete mood-axis model is deliberately subject to later usability
+  testing rather than fixed by this interview.
+- Every object may carry GM notes.
+
+## Sixth Breadth Block: Music, Note, And Treasure Boundaries
+
+1. Where do playable songs come from: a GM-managed local music library,
+   external music providers, or both? Can the GM edit every song's mood,
+   intensity, vibe-tag, and genre classification?
+2. Does automatic selection also start playback automatically? When Scene
+   inputs or content change, may SaltMarcher interrupt the current song, or do
+   the new criteria affect only the next automatic selection?
+3. When the Party is split across several Running Scenes, which Scene controls
+   automatic music: the currently focused Scene, a combination of all active
+   Scenes, or a GM-selected Scene?
+4. When noted content appears in a Running Scene, should its notes be visible
+   and editable there automatically? Does the GM also need one searchable view
+   across notes on all kinds of objects?
+5. What does one prepared treasure contain from the GM's perspective: a bundle
+   of currency, valuables, and Items, some other structure, or arbitrary
+   content? Can each contained reward be edited independently before and after
+   World placement?
+
 No consolidated interpretation of this workflow is confirmed yet.
 
 ## References

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -505,6 +505,124 @@ when the GM explicitly marks the conflict resolved.
    should selecting or enlarging the mini-map provide the complete mapped
    travel interaction while controls remain in the state tab?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] additiv ist default
+
+Every newly created generator-factor family uses additive inheritance by
+default. The GM may change that family to replacing inheritance for the place.
+
+> [Owner, wörtlich zu 2] Mehrere Karten, wie Dungeons. Mehrere Karten sollten
+> möglich sein. karten sind unbounded. Hex-durchmasser kann eingetellt werden
+> beim erstellen der Karte. hex karten können nested sein bzw. mehrere "Zoom
+> Stufen" haben, wenn man einen Kontinen erstellen möchte und dann eine genauere
+> Karte einer spezifischen Region erstellen will. Felder haben Terrain,
+> weiterhin müssen Flüsse, Straßen, Klippen und Schluchten eingezeichnet werden
+> können, sowie location marker platziert werden können. Fraktionen können
+> Einfluss auf karten verbreiten, was begegnungschancen dort beeinflusst.
+> karten sollten ex- und importiet werden können, Es sollte möglich sein assets
+> hinzuzufügen. Hex-generatoren sind ein weit entferntes komfort feature.
+> Klimadaten sind eine eigene Ebene überterrain, aber ich habe noch keine Ahnung
+> wie komplex die wetter simulation sein soll oder wie die dazu benötigten
+> karten daten aussehen könnten. Was mir wichtig ist, ist dass der Gm kontrolle
+> über das Wetter hat, wetter ereignisse erstellen und dafür sorgen kann dass
+> verschidene regionen unterschiedliche Klimata haben, und die generation
+> wetter realistisch und sinnvoll graduell sich ändern lässt in reaktion auf
+> Tages und Jahreszeit, sodass plötzliche Umschwünge sinn machen und man nicht
+> in jedem Hex komplett anderes zufälliges Wetter hat, sondern wetterphänomene
+> sich sinnvoll über die map bewegen. ich habe übrigens vergessen zu erwähnen,
+> dass neben Musik auch mehrere Layer an ambiance sound möglich sein sollen,
+> die auf location, wetter und tageszeit basieren.
+
+A Campaign may have several Hex maps. A map has no authored extent limit, and
+the GM chooses its Hex diameter when creating it. Maps may be nested as several
+zoom levels, such as a continent map whose selected region links to a more
+detailed regional map.
+
+Hexes own terrain. The GM can also author rivers, roads, cliffs, ravines,
+location markers, and visual assets. Factions can spread influence across a
+map, which changes local Encounter chances. Hex maps can be exported and
+imported. Procedural Hex generation is only a distant convenience feature.
+
+Climate is a distinct authored layer over terrain. Different regions may have
+different climates. Automatic weather must change gradually and plausibly with
+time of day and season; sudden changes must arise meaningfully rather than from
+independent random weather per Hex. Weather phenomena move coherently across
+the map. The GM retains control and can author weather events. The exact model
+and required climate inputs remain open.
+
+In addition to music, live play supports several simultaneous ambience-sound
+layers selected from location, weather, and time of day. Their sourcing,
+categorization, mixing, and manual controls remain open.
+
+> [Owner, wörtlich zu 3] Ja, alle genannten. Alle genannten.
+
+Terrain, roads, weather, travel mode, Party movement rates, chosen pace, rests,
+carried load, and future applicable travel facts all contribute to Hex route
+and duration calculation. The GM may override every one of those inputs for a
+particular journey. Whether the calculated duration itself remains binding as
+previously confirmed still needs explicit reconciliation.
+
+> [Owner, wörtlich zu 4] Ja, auch hier gibt es fog of war, sichtweite (von
+> Wetter und terrain höhe beeinflusst) und unbekannte regionen und so weiter.
+> Der Gm kann manuell teile der Karte oder bestimmte hex inhalte revealen.
+
+Hex maps distinguish unknown and revealed space through Fog of War. Current
+view distance is affected by weather and terrain elevation. The GM may manually
+reveal map regions or specific Hex content. Whether knowledge belongs to each
+Party subgroup or is shared across the complete Party remains unanswered.
+
+> [Owner, wörtlich zu 5] reist state-tab und mini-map müssen reichen. Der GM
+> soll während einer Session das szenen tab nicht verlassen müssen.
+> Suplementäre informationen und Controls müssen über top bar, details pane und
+> state pane tabs verfügbar sein.
+
+The travel state tab and mini-map provide the complete live travel workflow; no
+separate full travel workspace is required. During a Session the GM does not
+need to leave the Scene tab. Supplementary information and controls remain
+available through the top bar, detail pane, and state-pane tabs.
+
+### Literal Evidence So Far
+
+- Generator-factor inheritance is additive by default and configurable per
+  factor family and place.
+- A Campaign supports several unbounded Hex maps with chosen Hex diameter,
+  nested zoom levels, terrain, linear map features, locations, visual assets,
+  faction influence, and import or export.
+- Climate is separate from terrain. Coherent weather changes with region, time,
+  and season, moves across the map, and remains under GM control.
+- Live audio includes several simultaneous ambience layers driven by location,
+  weather, and time alongside music.
+- All applicable travel inputs affect route and duration and may be overridden
+  for a particular journey.
+- Hex exploration has Fog of War, weather- and elevation-sensitive view range,
+  unknown regions, and manual GM reveal.
+- The GM controls complete live travel from the Scene tab through the travel
+  state, mini-map, top bar, detail pane, and state pane.
+
+## Seventh Breadth Block: Map Scale, Factions, Weather, And Ambience
+
+1. How do nested Hex-map zoom levels relate? Does a parent-map region or Hex
+   explicitly link to a child map, and are terrain, locations, travel position,
+   faction influence, or other facts synchronized automatically between those
+   levels, or authored independently at each scale?
+2. How does faction influence spread across a Hex map: only through direct GM
+   editing, automatically as campaign time advances, through faction actions,
+   or a combination? Besides Encounter chances, what must influence visibly
+   affect or expose to the GM?
+3. What minimum climate facts must the GM be able to author for a region, and
+   what controls are required for weather events: area or path, start time,
+   duration, intensity, movement, and manual start, change, or end? Which parts
+   may SaltMarcher derive automatically?
+4. Are ambience sounds local files managed and categorized like songs? Which
+   tags or roles distinguish simultaneous layers, and must the GM be able to
+   start, stop, replace, loop, and independently adjust each layer while
+   automatic selection continues for the others?
+5. To reconcile the two confirmed answers: may the GM override all inputs used
+   to calculate a journey while the resulting calculated duration itself
+   remains non-editable, or should the GM now also be able to override the final
+   duration directly?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -845,6 +845,162 @@ terrain. The duration of manual ambience additions or removals remains open.
    ends, should automatic environment matching and mix balancing resume from
    the Scene's current location, weather, and time?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ja. Je feinkörniger das System, desto besser, jedoch
+> ohne die user experience zu stark zu belasten.
+
+Every map may use a quick fallback climate preset plus regional climate zones
+which replace or modulate it. The resulting climate may be as fine-grained as
+the product can make useful without burdening the GM. Whether the technical
+model blends overlaps or resolves one effective zone is not itself a user
+decision; the required outcome is quick broad setup with optional precise local
+control.
+
+> [Owner, wörtlich zu 2] Bestimmte Kreaturen könnten bestimmte Wetter oder
+> Tageseiten oder so bevorzugen, aber ertmal reichen die vorgeschlagenen
+> Punkte. Es sollte allerdings nicht zu schwierig sein, weitere einflüsse
+> später hinzuzufügen.
+
+The initial structured weather effects cover view distance, travel duration or
+cost, perception, temperature, ambience, and music. Combat-facing consequences
+such as disadvantage on ranged attacks may remain prominent GM-facing notes
+rather than automatic adjudication. Creature preferences for weather or time
+of day are a credible later extension, and adding such influence families must
+not require redesigning unrelated weather behavior.
+
+> [Owner, wörtlich zu 3] Eine Pop-up benachrichtigun reicht. Sie sollte
+> bleiben, bis das Wetter wieder verschwindet oder der GM sie weg-klickt.
+
+Mechanically relevant weather updates its structured effects and produces a
+persistent pop-up associated with the affected Scene or Scenes. Travel need not
+pause merely because weather arrived. The notification remains until the
+weather no longer applies or the GM dismisses it; how notifications from
+several Scenes are grouped is a later interaction-design choice.
+
+> [Owner, wörtlich zu 4] Ja. Nein, das wäre zu kompliziert, ein allgemeines
+> "revealen" tool oder so wäre praktischer.
+
+The passive map for the focused Scene shows the union of map knowledge held by
+the characters currently in that Scene. SaltMarcher does not require a
+character-to-character knowledge-copy workflow. A general GM reveal tool is
+the simpler required interaction for adding selected map knowledge to relevant
+characters.
+
+> [Owner, wörtlich zu 5] Ja. Ja. Zusatz: Es ist nicht entweder automatisch
+> oder manuell, der GM kann der automatischen auswahl dinge hinzufügen oder
+> dinge aus ihr entfernen.
+
+Manual ambience changes persist until the GM releases them, after which
+automatic matching and balancing resume from the Scene's current place,
+weather, and time. Manual control is an additive and subtractive overlay on the
+automatic selection: the GM may add sounds to it and suppress sounds from it
+without replacing automation as a whole.
+
+### Literal Evidence So Far
+
+- Climate authoring combines a quick fallback with optionally fine-grained
+  regional control, bounded by low GM setup and operation cost.
+- Initial structured weather effects cover visibility, travel, perception,
+  temperature, ambience, and music. Combat rulings remain GM-facing, and new
+  influence families must remain easy to add later.
+- Mechanically relevant weather creates a persistent notification but does not
+  force travel to stop.
+- The focused Scene's passive map unions the knowledge of its current
+  characters. Knowledge changes use a general GM reveal interaction rather
+  than explicit character-to-character copying.
+- Manual ambience additions and suppressions coexist with automatic selection
+  and persist until released; automation then resumes from current Scene
+  context.
+
+## Proposed Consolidated Interpretation For Owner Confirmation
+
+This interpretation is not yet canonical program truth. It consolidates the
+complete workflow for confirmation without choosing architecture, storage,
+simulation algorithms, or UI implementation beyond explicitly required GM
+interactions.
+
+1. `Travel` is one live GM workflow for the focused Scene across ordinary
+   places, Hex maps, and Dungeons. The GM works from the Scene tab through the
+   travel state tab, optional mini-map, top bar, detail pane, and state pane;
+   live travel does not require opening a separate workspace.
+2. A direct move selects an adjacent destination. A longer journey uses travel
+   points and a route within the current map. Cross-map route planning is a
+   desirable optional convenience, not a binding core capability.
+3. Travel advances position, campaign time, weather, tracks, perception,
+   events, and applicable autonomous World behavior. The GM may pause, resume,
+   change presentation speed, reroute, end, or step through several travel
+   checkpoints with undo and redo. Presentation speed does not alter in-world
+   duration.
+4. The GM may override any factors used to calculate travel duration, the final
+   duration, or both. A final-duration override is authoritative while active.
+5. Events, Traps, relevant tracks, and perceived NPCs interrupt travel at a
+   committed checkpoint for GM inspection. Perception makes an NPC available
+   in the Scene; an Encounter begins only after explicit GM confirmation.
+6. Travel undo removes the selected journey segment and everything that
+   segment alone introduced, but preserves facts already established by a
+   later authoritative Scene. An interruption is itself a travel checkpoint.
+7. Full places are Scene boundaries. Subplaces, Dungeon navigation areas, and
+   exact cells refine location inside the same Scene. Different full places
+   imply different Scenes; moving only part of a group creates or joins another
+   Scene, while moving the complete group changes the existing Scene's place.
+8. Places form a nested hierarchy on Hex and Dungeon maps. Unmapped places are
+   valid administrative Scene locations, but choosing one is not travel and
+   advances no time automatically.
+9. Weather, music tags, ambience context, and configurable loot, Encounter,
+   and faction-appearance factors flow through place hierarchy according to
+   their confirmed rules. Factor families may be additive or replacing per
+   place, with additive behavior as the default.
+10. Split Scenes advance independently. World behavior for an in-world period
+    is processed once and reused when an earlier Scene reaches that period. The
+    furthest-advanced Scene remains authoritative for shared World facts.
+11. The GM normally avoids earlier-time contradictions. If the GM knowingly
+    removes or changes something that already has later dependent history,
+    SaltMarcher warns, permits the change, marks affected history as
+    conflicting, and provides manual resolution whose marker clears only when
+    the GM confirms resolution.
+12. The solution-independent ideal is that the complete Campaign World
+    progresses with confirmed campaign time. Optional Actor Autonomy remains
+    GM-enabled and bounded; Party involvement pauses before autonomous danger
+    resolution, while permitted non-Party behavior may proceed. Later
+    technical work must determine how to meet this outcome at practical scale.
+13. A Hex map is one continuous, unbounded authored map with predetermined
+    mouse-wheel zoom levels from local three-mile Hexes to world scale. Several
+    such maps may exist. Coarse facts provide finer defaults, while detailed
+    edits recalculate coarse aggregates.
+14. Hex authoring supports terrain, rivers, roads, cliffs, ravines, location
+    markers, assets, GM-authored faction influence, import and export, Fog of
+    War, unknown regions, visibility affected by weather and elevation, and
+    manual reveal. Procedural Hex generation and autonomous faction simulation
+    remain distant extensions.
+15. Character-specific map knowledge is durable. The Party view is the union
+    of the characters in the focused Scene, and a general GM reveal tool adds
+    selected knowledge without requiring character-to-character transfer
+    bookkeeping.
+16. Weather uses a quick fallback climate plus paintable or otherwise
+    modulatable regional climate zones. Seasonal baselines and coherent moving
+    phenomena produce gradual, geographically sensible weather without
+    per-Hex random discontinuities or burdensome meteorological setup.
+17. The GM may author weather events with type, affected area, intensity,
+    movement, time extent, notes, and mechanical effects, and may pause, edit,
+    or end them. Structured effects initially cover visibility, travel,
+    perception, temperature, ambience, and music. Other influence families can
+    be added without rewriting unrelated behavior.
+18. Mechanically relevant weather updates its effects and creates a persistent
+    Scene-associated notification until the weather ends or the GM dismisses
+    it. It does not by itself force a travel stop. Combat-facing rulings may
+    remain prominent notes for GM adjudication.
+19. Music and ambience use locally managed, categorized files. Weather and
+    environment layers combine automatically and SaltMarcher balances the mix.
+    The GM may add sounds to or suppress sounds from the automatic selection;
+    those choices persist until released, then automation resumes from current
+    Scene context.
+
+If the owner confirms this interpretation, Workflow 4 can enter the draft
+Program Capability Requirements and the interview can continue with Workflow
+5: follow-up, possessions, progression, World consequences, history, and
+corrections.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -178,6 +178,95 @@ advance through overlapping in-world periods.
    GM see while focusing the earlier Scene B: the already current state from
    12:00, a historical 11:00 view, or some other behavior?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Wetter, Musik, Faktoren für Loot und begegnungs
+> generatoren, NPCs, Fraktionen und weiteres können vererbt werden.
+
+Weather, music selection, factors used by loot and Encounter generation, NPCs,
+factions, and other relevant place content may be inherited from containing
+places by their subplaces. Which inheritance is automatic, configurable, or
+overridable remains to be clarified.
+
+> [Owner, wörtlich zu 2] Nein. Navigationsbereiche in einem Raum sind nicht
+> verschiedene Orte, sie sind der selbe ort. Das Hinterzimmer in der Taverne
+> ist ebenfalls eher ein Unterort. Wenn die Taverne zwei Zimmer hat und die
+> party sich verteilt, dann werden das nicht zwei verschiedene Szenen. Ich
+> schätze hier müssen wir wirklich zwischen Orten und unterorten unterscheiden.
+
+Exact cells and navigation areas inside one Room are not separate places. A
+back room or another internal part of a tavern is a `subplace`, not necessarily
+a separate place. Party members distributed across such subplaces remain in
+one Scene. The product therefore needs an explicit distinction between places,
+which provide the co-location boundary of a Scene, and subplaces, which refine
+position and content within that boundary without creating Scenes.
+
+> [Owner, wörtlich zu 3] Ich wüsste nicht, wie wir das in der UI umsetzen
+> könnten, also würde ich erstmal nein sagen. Wäre aber cool wenn.
+
+The initial product need does not require one planned route to cross map
+boundaries. The owner considers that behavior desirable, but its status as a
+long-term target need rather than an optional future extension remains open
+because the answer was based on present UI uncertainty.
+
+> [Owner, wörtlich zu 4] Verlangsamung der Darstellung, echtzeit-dauer.
+> Rückgängig setzt die Reise und ihre Resultate zum letzten Punkt zurück.
+
+Accelerating or slowing changes presentation speed only; it does not change the
+journey's calculated in-world duration. Undo returns the journey and its results
+to the preceding travel point. The exact consequence boundary and treatment of
+the immutable Campaign history still need clarification.
+
+> [Owner, wörtlich zu 5] Wenn Szene A von 10-12 läuft haben wir die autonomen
+> Handlungen für 11 ja schon simuliert. Wir können einfach auf diesen für szene
+> A vergangenen Stand zurückgreifen und ihn für Szene B zur Gegenwart machen.
+
+Autonomous World behavior for a given in-world period is simulated only once.
+When an earlier Scene reaches a time already processed through a later Scene,
+SaltMarcher reuses the corresponding earlier World state and presents it as the
+earlier Scene's current state. The observable behavior when that Scene adds a
+new fact or consequence which was not part of the already processed future
+remains to be clarified.
+
+### Literal Evidence So Far
+
+- Places provide Scene-level co-location. Subplaces, exact cells, and navigation
+  areas refine position inside that same Scene boundary.
+- Containing places may contribute weather, music, generator factors, NPCs,
+  factions, and other content to their subplaces.
+- Planned routes initially remain within one map. Cross-map planning is desired
+  but not yet classified as a binding long-term need.
+- Route speed controls presentation speed rather than in-world travel time.
+  Undo returns travel and its results to the prior travel point.
+- Independently timed Scenes reuse already processed autonomous World state for
+  the same in-world period rather than simulating it again.
+
+## Third Breadth Block: Inheritance, Undo, And Earlier-Time Changes
+
+1. Is inheritance chosen separately per kind of place content and per concrete
+   object? For example, can the GM inherit a tavern's music and weather into its
+   back room, include one tavern NPC there, exclude another, and override the
+   inherited Encounter-generator factors specifically for that back room?
+2. Does creating or moving Party members into a new Scene remain an explicit GM
+   action regardless of their places and subplaces? In other words, may one
+   Scene temporarily contain characters at different full places if the GM has
+   not split them yet, or must different full places always imply different
+   Scenes?
+3. Ignoring how the UI would achieve it: should cross-map route planning be a
+   binding long-term target capability, merely an optional later convenience,
+   or explicitly outside the intended product?
+4. If the GM presses undo after a travel segment triggered a Trap or event,
+   revealed an NPC, changed weather, created tracks, or caused autonomous World
+   actions, which of those results are reversed? Does Campaign history retain
+   the original journey and its undo as an explicit correction, or should the
+   undone segment disappear from ordinary history?
+5. Scene A has already established a World state at 12:00. Scene B then plays at
+   11:00 and creates a new consequence that would have affected that future—for
+   example, it kills or moves an NPC whom Scene A encountered at 12:00. Should
+   the 12:00 history remain exactly as experienced while the new consequence
+   changes only the World state from now on, or should SaltMarcher recalculate
+   any part of the already established future?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-22
 Source of Truth: Verbatim owner answers and confirmed interpretations for the
@@ -913,12 +913,12 @@ without replacing automation as a whole.
   and persist until released; automation then resumes from current Scene
   context.
 
-## Proposed Consolidated Interpretation For Owner Confirmation
+## Confirmed Consolidated Interpretation
 
-This interpretation is not yet canonical program truth. It consolidates the
-complete workflow for confirmation without choosing architecture, storage,
-simulation algorithms, or UI implementation beyond explicitly required GM
-interactions.
+The owner confirmed this complete interpretation on 2026-07-22. It is the
+evidence promoted into the draft Program Capability Requirements without
+choosing architecture, storage, simulation algorithms, or UI implementation
+beyond explicitly required GM interactions.
 
 1. `Travel` is one live GM workflow for the focused Scene across ordinary
    places, Hex maps, and Dungeons. The GM works from the Scene tab through the
@@ -996,10 +996,8 @@ interactions.
     those choices persist until released, then automation resumes from current
     Scene context.
 
-If the owner confirms this interpretation, Workflow 4 can enter the draft
-Program Capability Requirements and the interview can continue with Workflow
-5: follow-up, possessions, progression, World consequences, history, and
-corrections.
+Workflow 4 is confirmed. The interview continues with Workflow 5: follow-up,
+possessions, progression, World consequences, history, and corrections.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -623,6 +623,132 @@ available through the top bar, detail pane, and state-pane tabs.
    remains non-editable, or should the GM now also be able to override the final
    duration directly?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Es handelt sich um eine Karte in die tatsächlih
+> einfach mit dem mausrad hineingezoomt werden kann. Es gibt eine
+> vorausbestimmte Menge an zo-stufen von einem lokal regionalen 3 meilen hex is
+> zur Weltkarte.
+
+The zoom levels are not separate linked maps. One continuous Hex map supports a
+predetermined set of mouse-wheel zoom levels, ranging from local or regional
+three-mile Hexes to a world-map scale. How authored detail appears or aggregates
+across those levels remains to be clarified.
+
+> [Owner, wörtlich zu 2] Erstmal wird er wir terrain vom GM gesetzt. Autonome
+> fraktions simulation ist ein weit-weit-weit entferntes feature. Ungefähr so
+> weit entfernt wie die vtt und spieler-facing funktionen.
+
+Faction influence is initially authored directly by the GM like terrain. An
+autonomous faction simulation is parked as a very distant extension, comparable
+to VTT and player-facing functionality, and does not constrain the local GM
+core.
+
+> [Owner, wörtlich zu 3] Ich weiß es nicht. Hier brauche ich deine Hilfe und
+> Recherche. Es muss für den GM simpel und schnell umzusetzen sein. Es sollte
+> kein unnötig großer Aufwandt sein eine wetter simulation auf der Karte
+> einzurichten.
+
+The exact climate inputs remain open and require source-backed assistance. The
+binding user need is that setting up useful map weather remains quick and
+simple for the GM and does not require unnecessary meteorological authoring.
+
+> [Owner, wörtlich zu 4] Ja, ambiance funktioniert wie Musik. nein, er muss
+> nicht jedes Layer unabhängig starten. Wetter ist ein layer und
+> location-basierte ambiance layert sich automatisch. Der GM kann eigene Sounds
+> hinzufügen oder automatische entfernen. Außerdem muss das Programm versuchen
+> sie bestmöglich zu balancen.
+
+Ambience uses locally managed and categorized audio like music. Weather sound
+forms one layer and location-based ambience layers automatically with it. The
+GM need not operate every layer independently, but can add a chosen sound or
+remove an automatically selected one. SaltMarcher automatically balances the
+combined layers as well as possible.
+
+> [Owner, wörtlich zu 5] Der GM kann die entgültige Reisedauer überschreiben
+> oder alle faktoren, aus denen sie sich ergibt. Er kann auch beides machen, nur
+> dann sind die faktoren irrelevant, weil das ergebnis bereits überschrieben
+> wurde.
+
+The GM may override the calculated journey duration, any of its input factors,
+or both. A direct duration override is authoritative, so input changes no
+longer affect that journey's duration while the override remains in force. This
+supersedes the earlier answer that calculated travel duration was initially
+non-editable.
+
+### Literal Evidence So Far
+
+- One continuous Hex map supports predetermined zoom levels from local
+  three-mile Hexes to world scale.
+- Faction influence is GM-authored for the local core; autonomous faction
+  simulation is parked as a distant extension.
+- Weather setup must be fast and simple and needs a source-backed minimal input
+  model rather than assumed meteorological complexity.
+- Ambience uses local categorized audio. Weather and location layers combine
+  automatically, the GM can add or remove sounds, and SaltMarcher balances the
+  mix.
+- The GM can override travel inputs, final calculated duration, or both; the
+  final-duration override wins.
+
+## Research Evidence For Minimal Climate Authoring
+
+The World Meteorological Organization describes climatological normals as both
+a benchmark and an indicator of conditions likely at a location. Its ordinary
+climate representation uses monthly means or totals. This supports a seasonal
+expected-condition baseline rather than requiring the GM to author daily
+weather. Evidence: `/home/aaron/Schreibtisch/projects/references/climate-weather/wmo-climatological-normals.md`
+([public source](https://wmo.int/wmo-climatological-normals)).
+
+NOAA explains that local weather results from large atmospheric patterns plus
+local geography, latitude, moisture, and solar input. Air masses and fronts
+cover large areas and move across the world. This supports coherent moving
+weather phenomena with local modifiers rather than unrelated random weather in
+each Hex. Evidence: `/home/aaron/Schreibtisch/projects/references/climate-weather/noaa-weather-systems-patterns.md`
+([public source](https://www.noaa.gov/education/resource-collections/weather-atmosphere/weather-systems-patterns)).
+
+The product inference from these sources is deliberately simpler than a real
+forecasting model:
+
+- a new map starts with one map-wide climate preset
+- the GM may optionally paint broad climate regions and choose another preset
+  for each
+- a preset supplies seasonal expected temperature, precipitation or
+  storminess, and prevailing weather movement without exposing raw scientific
+  parameters
+- terrain, elevation, water, time of day, and season provide automatic local
+  variation where their facts are available
+- a GM-authored weather event needs only a recognizable type, affected area,
+  intensity, movement, and time extent; SaltMarcher derives local transitions
+  and effects
+
+This is a research-informed proposal for owner confirmation, not yet confirmed
+product truth. Pressure fields, humidity curves, or detailed atmospheric
+simulation are not justified user inputs unless later evidence requires them.
+
+## Eighth Breadth Block: Minimal Weather Setup, Map Detail, And Knowledge
+
+1. Is the proposed default setup sufficient: choose one map-wide climate preset
+   and do nothing else, with optional painted climate regions for exceptions?
+   Should the preset expose only understandable seasonal summaries such as
+   temperature, wetness or storminess, and prevailing weather movement?
+2. Is this sufficient for authored weather events: choose a type such as rain,
+   snow, fog, storm, heat, cold, or strong wind; paint its starting area; set
+   intensity, movement direction and speed, start time, and duration; then let
+   SaltMarcher derive gradual local transitions? May the GM edit, move, pause,
+   or end the event at any time?
+3. On the one continuous multi-zoom map, does the GM author at whichever zoom
+   level is useful while SaltMarcher aggregates or reveals detail at the other
+   levels? For example, should a local road or location disappear at world
+   scale while regional terrain and faction influence remain summarized?
+4. Is Hex-map knowledge separate for each split Party subgroup, so one group
+   does not automatically reveal discoveries to another until the GM shares or
+   reunites their knowledge? Does a manual GM reveal change durable group
+   knowledge or only the passive display presentation?
+5. For automatic ambience, does the GM categorize each imported sound by its
+   role or context, such as weather, location, time of day, or general
+   background? Should a manual addition or removal last until the GM releases
+   the override, after which automatic selection and balancing resume?
+
 ## References
 
 - [Program Needs Interview Series](README.md)
@@ -631,3 +757,9 @@ available through the top bar, detail pane, and state-pane tabs.
 - [Dungeon Travel Requirements](../../../dungeon/requirements/requirements-dungeon-travel.md)
 - [Actor Autonomy Requirements](../../../autonomy/requirements/requirements-actor-autonomy.md)
 - [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)
+- WMO climatological normals:
+  `/home/aaron/Schreibtisch/projects/references/climate-weather/wmo-climatological-normals.md`
+  ([public source](https://wmo.int/wmo-climatological-normals))
+- NOAA weather systems and patterns:
+  `/home/aaron/Schreibtisch/projects/references/climate-weather/noaa-weather-systems-patterns.md`
+  ([public source](https://www.noaa.gov/education/resource-collections/weather-atmosphere/weather-systems-patterns))

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -67,6 +67,117 @@ program-wide truth.
    What should happen when autonomous activity reaches the Party or requires a
    GM decision?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Ja. GM nutz das reisen state tab und ggf. eine
+> mini-map im detail pane. Je nach Fortbewegungsart kann er auf hex-karten oder
+> in dungeons routen planen oder direkt angrenzende Bereiche (locations auf dem
+> hex, benachbarte hexes, benachbarte naigationsbereiche im Dungeon etc)
+> auswählen. Für eine Route werden reisepunkte gewählt, und eine route von
+> punkte zu punkt erstellt. Für direkt angrenzende Reise muss nur die jeweilige
+> Loation als button gewählt werden. Routen können angehalten, vorgespult oder
+> verlangsamt werden. Es gibt eien rückgängig-button.
+
+Travel is one GM workflow in the travel state tab, optionally supported by a
+mini-map in the detail pane. Depending on the movement context, the GM either
+selects directly adjacent locations or navigation areas, or chooses travel
+points from which SaltMarcher constructs a route. The GM can pause, accelerate,
+slow, and undo route progress. The observable meaning of speed changes and undo
+still needs clarification.
+
+> [Owner, wörtlich zu 2] die "Szene" ist alles ,was grade am selben Ort wie
+> die Party ist. Wenn der Ort "Taverne Löwenzahn" vom GM angelegt wurde sich
+> dort zwei NPCs aufhalten, eine magisches Item, und die Party, dann ist das die
+> aktuelle Szene.
+
+A Scene consists of everything currently at the same place as its Party
+subgroup. For example, if two NPCs, a magic Item, and the Party are at the
+authored place `Taverne Löwenzahn`, they form the current Scene there. This
+clarifies Scene content as a view of current co-location rather than an
+independent collection. How nested places, exact actor positions, pinned
+content, and narrative splits affect co-location still needs clarification.
+
+> [Owner, wörtlich zu 3] "Normale Orte" existieren auf Karten. Hex nr. 34 ist
+> ein Ort, auf dem sich der Ort "Dorf langen Weiler" existieren kann, in dem
+> der Ort "Taverne Löwenzahn" existieren kann, in dem der Ort "Hinterzimmer"
+> existieren kann. Räume sind Orte auf Dungoen Karten. Es kann orte geben, die
+> nicht einer karte zugeordnet sind, und die kann der GM dann eifach als
+> location auswählen, das ist aber keine Reise. In dem Fall muss er Zeit
+> manuell vorschtellen um ggf. Reisezeit zu simulieren. Was soll das heißen
+> "Als dieselbe Reise erhalten bleiben?"
+
+Places form a nested spatial hierarchy on maps: a Hex is a place and may
+contain a village, which may contain a tavern, which may contain a back room.
+Dungeon Rooms are places on Dungeon maps. An authored place may also have no
+map assignment. The GM may select such an unmapped place as the Scene's
+location, but this is an administrative location change rather than travel and
+does not advance time automatically. The GM advances time manually if desired.
+Whether one planned route may cross map and hierarchy boundaries was not
+understood from the original wording and remains to be asked concretely.
+
+> [Owner, wörtlich zu 4] Korrekt. Pausieren müsen davon nur ereignisse,
+> Fallen, Spuren falls die Party nach ihnen ausschau hällt, Wahrnehmung wenn die
+> party NPCs wahrnimmt.
+
+Ordinary travel may immediately advance position, time, weather, perception,
+tracks, and applicable event evaluation. Travel pauses for events and Traps,
+for tracks when the Party is actively looking for them, and when Party
+perception detects NPCs. These pauses do not themselves decide a fictional
+outcome.
+
+> [Owner, wörtlich zu 5] Das ist eine technische Frage, die ich nicht
+> beantworten kann und hängt davon ab, wieviel wir auf einmal simulieren
+> können. Im idealfall sollte die gesammte Kampagnen Welt sich autonom mit der
+> Party "mitdrehen" wann immer die Zeit voranschreitet, aber das ist nicht
+> unbedingt praktikabel.
+
+The solution-independent target need is that the entire Campaign World advances
+autonomously with the Party whenever campaign time advances. The later
+technical-needs and architecture work must determine what computation strategy
+can satisfy that observable goal at the required scale. The product interview
+still needs to define the expected result when independently timed split Scenes
+advance through overlapping in-world periods.
+
+### Literal Evidence So Far
+
+- Travel is one GM workflow with direct adjacent movement and planned routes
+  across mapped spatial contexts.
+- A Scene presents the Party subgroup and everything co-located with it at an
+  authored place.
+- Places may be nested on Hex and Dungeon maps. Selecting an unmapped place is
+  an administrative location change, not travel, and advances no time.
+- Ordinary travel progression is automatic, while events, Traps, relevant
+  tracks, and detected NPCs pause further travel for GM attention.
+- The ideal target advances the complete autonomous Campaign World whenever
+  campaign time advances; technical practicality must not silently redefine
+  that user need.
+
+## Second Breadth Block: Co-Location, Route Boundaries, And Time Semantics
+
+1. Does a Scene automatically include every object at its most specific current
+   place, plus relevant content inherited from containing places? In the
+   example `Hex 34 > Langen Weiler > Taverne Löwenzahn > Hinterzimmer`, what
+   appears when the Party is in the back room: only back-room content, or also
+   selected content from the tavern, village, and Hex?
+2. May characters in one Scene occupy different exact cells or neighboring
+   navigation areas while still being considered at the same place? Does only
+   the GM decide when separation becomes a new Scene, or should entering a
+   different authored place split or move characters automatically?
+3. Concretely, may one planned route contain points across map boundaries—for
+   example `Hex 34 > Langen Weiler > Taverne Löwenzahn > Hinterzimmer` or from
+   one Hex map through a Dungeon entrance into a Dungeon Room—or does travel
+   stop at each boundary and require the GM to start the next leg?
+4. Do accelerate and slow change only how quickly SaltMarcher presents the same
+   calculated journey, without changing its in-world duration? What exactly
+   does `undo` reverse: only an uncommitted route choice, the last completed
+   segment's position and time, or also events and other consequences produced
+   during that segment?
+5. Suppose Scene A advances the World from 10:00 to 12:00 while Scene B remains
+   at 10:00, and Scene B later advances to 11:00. Should autonomous World actors
+   progress only once for the 10:00-to-11:00 period? What World state should the
+   GM see while focusing the earlier Scene B: the already current state from
+   12:00, a historical 11:00 view, or some other behavior?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -429,6 +429,82 @@ original later history is not automatically recalculated or erased.
    link a corrective entry, or delete it? When is the conflict marker removed,
    and must the resolution itself remain visible in history?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] individuell
+
+The GM chooses additive or replacing inheritance independently for each factor
+family, including loot, Encounter composition, faction appearance, and future
+families. The default for a new place remains unanswered.
+
+> [Owner, wörtlich zu 2] Alles was Bs reise hinzugefügt hat wird zurückgesetzt.
+> Alles was A bereits etabliert hatte wird behalten.
+
+Undo removes everything introduced by Scene B's journey, including B's
+position, time, local results, and journey-owned World consequences. Anything
+already established by the authoritative later Scene A remains unchanged. Undo
+therefore respects the authority of the furthest-progressed Scene rather than
+rewriting its established truth.
+
+> [Owner, wörtlich zu 3] Ja. Eine Unterbrechung gilt als Reisepunkt, an dem die
+> Reise gestoppt und der Zwischenzustand festgehalten wird. Ja.
+
+Movement and elapsed time up to an interruption are already committed. Every
+interruption is a travel point: travel stops there and its intermediate state is
+preserved. The GM can inspect and resolve or dismiss the interruption, resume
+the route, choose another route, or end travel at that point.
+
+> [Owner, wörtlich zu 4] Ja.
+
+An interruption appears in the same Running Scene and travel state rather than
+creating another Scene. A perceived NPC becomes visible in the Scene
+immediately; starting an Encounter still requires explicit GM confirmation.
+
+> [Owner, wörtlich zu 5] Ja. Die markierung verschwindet, wenn der GM sie als
+> resolved markiert.
+
+Manual conflict resolution may keep an acknowledged inconsistency, edit its
+facts or time, link a corrective entry, or delete the conflicting entry. The
+resolution remains visible in Campaign history. Its conflict marker disappears
+when the GM explicitly marks the conflict resolved.
+
+### Literal Evidence So Far
+
+- Generator-factor inheritance mode is selected independently per factor
+  family.
+- Undo removes only what the earlier Scene's journey introduced and preserves
+  truth already established by the authoritative later Scene.
+- Every interruption commits a travel point and intermediate state before the
+  GM inspects, resolves, dismisses, reroutes, resumes, or ends travel.
+- Interruptions remain within the same Scene and travel state. Perceived NPCs
+  appear immediately, but Encounters still require GM confirmation.
+- Conflicting history supports acknowledgement, editing, correction, or
+  deletion. Resolution remains visible, and the GM explicitly clears the
+  marker by marking it resolved.
+
+## Sixth Breadth Block: Hex Maps And General Travel Controls
+
+1. What inheritance default should a newly created place use for each generator
+   factor family: additive, replacing, inherited from its parent, or explicitly
+   unset until the GM chooses?
+2. What must the GM be able to author for Hex maps: several maps per Campaign,
+   map name and scale, map extent, terrain per Hex, roads or other connections,
+   nested places, and links to other maps? Must maps begin empty, may the GM
+   import an image or data, and is procedural Hex generation a target need?
+3. When planning Hex travel, which facts determine the calculated route and
+   duration: terrain, roads, weather, travel mode, Party movement rates, chosen
+   pace, rests, carried load, or something else? Which of those may the GM
+   override for a particular journey?
+4. What does the GM and passive second display know about an unexplored Hex
+   map? Should Hexes distinguish unknown, previously explored, and currently
+   perceivable information, and should visibility belong to each Party subgroup
+   or be shared across the complete Party?
+5. You established the travel state tab as the GM's travel control surface,
+   optionally with a mini-map in the detail pane. Is a separate full Hex or
+   Dungeon travel workspace also required for route planning and inspection, or
+   should selecting or enlarging the mini-map provide the complete mapped
+   travel interaction while controls remain in the state tab?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -350,6 +350,85 @@ defined.
    keep, edit, or delete, or is a simpler manual correction interface enough?
    Whatever the GM chooses, what should remain visible in Campaign history?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Wird pro ort eingestellt, ob additiv oder
+> überschreibend gearbeitet wird.
+
+Each place defines whether its loot- and Encounter-generator factors add to the
+inherited factors or replace them.
+
+> [Owner, wörtlich zu 2] genau.
+
+If selected members of a Scene travel to another place, the travel action
+creates a new Scene for them. If the complete Scene travels together, the same
+Scene changes its place.
+
+> [Owner, wörtlich zu 3] Hmm... Die am weitesten fortgeschrittene Szene behällt
+> die Authorität.
+
+The Scene at the greatest in-world time retains authority over shared World
+state. An earlier Scene's travel undo cannot silently replace shared truth
+already established by that authoritative Scene. The precise user-visible undo
+result in that case remains to be clarified.
+
+> [Owner, wörtlich zu 4] Ja, es gibt ein redo zum undo und es gibt mehrere
+> tiefen von undo. Alle genannten.
+
+Travel provides multi-level undo and redo. Every adjacent move, selected route
+point, pause, and explicitly marked point establishes an undo point.
+
+> [Owner, wörtlich zu 5] Der GM kann sich dazu entscheiden dinge zu einem
+> Zeitpunkt zu entfernen, obwohl sie später schon history erzeigt haben. In
+> diesem Fall wird er gewarnt und muss, wenn er trotzdem weiter macht, alle
+> konflikte manuell resolven. Nicht sofort, aber entsprechende history einträge
+> werden als konfliktierend markiert.
+
+The GM may deliberately remove something at an earlier in-world time even when
+it already produced later history. SaltMarcher warns before the removal. If the
+GM proceeds, dependent later history entries are marked as conflicting and the
+GM resolves every conflict manually. Resolution need not be immediate. The
+original later history is not automatically recalculated or erased.
+
+### Literal Evidence So Far
+
+- Every place chooses additive or replacing inheritance for its loot- and
+  Encounter-generator factors.
+- Partial-group travel creates a new Scene; whole-Scene travel moves the
+  existing Scene to the destination place.
+- The Scene furthest ahead in in-world time is authoritative for shared World
+  state.
+- Travel has multi-level undo and redo across adjacent moves, route points,
+  pauses, and explicit points.
+- Earlier removal which contradicts later history requires a warning, marks
+  dependent history as conflicting, and leaves manual resolution to the GM
+  without blocking unrelated work or automatically rewriting history.
+
+## Fifth Breadth Block: Authoritative Time And Travel Interruptions
+
+1. Is the additive-versus-replacing generator setting one shared choice for all
+   loot and Encounter factors at a place, or may the GM choose independently
+   for loot, Encounter composition, faction appearance, and other factor
+   families? What default should a newly created place use?
+2. Scene A is authoritative at 12:00. Scene B at 11:00 undoes a travel segment
+   whose autonomous results contributed to A's World state. Should B's own
+   position, time, and local travel results still undo while the shared World
+   results remain as established by A, with a conflict marker? Or should the
+   undo be unavailable until the GM resolves the shared conflict?
+3. When an event, Trap, detected NPC, or relevant track pauses travel, has the
+   just-completed movement and elapsed time already taken effect? Which actions
+   must the GM have immediately: inspect, resolve or dismiss the interruption,
+   resume the route, choose a different route, or end travel at the current
+   point?
+4. Does a travel interruption appear as context inside the same Running Scene
+   and travel state, rather than creating another Scene? When an NPC is
+   perceived, does that NPC become visible in the Scene immediately while an
+   Encounter still requires separate GM confirmation?
+5. For a history entry marked as conflicting, what must manual resolution let
+   the GM do: keep it as an acknowledged inconsistency, edit its facts or time,
+   link a corrective entry, or delete it? When is the conflict marker removed,
+   and must the resolution itself remain visible in history?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -709,9 +709,9 @@ each Hex. Evidence: `/home/aaron/Schreibtisch/projects/references/climate-weathe
 The product inference from these sources is deliberately simpler than a real
 forecasting model:
 
-- a new map starts with one map-wide climate preset
-- the GM may optionally paint broad climate regions and choose another preset
-  for each
+- a new map may start quickly with one map-wide fallback climate preset
+- a world-to-local map supports painted broad climate regions which replace or
+  modulate that fallback
 - a preset supplies seasonal expected temperature, precipitation or
   storminess, and prevailing weather movement without exposing raw scientific
   parameters
@@ -748,6 +748,102 @@ simulation are not justified user inputs unless later evidence requires them.
    role or context, such as weather, location, time of day, or general
    background? Should a manual addition or removal last until the GM releases
    the override, after which automatic selection and balancing resume?
+
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Wenn eine Karte von weltkarte bis lokaler region
+> zoomen kann, dann reicht ein einziges Preset nicht aus, oder es muss mit
+> malbaren klima zonen ergänzt oder anders moduliert werden können.
+
+One map-wide climate preset alone is insufficient for a continuous world-to-
+local map. The GM must be able to paint climate zones or otherwise modulate the
+baseline regionally. A map-wide preset may remain a quick fallback, but regional
+climate variation is binding behavior rather than an optional exception.
+
+> [Owner, wörtlich zu 2] Wetterereignisse müssen auch Notzinen enthalten
+> können, wie z.b. "nachteil auf vernkampf angriffe" oder Reisezeit, sichtweiter
+> etc. beinflussen können. Wenn ein mechanisch relevantes Wetterereigniss
+> stattfindet muss der Gm informiert werden. Ich wüsste nicht, wie der GM ein
+> ereigniss verschieben können sollte. Pausieren, bearbeiten und beenden können
+> sollte er es aber schon.
+
+Weather events may carry free-form GM notes and mechanically relevant effects,
+including travel duration, view distance, or a note such as disadvantage on
+ranged attacks. SaltMarcher informs the GM when a mechanically relevant weather
+event occurs. The GM can pause, edit, or end an event. Direct manual relocation
+is not a required interaction; coherent automatic movement remains part of the
+weather behavior.
+
+> [Owner, wörtlich zu 3] Ja. Andersherum, wenn ein hex auf der Weltkarte berg
+> terrain hat und man hineinzoom sollte das Terrain entsprechend vererbt
+> werden. Wird es auf der regionalen Ebene geändert wird das globale hex aus
+> dem aggregat neu berechnet.
+
+The GM authors at the useful zoom level while SaltMarcher presents appropriate
+detail at other levels. Coarse facts propagate downward: a mountain Hex at
+world scale supplies corresponding terrain when zooming in. Fine changes
+propagate upward through aggregation: editing regional terrain recalculates the
+coarse world Hex from its detailed contents.
+
+> [Owner, wörtlich zu 4] Puh... Einerseits wäre es schon cool, wenn jeder
+> Charakter eigenes Karten Wissen hat, andererseits könnte das aber auch
+> anstrengend werden, wenn informationen geteilt werden oder charakter A im
+> roleplay charakter B eine Wegbeschreibung gibt... Ich schätze wen der GM
+> manuell teil der karte revealen und dem charakterwissen hinzufügen kann ist
+> charakter-spezifisches wissen aber cooler als generelles roster wissen. Die
+> Party sieht ja sowieso das aggregat aller charaktere.
+
+Map knowledge belongs to individual characters rather than to the Roster or
+Party as a single store. The GM can manually reveal map regions or content and
+add that knowledge to selected characters. The Party-facing view aggregates its
+characters' knowledge. The exact sharing workflow and the relationship to
+focused split Scenes still need confirmation.
+
+> [Owner, wörtlich zu 5] Ambiance wird nach der Art der umgebung kategorisiert.
+> Z.b. "Stadt" "Wald" "Hafen" "Menschenmenge" etc. Orte können entsprechend
+> getaggt werden (oder erhalten das per terrain)
+
+Ambience sounds are categorized by environment types such as city, forest,
+harbour, or crowd. Places carry matching tags explicitly or derive them from
+terrain. The duration of manual ambience additions or removals remains open.
+
+### Literal Evidence So Far
+
+- World-scale weather setup requires regionally paintable or otherwise
+  modulated climate zones; one undifferentiated map preset is insufficient.
+- Weather events carry notes and mechanical effects. The GM is notified of
+  mechanically relevant weather and may pause, edit, or end an event.
+- Multi-scale authored truth propagates both ways: coarse terrain supplies
+  finer defaults, while detailed edits recalculate coarse aggregates.
+- Map knowledge belongs to individual characters. Party presentation is an
+  aggregate, and the GM may add revealed knowledge to selected characters.
+- Ambience and places use environment tags which may be explicit or
+  terrain-derived.
+
+## Ninth Breadth Block: Weather Effects, Knowledge Sharing, And Overrides
+
+1. Is this climate setup sufficient: every map has a fallback climate preset,
+   while the GM may paint climate zones that replace or modify that baseline?
+   May zones overlap and blend, or should every map position resolve to exactly
+   one effective climate zone plus local terrain modifiers?
+2. Which weather effects should SaltMarcher apply automatically as structured
+   values: view distance, travel duration or cost, perception, temperature,
+   ambience, and music? Should combat-facing effects such as ranged-attack
+   disadvantage remain prominent GM notes rather than being adjudicated
+   automatically?
+3. When mechanically relevant weather reaches a Scene, should SaltMarcher only
+   notify the GM and update its effects, or must active travel pause at a new
+   travel point? Should the GM receive notifications for every affected Scene
+   or only the currently focused one?
+4. With character-specific map knowledge, does the focused Scene's passive map
+   show the union of only the characters currently in that Scene, preserving
+   the previously confirmed split-Scene behavior? Must the GM be able to copy
+   selected knowledge from one character to chosen others after an in-fiction
+   explanation or map exchange?
+5. When the GM manually adds or removes an ambience sound, does that override
+   remain until explicitly released, like weather and music overrides? When it
+   ends, should automatic environment matching and mix balancing resume from
+   the Scene's current location, weather, and time?
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -1,0 +1,77 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Verbatim owner answers and confirmed interpretations for the
+program-wide spatial travel and campaign-time progression workflow.
+
+# Spatial Travel And Progression Interview 2026-07-22
+
+## Scope
+
+This workflow connects ordinary Campaign places, Hex exploration, Dungeon
+exploration, travel, position, events, perception, tracks, and optional Actor
+Autonomy to the already confirmed Running Scene model. It asks what the GM must
+experience across those contexts without assuming that today's features,
+screens, state owners, or spatial detail levels are the correct target
+decomposition.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture, contracts, persistence, APIs, and delivery order remain out of
+scope.
+
+## Carried-Forward Confirmed Evidence
+
+- Every active Party character belongs to exactly one Running Scene. Split
+  Scenes progress independently, and the focused Scene controls the passive
+  second display.
+- Dungeon exploration already has accepted long-term needs for cell-precise
+  actor positions, routes, calculated travel time, interruptions, perception,
+  tracks, and a visibility-filtered map.
+- Dungeon travel distinguishes rule-based travel from a deliberate GM position
+  override. A completed travel segment changes position and time together;
+  events may interrupt later progress.
+- Optional Actor Autonomy advances only with GM-confirmed campaign time. Party
+  involvement pauses before autonomous danger resolution, while bounded
+  non-Party conflict may continue.
+- Hex travel and the transitions between ordinary places, Hexes, and Dungeons
+  have not yet been integrated into the program-wide workflow.
+
+These accepted feature needs remain evidence, but any wording that assumes one
+undivided Party, one global active context, or a feature-owned runtime must be
+reconciled with the now-confirmed Scene and Party behavior before it becomes
+program-wide truth.
+
+## First Breadth Block: One Journey Across Spatial Detail Levels
+
+1. Is `Travel` one continuous GM workflow for the focused Scene regardless of
+   whether the group moves between ordinary Campaign places, across a Hex map,
+   or through a cell-precise Dungeon? What does the GM choose to begin it: only
+   a destination, a route, a duration, a travel mode, or some combination?
+2. Which positions must exist at the same time? Does a Running Scene or Party
+   subgroup have one shared position, while individual PCs, NPCs, monster
+   groups, and travelling content may additionally have their own exact
+   positions? When does spatial separation require a new Scene rather than
+   several positions inside one Scene?
+3. When travel crosses from an ordinary place into a Hex map or Dungeon, or
+   back out again, should the same journey continue with its elapsed time,
+   route progress, travelling content, and participants intact? What should the
+   GM see or decide at that transition?
+4. During travel, which consequences may SaltMarcher apply immediately without
+   another GM confirmation: position and time progress, weather, perception,
+   tracks, planned events, random events, trap prompts, or something else?
+   Which of them must pause travel before any further segment is applied?
+5. When time advances in one Running Scene, which autonomous NPCs and monster
+   groups should also advance: only actors at that Scene's location, every
+   enabled actor in the same spatial context, or all enabled Campaign actors?
+   What should happen when autonomous activity reaches the Party or requires a
+   GM decision?
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Running Scene And Live Play](2026-07-22-running-scene-and-live-play.md)
+- [Dungeon Needs Interview](../2026-07-20-dungeon-needs-interview.md)
+- [Dungeon Travel Requirements](../../../dungeon/requirements/requirements-dungeon-travel.md)
+- [Actor Autonomy Requirements](../../../autonomy/requirements/requirements-actor-autonomy.md)
+- [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)

--- a/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
+++ b/docs/project/interviews/program-needs/2026-07-22-spatial-travel-and-progression.md
@@ -267,6 +267,89 @@ remains to be clarified.
    changes only the World state from now on, or should SaltMarcher recalculate
    any part of the already established future?
 
+### Owner Answers 2026-07-22
+
+> [Owner, wörtlich zu 1] Wetter wird auf hex-basis gemacht und an alle
+> sub-locations vererbt. Musik-relevante Tags werden vererbt, wenn der Sub-Ort
+> keine eigenen bereitstellt. Mit NPCs und fraktionen meine ich, dass Orte
+> definieren können, welche Fraktionen eine chance haben dort aufzutauchen, das
+> wird ebenfalls vererbt wenn es nicht explizit überschrieben ist.
+
+Weather is determined at Hex level and inherited by every subplace. Music tags
+use fallback inheritance: a subplace inherits them only when it supplies none
+of its own. Places do not inherit concrete NPCs or factions as Scene members.
+Instead, a place defines which factions have a chance to appear there; a
+subplace inherits those appearance factors unless it explicitly overrides
+them.
+
+> [Owner, wörtlich zu 2] Ja. Nein. Uerschiedliche Orte edeuten unterschiedliche
+> szenen.
+
+Creating or moving Party members into another Scene remains an explicit GM
+action. A Scene cannot contain Party members at different full places: different
+places imply different Scenes, while subplaces within the same place do not.
+
+> [Owner, wörtlich zu 3] Wäre cool wenn, muss aber nicht.
+
+Cross-map route planning is an optional future convenience, not a binding
+long-term target need.
+
+> [Owner, wörtlich zu 4] Ja. Nein.
+
+Travel undo reverses the listed results of the last segment, including triggered
+Traps or events, NPC discovery, weather changes, tracks, and autonomous World
+actions. The original segment and its undo do not remain visible in ordinary
+Campaign history. Travel undo is therefore an explicit, narrow exception to the
+otherwise immutable-history behavior. Its interaction with shared consequences
+observed by other Scenes still needs clarification.
+
+> [Owner, wörtlich zu 5] Das ist die Art von Zeitparadoxon, das ein GM im Spiel
+> sowieso vermeiden muss. Es sollte dafür explizite Tools geben um sowas zu
+> resolven wenn notwendig, aber die default annahme sollte sein, dass das
+> einfach nicht passiert weil der GM es vermeidet.
+
+The default product assumption is that the GM avoids introducing consequences
+at an earlier Scene time which contradict an already established future.
+SaltMarcher need not automatically rewrite that future. It must nevertheless
+provide explicit GM tools to resolve such a paradox when it occurs. The
+required detection, choices, and resulting history behavior remain to be
+defined.
+
+### Literal Evidence So Far
+
+- Hex weather always flows to subplaces. Music tags and faction-appearance
+  factors use fallback inheritance with explicit subplace replacement.
+- Concrete NPCs are not inherited as Scene members merely because a containing
+  place can generate appearances from their faction.
+- Different places require different Scenes; subplaces do not. Scene splitting
+  and character movement remain explicit GM actions.
+- Cross-map route planning is optional convenience rather than binding scope.
+- Route undo reverses every result of the latest segment and removes the segment
+  from ordinary history, creating a narrow exception to immutable history.
+- Earlier-time paradoxes are GM-avoided by default and resolved through explicit
+  tools rather than automatic future rewriting.
+
+## Fourth Breadth Block: Scene Movement, Shared Undo, And Paradox Repair
+
+1. How do loot- and Encounter-generator factors inherit across `Hex > place >
+   subplace`: does a child with its own factors replace the parent set entirely,
+   or may the GM combine selected parent and child factors?
+2. If only part of a Scene travels to another full place, does that travel
+   action itself create a new Scene for the selected characters? If every Party
+   member in the Scene travels together, does the same Scene simply change its
+   place?
+3. If undoing a travel segment would reverse autonomous actions or other World
+   changes that another Scene has already observed or depended on, should undo
+   still proceed, be blocked, or require the GM to resolve the conflict first?
+4. Can the GM press travel undo repeatedly to step back through several travel
+   points, and is there a corresponding redo? What establishes an undo point:
+   every adjacent move, every selected route point, every pause, or only points
+   the GM explicitly marks?
+5. What explicit paradox-resolution tools does the GM need? Should SaltMarcher
+   detect and flag likely contradictions, then let the GM choose which facts to
+   keep, edit, or delete, or is a simpler manual correction interface enough?
+   Whatever the GM chooses, what should remain visible in Campaign history?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -333,6 +333,143 @@ closes those gaps rather than inheriting the current implementation.
    Klassenfähigkeiten, Zaubern und regelvollständigem Equipment wäre weiterhin
    kein Kernbedarf.
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ersteres
+
+Each Campaign has a configurable fantasy calendar with authored month lengths,
+day length, weekdays, and year counting rather than being limited to a
+real-world calendar.
+
+> [Owner, wörtlich zu 2] ja, events wie feiertage oder sowas sollten im
+> kallender angelegt werden können. Sie sollten zeit und ortsgebunden sein
+> können.
+
+The GM can author calendar events such as holidays. An event may be bound to a
+time, a place, or both and becomes relevant to a Running Scene according to that
+Scene's time and location. It informs the GM or offers prepared content without
+automatically deciding narrative consequences.
+
+> [Owner, wörtlich zu 3] ersteres. Sie sind die Grundlage für Fraktionen und
+> anderes.
+
+Named, GM-editable Encounter Tables with weighted Monster or group entries are
+a real Campaign concept. Factions, places, and other context reference those
+tables as a foundational source for Encounter candidate pools and generation;
+contextual tags and other factors may further influence selection.
+
+> [Owner, wörtlich zu 4] nein
+
+SaltMarcher does not provide a general-purpose GM dice roller. The GM continues
+to roll ordinary table dice physically; generators and simulations may use
+internal randomness for their own automatic behavior.
+
+> [Owner, wörtlich zu 5] ja, alle für automatische systeme relevanten stats
+> müssen getrackt werden.
+
+A PC record tracks every structured statistic required by enabled automatic
+systems, including applicable level, XP, current and maximum HP, movement, and
+senses. Only the name remains universally required; a specific automatic
+workflow may require its relevant optional statistics before it can run. This
+does not turn SaltMarcher into a complete character-sheet, spell, class-feature,
+or rules-complete equipment manager.
+
+## Proposed Consolidated Interpretation For Confirmation
+
+This interpretation remains interview evidence until the owner confirms it.
+It establishes program-wide observable qualities and product boundaries without
+choosing architecture, storage, frameworks, extension technology, or delivery
+order.
+
+1. The complete local GM core works offline when its required rules, media, and
+   Campaign data are present locally. Network use occurs only through explicit
+   imports, downloads, GM-approved extension permissions, or future online
+   capabilities.
+2. Ordinary live-play actions respond without perceptible delay. Longer
+   generation, import, and simulation work is visible, cancellable, and runs
+   without making the Running Scene unusable.
+3. Failure of supporting music, weather, maps, generation, or World progression
+   affects only that capability. Running Scenes, Encounters, manual editing,
+   and preservation of confirmed work remain usable, with a clear error and
+   retry for the affected function.
+4. SaltMarcher supports practically large, long-lived Campaigns without
+   artificial content limits. Under exceptional load it degrades predictably
+   instead of truncating data or failing unpredictably. Representative scale
+   and response budgets are derived later through realistic scenarios and
+   tests.
+5. Capability areas can be added, omitted, removed, or replaced without
+   breaking unrelated workflows or Campaign data. New runtime masks, content
+   kinds, influences, and supporting systems can integrate without rebuilding
+   existing features.
+6. Cancellation or failure of a long operation keeps only independently
+   accepted results. Unconfirmed partial results are discarded cleanly.
+7. If new work cannot be persisted safely, SaltMarcher reports that immediately
+   and never presents it as stored. Safe reading, export, and retry remain
+   available.
+8. Application updates preserve Campaigns and resumable runtime state. A failed
+   data conversion leaves prior data untouched and usable with the prior
+   application version.
+9. Damage to one record does not prevent the remaining Campaign from opening.
+   SaltMarcher isolates and identifies the record and offers recovery or
+   explicit deletion.
+10. Data belonging to a disabled, missing, or temporarily unavailable
+    capability remains intact, stays in complete exports, and becomes usable
+    again when the capability returns.
+11. Linux, Windows, and macOS are supported desktop targets with portable
+    Campaign behavior across them.
+12. SaltMarcher runs fluidly on an ordinary current laptop without a dedicated
+    GPU or server hardware. Resource-intensive simulation adapts to available
+    resources rather than blocking live play.
+13. The GM installs a self-contained desktop application without separately
+    administering a database server, web server, runtime, or other
+    infrastructure.
+14. One local GM is the sole Campaign writer in the confirmed core. The passive
+    second display reads live state; concurrent multi-process, multi-computer,
+    or multi-user Campaign editing is not required.
+15. Campaign data, notes, maps, images, audio, and usage data leave the computer
+    only through a concrete, understandable GM action. There is no mandatory
+    cloud dependency, hidden upload, or telemetry enabled by default.
+16. D&D 5e 2014 is the only binding core rules profile. Supporting several D&D
+    versions or other game systems is parked as very late quality-of-life work
+    and does not require a generic multi-system core now.
+17. The interface is localizable for additional languages. Campaign-authored
+    text remains arbitrary user content independent of interface language.
+18. The complete core supports keyboard operation, scalable text and
+    interface, sufficient contrast, and information which does not rely on
+    color alone. These alternatives do not clutter the default interface or
+    slow its low-friction workflows.
+19. The interface remains usable at common laptop resolutions, on high-density
+    displays, and across multiple monitors. Touch, mobile, and smartphone
+    layouts are not core targets.
+20. The GM can install third-party extensions, plugins, or scripts. Each is
+    installed explicitly and discloses requested Campaign-data, file, network,
+    and other access before activation.
+21. Extensions have no default network or unrestricted file access. Additional
+    permissions require explicit GM consent.
+22. A faulty, damaged, missing, or update-incompatible extension is disabled
+    and identified without preventing SaltMarcher or the Campaign from opening.
+    Its data remains intact and an application update does not let it rewrite
+    Campaign data because compatibility failed.
+23. Extensions may add content kinds, runtime masks, generators, importers, and
+    presentations. They cannot silently bypass explicit deletion, local data
+    control, truthful history, or other confirmed safety boundaries.
+24. Each Campaign has a configurable fantasy calendar with authored month
+    lengths, day length, weekdays, and year counting.
+25. The GM can author calendar events such as holidays. Events may be bound to
+    time, place, or both and become relevant according to each Running Scene's
+    time and location without automatically deciding narrative consequences.
+26. Named, GM-editable Encounter Tables contain weighted Monster or group
+    entries. Factions, places, and other context use them as foundational
+    sources for Encounter candidate pools and generation, alongside applicable
+    contextual influences.
+27. SaltMarcher has no general-purpose GM dice roller. Ordinary table dice stay
+    physical; automatic generators and simulations may use internal randomness.
+28. A PC tracks every structured statistic required by enabled automatic
+    systems. Only its name is universally required; an automatic workflow may
+    require its relevant optional statistics before running. SaltMarcher does
+    not thereby become a complete character-sheet or rules-complete inventory
+    manager.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -177,6 +177,49 @@ becomes usable again when that capability returns.
    Aktion verlassen? Insbesondere gäbe es keine verpflichtende Cloud,
    versteckten Uploads oder standardmäßig aktive Telemetrie.
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1-5] ja
+
+The answer to question 1 is interpreted as including all three named desktop
+targets: Linux, Windows, and macOS. The complete core behavior and Campaign
+portability apply across those supported systems.
+
+SaltMarcher runs fluidly on an ordinary current laptop without requiring a
+dedicated GPU or server hardware. Resource-intensive simulation adapts its
+detail or pace to available resources rather than blocking live play.
+
+The GM installs a self-contained desktop application and does not separately
+install or administer a database server, web server, runtime, or other
+infrastructure.
+
+One local GM is the only writer for a Campaign in the confirmed core. The
+passive second display may read the live state, but concurrent editing of one
+Campaign by several processes, computers, or users is not required.
+
+Campaign data, notes, maps, images, audio, and usage data leave the computer
+only through a concrete, understandable action initiated by the GM. The core
+has no mandatory cloud dependency, hidden upload, or telemetry enabled by
+default.
+
+## Fourth Breadth Block: Rules, Extension Surface, And Accessibility
+
+1. Ist D&D 5e 2014 das einzige verbindliche Regelsystem des Kernprodukts, oder
+   soll dieselbe Installation später unterschiedliche D&D-Versionen oder ganz
+   andere Rollenspielsysteme pro Campaign unterstützen können?
+2. Bedeutet die bestätigte Modularität nur, dass wir SaltMarcher intern sauber
+   weiterentwickeln können, oder soll der GM später auch Erweiterungen, Plugins
+   oder Skripte von Dritten installieren können?
+3. Welche Oberflächensprachen gehören zum Ziel: zunächst nur Englisch, Deutsch
+   und Englisch, oder grundsätzlich eine lokalisierbare Oberfläche für weitere
+   Sprachen? Eigene Campaign-Inhalte bleiben davon unabhängig beliebiger Text.
+4. Soll der vollständige Kern mit Tastatur bedienbar sein sowie skalierbare
+   Schrift und Oberfläche, ausreichende Kontraste und Informationen bieten, die
+   nicht ausschließlich über Farbe vermittelt werden?
+5. Soll die Desktop-Oberfläche auf üblichen Laptop-Auflösungen ebenso wie auf
+   hochauflösenden und mehreren Monitoren vollständig nutzbar bleiben? Touch,
+   Mobilgeräte und kleine Smartphone-Layouts wären dagegen kein Kernbedarf.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
@@ -374,10 +374,11 @@ workflow may require its relevant optional statistics before it can run. This
 does not turn SaltMarcher into a complete character-sheet, spell, class-feature,
 or rules-complete equipment manager.
 
-## Proposed Consolidated Interpretation For Confirmation
+## Confirmed Consolidated Interpretation
 
-This interpretation remains interview evidence until the owner confirms it.
-It establishes program-wide observable qualities and product boundaries without
+The owner confirmed this complete interpretation on 2026-07-23. It is the
+evidence promoted into the draft Program Capability Requirements. It
+establishes program-wide observable qualities and product boundaries without
 choosing architecture, storage, frameworks, extension technology, or delivery
 order.
 
@@ -469,6 +470,12 @@ order.
     require its relevant optional statistics before running. SaltMarcher does
     not thereby become a complete character-sheet or rules-complete inventory
     manager.
+
+Workflow 7 and the repository-inventory completeness audit are confirmed. All
+seven interview workflows now have owner-confirmed interpretations. The draft
+Program Capability Requirements still require one final whole-baseline
+consistency review and owner confirmation before becoming the active target for
+technical-needs derivation.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -512,6 +512,57 @@ before the whole needs baseline can become active.
    automatisch laufen, oder soll der GM das Ergebnis immer erst ansehen und
    bestätigen, bevor es den aktuellen Bestand verändert?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] einen NPC oder einen Ort.
+
+A Shop inventory belongs to exactly one NPC or exactly one place. It is not
+simultaneously attached to several owners. Whether the Shop also needs a name
+independent of its owner remains to be clarified.
+
+> [Owner, wörtlich zu 2] ja
+
+The inventory supports quantity stacks for ordinary Item definitions and
+individual concrete or unique Items. Entries carry current quantity, Shop
+purchase and sale prices, and optional notes.
+
+> [Owner, wörtlich zu 3] ja
+
+One trade interaction updates both sides. A Party purchase reduces Shop stock
+and adds the Item to the selected character's ledger. A sale to the Shop
+increases its stock and marks the character ledger entry with the actual price
+and Shop or owning NPC as counterparty.
+
+> [Owner, wörtlich zu 4] ja sowohl als auch
+
+The GM can restock manually or define time- and calendar-event-based restock.
+Each fixed rule may refill to a target quantity or add a configured quantity.
+
+> [Owner, wörtlich zu 5] ja, automatisch
+
+Randomized stock uses GM-configured weighted Item tables or filters such as
+type, rarity, value, and tags. A configured automatic restock may change the
+current inventory without requiring per-run preview or confirmation.
+
+## Targeted Shop Clarifications
+
+1. Braucht das Shop-Inventar zusätzlich zum besitzenden NPC oder Ort einen
+   eigenen Namen, oder reicht der Besitzer als Identität und Anzeige?
+2. Soll ein im Shop gekauftes Item zwar im Charakter-Ledger erscheinen, aber
+   nicht als erhaltenes Loot in die Soll/Ist-Bilanz eingehen? Soll SaltMarcher
+   den bezahlten Betrag nur dokumentieren oder passende Münzen automatisch aus
+   dem Charakter-Ledger abbuchen?
+3. Wenn der besitzende NPC in der Running Scene anwesend oder der Shop-Ort der
+   aktuelle Scene-Ort ist: Soll das Shop-Inventar automatisch in der Scene
+   erreichbar sein und der GM beim Kauf den empfangenden Charakter auswählen?
+4. Soll zeitbasierter Restock mit der bereits bestätigten autoritativen
+   Campaign-Zeit genau einmal ausgeführt werden, auch wenn mehrere Scenes den
+   Zeitpunkt nacheinander erreichen? Sollen manuell hinzugefügte Bestände dabei
+   unverändert bleiben, sofern keine Restock-Regel sie ausdrücklich verwaltet?
+5. Soll jeder Kauf, Verkauf und automatische Restock als erklärender
+   History-Eintrag erhalten bleiben? Braucht automatischer Restock zusätzlich
+   eine Benachrichtigung, oder genügt der aktualisierte Bestand und die History?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -65,6 +65,65 @@ needs baseline are explicitly confirmed.
    Campaign-Daten brechen? Neue Masken, Inhaltsarten und Einflüsse sollen sich
    entsprechend ergänzen lassen, ohne bestehende Features neu bauen zu müssen.
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ja
+>
+> [Owner, wörtlich zu 2] ja
+>
+> [Owner, wörtlich zu 3] ja
+>
+> [Owner, wörtlich zu 4] ja
+>
+> [Owner, wörtlich zu 5] ja
+
+The complete local GM core works offline when its required rules, media, and
+Campaign data are present locally. Network use is limited to explicit imports,
+downloads, and future online capabilities rather than ordinary preparation or
+play.
+
+Ordinary live-play actions respond without perceptible delay. Long-running
+generation, import, and simulation work remains visible and cancellable in the
+background without making the Running Scene unusable.
+
+Failure of supporting music, weather, map, generation, or World-progression
+behavior does not disable Running Scenes, Encounters, manual editing, or
+preservation of confirmed work. Only the affected capability reports a clear
+failure and offers retry.
+
+SaltMarcher supports practically large, long-lived Campaigns without artificial
+content limits. Under exceptional load it degrades predictably rather than
+truncating data or failing unpredictably. Concrete supported scale and response
+budgets remain to be derived from representative scenarios and tests.
+
+Capability areas may be omitted, added, removed, or replaced without breaking
+unrelated workflows or existing Campaign data. New runtime masks, content
+types, and influences can be integrated without rebuilding existing features.
+
+## Second Breadth Block: Interrupted Work, Upgrades, And Missing Capabilities
+
+1. Wenn ein längerer Vorgang wie Import, Generierung oder Simulation abgebrochen
+   wird oder fehlschlägt: Sollen nur bereits einzeln bestätigte Ergebnisse
+   bestehen bleiben, während alle noch nicht bestätigten Teilergebnisse sauber
+   verworfen werden?
+2. Wenn SaltMarcher neue Änderungen gerade nicht sicher speichern kann, etwa
+   wegen vollem Datenträger oder fehlendem Zugriff: Soll es das sofort sichtbar
+   melden und Änderungen nicht fälschlich als gespeichert bestätigen? Lesen,
+   Exportieren und ein erneuter Speicherversuch sollen soweit sicher möglich
+   bleiben.
+3. Nach einem Programmupdate: Müssen alle bestehenden Campaigns und ihre
+   fortsetzbaren Zustände automatisch weiter nutzbar sein? Falls eine nötige
+   Umstellung fehlschlägt, soll der vorherige Datenstand unangetastet und mit
+   der vorherigen Programmversion wieder nutzbar bleiben?
+4. Wenn nur ein einzelner Datensatz beschädigt ist: Soll die restliche Campaign
+   trotzdem geöffnet werden, während SaltMarcher den betroffenen Datensatz
+   isoliert, verständlich markiert und Wiederherstellung oder ausdrückliches
+   Löschen anbietet?
+5. Wenn ein optionaler Funktionsbereich zeitweise nicht installiert oder
+   deaktiviert ist: Sollen seine vorhandenen Campaign-Daten unangetastet
+   erhalten und exportiert werden, auch wenn sie gerade nicht bearbeitet werden
+   können, und nach Rückkehr der Funktion wieder verfügbar sein?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -595,11 +595,12 @@ Purchases, sales, and automatic restocks remain in explanatory Campaign
 history. Automatic restock does not create an additional notification; the
 current inventory and history are sufficient.
 
-## Proposed Consolidated Shop Addition For Confirmation
+## Confirmed Consolidated Shop Addition
 
-This interpretation remains interview evidence until the owner confirms it.
-It extends the already confirmed workflows without choosing Shop persistence,
-scheduling, randomization, or transaction architecture.
+The owner confirmed this complete addition on 2026-07-23. It is the evidence
+promoted into the draft Program Capability Requirements and extends the already
+confirmed workflows without choosing Shop persistence, scheduling,
+randomization, or transaction architecture.
 
 1. A Shop is a named Campaign record with one structured inventory and belongs
    to exactly one NPC or exactly one place.
@@ -631,6 +632,24 @@ scheduling, randomization, or transaction architecture.
     unchanged unless an explicit restock rule owns that stock.
 12. Purchases, sales, and automatic restocks remain in explanatory Campaign
     history. Automatic restock creates no separate notification.
+
+Workflow 7 is re-confirmed with the structured Shop-inventory addition. The
+Program Capability Requirements require a refreshed whole-baseline consistency
+review and final owner confirmation before becoming the active target for
+technical-needs derivation.
+
+## Refreshed Shop Consistency Review
+
+The Shop addition is consistent with authoritative Campaign time, automatic
+World progression, Scene access, explanatory history, and the non-mechanical
+character ledger after distinguishing purchased Items from received loot and
+allowing a Shop as a trade counterparty.
+
+One lifecycle decision remains open. If the Shop's only owning NPC or place is
+explicitly deleted, should SaltMarcher warn and offer reassignment, and move the
+Shop into recoverable trash together with the owner if the GM continues without
+reassigning it? Restoring the owner would then restore the Shop relationship;
+completed trade history would remain explanatory in every case.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -124,6 +124,59 @@ types, and influences can be integrated without rebuilding existing features.
    erhalten und exportiert werden, auch wenn sie gerade nicht bearbeitet werden
    können, und nach Rückkehr der Funktion wieder verfügbar sein?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ja
+>
+> [Owner, wörtlich zu 2] ja
+>
+> [Owner, wörtlich zu 3] ja
+>
+> [Owner, wörtlich zu 4] ja
+>
+> [Owner, wörtlich zu 5] ja
+
+Cancellation or failure of a long-running import, generation, or simulation
+keeps only results the GM has already accepted independently. Unconfirmed
+partial results are discarded cleanly rather than leaking into Campaign state.
+
+If SaltMarcher cannot safely persist new changes, it reports that state
+immediately and never presents affected work as safely stored. Reading,
+exporting, and retrying persistence remain available wherever they are safe.
+
+Application updates preserve every existing Campaign and resumable runtime
+state. If required data conversion fails, it leaves the prior data untouched
+and usable with the prior application version rather than producing a partial
+upgrade.
+
+Damage to one record does not prevent the rest of its Campaign from opening.
+SaltMarcher isolates and clearly identifies the affected record and offers
+recovery or explicit deletion.
+
+Data owned by a temporarily disabled or unavailable capability remains intact,
+is included in complete Campaign export, cannot be silently discarded, and
+becomes usable again when that capability returns.
+
+## Third Breadth Block: Platform, Resources, And Trust Boundary
+
+1. Welche Desktop-Betriebssysteme gehören zum Ziel des lokalen Kernprodukts:
+   Linux, Windows und macOS oder zunächst nur eine Teilmenge davon?
+2. Soll SaltMarcher auf einem gewöhnlichen aktuellen Laptop ohne dedizierte GPU
+   oder Server-Hardware flüssig nutzbar sein? Aufwendige Wetter- oder
+   World-Simulation müsste ihre Detailtiefe dann kontrolliert an verfügbare
+   Ressourcen anpassen, statt den Live-Betrieb zu blockieren.
+3. Soll die Installation für den GM eine eigenständige Desktop-Anwendung sein,
+   ohne dass er zusätzlich einen Datenbankserver, Webserver, eine Laufzeit oder
+   andere Infrastruktur installieren und administrieren muss?
+4. Ist die bestätigte Kernnutzung genau ein lokal bearbeitender GM pro Campaign?
+   Die passive Zweitanzeige darf denselben Zustand lesen, aber gleichzeitige
+   Bearbeitung derselben Campaign durch mehrere Prozesse, Rechner oder Nutzer
+   wäre kein Kernbedarf.
+5. Sollen Campaign-Daten, Notizen, Karten, Bilder, Audio und Nutzungsdaten den
+   Rechner niemals ohne eine konkrete, verständliche und vom GM ausgelöste
+   Aktion verlassen? Insbesondere gäbe es keine verpflichtende Cloud,
+   versteckten Uploads oder standardmäßig aktive Telemetrie.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -276,6 +276,63 @@ devices, and small smartphone layouts are not core targets.
    wie explizite Löschung, lokale Datenkontrolle und unverfälschte History nicht
    unbemerkt umgehen?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1-5] ja
+
+Every extension is explicitly installed by the GM and discloses its requested
+access to Campaign data, files, network functions, and other capabilities
+before activation.
+
+Extensions have no default network access or unrestricted file access.
+Additional permissions require explicit GM consent. A faulty, damaged,
+missing, or update-incompatible extension is disabled and clearly identified
+without preventing SaltMarcher or the Campaign from opening. Its data remains
+intact and an application update does not let it rewrite Campaign data merely
+because compatibility failed.
+
+Extensions may add content kinds, runtime masks, generators, importers, and
+presentations. They cannot silently bypass confirmed safety boundaries such as
+explicit deletion, local control of data, or truthful Campaign history.
+
+## Repository Inventory Completeness Audit
+
+The current vision, roadmap, and feature documentation were inspected only as
+discovery prompts. Campaign knowledge, Catalog lookup, Party, Session planning
+and generation, Running Scenes, Encounters, follow-up, Items, World records,
+Dungeon and Hex maps, travel, weather, music and ambience, and optional Actor
+Autonomy all map to confirmed interview behavior or an explicit parked scope.
+
+The inventory exposed four product gaps which the earlier workflow questions
+did not decide explicitly: calendar and scheduled-event behavior, whether
+Encounter Tables are a real user concept, whether SaltMarcher provides general
+dice rolling, and the intended boundary of a PC record. The following block
+closes those gaps rather than inheriting the current implementation.
+
+## Final Completeness Block: Calendar, Tables, Dice, And PCs
+
+1. Braucht jede Campaign einen konfigurierbaren Fantasy-Kalender mit eigenen
+   Monaten, Tageslängen, Wochentagen und Jahreszählung, oder reicht ein fester
+   realweltlicher Kalender plus frei verstellbare Uhrzeit?
+2. Soll der GM Ereignisse und Erinnerungen auf einen Campaign-Zeitpunkt legen
+   können, die sichtbar werden, sobald eine Running Scene diesen Zeitpunkt
+   erreicht? Sie würden den GM informieren oder vorbereitete Inhalte anbieten,
+   aber keine erzählerische Konsequenz ohne seine Entscheidung ausführen.
+3. Sind ausdrücklich benannte, vom GM bearbeitbare `Encounter Tables` mit
+   gewichteten Monster- oder Gruppeneinträgen ein gewünschtes Konzept, das an
+   Orte und Fraktionen gehängt und als Quelle für Generierung genutzt wird?
+   Oder sollen allein Tags, Terrain, Fraktionen und andere Faktoren den
+   Kandidatenpool bestimmen, ohne eigene Tabellenobjekte?
+4. Braucht SaltMarcher einen allgemeinen Würfelroller für den GM, oder würfelt
+   der GM weiterhin physisch und nur automatische Generatoren und Simulationen
+   verwenden intern Zufall?
+5. Soll ein PC-Datensatz neben Name und frei ergänzbaren Notizen als optionale
+   strukturierte Kerndaten mindestens Level, XP, aktuelle/maximale HP,
+   Bewegungsraten und relevante Sinne enthalten, weil Planung, Encounter,
+   Reisen und Sicht sie benötigen? Ein vollständiger Charakterbogen mit
+   Klassenfähigkeiten, Zaubern und regelvollständigem Equipment wäre weiterhin
+   kein Kernbedarf.
+
 ## References
 
 - [Program Needs Interview Series](README.md)
@@ -286,3 +343,5 @@ devices, and small smartphone layouts are not core targets.
 - [Confirmed Follow-Up, Progression, And History](2026-07-22-follow-up-progression-and-history.md)
 - [Confirmed Local Data Lifecycle](2026-07-23-local-data-lifecycle.md)
 - [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)
+- [Project Vision](../../vision.md)
+- [Project Roadmap](../../roadmap.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -1,4 +1,4 @@
-Status: Confirmed Evidence
+Status: Active Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
@@ -476,6 +476,41 @@ seven interview workflows now have owner-confirmed interpretations. The draft
 Program Capability Requirements still require one final whole-baseline
 consistency review and owner confirmation before becoming the active target for
 technical-needs derivation.
+
+## Later Owner Addition: Structured Shop Inventories
+
+> [Owner, wörtlich am 2026-07-23] noch ein zusatz: GMs brauchen strukturierte
+> shop inventare, die sie an NPCs und Orte hängen können. Shops brauchen
+> restock-mechaniken und ggf. randomisation optionen.
+
+This reopens the completeness workflow after its prior confirmation. Structured
+Shop inventories, their NPC and place relationships, restocking, randomization,
+and interaction with Items and the character loot ledger must be clarified
+before the whole needs baseline can become active.
+
+## Shop Breadth Block: Identity, Stock, Trade, And Restock
+
+1. Soll ein Shop ein eigener benannter Campaign-Datensatz mit genau einem
+   strukturierten Inventar sein, der gleichzeitig an einen Ort und einen oder
+   mehrere NPCs gehängt werden kann? Alle diese Verknüpfungen würden dann
+   denselben aktuellen Bestand zeigen.
+2. Soll ein Shop-Inventar sowohl Mengenstapel normaler Item-Definitionen als
+   auch einzelne konkrete oder einzigartige Items enthalten? Braucht jeder
+   Eintrag mindestens aktuellen Bestand, Kaufpreis, Verkaufspreis und optionale
+   Notizen?
+3. Soll ein Kauf durch die Party den Shop-Bestand verringern und das Item über
+   einen gemeinsamen Handelsdialog direkt in das charakterbezogene Loot-Ledger
+   eintragen? Soll ein Verkauf an den Shop umgekehrt den Shop-Bestand erhöhen
+   und den Ledger-Eintrag mit tatsächlichem Preis und Shop/NPC als Gegenpartei
+   markieren?
+4. Soll der GM einen Shop jederzeit manuell auffüllen können und zusätzlich
+   zeitbasierte Restock-Regeln festlegen, etwa alle sieben Campaign-Tage oder an
+   bestimmten Kalendereignissen? Werden feste Einträge dabei auf eine
+   Zielmenge aufgefüllt oder jeweils um eine festgelegte Menge ergänzt?
+5. Soll Randomisierung über vom GM konfigurierbare gewichtete Item-Tabellen oder
+   Filter wie Typ, Seltenheit, Wert und Tags erfolgen? Darf sie beim Restock
+   automatisch laufen, oder soll der GM das Ergebnis immer erst ansehen und
+   bestätigen, bevor es den aktuellen Bestand verändert?
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -220,6 +220,62 @@ default.
    hochauflösenden und mehreren Monitoren vollständig nutzbar bleiben? Touch,
    Mobilgeräte und kleine Smartphone-Layouts wären dagegen kein Kernbedarf.
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] erstmal nur 2014, mehrere Systeme wären sehr spätes
+> QOL.
+
+D&D 5e 2014 is the only binding rules profile for the core. Supporting several
+D&D versions or other game systems is parked as very late quality-of-life work
+and does not require a generic multi-system core now.
+
+> [Owner, wörtlich zu 2] Letzteres
+
+Modularity is both an internal change-quality need and a future user-facing
+extension capability: the GM can install third-party extensions, plugins, or
+scripts. Delivery timing and the concrete extension mechanism remain outside
+this needs interview.
+
+> [Owner, wörtlich zu 3] Grundsätzlich lokalisierbar.
+
+The complete interface is localizable for additional languages. Campaign-authored
+text remains arbitrary user content and is not coupled to interface language.
+
+> [Owner, wörtlich zu 4] ja, solange das die UI nicht unübersichtlicher macht
+> oder workflows verlangsamt.
+
+The complete core supports keyboard operation, scalable text and interface,
+sufficient contrast, and information which does not rely on color alone.
+Accessibility must not clutter the default interface or slow the confirmed
+low-friction workflows; alternative input and presentation paths preserve the
+same efficient actions.
+
+> [Owner, wörtlich zu 5] ja
+
+The desktop interface remains fully usable on common laptop resolutions,
+high-density displays, and multi-monitor arrangements. Touch devices, mobile
+devices, and small smartphone layouts are not core targets.
+
+## Final Targeted Clarifications: Third-Party Extensions
+
+1. Muss der GM jede Erweiterung ausdrücklich installieren und vor der
+   Aktivierung verständlich sehen, auf welche Campaign-Daten, Dateien,
+   Netzwerkfunktionen oder anderen Fähigkeiten sie zugreifen möchte?
+2. Soll eine Erweiterung standardmäßig weder Netzwerkzugriff noch Zugriff auf
+   Dateien außerhalb ihrer freigegebenen Daten erhalten und zusätzliche
+   Berechtigungen nur nach ausdrücklicher Zustimmung des GM nutzen dürfen?
+3. Wenn eine Erweiterung fehlerhaft, beschädigt oder nicht mehr vorhanden ist:
+   Müssen SaltMarcher und die Campaign ohne sie weiter starten, die Erweiterung
+   deaktiviert und verständlich markiert sowie ihre Daten unangetastet erhalten
+   werden?
+4. Wenn eine Erweiterung nach einem SaltMarcher-Update nicht kompatibel ist:
+   Soll nur die Erweiterung deaktiviert werden, ohne Update, Campaign oder
+   Kernfunktionen zu blockieren oder Daten umzuschreiben?
+5. Dürfen Erweiterungen neue Inhaltsarten, Runtime-Masken, Generatoren,
+   Importeure und Darstellungen ergänzen, aber bestätigte Sicherheitsgrenzen
+   wie explizite Löschung, lokale Datenkontrolle und unverfälschte History nicht
+   unbemerkt umgehen?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -1,0 +1,77 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-23
+Source of Truth: Verbatim owner answers and confirmed interpretations for
+program-wide completeness, failure isolation, responsiveness, scale, optional
+use, and modular change needs.
+
+# Cross-Workflow Quality Interview 2026-07-23
+
+## Scope
+
+This final workflow establishes the qualities the complete local GM core must
+preserve across all previously confirmed capabilities. It covers observable
+offline availability, responsiveness, failure isolation, scale, optional use,
+and safe change without choosing modules, processes, storage, frameworks,
+threads, caches, or other architecture.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture work resumes only after this workflow and the final complete
+needs baseline are explicitly confirmed.
+
+## Carried-Forward Confirmed Evidence
+
+- The binding product horizon is the local GM-operated core. Player-operated
+  and remote-play features are parked; the passive GM-controlled second display
+  remains in scope.
+- During play, the GM should not have to leave the Scene tab. Supplementary
+  information and controls remain available through the top bar, detail pane,
+  and state-pane tabs.
+- Confirmed work persists automatically as soon as practical without
+  unnecessary user-visible load and resumes after restart wherever possible.
+- Campaign maps are unbounded in authored extent, may contain several zoom
+  levels, and may coexist in one Campaign.
+- Weather, ambience, music, generation, travel, Encounters, Chases, maps, and
+  optional future Actor Autonomy all contribute to workflows but do not define
+  the Campaign, Running Scene, or authored World by themselves.
+- The original review goal requires a clean, modular, readily extensible
+  development process in which behavior can be added, changed, removed, or
+  replaced without disproportionate unrelated work.
+
+## First Breadth Block: Availability, Responsiveness, And Isolation
+
+1. Soll das vollständige lokale GM-Kernprodukt ohne Internetverbindung
+   funktionieren, solange die benötigten Regeln, Medien und Campaign-Daten
+   bereits lokal vorhanden sind? Netzwerkzugriff wäre dann nur für ausdrücklich
+   gestartete Importe, Downloads oder spätere Online-Funktionen nötig.
+2. Während des Spiels: Sollen gewöhnliche Aktionen wie Scene-Wechsel, Auswahl,
+   Suche, Würfe, HP-Änderungen und das Öffnen von Detail- oder State-Panes ohne
+   spürbare Wartezeit reagieren? Längere Vorgänge wie Generierung, Import oder
+   umfangreiche Simulation würden sichtbar im Hintergrund laufen, abbrechbar
+   sein und die laufende Scene weiter bedienbar lassen.
+3. Wenn ein unterstützendes System wie Musik, Wetter, Karte, Generierung oder
+   autonome World-Fortschreibung ausfällt: Müssen Scene, Encounter und manuelle
+   Bearbeitung weiter funktionieren, bereits bestätigte Arbeit erhalten bleiben
+   und nur die betroffene Funktion mit verständlichem Fehler und Retry ausfallen?
+4. Soll SaltMarcher für praktisch große, über Jahre gewachsene Campaigns ohne
+   künstliche Inhaltsgrenzen ausgelegt sein und bei sehr großen Datenmengen
+   kontrolliert langsamer werden, statt Daten abzuschneiden oder Funktionen
+   unvorhersehbar ausfallen zu lassen? Feste garantierte Maximalgrößen könnten
+   später aus realistischen Tests abgeleitet werden.
+5. Sollen Musik, Wetter, Ambience, Generation, Dungeon-Karten, Encounters,
+   Chases und ähnliche Funktionsbereiche jeweils weggelassen oder später
+   ersetzt werden können, ohne dass unbeteiligte Workflows oder vorhandene
+   Campaign-Daten brechen? Neue Masken, Inhaltsarten und Einflüsse sollen sich
+   entsprechend ergänzen lassen, ohne bestehende Features neu bauen zu müssen.
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Campaign Foundation](2026-07-22-foundation-and-coverage.md)
+- [Confirmed Session And Scene Preparation](2026-07-22-session-and-scene-preparation.md)
+- [Confirmed Running Scene And Live Play](2026-07-22-running-scene-and-live-play.md)
+- [Confirmed Spatial Travel And Progression](2026-07-22-spatial-travel-and-progression.md)
+- [Confirmed Follow-Up, Progression, And History](2026-07-22-follow-up-progression-and-history.md)
+- [Confirmed Local Data Lifecycle](2026-07-23-local-data-lifecycle.md)
+- [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -563,6 +563,75 @@ current inventory without requiring per-run preview or confirmation.
    History-Eintrag erhalten bleiben? Braucht automatischer Restock zusätzlich
    eine Benachrichtigung, oder genügt der aktualisierte Bestand und die History?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ja
+
+A Shop is a named Campaign record in addition to belonging to exactly one NPC
+or one place.
+
+> [Owner, wörtlich zu 2] genau. ersteres.
+
+An Item bought from a Shop appears in the selected character's ledger but does
+not count as received loot in cumulative loot guidance. SaltMarcher records the
+price paid but does not automatically deduct matching coins from the character
+ledger.
+
+> [Owner, wörtlich zu 3] ja.
+
+A Shop is available directly in the Running Scene when its owning NPC is
+present or its owning place is the Scene's current place. During purchase, the
+GM selects the receiving character.
+
+> [Owner, wörtlich zu 4] genau.
+
+Time-based restock executes once through authoritative Campaign time even when
+several Scenes later reach the same trigger. Manually added stock remains
+unchanged unless a restock rule explicitly manages it.
+
+> [Owner, wörtlich zu 5] ja. nein.
+
+Purchases, sales, and automatic restocks remain in explanatory Campaign
+history. Automatic restock does not create an additional notification; the
+current inventory and history are sufficient.
+
+## Proposed Consolidated Shop Addition For Confirmation
+
+This interpretation remains interview evidence until the owner confirms it.
+It extends the already confirmed workflows without choosing Shop persistence,
+scheduling, randomization, or transaction architecture.
+
+1. A Shop is a named Campaign record with one structured inventory and belongs
+   to exactly one NPC or exactly one place.
+2. A Shop inventory contains quantity stacks of reusable Item definitions and
+   individual concrete or unique Items. An entry records current quantity, the
+   price charged when the Party buys, the price paid when the Shop buys, and
+   optional notes.
+3. The GM may add, remove, and edit Shop stock manually at any time.
+4. When the owning NPC is present in a Running Scene or the owning place is the
+   Scene's current place, the Shop is available directly from that Scene.
+5. One trade interaction updates Shop stock and the character loot ledger
+   together. On purchase, the GM selects the receiving character, Shop stock
+   decreases, and the acquired Item enters that character's ledger.
+6. A purchased Item is marked as a purchase and does not count as received
+   loot in cumulative loot guidance. SaltMarcher records the paid price but
+   does not automatically deduct coins from the character ledger.
+7. When a character sells an Item to the Shop, Shop stock increases and the
+   character ledger records the sold state, actual price, and Shop or owning
+   NPC as counterparty according to the existing sale rules.
+8. The GM can restock manually and can define automatic rules triggered by
+   elapsed Campaign time or configured calendar events.
+9. A fixed restock rule may refill an entry to a target quantity or add a
+   configured quantity.
+10. Randomized restock uses GM-configured weighted Item tables or filters such
+    as type, rarity, value, and tags and may update stock automatically without
+    per-run preview or confirmation.
+11. Time-based restock runs once according to authoritative Campaign time even
+    when several Scenes reach the trigger. It leaves manually added stock
+    unchanged unless an explicit restock rule owns that stock.
+12. Purchases, sales, and automatic restocks remain in explanatory Campaign
+    history. Automatic restock creates no separate notification.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
+++ b/docs/project/interviews/program-needs/2026-07-23-cross-workflow-quality.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
@@ -645,11 +645,24 @@ World progression, Scene access, explanatory history, and the non-mechanical
 character ledger after distinguishing purchased Items from received loot and
 allowing a Shop as a trade counterparty.
 
-One lifecycle decision remains open. If the Shop's only owning NPC or place is
-explicitly deleted, should SaltMarcher warn and offer reassignment, and move the
-Shop into recoverable trash together with the owner if the GM continues without
-reassigning it? Restoring the owner would then restore the Shop relationship;
-completed trade history would remain explanatory in every case.
+The review identified one lifecycle question. If the Shop's only owning NPC or
+place is explicitly deleted, should SaltMarcher warn and offer reassignment,
+and move the Shop into recoverable trash together with the owner if the GM
+continues without reassigning it? Restoring the owner would then restore the
+Shop relationship; completed trade history would remain explanatory in every
+case.
+
+### Owner Answer 2026-07-23
+
+> [Owner, wörtlich] ja
+
+Deleting a Shop's only owning NPC or place warns the GM and offers reassignment.
+If the GM continues without reassigning it, the Shop moves into recoverable
+trash with the owner. Restoring the owner restores the Shop relationship.
+Completed trade history remains explanatory regardless of deletion or restore.
+
+The refreshed Shop consistency review is complete. Workflow 7 is confirmed in
+full again, with no unresolved product decision inside the needs interview.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
+++ b/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
@@ -1,4 +1,4 @@
-Status: Active Evidence
+Status: Confirmed Evidence
 Owner: Aaron
 Last Reviewed: 2026-07-23
 Source of Truth: Verbatim owner answers and confirmed interpretations for
@@ -218,11 +218,12 @@ completed history is not recalculated.
 Deleting a Campaign first moves the complete Campaign into recoverable trash.
 Permanent deletion requires a separate explicit action.
 
-## Proposed Consolidated Interpretation For Confirmation
+## Confirmed Consolidated Interpretation
 
-This interpretation remains interview evidence until the owner confirms it.
-It deliberately states observable outcomes without choosing storage,
-transaction, file-format, backup, or synchronization mechanisms.
+The owner confirmed this complete interpretation on 2026-07-23. It is the
+evidence promoted into the draft Program Capability Requirements. It
+deliberately states observable outcomes without choosing storage, transaction,
+file-format, backup, or synchronization mechanisms.
 
 1. SaltMarcher preserves GM work automatically as soon as practical. Normal
    use does not depend on a manual Save action, should almost never lose
@@ -263,6 +264,10 @@ transaction, file-format, backup, or synchronization mechanisms.
     while completed history remains unchanged.
 11. Deleting a Campaign moves its complete data into recoverable trash.
     Permanent deletion requires a separate explicit GM action.
+
+Workflow 6 is confirmed. The interview continues with Workflow 7:
+cross-workflow completeness, failure semantics, scale, responsiveness, and
+modular change, removal, replacement, and extension needs.
 
 ## References
 

--- a/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
+++ b/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
@@ -58,6 +58,79 @@ scope.
    eine Vorschau vor Restore? Bezieht sich ein Restore auf eine Campaign oder
    auf die gesamte lokale SaltMarcher-Installation?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] soweit möglich sollte alles resumen wie es war.
+
+After restart, SaltMarcher resumes as much of the complete prior working state
+as possible, including Campaign, focused Scene, and live runtime contexts. The
+owner establishes no deliberate exclusion for music, dialogs, or another
+surface; later technical work must identify genuinely non-resumable transient
+effects without shrinking the general outcome.
+
+> [Owner, wörtlich zu 2] Soweit möglich sollte alles immer sofort gespeichert
+> werden. Solange es das Programm nicht unnötig belastet. Das fühlt sich aber
+> wieder nach technischem detail an, also interessiert es mich nur insoweit
+> dass ich meine Daten und meine Arbeit möglichst nie verlieren will.
+
+The observable need is continuous automatic durability which does not rely on
+a manual-save workflow to prevent loss: confirmed work persists as soon as
+practical, does not impose unnecessary user-visible load, and should almost
+never be lost. Exact write timing, draft persistence, crash boundaries, and
+performance mechanisms belong to later technical-needs and architecture work.
+
+> [Owner, wörtlich zu 3] Ja. Nein.
+
+A Campaign export includes its Campaign data, maps, images, local audio, and
+required reusable Creature, Item, and rule definitions. Selected partial export
+is not required.
+
+> [Owner, wörtlich zu 4] Ersteres.
+
+Import always creates a new independent Campaign. It never merges into an
+existing Campaign, so merge-conflict choices are not a required user workflow.
+
+> [Owner, wörtlich zu 5] Auch hier wieder: Ich will meine Daten nicht verlieren.
+> Für technische Details habe ich weder die expertise noch das interesse eine
+> hilfreiche Entscheidung zu treffen.
+
+The owner delegates backup interval, retention, snapshot controls, and restore
+granularity to later technical design. The binding product outcome is that
+Campaign work and local assets remain recoverable without requiring the GM to
+understand or operate backup internals, and that ordinary failures should not
+cause meaningful data loss.
+
+### Literal Evidence So Far
+
+- Restart resumes the complete useful working state wherever possible.
+- Confirmed work persists automatically as soon as practical without relying
+  on manual save or imposing unnecessary user-visible load.
+- Campaign export is complete, including referenced local assets and reusable
+  definitions; partial export is not required.
+- Import always creates a new independent Campaign and never merges into an
+  existing one.
+- Backup and restore mechanisms are technical decisions; reliable recovery and
+  near-zero loss of GM work are binding outcomes.
+
+## Second Breadth Block: Observable Portability And Recovery
+
+1. Soll ein vollständiger Campaign-Export auf einer anderen kompatiblen
+   SaltMarcher-Installation ohne Zugriff auf den ursprünglichen Rechner sofort
+   denselben Campaign-Inhalt, dieselben Assets und denselben fortsetzbaren
+   Zustand bereitstellen?
+2. Muss der Import garantiert jede bereits vorhandene Campaign und deren
+   wiederverwendbare Referenzen unverändert lassen, auch wenn importierte Namen
+   oder Definitionen identisch aussehen?
+3. Wenn der GM wiederverwendbare Creature-, Item- oder Regeldaten aktualisiert:
+   Soll SaltMarcher die Änderungen vorher anzeigen und einzelne Updates
+   überspringen lassen, oder darf ein ausdrücklich gestartetes Refresh alle
+   betroffenen Definitionen gemeinsam aktualisieren?
+4. Welche sichtbare Recovery-Erfahrung ist erforderlich: Soll SaltMarcher nach
+   beschädigten Daten automatisch den jüngsten sicheren Zustand öffnen, den GM
+   über jede unvermeidbare Abweichung informieren und nur dann eine Auswahl
+   alternativer Wiederherstellungspunkte zeigen, wenn Automatik nicht eindeutig
+   sicher ist?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
+++ b/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
@@ -131,6 +131,67 @@ cause meaningful data loss.
    alternativer Wiederherstellungspunkte zeigen, wenn Automatik nicht eindeutig
    sicher ist?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] ja.
+
+A complete Campaign export is self-contained enough to restore the same
+Campaign content, local assets, and resumable working state on another
+compatible SaltMarcher installation without access to the original computer.
+
+> [Owner, wörtlich zu 2] ja, aber monster/item und ähnliche nicht-primär custom
+> daten mit großen volumen werden zwischen campaigns geteilt.
+
+Existing Campaign-owned data remains unchanged when another Campaign is
+imported. Large reusable reference collections such as general Monster and Item
+data are deliberately installation-wide and shared between Campaigns rather
+than duplicated into every Campaign. Import collision behavior for differing
+versions of the same shared definition remains open.
+
+> [Owner, wörtlich zu 3] refresh?
+
+The term `refresh` was unclear and establishes no product behavior. The next
+question uses the concrete case of installing a newer shared Monster or Item
+data set.
+
+> [Owner, wörtlich zu 4] a
+>
+> [Owner, korrigierend zu 4] ja
+
+When local data is damaged, SaltMarcher automatically opens the newest
+unambiguously safe recoverable state, tells the GM what was recovered and what
+could not be preserved, and asks the GM to choose only when no single recovery
+choice is clearly safe.
+
+### Literal Evidence So Far
+
+- A complete export restores the same Campaign, local assets, and resumable
+  state on another compatible installation without the original computer.
+- Campaign-owned data is isolated, while high-volume reusable Monster, Item,
+  and similar reference collections are shared across Campaigns.
+- Import must not alter existing Campaign-owned data; handling conflicting
+  shared definitions is not yet decided.
+- Damaged local data recovers automatically to the newest uniquely safe state,
+  with visible disclosure of any loss and a choice only when safety is
+  ambiguous.
+
+## Third Breadth Block: Shared Data And Campaign Removal
+
+1. Eine importierte Campaign benötigt eine geteilte Monster- oder
+   Item-Definition. Wenn sie auf dem Zielrechner fehlt, soll SaltMarcher sie
+   automatisch zur dortigen geteilten Sammlung hinzufügen. Was soll passieren,
+   wenn dort bereits eine gleich bezeichnete Definition mit anderen Inhalten
+   existiert: beide Varianten behalten, die vorhandene verwenden oder den GM
+   beim Import entscheiden lassen?
+2. Mit `Refresh` war folgender konkrete Fall gemeint: Der GM installiert eine
+   neuere Ausgabe eines großen geteilten Monster-, Item- oder Regeldatensatzes.
+   Braucht SaltMarcher so eine Aktualisierung ganzer Datensätze überhaupt? Falls
+   ja, soll der GM vor der Übernahme die Änderungen sehen und einzelne
+   Definitionen überspringen können?
+3. Wenn der GM eine ganze Campaign löscht: Soll sie zunächst vollständig in
+   einem Papierkorb wiederherstellbar bleiben und erst durch eine zusätzliche
+   ausdrückliche Aktion endgültig gelöscht werden?
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
+++ b/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
@@ -1,0 +1,68 @@
+Status: Active Evidence
+Owner: Aaron
+Last Reviewed: 2026-07-23
+Source of Truth: Verbatim owner answers and confirmed interpretations for
+restart, import, export, reference refresh, backup, restore, recovery, and
+other local data-lifecycle needs.
+
+# Local Data Lifecycle Interview 2026-07-23
+
+## Scope
+
+This workflow covers what the GM expects when SaltMarcher closes, restarts,
+moves Campaign data between installations, refreshes reusable reference data,
+backs up or restores local work, or encounters damaged or unavailable local
+data. It asks for observable safety and recovery behavior without choosing file
+formats, databases, transaction mechanisms, or backup technology.
+
+The transcript is evidence only. Confirmed interpretations enter the
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Architecture, contracts, persistence, APIs, and delivery order remain out of
+scope.
+
+## Carried-Forward Confirmed Evidence
+
+- SaltMarcher stores several Campaigns and switches between them immediately.
+  Each Campaign's Running Scenes, Encounters, and travel state remain preserved
+  for later continuation.
+- Campaign content references reusable definitions; current and future play
+  reads the current definition, while completed history is not retroactively
+  recalculated after a definition update.
+- Explicit deletion removes current use but leaves explanatory history with an
+  unknown or recoverable-trash reference.
+- Hex maps support import and export, but the portable scope and collision
+  behavior have not yet been confirmed.
+- No confirmed workflow yet defines application restart, automatic saving,
+  whole-Campaign portability, backup retention, restore, or corruption
+  recovery.
+
+## First Breadth Block: Restart, Portability, And Backup
+
+1. Nach einem normalen Beenden und Neustart: Soll SaltMarcher die zuletzt
+   geöffnete Campaign, fokussierte Scene sowie jeden laufenden Encounter-,
+   Chase- und Travel-Zustand exakt wiederherstellen? Welche flüchtigen Dinge,
+   etwa aktuell spielende Musik oder offene Dialoge, sollen bewusst nicht
+   fortgesetzt werden?
+2. Soll jede bestätigte GM-Änderung sofort dauerhaft gespeichert werden, sodass
+   es keinen manuellen Save-Button gibt? Wie viel Arbeit darf bei einem Absturz
+   höchstens verloren gehen, insbesondere bei noch offenen Editierdialogen?
+3. Was muss ein Campaign-Export enthalten: nur Campaign-Daten oder auch ihre
+   verwendeten Karten, Bilder, lokalen Audio-Dateien und wiederverwendbaren
+   Creature-, Item- und Regeldefinitionen? Soll der GM auch ausgewählte
+   Teilmengen exportieren können?
+4. Darf ein Import nur eine neue unabhängige Campaign erstellen, oder auch in
+   eine bestehende Campaign zusammenführen? Was soll der GM bei gleichen IDs,
+   Namen oder bereits vorhandenen Referenzdefinitionen entscheiden können?
+5. Welche Backup-Bedienung braucht der GM: automatische rollierende Backups,
+   einen manuellen Snapshot, eine sichtbare Liste mit Zeitpunkt und Umfang und
+   eine Vorschau vor Restore? Bezieht sich ein Restore auf eine Campaign oder
+   auf die gesamte lokale SaltMarcher-Installation?
+
+## References
+
+- [Program Needs Interview Series](README.md)
+- [Confirmed Campaign Foundation](2026-07-22-foundation-and-coverage.md)
+- [Confirmed Running Scene And Live Play](2026-07-22-running-scene-and-live-play.md)
+- [Confirmed Spatial Travel And Progression](2026-07-22-spatial-travel-and-progression.md)
+- [Confirmed Follow-Up, Progression, And History](2026-07-22-follow-up-progression-and-history.md)
+- [Program Capability Requirements](../../requirements/requirements-program-capabilities.md)

--- a/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
+++ b/docs/project/interviews/program-needs/2026-07-23-local-data-lifecycle.md
@@ -192,6 +192,78 @@ choice is clearly safe.
    einem Papierkorb wiederherstellbar bleiben und erst durch eine zusätzliche
    ausdrückliche Aktion endgültig gelöscht werden?
 
+### Owner Answers 2026-07-23
+
+> [Owner, wörtlich zu 1] Der Gm entscheidet ob eine von beiden verworfen oder
+> beide getrennt behalten werden sollen.
+
+When an imported shared definition conflicts with an existing one, the GM
+chooses whether to discard either definition or retain both as separate
+definitions. SaltMarcher must make the effect of that choice visible: keeping
+both preserves both variants, discarding the imported variant makes the
+imported Campaign use the retained definition, and discarding the existing
+variant deliberately changes the shared definition available to existing
+Campaigns. Import never makes that choice silently.
+
+> [Owner, wörtlich zu 2] Monster/Item CRUD ist Spätes QOL feature.
+
+Monster and Item definition management, including bulk data-set refresh, is
+not a core workflow requirement. It is parked as a late quality-of-life
+capability. The already confirmed sharing semantics still govern any later
+definition change: current and future reads use the changed definition while
+completed history is not recalculated.
+
+> [Owner, wörtlich zu 3] Ja.
+
+Deleting a Campaign first moves the complete Campaign into recoverable trash.
+Permanent deletion requires a separate explicit action.
+
+## Proposed Consolidated Interpretation For Confirmation
+
+This interpretation remains interview evidence until the owner confirms it.
+It deliberately states observable outcomes without choosing storage,
+transaction, file-format, backup, or synchronization mechanisms.
+
+1. SaltMarcher preserves GM work automatically as soon as practical. Normal
+   use does not depend on a manual Save action, should almost never lose
+   confirmed work, and must not impose unnecessary user-visible load.
+2. After restart, SaltMarcher restores as much of the prior useful working
+   state as possible, including the active Campaign, focused Running Scene, and
+   live Encounter, Chase, and Travel contexts. Technical design may identify
+   effects which genuinely cannot resume, but there is no product-level list
+   of deliberately discarded runtime state.
+3. Backup schedules, retention, snapshot controls, restore granularity, and
+   persistence mechanisms are delegated technical decisions. The binding
+   product outcome is recovery of Campaign work and local assets without
+   requiring the GM to understand or operate backup internals.
+4. When local data is damaged, SaltMarcher automatically opens the newest
+   uniquely safe recoverable state, reports what it recovered and any
+   unavoidable loss, and asks the GM to choose only when no single recovery
+   choice is clearly safe.
+5. A complete Campaign export contains the Campaign data, maps, images, local
+   audio, required reusable Creature, Item, and rule definitions, and its
+   resumable working state. Partial Campaign export is not required.
+6. On another compatible SaltMarcher installation, that export restores the
+   same Campaign content, local assets, and resumable state without access to
+   the original computer.
+7. Import always creates a new independent Campaign and never merges Campaign
+   content into an existing Campaign.
+8. Campaign-owned data remains isolated between Campaigns. Large reusable
+   Monster, Item, rule, and similar reference collections are installation-wide
+   and shared between Campaigns rather than duplicated per Campaign.
+9. Missing shared definitions required by an imported Campaign join the shared
+   collection. When an imported definition conflicts with an existing one, the
+   GM explicitly chooses whether to discard either variant or retain both as
+   separate definitions. SaltMarcher does not silently choose, and it shows the
+   consequences for the imported and existing Campaigns before applying the
+   decision.
+10. Managing Monster and Item definitions, including whole-data-set refresh,
+    is a late quality-of-life feature rather than a core need. If definitions
+    are changed later, current and future reads use their current definition
+    while completed history remains unchanged.
+11. Deleting a Campaign moves its complete data into recoverable trash.
+    Permanent deletion requires a separate explicit GM action.
+
 ## References
 
 - [Program Needs Interview Series](README.md)

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -16,8 +16,17 @@ module boundaries are the correct product decomposition.
 The German transcripts are evidence. Only explicitly confirmed interpretations
 may enter the English
 [Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
-Neither the transcripts nor the draft requirements define architecture,
+Neither the transcripts nor the active requirements define architecture,
 contracts, persistence, source layout, or delivery order.
+
+## Completion State
+
+The interview series was completed and the whole baseline received final owner
+confirmation on 2026-07-23. The
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md)
+are therefore the `Active Target` and binding input to technical-needs
+derivation. Greenfield target architecture, comparison with the current system,
+and migration planning remain later phases.
 
 ## Confirmed Interview Rules
 
@@ -30,7 +39,7 @@ contracts, persistence, source layout, or delivery order.
   only gaps, conflicts, cross-capability operations, and quality-driving cases.
 - Each turn asks a small block of three to five concrete, related questions.
 - Each complete workflow receives a compact owner-confirmed interpretation
-  before it enters the draft program requirements.
+  before it enters the program requirements.
 - A final owner confirmation is required before the program requirements become
   `Active Target` or architecture work resumes.
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -49,9 +49,11 @@ The headings below are interview routes, not presumed feature boundaries.
 5. Encounter and session follow-up, awarded possessions, progression, World
    consequences, history, and corrections -- confirmed 2026-07-23
 6. Campaign switching, restart, import, export, reference refresh, backup,
-   restore, recovery, and other local data-lifecycle needs -- in progress
+   restore, recovery, and other local data-lifecycle needs -- confirmed
+   2026-07-23
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
-   modular change, removal, replacement, and extension scenarios
+   modular change, removal, replacement, and extension scenarios -- in
+   progress
 
 ## Evidence
 
@@ -61,6 +63,7 @@ The headings below are interview routes, not presumed feature boundaries.
 - [Spatial Travel And Progression 2026-07-22](2026-07-22-spatial-travel-and-progression.md)
 - [Follow-Up, Progression, And History 2026-07-22](2026-07-22-follow-up-progression-and-history.md)
 - [Local Data Lifecycle 2026-07-23](2026-07-23-local-data-lifecycle.md)
+- [Cross-Workflow Quality 2026-07-23](2026-07-23-cross-workflow-quality.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -47,10 +47,9 @@ The headings below are interview routes, not presumed feature boundaries.
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
    Autonomy during campaign-time progression -- confirmed 2026-07-22
 5. Encounter and session follow-up, awarded possessions, progression, World
-   consequences, history, and corrections -- consolidation awaiting owner
-   confirmation
+   consequences, history, and corrections -- confirmed 2026-07-23
 6. Campaign switching, restart, import, export, reference refresh, backup,
-   restore, recovery, and other local data-lifecycle needs
+   restore, recovery, and other local data-lifecycle needs -- in progress
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
    modular change, removal, replacement, and extension scenarios
 
@@ -61,6 +60,7 @@ The headings below are interview routes, not presumed feature boundaries.
 - [Running Scene And Live Play 2026-07-22](2026-07-22-running-scene-and-live-play.md)
 - [Spatial Travel And Progression 2026-07-22](2026-07-22-spatial-travel-and-progression.md)
 - [Follow-Up, Progression, And History 2026-07-22](2026-07-22-follow-up-progression-and-history.md)
+- [Local Data Lifecycle 2026-07-23](2026-07-23-local-data-lifecycle.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -39,8 +39,9 @@ contracts, persistence, source layout, or delivery order.
 The headings below are interview routes, not presumed feature boundaries.
 
 1. Campaign foundation, Party, reusable reference knowledge, and authored World
-   knowledge
-2. Session, Scene, Encounter, reward, weather, music, and note preparation
+   knowledge -- confirmed 2026-07-22
+2. Session, Scene, Encounter, reward, weather, music, and note preparation --
+   in progress
 3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
    and passive presentation during table play
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
@@ -55,6 +56,7 @@ The headings below are interview routes, not presumed feature boundaries.
 ## Evidence
 
 - [Foundation And Coverage 2026-07-22](2026-07-22-foundation-and-coverage.md)
+- [Session And Scene Preparation 2026-07-22](2026-07-22-session-and-scene-preparation.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -1,0 +1,73 @@
+Status: Active
+Owner: Aaron
+Last Reviewed: 2026-07-22
+Source of Truth: Routing, evidence boundary, and coverage order for the
+program-wide SaltMarcher needs interview.
+
+# Program Needs Interview Series
+
+## Purpose
+
+This series establishes the complete needs baseline for SaltMarcher's local GM
+core before any further greenfield architecture or current-state comparison.
+It interviews end-to-end GM workflows rather than assuming today's feature or
+module boundaries are the correct product decomposition.
+
+The German transcripts are evidence. Only explicitly confirmed interpretations
+may enter the English
+[Program Capability Requirements](../../requirements/requirements-program-capabilities.md).
+Neither the transcripts nor the draft requirements define architecture,
+contracts, persistence, source layout, or delivery order.
+
+## Confirmed Interview Rules
+
+- The binding horizon is the complete local GM core product. Player-operated,
+  remote-play, and other distant extensions remain parked separately.
+- Previously confirmed vision and verbatim owner answers remain evidence.
+  Existing feature requirements, architecture, and code are discovery prompts,
+  not target constraints.
+- Discovery proceeds breadth-first across the whole GM lifecycle, then deepens
+  only gaps, conflicts, cross-capability operations, and quality-driving cases.
+- Each turn asks a small block of three to five concrete, related questions.
+- Each complete workflow receives a compact owner-confirmed interpretation
+  before it enters the draft program requirements.
+- A final owner confirmation is required before the program requirements become
+  `Active Target` or architecture work resumes.
+
+## Workflow Coverage Order
+
+The headings below are interview routes, not presumed feature boundaries.
+
+1. Campaign foundation, Party, reusable reference knowledge, and authored World
+   knowledge
+2. Session, Scene, Encounter, reward, weather, music, and note preparation
+3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
+   and passive presentation during table play
+4. Dungeon, Hex, travel, position, events, perception, and optional Actor
+   Autonomy during campaign-time progression
+5. Encounter and session follow-up, awarded possessions, progression, World
+   consequences, history, and corrections
+6. Campaign switching, restart, import, export, reference refresh, backup,
+   restore, recovery, and other local data-lifecycle needs
+7. Cross-workflow completeness, failure semantics, scale, responsiveness,
+   modular change, removal, replacement, and extension scenarios
+
+## Evidence
+
+- [Foundation And Coverage 2026-07-22](2026-07-22-foundation-and-coverage.md)
+- [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
+- [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
+
+## Completion Rule
+
+The interview is complete only when every capability suggested by confirmed
+vision, roadmap, prior owner evidence, and the current product inventory is
+confirmed, explicitly excluded, or parked; every confirmed capability appears
+in an end-to-end GM workflow; and no unresolved product decision blocks later
+technical-needs derivation.
+
+## References
+
+- [Project Vision](../../vision.md)
+- [Documentation Standard](../../documentation.md)
+- [Project Interviews](../README.md)

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -52,8 +52,8 @@ The headings below are interview routes, not presumed feature boundaries.
    restore, recovery, and other local data-lifecycle needs -- confirmed
    2026-07-23
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
-   modular change, removal, replacement, extension scenarios, and the later
-   Shop-inventory addition -- reopened 2026-07-23
+   modular change, removal, replacement, extension scenarios, and structured
+   Shop inventories -- one Shop owner-deletion decision remains open
 
 ## Evidence
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -41,9 +41,9 @@ The headings below are interview routes, not presumed feature boundaries.
 1. Campaign foundation, Party, reusable reference knowledge, and authored World
    knowledge -- confirmed 2026-07-22
 2. Session, Scene, Encounter, reward, weather, music, and note preparation --
-   in progress
+   confirmed 2026-07-22
 3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
-   and passive presentation during table play
+   and passive presentation during table play -- in progress
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
    Autonomy during campaign-time progression
 5. Encounter and session follow-up, awarded possessions, progression, World
@@ -57,6 +57,7 @@ The headings below are interview routes, not presumed feature boundaries.
 
 - [Foundation And Coverage 2026-07-22](2026-07-22-foundation-and-coverage.md)
 - [Session And Scene Preparation 2026-07-22](2026-07-22-session-and-scene-preparation.md)
+- [Running Scene And Live Play 2026-07-22](2026-07-22-running-scene-and-live-play.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -52,8 +52,8 @@ The headings below are interview routes, not presumed feature boundaries.
    restore, recovery, and other local data-lifecycle needs -- confirmed
    2026-07-23
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
-   modular change, removal, replacement, and extension scenarios -- in
-   progress
+   modular change, removal, replacement, and extension scenarios -- confirmed
+   2026-07-23
 
 ## Evidence
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: Aaron
-Last Reviewed: 2026-07-22
+Last Reviewed: 2026-07-23
 Source of Truth: Routing, evidence boundary, and coverage order for the
 program-wide SaltMarcher needs interview.
 
@@ -47,7 +47,8 @@ The headings below are interview routes, not presumed feature boundaries.
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
    Autonomy during campaign-time progression -- confirmed 2026-07-22
 5. Encounter and session follow-up, awarded possessions, progression, World
-   consequences, history, and corrections -- in progress
+   consequences, history, and corrections -- consolidation awaiting owner
+   confirmation
 6. Campaign switching, restart, import, export, reference refresh, backup,
    restore, recovery, and other local data-lifecycle needs
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -45,7 +45,8 @@ The headings below are interview routes, not presumed feature boundaries.
 3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
    and passive presentation during table play -- confirmed 2026-07-22
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
-   Autonomy during campaign-time progression -- in progress
+   Autonomy during campaign-time progression -- consolidation awaiting owner
+   confirmation
 5. Encounter and session follow-up, awarded possessions, progression, World
    consequences, history, and corrections
 6. Campaign switching, restart, import, export, reference refresh, backup,

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -52,8 +52,8 @@ The headings below are interview routes, not presumed feature boundaries.
    restore, recovery, and other local data-lifecycle needs -- confirmed
    2026-07-23
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
-   modular change, removal, replacement, and extension scenarios -- confirmed
-   2026-07-23
+   modular change, removal, replacement, extension scenarios, and the later
+   Shop-inventory addition -- reopened 2026-07-23
 
 ## Evidence
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -45,10 +45,9 @@ The headings below are interview routes, not presumed feature boundaries.
 3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
    and passive presentation during table play -- confirmed 2026-07-22
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
-   Autonomy during campaign-time progression -- consolidation awaiting owner
-   confirmation
+   Autonomy during campaign-time progression -- confirmed 2026-07-22
 5. Encounter and session follow-up, awarded possessions, progression, World
-   consequences, history, and corrections
+   consequences, history, and corrections -- in progress
 6. Campaign switching, restart, import, export, reference refresh, backup,
    restore, recovery, and other local data-lifecycle needs
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
@@ -60,6 +59,7 @@ The headings below are interview routes, not presumed feature boundaries.
 - [Session And Scene Preparation 2026-07-22](2026-07-22-session-and-scene-preparation.md)
 - [Running Scene And Live Play 2026-07-22](2026-07-22-running-scene-and-live-play.md)
 - [Spatial Travel And Progression 2026-07-22](2026-07-22-spatial-travel-and-progression.md)
+- [Follow-Up, Progression, And History 2026-07-22](2026-07-22-follow-up-progression-and-history.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -53,7 +53,7 @@ The headings below are interview routes, not presumed feature boundaries.
    2026-07-23
 7. Cross-workflow completeness, failure semantics, scale, responsiveness,
    modular change, removal, replacement, extension scenarios, and structured
-   Shop inventories -- one Shop owner-deletion decision remains open
+   Shop inventories -- confirmed 2026-07-23
 
 ## Evidence
 

--- a/docs/project/interviews/program-needs/README.md
+++ b/docs/project/interviews/program-needs/README.md
@@ -43,9 +43,9 @@ The headings below are interview routes, not presumed feature boundaries.
 2. Session, Scene, Encounter, reward, weather, music, and note preparation --
    confirmed 2026-07-22
 3. Running Scenes, combat, lookup, notes, time, weather, music, improvisation,
-   and passive presentation during table play -- in progress
+   and passive presentation during table play -- confirmed 2026-07-22
 4. Dungeon, Hex, travel, position, events, perception, and optional Actor
-   Autonomy during campaign-time progression
+   Autonomy during campaign-time progression -- in progress
 5. Encounter and session follow-up, awarded possessions, progression, World
    consequences, history, and corrections
 6. Campaign switching, restart, import, export, reference refresh, backup,
@@ -58,6 +58,7 @@ The headings below are interview routes, not presumed feature boundaries.
 - [Foundation And Coverage 2026-07-22](2026-07-22-foundation-and-coverage.md)
 - [Session And Scene Preparation 2026-07-22](2026-07-22-session-and-scene-preparation.md)
 - [Running Scene And Live Play 2026-07-22](2026-07-22-running-scene-and-live-play.md)
+- [Spatial Travel And Progression 2026-07-22](2026-07-22-spatial-travel-and-progression.md)
 - [Goal Interview 2026-07-10](../2026-07-10-goal-interview.md)
 - [Dungeon Needs Interview 2026-07-20](../2026-07-20-dungeon-needs-interview.md)
 

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -200,16 +200,21 @@ across every kind of object.
 
 ### Runtime Clarification: Scene And Encounter
 
-The primary Running Scene always exists and cannot be paused, completed,
-closed, or discarded. It has zero or one current location. Changing location
+The primary Running Scene always exists and cannot be paused, completed, closed,
+or discarded. Empty Scenes are removed; a remaining populated Scene becomes
+primary. If the current Party is empty, all Scenes except one empty primary
+Scene are removed. A Scene has zero or one current location. Changing location
 changes the NPCs, Features, treasures, monster groups, and other location
 content shown in the Scene unless the GM explicitly makes content travel with
-the Party or pins it to the Scene.
+the Party or pins it to the Scene. Content that leaves the Scene remains at its
+location.
 
 An Encounter is not persistent World content. It is a temporary combat mask
 over a Running Scene that selects PCs and NPCs already present there and adds
-combat behavior such as HP tracking and initiative. Persistent preparation
-creates and places monster groups, not Encounters.
+combat behavior such as HP tracking and initiative. Chase and future mask types
+may provide other focused workflows. The Scene remains visible in the main
+panel while mask state remains available in its adjacent state panel. Persistent
+preparation creates and places monster groups, not Encounters.
 
 ## Confirmed Cross-Workflow Behavior
 
@@ -226,11 +231,11 @@ still-unconfirmed workflow.
 Party activation, deactivation, or deletion is authoritative immediately and is
 not rolled back by an unavailable Running Scene or Encounter. A later
 live-workflow answer supersedes the earlier allowance for an unassigned active
-character: every active Party character belongs to exactly one Running Scene.
-Inactive Roster characters belong to no Scene and retain their last location and
-other state. The destination Scene for a newly activated character remains
-under interview. Deactivated or deleted characters immediately stop counting as
-current Party members.
+character: every active Party character belongs to exactly one Running Scene,
+and activation assigns the character to the currently focused Scene. Inactive
+Roster characters belong to no Scene and retain their last location and other
+state. Deactivated or deleted characters immediately stop counting as current
+Party members.
 
 Only Running Scenes that reference the changed character and their Encounters
 reconcile. Until reconciliation succeeds, affected contexts are visibly pending

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -261,6 +261,12 @@ A correction appends a linked entry rather than rewriting prior history. The
 history is not required to replay the Campaign, reconstruct every intermediate
 application state, or restore an arbitrary whole-Campaign snapshot.
 
+Moving a Scene's in-world time backward or manually resolving different Scene
+times never deletes history or reverses confirmed World consequences. A fact
+recorded later at the table may carry an earlier in-world time and is treated as
+having happened then. Only an explicit GM deletion operation may remove its
+selected target.
+
 ## Awaiting Workflow Confirmation
 
 The following areas intentionally contain no normative behavior yet:

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -99,6 +99,104 @@ that recoverable object.
   while completed history keeps its fact with an unknown or recoverable-trash
   reference
 
+## Confirmed Workflow: Session Preparation And Supporting Content
+
+### Planning Workspace And Timeline
+
+`Session` is an unnamed, date-independent planning workspace rather than a
+Campaign content object. It holds one current plan that the GM may reuse or
+replace. The plan is an ordered timeline of expected Scene occurrences. Each
+entry may contain notes and reference zero or one location; the same location
+may appear in several entries. The GM can add, remove, reorder, and annotate
+entries at any time.
+
+Timeline entries are not stored Scenes. A Scene exists only as resumable runtime
+state. Ordinarily there is one Running Scene; a split Party may create several
+distinct Running Scenes.
+
+The GM can prepare the complete timeline, Encounters, treasures, and location
+placements manually without a planning Party, Adventure Day, name, date, or
+generation.
+
+### Assisted Generation
+
+Generation uses a planning-only expected Party selected from the Roster and
+does not change the current table Party. It requires an Adventure Day. For the
+selected characters and levels, the Adventure Day provides the DMG-guided
+Encounter amount, XP budget, and loot budget used to create Encounters and
+treasures.
+
+The GM may optionally provide a desired Scene count and select locations,
+factions, NPCs, Items, or other Campaign content. Every selected object is a
+binding constraint and must occur in the suggested Scenes. SaltMarcher may add
+other existing or newly created Campaign content. Before generation it checks
+whether all constraints fit the Adventure Day. If not, it explains the conflict
+and disables generation instead of producing a partial result.
+
+Generation returns a timeline with concrete Encounters and treasures. The GM
+can edit, regenerate, reject, accept, and place each result independently.
+Regenerating one result leaves every other result, manual edit, placement, and
+timeline change untouched.
+
+### Accepted World Content And Treasures
+
+Placing an Encounter or treasure accepts it as persistent World content. It
+remains editable and survives replacement of the current plan. Replacing the
+plan removes its timeline, timeline notes, and unaccepted drafts without
+changing any accepted placement.
+
+When the Party reaches a prepared location, its placed Encounters and treasures
+appear in the Running Scene UI. SaltMarcher does not start, resolve, or award
+them automatically; the GM decides what happens.
+
+A treasure may contain Items, including coins, trade goods, magic Items,
+equipment, and other possessions. The GM can independently add, remove,
+replace, and edit each Item before or after placement and move Items between
+treasures and locations.
+
+### Weather, Music, And Notes
+
+Weather is not Session preparation. It develops autonomously from location
+terrain and other available climate data; its live behavior remains part of a
+later workflow.
+
+Songs are stored locally. When adding a song, the GM assigns mood, intensity,
+vibe tags, and genre and can manage that data later. Scene sliders supply mood
+and intensity input; locations, NPCs, factions, monsters, and other Scene
+content contribute vibe tags and genres. The exact mood axes and categorization
+model remain subject to product testing.
+
+The GM may enable or disable autoplay. When enabled, the currently focused
+Running Scene drives the automatically generated music queue. Scene changes
+update that queue, and a song that no longer fits fades out gradually. Manual
+stop, skip, back, selection, queue, and loop actions take precedence until the
+manual choice ends, after which autoplay resumes if still enabled.
+
+Every authored or generated object may carry free-form GM notes. Notes relevant
+to a Running Scene are visible and editable there, and the GM can search notes
+across every kind of object.
+
+### Acceptance Criteria
+
+- the GM can build all preparation manually in an unnamed, undated planning
+  workspace without choosing a Party or using generation
+- the GM can freely edit and reorder a timeline whose entries each reference
+  zero or one location
+- replacing the current plan removes only its timeline and unaccepted work and
+  preserves all accepted World placements
+- generation remains unavailable with an explanation when its binding inputs
+  cannot fit the selected Party's Adventure Day
+- a generated Encounter or treasure can be changed or regenerated without
+  changing any other generated or manual preparation
+- reaching a prepared location exposes placed content without starting or
+  awarding it automatically
+- treasure Items remain individually editable and movable after placement
+- weather requires no Session preparation
+- the focused Running Scene drives optional autoplay while manual music
+  controls take precedence
+- the GM can edit relevant notes in a Running Scene and search notes across all
+  object kinds
+
 ## Confirmed Cross-Workflow Behavior
 
 ### Complete Encounter Outcome
@@ -144,8 +242,6 @@ application state, or restore an arbitrary whole-Campaign snapshot.
 
 The following areas intentionally contain no normative behavior yet:
 
-- session and Scene preparation, Encounter and reward generation, planned
-  weather, music, and notes
 - live table workflow outside the confirmed cross-workflow behavior above
 - spatial travel and campaign-time progression outside confirmed Dungeon needs
 - possessions, loot award, follow-up, and general correction workflows

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -2,8 +2,8 @@ Status: Draft
 Owner: Aaron (Product Owner)
 Last Reviewed: 2026-07-23
 Source of Truth: Owner-confirmed observable cross-workflow needs for the
-complete local SaltMarcher GM core. This draft is incomplete and is not yet an
-architecture input.
+complete local SaltMarcher GM core. This complete candidate still awaits final
+whole-baseline owner confirmation and is not yet an architecture input.
 
 # SaltMarcher Program Capability Requirements
 
@@ -33,7 +33,7 @@ spans or precedes individual feature requirements.
   transaction mechanisms, frameworks, or other technologies
 - scheduling implementation or preserving current implementation behavior that
   the owner has not confirmed as need
-- treating this incomplete draft as the baseline for architecture review
+- treating this unconfirmed candidate as the baseline for architecture review
 
 ## Confirmed Workflow: Campaign Foundation And Knowledge
 
@@ -165,8 +165,8 @@ treasures and locations.
 ### Weather, Music, And Notes
 
 Weather is not Session preparation. It develops autonomously from location
-terrain and other available climate data; its live behavior remains part of a
-later workflow.
+terrain and other available climate data; its live behavior follows the
+confirmed Scene-time, climate, and override requirements below.
 
 Songs are stored locally. When adding a song, the GM assigns mood, intensity,
 vibe tags, and genre and can manage that data later. Scene sliders supply mood
@@ -610,24 +610,170 @@ deletion requires a separate explicit GM action.
 - Campaign deletion remains recoverable until the GM separately requests
   permanent deletion
 
+## Confirmed Program-Wide Quality And Product Boundaries
+
+### Offline Desktop Operation And Trust
+
+The complete local GM core works offline when its required rules, media, and
+Campaign data are present locally. Network use occurs only through explicit
+imports, downloads, GM-approved extension permissions, or future online
+capabilities.
+
+Linux, Windows, and macOS are supported desktop targets with portable Campaign
+behavior across them. The GM installs a self-contained application without
+separately administering a database server, web server, runtime, or other
+infrastructure. It runs fluidly on an ordinary current laptop without requiring
+a dedicated GPU or server hardware.
+
+One local GM is the sole Campaign writer in the confirmed core. The passive
+second display reads live state; concurrent multi-process, multi-computer, or
+multi-user Campaign editing is not required.
+
+Campaign data, notes, maps, images, audio, and usage data leave the computer
+only through a concrete, understandable GM action. There is no mandatory cloud
+dependency, hidden upload, or telemetry enabled by default.
+
+### Responsiveness, Scale, And Failure Isolation
+
+Ordinary live-play actions respond without perceptible delay. Longer
+generation, import, and simulation work is visible and cancellable and does not
+make the Running Scene unusable. Resource-intensive simulation adapts to
+available resources rather than blocking live play.
+
+SaltMarcher supports practically large, long-lived Campaigns without artificial
+content limits. Under exceptional load it degrades predictably instead of
+truncating data or failing unpredictably. Representative Campaign sizes and
+measurable response budgets are established during technical-needs derivation
+and verified with realistic scenarios rather than guessed by the GM.
+
+Failure of supporting music, weather, maps, generation, or World progression
+affects only that capability. Running Scenes, Encounters, manual editing, and
+preservation of confirmed work remain usable, with a clear error and retry for
+the affected function.
+
+Cancellation or failure of a long operation keeps only independently accepted
+results; unconfirmed partial results are discarded cleanly. If new work cannot
+be persisted safely, SaltMarcher reports that immediately and never presents it
+as stored. Safe reading, export, and retry remain available.
+
+Application updates preserve Campaigns and resumable runtime state. A failed
+data conversion leaves prior data untouched and usable with the prior
+application version. Damage to one record does not prevent the remaining
+Campaign from opening: SaltMarcher isolates and identifies the record and
+offers recovery or explicit deletion.
+
+Data belonging to a disabled, missing, or temporarily unavailable capability
+remains intact, stays in complete exports, and becomes usable again when the
+capability returns.
+
+### Modular Change And Third-Party Extensions
+
+Capability areas can be added, omitted, removed, or replaced without breaking
+unrelated workflows or Campaign data. New runtime masks, content kinds,
+influences, and supporting systems can integrate without rebuilding existing
+features.
+
+The GM can install third-party extensions, plugins, or scripts. Every extension
+is installed explicitly and discloses requested Campaign-data, file, network,
+and other access before activation. Extensions have no default network or
+unrestricted file access; additional permissions require explicit GM consent.
+
+A faulty, damaged, missing, or update-incompatible extension is disabled and
+identified without preventing SaltMarcher or the Campaign from opening. Its
+data remains intact, and application updates do not let an incompatible
+extension rewrite Campaign data.
+
+Extensions may add content kinds, runtime masks, generators, importers, and
+presentations. They cannot silently bypass explicit deletion, local data
+control, truthful history, or another confirmed safety boundary.
+
+### Rules, Localization, Accessibility, And Displays
+
+D&D 5e 2014 is the only binding core rules profile. Supporting several D&D
+versions or other game systems is parked as very late quality-of-life work and
+does not require a generic multi-system core now.
+
+The interface is localizable for additional languages. Campaign-authored text
+remains arbitrary user content independent of interface language.
+
+The complete core supports keyboard operation, scalable text and interface,
+sufficient contrast, and information which does not rely on color alone. These
+alternatives do not clutter the default interface or slow its low-friction
+workflows. The interface remains usable at common laptop resolutions, on
+high-density displays, and across multiple monitors. Touch, mobile, and
+smartphone layouts are not core targets.
+
+### Calendar, Encounter Tables, Dice, And PC Data
+
+Each Campaign has a configurable fantasy calendar with authored month lengths,
+day length, weekdays, and year counting. The GM can author calendar events such
+as holidays. Events may be bound to time, place, or both and become relevant
+according to each Running Scene's time and location without automatically
+deciding narrative consequences.
+
+Named, GM-editable Encounter Tables contain weighted Monster or group entries.
+Factions, places, and other context use them as foundational sources for
+Encounter candidate pools and generation, alongside applicable contextual
+influences.
+
+SaltMarcher has no general-purpose GM dice roller. Ordinary table dice stay
+physical; automatic generators and simulations may use internal randomness.
+
+A PC tracks every structured statistic required by enabled automatic systems.
+Only its name is universally required; an automatic workflow may require its
+relevant optional statistics before running. SaltMarcher does not thereby
+become a complete character-sheet, spell, class-feature, or rules-complete
+inventory manager.
+
+### Acceptance Criteria
+
+- ordinary core preparation and play remain usable without network access
+- the same complete Campaign can be used across supported desktop systems
+  without separately administered infrastructure
+- common live actions remain responsive while long operations expose progress,
+  cancellation, and non-blocking behavior
+- a supporting-capability failure leaves unrelated live and manual workflows
+  usable and retains confirmed work
+- cancelled work leaks no unaccepted partial result into Campaign truth
+- updates, damaged individual records, and missing capabilities preserve the
+  last safe unaffected Campaign data
+- an optional capability can be removed or replaced without breaking unrelated
+  workflows, and its retained data returns with the capability
+- an extension obtains network, file, or Campaign-data access only after
+  explicit disclosure and GM consent
+- an incompatible extension cannot block Campaign opening or silently bypass
+  deletion, privacy, or history boundaries
+- keyboard, scaling, contrast, and non-color alternatives preserve the same
+  efficient workflows across supported display configurations
+- Calendar events respond to applicable Scene time and place without executing
+  a narrative decision automatically
+- Encounter Tables can provide weighted candidates to factions, places, and
+  generation
+- ordinary dice rolling remains outside SaltMarcher while automatic systems may
+  randomize internally
+- an automatic PC workflow clearly requires its missing relevant statistics
+  without making unrelated optional character data mandatory
+
 ## Confirmed Cross-Workflow Behavior
 
 ### Complete Encounter Outcome
 
-The GM confirms one complete Encounter outcome. Encounter result and completion,
-calculated Party XP, selected named-NPC lifecycle effects, selected finite-stock
-effects become effective together or remain wholly unchanged.
-The associated Running Scene remains active. Reward distribution, character
-loot ledger, progression, and correction behavior follow the confirmed
-follow-up workflow above.
+The GM confirms one complete Encounter outcome. Encounter completion and the
+selected participant XP distribution become effective together or remain
+wholly unchanged. Tracked HP and rule-derived deaths carry forward; SaltMarcher
+does not infer named-NPC lifecycle, finite-stock, condition, capture, location,
+resource-use, or other narrative consequences from completion. The associated
+Running Scene remains active. Reward distribution, character loot ledger,
+progression, and correction behavior follow the confirmed follow-up workflow
+above.
 
 ### Authoritative Party With Dependent Running Contexts
 
 Party activation, deactivation, or deletion is authoritative immediately and is
-not rolled back by an unavailable Running Scene or Encounter. A later
-live-workflow answer establishes the Scene assignment behavior above.
-Deactivated or deleted characters immediately stop counting as current Party
-members.
+not rolled back by an unavailable Running Scene or Encounter. Activation
+assigns the character to the focused Running Scene; deactivated or deleted
+characters immediately stop counting as current Party members and leave their
+Running Scene and masks according to the confirmed live-play behavior above.
 
 Only Running Scenes that reference the changed character and their Encounters
 reconcile. Until reconciliation succeeds, affected contexts are visibly pending
@@ -646,8 +792,8 @@ from the saved Scene change.
 
 The GM can inspect an ordinarily immutable chronological history of meaningful
 confirmed Campaign consequences, including campaign-time progression, travel,
-Encounter completion, XP, Party membership, NPC or finite-stock effects, and
-GM corrections.
+Encounter completion, XP, Party membership, manually confirmed NPC or
+finite-stock effects, and GM corrections.
 
 A correction appends a linked entry rather than rewriting prior history. The
 history is not required to replay the Campaign, reconstruct every intermediate
@@ -661,12 +807,20 @@ it removes the undone segment and results introduced only by it. An explicit
 GM deletion may remove its selected target even when that produces marked
 history conflicts which the GM must later resolve.
 
-## Awaiting Workflow Confirmation
+## Whole-Baseline Confirmation State
 
-The following areas intentionally contain no normative behavior yet:
+All seven interview workflows and the repository-inventory completeness audit
+have owner-confirmed interpretations. The whole-document consistency review
+found no unresolved product decision: later clarifications govern earlier
+questions, and the cross-workflow Encounter outcome now excludes narrative
+effects which the GM manages separately.
 
-- measurable program-wide responsiveness, scale, modular change, removal,
-  replacement, and extension needs
+Exact responsiveness and scale budgets, the detailed weather model, the
+published-rule derivation, persistence and backup mechanisms, and extension
+technology remain deliberate technical-needs, source-backed rule, or product-
+testing work. They do not change the observable needs recorded here. Only one
+final explicit owner confirmation remains before this document becomes the
+`Active Target` for technical-needs derivation.
 
 ## Acceptance Of This Baseline
 
@@ -684,5 +838,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 - [Spatial Travel And Progression Interview](../interviews/program-needs/2026-07-22-spatial-travel-and-progression.md)
 - [Follow-Up, Progression, And History Interview](../interviews/program-needs/2026-07-22-follow-up-progression-and-history.md)
 - [Local Data Lifecycle Interview](../interviews/program-needs/2026-07-23-local-data-lifecycle.md)
+- [Cross-Workflow Quality Interview](../interviews/program-needs/2026-07-23-cross-workflow-quality.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,9 +1,9 @@
-Status: Draft
+Status: Active Target
 Owner: Aaron (Product Owner)
 Last Reviewed: 2026-07-23
-Source of Truth: Owner-confirmed observable cross-workflow needs for the
-complete local SaltMarcher GM core. This complete candidate awaits final
-whole-baseline confirmation and is not yet an architecture input.
+Source of Truth: Final owner-confirmed observable cross-workflow needs for the
+complete local SaltMarcher GM core and the active input to technical-needs
+derivation.
 
 # SaltMarcher Program Capability Requirements
 
@@ -33,7 +33,15 @@ spans or precedes individual feature requirements.
   transaction mechanisms, frameworks, or other technologies
 - scheduling implementation or preserving current implementation behavior that
   the owner has not confirmed as need
-- treating this unconfirmed candidate as the baseline for architecture review
+
+## Derivation Boundary
+
+This Active Target is the binding product input to the next phase: deriving the
+technical needs implied by these observable capabilities. It does not choose an
+architecture, technology, contract, persistence model, source layout, or
+delivery sequence. Greenfield target architecture, comparison with the current
+system, and migration planning remain later phases and may begin only after the
+technical needs have been made explicit.
 
 ## Confirmed Workflow: Campaign Foundation And Knowledge
 
@@ -879,28 +887,29 @@ it removes the undone segment and results introduced only by it. An explicit
 GM deletion may remove its selected target even when that produces marked
 history conflicts which the GM must later resolve.
 
-## Whole-Baseline Confirmation State
+## Active Baseline State
 
 All seven interview workflows, the repository-inventory completeness audit,
 and the later structured Shop-inventory addition have owner-confirmed
 interpretations. The refreshed consistency review reconciled Shop purchases
 and counterparties with the character ledger and resolved owner deletion
 without orphaning or silently deleting the Shop. No unresolved product
-decision remains in the needs baseline.
+decision remains in the needs baseline. The owner confirmed this complete
+baseline on 2026-07-23.
 
 Exact responsiveness and scale budgets, the detailed weather model, the
 published-rule derivation, persistence and backup mechanisms, and extension
 technology remain deliberate technical-needs, source-backed rule, or product-
-testing work. They do not change the observable needs recorded here. Only final
-explicit owner confirmation remains before this document becomes the
-`Active Target` for technical-needs derivation.
+testing work. They do not change the observable needs recorded here and do not
+block technical-needs derivation.
 
-## Acceptance Of This Baseline
+## Baseline Acceptance
 
-This document may become `Active Target` only after every interview workflow has
-an explicitly confirmed interpretation, every known capability is included,
-excluded, or parked, all cross-workflow handoffs have observable desired
-behavior, and no unresolved product decision blocks technical-needs derivation.
+Every interview workflow has an explicitly confirmed interpretation, every
+known capability is included, excluded, or parked, all cross-workflow handoffs
+have observable desired behavior, and no unresolved product decision blocks
+technical-needs derivation. The owner's final whole-baseline confirmation on
+2026-07-23 satisfies the completion rule of the interview series.
 
 ## References
 

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -224,9 +224,13 @@ still-unconfirmed workflow.
 ### Authoritative Party With Dependent Running Contexts
 
 Party activation, deactivation, or deletion is authoritative immediately and is
-not rolled back by an unavailable Running Scene or Encounter. Activation creates
-no automatic Scene assignment. Deactivated or deleted characters immediately
-stop counting as current Party members.
+not rolled back by an unavailable Running Scene or Encounter. A later
+live-workflow answer supersedes the earlier allowance for an unassigned active
+character: every active Party character belongs to exactly one Running Scene.
+Inactive Roster characters belong to no Scene and retain their last location and
+other state. The destination Scene for a newly activated character remains
+under interview. Deactivated or deleted characters immediately stop counting as
+current Party members.
 
 Only Running Scenes that reference the changed character and their Encounters
 reconcile. Until reconciliation succeeds, affected contexts are visibly pending

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -53,6 +53,11 @@ concrete Item instances belong to one Campaign. A Campaign-specific object may
 be copied into another Campaign, where it becomes fully independent. Objects of
 the same kind may share a name.
 
+Quests, rumours, and similarly complex narrative concepts are lightweight,
+note-first GM records which may be attached to places, factions, or NPCs.
+SaltMarcher does not require encoded completion conditions, NPC trigger graphs,
+or automatic resolution; the GM resolves the record manually.
+
 Campaign content references reusable definitions rather than owning copies.
 Current and future play reads the current definition. Updating a definition does
 not retroactively recalculate completed Scenes or their historical facts.
@@ -93,6 +98,8 @@ that recoverable object.
   independently editable object
 - a changed reusable definition affects current and future reads without
   changing completed Scene facts
+- the GM can attach a note-first Quest or rumour to a place, faction, or NPC and
+  resolve it manually without authoring automated completion conditions
 - name-only creation from a Running Scene attaches there by default and exposes
   an opt-out before confirmation
 - explicit deletion removes current references and dependent Encounter runtime
@@ -241,8 +248,9 @@ confirmed consequences apply while the Running Scene continues.
 
 The GM can search all content without leaving the Scene and add a result
 directly to it. The GM can also create lightweight, note-first Campaign content
-there, including NPCs, locations, factions, and similar objects. Complete data
-records such as Items and monsters remain outside Scene-local creation.
+there, including NPCs, locations, factions, Quests, rumours, and similar
+objects. Complete data records such as Items and monsters remain outside
+Scene-local creation.
 
 Relevant object notes remain visible and editable in the Scene, while notes
 across every object kind remain searchable. The focused Scene drives optional

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,6 +1,6 @@
 Status: Draft
 Owner: Aaron (Product Owner)
-Last Reviewed: 2026-07-22
+Last Reviewed: 2026-07-23
 Source of Truth: Owner-confirmed observable cross-workflow needs for the
 complete local SaltMarcher GM core. This draft is incomplete and is not yet an
 architecture input.
@@ -440,6 +440,105 @@ Scene's current place, weather, and time.
 - manual ambience additions and suppressions coexist with automatic selection
   and balancing until the GM releases them
 
+## Confirmed Workflow: Follow-Up, Progression, And Reward Ledger
+
+### Encounter Consequences And XP
+
+Ending an Encounter carries forward tracked HP, rule-derived deaths, and XP
+while the Running Scene continues. Conditions, capture, location, resource use,
+notes, and other narrative consequences remain ordinary GM edits rather than
+inferred completion results.
+
+A dead PC or NPC remains as a dead character in the Roster or at its place, may
+be revived by the GM, and is never automatically deleted.
+
+Encounter XP defaults to participating PCs in the initiative order. The GM may
+add or remove recipients before distribution. SaltMarcher divides XP equally
+and rounds each individual share up. Crossing an XP threshold immediately
+changes the character's derived level state without GM confirmation.
+
+An XP correction immediately recalculates derived level state while history
+retains the original award and linked correction. If an inactive character
+receives XP, the GM is informed once when that character is next activated;
+the information then clears automatically.
+
+### Rewards And Narrative Notes
+
+Encounter and manually resolved Quest rewards use one GM-facing distribution
+dialog. A Treasure may be distributed partially or completely, and
+undistributed Items may remain with the Treasure or at its place. The GM chooses
+every Item recipient; SaltMarcher does not choose one automatically.
+
+Quests, rumours, and similarly complex narrative concepts are lightweight
+records attached to places, factions, or NPCs. They contain open-or-closed
+state, free text, optional structured Rewards, and, for a Quest, a structured
+contributor set. A new Quest begins without contributors unless its creation
+context supplies selected characters.
+
+SaltMarcher does not model Quest completion conditions, NPC trigger graphs, or
+automatic narrative resolution. The GM resolves the note manually. Structured
+narrative Rewards are XP and Items, where Items include coins, equipment, trade
+goods, magic Items, and other concrete goods. Quest contributors default the
+XP recipient set, which remains GM-adjustable; XP follows the same equal
+rounded-up distribution rule as Encounter XP.
+
+### Character Loot Ledger
+
+Awarded Items appear in a searchable and filterable character-specific loot
+ledger. It is a GM reminder and Reward-accounting surface, not a player-operated
+or rules-complete inventory simulation. The GM may add, remove, or correct
+ledger Items manually without a Reward source. Coins, trade goods, and
+equivalent Items support quantity stacks which may be split and merged.
+
+`Received`, `given away`, and `sold` are non-mechanical reminders. Sold or
+given-away Items remain visible and continue to count as received loot. A sale
+or handoff records a structured counterparty link to an existing NPC, place, or
+faction when available, plus optional free text. A sale also records its actual
+price, which becomes authoritative for final loot valuation of that sold Item.
+A separate per-instance value override is not required.
+
+Item provenance records available Treasure, Encounter or Quest, Scene or
+place, in-world time, and award time, with optional free-form provenance for
+manual and exceptional cases.
+
+### Cumulative Loot Guidance
+
+Expected loot follows a versioned D&D 5e 2014 rule profile based on the owner's
+confirmed DMG guidance: character-level expectations produce a loot-per-XP
+value. Session planning compares cumulative received loot with cumulative
+expected loot for all XP the characters have received so far.
+
+Session generation automatically adjusts proposed Rewards to compensate for
+the cumulative loot surplus or deficit. The GM retains the previously confirmed
+ability to inspect and edit each proposed Reward independently. The exact
+published-rule derivation remains a later source-backed rule decision rather
+than an assumed formula in this requirements document.
+
+### Corrections And History
+
+A later correction immediately updates current Item, XP, HP, death, or other
+corrected truth while explanatory history retains the original fact and a
+linked correction. Existing explicit-deletion and travel-undo exceptions remain
+governed by their previously confirmed behavior.
+
+### Acceptance Criteria
+
+- Encounter completion preserves tracked HP, derives death, distributes XP to
+  a GM-adjustable participant set, and leaves the Running Scene active
+- equal XP shares round up, threshold-derived level state updates immediately,
+  and a correction retains its linked explanatory history
+- an inactive XP recipient produces one information message on next activation
+- Encounter and manually resolved Quest Rewards use the same distribution
+  interaction without automatic Item-recipient selection
+- Quests and rumours remain manually resolved note-first records without
+  completion-condition or NPC-trigger automation
+- the GM can search and filter each character's Item ledger, correct it
+  manually, and split or merge quantity stacks
+- sold and given-away Items remain visible as non-mechanical reminders and keep
+  their provenance, counterparty, and applicable sale information
+- Session generation compensates proposed Rewards for the cumulative difference
+  between expected loot for received XP and actual received loot
+
 ## Confirmed Cross-Workflow Behavior
 
 ### Complete Encounter Outcome
@@ -447,8 +546,9 @@ Scene's current place, weather, and time.
 The GM confirms one complete Encounter outcome. Encounter result and completion,
 calculated Party XP, selected named-NPC lifecycle effects, selected finite-stock
 effects become effective together or remain wholly unchanged.
-The associated Running Scene remains active. Loot persistence is a separate,
-still-unconfirmed workflow.
+The associated Running Scene remains active. Reward distribution, character
+loot ledger, progression, and correction behavior follow the confirmed
+follow-up workflow above.
 
 ### Authoritative Party With Dependent Running Contexts
 
@@ -494,7 +594,6 @@ history conflicts which the GM must later resolve.
 
 The following areas intentionally contain no normative behavior yet:
 
-- possessions, loot award, follow-up, and general correction workflows
 - import, export, reference refresh, backup, restore, and recovery
 - measurable program-wide responsiveness, scale, modular change, removal,
   replacement, and extension needs
@@ -513,5 +612,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 - [Session And Scene Preparation Interview](../interviews/program-needs/2026-07-22-session-and-scene-preparation.md)
 - [Running Scene And Live Play Interview](../interviews/program-needs/2026-07-22-running-scene-and-live-play.md)
 - [Spatial Travel And Progression Interview](../interviews/program-needs/2026-07-22-spatial-travel-and-progression.md)
+- [Follow-Up, Progression, And History Interview](../interviews/program-needs/2026-07-22-follow-up-progression-and-history.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,0 +1,106 @@
+Status: Draft
+Owner: Aaron (Product Owner)
+Last Reviewed: 2026-07-22
+Source of Truth: Owner-confirmed observable cross-workflow needs for the
+complete local SaltMarcher GM core. This draft is incomplete and is not yet an
+architecture input.
+
+# SaltMarcher Program Capability Requirements
+
+## Goal
+
+Define one coherent needs baseline for preparing, running, and following up on a
+local tabletop Campaign before deriving technical needs or deciding feature,
+module, persistence, integration, or technology boundaries.
+
+The [Project Vision](../vision.md) remains the owner of users, top-level jobs,
+and product non-goals. This document owns confirmed observable behavior that
+spans or precedes individual feature requirements.
+
+## Scope Boundary
+
+- The binding horizon is the complete local GM-operated core product.
+- Player-operated applications, remote play, and unspecified distant
+  extensions are parked and cannot constrain the core architecture.
+- A passive GM-controlled second-monitor output remains eligible for the core
+  because it accepts no player input.
+- Current code, feature names, feature requirements, architecture, and storage
+  are not target constraints.
+
+## Non-Goals
+
+- choosing source modules, feature boundaries, APIs, schemas, databases,
+  transaction mechanisms, frameworks, or other technologies
+- scheduling implementation or preserving current implementation behavior that
+  the owner has not confirmed as need
+- treating this incomplete draft as the baseline for architecture review
+
+## Confirmed Cross-Workflow Behavior
+
+### Complete Encounter Outcome
+
+The GM confirms one complete Encounter outcome. Encounter result and completion,
+calculated Party XP, selected named-NPC lifecycle effects, selected finite-stock
+effects become effective together or remain wholly unchanged.
+The associated Running Scene remains active. Loot persistence is a separate,
+still-unconfirmed workflow.
+
+### Authoritative Party With Dependent Running Contexts
+
+Party activation, deactivation, or deletion is authoritative immediately and is
+not rolled back by an unavailable Running Scene or Encounter. Activation creates
+no automatic Scene assignment. Deactivated or deleted characters immediately
+stop counting as current Party members.
+
+Only Running Scenes that reference the changed character and their Encounters
+reconcile. Until reconciliation succeeds, affected contexts are visibly pending
+and stale Encounter context is not presented as synchronized. Initialization,
+refresh, and explicit retry resume the saved work without repeating the Party
+change. Unaffected contexts do not change.
+
+### Scene Save Before Encounter Synchronization
+
+A valid Running Scene change remains saved and usable when its Encounter cannot
+accept the corresponding context. The exact Scene state remains visibly pending,
+stale Encounter context is never presented as synchronized, and retry continues
+from the saved Scene change.
+
+### Explanatory Campaign History
+
+The GM can inspect an immutable chronological history of meaningful confirmed
+Campaign consequences, including campaign-time progression, travel, Encounter
+completion, XP, Party membership, NPC or finite-stock effects, and GM
+corrections.
+
+A correction appends a linked entry rather than rewriting prior history. The
+history is not required to replay the Campaign, reconstruct every intermediate
+application state, or restore an arbitrary whole-Campaign snapshot.
+
+## Awaiting Workflow Confirmation
+
+The following areas intentionally contain no normative behavior yet:
+
+- Campaign foundation, switching, reusable reference knowledge, and authored
+  Campaign knowledge
+- session and Scene preparation, Encounter and reward generation, planned
+  weather, music, and notes
+- live table workflow outside the confirmed cross-workflow behavior above
+- spatial travel and campaign-time progression outside confirmed Dungeon needs
+- possessions, loot award, follow-up, and general correction workflows
+- import, export, reference refresh, backup, restore, and recovery
+- measurable program-wide responsiveness, scale, modular change, removal,
+  replacement, and extension needs
+
+## Acceptance Of This Baseline
+
+This document may become `Active Target` only after every interview workflow has
+an explicitly confirmed interpretation, every known capability is included,
+excluded, or parked, all cross-workflow handoffs have observable desired
+behavior, and no unresolved product decision blocks technical-needs derivation.
+
+## References
+
+- [Program Needs Interview Series](../interviews/program-needs/README.md)
+- [Program Needs Foundation And Coverage](../interviews/program-needs/2026-07-22-foundation-and-coverage.md)
+- [Project Vision](../vision.md)
+- [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -539,6 +539,77 @@ governed by their previously confirmed behavior.
 - Session generation compensates proposed Rewards for the cumulative difference
   between expected loot for received XP and actual received loot
 
+## Confirmed Workflow: Local Data Lifecycle
+
+### Continuous Preservation And Resume
+
+SaltMarcher preserves confirmed GM work automatically as soon as practical.
+Normal use does not depend on a manual Save action, should almost never lose
+confirmed work, and does not impose unnecessary user-visible load.
+
+After restart, SaltMarcher restores as much of the prior useful working state
+as possible, including the active Campaign, focused Running Scene, and live
+Encounter, Chase, and Travel contexts. There is no product-level list of
+runtime state which SaltMarcher deliberately discards on restart.
+
+Backup schedules, retention, snapshot controls, restore granularity, and
+persistence mechanisms remain technical decisions. The required outcome is
+recovery of Campaign work and local assets without requiring the GM to
+understand or operate backup internals.
+
+When local data is damaged, SaltMarcher automatically opens the newest uniquely
+safe recoverable state, tells the GM what it recovered and what could not be
+preserved, and asks the GM to choose only when no single recovery choice is
+clearly safe.
+
+### Complete Campaign Portability
+
+A complete Campaign export includes Campaign data, maps, images, local audio,
+required reusable Creature, Item, and rule definitions, and resumable working
+state. Partial Campaign export is not required.
+
+On another compatible SaltMarcher installation, that export restores the same
+Campaign content, local assets, and resumable state without access to the
+original computer. Import always creates a new independent Campaign and never
+merges Campaign content into an existing Campaign.
+
+Campaign-owned data remains isolated between Campaigns. Large reusable Monster,
+Item, rule, and similar reference collections are installation-wide and shared
+between Campaigns rather than duplicated per Campaign.
+
+If an imported Campaign requires a missing shared definition, the definition
+joins the shared collection. If an imported definition conflicts with an
+existing one, the GM explicitly chooses whether to discard either variant or
+retain both as separate definitions. SaltMarcher shows the consequences for
+the imported and existing Campaigns before applying that decision and never
+chooses silently.
+
+Managing Monster and Item definitions, including whole-data-set refresh, is a
+late quality-of-life feature rather than a core need. If definitions are
+changed later, current and future reads use their current definition while
+completed history remains unchanged.
+
+### Campaign Deletion
+
+Deleting a Campaign moves its complete data into recoverable trash. Permanent
+deletion requires a separate explicit GM action.
+
+### Acceptance Criteria
+
+- confirmed work persists without a manual Save action and survives normal
+  restart with the useful runtime state restored wherever possible
+- damaged local data automatically opens the newest uniquely safe recovery,
+  discloses any loss, and asks only when recovery is ambiguous
+- a complete export restores the same Campaign, assets, definitions, and
+  resumable state on another compatible installation without the source
+  computer
+- import creates a new Campaign without merging Campaign-owned data into an
+  existing Campaign
+- a shared-definition conflict requires an informed explicit GM decision and
+  may retain both definitions independently
+- Campaign deletion remains recoverable until the GM separately requests
+  permanent deletion
+
 ## Confirmed Cross-Workflow Behavior
 
 ### Complete Encounter Outcome
@@ -594,7 +665,6 @@ history conflicts which the GM must later resolve.
 
 The following areas intentionally contain no normative behavior yet:
 
-- import, export, reference refresh, backup, restore, and recovery
 - measurable program-wide responsiveness, scale, modular change, removal,
   replacement, and extension needs
 
@@ -613,5 +683,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 - [Running Scene And Live Play Interview](../interviews/program-needs/2026-07-22-running-scene-and-live-play.md)
 - [Spatial Travel And Progression Interview](../interviews/program-needs/2026-07-22-spatial-travel-and-progression.md)
 - [Follow-Up, Progression, And History Interview](../interviews/program-needs/2026-07-22-follow-up-progression-and-history.md)
+- [Local Data Lifecycle Interview](../interviews/program-needs/2026-07-23-local-data-lifecycle.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -2,8 +2,8 @@ Status: Draft
 Owner: Aaron (Product Owner)
 Last Reviewed: 2026-07-23
 Source of Truth: Owner-confirmed observable cross-workflow needs for the
-local SaltMarcher GM core. The draft still awaits one Shop owner-deletion
-decision and final confirmation and is not yet an architecture input.
+complete local SaltMarcher GM core. This complete candidate awaits final
+whole-baseline confirmation and is not yet an architecture input.
 
 # SaltMarcher Program Capability Requirements
 
@@ -556,6 +556,11 @@ The GM may add, remove, and edit Shop stock manually at any time. When the
 owning NPC is present in a Running Scene or the owning place is the Scene's
 current place, the Shop is available directly from that Scene.
 
+Deleting the Shop's owning NPC or place warns the GM and offers reassignment.
+If the GM proceeds without reassigning it, the Shop moves into recoverable trash
+with the owner. Restoring the owner restores the Shop relationship. Completed
+trade history remains explanatory regardless of deletion or restore.
+
 ### Trade And Character Ledger
 
 One trade interaction updates Shop stock and the character loot ledger
@@ -591,6 +596,8 @@ history. Automatic restock creates no separate notification.
 
 - a named Shop belongs to one NPC or one place and exposes stacks and unique
   Items with quantities, both trade prices, and optional notes
+- deleting the owning NPC or place offers Shop reassignment and otherwise moves
+  the Shop into recoverable trash with a restorable relationship
 - the Scene exposes a Shop when its owning NPC is present or its owning place
   is current
 - one purchase decreases Shop stock and records the selected character's
@@ -877,15 +884,16 @@ history conflicts which the GM must later resolve.
 All seven interview workflows, the repository-inventory completeness audit,
 and the later structured Shop-inventory addition have owner-confirmed
 interpretations. The refreshed consistency review reconciled Shop purchases
-and counterparties with the character ledger. One Shop lifecycle decision
-remains open: what happens when its only owning NPC or place is deleted.
+and counterparties with the character ledger and resolved owner deletion
+without orphaning or silently deleting the Shop. No unresolved product
+decision remains in the needs baseline.
 
 Exact responsiveness and scale budgets, the detailed weather model, the
 published-rule derivation, persistence and backup mechanisms, and extension
 technology remain deliberate technical-needs, source-backed rule, or product-
-testing work. They do not change the observable needs recorded here. The Shop
-owner-deletion decision and final explicit owner confirmation remain before
-this document becomes the `Active Target` for technical-needs derivation.
+testing work. They do not change the observable needs recorded here. Only final
+explicit owner confirmation remains before this document becomes the
+`Active Target` for technical-needs derivation.
 
 ## Acceptance Of This Baseline
 

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -253,8 +253,9 @@ the GM's manual player actions take precedence.
 
 Every Scene advances its own time through travel, exploration, and mask
 activity. Encounter and Chase rounds last six seconds. Travel duration is
-calculated and initially cannot be overridden; overriding it remains a
-low-priority quality-of-life extension. The GM chooses exploration duration.
+calculated from applicable factors. The GM may override any input factor, the
+final duration, or both; a final-duration override is authoritative while it
+remains active. The GM chooses exploration duration.
 
 The GM may increment Scene time forward or backward. When groups with different
 times reunite, the GM manually chooses their temporal resolution. Moving
@@ -271,9 +272,10 @@ autonomous weather resumes.
 
 The passive second display immediately follows the focused Scene. During travel
 it automatically shows the map; at a location it automatically shows background
-art. Map visibility is the union of what at least one character in the focused
-Scene can perceive and updates with position, line of sight, light, hidden
-state, and similar visibility changes.
+art. The map combines the durable map knowledge of all characters in the
+focused Scene. Current visibility is the union of what at least one of those
+characters can perceive and updates with position, line of sight, light,
+hidden state, weather, elevation, and similar visibility changes.
 
 NPC artwork appears only when highlighted by the GM. During an Encounter or
 Chase, the GM may enable automatic artwork for the current actor. The display
@@ -300,9 +302,135 @@ visual at any time.
   never deletes history or reverses confirmed World state
 - automatic weather follows each Scene independently and resumes when the GM
   releases a manual override
-- the passive second display switches with Scene focus, reveals only currently
-  perceivable map content, never exposes textual or mechanical state, and can
-  be blanked or replaced by the GM
+- the passive second display switches with Scene focus, distinguishes current
+  perception from remembered knowledge without revealing unknown or hidden
+  live details, never exposes textual or mechanical state, and can be blanked
+  or replaced by the GM
+
+## Confirmed Workflow: Spatial Travel And Campaign-Time Progression
+
+### Places, Subplaces, And Scene Continuity
+
+Travel is one live GM workflow for the focused Scene across ordinary places,
+Hex maps, and Dungeons. A full place is a Scene boundary. Subplaces, Dungeon
+navigation areas, and exact cells refine position within that Scene without
+creating another one. Characters at different full places require different
+Scenes.
+
+Moving only part of a Scene's Party subgroup to another full place creates or
+joins another Scene. Moving the complete subgroup changes the existing Scene's
+place. Places may be nested on Hex and Dungeon maps. The GM may assign an
+unmapped place administratively, but that action is not travel and advances no
+time automatically.
+
+Weather, music tags, ambience context, and loot-, Encounter-, and
+faction-appearance factors may flow from containing places into children. The
+GM chooses additive or replacing behavior separately for each factor family
+and place; additive behavior is the default.
+
+### Travel, Interruptions, And Overrides
+
+For adjacent movement the GM selects a destination. For a longer journey the
+GM selects travel points and uses a route within the current map. Cross-map
+route planning is optional future convenience rather than binding core scope.
+
+Travel advances position, Scene time, weather, tracks, perception, events, and
+applicable autonomous World behavior. The GM may pause, resume, reroute, end,
+or change the real-time presentation speed without changing in-world duration.
+Every route point and interruption is a committed checkpoint.
+
+Events, Traps, relevant tracks, and perceived NPCs stop further route progress
+at a checkpoint for GM inspection. Perceiving an NPC exposes it in the Scene
+but does not start an Encounter without explicit GM confirmation.
+
+The GM may override any travel-duration input, the calculated final duration,
+or both. While present, a final-duration override wins over all inputs. The GM
+may undo and redo several travel checkpoints. Undo removes the journey segment
+and every result introduced only by that segment, while preserving facts
+already established by a later authoritative Scene.
+
+### Independent Scene Time And World Progression
+
+Split Scenes advance independently. Autonomous World behavior for one
+in-world period occurs once and is reused when an earlier Scene reaches that
+period. The furthest-advanced Scene is authoritative for shared World facts.
+
+The target outcome is that the complete Campaign World progresses with
+GM-confirmed campaign time. Optional Actor Autonomy remains individually
+GM-enabled and bounded. Party involvement pauses before autonomous danger
+resolution; permitted non-Party behavior may continue. Computation strategy
+and scale handling remain later technical decisions rather than product-scope
+reductions.
+
+The GM normally avoids introducing an earlier-time contradiction. If a change
+would conflict with already dependent later history, SaltMarcher warns but
+allows it, marks the affected history as conflicting, and lets the GM resolve
+it manually. The marker remains until the GM explicitly confirms resolution.
+
+### Hex Maps, Knowledge, And Visibility
+
+SaltMarcher supports several continuous Hex maps. Each has no fixed authored
+extent and provides predetermined mouse-wheel zoom levels from local
+three-mile Hexes to world scale. Coarse facts supply finer defaults; detailed
+edits recalculate their coarse aggregate.
+
+The GM can author terrain, rivers, roads, cliffs, ravines, location markers,
+assets, and faction influence; import and export maps; and control Fog of War,
+unknown regions, and manual reveal. Weather and elevation influence sight
+distance. Procedural Hex generation and autonomous faction simulation are
+distant extensions.
+
+Map knowledge belongs to individual characters. The passive map for the
+focused Scene shows the union of its characters' knowledge. A general GM
+reveal action adds selected knowledge to relevant characters without requiring
+character-to-character transfer bookkeeping.
+
+### Climate, Weather, And Ambience
+
+A Hex map has a quick fallback climate plus paintable or otherwise modulatable
+regional climate zones. Seasonal baselines and coherent moving phenomena
+produce gradual, geographically sensible weather without unrelated random
+weather per Hex or burdensome meteorological setup. The GM may author weather
+events with an affected area, type, intensity, movement, time extent, notes,
+and mechanical effects and may pause, edit, or end them.
+
+Structured weather effects initially cover visibility, travel, perception,
+temperature, ambience, and music. Combat-facing effects may remain prominent
+notes for GM adjudication. A mechanically relevant weather change updates its
+effects and creates a Scene-associated notification which remains until the
+weather ends or the GM dismisses it; it does not itself stop travel. New
+influence families, such as creature preferences for weather or time of day,
+remain locally extensible needs.
+
+Music and ambience use locally managed and categorized files. Weather and
+environment layers combine automatically, and SaltMarcher balances the mix.
+The GM may add sounds to or suppress sounds from the automatic selection.
+Those choices persist until released, after which automation resumes from the
+Scene's current place, weather, and time.
+
+### Acceptance Criteria
+
+- the GM can move a complete or partial Scene subgroup through one travel
+  workflow without leaving the Scene workspace
+- adjacent movement and routed travel advance position and in-world time
+  together to explicit checkpoints
+- an event, Trap, relevant track, or perceived NPC stops further progress for
+  GM inspection without deciding its fictional outcome
+- the GM can override travel factors or final duration and can undo and redo
+  several checkpoints without erasing facts already established by a later
+  authoritative Scene
+- split Scenes reuse World behavior already processed for the same in-world
+  period and expose conflicts for manual resolution rather than silently
+  rewriting established history
+- coarse and fine Hex-map edits propagate across zoom levels while preserving
+  GM control over terrain, routes, locations, influence, visibility, and reveal
+- the focused Scene's passive map shows only the union of its characters'
+  knowledge and current perception
+- weather changes coherently across regions and time, applies its structured
+  effects, and keeps a dismissible notification visible while mechanically
+  relevant
+- manual ambience additions and suppressions coexist with automatic selection
+  and balancing until the GM releases them
 
 ## Confirmed Cross-Workflow Behavior
 
@@ -337,10 +465,10 @@ from the saved Scene change.
 
 ### Explanatory Campaign History
 
-The GM can inspect an immutable chronological history of meaningful confirmed
-Campaign consequences, including campaign-time progression, travel, Encounter
-completion, XP, Party membership, NPC or finite-stock effects, and GM
-corrections.
+The GM can inspect an ordinarily immutable chronological history of meaningful
+confirmed Campaign consequences, including campaign-time progression, travel,
+Encounter completion, XP, Party membership, NPC or finite-stock effects, and
+GM corrections.
 
 A correction appends a linked entry rather than rewriting prior history. The
 history is not required to replay the Campaign, reconstruct every intermediate
@@ -348,15 +476,16 @@ application state, or restore an arbitrary whole-Campaign snapshot.
 
 Moving a Scene's in-world time backward or manually resolving different Scene
 times never deletes history or reverses confirmed World consequences. A fact
-recorded later at the table may carry an earlier in-world time and is treated as
-having happened then. Only an explicit GM deletion operation may remove its
-selected target.
+recorded later at the table may carry an earlier in-world time and is treated
+as having happened then. Travel undo is the narrow exception described above:
+it removes the undone segment and results introduced only by it. An explicit
+GM deletion may remove its selected target even when that produces marked
+history conflicts which the GM must later resolve.
 
 ## Awaiting Workflow Confirmation
 
 The following areas intentionally contain no normative behavior yet:
 
-- spatial travel and campaign-time progression outside confirmed Dungeon needs
 - possessions, loot award, follow-up, and general correction workflows
 - import, export, reference refresh, backup, restore, and recovery
 - measurable program-wide responsiveness, scale, modular change, removal,
@@ -375,5 +504,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 - [Program Needs Foundation And Coverage](../interviews/program-needs/2026-07-22-foundation-and-coverage.md)
 - [Session And Scene Preparation Interview](../interviews/program-needs/2026-07-22-session-and-scene-preparation.md)
 - [Running Scene And Live Play Interview](../interviews/program-needs/2026-07-22-running-scene-and-live-play.md)
+- [Spatial Travel And Progression Interview](../interviews/program-needs/2026-07-22-spatial-travel-and-progression.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,9 +1,9 @@
 Status: Draft
 Owner: Aaron (Product Owner)
 Last Reviewed: 2026-07-23
-Source of Truth: Owner-confirmed observable cross-workflow needs for the
-complete local SaltMarcher GM core. This complete candidate still awaits final
-whole-baseline owner confirmation and is not yet an architecture input.
+Source of Truth: Owner-confirmed observable cross-workflow needs for the local
+SaltMarcher GM core. The draft is reopened for the owner's later structured
+Shop-inventory addition and is not yet an architecture input.
 
 # SaltMarcher Program Capability Requirements
 
@@ -809,18 +809,20 @@ history conflicts which the GM must later resolve.
 
 ## Whole-Baseline Confirmation State
 
-All seven interview workflows and the repository-inventory completeness audit
-have owner-confirmed interpretations. The whole-document consistency review
-found no unresolved product decision: later clarifications govern earlier
-questions, and the cross-workflow Encounter outcome now excludes narrative
-effects which the GM manages separately.
+The seven original interview workflows and repository-inventory completeness
+audit have owner-confirmed interpretations. The whole-document consistency
+review resolved their internal conflicts. The owner's later addition of
+structured Shop inventories, restock, and optional randomization reopens the
+completeness workflow; its observable behavior is not yet confirmed and does
+not yet appear as normative behavior in this document.
 
 Exact responsiveness and scale budgets, the detailed weather model, the
 published-rule derivation, persistence and backup mechanisms, and extension
 technology remain deliberate technical-needs, source-backed rule, or product-
-testing work. They do not change the observable needs recorded here. Only one
-final explicit owner confirmation remains before this document becomes the
-`Active Target` for technical-needs derivation.
+testing work. They do not change the observable needs recorded here. Shop
+clarification, a refreshed consistency review, and final explicit owner
+confirmation remain before this document becomes the `Active Target` for
+technical-needs derivation.
 
 ## Acceptance Of This Baseline
 

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -35,6 +35,70 @@ spans or precedes individual feature requirements.
   the owner has not confirmed as need
 - treating this incomplete draft as the baseline for architecture review
 
+## Confirmed Workflow: Campaign Foundation And Knowledge
+
+### Campaign Lifecycle
+
+The GM can create a Campaign with only a name and keep several Campaigns in
+SaltMarcher. Switching happens immediately through options or settings. Running
+Scene, Encounter, and travel state in the Campaign being left remains preserved
+and resumes when the GM returns; switching requires no warning, confirmation,
+or prior closure.
+
+### Reusable And Campaign-Specific Knowledge
+
+Rules, general Creature data, and Item definitions are reusable references
+across Campaigns. PCs, NPCs, places, factions, quests, rumours, possessions, and
+concrete Item instances belong to one Campaign. A Campaign-specific object may
+be copied into another Campaign, where it becomes fully independent. Objects of
+the same kind may share a name.
+
+Campaign content references reusable definitions rather than owning copies.
+Current and future play reads the current definition. Updating a definition does
+not retroactively recalculate completed Scenes or their historical facts.
+
+### Roster, Current Party, And Planning Party
+
+Each Campaign has one `Roster` containing every Campaign PC, whether currently
+participating or not. At most one current `Party` contains those Roster
+characters whose players currently participate at the table. Groups assigned
+to different Running Scenes are subdivisions of that Party, not separate
+Parties.
+
+A Session may be authored without a Party. Before generation, the GM selects a
+planning-only expected Party from the Roster. This selection enables planning
+calculations but neither is nor changes the current table Party.
+
+### Minimal Creation And Explicit Deletion
+
+A Campaign object requires only a name; every other property is optional and may
+be completed later. When the GM creates an object from a Running Scene, the
+creation dialog attaches it to that Scene by default and lets the GM opt out.
+
+Explicit deletion removes an object from preparation, Running Scenes, and
+Running Encounters, including runtime state that depends on it. Completed
+history retains the historical fact but displays the missing identity as
+`[UNKNOWN]`. If the object remains recoverable in trash, the history may link to
+that recoverable object.
+
+### Acceptance Criteria
+
+- the GM can create a usable empty Campaign by entering only a name
+- the GM can switch Campaigns immediately and later resume the exact Running
+  Scene, Encounter, and travel state left in each Campaign
+- a Session can be manually authored without selecting any Party
+- generation uses a Session-owned expected Party selected from the Roster and
+  does not change the current table Party
+- copying Campaign-specific content into another Campaign creates an
+  independently editable object
+- a changed reusable definition affects current and future reads without
+  changing completed Scene facts
+- name-only creation from a Running Scene attaches there by default and exposes
+  an opt-out before confirmation
+- explicit deletion removes current references and dependent Encounter runtime
+  while completed history keeps its fact with an unknown or recoverable-trash
+  reference
+
 ## Confirmed Cross-Workflow Behavior
 
 ### Complete Encounter Outcome
@@ -80,8 +144,6 @@ application state, or restore an arbitrary whole-Campaign snapshot.
 
 The following areas intentionally contain no normative behavior yet:
 
-- Campaign foundation, switching, reusable reference knowledge, and authored
-  Campaign knowledge
 - session and Scene preparation, Encounter and reward generation, planned
   weather, music, and notes
 - live table workflow outside the confirmed cross-workflow behavior above
@@ -102,5 +164,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 
 - [Program Needs Interview Series](../interviews/program-needs/README.md)
 - [Program Needs Foundation And Coverage](../interviews/program-needs/2026-07-22-foundation-and-coverage.md)
+- [Session And Scene Preparation Interview](../interviews/program-needs/2026-07-22-session-and-scene-preparation.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -198,23 +198,111 @@ across every kind of object.
 - the GM can edit relevant notes in a Running Scene and search notes across all
   object kinds
 
-### Runtime Clarification: Scene And Encounter
+## Confirmed Workflow: Live Table Play
 
-The primary Running Scene always exists and cannot be paused, completed, closed,
-or discarded. Empty Scenes are removed; a remaining populated Scene becomes
-primary. If the current Party is empty, all Scenes except one empty primary
-Scene are removed. A Scene has zero or one current location. Changing location
-changes the NPCs, Features, treasures, monster groups, and other location
-content shown in the Scene unless the GM explicitly makes content travel with
-the Party or pins it to the Scene. Content that leaves the Scene remains at its
-location.
+### Continuous Scene State And Party Splits
 
-An Encounter is not persistent World content. It is a temporary combat mask
-over a Running Scene that selects PCs and NPCs already present there and adds
-combat behavior such as HP tracking and initiative. Chase and future mask types
-may provide other focused workflows. The Scene remains visible in the main
-panel while mask state remains available in its adjacent state panel. Persistent
-preparation creates and places monster groups, not Encounters.
+The primary Running Scene is always available as mutable runtime state in the
+Scene workspace; the GM neither creates nor completes it. A Scene has zero or
+one current location. Split Scenes need no name or label.
+
+Every active Party character belongs to exactly one Running Scene. Activating a
+Roster character assigns that character to the GM-focused Scene. Inactive
+Roster characters belong to no Scene and retain their last location and other
+state.
+
+The GM uses the same action to move selected characters into a new or existing
+Scene. An empty Scene is removed and a remaining populated Scene becomes the
+primary Scene. If the current Party is empty, one empty primary Scene remains
+available.
+
+Changing a Scene's location replaces its location-derived NPCs, Features,
+treasures, monster groups, and other content. The GM may instead pin any
+Scene-capable content to that Scene or assign it to travel with exactly one
+Party subgroup. Content that leaves or outlives a Scene remains at its location
+and is never implicitly deleted.
+
+### Masks And Prepared Monster Groups
+
+Persistent preparation creates editable monster groups at locations, not
+Encounters. At a Scene's current location, the GM selects individual monsters
+or groups and Scene participants to start an Encounter.
+
+Encounter, Chase, and possible future masks add focused runtime behavior over
+the continuously visible Scene. Several masks of the same or different types
+may coexist, and one PC, NPC, or monster may participate in several masks.
+Moving a character to another Scene removes that character from every mask
+without blocking the move.
+
+The GM ends an Encounter through the confirmed completion workflow. Its
+confirmed consequences apply while the Running Scene continues.
+
+### Live Search, Creation, Notes, And Music
+
+The GM can search all content without leaving the Scene and add a result
+directly to it. The GM can also create lightweight, note-first Campaign content
+there, including NPCs, locations, factions, and similar objects. Complete data
+records such as Items and monsters remain outside Scene-local creation.
+
+Relevant object notes remain visible and editable in the Scene, while notes
+across every object kind remain searchable. The focused Scene drives optional
+music autoplay. Scene changes update the queue, obsolete songs fade out, and
+the GM's manual player actions take precedence.
+
+### Independent Time And Weather
+
+Every Scene advances its own time through travel, exploration, and mask
+activity. Encounter and Chase rounds last six seconds. Travel duration is
+calculated and initially cannot be overridden; overriding it remains a
+low-priority quality-of-life extension. The GM chooses exploration duration.
+
+The GM may increment Scene time forward or backward. When groups with different
+times reunite, the GM manually chooses their temporal resolution. Moving
+temporal focus backward never deletes history, reverses World state, or rolls
+back another Scene. A fact recorded later at the table may carry an earlier
+in-world time and is treated as having happened then. Only an explicit deletion
+operation removes its selected target.
+
+Weather advances independently from each Scene's time, location, terrain, and
+climate data. A GM override remains until the GM disables it, after which
+autonomous weather resumes.
+
+### Passive Second Display
+
+The passive second display immediately follows the focused Scene. During travel
+it automatically shows the map; at a location it automatically shows background
+art. Map visibility is the union of what at least one character in the focused
+Scene can perceive and updates with position, line of sight, light, hidden
+state, and similar visibility changes.
+
+NPC artwork appears only when highlighted by the GM. During an Encounter or
+Chase, the GM may enable automatic artwork for the current actor. The display
+contains only maps and NPC or location artwork; it never exposes mechanics,
+text, or private notes. The GM can blank it or manually replace the automatic
+visual at any time.
+
+### Acceptance Criteria
+
+- one empty primary Scene remains usable when no Party character is active
+- every active Party character appears in exactly one Scene, and activation
+  assigns that character to the focused Scene
+- the GM can split and reunite the Party through the same character-move action
+  without implicitly deleting content left at a location
+- entering a location makes its prepared monster groups available without
+  creating or starting a persistent Encounter
+- several masks and shared mask participants may coexist while the Scene
+  remains continuously usable
+- moving a character to another Scene removes that character from every mask
+  without blocking the move
+- the GM can search all content, add a result, and create note-first Campaign
+  content without leaving the Scene
+- split Scenes may advance to different times, and their later reunification
+  never deletes history or reverses confirmed World state
+- automatic weather follows each Scene independently and resumes when the GM
+  releases a manual override
+- the passive second display switches with Scene focus, reveals only currently
+  perceivable map content, never exposes textual or mechanical state, and can
+  be blanked or replaced by the GM
 
 ## Confirmed Cross-Workflow Behavior
 
@@ -230,12 +318,9 @@ still-unconfirmed workflow.
 
 Party activation, deactivation, or deletion is authoritative immediately and is
 not rolled back by an unavailable Running Scene or Encounter. A later
-live-workflow answer supersedes the earlier allowance for an unassigned active
-character: every active Party character belongs to exactly one Running Scene,
-and activation assigns the character to the currently focused Scene. Inactive
-Roster characters belong to no Scene and retain their last location and other
-state. Deactivated or deleted characters immediately stop counting as current
-Party members.
+live-workflow answer establishes the Scene assignment behavior above.
+Deactivated or deleted characters immediately stop counting as current Party
+members.
 
 Only Running Scenes that reference the changed character and their Encounters
 reconcile. Until reconciliation succeeds, affected contexts are visibly pending
@@ -271,7 +356,6 @@ selected target.
 
 The following areas intentionally contain no normative behavior yet:
 
-- live table workflow outside the confirmed cross-workflow behavior above
 - spatial travel and campaign-time progression outside confirmed Dungeon needs
 - possessions, loot award, follow-up, and general correction workflows
 - import, export, reference refresh, backup, restore, and recovery
@@ -290,5 +374,6 @@ behavior, and no unresolved product decision blocks technical-needs derivation.
 - [Program Needs Interview Series](../interviews/program-needs/README.md)
 - [Program Needs Foundation And Coverage](../interviews/program-needs/2026-07-22-foundation-and-coverage.md)
 - [Session And Scene Preparation Interview](../interviews/program-needs/2026-07-22-session-and-scene-preparation.md)
+- [Running Scene And Live Play Interview](../interviews/program-needs/2026-07-22-running-scene-and-live-play.md)
 - [Project Vision](../vision.md)
 - [Documentation Standard](../documentation.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -111,19 +111,20 @@ may appear in several entries. The GM can add, remove, reorder, and annotate
 entries at any time.
 
 Timeline entries are not stored Scenes. A Scene exists only as resumable runtime
-state. Ordinarily there is one Running Scene; a split Party may create several
-distinct Running Scenes.
+state. The primary Running Scene is always available in the Scene tab and only
+changes its contents; the GM neither starts nor ends it. Splitting characters
+out of that Scene creates additional Running Scenes.
 
-The GM can prepare the complete timeline, Encounters, treasures, and location
-placements manually without a planning Party, Adventure Day, name, date, or
-generation.
+The GM can prepare the complete timeline, monster groups, treasures, and
+location placements manually without a planning Party, Adventure Day, name,
+date, or generation.
 
 ### Assisted Generation
 
 Generation uses a planning-only expected Party selected from the Roster and
 does not change the current table Party. It requires an Adventure Day. For the
 selected characters and levels, the Adventure Day provides the DMG-guided
-Encounter amount, XP budget, and loot budget used to create Encounters and
+Encounter amount, XP budget, and loot budget used to create monster groups and
 treasures.
 
 The GM may optionally provide a desired Scene count and select locations,
@@ -133,21 +134,21 @@ other existing or newly created Campaign content. Before generation it checks
 whether all constraints fit the Adventure Day. If not, it explains the conflict
 and disables generation instead of producing a partial result.
 
-Generation returns a timeline with concrete Encounters and treasures. The GM
-can edit, regenerate, reject, accept, and place each result independently.
+Generation returns a timeline with concrete monster groups and treasures. The
+GM can edit, regenerate, reject, accept, and place each result independently.
 Regenerating one result leaves every other result, manual edit, placement, and
 timeline change untouched.
 
 ### Accepted World Content And Treasures
 
-Placing an Encounter or treasure accepts it as persistent World content. It
+Placing a monster group or treasure accepts it as persistent World content. It
 remains editable and survives replacement of the current plan. Replacing the
 plan removes its timeline, timeline notes, and unaccepted drafts without
 changing any accepted placement.
 
-When the Party reaches a prepared location, its placed Encounters and treasures
-appear in the Running Scene UI. SaltMarcher does not start, resolve, or award
-them automatically; the GM decides what happens.
+When the Party reaches a prepared location, its placed monster groups and
+treasures appear in the Running Scene UI. SaltMarcher does not begin combat or
+award anything automatically; the GM decides what happens.
 
 A treasure may contain Items, including coins, trade goods, magic Items,
 equipment, and other possessions. The GM can independently add, remove,
@@ -186,7 +187,7 @@ across every kind of object.
   preserves all accepted World placements
 - generation remains unavailable with an explanation when its binding inputs
   cannot fit the selected Party's Adventure Day
-- a generated Encounter or treasure can be changed or regenerated without
+- a generated monster group or treasure can be changed or regenerated without
   changing any other generated or manual preparation
 - reaching a prepared location exposes placed content without starting or
   awarding it automatically
@@ -196,6 +197,19 @@ across every kind of object.
   controls take precedence
 - the GM can edit relevant notes in a Running Scene and search notes across all
   object kinds
+
+### Runtime Clarification: Scene And Encounter
+
+The primary Running Scene always exists and cannot be paused, completed,
+closed, or discarded. It has zero or one current location. Changing location
+changes the NPCs, Features, treasures, monster groups, and other location
+content shown in the Scene unless the GM explicitly makes content travel with
+the Party or pins it to the Scene.
+
+An Encounter is not persistent World content. It is a temporary combat mask
+over a Running Scene that selects PCs and NPCs already present there and adds
+combat behavior such as HP tracking and initiative. Persistent preparation
+creates and places monster groups, not Encounters.
 
 ## Confirmed Cross-Workflow Behavior
 

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,9 +1,9 @@
 Status: Draft
 Owner: Aaron (Product Owner)
 Last Reviewed: 2026-07-23
-Source of Truth: Owner-confirmed observable cross-workflow needs for the local
-SaltMarcher GM core. The draft is reopened for the owner's later structured
-Shop-inventory addition and is not yet an architecture input.
+Source of Truth: Owner-confirmed observable cross-workflow needs for the
+local SaltMarcher GM core. The draft still awaits one Shop owner-deletion
+decision and final confirmation and is not yet an architecture input.
 
 # SaltMarcher Program Capability Requirements
 
@@ -484,18 +484,21 @@ rounded-up distribution rule as Encounter XP.
 
 ### Character Loot Ledger
 
-Awarded Items appear in a searchable and filterable character-specific loot
-ledger. It is a GM reminder and Reward-accounting surface, not a player-operated
-or rules-complete inventory simulation. The GM may add, remove, or correct
-ledger Items manually without a Reward source. Coins, trade goods, and
-equivalent Items support quantity stacks which may be split and merged.
+Awarded and purchased Items appear in a searchable and filterable
+character-specific loot ledger. It is a GM reminder and Reward-accounting
+surface, not a player-operated or rules-complete inventory simulation. Awarded
+Items count as received loot; purchased Items carry their purchase source but
+do not. The GM may add, remove, or correct ledger Items manually without a
+Reward source. Coins, trade goods, and equivalent Items support quantity stacks
+which may be split and merged.
 
 `Received`, `given away`, and `sold` are non-mechanical reminders. Sold or
-given-away Items remain visible and continue to count as received loot. A sale
-or handoff records a structured counterparty link to an existing NPC, place, or
-faction when available, plus optional free text. A sale also records its actual
-price, which becomes authoritative for final loot valuation of that sold Item.
-A separate per-instance value override is not required.
+given-away awarded Items remain visible and continue to count as received loot.
+A sale or handoff records a structured counterparty link to an existing Shop,
+NPC, place, or faction when available, plus optional free text. A sale also
+records its actual price, which becomes authoritative for final loot valuation
+when that Item counts as received loot. A separate per-instance value override
+is not required.
 
 Item provenance records available Treasure, Encounter or Quest, Scene or
 place, in-world time, and award time, with optional free-form provenance for
@@ -538,6 +541,68 @@ governed by their previously confirmed behavior.
   their provenance, counterparty, and applicable sale information
 - Session generation compensates proposed Rewards for the cumulative difference
   between expected loot for received XP and actual received loot
+
+## Confirmed Workflow: Shops And Trade
+
+### Shop Identity And Inventory
+
+A Shop is a named Campaign record with one structured inventory and belongs to
+exactly one NPC or exactly one place. Its inventory contains quantity stacks of
+reusable Item definitions and individual concrete or unique Items. An entry
+records its current quantity, the price charged when the Party buys, the price
+paid when the Shop buys, and optional notes.
+
+The GM may add, remove, and edit Shop stock manually at any time. When the
+owning NPC is present in a Running Scene or the owning place is the Scene's
+current place, the Shop is available directly from that Scene.
+
+### Trade And Character Ledger
+
+One trade interaction updates Shop stock and the character loot ledger
+together. On purchase, the GM selects the receiving character, Shop stock
+decreases, and the acquired Item enters that character's ledger.
+
+A purchased Item is marked as a purchase and does not count as received loot
+in cumulative loot guidance. SaltMarcher records the paid price but does not
+automatically deduct coins from the character ledger.
+
+When a character sells an Item to the Shop, Shop stock increases and the
+character ledger records the sold state, actual price, and Shop or owning NPC
+as counterparty according to the existing sale rules.
+
+### Restock And Randomized Stock
+
+The GM can restock manually and can define automatic rules triggered by elapsed
+Campaign time or configured calendar events. A fixed rule may refill an entry
+to a target quantity or add a configured quantity.
+
+Randomized restock uses GM-configured weighted Item tables or filters such as
+type, rarity, value, and tags. A configured automatic restock may update stock
+without per-run preview or confirmation.
+
+Time-based restock runs once according to authoritative Campaign time even when
+several Scenes reach the trigger. It leaves manually added stock unchanged
+unless an explicit restock rule manages that stock.
+
+Purchases, sales, and automatic restocks remain in explanatory Campaign
+history. Automatic restock creates no separate notification.
+
+### Acceptance Criteria
+
+- a named Shop belongs to one NPC or one place and exposes stacks and unique
+  Items with quantities, both trade prices, and optional notes
+- the Scene exposes a Shop when its owning NPC is present or its owning place
+  is current
+- one purchase decreases Shop stock and records the selected character's
+  acquisition without counting it as received loot or deducting coins
+- one sale increases Shop stock and records the character's actual sale price
+  and counterparty
+- the GM can restock manually and configure target-quantity, additive, and
+  randomized restock rules
+- a time-based rule runs once at authoritative Campaign time and does not alter
+  manually added stock outside its explicit scope
+- trade and restock remain visible in history without an additional automatic-
+  restock notification
 
 ## Confirmed Workflow: Local Data Lifecycle
 
@@ -809,20 +874,18 @@ history conflicts which the GM must later resolve.
 
 ## Whole-Baseline Confirmation State
 
-The seven original interview workflows and repository-inventory completeness
-audit have owner-confirmed interpretations. The whole-document consistency
-review resolved their internal conflicts. The owner's later addition of
-structured Shop inventories, restock, and optional randomization reopens the
-completeness workflow; its observable behavior is not yet confirmed and does
-not yet appear as normative behavior in this document.
+All seven interview workflows, the repository-inventory completeness audit,
+and the later structured Shop-inventory addition have owner-confirmed
+interpretations. The refreshed consistency review reconciled Shop purchases
+and counterparties with the character ledger. One Shop lifecycle decision
+remains open: what happens when its only owning NPC or place is deleted.
 
 Exact responsiveness and scale budgets, the detailed weather model, the
 published-rule derivation, persistence and backup mechanisms, and extension
 technology remain deliberate technical-needs, source-backed rule, or product-
-testing work. They do not change the observable needs recorded here. Shop
-clarification, a refreshed consistency review, and final explicit owner
-confirmation remain before this document becomes the `Active Target` for
-technical-needs derivation.
+testing work. They do not change the observable needs recorded here. The Shop
+owner-deletion decision and final explicit owner confirmation remain before
+this document becomes the `Active Target` for technical-needs derivation.
 
 ## Acceptance Of This Baseline
 


### PR DESCRIPTION
## Summary

- starts a workflow-first needs interview for the complete local SaltMarcher GM core
- treats current feature requirements, architecture, and code as discovery prompts rather than target constraints
- preserves only previously confirmed owner evidence and explicitly excludes architecture decisions
- adds a draft program-level requirements owner that remains incomplete until every workflow is confirmed

## Superseded architecture work

PR #547 was closed as premature. Its architecture is not carried forward. The four already confirmed live-campaign answers are preserved as product evidence without the rejected root, storage, module, or transaction design.

## Interview boundary

The interview proceeds breadth-first across Campaign foundation, preparation, live play, spatial progression, follow-up, local data lifecycle, and finally cross-workflow quality needs. Questions arrive in small concrete blocks; each workflow needs explicit owner confirmation and the complete baseline needs one final acceptance.

## Validation

- relative Markdown links resolve locally
- `git diff --check`
- `./gradlew check --console=plain` — `BUILD SUCCESSFUL`

## Acceptance gate

Keep this PR as Draft while the interview is incomplete. Do not derive architecture from the draft, mark the program requirements `Active Target`, mark the PR ready, or merge until the owner confirms every workflow and the final baseline.
