### PR TITLE
docs: complete C5 host-launch integration

### DIFF
--- a/docs/project/delivery/aletheia/process-optimization.md
+++ b/docs/project/delivery/aletheia/process-optimization.md
@@ -1,8 +1,8 @@
 Status: Active
 Owner: Aletheia C
-Last Reviewed: 2026-07-26
-Charter Version: C-0.9.0
-Process Version: C-2.2.0
+Last Reviewed: 2026-07-27
+Charter Version: C-0.9.1
+Process Version: C-2.2.1
 Evaluation Version: E-0.7.0
 Source of Truth: Temporary protocol for measured GM-Core work-process optimization.
 
@@ -100,6 +100,18 @@ unresolved uncertainty, and remaining required handoffs.
   isolation, correlated controller loss, or host-failure safety. Reopen on any
   overlap, premature admission/release, material overhead regression, threat-
   boundary expansion, or operational maintenance burden.
+  C5 is an outer host scheduler, so its executable—not merely its payload—must
+  be launched with host execution. A sandboxed wrapper invocation is a launcher
+  integration failure and cannot establish C5 or workload unavailability.
+  Current paired evidence on `07ea4e183` reproduced the historical Gradle
+  wildcard-IP failure for both wrapped and unwrapped commands inside the same
+  restricted network sandbox, while direct host Gradle completed and unchanged
+  C5 wrapping the same host Gradle command also completed. The exact MAT Usage
+  preflight likewise completed with exit `13` in `4.96 s` direct and `5.40 s`
+  through unchanged host-launched C5; the historical 900-second result is not
+  currently reproducible. Operational use follows the Charter's one-canary,
+  two-minute-failure, immediate-A-fallback rule rather than launching a long C
+  investigation on A's critical path.
 
 - **Operation-scoped asynchronous terminal oracles — unevaluated:** required CI
   exposed three oracles sampling queue drains, fixture-wide absence, or an

--- a/docs/project/delivery/aletheia/program-charter.md
+++ b/docs/project/delivery/aletheia/program-charter.md
@@ -1,7 +1,7 @@
 Status: Active
 Owner: SaltMarcher Product Owner
-Last Reviewed: 2026-07-26
-Charter Version: C-0.9.0
+Last Reviewed: 2026-07-27
+Charter Version: C-0.9.1
 Source of Truth: User-given authority, workstream boundaries, agent assignment, maturity semantics, and completion boundary for the GM-Core program.
 
 # GM-Core Aletheia Program Charter
@@ -176,6 +176,24 @@ time. A retryable deferral waits and retries without becoming a blocked goal.
 Already-running workers are allowed to finish and are never killed merely to
 retrofit admission. This is local same-user scheduling, not a global
 coordinator, security boundary, or guarantee against host failure.
+
+The admission executable itself runs as a top-level host command. A nested
+sandboxed launch cannot observe or coordinate the host it is meant to guard and
+is invalid availability evidence. In Codex, invoke the adopted executable with
+host execution (`sandbox_permissions=require_escalated`) and keep the admitted
+payload, working directory, environment, and audit path explicit. This standing
+authorization covers only the local, finite, already-permitted workload; it
+does not authorize network egress, broader filesystem mutation, secrets, paid
+services, or real-data access.
+
+On the first heavy batch in a new execution envelope, run one representative
+startup canary through that exact host-launched path with a 60-second ceiling.
+Reuse its result while the envelope and tool identity remain unchanged. If the
+canary fails before the workload starts, C records a bounded process failure
+within two minutes; A does not wait for a new C experiment and may run its exact
+critical-path workload directly and serially while B1, B2, B3, and C defer new
+heavy batches. This fallback expires when the host-launched path is available
+again. It never changes product proof or permits overlapping heavy work.
 
 For M13, every B1, B2, B3, and C role coordinator posts an artifact-complete
 closure result against the exact candidate to the M13 PR, or to the umbrella

--- a/tools/quality/aletheia-c5/README.md
+++ b/tools/quality/aletheia-c5/README.md
@@ -48,6 +48,35 @@ cooperative same-user local use with this limitation through the standing
 autonomous-adoption direction recorded in the Program Charter. Any broader
 threat model remains outside the adopted claim.
 
+## Operational launch boundary
+
+C5 coordinates host processes and must itself be the top-level host-executed
+command. Running C5 inside a network- or process-isolated agent sandbox and
+then asking it to launch Gradle or another host workload is invalid: the
+wrapper cannot coordinate a host it cannot observe, and the nested payload no
+longer inherits a direct executable's host permission.
+
+For Codex, compile the pinned source as below, then invoke the generated
+`tools/quality/aletheia-c5/host-lease-native` with
+`sandbox_permissions=require_escalated`. Use one 60-second representative
+startup canary after an execution-envelope or C5 identity change. Do not repeat
+the canary while both remain unchanged.
+
+The 2026-07-27 integration calibration on target `07ea4e183` established:
+
+- exact MAT Usage preflight: direct exit `13` in `4.96 s`; unchanged C5 host
+  launch exit `13` in `5.40 s`;
+- Gradle in the restricted network sandbox: direct and C5-wrapped exit `1`
+  before build startup with the same wildcard-IP error;
+- Gradle on the host: direct `help` passed in `4 s`; unchanged C5 host launch
+  passed in `2 s` with the configuration cache reused.
+
+This discriminates an outer execution-policy failure from a C5 mechanism or
+payload failure. If the host-launched startup canary fails, retain its command,
+audit, environment, exit, and process cleanup and apply the Charter's bounded
+fallback immediately. Do not consume A's critical path with repeated launcher
+experiments.
+
 ## Provenance and build
 
 Direct API decisions use the preserved official Linux man-pages 6.13 extract


### PR DESCRIPTION
## Outcome

Completes C5's operational integration at the actual failure boundary: the C5 executable must be the top-level host-executed command, not a nested sandboxed wrapper.

## Evidence

- Restricted network sandbox: exact Gradle startup failed both direct and C5-wrapped with the same wildcard-IP error.
- Host execution: direct Gradle `help` passed; unchanged C5 wrapping host Gradle `help` passed.
- Exact MAT Usage preflight currently exits `13` in about five seconds both direct and through unchanged C5; the historical 900-second result is not reproducible.
- Candidate is documentation-only and `git diff --check` is green.

## Guardrails

- One 60-second startup canary per unchanged execution envelope.
- Bounded failure within two minutes.
- A immediately falls back to exact serial critical-path execution while other roles defer heavy work.
- No product, verification, data, egress, or acceptance weakening.
