### PR TITLE
chore: restore .gitignore deleted by governance cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.gradle/
+build/
+.codex
+tools/**/.gradle/
+tools/**/build/
+docs/references/
+tools/html/
+.local/dnd-source/
+__pycache__/
+*.pyc


### PR DESCRIPTION
PR #571 (`a89dcd469`, "Remove governance and verification harness") deleted the repository `.gitignore` along with the harness — collateral, not intent: the file ignored only build outputs and local mirrors (`.gradle/`, `build/`, `tools/**/.gradle/`, `tools/**/build/`, `.codex`, `docs/references/`, `tools/html/`, `.local/dnd-source/`).

Without it, every checkout with a build shows untracked `build/`/`.gradle/` trees and any `git add -A` risks committing build artifacts.

This restores the exact previous content from `e59ec0a57` (1 file, +10 lines). No production or docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)