### PR TITLE
Preserve useful agent work after budget expiry

### DIFF
--- a/docs/project/delivery/aletheia/process-optimization.md
+++ b/docs/project/delivery/aletheia/process-optimization.md
@@ -1,8 +1,8 @@
 Status: Active
 Owner: Aletheia C
 Last Reviewed: 2026-07-27
-Charter Version: C-0.9.2
-Process Version: C-2.3.0
+Charter Version: C-0.9.3
+Process Version: C-2.3.1
 Evaluation Version: E-0.7.0
 Source of Truth: Temporary protocol for measured GM-Core work-process optimization.
 
@@ -75,12 +75,13 @@ At candidate start, C records in its existing brief or handoff:
 An A-blocking candidate receives at most ten minutes before a bounded fallback
 or failure report removes C from the critical path; A replans around a method
 that cannot be bypassed safely. Every other C candidate must produce its first
-executable or externally observable signal
-within 15 minutes; otherwise C parks and narrows it before spending more. Long
-qualified measurements may continue only after that signal and only while A is
-not waiting. A five-minute checkpoint compares elapsed wall time, active-agent
-state, turns/token delta when available, new retries, and live A progress with
-the frozen expectation.
+executable or externally observable signal within 15 minutes; otherwise C
+closes the claim as `inconclusive` and follows the Charter's
+artifact-preservation and safe-boundary rule before parking or handing off the
+work. Long qualified measurements may continue only after that signal and only
+while A is not waiting. A five-minute checkpoint compares elapsed wall time,
+active-agent state, turns/token delta when available, new retries, and live A
+progress with the frozen expectation.
 
 C measures adoption effects at the next A checkpoint and the next applicable
 worker or CI result. If saved A wait time does not exceed C-imposed wait, the

--- a/docs/project/delivery/aletheia/program-charter.md
+++ b/docs/project/delivery/aletheia/program-charter.md
@@ -1,7 +1,7 @@
 Status: Active
 Owner: SaltMarcher Product Owner
 Last Reviewed: 2026-07-27
-Charter Version: C-0.9.2
+Charter Version: C-0.9.3
 Source of Truth: User-given authority, workstream boundaries, agent assignment, maturity semantics, and completion boundary for the GM-Core program.
 
 # GM-Core Aletheia Program Charter
@@ -65,10 +65,14 @@ worker, a temporarily unavailable host window, a retryable admission result, or
 a quiet phase agent is not a terminal blocker. The coordinator preserves the
 in-flight candidate and its artifacts, continues safe independent work, and
 retries within its frozen budget. It replaces a phase agent only after positive
-evidence of failure, budget expiry, or a falsified premise—not merely because
-the agent is quiet, slow, or nearly complete. If one candidate cannot proceed,
-the role may advance non-conflicting preparation but does not discard completed
-work or end its standing goal.
+evidence of failure or a falsified premise—not merely because the agent is quiet,
+slow, nearly complete, or past its budget. Budget expiry closes the candidate
+claim as `inconclusive`; it never by itself terminates useful or nearly complete
+running work. Preserve the latest durable artifact, checkpoint and hand off or
+park at a known safe boundary, and prevent the next duplicate. If no safe
+boundary is known, let useful running work finish. If one candidate cannot
+proceed, the role may advance non-conflicting preparation but does not discard
+completed work or end its standing goal.
 
 ## Critical-Path Priority And Impact Watch
 
@@ -82,10 +86,13 @@ never a reason to keep A waiting.
 Every delegated assignment declares a wall deadline, next observable signal,
 and maximum turns or token budget when the runtime exposes them. The
 coordinator checks impact at least every five minutes while the assignment is
-active. Quiet work is preserved, not replaced, but at budget expiry the
-coordinator parks it at its latest recoverable artifact, interrupts further
-spend, and chooses from that evidence. It does not restart the same work under
-a new agent merely to obtain a cleaner report.
+active. Quiet work is preserved, not replaced. At budget expiry the coordinator
+closes the candidate claim as `inconclusive`, preserves its latest durable
+artifact, and checkpoints, hands off, or parks it only at a known safe boundary.
+If no safe boundary is known, useful running work finishes and the next
+duplicate is prevented. Expiry alone never permits a signal, discard, or
+restart. Termination still requires positive failure or safety evidence, the
+worker's own role authority, or non-productive duplication.
 
 No C-owned process improvement may keep A blocked for more than ten minutes.
 Before that limit, C publishes the bounded evidence and an explicit safe
@@ -189,9 +196,10 @@ evidence pauses or reopens product work.
 
 A owns the delivery critical path. B1, B2, B3, and C may each hold at most one
 active candidate and preregister time, token or turn, compute, and external-cost
-budgets. They select the highest expected risk or process value, stop as
-`inconclusive` when a budget expires, and never prolong the program merely to
-search for hypothetical improvement.
+budgets. They select the highest expected risk or process value and close the
+candidate claim as `inconclusive` when a budget expires. They preserve useful
+running work under the safe-boundary rule above and never prolong the program
+merely to search for hypothetical improvement.
 
 At each A slice boundary, each B reviewer samples the changed surface through
 its own lens plus at most one highest program-wide risk. C tests at most one


### PR DESCRIPTION
## Summary
- close an expired candidate claim as inconclusive without treating expiry alone as termination authority
- preserve the latest artifact and use a known safe boundary for park/handoff
- let useful work finish when no safe boundary is known, while preventing the next duplicate

## Proof
- docs-only `git diff --check`: pass
- one causal TEST run: pass; 0 signals/kills, 0 lost work, 0 duplicates, worker exit 0
- one fresh evaluator replay: pass; rollback restored both parent blobs byte-for-byte
- independent verdict: Preliminary / qualified use

This PR deliberately does not adopt the parked federated-manager candidate or add coordination, monitoring, WIP, or host authority.