### PR TITLE
test: cover M1 publication close and resume boundary

### DIFF
--- a/test/app/CampaignRuntimeProductionJourneyTest.java
+++ b/test/app/CampaignRuntimeProductionJourneyTest.java
@@ -1295,8 +1295,12 @@ public final class CampaignRuntimeProductionJourneyTest {
 
         openCampaignDeskWithKeyboard(host.window(), host.production);
         fireCampaignRowWhenReady(host.window(), "Positive Alpha");
-        awaitCondition(() -> coordinator.snapshot().durableActivation().orElseThrow().campaign()
-                .map(campaign -> alphaId.equals(campaign.id())).orElse(false));
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE
+                && coordinator.snapshot().durableActivation().orElseThrow().campaign()
+                        .map(campaign -> alphaId.equals(campaign.id())).orElse(false));
+        assertFocusedSceneNotes(
+                host.window(), "Positive Alpha marker", betaMarker);
         openCampaignDeskWithKeyboard(host.window(), host.production);
         fireCampaignRowWhenReady(host.window(), "Positive Beta");
         awaitCondition(() -> coordinator.snapshot().phase()

--- a/test/app/CampaignRuntimeProductionJourneyTest.java
+++ b/test/app/CampaignRuntimeProductionJourneyTest.java
@@ -802,7 +802,6 @@ public final class CampaignRuntimeProductionJourneyTest {
         betaId = coordinator.snapshot().durableActivation().orElseThrow()
                 .campaign().orElseThrow().id();
         betaPath = coordinator.snapshot().campaignPath().orElseThrow();
-        betaGeneration = coordinator.snapshot().durableActivation().orElseThrow().generation();
         CampaignRuntime lateBetaRuntime = coordinator.activeRuntimeForTesting();
 
         openCampaignDeskWithKeyboard(host.window(), host.production);
@@ -838,6 +837,7 @@ public final class CampaignRuntimeProductionJourneyTest {
         assertEquals(betaId, coordinator.snapshot().durableActivation().orElseThrow()
                 .campaign().orElseThrow().id());
         assertEquals(betaPath, coordinator.snapshot().campaignPath().orElseThrow());
+        betaGeneration = coordinator.snapshot().durableActivation().orElseThrow().generation();
 
         long closeStarted = System.nanoTime();
         bootstrap.close();

--- a/test/app/CampaignRuntimeProductionJourneyTest.java
+++ b/test/app/CampaignRuntimeProductionJourneyTest.java
@@ -806,9 +806,7 @@ public final class CampaignRuntimeProductionJourneyTest {
         CampaignRuntime lateBetaRuntime = coordinator.activeRuntimeForTesting();
 
         openCampaignDeskWithKeyboard(host.window(), host.production);
-        awaitFxCondition(() -> campaignRow(host.window(), "Alpha") != null
-                && !campaignRow(host.window(), "Alpha").isDisabled());
-        runOnFx(() -> campaignRow(host.window(), "Alpha").fire());
+        fireCampaignRowWhenReady(host.window(), "Alpha");
         awaitCondition(() -> coordinator.snapshot().phase()
                 == CampaignActivationCoordinator.Phase.ACTIVE
                 && coordinator.snapshot().durableActivation().orElseThrow().campaign()
@@ -818,9 +816,7 @@ public final class CampaignRuntimeProductionJourneyTest {
         bootstrap.installCampaignActivationPhaseTimeoutForTesting(Duration.ofSeconds(2));
         host.holdNextReadinessTerminal();
         openCampaignDeskWithKeyboard(host.window(), host.production);
-        awaitFxCondition(() -> campaignRow(host.window(), "Beta") != null
-                && !campaignRow(host.window(), "Beta").isDisabled());
-        runOnFx(() -> campaignRow(host.window(), "Beta").fire());
+        fireCampaignRowWhenReady(host.window(), "Beta");
         host.awaitHeldReadinessReady();
         int recoveryBefore = host.recoveryPublications();
         int switchesAfterFaultPublication = host.campaignPublications();
@@ -1298,13 +1294,11 @@ public final class CampaignRuntimeProductionJourneyTest {
         betaPath = coordinator.snapshot().campaignPath().orElseThrow();
 
         openCampaignDeskWithKeyboard(host.window(), host.production);
-        awaitFxCondition(() -> campaignRow(host.window(), "Positive Alpha") != null);
-        runOnFx(() -> campaignRow(host.window(), "Positive Alpha").fire());
+        fireCampaignRowWhenReady(host.window(), "Positive Alpha");
         awaitCondition(() -> coordinator.snapshot().durableActivation().orElseThrow().campaign()
                 .map(campaign -> alphaId.equals(campaign.id())).orElse(false));
         openCampaignDeskWithKeyboard(host.window(), host.production);
-        awaitFxCondition(() -> campaignRow(host.window(), "Positive Beta") != null);
-        runOnFx(() -> campaignRow(host.window(), "Positive Beta").fire());
+        fireCampaignRowWhenReady(host.window(), "Positive Beta");
         awaitCondition(() -> coordinator.snapshot().phase()
                 == CampaignActivationCoordinator.Phase.ACTIVE
                 && coordinator.snapshot().durableActivation().orElseThrow().campaign()
@@ -1402,6 +1396,26 @@ public final class CampaignRuntimeProductionJourneyTest {
         awaitFxConditionUntil(() -> presentedTextArea(stage, "Szenennotizen") != null
                 && notes.equals(presentedTextArea(stage, "Szenennotizen").getText())
                 && presentedText(stage, "Szene aktualisiert."), deadline);
+    }
+
+    private static void fireCampaignRowWhenReady(Stage stage, String campaignName)
+            throws Exception {
+        long deadline = System.nanoTime() + TIMEOUT.toNanos();
+        AtomicBoolean fired = new AtomicBoolean();
+        while (!fired.get() && System.nanoTime() < deadline) {
+            runOnFx(() -> {
+                javafx.scene.control.Button row = campaignRow(stage, campaignName);
+                if (row != null && !row.isDisabled()) {
+                    row.fire();
+                    fired.set(true);
+                }
+            });
+            if (!fired.get()) {
+                java.util.concurrent.locks.LockSupport.parkNanos(
+                        TimeUnit.MILLISECONDS.toNanos(5));
+            }
+        }
+        assertTrue(fired.get(), () -> "Campaign row did not become actionable: " + campaignName);
     }
 
     private static void closeBootstrapAndWindow(

--- a/test/app/CampaignRuntimeProductionJourneyTest.java
+++ b/test/app/CampaignRuntimeProductionJourneyTest.java
@@ -760,6 +760,142 @@ public final class CampaignRuntimeProductionJourneyTest {
     }
 
     @Test
+    void publicationTimeoutLateTerminalClosesAndResumesDurableFocusedScene()
+            throws Exception {
+        runOnFx(() -> { });
+        long runtimeThreadsBefore = campaignRuntimeThreadCount();
+        assertPublicationCloseResumePositiveControl();
+        System.out.println("B1 close-resume positive-control=PASS");
+        assertPublicationCloseResumePreCommitNegativeControl();
+        System.out.println("B1 close-resume pre-commit-negative-control=PASS");
+
+        Path caseRoot = temporaryDirectory.resolve("publication-close-resume");
+        Path installationPath = caseRoot.resolve("installation.sqlite");
+        Path campaignRoot = caseRoot.resolve("campaigns");
+        String alphaMarker = "Alpha stale publication marker";
+        String betaMarker = "Beta focused resume marker";
+        String betaEdit = "Beta acknowledged after resume";
+        CampaignId betaId;
+        Path betaPath;
+        long betaGeneration;
+
+        ProductionHostHarness host = new ProductionHostHarness();
+        AppBootstrap bootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator coordinator = await(
+                bootstrap.openCampaignActivationAsync(campaignRoot, host));
+        host.attach(coordinator);
+        awaitFxCondition(() -> campaignNameField(host.window()) != null
+                && !campaignNameField(host.window()).isDisabled());
+
+        submitCampaignName(host.window(), "Alpha");
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE);
+        assertUsableEmptyPrimaryScene(host.window(), "Alpha", alphaMarker);
+        CampaignId alphaId = coordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id();
+
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        submitCampaignName(host.window(), "Beta");
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE);
+        assertUsableEmptyPrimaryScene(host.window(), "Beta", betaMarker);
+        betaId = coordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id();
+        betaPath = coordinator.snapshot().campaignPath().orElseThrow();
+        betaGeneration = coordinator.snapshot().durableActivation().orElseThrow().generation();
+        CampaignRuntime lateBetaRuntime = coordinator.activeRuntimeForTesting();
+
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        awaitFxCondition(() -> campaignRow(host.window(), "Alpha") != null
+                && !campaignRow(host.window(), "Alpha").isDisabled());
+        runOnFx(() -> campaignRow(host.window(), "Alpha").fire());
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE
+                && coordinator.snapshot().durableActivation().orElseThrow().campaign()
+                        .map(campaign -> alphaId.equals(campaign.id())).orElse(false));
+        assertFocusedSceneNotes(host.window(), alphaMarker, betaMarker);
+
+        bootstrap.installCampaignActivationPhaseTimeoutForTesting(Duration.ofSeconds(2));
+        host.holdNextReadinessTerminal();
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        awaitFxCondition(() -> campaignRow(host.window(), "Beta") != null
+                && !campaignRow(host.window(), "Beta").isDisabled());
+        runOnFx(() -> campaignRow(host.window(), "Beta").fire());
+        host.awaitHeldReadinessReady();
+        int recoveryBefore = host.recoveryPublications();
+        int switchesAfterFaultPublication = host.campaignPublications();
+        host.blockActivationDispatchUntilRecovery();
+        host.releaseHeldReadinessTerminal();
+
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.RECOVERY_REQUIRED);
+        awaitFxCondition(host::recoveryVisible);
+        runOnFx(() -> { });
+        assertEquals(recoveryBefore + 1, host.recoveryPublications(),
+                "timeout must replace the published Beta root with recovery exactly once");
+        assertEquals(switchesAfterFaultPublication, host.campaignPublications(),
+                "revoked late terminal must not publish another Campaign root");
+        runOnFx(() -> assertFalse(host.window().getScene().getRoot() instanceof AppShell,
+                "late terminal must leave recovery authoritative"));
+        assertEquals(
+                SceneMutationResult.Status.STORAGE_ERROR,
+                await(lateBetaRuntime.components().scene().application().execute(
+                        new SceneCommand.Create("Revoked late Beta mutation"))).status(),
+                "revoked late candidate must accept zero mutations");
+        assertEquals(betaId, coordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id());
+        assertEquals(betaPath, coordinator.snapshot().campaignPath().orElseThrow());
+
+        long closeStarted = System.nanoTime();
+        bootstrap.close();
+        long closeNanos = System.nanoTime() - closeStarted;
+        assertTrue(closeNanos <= Duration.ofSeconds(10).toNanos(),
+                () -> "normal close exceeded 10 s: " + formatMillis(closeNanos));
+        assertTrue(bootstrap.termination().toCompletableFuture().isDone());
+        assertFalse(bootstrap.campaignActivationRetainedForTesting());
+        assertFalse(bootstrap.installationRuntimeRetainedForTesting());
+        assertTrue(bootstrap.closeExecutorShutdownForTesting());
+        host.closeWindow();
+
+        ProductionHostHarness resumedHost = new ProductionHostHarness();
+        AppBootstrap resumedBootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator resumedCoordinator = await(
+                resumedBootstrap.openCampaignActivationAsync(campaignRoot, resumedHost));
+        resumedHost.attachAndResume(resumedCoordinator);
+        assertEquals(1, resumedHost.startupResumeAttempts());
+        assertEquals(CampaignActivationCoordinator.Phase.ACTIVE,
+                resumedCoordinator.snapshot().phase());
+        assertEquals(betaId, resumedCoordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id());
+        assertEquals(betaGeneration, resumedCoordinator.snapshot().durableActivation()
+                .orElseThrow().generation());
+        assertEquals(betaPath, resumedCoordinator.snapshot().campaignPath().orElseThrow());
+        assertSafeAttachedShell(resumedHost.window());
+        assertFocusedSceneNotes(resumedHost.window(), betaMarker, alphaMarker);
+        editFocusedSceneThroughUi(resumedHost.window(), betaEdit);
+        closeBootstrapAndWindow(resumedBootstrap, resumedHost);
+
+        ProductionHostHarness readbackHost = new ProductionHostHarness();
+        AppBootstrap readbackBootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator readbackCoordinator = await(
+                readbackBootstrap.openCampaignActivationAsync(campaignRoot, readbackHost));
+        readbackHost.attachAndResume(readbackCoordinator);
+        assertEquals(1, readbackHost.startupResumeAttempts());
+        assertEquals(betaId, readbackCoordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id());
+        assertEquals(betaPath, readbackCoordinator.snapshot().campaignPath().orElseThrow());
+        assertSafeAttachedShell(readbackHost.window());
+        assertFocusedSceneNotes(readbackHost.window(), betaEdit, alphaMarker);
+        closeBootstrapAndWindow(readbackBootstrap, readbackHost);
+
+        awaitCondition(() -> campaignRuntimeThreadCount() <= runtimeThreadsBefore);
+        System.out.println("B1 close-resume deciding-metrics=PASS close="
+                + formatMillis(closeNanos)
+                + " recovery-replacements=1 late-publications=0 late-mutations=0"
+                + " startup-resume-attempts=1 durable-readback=exact");
+    }
+
+    @Test
     void restartNeverCreatesOrMutatesMissingTruncatedDamagedOrSymbolicCampaignStore()
             throws Exception {
         runOnFx(() -> { });
@@ -1126,6 +1262,157 @@ public final class CampaignRuntimeProductionJourneyTest {
 
     private AppBootstrap bootstrap(Path installationPath) {
         return bootstrapAt(installationPath);
+    }
+
+    private void assertPublicationCloseResumePositiveControl() throws Exception {
+        Path caseRoot = temporaryDirectory.resolve("publication-close-resume-positive");
+        Path installationPath = caseRoot.resolve("installation.sqlite");
+        Path campaignRoot = caseRoot.resolve("campaigns");
+        String betaMarker = "Positive Beta focused marker";
+        String betaEdit = "Positive Beta acknowledged edit";
+        CampaignId betaId;
+        Path betaPath;
+
+        ProductionHostHarness host = new ProductionHostHarness();
+        AppBootstrap bootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator coordinator = await(
+                bootstrap.openCampaignActivationAsync(campaignRoot, host));
+        host.attach(coordinator);
+        awaitFxCondition(() -> campaignNameField(host.window()) != null
+                && !campaignNameField(host.window()).isDisabled());
+        submitCampaignName(host.window(), "Positive Alpha");
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE);
+        assertUsableEmptyPrimaryScene(
+                host.window(), "Positive Alpha", "Positive Alpha marker");
+        CampaignId alphaId = coordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id();
+
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        submitCampaignName(host.window(), "Positive Beta");
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE);
+        assertUsableEmptyPrimaryScene(host.window(), "Positive Beta", betaMarker);
+        betaId = coordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id();
+        betaPath = coordinator.snapshot().campaignPath().orElseThrow();
+
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        awaitFxCondition(() -> campaignRow(host.window(), "Positive Alpha") != null);
+        runOnFx(() -> campaignRow(host.window(), "Positive Alpha").fire());
+        awaitCondition(() -> coordinator.snapshot().durableActivation().orElseThrow().campaign()
+                .map(campaign -> alphaId.equals(campaign.id())).orElse(false));
+        openCampaignDeskWithKeyboard(host.window(), host.production);
+        awaitFxCondition(() -> campaignRow(host.window(), "Positive Beta") != null);
+        runOnFx(() -> campaignRow(host.window(), "Positive Beta").fire());
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE
+                && coordinator.snapshot().durableActivation().orElseThrow().campaign()
+                        .map(campaign -> betaId.equals(campaign.id())).orElse(false));
+        assertSafeAttachedShell(host.window());
+        assertFocusedSceneNotes(host.window(), betaMarker, "Positive Alpha marker");
+        editFocusedSceneThroughUi(host.window(), betaEdit);
+        closeBootstrapAndWindow(bootstrap, host);
+
+        ProductionHostHarness resumedHost = new ProductionHostHarness();
+        AppBootstrap resumedBootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator resumedCoordinator = await(
+                resumedBootstrap.openCampaignActivationAsync(campaignRoot, resumedHost));
+        resumedHost.attachAndResume(resumedCoordinator);
+        assertEquals(1, resumedHost.startupResumeAttempts());
+        assertEquals(betaId, resumedCoordinator.snapshot().durableActivation().orElseThrow()
+                .campaign().orElseThrow().id());
+        assertEquals(betaPath, resumedCoordinator.snapshot().campaignPath().orElseThrow());
+        assertSafeAttachedShell(resumedHost.window());
+        assertFocusedSceneNotes(resumedHost.window(), betaEdit, "Positive Alpha marker");
+        closeBootstrapAndWindow(resumedBootstrap, resumedHost);
+    }
+
+    private void assertPublicationCloseResumePreCommitNegativeControl() throws Exception {
+        Path caseRoot = temporaryDirectory.resolve("publication-close-resume-negative");
+        Path installationPath = caseRoot.resolve("installation.sqlite");
+        Path campaignRoot = caseRoot.resolve("campaigns");
+        String alphaMarker = "Negative Alpha remains authoritative";
+        String alphaEdit = "Negative Alpha remains writable";
+        ProductionHostHarness host = new ProductionHostHarness();
+        AppBootstrap bootstrap = bootstrapAt(installationPath);
+        CampaignActivationCoordinator coordinator = await(
+                bootstrap.openCampaignActivationAsync(campaignRoot, host));
+        host.attach(coordinator);
+        awaitFxCondition(() -> campaignNameField(host.window()) != null
+                && !campaignNameField(host.window()).isDisabled());
+        submitCampaignName(host.window(), "Negative Alpha");
+        awaitCondition(() -> coordinator.snapshot().phase()
+                == CampaignActivationCoordinator.Phase.ACTIVE);
+        assertUsableEmptyPrimaryScene(host.window(), "Negative Alpha", alphaMarker);
+        CampaignActivation durableAlpha = coordinator.snapshot().durableActivation().orElseThrow();
+        AppShell alphaShell = host.visibleCampaignRoot();
+
+        CampaignActivationCoordinator.Result rejected = await(
+                coordinator.create("Rejected before commit", 0L));
+        assertEquals(CampaignActivationCoordinator.Status.STALE_GENERATION, rejected.status());
+        assertEquals(durableAlpha, coordinator.snapshot().durableActivation().orElseThrow());
+        assertSame(alphaShell, host.visibleCampaignRoot());
+        editFocusedSceneThroughUi(host.window(), alphaEdit);
+        assertEquals(durableAlpha.campaign().orElseThrow().id(),
+                coordinator.snapshot().durableActivation().orElseThrow()
+                        .campaign().orElseThrow().id());
+        closeBootstrapAndWindow(bootstrap, host);
+    }
+
+    private static void assertSafeAttachedShell(Stage stage) throws Exception {
+        awaitFxCondition(() -> stage.isShowing()
+                && stage.getScene() != null
+                && stage.getScene().getRoot() instanceof AppShell);
+        runOnFx(() -> {
+            javafx.scene.Parent root = stage.getScene().getRoot();
+            root.applyCss();
+            root.layout();
+            javafx.geometry.Bounds screen = root.localToScreen(root.getBoundsInLocal());
+            assertTrue(root instanceof AppShell);
+            assertSame(stage.getScene(), root.getScene());
+            assertSame(stage, root.getScene().getWindow());
+            assertTrue(root.getLayoutBounds().getWidth() > 0.0);
+            assertTrue(root.getLayoutBounds().getHeight() > 0.0);
+            assertTrue(screen != null && screen.getWidth() > 0.0 && screen.getHeight() > 0.0);
+        });
+    }
+
+    private static void assertFocusedSceneNotes(
+            Stage stage,
+            String expected,
+            String forbidden
+    ) throws Exception {
+        fireNavigation(stage, "Szenen");
+        awaitFxCondition(() -> presentedTextArea(stage, "Szenennotizen") != null
+                && expected.equals(presentedTextArea(stage, "Szenennotizen").getText()));
+        runOnFx(() -> assertNotEquals(
+                forbidden, presentedTextArea(stage, "Szenennotizen").getText()));
+    }
+
+    private static void editFocusedSceneThroughUi(Stage stage, String notes) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        fireNavigation(stage, "Szenen");
+        awaitFxConditionUntil(() -> presentedTextArea(stage, "Szenennotizen") != null
+                && presentedButton(stage, "Szene speichern") != null, deadline);
+        runOnFxUntil(deadline, () -> {
+            presentedTextArea(stage, "Szenennotizen").setText(notes);
+            presentedButton(stage, "Szene speichern").fire();
+        });
+        awaitFxConditionUntil(() -> presentedTextArea(stage, "Szenennotizen") != null
+                && notes.equals(presentedTextArea(stage, "Szenennotizen").getText())
+                && presentedText(stage, "Szene aktualisiert."), deadline);
+    }
+
+    private static void closeBootstrapAndWindow(
+            AppBootstrap bootstrap,
+            ProductionHostHarness host
+    ) throws Exception {
+        bootstrap.close();
+        assertTrue(bootstrap.termination().toCompletableFuture().isDone());
+        assertFalse(bootstrap.campaignActivationRetainedForTesting());
+        assertFalse(bootstrap.installationRuntimeRetainedForTesting());
+        host.closeWindow();
     }
 
     private static void awaitRegistryOperation(AppBootstrap bootstrap) {
@@ -2085,9 +2372,15 @@ public final class CampaignRuntimeProductionJourneyTest {
         private final Stage window;
         private final CampaignDeskHost production;
         private final AtomicBoolean hideOnNextReadiness = new AtomicBoolean();
+        private final AtomicBoolean holdNextReadinessTerminal = new AtomicBoolean();
         private final AtomicReference<CampaignDeskHost.RootReadinessAttempt> lastReadiness =
                 new AtomicReference<>();
+        private final AtomicReference<HeldReadinessAttempt> heldReadiness =
+                new AtomicReference<>();
         private final AtomicReference<AppShell> lastSwitchedShell = new AtomicReference<>();
+        private final AtomicReference<CountDownLatch> blockedFxRelease = new AtomicReference<>();
+        private final AtomicInteger campaignPublications = new AtomicInteger();
+        private final AtomicInteger recoveryPublications = new AtomicInteger();
 
         private ProductionHostHarness() throws Exception {
             AtomicReference<Stage> stage = new AtomicReference<>();
@@ -2125,6 +2418,7 @@ public final class CampaignRuntimeProductionJourneyTest {
                 AppShell shell
         ) {
             lastSwitchedShell.set(shell);
+            campaignPublications.incrementAndGet();
             return production.switchCampaign(campaign, generation, shell);
         }
 
@@ -2135,6 +2429,7 @@ public final class CampaignRuntimeProductionJourneyTest {
                 CampaignActivationCoordinator.PublicationSurface surface
         ) {
             lastSwitchedShell.set(java.util.Objects.requireNonNull(surface.shell()));
+            campaignPublications.incrementAndGet();
             return production.switchCampaign(campaign, generation, surface);
         }
 
@@ -2143,6 +2438,11 @@ public final class CampaignRuntimeProductionJourneyTest {
                 java.util.Optional<features.campaign.api.CampaignActivation> durableActivation,
                 Class<? extends Throwable> failureType
         ) {
+            recoveryPublications.incrementAndGet();
+            CountDownLatch release = blockedFxRelease.getAndSet(null);
+            if (release != null) {
+                release.countDown();
+            }
             return production.showRecovery(durableActivation, failureType);
         }
 
@@ -2157,6 +2457,11 @@ public final class CampaignRuntimeProductionJourneyTest {
                     (CampaignDeskHost.RootReadinessAttempt)
                             production.awaitPublishedRootReady(shell);
             lastReadiness.set(readiness);
+            if (holdNextReadinessTerminal.compareAndSet(true, false)) {
+                HeldReadinessAttempt held = new HeldReadinessAttempt(readiness);
+                heldReadiness.set(held);
+                return held;
+            }
             return readiness;
         }
 
@@ -2175,6 +2480,67 @@ public final class CampaignRuntimeProductionJourneyTest {
 
         void hideOnNextReadiness() {
             hideOnNextReadiness.set(true);
+        }
+
+        void holdNextReadinessTerminal() {
+            holdNextReadinessTerminal.set(true);
+        }
+
+        void awaitHeldReadinessReady() throws Exception {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            HeldReadinessAttempt held;
+            while ((held = heldReadiness.get()) == null && System.nanoTime() < deadline) {
+                java.util.concurrent.locks.LockSupport.parkNanos(
+                        TimeUnit.MILLISECONDS.toNanos(5));
+            }
+            if (held == null) {
+                throw new AssertionError("No held readiness attempt was observed");
+            }
+            assertTrue(held.productionReady.await(10, TimeUnit.SECONDS),
+                    "production published-root readiness did not become ready");
+        }
+
+        void blockActivationDispatchUntilRecovery() throws Exception {
+            CountDownLatch entered = new CountDownLatch(1);
+            CountDownLatch release = new CountDownLatch(1);
+            if (!blockedFxRelease.compareAndSet(null, release)) {
+                throw new IllegalStateException("JavaFX activation dispatch is already blocked");
+            }
+            Platform.runLater(() -> {
+                entered.countDown();
+                boolean interrupted = false;
+                for (;;) {
+                    try {
+                        release.await();
+                        break;
+                    } catch (InterruptedException failure) {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertTrue(entered.await(10, TimeUnit.SECONDS),
+                    "JavaFX activation terminal blocker did not start");
+        }
+
+        void releaseHeldReadinessTerminal() {
+            java.util.Objects.requireNonNull(
+                    heldReadiness.get(), "No held readiness attempt was observed")
+                    .release();
+        }
+
+        int campaignPublications() {
+            return campaignPublications.get();
+        }
+
+        int recoveryPublications() {
+            return recoveryPublications.get();
+        }
+
+        int startupResumeAttempts() {
+            return production.startupResumeAttemptsForTesting();
         }
 
         CampaignDeskHost.RootReadinessAttempt lastReadinessAttempt() {
@@ -2207,6 +2573,38 @@ public final class CampaignRuntimeProductionJourneyTest {
 
         void closeWindow() throws Exception {
             runOnFx(window::close);
+        }
+
+        private static final class HeldReadinessAttempt
+                implements CampaignActivationCoordinator.PublishedRootReadinessAttempt {
+            private final CampaignDeskHost.RootReadinessAttempt delegate;
+            private final CompletableFuture<Void> terminal = new CompletableFuture<>();
+            private final CountDownLatch productionReady = new CountDownLatch(1);
+
+            private HeldReadinessAttempt(CampaignDeskHost.RootReadinessAttempt delegate) {
+                this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
+                delegate.completion().whenComplete((ignored, failure) -> {
+                    if (failure == null) {
+                        productionReady.countDown();
+                    } else {
+                        terminal.completeExceptionally(failure);
+                    }
+                });
+            }
+
+            @Override
+            public CompletionStage<Void> completion() {
+                return terminal;
+            }
+
+            @Override
+            public CompletionStage<Void> cancel() {
+                return delegate.cancel();
+            }
+
+            private void release() {
+                terminal.complete(null);
+            }
         }
     }
 

--- a/test/app/CampaignRuntimeProductionJourneyTest.java
+++ b/test/app/CampaignRuntimeProductionJourneyTest.java
@@ -833,10 +833,7 @@ public final class CampaignRuntimeProductionJourneyTest {
                 "revoked late terminal must not publish another Campaign root");
         runOnFx(() -> assertFalse(host.window().getScene().getRoot() instanceof AppShell,
                 "late terminal must leave recovery authoritative"));
-        assertEquals(
-                SceneMutationResult.Status.STORAGE_ERROR,
-                await(lateBetaRuntime.components().scene().application().execute(
-                        new SceneCommand.Create("Revoked late Beta mutation"))).status(),
+        assertFalse(lateCandidateAcceptsMutation(lateBetaRuntime),
                 "revoked late candidate must accept zero mutations");
         assertEquals(betaId, coordinator.snapshot().durableActivation().orElseThrow()
                 .campaign().orElseThrow().id());
@@ -1400,6 +1397,20 @@ public final class CampaignRuntimeProductionJourneyTest {
         awaitFxConditionUntil(() -> presentedTextArea(stage, "Szenennotizen") != null
                 && notes.equals(presentedTextArea(stage, "Szenennotizen").getText())
                 && presentedText(stage, "Szene aktualisiert."), deadline);
+    }
+
+    private static boolean lateCandidateAcceptsMutation(CampaignRuntime runtime)
+            throws Exception {
+        try {
+            return await(runtime.components().scene().application().execute(
+                    new SceneCommand.Create("Revoked late Beta mutation"))).status()
+                    == SceneMutationResult.Status.SUCCESS;
+        } catch (IllegalStateException unavailable) {
+            assertTrue(unavailable.getMessage() != null
+                            && unavailable.getMessage().contains("PARKED"),
+                    () -> "unexpected late-candidate rejection: " + unavailable);
+            return false;
+        }
     }
 
     private static void fireCampaignRowWhenReady(Stage stage, String campaignName)

--- a/tools/quality/experiments/aletheia-b1/m1-publication-close-resume-concept.md
+++ b/tools/quality/experiments/aletheia-b1/m1-publication-close-resume-concept.md
@@ -1,0 +1,69 @@
+Status: Frozen concept
+Owner: Aletheia B1
+Last Reviewed: 2026-07-27
+Source of Truth: One temporary B1 question and its frozen test boundary; not product, architecture, or maturity truth.
+
+# M1 Publication, Close, And Resume Behavior Concept
+
+## Decision
+
+The highest unresolved B1 question on the exact stable product baseline remains:
+
+> After a committed Campaign activation times out at visible publication and recovery is shown, can a late terminal publication callback settle, the application close normally, and a fresh production start resume the durable Beta Campaign as a safely rendered focused Scene which visibly acknowledges and durably preserves the next mutation?
+
+This is falsifiable and remains higher B1 risk than another nominal switch sample. Existing production journeys separately prove publication timeout/recovery, ordinary close cleanup, restart, safe rendering, and a next mutation, but no journey composes that adversarial boundary. A failure can expose stale mutation authority after recovery, abandon terminal ownership during close, or resume truth that is durable but not safely usable. The canonical roadmap separately reopens M1 for a B3 memory-retirement finding; that structural work neither answers nor supersedes this B1 behavior question.
+
+## Frozen Authority And Baseline
+
+- Product commit: `3eb1e0746d60e3e36fe25bd0b791e0f1bb0e9b71` (`origin/main`).
+- Owner IDs: `AC-F01`, `AC-F02`, `AC-L01`, `AC-D01`; chiefly `TN-01`, `TN-02`, `TN-07`, `TN-15`, `TN-16`, `TN-21`.
+- Binding interview meaning: immediate switch needs no warning or prior closure; complete Running Scene/Encounter/travel state resumes; the primary Scene never ends and remains mutable; restart restores as much useful state as possible; acknowledged work is automatically durable.
+- Process authority commits/blobs at the product baseline:
+  - `AGENTS.md`: commit `95fcdb199f70a42be2ee0358b119d8915912267a`, blob `80569edc6949f99a0c9b5457e213b26fbeeb0c31`.
+  - Charter C-0.9.0: commit `18a813318193440e5535a51575b590846c0d3af7`, blob `29972e2b6d5699ec6a168e09d024288b8b1fed90`.
+  - B1-1.1.0: commit `bbd5988b4d804cba86a51ced0c7a19c564d5c166`, blob `38f7df43743634b66be92f331d973484c3064d8b`.
+  - Evaluation E-0.7.0: commit `bbd5988b4d804cba86a51ced0c7a19c564d5c166`, blob `50e128b7f16d4069f9ec9c730aa161f8391a3d60`.
+  - Product Process A-0.8.0: commit `bbd5988b4d804cba86a51ced0c7a19c564d5c166`, blob `30c2c0e6667e9752ffe82eff0485a66c71f2104e`.
+  - Process Optimization C-2.2.0: commit `18a813318193440e5535a51575b590846c0d3af7`, blob `825525d137aea3ffc4e0df40b98c88a31d0913f2`.
+- Product-owner blobs: capabilities `6c3318f84154f15abc4991ef41d24d31e79c2446`; technical needs `089e10de4ab2342d70708da0c62340b9162b490b`; foundation interview `d598a77e31a6f328f1e42fe2648618e724ec6ff0`; Scene interview `1c9a1553eac3aae4f55af1b9e8a2faa45ebe2056`; lifecycle interview `18103d28a1140f960e3702c740858f8dcc015027`.
+- Delivery context only: canonical checkout commit `2160ffeaf53edec7d92905af8daec4a2a1d38183`, roadmap blob `15e57d84fd44aa5bbb1c4974e82618e460f6a634`. It is not product evidence.
+
+The change from historical concept base `0b5cb6952135c957f846b95d344cc032bbf8958f` to this baseline changes no `app/**`, `shell/**`, `platform/**`, `features/**`, `test/**`, requirement, technical-need, or interview blob. It adopts C5 host admission, changes Charter/process authority, and removes the historical concept. Therefore it changes test admission only, not the premise, workload, production route, or oracle. Earlier candidates are not authority and were not reused.
+
+## Interpretation And Production Journey
+
+The narrowest interpretation is insufficient: a durable pointer alone does not prove useful resume. The strongest wording is also not invented: transient pixels need not survive process death. The coherent interpretation across adjacent needs is 100% durable observable-state equivalence at readiness, recovery remaining authoritative after timeout, no late mutation authority, a safely rendered focused Scene, and a visible next mutation that is acknowledged only after durability.
+
+One JUnit UI journey shall use the production composition already owned by `AppBootstrap.openCampaignActivationAsync`, `CampaignDeskHost`, a shown JavaFX `Stage`, real `CampaignRuntime`/SQLite stores, and the actual Scene UI:
+
+1. Create Alpha and Beta through the production Campaign desk; make Beta durable, retain its runtime reference, seed a uniquely visible focused-Scene marker, then switch back to Alpha.
+2. Switch from Alpha to the already durable Beta through the real host, hold the published-root readiness terminal, let the configured publication timeout show recovery after Beta's durable pointer commits, then release the terminal callback after revocation.
+3. Prove recovery stays rendered and authoritative, the late candidate rejects mutation, and the exact publication/recovery terminal obligations settle.
+4. Close the ordinary `AppBootstrap`; require bounded successful termination with no retained coordinator or installation runtime and no test-forced resource close.
+5. Create a fresh `AppBootstrap` and production host on the same synthetic installation, call the normal startup resume route once, and require durable Beta, its exact focused Scene marker, positive rendered bounds after production readiness, and no Alpha/stale-root content.
+6. Edit the focused Scene through the rendered production UI. Require visible acknowledgement, a successful production mutation result, then close and reopen once more to read back that exact edit.
+
+## Metrics, Controls, And Oracle
+
+Deciding metrics are all-or-nothing:
+
+- recovery-root replacements after timeout: exactly `1`; normal Campaign activations from the revoked late callback: `0`; late-candidate accepted mutations: `0`;
+- normal close result: success within `10 s`; retained coordinator/runtime after settlement: `0`;
+- fresh startup resume attempts: `1`; resumed Campaign ID/path/generation and focused Scene marker: exact Beta truth;
+- safe render: current root is the resumed production `AppShell`, attached to the shown Stage, with positive layout and screen bounds after the real readiness gate;
+- next mutation: UI-visible acknowledgement within the existing `TN-21` timeout, production result `SUCCESS`, and exact readback after the second fresh start;
+- Alpha/stale marker exposure, cross-Campaign mutation, acknowledged-work loss, uncaught asynchronous failure, or leaked live test handle: `0`.
+
+Positive control: the same production route without the held terminal must activate Beta, render it safely, accept the same Scene edit, close, and resume it exactly. Negative control: a pre-commit rejection must leave Alpha rendered, writable, and durable, proving the oracle does not reject an unrelated safe fallback.
+
+Causal known-bad control: in a disposable evaluator-only checkout, alter only `PublicationAttempt.activateAndCommit` so a revoked late callback invokes `activateVisibleShell` instead of rejecting stale publication authority. The unchanged journey must fail specifically on late mutation authority and/or recovery authority while the positive and unrelated negative controls still pass. The mutation is never committed or handed off. Failure to discriminate restarts concept/oracle work.
+
+## Tool, Risk, Boundary, And Budget
+
+JUnit Jupiter `6.1.2`, JavaFX/Monocle `21.0.2`, SQLite JDBC `3.53.2.0`, existing deterministic latches, production hosts, and semantic/UI readback are suitable and already repository-owned (`build.gradle.kts` blob `4d38ee90920f4b2b8cc3f995650ad406f97aba9f`). No external tool better controls this Java lifecycle interleaving, so no online research or external acquisition is justified; local canonical evidence defines both question and oracle.
+
+The test phase may commit only one test change under `test/app/CampaignRuntimeProductionJourneyTest.java` plus test-harness code in that same file. It may not change shipped source, resources, dependencies, build wiring, product contracts, or durable owner documents. Existing package-private test seams may be called; no new production seam is authorized. A defect-demonstrating red test remains on its handoff branch.
+
+New heavy execution must compile/use adopted `tools/quality/aletheia-c5/host-lease-native` as a finite non-A batch; exit `75` means retry within budget. Freeze: `15 min` wall, one admitted focused-test batch plus one causal-control batch, at most `0.25 CPU-hour`, `100 MiB` retained output, `$0`, synthetic temporary data only, zero network/egress. No rerun or threshold change after a literal product result; infrastructure-only non-admission does not consume the test batch.
+
+Rollback deletes only the temporary synthetic installation and disposable known-bad checkout after proving no live Stage, JavaFX timer, worker, coordinator, runtime, SQLite handle, or host lease remains; it restores the unmodified product commit and retains only literal test evidence. Restart concept if any authority/product blob changes, the production route cannot create the interleaving without a new shipped seam, the known-bad does not discriminate, safe rendering or visible durability cannot be observed, another B1 risk becomes demonstrably higher, or the budget expires. Missing runtime detail is `inconclusive`, never success.


### PR DESCRIPTION
## What changed

- adds one production-composition journey covering publication timeout, late terminal settlement, normal close, fresh resume of durable Beta, safe Scene rendering, and the next durable UI mutation
- retains the frozen B1 concept and causal control boundary

## Why

Existing tests covered the lifecycle pieces separately but did not compose this adversarial recovery-to-close-to-resume boundary.

## Validation

- independent Aletheia B1 evaluation: Preliminary / qualified use
- clean journey replay: PASS
- disposable stale-publication known-bad: causal FAIL while positive and pre-commit negative controls remain PASS
- `./gradlew check --console=plain --offline` through adopted C5 host admission: BUILD SUCCESSFUL in 11m 2s

No shipped product, resource, dependency, build-wiring, or contract changes.