### PR TITLE
Add adversarial architecture planning skill

### DIFF
--- a/docs/project/architecture/agent-instructions.md
+++ b/docs/project/architecture/agent-instructions.md
@@ -1,6 +1,6 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-15
+Last Reviewed: 2026-07-23
 Source of Truth: Minimal SaltMarcher agent execution and review rules.
 
 # Agent Instruction Standard
@@ -12,6 +12,12 @@ clear. Planning, design notes, role chains, model assignments, writer
 allocations, and phase artifacts are optional tools, never prerequisites.
 Use them only when they remove a concrete implementation risk or the user asks
 for them.
+
+Use the opt-in `architecture-planning` skill when the user explicitly requests
+greenfield target architecture or architecture-significant refactor design with
+independent error search and replanning. That skill produces a reviewed design,
+not implementation or migration sequencing; ordinary planning remains with the
+lightweight `planner` skill after architecture decisions are settled.
 
 For work spanning context compactions, one short delivery file may record the
 current tree, completed work, proof, and next action. It must not become a

--- a/tools/quality/skills/architecture-planning/SKILL.md
+++ b/tools/quality/skills/architecture-planning/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: architecture-planning
+description: Runs a bounded generate-verify-revise loop for explicitly requested SaltMarcher greenfield target architecture or architecture-significant refactor planning. Use when the user requests a decision-complete architecture design with independent error search and revision or replanning. Do not use for ordinary implementation sequencing, implementation or migration execution, or review-only work.
+---
+
+# Architecture Planning
+
+Produce an architecture candidate, not an implementation. Separate generation,
+error search, and revision so that a candidate never verifies or repairs itself.
+
+## Non-Negotiable Rules
+
+- Main owns the input packet, neutral role briefs, finding aggregation, candidate
+  count, and final verdict. Do not add a coordinator or finding-classifier role.
+- Give every Planner, Verifier, and Reviser a fresh context containing only the
+  applicable contract, neutral task, and contractually allowed inputs. Do not
+  pass conversation history, prior reasoning, or intended fixes. Reviewers
+  remain read-only and launch no agents.
+- Review at most three candidate versions, `v1` through `v3`. If `v3` is
+  rejected, report that no acceptable architecture was found and stop.
+- Never call a candidate accepted while a blocker or major finding remains.
+  Dispose every minor by repair or by recording an explicit risk, trigger, and
+  verification owner in the candidate.
+- Keep candidate drafts and finding ledgers temporary. Persist only the final
+  owner document and genuinely necessary narrow decisions when the user asks
+  for durable documentation.
+- Stop on product ambiguity and route it to the requirements owner. Do not turn
+  an architectural preference into product behavior.
+
+Read [stage-contracts.md](references/stage-contracts.md) and
+[error-search.md](references/error-search.md) completely before starting.
+
+## Select The Mode
+
+Use `Greenfield` when the request asks for a target independent of the current
+system. Treat the active solution-neutral needs as authority. Upstream
+requirements, vision, policy, and preserved evidence are readback sources only.
+Do not inspect current code, tests, architecture, technologies, delivery state,
+or migration constraints during generation, verification, or revision.
+
+Use `Evolution` for an architecture-significant refactor of an existing system.
+Read the active needs and requirements plus current architecture owners,
+contracts, production routes, state and persistence paths, tests, enforcement,
+and compatibility constraints. Current structure is evidence, not automatic
+target truth.
+
+If the mode is unclear after inspecting the request and owner documents, ask
+before generating a candidate.
+
+## Run The Loop
+
+1. Freeze the input packet and an immutable version of every included input.
+   Complete the Main gate in the Stage Contracts before generating. Restart at
+   `v1` if a binding input changes.
+2. Ask a fresh Planner to generate `v1` using the Planner contract.
+3. Run the three independent specialist passes. They may run in parallel.
+4. Run the clean-start audit afterward without showing it specialist findings.
+5. Aggregate duplicate findings directly in Main and give the candidate plus
+   normalized ledger to a fresh Reviser.
+6. Apply a local revision only when the selected decision and its rationale
+   remain valid. Return to a fresh Planner when a core assumption, alternative,
+   tradeoff, or downstream decision is invalidated.
+7. Re-run every specialist pass and the clean-start audit for each new version.
+   Do not verify only the edited section.
+
+Verifier approval establishes a reviewed architecture candidate only. It does
+not activate a repository document, authorize implementation, or replace the
+normal branch, proof, pull-request, and owner rules.
+
+## Evidence
+
+Use `source-references` before relying on external evidence. The methodological
+inspiration is the Generator-Verifier-Reviser loop in:
+
+- `/home/aaron/Schreibtisch/projects/references/agent-methods/aletheia-towards-autonomous-mathematics-research.md`
+- <https://arxiv.org/abs/2602.10177>
+
+Adopt the separation and bounded retry, not an assumption that natural-language
+verification guarantees correctness. Preserve the explicit failure outcome.

--- a/tools/quality/skills/architecture-planning/agents/openai.yaml
+++ b/tools/quality/skills/architecture-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Architecture Planning"
+  short_description: "Plan and adversarially refine architectures"
+  default_prompt: "Use $architecture-planning to derive and adversarially refine a decision-complete architecture plan."

--- a/tools/quality/skills/architecture-planning/references/error-search.md
+++ b/tools/quality/skills/architecture-planning/references/error-search.md
@@ -1,0 +1,86 @@
+# Architecture Planning Error Search
+
+## Role Isolation
+
+Give each specialist the Error Search contract, assigned specialist section,
+neutral task, frozen input packet, and candidate. Do not provide conversation
+history, Planner notes, other findings, or an intended fix. Specialists remain
+read-only, do not launch agents, and report only evidence-backed findings.
+
+After all specialist passes finish, give the clean-start auditor the same packet
+and candidate but no specialist output. Main aggregates afterward.
+
+## Universal Checks
+
+Every pass checks relevant concerns for:
+
+- complete and exact source-to-decision traceability;
+- internal consistency across views, rules, and decisions;
+- objective verification and feasible fitness functions;
+- meaningful alternatives and honest tradeoffs;
+- no invented product behavior or hidden requirement;
+- no current-system anchoring in `Greenfield` mode;
+- no unjustified preservation or reinvention in `Evolution` mode;
+- explicit one-way doors, assumptions, and failure boundaries.
+
+## Specialist A: Architecture And State
+
+Search for counterexamples involving scope, vocabulary, identity, state owner,
+mutation authority, aggregate and consistency boundaries, lifecycle, history,
+cross-workflow atomicity, dependency direction, runtime ordering, stale state,
+and contradictions between static and runtime views.
+
+## Specialist B: Resilience And Performance
+
+Search for counterexamples involving preservation, recovery, conversion,
+portability, cancellation, partial success, retry, scheduling, contention,
+resource exhaustion, startup and resume, large workloads, latency budgets,
+background-work interference, measurement populations, and unverifiable or
+physically inconsistent targets.
+
+## Specialist C: Security And Modularity
+
+Search for counterexamples involving trust boundaries, untrusted input,
+permissions and revocation, egress, privacy, deletion, extension failure,
+optional-capability removal, change isolation, accessibility, localization, and
+hidden dependence on a technology or service. In `Evolution` mode, also search
+for violated compatibility and transition constraints; do not introduce them in
+`Greenfield` mode.
+
+Do not add a default UX pass. Use a separate UX review only when the user asks
+for it or the architecture question explicitly owns interaction design.
+
+## Clean-Start Audit
+
+Re-derive the expected obligations from the frozen packet and compare them with
+the candidate. Check the specialist blind spots: omitted needs, nominal rather
+than substantive mappings, mutually impossible rules, missing decision edges,
+solution-shaped requirements, and claims stronger than their proof route.
+
+Return `approve` or `reject`. Approval requires zero blocker and major findings
+and every minor already repaired or recorded in the candidate with its explicit
+risk, trigger, and verification owner.
+
+## Finding Contract
+
+Use this shape for every actionable finding:
+
+| Field | Meaning |
+| --- | --- |
+| ID | Stable `F-*` identifier within the candidate version |
+| Severity | `blocker`, `major`, or `minor` |
+| Source | Violated need, constraint, decision, or candidate passage |
+| Counterexample | Concrete scenario showing the failure |
+| Impact | Quality, behavior, safety, or change consequence |
+| Evidence | Reproduction, calculation, source, or trace mismatch |
+| Affected decisions | `AD-*` dependency closure |
+| Correction criterion | Outcome required for the finding to close, without prescribing implementation |
+
+Use `blocker` for an impossible or contradictory candidate, invalid baseline,
+or missing information that prevents a coherent architecture. Use `major` when
+a binding need, quality scenario, safety boundary, one-way door, or objective
+proof is missing or violated. Use `minor` for local precision or risk-recording
+gaps that do not invalidate the selected architecture.
+
+Do not report preferences, style suggestions, or speculative improvements as
+findings. Do not repair the candidate in the verifier response.

--- a/tools/quality/skills/architecture-planning/references/stage-contracts.md
+++ b/tools/quality/skills/architecture-planning/references/stage-contracts.md
@@ -1,0 +1,118 @@
+# Architecture Planning Stage Contracts
+
+## Input Packet
+
+Main freezes one packet before candidate generation:
+
+| Field | Required content |
+| --- | --- |
+| Goal | Architecture question and intended decision outcome |
+| Mode | `Greenfield` or `Evolution` |
+| Audience | Consumers of the candidate and its decisions |
+| Baseline | Exact owner documents plus repository revision, immutable source version, or content hash for every included input |
+| Binding inputs | Mode-specific authorities defined below |
+| Readback inputs | Sources used only to resolve or audit an existing binding input |
+| Current evidence | `Evolution` starting-point owners, contracts, production paths, tests, and enforcement; `none, forbidden` in `Greenfield` |
+| Exclusions | Current-system or delivery evidence forbidden in this mode |
+| Success | Objective candidate and review acceptance facts |
+| Output owner | Conversation plan or one canonical architecture owner document |
+
+An external source is eligible only after its readable extract and original are
+preserved through `source-references`. If a binding input changes, discard the
+candidate count and start again at `v1`.
+
+In `Greenfield`, only the active solution-neutral needs and constraints stated
+inside that owner are binding. Requirements, vision, policy, and preserved
+evidence are readback sources for checking provenance or resolving an ambiguity;
+they do not independently add target behavior. Record a repository revision or
+content hash for the allowed inputs without inspecting excluded current-system
+material.
+
+In `Evolution`, the active needs and confirmed requirements plus an explicitly
+accepted refactor outcome, must-preserve behavior, and compatibility constraints
+are binding. Current structure, production paths, and tests are evidence about
+the starting point, not automatic target requirements.
+
+Before `v1`, Main checks that every packet field is present and that no product
+ambiguity or missing measurement population can alter selection criteria. Route
+such gaps to the requirements owner and do not generate. A non-blocking
+technical evidence gap may remain in a candidate only when all affected choices
+stay reversible and the candidate records the evidence owner, decision trigger,
+and proof needed before commitment.
+
+## Planner Contract
+
+Give the Planner the Planner contract, neutral task, and frozen packet only.
+Require it to:
+
+1. Restate the entity, scope, stakeholders, concerns, and binding priorities.
+2. Enumerate architecture decision questions and their dependency order.
+3. Generate at least two genuinely different alternatives for every
+   quality-critical or hard-to-reverse decision. `Do nothing` is an alternative
+   only in `Evolution` mode.
+4. Compare alternatives against the binding needs, quality and change
+   scenarios, failure modes, reversibility, and proof cost.
+5. Select a coherent candidate from evidence and priorities, never by vote or
+   by combining incompatible advantages from different alternatives.
+6. Assign stable `AD-*` decision identifiers and map every binding need through
+   `Need -> AD -> View or rule -> Verification`.
+
+Use only the views needed by the concerns. A program-wide candidate normally
+covers context, state and ownership, static boundaries, runtime and concurrency,
+data and recovery, trust and extensions, deployment, and verification. A
+feature or refactor candidate may omit irrelevant views but must say why.
+
+The candidate must contain:
+
+- scope, vocabulary, assumptions, and exclusions;
+- selected decisions, alternatives, rationale, costs, and reversibility;
+- boundary ownership and dependency direction;
+- runtime and consistency behavior for critical cross-workflows;
+- quality-scenario and failure containment consequences;
+- exact traceability and proposed fitness functions;
+- compatibility and transition constraints in `Evolution` mode only;
+- unresolved evidence gaps and risks without invented answers.
+
+## Reviser Contract
+
+Give a fresh Reviser the Reviser contract, neutral task, frozen packet,
+candidate, and normalized findings only. For every finding, record `accept`,
+`reject`, or `route` with evidence.
+
+`accept` means the finding is valid and must be corrected. `reject` means the
+finding is invalid or out of scope and records why. `route` means the finding
+requires a binding-input decision or external evidence before architecture work
+can continue; it pauses both local revision and replanning. Process routed items
+before accepted findings. If they change a binding input, discard the candidate
+count and restart at `v1`.
+
+Use a local revision when the finding adds missing precision, traceability,
+proof, or containment without changing the selected alternative or its
+rationale. Re-enter the Planner contract when correction changes a decision's
+objective, invalidates its selection criteria, reverses a quality tradeoff, or
+invalidates any dependent decision.
+
+Route product ambiguity to the requirements owner. Resolve missing technical
+evidence through `source-references`. Neither case consumes another candidate
+version until the frozen packet changes or becomes complete.
+
+## Version And Stop Contract
+
+- `v1`: initial Planner candidate.
+- `v2`: first revised or replanned candidate after a rejected `v1`.
+- `v3`: final permitted candidate after a rejected `v2`.
+
+Every candidate receives the full Error Search contract. Approval ends the
+loop. Rejection of `v3` returns `No acceptable architecture found`, the
+remaining findings, and the earliest invalid decision. It must not emit a
+fallback architecture or activation claim.
+
+Intermediate candidates, role notes, and findings remain untracked scratch
+state. When context compaction makes a handoff file necessary, use the one short
+delivery note already permitted by the agent instruction owner; do not create a
+new planning registry.
+
+An approved final result names the accepted candidate version, covered needs,
+decision and verification trace, disposed findings, accepted risks with owners
+and triggers, and any later implementation or migration planning boundary. A
+failed final result names the remaining findings and earliest invalid decision.

--- a/tools/quality/skills/planner/SKILL.md
+++ b/tools/quality/skills/planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planner
-description: Produces short M-tier implementation plans and L-tier journal design notes for SaltMarcher work. Use when a change needs implementation sequencing before editing.
+description: Produces short M-tier implementation plans and L-tier journal design notes for SaltMarcher work after architecture decisions are settled. Use when a change needs implementation sequencing before editing; use architecture-planning instead when the user explicitly requests greenfield or architecture-significant refactor design with independent error search and replanning.
 ---
 
 # Planner
@@ -19,8 +19,9 @@ Write 5-15 lines covering:
 
 ## L-Tier Design Note
 
-Append one page to `docs/project/journal/YYYY-MM.md` before implementation,
-unless the user waives it. Cover:
+When the user asks for a durable L-tier note or it removes a concrete
+implementation risk, append one page to `docs/project/journal/YYYY-MM.md` before
+implementation. Cover:
 
 - problem
 - target state


### PR DESCRIPTION
## What changed

- add an opt-in `architecture-planning` skill with separate Planner, Error Search, and Reviser stages
- define Greenfield and Evolution input boundaries, bounded `v1`-`v3` retries, traceability, findings, and explicit failure outcomes
- add three independent specialist reviews plus a blind clean-start audit
- keep the lightweight `planner` focused on post-architecture implementation sequencing
- route explicit adversarial architecture planning from the canonical agent instruction owner

## Why

Architecture planning needs a repeatable way to generate a candidate, search independently for errors, and either fix locally or re-plan without letting a candidate validate itself. The method is inspired by Aletheia's Generator-Verifier-Reviser separation while preserving an explicit no-acceptable-result outcome.

## Impact

This adds planning instructions only. It does not select a target architecture, alter runtime behavior, or authorize implementation or migration.

## Verification

- `python3 /home/aaron/.codex/skills/.system/skill-creator/scripts/quick_validate.py tools/quality/skills/architecture-planning`
- `python3 /home/aaron/.codex/skills/.system/skill-creator/scripts/quick_validate.py tools/quality/skills/planner`
- `git diff --cached --check`
- `./gradlew check --console=plain`
- fresh-context Greenfield, Evolution, and rejection/replanning forward tests
- independent adversarial instruction review with all findings resolved
