### PR TITLE
docs: enforce critical-path impact budgets

### DIFF
--- a/docs/project/delivery/aletheia/process-optimization.md
+++ b/docs/project/delivery/aletheia/process-optimization.md
@@ -1,8 +1,8 @@
 Status: Active
 Owner: Aletheia C
 Last Reviewed: 2026-07-27
-Charter Version: C-0.9.1
-Process Version: C-2.2.1
+Charter Version: C-0.9.2
+Process Version: C-2.3.0
 Evaluation Version: E-0.7.0
 Source of Truth: Temporary protocol for measured GM-Core work-process optimization.
 
@@ -61,6 +61,34 @@ frozen real A, B1, B2, B3, or C incident on every deciding and guard signal.
 Without that fidelity, the result is capped at `Proof of Concept` or
 `Preliminary` and cannot justify durable adoption. Read-only argument, model
 consensus, or an unmeasured shorter prompt is not proof.
+
+### C Impact Budget
+
+At candidate start, C records in its existing brief or handoff:
+
+- whether A is blocked and the exact unblock condition;
+- coordinator start time, first-signal deadline, terminal wall deadline, and
+  maximum delegated turns or tokens when exposed by the runtime;
+- the expected A time saved, affected worker or CI path, and rollback trigger;
+- the latest artifact that must be preserved if the work is parked.
+
+An A-blocking candidate receives at most ten minutes before a bounded fallback
+or failure report removes C from the critical path; A replans around a method
+that cannot be bypassed safely. Every other C candidate must produce its first
+executable or externally observable signal
+within 15 minutes; otherwise C parks and narrows it before spending more. Long
+qualified measurements may continue only after that signal and only while A is
+not waiting. A five-minute checkpoint compares elapsed wall time, active-agent
+state, turns/token delta when available, new retries, and live A progress with
+the frozen expectation.
+
+C measures adoption effects at the next A checkpoint and the next applicable
+worker or CI result. If saved A wait time does not exceed C-imposed wait, the
+change creates a new failure, or work is being discarded to maintain the
+process, C rolls back, repairs, or reduces scope immediately. Missing token
+counters never justify unbounded work; wall time and delegated turns remain
+the fallback controls. Report only the compact deltas in the existing PR,
+handoff, or umbrella issue.
 
 ## Adoption And Handoff
 

--- a/docs/project/delivery/aletheia/program-charter.md
+++ b/docs/project/delivery/aletheia/program-charter.md
@@ -1,7 +1,7 @@
 Status: Active
 Owner: SaltMarcher Product Owner
 Last Reviewed: 2026-07-27
-Charter Version: C-0.9.1
+Charter Version: C-0.9.2
 Source of Truth: User-given authority, workstream boundaries, agent assignment, maturity semantics, and completion boundary for the GM-Core program.
 
 # GM-Core Aletheia Program Charter
@@ -69,6 +69,37 @@ evidence of failure, budget expiry, or a falsified premise—not merely because
 the agent is quiet, slow, or nearly complete. If one candidate cannot proceed,
 the role may advance non-conflicting preparation but does not discard completed
 work or end its standing goal.
+
+## Critical-Path Priority And Impact Watch
+
+Before starting or continuing delegated work, every coordinator checks the
+live roadmap, current PR or umbrella-issue handoffs, active agents, and whether
+its action is blocking A. If C owns an A blocker, C unblocks A first with the
+smallest safe bounded result, fallback, or temporary rule; the broader process
+repair continues afterward and off A's critical path. Process completeness is
+never a reason to keep A waiting.
+
+Every delegated assignment declares a wall deadline, next observable signal,
+and maximum turns or token budget when the runtime exposes them. The
+coordinator checks impact at least every five minutes while the assignment is
+active. Quiet work is preserved, not replaced, but at budget expiry the
+coordinator parks it at its latest recoverable artifact, interrupts further
+spend, and chooses from that evidence. It does not restart the same work under
+a new agent merely to obtain a cleaner report.
+
+No C-owned process improvement may keep A blocked for more than ten minutes.
+Before that limit, C publishes the bounded evidence and an explicit safe
+fallback. If a protected boundary makes fallback impossible, C publishes that
+bounded failure and A replans around the unavailable method; neither waits for
+the background process repair.
+After any adopted process change, C checks the next observable A checkpoint
+and one subsequent relevant worker or CI result for queue time, time to first
+useful signal, retries, failures, work discarded, and coordinator wall time.
+It also records goal-token and delegated-turn deltas when available; unavailable
+runtime counters stay explicitly unavailable. A regression, missing promised
+benefit, or new blocker triggers immediate rollback, repair, or scope reduction.
+These facts live in the existing handoff, PR, or umbrella issue, never a new
+progress ledger.
 
 ## Research, Evidence, And Tooling
 


### PR DESCRIPTION
## Outcome

Makes A-critical-path priority and process-impact monitoring executable rules instead of informal intent.

## Controls

- Check live roadmap, handoffs, active agents, and A-blocking status before continuing delegated work.
- Five-minute impact checkpoints with wall time, agent state, retries, live A progress, and turns/tokens when available.
- Ten-minute maximum before C removes itself from A's critical path through a bounded fallback or failure handoff.
- Fifteen-minute first-signal deadline for non-blocking C work.
- Preserve and park work at budget expiry; never restart it merely for a cleaner report.
- Verify each adoption at the next A checkpoint and next relevant worker/CI result; rollback, repair, or reduce scope on regression.
- Store compact deltas only in existing PRs/handoffs/issues—no new ledger.

## Real calibration

The rule matches the corrected C5 incident response: A was unblocked first through a bounded handoff, advanced while C5 integration continued off-path, and C5 then merged with green CI.

Documentation-only candidate; `git diff --check` is green.
