### PR TITLE
docs: gekoppelten Aletheia-Delivery-Prozess starten

### DIFF
--- a/docs/project/delivery/README.md
+++ b/docs/project/delivery/README.md
@@ -1,16 +1,27 @@
 Status: Active
 Owner: SaltMarcher Team
-Last Reviewed: 2026-07-19
-Source of Truth: Routing to active temporary migration roadmaps.
+Last Reviewed: 2026-07-24
+Source of Truth: Routing to active temporary project delivery owners.
 
 # Active Project Delivery
 
-This directory routes active migrations. It does not own product behavior,
+This directory routes active delivery work. It does not own product behavior,
 architecture, contracts, proof history, or feature status beyond these links.
+
+## Active Programs
+
+The GM-Core program uses two coupled Aletheia workstreams. Their current,
+temporary process owners are:
+
+- [Program umbrella issue](https://github.com/ThonkTank/Salt-Marcher/issues/555)
+- [Program Charter](aletheia/program-charter.md)
+- [Product Process](aletheia/product-process.md)
+- [Process Improvement](aletheia/process-improvement.md)
+- [Process Evaluation](aletheia/process-evaluation.md)
 
 ## Active Migrations
 
 There are no active migration roadmaps.
 
-Each roadmap is temporary and is removed after its own finish criteria are
-met. Durable decisions remain in the linked owner documents.
+Each delivery owner is temporary and is removed after its own finish criteria
+are met. Durable decisions remain in the linked product owner documents.

--- a/docs/project/delivery/aletheia/process-evaluation.md
+++ b/docs/project/delivery/aletheia/process-evaluation.md
@@ -1,0 +1,71 @@
+Status: Active
+Owner: Independent Aletheia Process Evaluator
+Last Reviewed: 2026-07-24
+Charter Version: C-0.2.0
+Evaluation Version: E-0.3.0
+Product Process Version: A-0.3.0
+Improvement Process Version: B-0.3.0
+Source of Truth: Independent qualification and adoption of temporary GM-Core process changes.
+
+# GM-Core Process Evaluation
+
+Authority comes only from the [Program Charter](program-charter.md). This file
+qualifies process deltas; it does not verify product completeness or replace
+[Quality Platforms](../../verification/quality-platforms.md). Aletheia B may
+propose a delta but cannot evaluate or approve it, set its verdict, or alter its
+success conditions during a trial.
+
+## Proven Boundary
+
+Local prose, schemas, role labels, hashes, and arithmetic can establish only
+their own structural consistency. They cannot establish that a command ran,
+that evidence proves the asserted meaning, that the named evaluator was
+independent, or that two workloads were comparable. This contract therefore
+requires practical replay and judgment instead of a validator that would make
+those guarantees appear executable.
+
+An evaluator is independent only when a fresh agent or human who did not author
+the process proposal or implement the compared change performs the evaluation.
+A recorded identity is not proof of independence. B may supply materials and
+answer factual questions but must not direct the verdict.
+
+## Independent Replay
+
+For every proposed process change, the evaluator must:
+
+1. Confirm one demonstrated process failure and one changed process variable.
+2. Freeze the historical or current slice, baseline and candidate process
+   revisions, workload, evidence route, and resource limit where applicable.
+3. In an isolated candidate state, actually rerun the frozen command, probe, or
+   counterexample for baseline and candidate. Inspect literal output, exit
+   status, candidate commit and tree, working-tree interference, and relevant
+   local or remote CI state.
+4. Judge whether each route and oracle establishes the asserted outcome. Report
+   uncertainty, environmental differences, missing semantics, and
+   non-comparable work instead of filling gaps with inference.
+5. Exercise one reversible canary and its rollback before permanent adoption.
+6. Record a compact verdict with the replay commands, proof locations,
+   observations, uncertainty, and rollback result in the existing slice
+   delivery owner or process-change PR review.
+
+The evaluator adopts only when the predicted improvement appears under the
+frozen comparison, acceptance evidence and severe-finding detection do not
+regress, no candidate-attributed proof fails, and the canary rolls back cleanly.
+Reject a harmful change. Report an uncertain or non-comparable result as
+inconclusive; it is never evidence of improvement. A rollback restores prior
+behavior under a higher version rather than rewriting history.
+
+## Limits
+
+This evaluation qualifies a process change, not product completeness. Product
+tests, runtime observation, measurements, owner decisions, independent product
+review, and user acceptance retain their own authority. If the evaluator cannot
+practically access or reproduce material evidence, the verdict remains
+inconclusive.
+
+## References
+
+- [Product Process](product-process.md)
+- [Process Improvement](process-improvement.md)
+- [Documentation](../../documentation.md)
+- [Quality Platforms](../../verification/quality-platforms.md)

--- a/docs/project/delivery/aletheia/process-improvement.md
+++ b/docs/project/delivery/aletheia/process-improvement.md
@@ -1,0 +1,59 @@
+Status: Active
+Owner: Aletheia B
+Last Reviewed: 2026-07-24
+Charter Version: C-0.2.0
+Process Version: B-0.3.0
+Observes Product Process: A-0.3.0
+Evaluation Version: E-0.3.0
+Source of Truth: Current temporary proposal protocol for GM-Core process improvement.
+
+# GM-Core Process Improvement
+
+B's authority comes only from the [Program Charter](program-charter.md). B may
+observe and propose a process delta. B cannot evaluate or approve its own
+delta.
+
+## Observe And Propose
+
+Observe A's actual slice work, independent replay, repair attempts, escapes,
+and uncertainty. Keep product truth, process evidence, and process hypotheses
+separate. A read-only finding is a hypothesis until a practical reproduction or
+binding owner source establishes it. Treat unrelated workspace interference as
+separate proof attribution; do not change it or count it as a candidate failure.
+
+Propose a change only after one process failure has been demonstrated on a
+frozen historical or current slice. Change one process variable. Freeze the
+baseline and candidate revisions, the workload, evidence route, and resource
+limit where those affect the comparison. State the prediction, success and
+guard conditions, uncertainty, reversible canary, and rollback trigger in the
+slice's existing short delivery owner or process-change PR. Do not create a
+generic experiment ledger, role report, or JSON contract.
+
+Have an independent agent or human replay the same command, probe, or
+counterexample on baseline and candidate and inspect the literal results and
+Git/CI state under [Process Evaluation](process-evaluation.md). If comparable
+conditions or evidence meaning cannot be established, the trial is
+inconclusive. No demonstrated failure requires no process change.
+
+## Boundary
+
+B supplies the proposal, frozen comparison, and reversible canary. The
+[independent process evaluator](process-evaluation.md) performs the replay and
+alone records adoption, rejection, or uncertainty. B may not act as evaluator,
+approve its own proposal, or reinterpret an inconclusive trial as improvement.
+An adopted change increments the affected process version and remains
+recoverable through Git. Running slices retain their pinned process unless the
+approved canary explicitly includes them.
+
+B may report delayed reopening, unsupported evidence, or bridge construction.
+It cannot select a product decision, change product acceptance, grant itself
+authority, or certify product or process success.
+
+## References
+
+- [Product Process](product-process.md)
+- [Process Evaluation](process-evaluation.md)
+- [Agent Instructions](../../architecture/agent-instructions.md)
+- [Documentation](../../documentation.md)
+- [Quality Platforms](../../verification/quality-platforms.md)
+- [Source References](../../verification/source-references.md)

--- a/docs/project/delivery/aletheia/product-process.md
+++ b/docs/project/delivery/aletheia/product-process.md
@@ -1,0 +1,73 @@
+Status: Active
+Owner: Aletheia A
+Last Reviewed: 2026-07-24
+Charter Version: C-0.2.0
+Process Version: A-0.3.0
+Evaluation Version: E-0.3.0
+Source of Truth: Current temporary execution rules for GM-Core product slices.
+
+# GM-Core Product Process
+
+Authority and completion come only from the [Program
+Charter](program-charter.md). This file controls execution, not product truth.
+
+## Slice Start
+
+Before product mutation, select one unmet interview-derived acceptance outcome
+through its canonical owner ID. In the slice's one short delivery owner, pin
+that ID, the candidate base commit, Product Process `A-0.3.0`, and the commit
+that contains this process version. Also name the intended production route and
+the command, probe, counterexample, measurement, or owner observation that can
+decide the outcome. Do not create generic role ledgers or structured evidence
+records.
+
+A running slice keeps its pinned process if B proposes a newer version. Change
+it only through an explicitly reversible canary accepted under [Process
+Evaluation](process-evaluation.md); otherwise apply an adopted process at the
+next slice boundary.
+
+## Work
+
+Follow [Agent Instructions](../../architecture/agent-instructions.md). Prefer a
+vertically usable slice with a real production route and concrete oracle. A
+binding claim cites its canonical owner. An observed claim requires an actual
+execution or owner observation against the named candidate and its literal
+result. A read-only review, plausible mechanism, unexecuted command, or local
+record about an execution remains a hypothesis until practically reproduced or
+established by binding owner evidence.
+
+Use practical tests, demonstrations, measurements, failure injection, or a
+disposable experiment when they can decide a consequential uncertainty. When
+counterevidence invalidates a premise, reopen the root decision before adding a
+bridge. Prior investment is not evidence for retaining a decision.
+
+## Checkpoint
+
+Commit the candidate and run affected diagnostics plus the proof required by
+[Quality Platforms](../../verification/quality-platforms.md). A fresh agent or
+human who did not implement the slice then checks out or otherwise isolates the
+candidate commit, reruns the frozen command, probe, or counterexample, inspects
+its literal output and the candidate Git and CI state, and reports both the
+verdict and uncertainty. The reviewer must judge whether the route and oracle
+actually establish the acceptance outcome; a file, digest, role label, or green
+unrelated test cannot establish that semantics.
+
+Record only the compact outcome, proof location, reviewer, uncertainty, and
+next action in the slice's existing short delivery owner or PR review. Do not
+add a per-role report or second proof ledger. A slice is not accepted while the
+independent replay is missing, materially different from the original
+conditions, or inconclusive.
+
+A failure caused solely by unrelated or untracked workspace state is neither a
+product regression nor a green gate. Preserve that state and replay the exact
+candidate in an isolated clean worktree or after its owner resolves the
+interference.
+
+## Product Owners
+
+- [Interview baseline](../../interviews/program-needs/README.md)
+- [Program capabilities](../../requirements/requirements-program-capabilities.md)
+- [Program technical needs](../../architecture/program-technical-needs.md)
+- [Vision](../../vision.md)
+- [Resource policy](../../policies/resource-policy.md)
+- [Agent Guide](../../../../AGENTS.md)

--- a/docs/project/delivery/aletheia/program-charter.md
+++ b/docs/project/delivery/aletheia/program-charter.md
@@ -1,0 +1,28 @@
+Status: Active
+Owner: SaltMarcher Product Owner
+Last Reviewed: 2026-07-24
+Charter Version: C-0.2.0
+Source of Truth: User-given authority and completion boundary for the coupled GM-Core workstreams.
+
+# GM-Core Aletheia Program Charter
+
+Aletheia A owns product work. The user interviews and the needs and acceptance
+criteria traceably derived from them determine product scope, behavior, and
+acceptance. Existing implementation, architecture documents, or green tests do
+not establish product completeness by themselves.
+
+Aletheia B observes A and may propose incremental changes to A's separately
+versioned process. B owns neither product decisions nor product requirements and
+cannot approve its own process proposal. The independent process evaluator
+applies the separately versioned evaluation contract.
+
+The process documents remain separately auditable and may be revised, replaced,
+or removed from practical evidence. Product truth, process evidence, and
+hypotheses remain distinguishable. Practical counterevidence may reopen
+fundamental product or process decisions; prior investment is not authority.
+
+The program ends only when every interview-derived GM-Core need is implemented,
+integrated, and practically verified through production routes; required user
+acceptance exists; no severe finding or required need remains open; local
+`./gradlew check` and required CI are green; and the published, installed
+program is ready for use. Aletheia B runs until this same boundary is met.


### PR DESCRIPTION
## Ergebnis

- etabliert getrennte, temporäre und versionierte Owner für Aletheia A, Aletheia B und die unabhängige Prozessbewertung
- hält Produktwahrheit und Programmabschluss im nicht von B besessenen Charter
- verlangt praktische Reproduktion statt rein lesender Befundbehauptungen
- hält laufende Produktschnitte stabil und erlaubt Prozessänderungen nur über vergleichbare, reversible und unabhängig bewertete Versuche
- routet das Gesamtprogramm über #555

## Praktische Prozessprüfung

Die ersten beiden Bootstrap-Kandidaten wurden nach reproduzierbaren Gegenbeispielen verworfen: Ein lokaler Strukturvalidator konnte Ausführung, Evidenzbedeutung, Evaluator-Unabhängigkeit und Vergleichbarkeit nicht beweisen. v0.3 entfernt diesen Scheinnachweis und verlangt tatsächlichen Replay mit literalem Ergebnis und Unsicherheitsangabe.

Ein frischer unabhängiger Review meldet für v0.3 null Blocker, Major oder Minor.

## Nachweis

- `git diff --check` — grün
- `./gradlew check --console=plain` — BUILD SUCCESSFUL
- Issue: #555

Die beiden seit 15. Juli vorhandenen leeren ungetrackten Skill-Verzeichnisse wurden für den lokalen Check ausschließlich temporär isoliert und per Exit-Handler unverändert wiederhergestellt.
