### PR TITLE
Restore product documentation after repository cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,2 @@
 .gradle/
 build/
-.codex
-tools/**/.gradle/
-tools/**/build/
-docs/references/
-tools/html/
-.local/dnd-source/
-__pycache__/
-*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# SaltMarcher
+
+SaltMarcher is a local-first JavaFX tabletop-campaign tool for map travel,
+dungeon editing, session planning, catalog data, encounters, and party state.
+
+## Quickstart
+
+Run the app from the repository root:
+
+```bash
+./gradlew run --console=plain
+```
+
+## Local Data
+
+SaltMarcher stores SQLite data below the XDG data directory. If
+`XDG_DATA_HOME` is set, data lives in `$XDG_DATA_HOME/salt-marcher/`; otherwise
+it lives in `~/.local/share/salt-marcher/`. The current database file is
+`installation.sqlite`; Campaign data is stored separately under
+`campaigns/<id>/campaign.sqlite`. Location and lifecycle rules are owned by the
+[Persistence Lifecycle contract](docs/project/contract/persistence-lifecycle.md).
+
+## Project Map
+
+- `app/`: explicit application startup, composition, and lifecycle
+- `shell/`: generic shell API and host runtime
+- `platform/`: feature-neutral execution, persistence, diagnostics, state, and UI mechanisms
+- `features/`: vertical feature APIs, domains, applications, adapters, and composition roots
+- `resources/`: static resources and centralized application styling
+- `docs/`: canonical project and feature documentation
+
+Start with `docs/README.md` for the documentation map.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# SaltMarcher Documentation
+
+## Purpose
+
+This directory is the entry point for project-wide and feature-owned
+SaltMarcher product documentation.
+
+## Documentation Layers
+
+- Vision: [Project Vision](project/vision.md) records why SaltMarcher
+  exists, for whom, and what it will not become.
+- Behavior: feature requirements under `docs/<feature>/requirements/`
+  record target behavior.
+- Domain documents define business truth and invariants.
+- Contracts define APIs, persistence, validation, errors, and compatibility.
+- Architecture documents define boundaries, dependencies, and quality-driving
+  decisions.
+
+## Project Documentation
+
+- [Project Documentation Index](project/README.md)
+
+## Feature Documentation
+
+- [Actor Autonomy](autonomy/README.md): GM-authorized NPC and monster needs,
+  jobs, catch-up, and bounded non-party conflict resolution.
+- [Campaign](campaign/README.md): installation-wide Campaign registry and
+  active-Campaign pointer persistence.
+- [Catalog](catalog/README.md): shared catalog workspace behavior.
+- [Creatures](creatures/README.md): creature catalog, detail, and
+  encounter-candidate reference behavior.
+- [Dungeon](dungeon/README.md): dungeon authoring, editing, travel, and domain
+  truth.
+- [Encounter](encounter/README.md): encounter generation and saved encounter
+  plans.
+- [Encounter Table](encountertable/README.md): authored encounter-table
+  candidate sources.
+- [Hex](hex/README.md): hex-map editing and travel behavior.
+- [Items](items/README.md): local imported item reference data.
+- [Maps](maps/README.md): shared passive map-canvas behavior and contracts.
+- [Party](party/README.md): party composition and party state.
+- [Scene](scene/README.md): running-scene behavior and state.
+- [Session Generation](sessiongeneration/README.md): deterministic encounter
+  and reward generation.
+- [Session Planner](sessionplanner/README.md): session-owned planning records.
+- [Travel](travel/README.md): feature-neutral global travel-context selection
+  across Party, Dungeon, and Hex readbacks.
+- [World Planner](worldplanner/README.md): campaign-world planning records.
+
+## References
+
+- [Repository README](../README.md)

--- a/docs/autonomy/README.md
+++ b/docs/autonomy/README.md
@@ -1,0 +1,27 @@
+# Actor Autonomy Feature Docs
+
+## Purpose
+
+Actor Autonomy owns GM-authorized needs, job selection and execution, group
+behavior, inactive-context catch-up, explainability, and bounded NPC or monster
+conflict resolution. It references actor identity, rules, spatial context,
+Features, and inventory through their owning capabilities rather than copying
+their truth.
+
+The Party remains GM-controlled. Dungeon owns Dungeon geometry, local travel,
+perception, tracks, and spatial job offers; Actor Autonomy owns why and when an
+enabled actor chooses work.
+
+## Document Set
+
+### Requirements
+
+- [Actor Autonomy Requirements](requirements/requirements-actor-autonomy.md)
+
+## Related Owners
+
+- [Dungeon Feature Docs](../dungeon/README.md)
+- [World Planner Feature Docs](../worldplanner/README.md)
+- [Creatures Feature Docs](../creatures/README.md)
+- [Party Feature Docs](../party/README.md)
+- [Project Vision](../project/vision.md)

--- a/docs/autonomy/requirements/requirements-actor-autonomy.md
+++ b/docs/autonomy/requirements/requirements-actor-autonomy.md
@@ -1,0 +1,221 @@
+# Actor Autonomy Requirements
+
+## Goal
+
+Let one GM delegate bounded, explainable campaign-time behavior to individual
+NPCs and monsters and to groups formed from them. Enabled actors satisfy needs,
+select reachable work, move, interact, and resolve non-party conflicts without
+wall-clock simulation or loss of GM control.
+
+## Authority And Scope
+
+- the GM explicitly enables, pauses, or disables autonomy per actor or group
+- the Party and its members remain GM-controlled
+- GM confirmation of campaign time authorizes enabled actors to act within
+  their configured bounds
+- the GM may directly assign or cancel a job and change role or job priorities
+- autonomy never creates or deletes actor identities, campaign places,
+  Features, or other authored content
+- external actor, creature, inventory, Dungeon, Feature, rule, and calendar
+  facts remain owned by their respective capabilities
+- the capability may change foreign truth only through an explicit operation
+  offered by its owner
+
+Actor autonomy is the confirmed exception to the general product principle that
+SaltMarcher does not make campaign decisions. The exception is limited to
+enabled actors, confirmed campaign time, configured job and consequence bounds,
+and the behaviors specified here.
+
+## Needs And Job Offers
+
+Every enabled individual is a simulation unit with current need state. Built-in
+needs are:
+
+- hunger
+- thirst
+- rest
+- safety
+- social proximity
+
+The GM may disable or parameterize built-in needs and add custom needs. Needs
+change their own state and job priority. They do not independently apply D&D
+damage, exhaustion, conditions, or another feature's mechanical effects; such
+effects require an operation from the owning capability or GM confirmation.
+
+Roles, Rooms, campaign places, Curiosities, Loot, Traps, and other referenced
+targets may offer jobs. Initial useful jobs include guarding, patrolling,
+resting, eating, working, resetting a mechanism, traveling, waiting, and an
+explicit simple interaction offered by a referenced Feature.
+
+A job is eligible only while its preconditions hold, its target is reachable,
+and every required foreign operation is currently available. Free fictional
+consequences remain GM-owned unless covered by the bounded non-party conflict
+rules below.
+
+## Job Selection And Execution
+
+For each actor, SaltMarcher considers valid jobs using current needs, danger,
+role, GM priorities, campaign time, place, reachable target, and reservations.
+It selects the highest-priority candidate deterministically. Equal candidates
+use a stable deterministic tie-break; ordinary job selection contains no
+randomness.
+
+An exclusive target is reserved for one actor or group. A reservation conflict
+makes that candidate invalid, causes selection of the next valid job, and
+appears in the explanation.
+
+A higher-priority need, newly perceived danger, invalidated target, or GM
+override may interrupt a job. A paused job resumes when it remains valid. A job
+may mark a short critical step as non-interruptible; this does not permit it to
+cross a Party-danger or GM-decision boundary.
+
+Individuals are authoritative simulation units. A group normally shares one
+job and travels together, but may split or merge autonomously when the GM's
+configuration permits it. An urgent individual need may split its actor from a
+group. Group changes preserve individual identity and are logged.
+
+## Campaign Time And Contexts
+
+Autonomy advances only through GM-confirmed campaign or exploration time. It
+never advances from wall-clock time, application downtime, or merely opening a
+screen.
+
+The active campaign context is simulated in detail. Other autonomy-enabled
+contexts retain the elapsed campaign-time boundary and are caught up
+deterministically when activated. Catch-up uses the same authored facts and
+rules that were valid for the elapsed periods; it does not fabricate wall-clock
+activity.
+
+Catch-up stops immediately before the first action whose effect requires a GM
+decision. The affected context remains paused and shows the pending decision
+when opened. Independent read access and inspection remain available.
+
+Non-party NPC or monster conflict is the explicit exception: it may be
+resolved during ordinary progression or catch-up without stopping for GM
+confirmation. Party involvement always pauses and notifies before any danger
+resolution, movement into engagement, or conflict consequence.
+
+## Perception And Local Behavior
+
+Spatial capabilities provide position, route, environmental perception,
+tracks, and local job offers. A new perception result may invalidate or
+reprioritize jobs.
+
+NPCs and monsters may autonomously flee, warn, pursue, take position, or engage
+when the Party is not involved. When the Party is or becomes involved, the
+affected jobs and routes pause and the GM receives the relevant context. An
+Encounter starts only after GM confirmation.
+
+## Bounded Non-Party Conflict
+
+Conflicts involving only enabled NPCs or monsters use a simplified abstract
+D&D 5e 2014 resolution. Relevant actor values, group size, environment,
+position, resources, and configured protection bounds influence a small number
+of abstract conflict steps. Full tactical initiative, action-by-action combat,
+and a hidden battlemap simulation are not required.
+
+Conflict resolution uses real random rolls. Every roll, applicable modifier,
+input reference, step, and result is durably logged. Repeating the same inputs
+need not reproduce the same result.
+
+Allowed durable outcomes are:
+
+- changed position, retreat, or escape
+- captured state
+- injury or death state owned through the relevant actor or rules capability
+- consumption of relevant resources
+- transfer of referenced possessions through their owning capability
+
+The simulation never deletes an identity or authored record. Per actor or group
+the GM may prohibit severe consequences, including death, capture, or permanent
+possession loss. Resolution then stops at the strongest permitted result rather
+than silently ignoring the bound.
+
+Non-party conflicts do not interrupt catch-up merely to report their outcome.
+They remain available in the detailed log and appear in a compact summary when
+the GM next opens the context.
+
+## Atomicity, Cancellation, And Correction
+
+One confirmed campaign-time step commits all affected needs, jobs, movements,
+group changes, reservations, foreign effects, random conflict results, and
+events atomically or commits none of them. A crash leaves either the complete
+old step or the complete new step.
+
+Before commit, a long-running step is cancellable and leaves no behavioral or
+random-result effects. A completed autonomy step has no runtime undo. The GM
+corrects the resulting campaign state through normal owner-provided overrides;
+the correction is logged without rewriting the original history.
+
+## Explainability And Log
+
+For the current decision the GM can inspect:
+
+- current needs and their contribution to priority
+- considered eligible and rejected jobs
+- reachability, reservation, role, time, danger, and target constraints
+- the selected job and deterministic tie-break
+- pause, interruption, completion, or failure reason
+
+The durable factual log records job start, pause, cancellation, resumption and
+completion; group and reservation changes; confirmed movement and simple
+effects; time boundaries; conflict rolls and outcomes; GM overrides; and
+corrections. Full candidate evaluation is diagnostic and need not be retained
+as permanent campaign history.
+
+## Persistence And Failure States
+
+Needs, enabled state, priorities, jobs, reservations, groups, time boundaries,
+paused decisions, protection bounds, and committed outcomes survive restart.
+Broken or missing referenced targets invalidate only affected jobs and expose a
+specific reason; they do not delete actor state or choose an unrelated target
+silently.
+
+An owner capability rejecting an effect aborts the complete uncommitted time
+step. Catch-up or active simulation then remains at its previous confirmed time
+with diagnostics and a repairable reason.
+
+## Quality Needs
+
+- qualification includes at least 200 autonomous individuals
+- a confirmed 200-actor time step completes within 2 seconds p95
+- progress appears within 100 ms
+- an uncommitted operation expected to exceed 2 seconds is cancellable
+- simulation does not block camera, selection, or independent reads
+- work scales with active actors, locally reachable candidates, and touched
+  routes rather than every Dungeon cell or dormant campaign record
+- adding a need, job family, job-offer source, spatial adapter, or effect owner
+  remains a local change and does not require unrelated feature rewrites
+
+## Non-Goals
+
+- autonomous Party or player-character decisions
+- wall-clock or offline simulation
+- full tactical D&D combat
+- unrestricted scripting of arbitrary campaign mutations
+- autonomous creation or deletion of authored campaign content
+- ownership of Dungeon geometry, actor identity, creature statistics,
+  inventory, calendar, or Feature truth
+
+## Acceptance Outcomes
+
+- an enabled actor selects the same job from the same eligible candidates and
+  priorities, excluding separately logged random conflict resolution
+- an exclusive target is never simultaneously committed to conflicting jobs
+- a GM-confirmed time step is atomic across all affected actors and effects
+- catch-up stops before a GM-owned decision but may complete bounded non-party
+  conflicts
+- any Party involvement pauses before danger resolution and notifies the GM
+- protection bounds prevent prohibited severe conflict outcomes
+- every random conflict outcome can be audited from recorded inputs, rolls,
+  modifiers, and steps
+- restart preserves enabled state, jobs, needs, reservations, time boundaries,
+  and committed results
+- no completed autonomy step can be silently undone or history-rewritten
+
+## References
+
+- [SaltMarcher Vision](../../project/vision.md)
+- [Dungeon Travel Requirements](../../dungeon/requirements/requirements-dungeon-travel.md)
+  ([public source](https://github-wiki-see.page/m/CBornholdt/RimWorld-AI-Tutorial/wiki/Part-1---Introduction))
+  ([public source](https://www.dndbeyond.com/sources/dnd/basic-rules-2014/adventuring))

--- a/docs/campaign/README.md
+++ b/docs/campaign/README.md
@@ -1,0 +1,6 @@
+# Campaign Feature README
+
+The Campaign feature owns the installation-wide Campaign registry and durable
+active-Campaign pointer. User-visible Campaign behavior remains in the program
+requirements; persistence shape and failure semantics are owned by the
+[Campaign Registry Persistence Contract](contract/contract-campaign-registry-persistence.md).

--- a/docs/campaign/contract/contract-campaign-registry-persistence.md
+++ b/docs/campaign/contract/contract-campaign-registry-persistence.md
@@ -1,0 +1,57 @@
+# Campaign Registry Persistence Contract
+
+## Purpose And Boundary
+
+The Campaign feature owns the installation-wide registry of stable Campaign
+identities and names plus the single durable active-Campaign pointer. The
+registry lives in `installation.sqlite`; Campaign-authored truth remains in the
+physically separate store for that Campaign. Consumers receive only
+`CampaignRegistryApi`, never JDBC, a database path, or another owner's handle.
+
+## Stored Truth
+
+- `campaign_registry_campaigns` stores one non-blank display name for each
+  stable Campaign identity. Duplicate display names are valid.
+- `campaign_registry_activation` stores at most one pointer and its strictly
+  positive activation generation. Its target must exist in the Campaign table.
+- Registering a Campaign and committing its first active pointer is one
+  transaction. A failed or stale commit cannot leave a new registry row behind.
+
+## Schema Ownership And Validation
+
+The two tables, their columns, primary keys, checks, foreign key, automatic
+SQLite indexes, and the complete persistent `campaign_registry_*` object
+inventory form one exact schema. Readiness compares that target to a separately
+derived SQLite reference schema without mutating the installation store.
+Malformed or adjacent owner objects make the registry unavailable; they are
+not repaired, dropped, or ignored.
+
+## Compatibility And Initialization
+
+Compatibility obligations begin with the first released format.
+Before the first released format, the Campaign registry has one disposable current format:
+owner version `1`. Its single initializer requires an empty
+`campaign_registry_*` namespace and creates the complete current target
+directly. An unversioned partial namespace and a malformed recorded version `1`
+fail without schema, row, or ledger mutation. A recorded version above `1`
+fails as newer without downgrade.
+
+Until activation there is no predecessor conversion, compatibility reader,
+backfill, or repair path. After activation, future format changes are governed
+by project `TN-18` and `TN-19` and must introduce explicit qualified
+preservation behavior rather than changing the meaning of version `1`.
+
+## Error And Consistency Behavior
+
+Registry operations fail through Campaign result statuses and do not expose
+SQLite exceptions. Pointer compare-and-set uses the expected generation; a
+stale generation returns current durable activation truth. Shutdown rejects
+new work and prevents an accepted mutation from committing after terminal
+revocation.
+
+## References
+
+- [Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
+
+- [Source Architecture](../../project/architecture/source-architecture.md)
+- [Program Capability Requirements](../../project/requirements/requirements-program-capabilities.md)

--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -1,0 +1,23 @@
+# Catalog Feature
+
+Catalog is the application capability for finding, evaluating, and explicitly
+handing reference content to another active workspace. It presents Creatures,
+Items, saved Encounters, World Planner records, and Encounter Tables inside one
+`Katalog` left-bar tab.
+
+## Reading Order
+
+1. Read [Catalog Requirements](requirements/requirements-catalog.md) for
+   user-visible behavior and acceptance criteria.
+2. Read [Catalog Architecture](architecture/architecture-catalog.md) for the
+   durable target structure, ownership, and dependency direction.
+
+## Document Set
+
+### Requirements
+
+- [Catalog Requirements](requirements/requirements-catalog.md)
+
+### Architecture
+
+- [Catalog Architecture](architecture/architecture-catalog.md)

--- a/docs/catalog/architecture/architecture-catalog.md
+++ b/docs/catalog/architecture/architecture-catalog.md
@@ -1,0 +1,234 @@
+# Catalog Architecture
+
+## Purpose And Boundary
+
+Catalog is the read-and-handoff workspace for reference content. It owns the
+user's transient browsing experience: active section, unfinished input,
+committed query, result lifecycle, sort, page, selection, and explicit actions.
+It owns no creature, item, Encounter, World Planner, or Encounter Table truth
+and has no persistence adapter.
+
+Provider features remain the sole owners of durable records, validation,
+migrations, details, and mutations. Catalog consumes only their public APIs.
+Encounter owns generation pool criteria; the visible Monster filter editor
+edits that typed capability and queries Creatures with the accepted revision.
+
+## Target Topology
+
+```text
+features/catalog/
+├── application/
+│   ├── CatalogWorkspace
+│   ├── BrowseSession
+│   ├── CatalogSectionDefinition
+│   ├── CatalogSectionState
+│   └── CatalogResult
+├── adapter/javafx/
+│   ├── CatalogContribution
+│   ├── CatalogWorkspaceView
+│   ├── CatalogSectionRenderer
+│   ├── CatalogControlFactory
+│   └── CatalogPicker
+└── CatalogFeature
+```
+
+The seven sections are statically and explicitly composed. They are not seven
+controllers or JavaFX view classes. Each is a typed definition that supplies
+provider query translation, immutable filter fields, columns, stable identity,
+and available actions to shared application and presentation mechanisms.
+
+Runtime discovery and a plugin registry are rejected because the product owns
+exactly seven sections and has no extension need.
+
+## Typed Section Definition
+
+`CatalogSectionDefinition<Q, R, K>` contains:
+
+- stable section id, label, and initial immutable query draft
+- typed filter specifications with getters and immutable updaters
+- provider query function and provider-result translation
+- stable row identity and table column specifications
+- optional paging and typed row or section action declarations
+- optional provider revision observation used only while the section is active
+
+`CatalogWorkspaceController` binds each declared action to the explicitly
+composed outward route for that section. The three provider-owned create routes
+and the four non-mutating unavailable outcomes are exhaustively composed there;
+the renderer cannot infer availability or invent a mutation.
+
+Filter specifications are a sealed family for text search, single choice,
+multi-choice, range, and tri-state values. They do not use string-keyed maps,
+untyped values, reflection, JavaFX nodes, CSS classes, or provider persistence
+types.
+
+Provider APIs keep their own result vocabularies. The definition translates at
+the real consumer boundary into one Catalog result model rather than requiring
+providers to depend on Catalog.
+
+## Browse Session And Workspace State
+
+One reusable `BrowseSession<Q, R, K>` owns the lifecycle shared by all sections:
+
+- unfinished draft and last committed query
+- 200 ms debounce and immediate Enter submission
+- request epoch and cancellation or invalidation of superseded work
+- page, total, stable selection, provider revision, stale marker, and one
+  generic `SortState` consisting of a declared column id and direction
+- immutable result state: uninitialized, loading, refreshing, ready, empty,
+  invalid, unavailable, or failed
+
+Only the selected session is active. Activating a section observes its provider
+and queries when uninitialized, stale, or edited. Deactivating it releases the
+subscription and invalidates in-flight publication while retaining immutable
+state. An inactive section performs no query, option load, or provider
+subscription.
+
+The workspace owns the active section and the seven retained session states.
+It publishes one revisioned immutable snapshot. JavaFX state is never the
+source of unfinished input or selection.
+
+Sorting is application state rather than a control-specific callback. A
+section maps the generic sort state to its typed provider query and declares
+which columns accept it. Header activation is the sole presentation input for
+changing that state; providers do not leak their own sort widgets into Catalog.
+
+A refresh retains the last successful rows while exposing `refreshing`. A
+failure may retain that read-only result with a retry action, but it cannot be
+reported as current success. A selected identity survives refresh only when it
+is present in the accepted result.
+
+## Actions And Cross-Feature State
+
+Selecting or opening a row is read-only with respect to Encounter and Scene.
+Every external change uses a named typed action route. Catalog consumes a typed
+outcome where the provider API supplies one; synchronous provider callbacks and
+unavailable create capabilities publish only their explicit local feedback.
+
+Catalog consumes exact routes for:
+
+- provider-owned details and editors in the Inspector
+- adding a Creature or NPC to Encounter or focused Scene
+- opening a saved Encounter with the provider-owned discard decision
+- selecting faction, location, or Encounter Table sources for Encounter
+- assigning the focused Scene location
+
+Catalog does not coordinate a cross-provider transaction. A future action that
+requires one must be owned by the feature that owns the consistency boundary,
+not by callbacks or a Catalog database.
+
+Monster generation filters have one canonical owner: Encounter. Catalog keeps
+only the unfinished editor value required to show invalid or not-yet-debounced
+input. An accepted filter command returns or publishes its revision; the
+Creature query records that revision so late readback cannot replace newer
+visible work.
+
+## JavaFX Presentation
+
+Three section-neutral presentation owners implement the shared Catalog surface:
+`CatalogSectionRenderer`, `CatalogControlFactory`, and `CatalogPicker`.
+`CatalogSectionRenderer` composes the selected section from the sealed filter
+specifications, column specifications, paging capability, action specifications,
+and immutable state. Changing section rebinds or rebuilds this one renderer;
+application state, not seven retained node trees, preserves work.
+
+`CatalogWorkspaceView` owns one main JavaFX root for the lifetime of the
+workspace. `CatalogSectionRenderer` replaces or rebinds only content beneath
+that root; a section cannot supply another main root, nested workspace shell,
+or retained node tree.
+
+`CatalogPicker` owns the section-neutral virtualized choice and multi-choice
+picker, including its popup, selection, and option-cell lifecycle.
+`CatalogControlFactory` owns the remaining declared Catalog visual roles and
+creates their controls. Section definitions cannot construct controls or assign
+styles. The renderer owns:
+
+- the persistent section selector and compact wrapping controls area
+- inside-label search, selection, range, and filter controls
+- one chip per active filter value, selective removal, and whole-filter reset
+- status, empty and failure presentation, table, paging, keyboard,
+  accessibility, and stable-id selection
+- header-only sort interaction and the unified result footer containing count,
+  status, and optional pagination
+- one consistent create control backed by a typed provider route or a
+  side-effect-free unavailable capability that returns visible feedback;
+  details remain row-driven and have no dedicated button
+- the shared 28 px control and 12 px regular type contract, plus the compact
+  chip information style
+
+Section-specific behavior is limited to typed data, columns, filters, and
+actions. A one-off JavaFX escape hatch is not a supported section capability.
+
+Choice and multi-choice filters use virtualized picker content so node count
+tracks visible options rather than provider result size. Their option source is
+loaded only for the active session. Overlapping requests share one in-flight
+load, and its successful result is cached independently of page request epochs.
+A failure is never cached as an empty success: successful page rows remain
+read-only, the footer reports the option failure, and the next active query
+retries the load.
+
+## Persistence, Execution, And Failure Isolation
+
+Catalog never receives `SqliteDatabase`, JDBC, paths, or migration plans.
+Provider services are created only after their owner-scoped storage readiness
+is known under the [persistence lifecycle](../../project/contract/persistence-lifecycle.md).
+
+Persistence-backed queries run outside the JavaFX thread. Creature and Item
+catalog reads use independent bounded read lanes, so a slow or failed Item read
+cannot queue behind or block Creature lookup, and vice versa. Other independent
+provider reads may likewise execute concurrently; ordered writes are serialized
+by their owning feature or store, not by one application-wide queue. One
+provider's newer schema, migration failure, unavailable source, option-load
+failure, or query failure becomes only that section's typed unavailable or
+failed state.
+
+These read lanes, caches, sort state, and presentation mechanisms do not move
+record or persistence ownership into Catalog. Creature, Item, Encounter, World
+Planner, and Encounter Table APIs remain the authoritative routes; their
+provider and persisted truth is unchanged.
+
+Diagnostics remain payload-free and local. A visible failure carries a stable
+local diagnostic id and retryability, not SQL, paths, or exception messages.
+
+## Composition
+
+`CatalogFeature` receives the seven definitions plus the UI dispatcher and
+constructs the workspace and contribution. `app` explicitly supplies provider
+APIs and outward routes; neither Catalog nor shell locates services.
+
+The permanent structural constraints are:
+
+- Catalog application imports provider APIs but no foreign implementation,
+  JavaFX, JDBC, or persistence package
+- Catalog has no domain or SQLite role
+- exactly seven definitions are explicitly composed
+- section definitions contain no JavaFX nodes or style decisions
+- only `CatalogSectionRenderer`, `CatalogControlFactory`, and the section-neutral
+  `CatalogPicker`, including their nested classes, depend on JavaFX controls
+- exactly one Catalog main root exists and sections cannot provide another
+- all sortable sections consume the generic sort state through declared columns
+- option pickers are virtualized, overlapping loads are coalesced, and only
+  successful option results are cached
+- Creature and Item stateless Catalog reads use separate bounded lanes while
+  Creature state-publishing commands retain their serialized execution lane
+- no section-specific lifecycle controller or JavaFX section class returns
+- inactive sections cannot acquire subscriptions or issue provider calls
+
+## Rejected Alternatives
+
+- Seven controllers and seven JavaFX section roots are rejected because they
+  duplicate one browsing lifecycle and one presentation grammar.
+- Eager activation is rejected because invisible sections have no user work to
+  perform and failures or latency must remain isolated.
+- A dynamic form map is rejected because it sacrifices typed update semantics.
+- A Catalog-owned read database is rejected because it duplicates provider
+  truth and creates synchronization invariants.
+- One global serial execution lane is rejected because independent reads and
+  failures do not share an ordering invariant.
+
+## References
+
+- [Catalog Requirements](../requirements/requirements-catalog.md)
+- [Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
+- [Source Architecture](../../project/architecture/source-architecture.md)
+- [Feature Boundaries](../../project/architecture/patterns/feature-boundaries.md)
+- [Shell Layer](../../project/architecture/patterns/shell-layer.md)

--- a/docs/catalog/requirements/requirements-catalog.md
+++ b/docs/catalog/requirements/requirements-catalog.md
@@ -1,0 +1,160 @@
+# Catalog Requirements
+
+## Goal
+
+The GM MUST be able to find, evaluate, and explicitly hand reference content
+to an active Encounter or Scene from one `Katalog` navigation entry. The
+workspace serves both game preparation and running-session lookup.
+
+## Primary Flows
+
+1. The GM opens `Katalog`, chooses one of the seven visible sections, and uses
+   that section's search or filters.
+2. The GM opens a selected record in the Inspector without changing Encounter
+   or Scene state.
+3. The GM uses an explicit action when a Monster, NPC, faction, location, or
+   Encounter Table should affect the active Encounter or focused Scene.
+4. The GM switches sections and later returns without losing unfinished input
+   or the previous result position.
+
+## Target Behavior
+
+- The workspace MUST expose Monster, Items, Encounter, NPCs, Fraktionen, Orte,
+  and Encounter-Tabellen as distinct visible sections.
+- One persistent section selector MUST remain at the top of the Catalog
+  controls area. The selected section's controls MUST always appear below it,
+  and its results MUST appear in the main area.
+- Search text and filter edits MUST update the selected section automatically
+  after 200 ms without another edit. Enter MUST submit the current valid input
+  immediately. All seven sections use this behavior when they expose search or
+  filters.
+- Only the selected section may load or observe provider results. Switching
+  sections MUST stop invisible work without discarding that section's input,
+  accepted result, selection, sort, or page.
+- Every section MUST use the same compact control hierarchy: one wrapping row
+  for search and section actions, wrapping inside-labeled filters, removable
+  active-filter chips, and one feedback area when those capabilities exist.
+  Empty regions MUST not render placeholders or consume space.
+- Controls MUST remain content-sized instead of stretching to consume unused
+  row width. The selected section MUST read as one coherent result workspace,
+  without nested section panels or duplicate visual roots.
+- Equivalent section, search, filter, paging, and action controls MUST
+  render at 28 pixels high with the same 12-pixel regular-weight type style.
+  Removable filter chips use the shared compact information style.
+- Search and filter meaning MUST appear inside the interactive element through
+  its prompt or displayed value. Redundant field-side labels, `FILTER`, and
+  `AKTIONEN` headings MUST not appear.
+- Choice filters MUST support direct keyboard selection by typing an option's
+  visible text, in addition to pointer and arrow-key navigation. Long option
+  lists MUST remain scrollable and responsive.
+- Each active discrete filter value or entered criterion MUST render as its own
+  removable chip. Removing one chip MUST clear only that value. A single
+  `Filter zurücksetzen` action MUST clear all filters of the selected section
+  without changing its section, sort, or retained selection unnecessarily.
+- Table column headers MUST be the only sort controls. Activating a sortable
+  header MUST select that column and toggle its direction with a visible
+  indicator; a separate sort selector MUST not appear.
+- Switching sections MUST preserve each section's filters, selection, paging,
+  and unfinished input for the lifetime of the Catalog workspace.
+- Sections MUST use consistent table, status, paging, keyboard, and selection
+  behavior while retaining section-specific columns, filters, and actions.
+- Every section MUST distinguish loading, empty, unavailable, invalid-input,
+  and failed outcomes whenever the underlying operation can produce them.
+- Refreshing an already successful section MUST keep its accepted rows visible
+  while communicating that they are being refreshed. A failed refresh MUST not
+  present stale rows as current success.
+- Every result table MUST end in one shared footer that shows the visible or
+  total result count, the current loading/refresh/error status when applicable,
+  and pagination controls when more than one page exists. These signals MUST
+  not be split across unrelated regions.
+- Each section MUST show one consistently placed and styled `Erstellen`
+  control. Where the owning provider exposes a real creation workflow, the
+  control MUST open that provider-owned route. Otherwise it MUST remain an
+  activatable, side-effect-free placeholder that reports `Erstellen ist für …
+  noch nicht verfügbar` and MUST NOT invent a Catalog-owned record or report
+  false success.
+- Activating a row through its name, Enter, or double-click MUST expose available
+  provider details in the Inspector without a separate `Details` button. Merely
+  selecting a row remains side-effect free.
+- Monster search and encounter-builder controls MUST preserve their accepted
+  behavior, including creature details and explicit add-to-Encounter and
+  add-to-focused-Scene actions.
+- Items MUST be read-only, searched asynchronously, distinguish loading,
+  unavailable, empty, invalid, and storage-failure outcomes, and open details
+  without blocking the JavaFX thread.
+- Saved encounters MUST open in the global Encounter state tab. If the focused
+  Encounter has unsaved roster changes, opening another plan MUST require an
+  explicit discard confirmation.
+- NPC, faction, and location details and edit actions MUST remain available in
+  the Inspector.
+- NPCs MUST support explicit Encounter and focused-Scene actions. Factions,
+  locations, and Encounter tables MUST support explicit Encounter-source
+  actions; locations MUST support assigning the focused Scene location.
+- Selecting or opening a row alone MUST NOT mutate Encounter or Scene state.
+- Changes to the visible Monster filters MUST also constrain Encounter
+  generation. Difficulty, balance, amount, and diversity controls MUST remain
+  in a collapsible section in the global Encounter state tab.
+- The separate World Planner navigation entry and local state-panel slot MUST
+  not be registered. World data and edit capabilities remain available through
+  Catalog and Inspector.
+- Activating or refreshing Scene MUST NOT change the visible Monster query,
+  rows, sort, page, selection, or loading state.
+- Typing, filter keyboard selection, section switching, header sorting, row
+  selection, and paging feedback MUST remain available while provider reads are
+  pending. Each interaction MUST update its local visible state within 100 ms
+  on the supported desktop target and MUST NOT wait for Creature, Item, or
+  option-provider I/O on the JavaFX thread.
+
+## Non-Goals
+
+Catalog does not edit creature statblocks, import external items, replace the
+Encounter or Scene workspaces, or expose a second World Planner workspace.
+
+## Acceptance Criteria
+
+- One `Katalog` contribution shows all seven sections in the common controls
+  and main workspace.
+- At 1150×700 and 900×650, the selected section retains the persistent selector,
+  compact controls, and a visible result workspace without horizontal scrolling.
+- Equivalent controls satisfy the shared 28-pixel and 12-pixel visual contract,
+  use inside labels, remain content-sized, and do not render redundant group
+  headings or nested section roots.
+- Sortable table headers are the only visible sort controls and expose the
+  active direction.
+- A user can type to select a filter option, remove each active value through
+  its own chip, and clear the selected section's filters with one reset action.
+- Every section presents the same `Erstellen` control position and style; the
+  action reaches a real provider workflow or reports its unavailable placeholder
+  without side effects.
+- No section renders a `Details` button; row interaction exposes available
+  Inspector details without mutating Encounter or Scene.
+- The shared result footer presents count, current status, and pagination when
+  paging is available.
+- Typing several characters inside 200 ms publishes only the final query;
+  Enter publishes the current valid query immediately.
+- Inactive sections issue no provider query and retain their last state.
+- Switching through every section and returning preserves each section's
+  current query, filter draft, selected record, page, and unfinished input.
+- Refreshing provider results preserves a still-present selected record by its
+  stable identity.
+- Each reachable result state renders a distinct visible outcome and leaves the
+  JavaFX event thread responsive.
+- Local feedback for typing, filtering, sorting, section switching, selection,
+  and paging appears within 100 ms while Creature, Item, and option reads remain
+  independently non-blocking.
+- Opening details changes only Inspector content.
+- Each explicit Encounter or Scene action changes only its named destination.
+- Opening a saved Encounter with unsaved roster changes requires confirmation
+  before replacement.
+- Encounter tuning controls are absent from Catalog and remain available in the
+  global Encounter state tab.
+- Activating or refreshing Scene does not change the visible Monster query,
+  rows, sort, page, selection, or loading state.
+- Final visual and interaction acceptance remains owner manual testing.
+
+## References
+
+- [Catalog Architecture](../architecture/architecture-catalog.md)
+- [Items Requirements](../../items/requirements/requirements-items-catalog.md)
+- [Encounter State Requirements](../../encounter/requirements/requirements-encounter-state-tab.md)
+- [World Planner Requirements](../../worldplanner/requirements/requirements-world-planner.md)

--- a/docs/creatures/README.md
+++ b/docs/creatures/README.md
@@ -1,0 +1,35 @@
+# Creatures Feature README
+
+## Purpose
+
+The creatures feature owns read-only creature catalog access for reference and
+encounter-generation workflows.
+
+Its public backend surfaces are `CreaturesApi`, `CreatureCatalogQueryApi`, the
+revisioned `CreatureReferenceIndexModel`, and the synchronous single-detail
+`CreatureReferenceApi`. `CreaturesApi` also owns the direct one-shot facts
+query used by cross-feature batch policy; implementation packages remain
+feature-private.
+
+## Documentation Set
+
+- [Creatures Domain Model](domain/domain-creatures.md)
+- [Creatures Persistence](contract/contract-creatures-persistence.md)
+- [Catalog Tab UI](requirements/requirements-creatures-catalog.md)
+- [Creature Details UI](requirements/requirements-creatures-details.md)
+
+## Scope
+
+In scope:
+
+- catalog browsing and filtering
+- creature detail lookup
+- encounter-ready candidate lookup for downstream runtime features
+- shared creature filter controls consumed by encounter-facing tabs
+- one full immutable reference index for foreign selectors and projections
+
+Out of scope:
+
+- authored encounter generation policy
+- party balancing rules
+- shell-wide interaction policy

--- a/docs/creatures/contract/contract-creatures-persistence.md
+++ b/docs/creatures/contract/contract-creatures-persistence.md
@@ -1,0 +1,88 @@
+# Creatures Persistence
+
+This document is normative for the `creatures` feature's persistence path.
+
+## Adapter Boundary
+
+- The creatures SQLite adapter satisfies feature-owned application ports and
+  remains private to the creatures composition entry point.
+- The application composition supplies the creatures API explicitly; no
+  registry, discovery convention, or adapter type is a public boundary.
+- SQL rows, mappers, gateways, and schema helpers MUST NOT cross the feature
+  API.
+
+## Mandatory Schema
+
+- The feature-owned persistence schema declaration is the canonical in-code
+  owner of the complete current schema. It contains exactly:
+  - `creatures`
+  - `creature_biomes`
+  - `creature_subtypes`
+  - `creature_actions`
+- The declaration also owns the complete current column, key, relationship,
+  constraint, and index signatures for those tables. Persistent tables,
+  indexes, views, or triggers in the `creatures*`, `creature_*`,
+  `idx_creatures_*`, or `idx_creature_*` namespaces are invalid unless they
+  occur in that declaration.
+- Provider-native fields are mapped into this current schema before they become
+  live installation truth. A provider's wider native table is not a compatible
+  Creatures store and is never adopted or repaired in place.
+
+## Read Path Responsibilities
+
+- the shared platform owns connection lifecycle; the Creatures SQLite adapter
+  owns feature schema readiness
+- Query construction and row mapping remain private SQLite-adapter concerns.
+- Shared SQL filter-clause and parameter-binding helpers stay local to that
+  package and must not become public feature boundaries.
+- A direct facts query resolves the complete requested XP-value or creature-ID
+  union in one set-based adapter operation. It has no UI page size or hidden
+  result limit and returns stable creature-ID order.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the exact feature-declared schema and owner
+object inventory against a separately derived SQLite reference schema.
+Validation is read-only. Semantic row validation remains on typed provider read
+paths and fails closed through the feature contract.
+
+- feature-local schema readiness MUST be verified before the catalog exposes a
+  successful lookup result
+- a malformed current schema MUST fail without changing its schema, rows, or
+  recorded owner version
+- malformed or incomplete source rows MUST be rejected or mapped to a clear
+  storage-failure result instead of silently fabricating creature truth
+- storage and schema failures MUST surface through Creatures API result status
+  vocabulary rather than leaking SQLite exceptions to consumers
+- filter normalization with domain meaning belongs to the creatures domain
+  boundary; the persistence slice validates only source-shape and storage
+  readiness concerns
+
+## Stability Rules
+
+- The creatures query adapter is injected through the feature composition
+  entry point.
+- Creature persistence helpers may be refactored internally while one
+  feature-owned read port remains the application-to-SQLite boundary.
+
+## Compatibility And Initialization
+
+Compatibility obligations begin with the first released format.
+Before the first released format, Creatures has one disposable current format: owner
+version `1`. Its single initializer runs only when the complete Creatures owner
+namespace is empty, then creates the current tables and indexes directly. It
+does not inspect predecessor columns, add missing columns, copy rows, or repair
+partial tables.
+
+An unversioned partial owner namespace and a malformed recorded version `1`
+fail as unavailable without ledger fabrication or mutation. A recorded owner
+version above `1` fails as newer and is neither downgraded nor rewritten. Until
+activation there is no compatibility reader or migration chain. After
+activation, later format changes are governed by `TN-18` and `TN-19`.
+
+
+## References
+
+- [Creatures Domain Model](../domain/domain-creatures.md) (line 1)
+- [Catalog Tab UI](../requirements/requirements-creatures-catalog.md) (line 1)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/creatures/domain/domain-creatures.md
+++ b/docs/creatures/domain/domain-creatures.md
@@ -1,0 +1,100 @@
+# Creatures Domain Model
+
+## Context Role
+
+Context Role: Reference Catalog Context
+Context Name: Creatures
+
+- `creatures` is a reference catalog context over imported creature truth.
+- Its public boundary is `CreaturesApi`.
+- The feature intentionally exposes catalog search, filtering, detail lookup,
+  encounter-candidate lookup, and direct one-shot facts snapshots without
+  owning encounter generation policy or creature lifecycle truth.
+
+## Published Language
+
+`CreaturesApi` owns public catalog queries, result pages, lookup statuses,
+filter options, creature details, action details, catalog rows,
+encounter-candidate reference profiles, and direct facts snapshots selected by
+an XP-value union or creature-ID union.
+
+A direct facts query is one complete, unpaged read. It returns every matching
+creature in stable creature-ID order and never inherits UI paging or catalog
+result limits. Consumers may apply their own ranking policy only after this
+immutable query result crosses the API boundary.
+
+Creatures API carriers describe imported creature facts and lookup results.
+They do not encode encounter ranking, choice, balancing, or composition policy.
+
+## Application Boundary
+
+The application boundary owns query normalization, paging coordination, detail
+lookup, filter option loading, and domain lookup-port coordination. It maps
+imported catalog truth into API carriers.
+
+It does not own encounter ranking, candidate scoring, or creature lifecycle
+policy.
+
+## Catalog Model
+
+`catalog/` owns the domain role packages for imported creature reference
+catalog access. Read-only catalog lookup ports belong under `catalog/port/`.
+They express domain-facing lookup needs, not data adapter placement or storage
+shape.
+
+## Write Model And Derived State
+
+Write Model: None
+
+`creatures` does not own authored creature mutation flows in SaltMarcher. The
+feature consumes imported creature reference truth and exposes it through its
+own API language.
+
+Derived state:
+
+- filtered catalog result pages
+- normalized filter option sets
+- creature detail projections
+- encounter-candidate reference profiles and one-shot facts snapshots for
+  downstream generator policy
+
+## Invariants
+
+- creature catalog lookups remain read-only within SaltMarcher
+- API creature detail and encounter-candidate carriers reflect imported
+  creature truth rather than encounter-balancing policy
+- missing or broken source data becomes lookup failure state, not synthesized
+  creature facts
+- query normalization may narrow invalid ranges or defaults, but it must not
+  invent authored creature truth
+
+## Consistency Model
+
+The creatures context is a reference-catalog context with imported upstream
+truth. A lookup result is internally consistent within one query or detail
+request, but the feature does not own cross-request authored mutation
+consistency because it has no local write model.
+
+## Promotion Triggers
+
+Reclassify `creatures` before adding any of:
+
+- authored creature creation or editing policy
+- creature validation beyond query/default normalization
+- encounter balancing, ranking, or candidate-choice policy
+- persisted creature lifecycle or ownership rules
+- mutable catalog truth owned by this feature rather than imported lookup data
+
+## Ubiquitous Language
+
+- `Creature Catalog`: imported creature reference data.
+- `Creature Detail`: public reference profile for one creature.
+- `Catalog Query`: public lookup request over imported reference truth.
+- `Encounter Candidate`: reference creature profile consumed by encounter
+  generation.
+
+## References
+
+- [Creatures Persistence](../contract/contract-creatures-persistence.md)
+- [Catalog Tab UI](../requirements/requirements-creatures-catalog.md)
+- [Creature Details UI](../requirements/requirements-creatures-details.md)

--- a/docs/creatures/requirements/requirements-creatures-catalog.md
+++ b/docs/creatures/requirements/requirements-creatures-catalog.md
@@ -1,0 +1,88 @@
+# Catalog Tab UI
+
+## Component Purpose
+
+The Monster section is the creature provider's read-only browsing experience
+inside the consolidated `Katalog` workspace. Catalog owns section composition;
+Creatures owns query, reference-index, detail, and encounter-candidate reads.
+
+Creature detail display is published to the shell Inspector through the
+creature detail entry. Creatures remains the owner of imported statblock truth;
+Catalog only composes its presentation with other providers.
+
+## Visible Surfaces
+
+- The shell title is `Katalog`. The left navigation entry is icon-only and uses
+  the crossed-blades reference graphic from
+  `resources/view/leftbartabs/catalog/navigation-icon.svg`.
+- The common Catalog section rail and active Monster controls in
+  `COCKPIT_CONTROLS` contain creature filters, active
+  filter chips, encounter-table selection, and World Planner source selection.
+- `COCKPIT_MAIN` contains the active Catalog result surface, result count, sort
+  selection, and page controls.
+- Difficulty, balance, amount, and diversity controls live in a collapsible
+  section of the global Encounter state tab.
+- Because the Catalog tab does not publish active-tab state content, the shell
+  shows the global state-tab strip with `Encounter` and `Reise`.
+- Creature Inspector content is defined separately in
+  [Creature Details UI](requirements-creatures-details.md).
+
+## Interactions
+
+- The tab opens directly to the creature catalog.
+- Name search debounces before applying filters.
+- CR min/max clamps to a valid range and omits default full-range bounds from
+  the query.
+- Size, type, subtype, biome, and alignment filters use searchable multi-select
+  popups.
+- Name, CR, size, type, subtype, biome, alignment, encounter-table, faction,
+  and location selections publish only `EncounterPoolFilters`.
+- Every visible creature filter constrains generation. Encounter-table
+  candidates are intersected with the filtered creature pool.
+- Encounter-table multi-selection publishes selected table IDs for the
+  Encounter state tab; an empty selection means normal monster catalog
+  generation.
+- Selecting encounter tables shows active chips. Multiple selected tables with
+  different linked loot-table IDs mark the table trigger with `Loot-Konflikt`.
+- Active chips remove their corresponding filter when clicked.
+- `Leeren` clears all creature filters and reloads the first page.
+- Sort changes reset to page one.
+- Previous and next page controls move in fixed 50-row pages.
+- A late completion from an older Monster query does not replace a newer query.
+- Scene and World Planner reference refreshes do not replace Monster rows.
+- Row refreshes retain table columns and preserve selection when the same
+  creature id remains visible.
+- Clicking a creature name or pressing Enter on a selected row opens that
+  creature in the shell Inspector.
+- Each creature row exposes explicit `+ Encounter` and `+ Scene` actions. The
+  Scene action adds one mob of that statblock to the focused running Scene.
+
+## Visible States
+
+- Loading: the list placeholder shows that monsters are loading.
+- Empty: the list reports that no monsters match the current filters.
+- Invalid filter: the list reports invalid filters.
+- Storage error: the list reports a catalog load failure.
+
+## Acceptance Criteria
+
+- the catalog tab opens directly to the creature catalog without requiring a
+  second navigation step inside the tab
+- active filter chips reflect the currently applied filter state and remove only
+  their own filter when clicked
+- clearing filters resets the creature query to the unfiltered first page
+- changing sort order resets pagination to the first page
+- clicking a creature name or confirming the selected row opens the creature in
+  the shell Inspector
+- clicking `+ Encounter` or `+ Scene` publishes only the selected target
+  command without mutating creature catalog truth
+- an empty encounter-table selection keeps the normal creature-catalog source,
+  while a non-empty encounter-table selection publishes selected table ids for
+  the Encounter state tab
+- Scene activation leaves the current Monster query and visible rows unchanged
+- changing Catalog pool filters does not overwrite Encounter-owned tuning
+
+## References
+
+- [Creature Details UI](requirements-creatures-details.md)
+- [Encounter Runtime State UI](../../encounter/requirements/requirements-encounter-state-tab.md)

--- a/docs/creatures/requirements/requirements-creatures-details.md
+++ b/docs/creatures/requirements/requirements-creatures-details.md
@@ -1,0 +1,49 @@
+# Creature Details UI
+
+## Component Purpose
+
+The creature detail entry renders a read-only stat block in the shell Inspector.
+It is opened by catalog rows and may be reused by later encounter-facing views.
+The Creatures feature owns one reusable Inspector detail experience for every
+surface that opens a creature by id.
+
+## Visible Surfaces
+
+- The shell Inspector header and history controls remain shell-owned.
+- The detail content renders a D&D-style stat block with creature name, meta
+  text, core stats, ability scores, traits, properties, and actions.
+
+## Interactions
+
+- An owning surface opens the creature detail entry and requests one creature by
+  id through the Creatures feature's public read API.
+- The Inspector entry presents the resulting creature detail state.
+- The entry does not mutate creature data.
+- Missing or inaccessible details show a compact error message inside the
+  Inspector content area.
+
+## Visible States
+
+- Loading: `Loading stat block...`
+- Not found: `Creature not found.`
+- Storage error: `Creature details could not be loaded.`
+- Loaded: the stat block consistently presents the pane, heading, meta text,
+  separators, ability grid, property text, section headers, and actions.
+
+## Acceptance Criteria
+
+- opening creature details from a catalog row shows exactly one Inspector detail
+  entry for the selected creature
+- the detail surface remains read-only and exposes no mutation controls for
+  creature truth
+- missing creature ids render a compact not-found message inside the Inspector
+  content area rather than leaving the shell details area blank
+- storage failures render an inline error message without crashing the shell
+  Inspector host
+- loaded stat blocks consistently render pane structure, meta text, ability
+  grid, property sections, and actions
+
+## References
+
+- [Catalog Tab UI](requirements-creatures-catalog.md)
+- [Creatures Domain Model](../domain/domain-creatures.md)

--- a/docs/dungeon/README.md
+++ b/docs/dungeon/README.md
@@ -1,0 +1,52 @@
+# Dungeon Feature Docs
+
+## Purpose
+
+The dungeon feature owns authored dungeon truth, dungeon travel runtime
+behavior, dungeon editor behavior, and dungeon persistence truth.
+
+Generic passive map-canvas mechanisms live in `platform.ui.mapcanvas`; the
+Dungeon architecture owns how its API facts adopt those mechanisms.
+
+## Document Set
+
+### Reading Order
+
+1. Start here to find the owning document family.
+2. Read [Dungeon Architecture](./architecture/architecture-dungeon-domain.md)
+   for feature ownership, authored-core boundaries, runtime capabilities, and
+   dependency direction.
+3. Read [Dungeon Domain Model](./domain/domain-dungeon.md) for domain truth,
+   write-model ownership, API language, and invariants.
+4. Read the relevant requirements document for user-visible behavior.
+
+### Architecture
+
+- [Dungeon Domain Architecture](./architecture/architecture-dungeon-domain.md)
+
+### Requirements
+
+- [Dungeon Feature Requirements](./requirements/requirements-dungeon.md)
+- [Dungeon Editor Requirements](./requirements/requirements-dungeon-editor.md)
+- [Dungeon Travel State Requirements](./requirements/requirements-dungeon-travel-state.md)
+- [Dungeon Travel Requirements](./requirements/requirements-dungeon-travel.md)
+
+### Contracts
+
+- [Dungeon Persistence Contract](./contract/contract-dungeon-persistence.md)
+
+### Domain
+
+- [Dungeon Domain Model](./domain/domain-dungeon.md)
+
+### Related Map Canvas Docs
+
+- [Map Canvas Overview](../maps/README.md) (line 1)
+- [Dungeon Map Adoption Architecture](../maps/architecture/architecture-maps-dungeon-adoption.md) (line 1)
+- [Dungeon Map Surface Contract](../maps/contract/contract-maps-dungeon-surface.md) (line 1)
+- [Maps Canvas Requirements](../maps/requirements/requirements-maps-canvas.md) (line 1)
+
+### Related Actor Autonomy Docs
+
+- [Actor Autonomy Overview](../autonomy/README.md)
+- [Actor Autonomy Requirements](../autonomy/requirements/requirements-actor-autonomy.md)

--- a/docs/dungeon/architecture/architecture-dungeon-domain.md
+++ b/docs/dungeon/architecture/architecture-dungeon-domain.md
@@ -1,0 +1,142 @@
+# Dungeon Architecture
+
+## Entity And Concerns
+
+This specification serves maintainers of Dungeon authored truth, editor and
+travel workflows, persistence, and JavaFX map surfaces. Product behavior,
+stored schema details, and domain invariants remain in their neighboring owner
+documents.
+
+Dungeon remains one feature. It owns authored maps and their topology while
+publishing separate capabilities for authored catalog work, editing, and
+travel.
+
+## Feature Topology
+
+```text
+features/dungeon/api/
+features/dungeon/domain/core/
+features/dungeon/application/authored/
+features/dungeon/application/editor/
+features/dungeon/application/travel/
+features/dungeon/adapter/sqlite/
+features/dungeon/adapter/javafx/
+features/dungeon/DungeonFeature
+```
+
+## Authored Core
+
+The authored core owns `DungeonMap`, stable topology identity, aggregate
+transactions, revision, and map-wide coordination. Its internal ownership
+flows from immutable geometry and components through structures to read-only
+graph queries and projections.
+
+- Rooms, clusters, corridors, walls, paths, doors, stairs, transitions, and
+  topology-affecting behavior remain inside the aggregate boundary.
+- Repair, split or merge behavior, identity preservation, validation, and
+  derived rebuilds belong to the deepest owning core object.
+- Graph and projection code may describe authored structures but MUST NOT
+  persist or mutate them.
+- JavaFX, SQL, party state, editor selection, pointer interpretation, and travel
+  session state MUST NOT enter authored core truth.
+
+## Application Capabilities
+
+- `DungeonAuthoredApi` owns map catalog and authored-map commands/results.
+- `DungeonEditorApi.current/subscribe/dispatch` owns one atomic editor session
+  state, tool families and options, selection, previews, typed command outcomes,
+  and committed authored mutations over core truth.
+- `DungeonTravelApi` owns stable travel actions, direct reachable-cell movement,
+  and travel-session workflows over dungeon facts and party-owned position facts
+  received through `PartyApi`.
+- Preview or interaction state MUST NOT mutate authored truth before an
+  explicit successful command commits.
+- All published state is immutable and revisioned; persistence-backed calls are
+  non-blocking and publish through the UI dispatcher.
+
+One immutable `DungeonEditorState` supplies controls, map, and state-pane facts
+for a publication revision. Application code MUST NOT reconstruct input by
+reading independently published presentation models. Camera, hover, focus,
+caret, popup, and other passive presentation values remain JavaFX-local.
+
+Authored commands return either a typed rejection or an accepted `DungeonPatch`
+with its inverse, touched chunks, and published result facts. Cross-map
+transition changes use one `DungeonCompoundPatch`. An unchanged aggregate is
+not the only rejection signal, and user-facing feedback does not parse strings
+to recover domain meaning.
+
+## Sparse Authored Worksets
+
+The authored aggregate remains the consistency owner, while editor and travel
+read only the spatial workset needed by their current viewport.
+
+- one chunk is `64 x 64` cells identified by
+  `(mapId, level, chunkQ, chunkR)`; negative coordinates use floor division
+- one viewport request loads visible chunks plus one surrounding ring
+- `DungeonViewportSnapshot` carries map revision, request generation, loaded
+  chunk identities, window facts, and optional authored bounds; fixed width and
+  height are not authored limits
+- the in-memory authored workset is the preview source after load; pointer
+  preview has no repository route
+- committed edits publish one immutable change result and advance the map
+  revision once; per-session undo/redo restores content as a new revision
+- viewport caches use bounded weighted eviction while visible and actively
+  edited chunks remain protected
+
+The application boundary is split by responsibility:
+
+- `DungeonCatalogStore` reads and mutates map metadata
+- `DungeonWindowStore` loads explicit chunk facts with stable headers and
+  continuations, then loads full command-specific identity closure on demand
+- `DungeonUnitOfWork` commits one patch or compound patch against expected map
+  revisions
+- `DungeonIdentityAllocator` reserves bounded stable identity ranges for every
+  map-wide authored family created by commands without creating placeholder
+  authored entities
+
+Chunk membership is source-local indexing, never a second entity owner. One
+entity is returned once even when it intersects several requested chunks.
+Commands that require unseen authored truth request more identity closure and
+do not guess from a partial window.
+
+Late viewport results are rejected by request generation and map revision.
+Replaceable pointer-move work is coalesced on the owning serial lane; discrete
+gesture inputs invalidate older move samples.
+
+## Passive Map Canvas
+
+Generic camera, visible-window calculation, weighted viewport caching, layered
+JavaFX canvas hosting, and replaceable input scheduling live under
+`platform.ui.mapcanvas` and `platform.execution`. They are mechanisms, not a
+Maps business feature. Dungeon JavaFX code owns the translation between Dungeon
+API facts and canvas-native drawing or hit evidence.
+
+## Adapters And Composition
+
+The SQLite adapter persists authored Dungeon truth and satisfies feature-owned
+ports. The JavaFX adapter renders, hit-tests, and translates input through the
+three Dungeon APIs without importing application, domain, or SQLite packages.
+
+`DungeonFeature` receives platform services and `PartyApi`, constructs the
+three APIs and shell contributions, and exposes no internal repository or
+adapter. Its JavaFX adapter consumes the feature-neutral map-canvas mechanism;
+there is no `features.maps` dependency or composition lifecycle.
+
+Dungeon Travel reads authored facts through Catalog and Window capabilities.
+It does not hydrate a complete `DungeonMap` and does not depend on the Authored
+application service as a read facade.
+
+The global `Reise` state contribution is not owned by Dungeon or Hex. A
+feature-neutral Travel capability consumes party position plus feature-owned
+Dungeon and Hex travel readbacks and selects one compact runtime context.
+Dungeon continues to own Dungeon movement semantics and its detailed travel
+workspace.
+
+
+## References
+
+- [Dungeon Feature Docs](../README.md)
+- [Dungeon Domain Model](../domain/domain-dungeon.md)
+- [Dungeon Editor Requirements](../requirements/requirements-dungeon-editor.md)
+- [Dungeon Persistence Contract](../contract/contract-dungeon-persistence.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/dungeon/contract/contract-dungeon-persistence.md
+++ b/docs/dungeon/contract/contract-dungeon-persistence.md
@@ -1,0 +1,330 @@
+# Dungeon Persistence Contract
+
+## Purpose
+
+This contract defines what crosses between the dungeon domain and its data
+adapters.
+
+Owners:
+
+- provider: dungeon domain outbound repositories and searches
+- consumers: dungeon SQLite adapters
+
+It owns stored truth, adapter boundaries, schema ownership, and stability
+rules. It does not own dungeon behavior requirements or shared canvas
+contracts.
+
+## Persisted Truth
+
+Persisted authored truth includes:
+
+- map identity and revision
+- authored map metadata
+- authored topology-backed geometry
+- stable topology identity and semantic bindings
+- authored room, room-cluster, connection, stair, and transition facts
+- authored feature marker facts
+- authored room and room-cluster names
+- authored room narration
+
+## Explicit Non-Persisted Truth
+
+- derived area, relation, and traversal facts
+- preview state
+- render or hit structures
+- presentation-local selection state
+- party-owned runtime travel state
+
+## Adapter Boundary
+
+- `DungeonCatalogStore` owns map metadata lookup and catalog mutations
+- `DungeonWindowStore` owns explicit chunk reads and command-specific stable
+  identity closure reads
+- `DungeonIdentityAllocator` owns atomic typed reservation of bounded stable
+  identity ranges for map-wide authored families without writing placeholder
+  authored state
+- `DungeonUnitOfWork` owns revision-checked `DungeonPatch` and
+  `DungeonCompoundPatch` commits
+- SQLite adapters translate source-local rows into dungeon-domain values and
+  immutable API or application read facts
+- multi-map authored patches MUST commit every supplied map change together or
+  roll back every supplied map change together; adapters do not infer
+  additional authored maps or mutations
+- SQLite rows MUST NOT become the owner of topology behavior, semantic repair
+  policy, preview logic, or travel semantics
+
+## Schema Ownership
+
+- the feature-owned Dungeon persistence schema declaration is the in-code
+  schema owner
+- `dungeon_topology_elements` is authoritative for persisted topology identity
+- detail tables remain source-local storage and correlation detail, not
+  alternate semantic owners
+
+The current owner target has one direct schema initializer and owner-ledger
+version `1`. The version identifies only this current target; it does not imply
+a supported predecessor chain.
+
+Compatibility obligations begin with the first released format.
+Before the first released format, the initializer runs only when no Dungeon-owned table or
+view exists. Any pre-existing development shape, incomplete current-target
+signature, or different nonzero owner-ledger version fails closed. The
+application MUST NOT add columns, drop tables, delete rows, advance the owner
+ledger, or otherwise convert such a database. A developer may discard and
+recreate a development database outside the product, but that is not a runtime
+migration contract.
+
+After initialization, every startup validates the exact Dungeon object inventory,
+declared column types, nullability and defaults, primary and unique constraints,
+checks, complete map/chunk/bounds/route and other foreign-key signatures, table
+flags, and named indexes before the Dungeon store becomes ready. An adjacent
+retired Dungeon object at owner version 1 fails closed rather than being ignored.
+Current-format authored rows survive restart unchanged. Physical integrity,
+foreign-key integrity, transaction rollback, snapshot, and recovery guarantees
+remain owned by the shared persistence lifecycle.
+
+`dungeon_maps.revision` stores the last committed authored revision. Adapters
+MUST read and write that value; they MUST NOT replace it with a constant
+readback revision.
+
+`dungeon_identity_sequences` is technical allocation state keyed by supported
+identity kind. Reserving an identity or bounded contiguous range advances only
+its sequence in one short transaction; it MUST NOT create a dummy map,
+topology element, authored entity, or child row. Every map-wide stable identity
+family that a command can create uses this allocation boundary rather than a
+partial-workset maximum. The schema initializes the table directly and does not
+derive it from authored Dungeon rows.
+
+`dungeon_chunks` is a source-local spatial inventory keyed by
+`(dungeon_map_id, level_z, chunk_q, chunk_r)`. One chunk covers `64 x 64`
+cells, and negative coordinates use mathematical floor division. Its content
+revision changes only when authored content intersecting that chunk changes.
+Chunk rows are indexing metadata, not authored semantic truth.
+
+`dungeon_entity_chunks` indexes map-wide stable entity identity to every chunk
+whose stored authored geometry it intersects. Its key contains map id, entity
+kind, entity id, level, chunk q, and chunk r. It MUST NOT duplicate an entity's
+semantic facts or mint chunk-local entity identity.
+
+`dungeon_corridor_route_cells` is a replaceable source-local read index derived
+from the complete authored corridor controls and room geometry. It stores exact
+canonical route cells with corridor identity, segment order, cell order, and
+their containing chunk solely so explicit-chunk windows can read clipped route
+facts without hydrating off-window authored geometry. It MUST be rebuilt or
+updated atomically with `dungeon_entity_chunks` and `dungeon_chunks`, MUST NOT
+be treated as authored corridor truth, and MUST NOT be repaired independently
+of the authored controls that produced it.
+
+## Window Reads And Identity Closure
+
+- a viewport read MUST address explicit chunk keys and return request
+  generation, committed map revision, and per-chunk content revisions needed to
+  reject late results without invalidating untouched chunks
+- a loaded viewport consists of visible chunks plus one surrounding ring
+- a window read returns authored facts intersecting the requested chunks plus
+  stable entity headers and continuation refs for content outside the window
+- command handling loads full command-relevant identity closure explicitly when
+  validation cannot be completed from window facts alone
+- entities retain map-wide stable identities and MAY cross chunk boundaries;
+  an adapter MUST NOT clone identity or semantic facts merely to fit storage
+  partitions
+- a missing required closure is reported as incomplete input; application or
+  adapter code MUST NOT guess at unseen authored truth
+- catalog reads MUST NOT hydrate authored map content
+
+## Patch And Compound Writes
+
+- an authored commit MUST validate every expected map revision, write only
+  affected authored rows and spatial index rows, and advance each affected map
+  revision once in the same transaction
+- a patch identifies inserted, updated, and removed stable entities plus every
+  touched chunk; it MUST NOT carry complete before and after maps
+- a compound patch is one transaction and one user-command outcome even when it
+  changes several maps
+- affected chunk content revisions advance with their content; untouched chunk
+  content revisions remain stable and cacheable
+- a failed validation or storage write MUST roll back authored rows, entity
+  membership, chunk inventory, chunk revisions, and map revisions together
+- successful writes return committed patch result facts; the application MUST
+  NOT require an unconditional whole-map readback to discover what it wrote
+- preview, hover, camera movement, and undo/redo stacks MUST NOT write SQLite;
+  applying an accepted undo or redo patch is a normal authored commit
+
+## Authored Name Storage Semantics
+
+`dungeon_rooms.name` stores the authored room display name. The committed value
+is nonblank and already normalized by the domain.
+
+`dungeon_room_clusters.name` stores the authored cluster display name. The
+committed value is nonblank and already normalized by the domain.
+
+SQLite adapters MUST persist the domain-provided room and room-cluster names
+with the corresponding authored record graph. Adapters do not infer default
+names from render state, preview state, or missing source values.
+
+## Room And Cluster Geometry Storage Semantics
+
+`dungeon_room_cells` stores the authored floor cells owned by one stable room
+identity. Room id plus cell coordinate is unique. Room anchors and cluster floor
+are derived and have no authored storage table.
+
+`dungeon_room_cluster_edges` stores cluster boundary facts. For freshly
+authored room creation, the stored perimeter is explicit
+`edge_type='WALL'` rows around the union of committed member-room cells. Adapter
+reads use room-owned cells plus cluster boundary rows as the only room-cluster
+geometry source.
+
+The `level_z`, `cell_x`, and `cell_y` columns identify the absolute authored
+boundary cell. They MUST NOT depend on a persisted cluster anchor, center, or
+centroid. Any presentation anchor or centroid derives from the ordered union of
+member-room cells; adapters translate absolute boundary values only at the
+adapter boundary.
+
+`dungeon_room_floors`, `dungeon_room_cluster_floor_cells`, and
+`dungeon_room_cluster_vertices` are not part of the schema. Duplicate room or
+cluster geometry is not accepted as an alternate persistence representation.
+
+## Room Boundary Edge Semantics
+
+`dungeon_room_cluster_edges` stores authored boundary overrides for keyed room
+cluster edges:
+
+- no row means the edge is un-authored; derived perimeter walls from room cells
+  are preview or command-planning facts only and are not committed output for
+  editor-authored room creation
+- `edge_type='WALL'` means an authored renderable wall edge
+- `edge_type='DOOR'` means an authored renderable door edge
+- `edge_type='OPEN'` means an authored negative perimeter override that
+  suppresses derived wall publication for that keyed edge
+
+`OPEN` rows MUST have no topology element identity and MUST NOT create
+`dungeon_topology_elements` rows. Adapter reads and writes MUST preserve
+`OPEN` rows as authored persistence truth, while published map and render
+surfaces emit no boundary primitive for them.
+
+## Stair Stored Geometry Semantics
+
+`dungeon_stairs` stores the scalar stair geometry spec:
+
+- `shape` stores the domain stair shape name
+- `direction` stores the cardinal direction code: `0=NORTH`, `1=EAST`,
+  `2=SOUTH`, `3=WEST`
+- `dimension1` and `dimension2` store the requirements-owned shape parameters
+- `corridor_id` stores the optional owning corridor binding for generated
+  cross-level corridor stair segments
+
+`dungeon_stair_path_nodes` stores the committed path produced by the dungeon
+domain recompute, ordered by `sort_order`. `dungeon_stair_exits` stores the
+committed generated exits and labels for the same stair. These rows are
+persisted authored geometry facts, but their meaning is owned by the dungeon
+domain model rather than by adapter-local recompute logic.
+
+SQLite adapters MUST persist the domain-provided stair spec, path nodes, exits,
+and corridor binding as one stair record graph. They MUST NOT infer missing path
+nodes, generate exits, choose labels, or repair corridor bindings during read or
+write. Malformed stair rows, unsupported scalar combinations, missing generated
+path or exit rows for a readable stair, or dangling corridor bindings are
+boundary errors for the domain/repository result, not view-layer behavior.
+
+Only requirements-owned editor stair shapes are valid in the schema.
+Unsupported shape rows are malformed persistence input.
+
+## Transition Destination Storage Semantics
+
+`dungeon_transitions` stores authored transition facts for one dungeon map:
+
+- `transition_id` stores the stable map-owned transition id
+- `dungeon_map_id` stores the owning authored map
+- `anchor_type` stores the transition anchor kind: `NONE`, `CELL`, or `EDGE`
+- `cell_x`, `cell_y`, and `level_z` store the transition anchor coordinate for
+  `CELL` and `EDGE` anchors and are null for `NONE`
+- `anchor_edge_direction` stores the cardinal edge direction only for `EDGE`
+  anchors
+- `destination_type` stores the domain destination type
+- destination target columns store only the fields required by that
+  destination type
+- `description` stores the authored transition description
+
+SQLite adapters MUST preserve these destination row shapes:
+
+- `UNLINKED_ENTRANCE`: all target columns are null. This is a valid authored
+  entrance placeholder, not malformed persistence input.
+- `OVERWORLD_TILE`: `target_overworld_map_id` and
+  `target_overworld_tile_id` are present; `target_dungeon_map_id` and
+  `target_transition_id` are null.
+- `DUNGEON_MAP`: `target_dungeon_map_id` is present,
+  `target_transition_id` is present when the destination names a placed target
+  entrance, and the overworld target columns are null.
+
+Runtime travel targets are derived projection/session state. A null runtime
+travel target for `UNLINKED_ENTRANCE` is not stored authored truth and MUST NOT
+be backfilled into a fake overworld tile or dungeon transition target by the
+adapter.
+
+Rows with missing, blank, or null `anchor_type`, inconsistent coordinate fields,
+or an edge direction outside an `EDGE` anchor are malformed and reject the
+window or identity-closure read. Adapters do not repair them into authored
+absence.
+
+## Feature Marker Storage Semantics
+
+`dungeon_feature_markers` stores authored feature marker facts for one dungeon
+map:
+
+- `feature_marker_id` stores the stable map-owned marker id
+- `dungeon_map_id` stores the owning authored map
+- `marker_kind` stores the domain marker kind: `OBJECT`, `ENCOUNTER`, or `POI`
+- `cell_x`, `cell_y`, and `level_z` store the anchor cell coordinates
+- `label` stores the authored marker label
+- `description` stores the authored marker description
+
+SQLite adapters MUST map these rows into domain-owned `FeatureMarker` values and
+persist marker inserts, updates, or removals named by a patch. The table is
+source-local storage only; it MUST NOT own marker defaults, marker validation,
+encounter/object foreign-key semantics, preview state, render state, or travel
+behavior.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared target schema signature
+against a separate non-mutating reference schema; semantic row validation remains
+on typed provider read/write paths and fails closed through the feature contract.
+
+- authored persistence writes MUST reject incomplete identity, topology, or
+  semantic-binding payloads instead of synthesizing replacement authored truth
+- adapter reads MUST distinguish absent authored state, malformed source rows,
+  and storage failures in the dungeon domain boundary instead of leaking raw
+  SQLite failures to the view layer
+- preview state, render structures, and other explicit non-persisted truth MUST
+  be rejected from authored write payloads
+- stair persistence writes MUST reject a stair record graph whose scalar spec,
+  path nodes, exits, or corridor binding is incomplete for the domain-authored
+  stair being saved
+- feature marker persistence writes MUST reject incomplete marker identity,
+  kind, anchor, label, or description payloads instead of storing preview or
+  render-derived substitutes
+
+## Schema Stability Rules
+
+- new fields belong in source-local records first, then map into domain-owned
+  values
+- until feature completion, a changed target schema replaces the development
+  initializer directly; the runtime does not acquire a compatibility step for
+  a database shape that users cannot yet have created
+- once feature completion permits user-created durable data, any future schema
+  change requires a separately owned compatibility and migration decision
+  before the current-target initializer may change
+- the canonical schema uses the room-cell, boundary, entity-membership,
+  chunk-revision, and patch representations defined by this contract; alternate
+  whole-record, fixed-bounds, or enum-compatibility representations are not
+  accepted
+- direct runtime token movement does not justify new authored-position tables;
+  runtime party position remains owned outside dungeon persistence
+- Dungeon schema changes MUST NOT modify Party, Hex, or other feature rows
+
+
+## References
+
+- [Dungeon Domain Model](../domain/domain-dungeon.md) (line 1)
+- [Dungeon Map Surface Contract](../../maps/contract/contract-maps-dungeon-surface.md) (line 1)
+- [Map Canvas Overview](../../maps/README.md) (line 1)

--- a/docs/dungeon/domain/domain-dungeon.md
+++ b/docs/dungeon/domain/domain-dungeon.md
@@ -1,0 +1,305 @@
+# Dungeon Domain Model
+
+Architecture note: Dungeon-specific domain architecture, model-family
+placement, and dependency direction live in
+[Dungeon Domain Architecture](../architecture/architecture-dungeon-domain.md).
+This document owns domain truth only.
+
+## Context Role
+
+Context Role: Authored Dungeon Map Context
+Context Name: Dungeon
+
+- `dungeon` owns authored dungeon map truth plus editor-session and travel
+  application state over that same authored truth
+- `DungeonMap` is the aggregate root for one authored map
+- authored committed snapshots, authored operation results, authored selection
+  inspectors, and runtime travel session surfaces are projections over the same
+  authored dungeon write model
+- authored feature markers are tiny committed map annotations for object,
+  encounter, and point-of-interest authoring
+- render-oriented display models are not dungeon-owned output
+
+## Published Language
+
+The Dungeon APIs own public commands, queries, results, IDs, statuses, authored
+map facts, authored operation results, and runtime travel facts.
+
+Published dungeon carriers must not own:
+
+- render layers
+- canvas geometry
+- passive-view hit payloads
+- display styling
+
+## Write Model
+
+Only authored write-model state and stable identities may persist.
+
+Each `RoomRegion` owns its stable room identity, cluster identity, authored
+floor-cell set, name, and narration. Each `RoomCluster` owns its stable cluster
+identity, name, and authored boundary set. Cluster floor, anchors, centroids,
+corner handles, wall-run handles, and perimeter projections derive from member
+room cells plus authored boundaries and MUST NOT become independent authored
+owners.
+
+Derived state must not become a second source of truth. This includes:
+
+- inspector text
+- adjacency lists
+- travel exits
+- render overlays
+- runtime party position
+
+Application-owned editor-session values/effects and travel-session state may
+exist outside the authored write model when they are not persisted as dungeon
+truth. Pointer interpretation, transient interaction state, and draft workflows
+are application concerns, not authored domain truth.
+
+Chunks are a spatial partition of authored facts, not a second write model.
+Chunk identity, viewport membership, cache residency, request generation, and
+authored bounds are derived indexing or application state. Stable entity and
+topology identities remain map-wide even when an entity touches several
+chunks.
+
+## Aggregate Model
+
+Aggregate Root: `DungeonMap`
+
+```text
+DungeonMap
+- DungeonMapId id
+- DungeonMapMetadata metadata
+- List<RoomRegion> rooms
+- List<RoomCluster> clusters
+- List<Boundary> boundaries
+- List<Connection> connections
+- List<FeatureMarker> markers
+- stable topology identity and bindings
+- long revision
+```
+
+The aggregate is the transaction boundary and the behavioral owner of mutable
+topology.
+
+`DungeonMap` remains the logical aggregate root, transaction boundary, and
+revision owner even when an application command hydrates only the window and
+identity closure it requires. It must not become the central policy owner for floor,
+wall, path, door, or transition behavior. Room clusters, corridors, stairs,
+doors, and transitions compose durable core owners for those concepts inside
+the aggregate boundary; those owners keep their own local and collection-wide
+invariants while `DungeonMap` coordinates cross-owner consistency and
+publication.
+
+## Canonical Model Language
+
+Each authored concept has one domain representation. `Cell`, `Edge`,
+`Direction`, topology identity, room region, boundary, connection, transition,
+and marker values MUST NOT have same-layer wrapper and core variants that
+convert through names or copied fields. Public immutable API state and
+source-local persistence records may translate at their respective boundaries,
+but neither becomes a second domain owner.
+
+Canonical authored structure uses:
+
+- `RoomRegion` for room-owned floor cells and room semantics
+- `RoomCluster` for cluster identity and cluster semantics; its floor is the
+  union of member room cells
+- `Boundary` for authored wall, door, or explicit open-edge truth
+- `Connection` variants for corridor, stair, and transition semantics
+- `FeatureMarker` for object, encounter, and point-of-interest annotations
+
+The topology index, room anchors, cluster floor, authored bounds, traversal
+links, and render handles derive from these values. They may be indexed for
+query performance but are not parallel authored models.
+
+Editor tools use product language rather than storage or operation variants:
+
+- `ToolFamily` identifies selection, room, wall, door, corridor, stair,
+  transition, or feature work
+- `ToolOptions` carries family-specific shape, mode, destination, or marker
+  choices
+- `PointerGesture` identifies primary, secondary, or modified intent
+
+Create, delete, and alternate behavior derive from the family plus gesture. The
+domain does not own JavaFX buttons, pointer coordinates, or dropdown state.
+
+## Command Outcomes And Patches
+
+An authored command returns one of two outcomes:
+
+- `Rejected` contains a stable typed reason and leaves authored truth and
+  revision unchanged
+- `Accepted` contains a `DungeonPatch`, its inverse, touched chunks, and result
+  facts required for publication
+
+Typed rejection reasons own domain meaning such as protected boundary,
+referenced connection, blocked route, invalid stair geometry, insufficient
+loaded closure, missing destination, or stale revision. User-visible text is a
+presentation mapping from these reasons, not domain truth.
+
+A patch expresses changed stable identities and authored facts; it is not a
+second write model. `DungeonCompoundPatch` groups changes for more than one map
+when one user command, such as a bidirectional transition link, must commit and
+undo atomically.
+
+## Stair Geometry Domain Truth
+
+`DungeonMap` owns stair geometry as authored connection truth. A stair's
+domain value is a `StairGeometrySpec` plus stable map-owned identity:
+
+- stable stair id and topology ref
+- shape, anchor cell, direction, `dimension1`, and `dimension2`
+- generated path cells
+- generated exits
+- optional owning corridor id for cross-level corridor segments
+
+The domain, not the view or data adapter, owns deterministic stair recompute.
+When shape, direction, dimensions, anchor, or exit span changes through a full
+stair edit, the aggregate must recompute the generated path and exits in the
+same mutation that preserves the stair identity. Direct handle movement of one
+path node is a narrower mutation and does not imply a full geometry recompute.
+
+Stair invariants:
+
+- supported editor-authored shapes are `STRAIGHT`, `SQUARE`, and `CIRCULAR`
+- direction is a cardinal dungeon edge direction
+- dimensions must already satisfy the requirements-owned min/max bounds before
+  the aggregate accepts the mutation
+- every readable stair has at least one path cell and at least two exits on
+  distinct levels
+- generated path cells are deterministic and unique for one stair
+- generated exits are ordered by level role and own stable exit ids where the
+  same role survives recompute
+- generated exit labels are domain-owned defaults unless an explicit authored
+  label exists
+
+Cross-level corridor binding:
+
+- a corridor that connects authored endpoints on different levels owns the
+  intermediate stair segment through the stair's corridor binding
+- the bound stair remains selectable as a stair feature, but its edits must
+  preserve the owning corridor's endpoint levels and route continuity
+- deleting a bound stair directly is rejected; deleting the owning corridor
+  branch is the mutation that may remove the bound stair segment
+
+The aggregate rejects detected invalid stair geometry atomically. Rejection
+preserves the previous stair, path, exits, topology binding, selection target,
+and authored revision. Editor-authored create and full-recompute routes reject
+unsupported editor shapes, non-cardinal directions, out-of-range dimensions,
+nonunique generated path cells, and room-interior crossings outside generated
+exits when those values reach the aggregate.
+
+## Feature Marker Domain Truth
+
+`DungeonMap` owns authored feature markers as tiny committed annotation facts.
+A feature marker has only:
+
+- stable marker id and map-owned `FEATURE_MARKER` topology ref
+- optional map id for boundary correlation
+- marker kind: `OBJECT`, `ENCOUNTER`, or `POI`
+- anchor cell
+- label
+- description
+
+Feature markers do not own encounter rosters, creatures, inventory, scripts,
+hex coordinates, transition destinations, or travel actions. They may publish
+as feature facts for editor selection and authored readback. Runtime travel
+surfaces still treat only stairs and transitions as travel features.
+
+## Transition Anchor Domain Truth
+
+`Transition` owns authored placement through one `TransitionAnchor` value:
+
+- `NONE` means the authored transition exists without a placed entrance marker
+- `CELL` means the transition is placed at one authored map cell
+- `EDGE` means the transition is placed at one authored map cell plus one
+  cardinal edge direction
+
+`TransitionAnchor` is the only durable placement fact for transitions. Editor
+map clicks create `CELL` anchors from cell hits and `EDGE` anchors from wall or
+door boundary hits. Destination
+`UNLINKED_ENTRANCE` remains separate from anchor `NONE`: the former means a
+placed or unplaced entrance has no destination, while the latter means the
+transition has no placed entrance marker.
+
+For `EDGE` anchors, the anchor cell is the authored edge owner and travel
+entry cell; it is not a renderable transition feature cell. Editor render and
+hit-test projection derive an edge marker from the anchor edge, while cell
+surfaces remain reserved for `CELL` anchors.
+
+## Application Ports And Foreign APIs
+
+The Dungeon application owns non-blocking catalog, window-read, identity
+allocation, and unit-of-work ports for authored maps. Identity allocation
+reserves bounded stable ranges for every map-wide authored identity family that
+commands may create, without inserting placeholder maps, topology elements,
+authored entities, or child rows. Its SQLite adapter implements those ports;
+adapters never surface JDBC types or exceptions through Dungeon APIs.
+
+Party-aware travel composition consumes `PartyApi`, supplied explicitly during
+application composition, for party state and outbound travel-position changes.
+Dungeon does not own party roster truth or persisted party travel position.
+`DungeonEditorApi` and `DungeonTravelApi` expose the typed, revisioned editor
+and travel capabilities without publishing repositories or adapters. A
+feature-neutral Travel capability may consume Dungeon travel readback to select
+the global compact `Reise` context, but it does not own Dungeon movement rules.
+
+## Invariants
+
+- authored dungeon truth has one aggregate owner per map
+- transition placement has one `TransitionAnchor` owner; travel cells and
+  render marker placement are derived from that value and must not become
+  independent anchor facts
+- stable topology refs identify selectable and mutable map elements
+- authored feature markers use `FEATURE_MARKER` topology refs and do not reuse
+  stair or transition identity
+- preview state never mutates authored truth
+- one successful user command advances the authored map revision exactly once
+- per-session undo and redo apply inverse or forward patches as new commits;
+  their stacks and encoded memory weights are not durable domain truth
+- room geometry authority comes from room-owned floor cells and cluster-owned
+  boundary segments; cluster floor, boundary-corner, and wall-run handles derive
+  without creating a second authored floor or relative-row domain truth
+- runtime travel state never becomes authored dungeon persistence
+- data rows and view models may transport dungeon facts, but they are not the
+  owner of dungeon meaning
+- authored corridor anchors belong to one host corridor and may be referenced
+  by other corridor segments
+- a corridor owning still-referenced anchors cannot be deleted
+- stair geometry recompute is aggregate-owned and must not be performed by view
+  models or SQLite adapters
+- bound stair segments cannot outlive the owning corridor and cannot be deleted
+  independently from that owning corridor branch
+- a compound command commits or rejects every involved map together
+- command rejection has a typed reason and never relies only on object equality
+- partial hydration never authorizes a command to infer unseen authored truth
+
+## Cross-Context Boundary
+
+- `dungeon` publishes `DungeonViewportSnapshot`, one `DungeonEditorState` with
+  typed `DungeonEditorCommandOutcome`, `DungeonTravelState`, and stable
+  travel-action results rooted in authored dungeon truth
+- the Dungeon authored core owns authored truth and the structures
+  that mutate it
+- `DungeonEditorApi` and its application owner own editor session values,
+  pointer interpretation, transient interaction, drafts, and composition over
+  authored facts
+- `DungeonTravelApi` and its application owner own travel-session composition that
+  combines raw dungeon facts with party-owned position state
+- the feature-neutral Travel capability owns only global compact-context
+  selection across Dungeon and Hex readbacks
+- `dungeon` does not own party roster truth or persisted party travel position
+- `dungeon` does not publish render-ready cells, edges, labels, markers,
+  graph nodes, or graph links for the map canvas; those are presentation-owned
+  projections derived from Dungeon API state
+
+## References
+
+- [Dungeon Feature Docs](../README.md) (line 1)
+- [Dungeon Domain Architecture](../architecture/architecture-dungeon-domain.md) (line 1)
+- [Dungeon Feature Requirements](../requirements/requirements-dungeon.md) (line 1)
+- [Dungeon Editor Requirements](../requirements/requirements-dungeon-editor.md) (line 1)
+- [Dungeon Map Adoption Architecture](../../maps/architecture/architecture-maps-dungeon-adoption.md) (line 1)
+- [Dungeon Map Surface Contract](../../maps/contract/contract-maps-dungeon-surface.md) (line 1)
+- [Dungeon Persistence Contract](../contract/contract-dungeon-persistence.md) (line 1)

--- a/docs/dungeon/requirements/requirements-dungeon-editor.md
+++ b/docs/dungeon/requirements/requirements-dungeon-editor.md
@@ -1,0 +1,609 @@
+# Dungeon Editor Requirements
+
+## Goal
+
+Let one GM author and maintain complete multi-level Dungeon truth through three
+specialized, synchronized views without requiring duplicate edits or exposing
+internal storage and routing concepts.
+
+## Shared Authoring Outcomes
+
+The editor MUST let the GM:
+
+- create, rename, load, reload, and delete Dungeons
+- author and inspect rooms, named room groups or areas, walls, doors, corridors,
+  stairs, transitions, traps, descriptions, and campaign references
+- copy a complete authored Room, door, or comparable content identity, or
+  selected reusable parts of its authored content, and assign the copy to
+  suitable geometry
+- work on positive and negative levels and coordinates without a fixed Dungeon
+  boundary
+- select a stable authored object and find the same object in every applicable
+  view
+- preview, confirm, cancel, undo, and redo supported changes
+- receive a clear, specific explanation when a change cannot be applied
+
+Exact pointer buttons, menus, dropdown behavior, pixel widths, and control
+placement are replaceable UX design. Required outcomes are fast selection,
+understandable preview, explicit completion or cancellation, safe rejection,
+and discoverable tools.
+
+## Authoring Entry Points
+
+The raster view and relationship graph are equal primary entry points for a new
+Dungeon. Both represent one continuous Dungeon whole rather than separate maps. A GM may begin and continue structural authoring in either view.
+Changes in each view synchronously affect the same Dungeon structure; neither
+view is merely a downstream presentation of the other.
+
+The Dungeon Key is a secondary refinement surface for descriptions and other
+primarily textual content after or alongside structural authoring.
+
+## Raster Authoring View
+
+The editor raster view owns direct spatial authoring. Ordinary floor drawing
+uses 5-foot horizontal cells and 5-foot vertical resolution, and automatically
+creates floor, traversable Volume, and a 10-foot-clear default ceiling. The
+normal editor presents one 10-foot story as a 2D active slice spanning two
+vertical steps. Geometry immediately above and below appears through
+onion-slicing.
+
+The GM may switch slices before or during an editing gesture. A click-and-drag
+surface operation may therefore span several slices and create a 3D Volume.
+Stories may be stacked directly; removing an intermediate floor opens the
+vertical geometry. Floors and walls remain independently editable despite the
+automatically created standard shell.
+
+Floor mode paints or erases horizontal faces on cells at the active height
+using the configured brush and eraser forms. Wall mode draws walls through
+click-and-drag along cell edges and sets vertical extent in 5-foot steps.
+Selection can then move, extend, shorten, or change their height. Automatically
+created boundaries become ordinary editable floors and walls. Off-grid walls
+remain deferred.
+
+Its foundational fixed-Area tools are:
+
+- a brush with selectable shapes and adjustable radius
+- a polygon or surface tool that draws different area forms through
+  click-and-drag
+- an eraser with matching shape and radius capabilities
+- selection that can move, distort, and edit existing geometry
+
+Selection supports one target, additive selection, rectangle, lasso, a 3D
+range, and type or property filters. If several objects occupy the hit point,
+the editor shows a candidate list that can be cycled; it never relies on a
+silent fixed hit priority. A spatial range touching only part of a Volume
+selects the whole Volume for transforms and does not cut it.
+
+Selected Volumes may be moved and copied on the grid, rotated in 90-degree
+steps, mirrored horizontally or vertically, and deformed through corner or edge
+handles. Ground-plan handles change the complete prism by default. Arbitrary
+angles and off-grid scaling are not required. Multiple selected Volumes
+transform as one arrangement while preserving their relative spacing and
+internal links; external Paths reroute in preview.
+
+Brush, surface tool, and eraser operate directly on geometry regardless of the
+current selection. Overlapping or newly connected geometry automatically merges
+Volumes; separating geometry automatically splits a Volume. Completion requires
+no additional confirmation dialog, and ordinary undo is the expected recovery
+path.
+
+After every merge or split, SaltMarcher immediately makes a best-effort complete
+Room assignment for every resulting Volume. The assignment does not block
+geometry editing and the GM may change it afterward. Existing authored Rooms
+not selected for an assignment remain preserved without geometry.
+
+After a split, the existing Room follows the best-matching resulting Volume.
+Every other resulting Volume receives a new initially empty Room. Inherited
+Dungeon, Level, and group attributes continue to apply. Voxel-anchored Features
+and described surface regions follow their geometry, while complete Room prose
+is not duplicated automatically. The GM may copy or reassign it afterward.
+Selection remains relevant to transforms and detailed edits, not to
+choosing the target of drawing or erasing.
+
+Floor, traversable Volume, and default ceiling remain one coordinated spatial
+result while these tools operate.
+
+The raster model supports two foundational geometry forms:
+
+- directly drawn anchored Areas whose geometry changes only through explicit GM
+  edit or removal
+- unified non-branching generated 3D Paths between two endpoints and optional
+  waypoints; one Path may combine corridor, stair, ramp, ladder, shaft, and
+  comparable segments
+
+Both forms produce bounded, standable geometric Volumes. Chambers, corridors,
+stair spaces, and comparable forms use equivalent movement semantics even when
+their authoring behavior differs. A Volume may be partitioned into navigation
+areas at meaningful internal decisions such as corridor junctions.
+
+A Path remains parametrically defined by two endpoints, optional waypoints,
+cross-section, and further path properties. One Path never branches;
+T-junctions and networks arise from separate Paths meeting at a common anchor
+or Volume. It may carry an authored connection form for individual segments,
+including corridor, stair, ramp, ladder, or shaft. SaltMarcher proposes route,
+Passages, and segment forms in a protected preview. The GM can override a form
+or refine the route with waypoints and pins. Segment forms remain properties of
+the same Path rather than separate foundational content objects.
+
+The Path's exact voxel geometry derives from those facts. Moving a connected
+endpoint produces a rerouted preview rather than a silent commit. Normal path
+editing changes points or parameters. Routing avoids existing geometry and
+rejects an impossible route instead of silently breaking through it. The
+default cross-section is 5 feet wide and 10 feet high; the complete Path or an
+individual segment may override width and height in 5-foot steps.
+
+The GM may explicitly convert a Path into a fixed Area for fully custom
+geometry. Conversion preserves its current materialized volume and ends
+automatic rerouting.
+
+Every Path endpoint has an exact 3D anchor on a Volume boundary. When the GM
+connects Rooms without choosing exact anchors, SaltMarcher proposes suitable
+boundary anchors. The GM can move or pin them. Current navigation areas may be
+derived from geometry for routing and graph presentation but are not stable
+semantic endpoint identities. An unpinned endpoint may move to a suitable new
+boundary after geometry changes. A pinned endpoint follows its local position
+on the Volume and produces a repairable preview conflict if no valid route can
+preserve it.
+
+A Path meets each Volume through a separate Passage at its boundary. Passage is
+one functional concept; door, opening, gate, hatch, window, secret door, and
+comparable forms are visual assets or decorations. A Passage may be placed only
+on an existing wall or Volume boundary, but one Volume side is sufficient for a
+dangling authored approach into unbuilt space.
+
+Passage geometry uses complete 5-foot boundary faces, with 10-foot default
+height. Width and height remain resizable in 5-foot steps under the same
+identity. A wide Passage is authored as one wide object; adjacent independently
+created Passages remain independent. Overlap with another Passage is rejected
+atomically with a specific reason.
+
+Removing Passage geometry restores the wall but preserves Passage identity,
+description, and authored facts unassigned until reassigned or explicitly
+deleted. If later geometry has one unambiguous fit, it rebinds automatically;
+ambiguous fits require a preview and GM choice.
+
+Any Passage may link to another Passage in the same or another Dungeon or to an
+external campaign place. There is no special exit kind. Direction and return
+link are authored independently per side, and each side keeps its own
+description, passability, sensory facts, and optional added travel duration. A
+missing target leaves a visible broken and unavailable link until relinked or
+removed.
+
+## Feature Placement And Environment Authoring
+
+Encounter, Trap, Loot, and Curiosity use one shared placement mode: select the
+kind or owning source, place its exact voxel anchor, then edit kind-specific
+details. An existing Feature anchor may be dragged or reassigned across Volumes
+without changing identity. Several Features may share a voxel and use the same
+candidate-list selection behavior as other ambiguous hits.
+
+Trap trigger editing is a raster overlay with brush, range, and eraser tools.
+All trigger voxels for one Trap form one semantic set, even when they span
+Volumes. Feature layers are independently toggleable, show a type symbol, and
+show the name on hover or selection. Secret visibility follows the selected GM
+or player perspective.
+
+The editor lets the GM author light sources attached to geometry, Features,
+items, or actors, plus optional ambient light inherited from Dungeon through
+Level to Room. It independently edits passability and boundary transmission
+for sight, light, sound, and later sensory channels. Persistent sound sources
+and authored state actions may also be spatially anchored.
+
+A Feature may offer named, GM-confirmed state actions that atomically set or
+toggle several Passage, light, sound, or mechanism states. Only explicit
+authored triggers such as time, entering an area, elapsed duration, or a
+confirmed action may invoke such an action automatically. The resulting state
+persists until another action, trigger, or GM edit changes it.
+
+Additional raster capabilities include:
+
+- draw and reshape room and area geometry
+- place and edit walls, Passages, unified connection Paths, links, traps,
+  and other purpose-specific spatial objects
+- select authored objects, rooms, and areas for detailed inspection
+- change levels, pan, zoom, jump to coordinates, fit selection, and fit authored
+  content
+- show pending geometry as a non-persisted preview
+- expose enough specific feedback to repair invalid or conflicting geometry
+
+The runtime travel raster is not an authoring surface. It displays the Dungeon
+passively and lets the GM select rooms, objects, actors, and other targets to
+open their descriptions in a detail pane.
+
+## Relationship-Graph Design View
+
+The graph is an abstract, zoomed-out Dungeon-design and debugging surface. It
+represents the party's meaningful navigation decisions rather than mirroring
+every raster object one-to-one. Rooms, room groups, and relevant decision
+points may appear as nodes; routes and transitions appear as edges. Incidental
+geometry may be collapsed only when real choices, connection types, current
+states, and travel effects remain understandable.
+
+Authored Passages, Paths, and links influence graph
+relationships. Mere geometric adjacency without an authored opening does not
+create an edge. A structurally present but currently impassable connection
+remains visible with a distinct state. Geometrically detected climb, jump, or
+similar special-route candidates remain distinguishable from ordinary safe
+connections.
+
+It MUST help the GM inspect and manage:
+
+- room and room-group flow
+- the distribution of decision complexity
+- travel times between relevant points
+- placement and density of puzzles, loot, encounters, curiosities, and similar
+  content
+- important relationships and transitions that are difficult to understand at
+  raster scale
+
+Graph detail is adjustable. At maximum detail the graph may show every
+individual door, room, and connection. At progressively reduced levels it
+collapses unbranched routes, individual rooms, and then room groups into
+higher-level routes and navigation decisions. Flow, travel-time, and content
+facts aggregate to the visible level without replacing or discarding their
+underlying authored facts.
+
+The strongest reduction follows Melan-diagram principles documented by The
+Alexandrian:
+
+- straighten non-branching routes and remove irrelevant turns
+- collapse doors, intermediate spaces, and short dead ends that do not create a
+  meaningful macro-level navigation choice
+- preserve true forks, loops, secret or unusual paths, and level connections
+- avoid counting fake loops whose branches immediately rejoin without creating
+  meaningful route diversity
+- let edge length communicate approximate travel effort without reproducing
+  raster geometry
+
+Unlike the original analysis-only method, SaltMarcher's graph is also an
+authoring surface. It MUST preserve the distinction between abstract planned
+structure and protected provisional raster translation.
+
+The graph additionally supports a debug-style content heatmap. A route in this
+primary diagnostic means one edge between two visible graph nodes, not a full
+multi-node start-to-destination journey. Nodes and edges use colors, icons, or
+comparable encodings to show the type and concentration of Treasure,
+Encounters, Curiosities, puzzles, danger, rewards, and comparable authored
+content across the Dungeon.
+
+A later full-path comparison may build on these facts but has lower priority
+than the immediate node-and-edge heatmap. Diagnostics inform GM judgment and
+MUST NOT enforce one supposedly correct Dungeon structure or content balance.
+
+The GM can toggle individual heatmap layers for danger, Encounters, Treasure,
+other rewards, Curiosities, puzzles, secrets, and additional content types.
+One active layer uses a clear intensity scale across nodes and edges. A combined
+overview uses distinguishable icons, bars, or a comparable multi-category
+encoding rather than one ambiguous mixed color.
+
+The graph can switch between absolute content amount and concentration relative
+to travel time or route extent. Collapsing graph detail aggregates the
+underlying node and edge values to the visible level without losing category
+distinctions.
+
+Heatmap facts come only from explicit authored Dungeon Features, not from
+guessing content out of room prose. Initial feature kinds include Encounter,
+Trap, Loot, and Curiosity.
+
+A Curiosity is the common Feature kind for puzzles, individually authored
+flavor, table-facing interactions, and concrete furnishings such as a table,
+statue, or fountain. There is no separate generic Prop kind. Incidental
+furnishing may remain Room or surface description, while Loot or other
+purpose-specific Features may reference the Curiosity. Puzzle is a built-in Curiosity classification rather than a
+separate foundational Feature kind; additional GM-defined tags may be added.
+Its initial content consists of a name, player-readable or read-aloud free text,
+GM-only notes for operation, solution, or possible reactions, plus categories
+and tags. It has no programmed solution steps, success conditions, or automatic
+consequences. Later versions may add optional links or simple consequences such
+as changing lights or unlocking a referenced door without replacing GM-authored
+text or authority.
+Diagnostics may count all Curiosities and the Puzzle-classified subset
+separately, but MUST NOT assign Curiosities a qualitative score.
+
+The graph may show advisory pacing warnings for probable underfilling,
+overfilling, or local content concentration. Warnings remain explainable,
+overridable, and non-blocking.
+
+Danger and Loot diagnostics use the existing DMG-guided budget models already
+owned by SaltMarcher. The GM can define intended character level and planned
+session count for a complete Dungeon, one level, or one area. Authored Encounter,
+Trap, and Loot Features are compared with the resulting XP, gold, and magic-item
+budgets.
+
+Curiosity diagnostics use count and local density only. They MUST NOT infer
+quality or importance from Curiosity prose. General content-density references
+such as The Alexandrian's approximate content-bearing-room guidance may add
+separate pacing hints, but MUST NOT replace the rule-based danger and Loot
+budgets.
+
+Target level inherits from the complete Dungeon into levels and areas unless the
+GM overrides it at a narrower scope. Planned sessions do not duplicate into
+every child scope. The GM explicitly allocates Dungeon session shares to levels
+or areas, and unallocated shares remain visible.
+
+Child budget and actual-content summaries roll up without double counting. A
+scope without allocated sessions still receives neutral heatmaps, Curiosity
+density, and general distribution hints, but no misleading XP, gold, or
+magic-item budget warning.
+
+The GM may rearrange rooms and room groups in the graph. SaltMarcher translates
+those changes into raster geometry as far as possible.
+
+Creating a room in the graph immediately creates provisional raster geometry.
+Graph position and relationships provide the initial room and connections. The
+GM may optionally supply rough size, shape, or level hints without drawing
+cells in the graph. The result remains protected Graph-Edit Preview state until
+the GM returns to the raster editor, refines or restores it, and explicitly
+accepts it.
+
+Every graph detail level remains editable with abstraction-appropriate
+operations:
+
+- detailed views edit individual rooms, doors, and connections
+- middle detail may move, duplicate, connect, or remove complete rooms and room
+  groups as units
+- the strongest reduction may restructure high-level routes and groups
+
+A connection authored between collapsed groups is provisional planning intent.
+SaltMarcher may generate plausible concrete endpoints and raw geometry for the
+protected raster preview, but MUST NOT silently resolve ambiguity to an
+arbitrary door or cell.
+
+### Protected Graph-Edit Preview
+
+- graph rearrangement begins a protected, transient edit mode
+- the raster result appears only when the GM returns to the raster editor
+- the GM may repair translated geometry with ordinary raster-editor tools
+- no graph-edit result becomes permanent until the GM accepts the combined
+  result
+- before acceptance, one action restores the complete Dungeon state from
+  immediately before graph editing began
+- this protected restoration remains available independently of the ordinary
+  undo/redo depth or memory cap
+- failed or ambiguous translation MUST NOT silently discard authored content
+
+## Room List And Dungeon Key
+
+The room-list view presents a focused, human-readable Dungeon Key. It MUST let
+the GM efficiently edit primarily textual and semantic content through spacious
+room-editing dialogs.
+
+Each room entry includes at least:
+
+- stable editable display number
+- name
+- read-aloud description
+- GM description or notes
+- exits and relationships
+- linked actors, objects, encounters, and events
+
+SaltMarcher initially assigns display numbers unique within one conceptual
+Level. The GM may change or reorder them without changing internal Room
+identity or breaking references. Moving a Room into a Level with a conflict
+assigns the next free number. Cross-Level and Dungeon-wide references and
+exports show `Level + number`.
+
+Full-text search, filters for number, Level, group, Feature, secret, and status,
+and sorting support large Dungeon Keys. Selecting a result navigates to the same
+object in graph and raster.
+
+Batch editing may change every supported field, including names, read-aloud
+text, and GM notes. Text batches support complete replacement, prepend, append,
+and search/replace. A batch applies immediately and atomically as one undoable
+editor action; it does not require a separate preview.
+
+## Hybrid Room Descriptions
+
+A rendered room description combines:
+
+- dynamic geometry facts and spatial relationships
+- GM-authored descriptive attributes such as shape, height, materials,
+  atmosphere, temperature, moisture, door appearance, and similar qualities
+
+During travel, relative language such as “in front of you”, “left”, and
+“right” derives from current party heading and approach. Outside current travel,
+the Dungeon Key, editor, and document export use stable map directions such as
+north or southwest.
+
+The rendered description is an ordered sequence of blocks. Blocks may contain
+GM-authored read-aloud prose, derived geometry facts, inherited or local
+attributes, exits and visible Passages, and additional authored transitions or
+prose. The GM may reorder blocks, suppress individual derived facts, and insert
+authored text between them.
+
+The editor lets the GM choose an entrance or heading to preview the relative
+read-aloud result. Geometry changes recompute only affected derived facts
+without overwriting or reordering GM-authored text and attributes.
+
+Description blocks and relevant authored objects may be normally visible,
+GM-only, or hidden until discovered. An undiscovered secret Passage is omitted
+from player-readable text and visible exits. Secret status remains authored
+truth; discovery by the current party is separate runtime state. The editor can
+preview both undiscovered and discovered renderings. Visibility does not alter
+explicit passability.
+
+Hidden content may optionally define a search method, DC, private discovery
+notes, and the text or facts revealed afterward. SaltMarcher may compare passive
+values or a GM-entered active-check result and privately notify the GM. It MUST
+NOT reveal content without GM confirmation. The GM may manually reveal or hide
+it again.
+
+Descriptions such as blocked, locked, heavy, cold, or damp affect generated
+wording and placement in the dynamic description. They MUST NOT silently create
+passability or action rules.
+
+Common categories such as material, condition, light, temperature, moisture,
+smell, sound, and atmosphere accept freely authored values. The GM may add
+custom named attributes and exceptional free-text phrasing.
+
+Descriptive attributes inherit through Dungeon, optional Level, optional room
+group, Room, and explicitly described surface-region scopes. A Level is a
+GM-defined set of z-levels in the same continuous 3D Dungeon, not another map.
+Every inheriting object has one unambiguous parent path. A Room belongs to at
+most one Level; SaltMarcher may propose one from geometry, but the GM may assign
+the conceptual Level or skip the Level scope entirely. A multi-z-level Room is
+never geometrically split to satisfy inheritance. Level z-level sets do not
+overlap for inheritance. Allowed parent paths are Dungeon to Room, Dungeon to
+room group to Room, Dungeon to Level to Room, and Dungeon to Level to room group
+to Room. A Dungeon-level group may span z-levels; a Level-owned group remains
+within that conceptual Level. Further nested room-group levels are initially
+excluded. Different attribute keys accumulate through inheritance. A more
+specific value for the same key replaces only that key, while other inherited
+values remain. The GM may explicitly suppress or clear an inherited key.
+Additional overlapping collections or tags may support filtering and heatmaps
+but do not inherit attributes. The editor exposes every effective value and its
+origin and lets the GM restore inheritance. Attribute inheritance MUST NOT
+create rules, passability, or effects.
+
+## Geometry And Authored-Content Lifecycles
+
+- a Room may provide default descriptive attributes for its complete associated
+  Volume
+- the GM may select a contiguous wall, floor, or ceiling region and assign
+  overriding descriptions, attributes, or templates to that surface region
+- an explicitly described surface region receives a stable authored content
+  identity and the same preservation and reassignment guarantees as Rooms and
+  doors
+- raw undescribed voxel faces do not each require a separate content identity
+- Passages remain explicit independent objects because they affect travel
+- every Dungeon Feature initially has one exact 3D voxel anchor within a Volume
+- moving or reshaping that Volume carries the Feature anchor with it
+- when destructive geometry prevents reliable anchor mapping, the Feature
+  remains preserved for reassignment
+- Encounter context may follow referenced mobile actors or groups without
+  duplicating their identity
+- only Traps and Encounters initially support automatic proximity activation
+- a Trap may own zero or more trigger fields separate from its Feature anchor
+- each trigger field is an arbitrary GM-marked voxel set rather than a required
+  radius or fixed shape
+- trigger voxels remain associated with their Volumes and follow Volume movement
+  or deformation; one Trap may span fields in several adjacent Volumes
+- trigger fields only notify and interrupt travel, and do not alter passability
+  or decide fictional outcomes
+- a Trap defines maximum and current Charges; only a GM-confirmed actual
+  activation consumes one
+- at zero Charges the Trap cannot activate automatically
+- Reset Duration restores all Charges together
+- per Trap, the GM chooses whether the reset countdown starts only at zero or as
+  soon as current Charges fall below maximum
+- consuming another Charge does not restart a running countdown; its completion
+  restores all Charges regardless of intervening use
+- the GM may manually correct current Charges and reset state
+- an explicit Actor Autonomy job may perform a Trap reset
+- a placed Dungeon Encounter primarily references the existing SaltMarcher
+  Encounter capability for monster composition and statistics rather than
+  duplicating them
+- the Dungeon placement adds its voxel anchor, local Dungeon notes, detection
+  behavior, and autonomy integration
+- one concrete Encounter or monster group has at most one current Dungeon
+  placement; repeated equivalent encounters require independent Encounter copies
+- later movement changes that group's existing anchor rather than creating
+  another placement
+- Encounter detection uses the shared perception behavior
+- Dungeon Loot placement uses existing Loot content and ultimately the same
+  shared Loot object used by Encounter and Session Generation, rather than
+  duplicating currencies, items, or magic-item truth
+- the Dungeon placement adds the voxel anchor and local Dungeon context
+- one concrete Loot object has at most one current Dungeon anchor; Encounter
+  and Session Generation references do not create additional spatial copies
+- repeated physical Loot requires independent copies, while movement changes
+  the existing anchor
+- Loot and Curiosity Features do not activate solely because the party is nearby
+- a Volume is geometric truth; a Room is stable GM-authored content associated
+  with a Volume
+- one Room is assigned to at most one Volume and one Volume to at most one Room
+  at a time; either may temporarily be unassigned
+- navigation areas are silently derived from Volume geometry for routing and
+  decision presentation; they have no stable identity, name, description, or
+  authored content and may be freely recalculated
+- manual navigation-area correction is optional and low priority, while room
+  groups collect several Rooms or Volumes
+- moving a Volume preserves its Room association and Room identity
+- after a Volume is removed, split, or made unrecognizable, SaltMarcher attempts
+  a safe reassociation to suitable resulting geometry
+- when reliable reassociation is not possible, the Room and all of its authored
+  content remain available without a geometry assignment
+- the same protection applies to other described authored identities, including
+  doors: deleting their geometry does not delete their description or semantic
+  content
+- only an explicit content-deletion action removes preserved GM-authored content
+- the GM may duplicate whole authored identities or selected content parts and
+  assign the resulting content independently to other suitable geometry
+- an ordinary reassignment or copy receives its own identity and changes
+  independently
+- the GM may explicitly turn supported authored content into a reusable template
+  and assign that template to several instances
+- template assignments remain linked and automatically receive later template
+  changes
+- a template initially contains a GM-selected set of authored content blocks;
+  geometry, geometry assignment, and stable object identity remain excluded
+- only included blocks stay linked; other instance content remains independently
+  editable, while editing a linked block requires deliberate detachment
+- the GM may deliberately detach one linked instance or block; detached content
+  preserves its current value and changes independently
+- this template granularity is an initial testable workflow and may be refined
+  after practical usability evaluation
+- the reassociation mechanism is replaceable; the required outcome is visible,
+  recoverable preservation without silent data loss
+
+## Commit, Preview, And History
+
+- each completed, validated authoring action persists immediately
+- previews, canceled gestures, camera changes, selection, and rejected work do
+  not persist authored truth
+- rejection preserves the last valid authored state and identifies the reason
+- undo/redo covers at least the latest 200 ordinary committed changes in the
+  current editor session
+- unusually large operations may be limited by a documented encoded-memory
+  budget
+- a new commit after undo discards that session's redo branch
+- undo/redo preserves stable authored identities
+- history is session-scoped and is not exported as Dungeon truth
+- one action spanning several Dungeons, such as paired Passage links, commits
+  and reverses atomically
+- all geometry and content tools remain available during active exploration;
+  a committed change becomes travel truth immediately
+- a geometry or passability commit revalidates active autoroutes; an invalid
+  route stops at its last completed segment with a specific reason
+- if edited geometry removes an actor cell, the preview first relocates that
+  actor to the nearest valid cell in the same Volume, then a directly connected
+  Volume; without such a cell the edit is rejected
+- geometry and administrative actor relocations commit and undo atomically;
+  relocation consumes no travel time or events and is logged with the edit
+- committed geometry is always structurally travel-valid; empty Dungeons,
+  disconnected locally valid Volumes, and dangling Passages remain valid
+
+## Sparse-Dungeon Responsiveness
+
+- authored coordinates have no fixed width or height boundary
+- camera, hover, selection, preview, and rendering work scales with visible
+  primitives and touched spatial regions
+- off-screen authored content does not force global work for a local gesture
+- camera and hover work meet a 16 ms p95 budget
+- preview over already available local data meets a 50 ms p95 budget
+- qualification includes at least 100,000 authored cells in a sparse Dungeon
+
+## Extensibility Qualification
+
+The editor design is considered adaptable only when adding a new authored
+object or tool family requires local, explicit changes and does not require
+unrelated feature, travel, persistence, or shell rewrites.
+
+## Acceptance Outcomes
+
+- one room, area, object, relationship, and description remains recognizable
+  across raster, graph, and Dungeon-Key views
+- geometry editing stays in the raster authoring view
+- graph edits remain safely reversible until raster cleanup and final acceptance
+- text-centric editing is efficient in the Dungeon-Key view
+- selection, transforms, Path routing, Passage lifecycle, Feature placement,
+  and live actor relocation preserve stable authored identities
+- generated geometry text updates without destroying GM-authored semantics
+- document output remains understandable without current runtime party state
+- ordinary local work remains responsive in the sparse qualification Dungeon
+
+## References
+
+- [Dungeon Feature Requirements](./requirements-dungeon.md)
+- [Dungeon Travel Requirements](./requirements-dungeon-travel.md)
+- [Maps Canvas Requirements](../../maps/requirements/requirements-maps-canvas.md)

--- a/docs/dungeon/requirements/requirements-dungeon-travel-state.md
+++ b/docs/dungeon/requirements/requirements-dungeon-travel-state.md
@@ -1,0 +1,141 @@
+# Dungeon Travel State Requirements
+
+## Goal
+
+Provide the GM with one persistent Dungeon travel-control surface that remains
+available independently of the currently displayed travel map view. It
+communicates current travel state and starts or adjusts travel without turning
+the map itself into a player-operated VTT.
+
+## User And Authority
+
+- only the GM operates the `Reisen` state tab
+- the GM enters or confirms table decisions on behalf of players and NPCs
+- controls issue travel intent; they do not automate unrestricted exploration
+  actions or decide fictional outcomes
+- the passive travel map may select targets and open details, but it does not
+  own these controls
+
+## Required Context
+
+The state tab communicates at least:
+
+- active Dungeon and current area
+- active party or selected actor/group
+- current Room, read-aloud text, GM notes, visible exits, nearby Features and
+  actors, and reachable neighboring decisions
+- cell-precise position and heading
+- current movement, route, pursuit, loading, interruption, or failure status
+- selected destination, transition, or tracked target when applicable
+- current exploration-round duration
+- effective movement speed and relevant overrides
+- current perception result or override, visible track and pursuit state, and
+  any paused autonomy or catch-up boundary relevant to this Dungeon
+- the next GM decision or available continuation
+
+## Exploration Timing Controls
+
+The GM chooses one fixed round duration from:
+
+- 1 minute
+- 5 minutes
+- 10 minutes
+- 15 minutes
+- 30 minutes
+- a custom duration
+
+Only movement receives a system-calculated duration. Other exploration actions
+remain free table actions and do not require programmed action types or
+durations.
+
+## Movement-Speed Controls
+
+For a grouped token:
+
+- the default effective speed is the slowest included member
+- every included member arrives with the group at the same time
+- the GM may override the effective speed of the whole group
+- the GM may exclude a member from speed calculation, for example when that
+  member is carried
+- the GM may override an individual member's effective travel speed
+
+These overrides are visible travel-session state, not authored Dungeon truth.
+
+## Route And Transition Controls
+
+The state tab lets the GM:
+
+- select a transition or destination
+- begin a local journey
+- plan and start a longer route
+- start dynamic pursuit of another movable actor or group
+- continue or abort travel after a GM-resolved prompt
+- freely set an actor position without route validation, time advancement, or
+  event activation
+- split characters from a party token, form separate groups, and merge groups
+
+Exploration may start at any Passage whose target is external to the Dungeon,
+or by deliberate GM placement. No separate entrance flag exists.
+
+## Perception, Tracks, And Autonomy Controls
+
+The long-term surface lets the GM:
+
+- enter and clear active Perception, Survival, or tracking results
+- inspect directional detection and party-knowledge state
+- confirm discovery, force known or unknown state, and request reevaluation
+- inspect, correct, suppress, or add tracks and start segment-based pursuit
+- pause or resume autonomy for a selected NPC or monster and directly assign or
+  cancel a job
+- inspect why a job was selected, interrupted, failed, or blocked
+- inspect an inactive-context catch-up summary and the first pending GM
+  decision boundary
+
+These are binding target capabilities even when delivered after core travel.
+
+## Visible States
+
+- no active Dungeon context
+- ready at a cell-precise location
+- route planning
+- traveling through the current round or route segment
+- pursuing a movable target
+- waiting for a GM decision after an event, trap, lock, encounter, or similar
+  prompt
+- paused before a Party-involved danger or an autonomy catch-up decision
+- reviewing a found, lost, weak, or ambiguous track
+- blocked or failed travel with a clear reason
+- completed or GM-aborted travel
+
+## Non-Goals
+
+- a compact read-only replacement for the actual travel controls
+- direct player control
+- tactical combat initiative or six-second action economy
+- attacks, spells, damage, conditions, or encounter resolution
+- automatic durations for arbitrary table actions
+- ownership of authored Dungeon truth or party roster truth
+
+## Acceptance Outcomes
+
+- the GM can inspect and adjust travel state without depending on which Dungeon
+  presentation is visible
+- a grouped token uses the slowest included member unless the GM overrides the
+  calculation
+- a custom exploration-round duration works without inventing new action types
+- route, transition, and pursuit controls address stable authored or runtime
+  targets
+- a GM can continue or abort after resolving a prompt at the table
+- position override remains visibly distinct from rule-based travel
+- travel-session controls do not mutate authored Dungeon descriptions or
+  geometry
+- active-check overrides persist until the GM clears or explicitly reevaluates
+  them
+- Party-involved danger is visible as paused before autonomous resolution
+
+## References
+
+- [Dungeon Feature Requirements](./requirements-dungeon.md)
+- [Dungeon Travel Requirements](./requirements-dungeon-travel.md)
+- [Dungeon Editor Requirements](./requirements-dungeon-editor.md)
+- [Actor Autonomy Requirements](../../autonomy/requirements/requirements-actor-autonomy.md)

--- a/docs/dungeon/requirements/requirements-dungeon-travel.md
+++ b/docs/dungeon/requirements/requirements-dungeon-travel.md
@@ -1,0 +1,325 @@
+# Dungeon Travel Requirements
+
+## Goal
+
+Let one GM run spatial Dungeon exploration over committed authored truth and
+party-owned runtime state. Travel maintains cell-precise position, time, routes,
+events, and a factual log while leaving free actions and fictional outcomes to
+the table.
+
+## Runtime Actors And Groups
+
+- the active party and selected relevant NPCs, groups, or movable
+  campaign objects may have cell-precise Dungeon positions
+- characters may be split from one party token, moved alone, placed into
+  separate groups, and later regrouped
+- a grouped token travels at the slowest included member's effective speed by
+  default and arrives together
+- GM group-speed, individual-speed, and member-exclusion overrides apply from
+  the `Reisen` state tab
+- the GM is the only interface operator; actors do not represent player-owned
+  VTT clients
+
+Rooms, derived corridor sections, junctions, stair landings, and comparable
+decision points may organize choices and presentation, but do not replace
+cell-precise runtime position.
+Every bounded standable interior Volume uses the same travel semantics,
+including chambers, corridors, and stair spaces. A Room supplies stable authored
+content associated with such a Volume. SaltMarcher silently derives
+identityless navigation areas at meaningful choices such as branches,
+junctions, and landings. They may be freely recalculated and do not own names,
+descriptions, content, movement semantics, or runtime position.
+
+## Passive Travel Map
+
+The runtime raster map:
+
+- shows relevant authored geometry and runtime actors
+- lets the GM select rooms, areas, objects, actors, and destinations
+- opens the selected target's description in a detail pane
+- does not edit authored geometry
+- does not need to contain the travel controls, which live in the independent
+  `Reisen` state tab
+
+## Valid Travel Options
+
+Travel options arise from both authored semantics and actual geometry.
+
+Authored Passages and unified generated connection Paths provide internal travel
+meaning. Any Passage may link to another Passage in the same or another Dungeon
+or to an external campaign place. Link and return direction are independent,
+and each side has its own description, passability, sensory facts, and optional
+additional travel time. A missing target makes the link visibly broken and
+unavailable without deleting its local Passage.
+Geometry may additionally expose long-room and corridor travel, junctions,
+complex path forks, open vertical relationships, and potential climb, jump, or
+similar special routes.
+
+SaltMarcher may detect a potential geometric special route without consulting
+character ability or equipment. The GM decides whether the attempted route is
+possible and succeeds. The Dungeon feature then records only a confirmed
+journey or a deliberate position override.
+
+## Passability Boundary
+
+A Passage has one explicit travel fact: passable or not passable.
+Passages occur at Volume boundaries and are distinct from the Paths that own
+route and travel properties. Their authored identities and descriptions may
+remain preserved even while no Passage geometry is assigned.
+
+Passability, geometric resolution, sight, light, and sound transmission are
+independent. A passable dangling Passage is not travelable until geometry or a
+valid linked target resolves it. Door, window, gate, or opening appearance does
+not infer any of those facts.
+
+Travel through a Passage link arrives on the valid cell immediately inside the
+target Passage with heading derived from that target. It uses ordinary
+through-time plus any GM-authored additional duration. Every Passage whose
+target is external to the current Dungeon is an available Dungeon entrance;
+the GM may alternatively begin exploration by deliberate position placement.
+
+Descriptions such as locked, blocked, heavy, hidden, cold, or difficult do not
+create additional passability logic. Authored secret status controls whether
+content appears in player-readable descriptions; current-party discovery is
+separate runtime state and likewise does not change passability. Hidden content
+may carry optional search method and DC facts. Passive values or a GM-entered
+active check may privately notify the GM, but reveal requires GM confirmation.
+These attributes affect generated description text and
+may expose a GM-authored prompt, but SaltMarcher does not infer what actors are
+allowed to attempt.
+
+A lock may behave like a trap prompt, for example “Lock, lockpicking DC 16”.
+The GM resolves it freely at the table and then continues or aborts travel.
+SaltMarcher does not roll, adjudicate, or encode the result.
+
+Difficult terrain, climbing, and comparable movement factors may change
+calculated travel time without creating another passability condition or
+requiring a separate GM prompt.
+
+## Local Travel And Long Routes
+
+- ordinary point-to-point navigation proceeds to the next relevant decision
+  point
+- the GM may plan a complete route between two points in the overview
+- an autoroute executes as consecutive segments ending at decision points
+- position and time commit atomically for each completed segment
+- an event, newly invalid route, lost pursuit track, reached destination, or
+  GM abort stops or completes automatic travel as applicable
+- completed segments remain committed when a later segment stops
+- travel does not require confirmation in every ordinary exploration round
+
+## Dynamic Pursuit
+
+The GM may route one actor or group toward another movable actor or group.
+
+- pursuit recalculates toward the target's current position as travel advances
+- pursuit ends when the target is caught
+- a lost track interrupts pursuit
+- catching a target does not automatically merge tokens; the GM decides whether
+  to regroup them
+
+## Movement Rules And Time
+
+- distance, terrain, climbing, jumping, movement modes, and effective movement
+  rates use an explicitly versioned D&D 5e 2014 rule profile
+- diagonal and free path length use geometrically accurate distance rather than
+  the simplified five-foot or alternating five/ten-foot grid methods
+- movement modifiers apply to that precise distance
+- the resulting travel-time calculation runs without an additional GM decision
+- terrain and movement-cost calculation remains unobtrusive during travel
+- the GM chooses an exploration-round duration of 1, 5, 10, 15, or 30 minutes,
+  or enters a custom duration
+- when movement lasts longer than one round, subsequent actor rounds remain
+  occupied by that journey until destination or interruption
+- non-movement actions receive no programmed action categories or durations
+
+## Position Override
+
+`Travel` and `Set position` are distinct GM actions.
+
+- travel follows current valid routes and advances time and event context
+- set position places the selected actor at a chosen cell without reachability
+  validation, automatic time advancement, or event activation
+
+## Events, Prompts, And GM Authority
+
+Confirmed travel advances calendar time automatically and activates applicable
+events.
+
+Event sources include:
+
+- GM-planned events
+- GM-configured location-, time-, or actor-dependent event pools
+- GM-authored traps
+- random encounters
+- track, pursuit, and perception notifications
+
+A triggered event opens the relevant GM context and interrupts travel when
+resolution is required. SaltMarcher may open, repeat, or dismiss a prompt, but
+does not decide or log its fictional outcome.
+
+A trap is an authored Dungeon Feature at an exact voxel anchor within a Volume;
+its trigger opens a description. The GM resolves it at the table and dismisses
+the prompt to continue or aborts travel. Other Dungeon Features likewise begin
+with exact voxel anchors; Encounter context may follow referenced mobile actors
+or groups.
+
+Only Traps and Encounters activate automatically through spatial
+proximity. A Trap may define zero or more arbitrary voxel-set trigger fields
+distinct from its own anchor; fields may lie in several adjacent Volumes and
+follow their Volume geometry. Entering a field may notify and interrupt travel,
+but the field never changes passability or decides the Trap outcome. Without a
+field, the Trap remains manually handled by the GM.
+
+A Trap has maximum and current Charges limiting how many times it can actually
+activate in succession. Charge use follows a GM-confirmed actual activation
+rather than mere entry into a trigger field. At zero Charges it cannot activate
+automatically.
+
+Reset Duration restores all Charges together. Per Trap, the GM chooses whether
+the countdown begins only at zero Charges or as soon as current Charges fall
+below maximum. Consuming another Charge does not restart a running countdown;
+completion restores all Charges regardless of intervening use. The GM may
+manually correct current Charges and reset state. An explicit Actor Autonomy
+job may perform a reset.
+
+A Dungeon Encounter placement primarily uses the existing SaltMarcher Encounter
+capability for monster composition and statistics. The Dungeon adds its voxel
+anchor, local notes, detection context, and autonomy integration. One concrete
+Encounter or monster group has at most one current Dungeon placement; repeated
+equivalent groups require copied Encounters. Movement changes the same group's
+anchor. Encounter detection uses the shared perception behavior. Loot and
+Curiosity Features do not open automatically from
+proximity alone.
+
+More interaction may be added later, but comprehensive trap simulation is not a
+requirement.
+
+Position and time commit together or not at all for one travel segment. Opening
+the following event may fail and be retried without corrupting the committed
+travel state.
+
+Named state actions may atomically change several authored Passage, light,
+sound, or mechanism states. They run only after GM confirmation or an explicit
+authored trigger based on time, entering an area, elapsed duration, or a
+confirmed action. Their result persists and is logged.
+
+## Factual Travel Log
+
+SaltMarcher records confirmed:
+
+- cell or area changes
+- elapsed calendar time
+- used transitions
+- opened events and prompts
+
+The log records what the system confirmed, not GM-decided event outcomes.
+
+## Perception And Knowledge
+
+Perception follows the versioned D&D 5e 2014 profile plus committed 3D Dungeon
+facts. Passive Perception or a GM-entered active result is compared with
+Stealth, while line of sight, lighting, distance, cover, and the actor's
+relevant senses gate detection. An entered active result remains in force until
+the GM clears it.
+
+Detection is directional: each actor or group keeps independent knowledge of
+the other. A new relevant sighting updates knowledge and notifies the GM. If the
+Party is involved, its active route and the involved autonomous behavior pause
+before further danger resolution. An Encounter begins only after GM
+confirmation.
+
+The GM may force known or unknown state with an optional logged reason. The
+override remains until an explicit reevaluation; ordinary perception updates do
+not silently replace it.
+
+Environmental perception starts with sight, light, and sound and remains
+extensible to senses such as blindsight or tremorsense. Movement, jobs,
+conflicts, and interactions create transient sound events; Features or places
+may own persistent sound sources.
+
+## Tracks And Pursuit
+
+Confirmed movement automatically creates tracks according to actor, movement,
+and surface. The GM may suppress generation, correct a track, or add one
+manually. A track records a known or unknown source, voxel path and direction,
+creation time, strength, search DC, and relevant movement facts.
+
+Track strength decays according to a versioned time, surface, environment, and
+movement profile that the GM may override. Track knowledge is separate per
+actor or group; the GM can inspect every track.
+
+Searching uses D&D Perception or Survival, or a GM-entered active result,
+against the track DC. GM confirmation records discovery. Following proceeds in
+segments along the stored path. Weak, broken, or crossing segments require a
+new check; loss or ambiguity pauses the route.
+
+## Passive Player Display
+
+The second-monitor player view is display-only and accepts no player input. Its
+camera automatically follows the active Party actor or group in the exploration
+initiative; autonomous NPC or monster jobs never switch it.
+
+Fog distinguishes currently visible space, dim remembered geometry without
+live details, and unknown space. Current visibility derives from D&D senses,
+light and darkness, darkvision, 3D line of sight, height, and cover. The
+knowledge filter is the union of the complete Party's knowledge.
+
+Party members and other actors appear only when allowed by party knowledge and
+current perception. The GM may temporarily reveal or hide presentation without
+changing discovery truth. The view updates within 100 ms p95 after movement or
+a visibility change.
+
+## Actor Autonomy Integration
+
+Dungeon travel supplies local position, routing, perception, tracks, and job
+offers to the project-wide Actor Autonomy capability. A confirmed campaign-time
+step may move enabled NPCs or monsters, update their jobs, and invoke explicit
+simple Feature interactions. The owning autonomy requirements define needs,
+selection, catch-up, conflict resolution, authority, atomicity, and logs.
+
+Party involvement is a hard boundary: an emerging danger pauses and notifies
+before autonomous resolution. Non-party conflicts may be resolved by the
+bounded abstract simulation owned by Actor Autonomy.
+
+## Non-Goals
+
+Dungeon travel does not own or automate:
+
+- tactical attacks, spells, combat actions, or full combat rounds
+- tactical initiative or six-second combat rounds
+- encounter, trap, lock, or unrestricted exploration-action outcomes
+- direct player controls
+- full tactical Battlemap behavior
+
+An encounter or another open situation involving the Party interrupts travel
+and is resolved at the table or by another owning feature. Actor Autonomy may
+resolve bounded non-party conflicts without making Dungeon travel their owner.
+
+## Acceptance Outcomes
+
+- travel reads committed authored Dungeon truth plus runtime actor state
+- every confirmed segment updates position and time atomically
+- route failure never leaves partially committed position or time for the
+  failed segment
+- a dynamic pursuit follows current target position and stops on catch or lost
+  track
+- explicit passability, not descriptive text, determines whether pathfinding may
+  use a door or passage
+- precise geometric distance and the versioned movement profile determine
+  unobtrusive travel time
+- a position override never silently behaves like rule-based travel
+- triggered content pauses for GM resolution without SaltMarcher deciding the
+  outcome
+- Party-involved danger pauses before autonomous conflict resolution
+- perception, tracks, Fog of War, and player display use the same committed
+  geometry, environment, and knowledge facts as travel
+- runtime travel state does not become authored Dungeon-package truth
+
+## References
+
+- [Dungeon Feature Requirements](./requirements-dungeon.md)
+- [Dungeon Travel State Requirements](./requirements-dungeon-travel-state.md)
+- [Dungeon Editor Requirements](./requirements-dungeon-editor.md)
+- [Actor Autonomy Requirements](../../autonomy/requirements/requirements-actor-autonomy.md)
+  ([public source](https://www.dndbeyond.com/sources/dnd/basic-rules-2014/adventuring))

--- a/docs/dungeon/requirements/requirements-dungeon.md
+++ b/docs/dungeon/requirements/requirements-dungeon.md
@@ -1,0 +1,344 @@
+# Dungeon Feature Requirements
+
+## Goal
+
+Provide one local, GM-operated Dungeon capability for authoring, inspecting,
+running, exchanging, and documenting multi-level dungeons. Every surface reads
+and changes one coherent dungeon truth while preserving the GM's authority over
+fiction and outcomes.
+
+## User And Authority
+
+- one GM is the only operator of the local desktop interface
+- players do not receive direct character control or a multi-user editing
+  surface
+- the GM translates table decisions into Dungeon commands
+- SaltMarcher may calculate objective travel facts, expose triggered content,
+  and maintain state, but it MUST NOT decide fictional outcomes reserved for
+  the GM
+- project-wide actor autonomy is the explicit exception: for enabled NPCs and
+  monsters it may choose and execute bounded jobs and resolve non-party
+  conflicts as defined by the Actor Autonomy Requirements
+- remote access and collaborative multi-user authoring are not required
+
+## Long-Term Capability Scope
+
+One Dungeon is one continuous spatial whole containing all of its rooms,
+surfaces, levels, and spatial content. It is not a collection of internal
+Dungeon maps. The raster map is a view of this whole, not a separate authored
+container. A Passage link may transition to another Dungeon or external place.
+
+Its spatial foundation behaves as one voxel-like 3D grid with 5-foot horizontal
+cells and 5-foot vertical resolution. Creating ordinary walkable space produces
+floor, traversable volume, and a default ceiling together with 10 feet of clear
+height. The GM may later change height in 5-foot steps, including intentional
+5-foot crawlspaces and taller chambers. Stacked spaces and minor elevation
+shifts remain part of the same Dungeon.
+
+The raster editor presents an active 10-foot 2D story over two 5-foot vertical
+steps and onion-slices geometry above and below. The GM may change slices during
+a gesture, allowing click-and-drag operations to span a 3D Volume. Stacked
+stories share the same Dungeon geometry; intermediate floors, floors generally,
+and walls remain independently editable.
+
+A Volume is bounded, standable geometric interior space. Chambers, corridors,
+stair spaces, and comparable geometric forms share movement semantics. A
+SaltMarcher silently derives navigation areas from Volume geometry to expose
+meaningful internal choices such as corridor junctions and branches. They have
+no stable identity, name, description, or authored content and may be freely
+recalculated after geometry changes. Manual correction is low priority.
+
+A Room is a stable GM-authored content identity associated with a Volume. It
+owns name, descriptions, Features, references, and comparable semantic work.
+One Room is associated with at most one Volume and one Volume with at most one
+Room at a time; either may temporarily remain unassigned. Moving the Volume
+preserves that Room identity and association. After a Volume merge or split,
+SaltMarcher immediately makes a best-effort Room assignment for every resulting
+Volume; the GM may revise it, and unused authored Rooms remain preserved.
+After a split, the existing Room follows the best-matching result and every
+other Volume receives a new empty Room. Inherited attributes still apply;
+voxel-anchored Features and surface content follow geometry, while full Room
+prose is not duplicated automatically. Derived navigation areas
+structure a Volume, while room groups collect several Rooms or Volumes.
+
+A Room may provide descriptive defaults for its associated Volume. The GM may
+assign overriding authored descriptions, attributes, or templates to selected
+contiguous wall, floor, or ceiling regions. Only explicitly described surface
+regions require stable content identities and preservation; undescribed voxel
+faces remain plain geometry.
+
+Descriptive attributes use common freely valued categories plus GM-defined
+attributes and exceptional free text. Values inherit from Dungeon through an
+optional Level, an optional room group, Room, and finally an explicitly
+described surface region. A Level is a GM-defined set of z-levels within the
+same continuous 3D Dungeon, not a map. Level z-level sets do not overlap for
+inheritance. Each Room belongs to at most one Level, which the GM may choose or
+skip even when the Volume spans several z-levels. SaltMarcher may propose but
+MUST NOT force the assignment or split geometry. Allowed parent paths are
+Dungeon/Room, Dungeon/Group/Room, Dungeon/Level/Room, and
+Dungeon/Level/Group/Room. Dungeon-level groups may span z-levels; Level-owned
+groups stay within that Level. Further nested group levels are initially
+excluded. Each inheritance path is unambiguous. Different attribute keys
+accumulate; a more specific value for the same key replaces only that key. The
+GM may explicitly suppress or clear an inherited key. Overlapping collections
+or tags may support filters and diagnostics but do not inherit. Attribute
+inheritance does not create rules, passability, or effects.
+
+A rendered Room description is a GM-ordered sequence of authored prose, derived
+geometry facts, effective attributes, exits, visible Passages, and optional
+authored transition text. The GM may reorder blocks and suppress individual
+derived facts. Geometry changes update only affected derived content and never
+overwrite or reorder GM-authored text.
+
+Description blocks and relevant authored objects may be visible, GM-only, or
+hidden until discovered. Secret status is authored truth; discovery by the
+current party is separate runtime state. Undiscovered secrets remain absent
+from player-readable descriptions and exits without changing explicit
+passability. Hidden content may optionally define a search method, DC, private
+discovery notes, and revealed text or facts. A passive or GM-entered active
+result may prompt the GM privately, but only GM confirmation reveals the
+content; manual reveal and re-hide remain available.
+
+Every Dungeon Feature initially has an exact 3D voxel position anchored within
+one Volume. Moving or reshaping the Volume carries its Feature anchors with it.
+If destructive geometry makes reliable mapping impossible, the Feature remains
+preserved without an anchor until reassigned. Encounter context may follow
+referenced mobile actors or groups without duplicating their identity. Only
+Traps and Encounters support automatic proximity activation. Traps may define zero or more
+arbitrary voxel-set trigger fields separate from their anchors. Trigger voxels
+remain associated with their Volumes, may span several adjacent Volumes, and
+only control notification or travel interruption; they do not alter
+passability or decide outcomes. A Trap may own maximum and current Charges for consecutive GM-confirmed actual
+activations and a Reset Duration that restores all Charges together. The GM
+chooses whether recharge begins at zero Charges or immediately below maximum.
+Further activation does not restart a running countdown; completion restores all
+Charges. The GM may manually correct the state. An explicit Actor Autonomy job
+may reset a Trap. A placed Dungeon Encounter primarily uses
+the existing Encounter capability as the source of monster composition and
+statistics. Its Dungeon placement adds the voxel anchor, local notes, detection
+context, and autonomy integration rather than duplicating Encounter truth. One
+concrete Encounter or monster group has at most one current Dungeon placement;
+equivalent repetitions require independent Encounter copies. Movement changes
+the same group's anchor rather than creating another placement. Encounter
+detection uses the shared perception behavior rather than a private proximity
+radius. Dungeon Loot placement uses existing Loot content and ultimately
+the same shared Loot object as Encounter and Session Generation. The Dungeon
+adds voxel placement and local context rather than duplicating currencies,
+items, or magic-item truth. One concrete Loot object has at most one current
+Dungeon anchor; other feature references do not duplicate it spatially, and
+multiple physical occurrences require independent copies. Loot and Curiosities do not activate from proximity alone. Puzzle is a
+built-in Curiosity classification rather than a separate foundational Feature
+kind; other GM-defined Curiosity tags may be added. Initial Curiosity content
+is limited to name, player-readable or read-aloud text, GM-only operation or
+solution notes, categories, and tags. It does not program solution steps,
+success conditions, or consequences.
+
+The GM may copy a complete Room, door, or comparable authored identity, or
+selected parts of its authored content, and assign the resulting content to
+other suitable geometry without violating one-to-one assignment. Ordinary
+copies receive independent identities. The GM may instead explicitly create a
+reusable template whose assigned instances remain linked and automatically
+receive template changes. A linked instance or content block may be deliberately detached,
+preserving its current content for independent editing. Templates initially
+contain GM-selected authored content blocks and never geometry, geometry
+assignment, or stable object identity. This granularity remains subject to
+practical usability validation.
+
+Spatial authoring has two foundational forms: directly drawn anchored Areas and
+non-branching dynamically generated Paths between two endpoints with optional
+waypoints.
+Corridors, stairs, ramps, ladders, shafts, and comparable connection segments
+are generated parts of one unified 3D Path model. One Path may combine several
+forms between endpoints at different elevations. Segment forms and optional
+position constraints are authored properties of the Path, while its exact voxel
+route may be derived. Generated Paths materialize ordinary bounded Volumes; Area and Path describe
+construction behavior rather than incompatible runtime space types.
+
+Each Path endpoint carries an exact 3D anchor on a Volume boundary.
+SaltMarcher may propose boundary anchors when the GM connects Rooms; the GM may
+reposition or pin them. A current navigation area may be derived for routing
+but is not part of endpoint identity.
+
+A Path connects through separate Passages in Volume boundaries. Door, opening,
+gate, hatch, window, secret door, and comparable depictions are visual assets or
+decorations of one functional Passage concept. A Passage owns its stable
+authored identity, description, whole-face geometry, explicit passability, and
+independent sight, light, and sound transmission facts. A Path owns route and
+travel properties.
+
+Any Passage may connect geometrically or link to another Passage in the same or
+another Dungeon, or to an external campaign place. There is no separate Dungeon
+exit type. Link direction and return link are independent per side. Each side
+keeps its own description, passability, sensory facts, and optional added
+travel time. A missing target leaves a visible, unavailable broken link without
+deleting the local Passage or its content.
+
+The Dungeon capability includes:
+
+- Dungeon catalog management
+- square-cell, multi-level authored geometry
+- rooms, larger named room groups or areas, walls, doors, unified generated
+  3D connection Paths, transitions, and GM-authored traps
+- descriptions, inspection, stable Dungeon-Key numbering, and campaign-object
+  references
+- synchronized raster-map, relationship-graph, and Dungeon-Key workflows
+- cell-precise runtime positions for the party and selected relevant actors
+- GM-operated dungeon travel with time, routes, events, and factual logging
+- a human-readable document export containing the map, Dungeon Key, and stable
+  references
+- a versioned portable Dungeon package for authored Dungeon truth
+- a passive display-only second-monitor view using party knowledge, current
+  perception, and Fog of War
+
+There is no generic spatial Marker or Prop kind; placed content has a
+purpose-specific Dungeon role. An individually authored furnishing, flavor
+element, or table-facing interaction is a Curiosity. Incidental furnishing may
+remain Room or surface description, and other Features such as Loot may
+reference a Curiosity.
+
+New authored object families, tools, rules, and integrations MUST remain
+locally addable in source code. A runtime plugin system is not required.
+
+Map-image import and procedural Dungeon generation are not core requirements.
+
+## Primary Surfaces
+
+- raster authoring editor
+- abstract relationship-graph design view
+- room-list and Dungeon-Key authoring view
+- passive runtime raster view for selection, orientation, and detail inspection
+- independent runtime `Reisen` state tab for travel controls and status
+- human-readable map and Dungeon-Key export
+
+The specialized surfaces MUST select and navigate to the same stable room,
+area, object, or actor and MUST remain consistent with one authored Dungeon
+truth.
+
+## Campaign Relationships
+
+Rooms, areas, Passages, and Dungeon Features may reference suitable
+campaign-owned places, NPCs,
+factions, encounters, items, scenes, and similar objects. Dungeon stores stable
+references without copying or taking ownership of the referenced object's
+truth.
+
+## Durability And Safety
+
+Until feature completion, there are no users and therefore no legacy Dungeon
+data to preserve. Development database shapes are unsupported inputs and fail
+closed rather than being migrated by the product. The migration and backup
+outcomes below become applicable when users can first create durable data;
+current-format persistence, restart, integrity, and recovery obligations apply
+throughout development.
+
+- every completed, validated authoring action persists immediately
+- previews and canceled gestures remain transient
+- removing, splitting, or making geometry unrecognizable does not silently
+  delete associated Rooms, door descriptions, or other GM-authored semantic
+  content
+- SaltMarcher attempts safe reassociation after geometry changes; content that
+  cannot be reliably reassociated remains available without geometry until the
+  GM reassigns or explicitly deletes it
+- saved Dungeons survive restarts and application updates
+- complete exploration runtime state survives restarts, including actors,
+  groups, headings, routes, knowledge, timed states, and open prompts
+- every migration creates and restore-tests a backup before mutation
+- rolling backups use configurable time, count, and storage retention with safe
+  defaults, and the GM may request a manual backup
+- after a crash, a committed operation is observably either wholly old or
+  wholly new, never partial
+- a failed migration leaves original and backup unchanged, prevents writable
+  opening, and offers diagnostics, retry, and restore
+- import MUST preview identity conflicts and missing external references
+- the GM may create new identities or map missing external references before import
+- import MUST NOT silently overwrite existing authored content
+- a portable Dungeon package contains authored Dungeon truth and stable
+  references, but not party or actor positions, travel logs, or undo history
+- the human-readable export is configurable across raster slices, reduced or
+  detailed graph, Dungeon Key, and optional Feature or GM appendices; a
+  visibility profile controls secrets and GM-only material
+- normal catalog deletion archives a Dungeon, pauses active exploration, and
+  preserves links and runtime state
+- final deletion moves the Dungeon into a restorable local trash for 30 days;
+  explicit immediate destruction remains available
+- duplication creates new authored identities and remaps internal references,
+  preserves external references, and excludes runtime, knowledge, logs, and
+  undo history
+
+## Environment And Runtime Integration
+
+The long-term requirement includes:
+
+- light sources attached to geometry, Features, items, or actors, with optional
+  ambient light inherited from Dungeon through Level to Room
+- event and persistent sound sources, plus extensible sensory channels
+- independent boundary facts for passability, sight, light, and sound
+- persistent, logged state actions that may atomically change several authored
+  environment states after GM confirmation or an explicit authored trigger
+- D&D 5e 2014 perception over 3D line of sight, lighting, distance, cover, and
+  relevant senses
+- persistent movement tracks, per-actor or per-group track knowledge, search,
+  decay, and segment-based pursuit
+- integration with project-wide actor autonomy for local spatial jobs,
+  movement, perception, tracks, and conflict context
+- a passive second-monitor player view with current visibility, remembered
+  geometry, unknown space, secrets, and the union of party knowledge
+
+These are binding target capabilities even when delivery is deferred. The
+player view remains display-only and does not change the GM-only control model.
+
+## Non-Goals
+
+- a tactical battlemap or combat action economy
+- automated resolution of attacks, spells, traps, encounters, or unrestricted
+  exploration actions
+- direct player control
+- remote or multi-user operation
+- a runtime user-plugin system
+- ownership of external campaign-object truth
+- procedural Dungeon generation as a core workflow
+- player interaction with the passive second-monitor output
+
+## Quality Needs
+
+- very large sparse Dungeons remain responsive; a qualification Dungeon contains at
+  least 100,000 authored cells
+- camera and hover work complete within a 16 ms p95 budget
+- editor preview completes within a 50 ms p95 budget
+- work scales with the visible or touched region rather than total off-screen
+  Dungeon content
+- a 100,000-authored-cell Dungeon presents its first usable viewport and
+  context within 2 seconds p95; remaining data may load progressively
+- heavy route, graph, and batch previews show progress within 100 ms, become
+  cancellable above 2 seconds, and do not block camera, selection, or
+  independent reads
+- an ordinary editor commit completes within 500 ms p95
+- passive player-view updates complete within 100 ms p95 after movement or a
+  visibility change
+- loading and committing expose distinct visible states
+- new authored object or tool families, a travel/time/event-rule change, and a
+  UI or persistence adapter replacement remain local and do not require changes
+  to unrelated features
+
+## Acceptance Outcomes
+
+- authoring, inspection, travel, document export, and package exchange refer to
+  the same stable authored identities
+- runtime actor state and logs do not become authored Dungeon-package content
+- no surface silently invents a second room, connection, description, or
+  passability truth
+- disconnected but locally valid Volumes and dangling Passages remain valid;
+  invalid structural geometry cannot be committed
+- the GM can understand what changed, cancel transient work, and recover safely
+  from rejected or failed operations
+- system-calculated facts remain distinguishable from GM-authored content and
+  GM-decided outcomes
+
+## References
+
+- [Dungeon Editor Requirements](./requirements-dungeon-editor.md)
+- [Dungeon Travel State Requirements](./requirements-dungeon-travel-state.md)
+- [Dungeon Travel Requirements](./requirements-dungeon-travel.md)
+- [Dungeon Domain Model](../domain/domain-dungeon.md)
+- [Actor Autonomy Requirements](../../autonomy/requirements/requirements-actor-autonomy.md)
+  ([public source](https://www.dndbeyond.com/sources/dnd/basic-rules-2014/adventuring))

--- a/docs/encounter/README.md
+++ b/docs/encounter/README.md
@@ -1,0 +1,16 @@
+# Encounter Feature README
+
+## Documentation Set
+
+- [Feature Spec](requirements/requirements-encounter.md)
+- [Domain Model](domain/domain-encounter.md)
+- [Persistence](contract/contract-encounter-persistence.md)
+- [Saved Plans Contract](contract/contract-encounter-saved-plans.md)
+- [Plan Budget Contract](contract/contract-encounter-plan-budget.md)
+- [Builder Inputs Contract](contract/contract-encounter-builder-inputs.md)
+- [Encounter State Contract](contract/contract-encounter-state.md)
+- [Generated Preparation Contract](contract/contract-encounter-generated-import.md)
+- [Architecture](architecture/architecture-encounter.md)
+- [Runtime Context Contract](contract/contract-encounter-runtime-contexts.md)
+- [Encounter Table Feature README](../encountertable/README.md)
+- [Encounter UI](requirements/requirements-encounter-state-tab.md)

--- a/docs/encounter/architecture/architecture-encounter.md
+++ b/docs/encounter/architecture/architecture-encounter.md
@@ -1,0 +1,156 @@
+# Encounter Architecture
+
+## Objective
+
+Encounter provides manual and generated roster construction while remaining the
+only owner of saved Encounter-plan truth. Generated preparation resolves one
+ordered intent batch into concrete rosters before any write and publishes the
+complete saved-plan mapping only after one successful idempotent batch commit.
+
+## Stakeholders And Concerns
+
+- Game masters need useful concrete rosters, stable saved plans, and unchanged
+  visible state when preparation fails.
+- Session Planner needs one ordered all-or-nothing batch seam and bounded
+  summary reads.
+- Party, Creatures, Encounter Table, and World Planner maintainers need their
+  facts consumed only through public APIs.
+- Encounter maintainers need one saved-plan write model shared by manual and
+  generated flows.
+
+This document owns Encounter structure and quality decisions. User-visible
+behavior belongs to requirements, write-model truth to the domain, and command,
+compatibility, and persistence semantics to contracts.
+
+## Topology And Dependency Direction
+
+```text
+features/encounter/api/
+features/encounter/domain/
+features/encounter/application/
+features/encounter/adapter/sqlite/
+features/encounter/adapter/javafx/
+features/encounter/EncounterFeature
+```
+
+Domain code depends on no API carriers, SQL, JavaFX, platform service, or
+foreign feature. Application code translates public commands and foreign API
+results, invokes Encounter policies, and depends outward only on
+feature-owned ports. SQLite and JavaFX adapters implement those ports.
+Composition is the only construction point.
+
+Encounter may consume `PartyApi`, `CreaturesApi`, `EncounterTableApi`, and
+`WorldPlannerApi`. Session Planner consumes `EncounterApi`; Encounter never
+calls Session Planner or Session Generation and never reads a foreign
+repository or table directly.
+
+Creature catalog truth is installation-owned while Encounter saved plans are
+Campaign-owned. Encounter validates and refreshes Creature references through
+`CreaturesApi`, then stores only the positive identity and a last-known display
+name snapshot. A database foreign key cannot cross those stores and is not part
+of the Encounter schema; Campaign-local parent-child truth retains ordinary
+foreign keys.
+
+## Generated-Batch Orchestration
+
+```text
+prepareGeneratedBatch(command)
+  -> validate complete ordered intent batch
+  -> load one union creature-candidate snapshot
+  -> resolve and validate every concrete roster in memory
+  -> publish complete prepared batch or one failure
+
+commitGeneratedBatch(command)
+  -> validate identity, batch fingerprint, and every EncounterPlan
+  -> write all plans, roster rows, and canonical generated origins
+  -> publish complete ordered plan mapping or one failure
+```
+
+Prepare and commit are separate because Session Planner must validate the whole
+cross-feature preparation before Encounter truth becomes durable. The prepared
+batch is transient typed state. Commit creates ordinary `EncounterPlan`
+aggregates and retains generated origin only for audit and idempotency.
+
+Manual builder generation remains an independent application use case but uses
+the same Encounter math, candidate, ranking, and saved-plan invariants. It does
+not create a second plan model or generated-batch writer.
+
+## Execution
+
+- command dispatch and immutable snapshot application are the only Encounter
+  work allowed on the JavaFX thread
+- foreign reads and SQLite work run on I/O execution
+- deterministic candidate evaluation and roster construction run on bounded
+  CPU execution
+- candidate search never runs inside a database transaction
+- cancellation stops avoidable preparation work before commit; a commit that
+  has started resolves as one complete success or failure
+- preparation is not submitted as one global serial chain
+
+## Publication Semantics
+
+Prepare publishes one complete ordered `PreparedEncounterRoster` batch or no
+applicable batch. Commit publishes one complete ordered Encounter-number-to-plan
+mapping or no mapping. A validation, resolution, conflict, cancellation, or
+storage failure does not publish a partial set and does not advance visible
+saved-plan state.
+
+Runtime builder, initiative, combat, and result state is published as immutable
+revisioned Encounter state. Generated-batch completion does not mutate those
+runtime sessions. Saved-plan summary batch reads preserve request order and
+report missing identities explicitly.
+
+## Quality Targets
+
+- one generated prepare performs one candidate-snapshot read for the complete
+  intent union; query count is independent of Encounter, CR/role-block, and
+  selected-roster-member cardinality
+- commit uses one Encounter transaction with set-based plan, roster, and origin
+  writes and exposes no partial rows
+- one workspace hydration request uses one saved-plan summary batch read rather
+  than one read per scene or plan
+- deterministic reference-input replay yields the same ordered concrete rosters for
+  the same intent batch, candidate snapshot, engine meaning, and preparation
+  identity
+- the shared warmed workload of three generated Encounters records candidate
+  load, roster construction, commit, and summary hydration separately and fits
+  within the Session Planner 2-second p95 end-to-end target over 20 runs
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- concrete creature identities and positive quantities exist for the complete
+  batch before any write
+- one union candidate snapshot supports joint deterministic selection and
+  deliberate roster diversity
+- one idempotent generated-batch commit is the publication boundary
+- manual and generated plans share `EncounterPlan` ownership and invariants
+- one canonical generated-origin representation is used for both read and
+  write; incomplete pre-completion origin shapes are invalid disposable state
+- one empty-namespace current-v1 initializer and an exact read-only schema
+  signature replace additive schema repair before feature completion
+
+Rejected alternatives:
+
+- abstract XP/role slot persistence as a saved Encounter plan
+- exact-XP point queries per slot or creature-detail reads per roster member
+- first-match selection that accidentally repeats equivalent rosters
+- one transaction per generated Encounter or a duplicate generated-origin
+  writer
+- rewards, packing, audits, session scenes, or copied creature statblocks in
+  Encounter persistence
+- cross-feature database access, JavaFX orchestration, a shared workflow
+  transaction, or compensating deletion
+- a Campaign-to-installation Creature foreign key or copied Creature catalog
+  table inside the Campaign store
+
+
+## References
+
+- [Requirements](../requirements/requirements-encounter.md)
+- [Domain](../domain/domain-encounter.md)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Encounter Persistence](../contract/contract-encounter-persistence.md)
+- [Session Planner Architecture](../../sessionplanner/architecture/architecture-session-planner.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/encounter/contract/contract-encounter-builder-inputs.md
+++ b/docs/encounter/contract/contract-encounter-builder-inputs.md
@@ -1,0 +1,43 @@
+# Encounter Builder Inputs Contract
+
+## Purpose
+
+This contract defines the builder-input surface shared by Catalog-owned pool
+filters and Encounter-owned generation tuning.
+
+## Read Surface
+
+- `EncounterApi` publishes immutable, revisioned builder input state
+- `EncounterBuilderInputs` publishes `EncounterPoolFilters` and
+  `EncounterTuningSettings` as separate immutable values
+- pool filters include name, challenge-rating range, size, type, subtype,
+  biome, alignment, encounter tables, World Planner factions, and location
+
+## Write Surface
+
+- Catalog submits `UpdateEncounterPoolFiltersCommand`
+- Encounter state submits `UpdateEncounterTuningCommand`
+- the application merges either partial update with the current focused
+  runtime context before persistence and publication
+- `UpdateEncounterBuilderInputsCommand` is the application-internal atomic
+  replacement primitive used to persist one already merged complete snapshot;
+  workflow consumers submit the partial commands above
+
+## Boundary Rules
+
+- the contract is workflow-oriented, not a mirror of the internal encounter
+  session carrier
+- late update results must not overwrite a newer published revision
+- a pool-filter update MUST preserve tuning and a tuning update MUST preserve
+  pool filters
+- all visible pool filters constrain candidate loading; selected Encounter
+  tables are intersected with the filtered creature pool
+- it does not expose saved plans, roster cards, initiative rows, combat
+  runtime, or result state
+- it does not expose foreign creature, party, or encounter-table internals
+- Auto difficulty and Auto tuning stay public request language only
+
+## References
+
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Encounter UI](../requirements/requirements-encounter-state-tab.md) (line 1)

--- a/docs/encounter/contract/contract-encounter-generated-import.md
+++ b/docs/encounter/contract/contract-encounter-generated-import.md
@@ -1,0 +1,112 @@
+# Encounter Generated Preparation Contract
+
+## Purpose And Ownership
+
+Encounter owns the conversion of one ordered Session Generation intent batch
+into concrete saved Encounter rosters. Session Planner is the consumer. The
+boundary contains no rewards, packing, audits, session scenes, repository
+types, or persistence rows.
+
+## Public Operations
+
+```text
+prepareGeneratedBatch(PrepareGeneratedEncounterBatchCommand)
+  -> PreparedGeneratedEncounterBatchResult
+
+commitGeneratedBatch(CommitGeneratedEncounterBatchCommand)
+  -> CommittedGeneratedEncounterBatchResult
+
+loadGeneratedPlanSummaries(GeneratedEncounterPlanSummaryBatchQuery)
+  -> GeneratedEncounterPlanSummaryBatchResult
+```
+
+All operations are asynchronous. The summary query accepts unique Encounter
+plan identities and returns existing structured summaries in request order,
+with missing identities reported explicitly rather than omitted.
+
+Summary hydration captures the current active Party composition once and
+loads one complete current Creature facts snapshot for the union of referenced
+creature IDs. It derives base XP, adjusted XP, and difficulty from those two
+current inputs. Stored display names are last-known fallbacks only; resolvable
+current Creature names take precedence. A missing plan and a plan whose current
+creature facts cannot be resolved remain distinct ordered result states.
+
+The prepare command contains a stable preparation identity, generation-run
+identity, declared engine version, and an ordered non-empty list of intents.
+Each intent has one unique positive Encounter number, display label, target XP,
+difficulty, and non-empty ordered CR-and-role blocks with positive quantity and
+XP.
+
+## Batch Resolution
+
+Encounter validates the whole command, then obtains one immutable creature
+candidate snapshot containing all fields needed to resolve the batch. It does
+not query exact XP once per block or load creature detail once per selected
+member.
+
+Encounter-owned deterministic policy resolves the intents jointly. It may
+reuse candidates across Encounters unless a declared source constraint forbids
+that, but it avoids accidental identical rosters when equivalent alternatives
+exist. Role and CR are selection inputs, not persisted creature truth.
+
+Success returns one `PreparedEncounterRoster` per intent in request order. Each
+contains:
+
+- Encounter number and normalized roster fingerprint
+- concrete stable creature identities, quantities, and display names
+- total creature count, adjusted XP, difficulty, and display summary
+
+Prepare performs no persistence write. If any intent is invalid or
+unresolvable, it returns no roster draft.
+
+## Atomic Commit And Retry
+
+Commit accepts the stable preparation and generation-run identities plus the
+complete prepared batch. It revalidates batch identity, roster fingerprints,
+and saved-plan invariants, then inserts every plan, roster row, and
+generated-origin row in one Encounter transaction.
+
+Generated batch identity is unique by `(engineVersion, preparationIdentity)`
+and stores the normalized batch fingerprint and cardinality. An identical
+completed retry returns the existing ordered mapping without duplicate plans.
+A subset, superset, reordered batch, partial stored origin, or mismatched
+fingerprint returns `CONFLICT` and writes nothing.
+
+Success returns exactly one Encounter plan ID and structured saved-plan summary
+per Encounter number. No partial mapping is returned.
+
+## Status And Errors
+
+Statuses are `SUCCESS`, `INVALID_REQUEST`, `UNRESOLVABLE`, `CONFLICT`, and
+`STORAGE_FAILURE`. Display-safe messages contain no SQL, exception text, paths,
+catalog payloads, or creature detail. Non-success returns no applicable draft
+or committed mapping.
+
+## Persistence And Current Format
+
+Saved plans retain optional generated origin, normalized roster fingerprint,
+declared batch cardinality, and order. Manual plans have no generated origin.
+Deleting or changing a Session Generation run does not cascade into Encounter.
+
+Preparation commits and reads use one canonical generated-origin
+representation containing preparation identity, engine version,
+generation-run identity, and a concrete roster fingerprint. Missing canonical
+identity fields make an internal pre-completion record invalid; no historical
+origin derivation, second writer, dual write, or compatibility carrier is part
+of this contract.
+
+## Performance Contract
+
+- one candidate snapshot read serves the complete prepared batch
+- persistence uses one transaction and set-based row writes
+- `loadGeneratedPlanSummaries` hydrates the complete requested identity set as
+  one batch operation
+- read query count is bounded by data family, not Encounter, block, or roster
+  member count
+
+## References
+
+- [Encounter Domain](../domain/domain-encounter.md)
+- [Encounter Persistence](contract-encounter-persistence.md)
+- [Session Generation Contract](../../sessiongeneration/contract/contract-session-generation.md)
+- [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md)

--- a/docs/encounter/contract/contract-encounter-persistence.md
+++ b/docs/encounter/contract/contract-encounter-persistence.md
@@ -1,0 +1,126 @@
+# Encounter Persistence
+
+This document is normative for the `encounter` feature's saved-plan
+persistence path.
+
+## Adapter Boundary
+
+- The encounter SQLite adapter satisfies encounter-owned application ports and
+  remains private to the encounter composition entry point.
+- The application composition supplies `EncounterApi` explicitly; registry,
+  discovery, repository, gateway, mapper, and schema types are not public
+  boundaries.
+- SQL records and adapter failures MUST NOT cross `EncounterApi`.
+
+## Mandatory Schema
+
+- The feature-owned persistence schema declaration is the canonical in-code
+  schema owner.
+- The schema owns:
+  - `saved_encounter_plans`
+  - `saved_encounter_plan_creatures`
+  - `generated_encounter_plan_batches`
+  - `generated_encounter_plan_origins`
+- `saved_encounter_plans` stores plan identity, display name, generated label,
+  and timestamps.
+- `saved_encounter_plan_creatures` stores ordered creature identity, quantity,
+  and the last-known display name captured when the plan was saved. Creature
+  identity is a positive external reference validated through `CreaturesApi`
+  before it enters prepared Encounter truth; the Encounter row retains that ID
+  and display-name snapshot but does not duplicate statblocks.
+- `generated_encounter_plan_batches` stores the immutable source identity,
+  normalized batch fingerprint, and declared encounter cardinality.
+- `generated_encounter_plan_origins` stores the stable batch order,
+  encounter number, normalized spec fingerprint, and saved-plan reference.
+
+## Saved-Plan Mapping
+
+This contract governs only the saved-plan and generated-batch payload. That
+payload stores saved encounter-plan roster truth and does not contain:
+
+- generated-alternative lists
+- active generator filters
+- initiative values
+- combat HP or turn order
+- defeated-result state
+- loot or XP-award resolution
+
+Initiative, combat, and result state for a running Encounter are separate
+Encounter-owned runtime-context truth. They are persisted relationally under
+the [Encounter Runtime Context Contract](contract-encounter-runtime-contexts.md)
+and MUST NOT be copied into a saved-plan or generated-batch payload.
+
+Optional generated origin consists only of engine version, preparation and
+generation-run identities, normalized batch and roster fingerprints and
+cardinality, encounter order and number, normalized-intent fingerprint, and
+saved-plan reference. It does not copy a Session Generation result.
+Preparation-level uniqueness plus ordered origin uniqueness makes identical
+completed commits idempotent and makes subset, superset, reordered, relabeled,
+or changed-roster retries distinguishable.
+
+The Encounter SQLite adapter maps private rows into `EncounterPlan` aggregate
+values. The stored name remains a last-known fallback; current creature facts
+are reloaded through one `CreaturesApi` ID-union snapshot when summaries are
+requested. Base XP, adjusted XP, and difficulty are derived for that read from
+the current active Party composition and current Creature facts. Those derived
+summary values are not persisted as historical truth.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared current target schema
+signature exactly, including columns, declared types, nullability, defaults,
+primary and foreign keys, checks, table flags, and named or automatic indexes.
+Semantic row validation remains on typed provider read/write paths and fails
+closed through the feature contract. Compatibility obligations begin with the
+first released format.
+Before the first released format, the current owner target is v1; its one construction
+step requires an empty Encounter namespace, creates the complete fresh
+current-format schema, and carries no obligation to read, repair, convert, or
+preserve an earlier development format. An unversioned partial namespace, a
+different owner version, or a current-format store with an invalid target
+signature fails closed without schema or row repair.
+
+- encounter-plan writes MUST reject empty or malformed roster rows instead of
+  silently persisting partial encounter truth
+- the Campaign database MUST NOT declare a foreign key from an Encounter row
+  to installation-owned Creature storage; only Encounter-owned parent-child
+  relationships are enforced within the Campaign transaction
+- generated alternatives, initiative state, combat HP, result state, and loot
+  state MUST be rejected from the saved-plan and generated-batch payload;
+  runtime-context persistence remains governed separately
+- schema-readiness and storage failures MUST surface through Encounter API
+  result statuses rather than leaking SQLite exceptions to consumers
+- one generated batch MUST insert all plan roots, roster rows, and origin data
+  in one transaction; any failure MUST leave no member of the batch visible
+- a partial existing origin set, mismatched cardinality, reordered request, or
+  mismatched batch or spec fingerprint MUST fail closed instead of guessing or
+  creating duplicate plans
+
+## Stability Rules
+
+- The saved-plan write port remains an internal collaborator injected by the
+  encounter composition entry point.
+- Saved-plan storage remains encounter-owned even when generated plans are
+  built from party, creatures, or encounter-table source data.
+- Creature identity validation and current-fact refresh cross the public
+  `CreaturesApi`; neither Encounter schema initialization nor saved-plan reads
+  attach, query, or constrain the installation database.
+- The persistence adapter accepts the already-resolved reference and enforces
+  its positive identity, positive quantity, deterministic order, and snapshot
+  shape inside the Campaign transaction; it does not perform a second foreign
+  database lookup during that transaction.
+- Generated-origin and saved-plan truth share the one current-format
+  Encounter-owned schema; they MUST NOT create parallel stores or duplicate
+  mutable plan truth.
+- After the first released format, support for an earlier format belongs in an
+  explicit owning compatibility contract.
+  This contract grants no compatibility by itself.
+
+
+## References
+
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Encounter Feature Spec](../requirements/requirements-encounter.md) (line 1)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Generated Import Contract](contract-encounter-generated-import.md)
+- [Encounter Runtime Context Contract](contract-encounter-runtime-contexts.md)

--- a/docs/encounter/contract/contract-encounter-plan-budget.md
+++ b/docs/encounter/contract/contract-encounter-plan-budget.md
@@ -1,0 +1,41 @@
+# Encounter Plan Budget Contract
+
+## Purpose
+
+This contract defines the encounter-owned planning surface used by
+SessionPlanner to read one saved encounter plan as worker-facing planning
+facts.
+
+## Read Surface
+
+- `EncounterApi` provides a typed saved-plan planning operation returning one
+  `EncounterPlanFact`
+
+## Payload
+
+- `EncounterPlanFact`
+  returns availability, saved-plan identity, label, creature count, total base
+  XP, adjusted XP, multiplier, difficulty label, and status text
+
+## Status Semantics
+
+- `available = true`
+  the saved plan and active party were available and a planning fact was
+  produced
+- `available = false`
+  the saved plan, party data, or required creature detail could not be loaded,
+  or the plan id was invalid or missing
+
+## Boundary Rules
+
+- the planning payload is read-only
+- the service does not expose encounter persistence rows directly
+- creature XP stays creature-owned and is reloaded through creature detail
+  reads instead of being duplicated into encounter-plan persistence
+- SessionPlanner consumes the facts through `EncounterApi`, supplied during
+  explicit application composition
+
+## References
+
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md) (line 1)

--- a/docs/encounter/contract/contract-encounter-runtime-contexts.md
+++ b/docs/encounter/contract/contract-encounter-runtime-contexts.md
@@ -1,0 +1,52 @@
+# Encounter Runtime Context Contract
+
+## Purpose And Boundary
+
+Encounter owns the mutable builder, initiative, combat, and result state of
+each running context. Scene owns which contexts exist, their focus, assigned
+PCs, location, initial prepared plan, and NPC role facts. Synchronization MUST
+NOT transfer Encounter-owned runtime state back to Scene.
+
+## API Surface
+
+`EncounterRuntimeContextApi.synchronize` accepts one complete context set with
+a monotonically increasing source revision, one focused typed context ID, and
+immutable foreign facts per context. The operation is asynchronous. IDs MUST
+be non-blank and unique, the set MUST be non-empty, and the focused ID MUST be
+present.
+
+A newer revision creates missing contexts, updates foreign facts without
+overwriting existing runtime state, removes contexts absent from the complete
+set, and changes focus atomically. A revision not newer than the accepted
+revision returns `STALE_IGNORED`. Invalid sets return `INVALID`; persistence
+failure returns `STORAGE_ERROR`. Scene retries failed synchronization after
+initialization or refresh.
+
+Hostile NPC facts enter the context as enemies, friendly facts enter as allies,
+and neutral facts remain outside combat. The first synchronization of a new
+context MAY open its initial saved plan; later synchronizations MUST NOT reset
+the runtime to that plan.
+
+## Persistence And Current-Format Integrity
+
+Encounter's current declared schema target owns the context root, foreign-fact
+children, builder values, roster and tags, initiative entries, combatants, and
+result enemies. Before the first released format,
+its internal version and construction steps identify only this current target
+and create no obligation to consume or preserve an earlier development format.
+Collections are stored in named relational tables; opaque payloads and text
+codecs are not current-format storage. Cross-feature identifiers are stable
+values and MUST NOT use cross-owner foreign keys.
+
+Replacing the complete context set and all changed runtime rows occurs in one
+SQLite transaction. Saved-plan and runtime-context truth remain distinct in the
+same current Encounter format. A store outside the declared target fails closed
+under the shared persistence lifecycle. After the first released format, any older
+released-format handling must be defined by its owning compatibility contract.
+
+
+## References
+
+- [Encounter Requirements](../requirements/requirements-encounter.md)
+- [Scene Requirements](../../scene/requirements/requirements-scene.md)
+- [Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)

--- a/docs/encounter/contract/contract-encounter-saved-plans.md
+++ b/docs/encounter/contract/contract-encounter-saved-plans.md
@@ -1,0 +1,42 @@
+# Encounter Saved Plans Contract
+
+## Purpose
+
+This contract defines the encounter-owned saved-plan chooser surface consumed
+by SessionPlanner.
+
+## Search Surface
+
+- `EncounterApi.searchSavedPlans(SearchSavedEncounterPlansQuery)` is the typed,
+  demand-driven chooser operation
+- queries are trimmed and case-normalized; fewer than two characters are an
+  invalid request and perform no persistence read
+- a successful result exposes at most eight ordered
+  `SavedEncounterPlanSearchHit` values plus `hasMore`
+- each hit contains only the stable plan id, name, and one Encounter-owned
+  `summaryText` display line
+- matching covers the saved name and generated label, treats `%` and `_` as
+  literal characters, and uses deterministic newest-first ordering with plan
+  identity as the tie-breaker
+- the SQLite adapter reads at most nine roots in one parameterized statement;
+  the ninth root establishes `hasMore` and is never published as a hit
+
+## Boundary Rules
+
+- search is read-only and does not publish or transport the global saved-plan
+  catalog
+- encounter owns the summary-text formatting and supplies it as a thin chooser
+  display form
+- results are returned through `EncounterApi`; there is no second reply channel
+- search does not expose encounter persistence rows directly
+- creature detail remains creature-owned and does not appear in the summary
+- generated-origin plans appear through the same chooser surface as manual
+  plans; origin metadata is not a chooser label or a second plan kind
+- concrete roster and XP hydration remains a separate bounded summary read for
+  the selected result identities; search hits are not copied Encounter detail
+
+## References
+
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md) (line 1)
+- [Generated Import Contract](contract-encounter-generated-import.md)

--- a/docs/encounter/contract/contract-encounter-state.md
+++ b/docs/encounter/contract/contract-encounter-state.md
@@ -1,0 +1,36 @@
+# Encounter State Contract
+
+## Purpose
+
+This contract defines the public runtime workflow surface used by the encounter
+state tab.
+
+## Read Surface
+
+- `EncounterApi` publishes immutable, revisioned encounter workflow state for
+  the builder, initiative, combat, and resolution panes plus one status line
+- consumers may read the current state and observe later revisions without
+  depending on an implementation-owned model handle
+
+## Write Surface
+
+- `ApplyEncounterStateCommand` submits workflow actions such as generate, save
+  current plan, open saved plan, roster edits, initiative confirmation, combat
+  mutations, XP award, and refresh through `EncounterApi`
+
+## Boundary Rules
+
+- the contract is view-facing workflow language, not a transport mirror of
+  `EncounterSession`
+- readback and commands share the typed Encounter API while remaining separate
+  operations
+- builder filters live in the separate builder-input contract
+- planner-facing saved-plan list and plan-budget reads stay separate from this
+  state-tab workflow contract
+- commands mutate the encounter runtime session only; they do not expose data
+  storage rows or foreign feature internals
+
+## References
+
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Encounter UI](../requirements/requirements-encounter-state-tab.md) (line 1)

--- a/docs/encounter/domain/domain-encounter.md
+++ b/docs/encounter/domain/domain-encounter.md
@@ -1,0 +1,126 @@
+# Encounter Domain Model
+
+## Context Role And Ownership
+
+Context Name: `Encounter`
+
+Context Role: Roster Truth Context
+
+Encounter owns saved encounter-plan roster truth and encounter-generation
+policy. Party membership, creature facts, encounter-table membership, World
+Planner facts, Session Generation rewards, and Session Planner scenes remain
+foreign truth.
+
+## Published Language
+
+`EncounterApi` publishes Encounter-owned immutable language for:
+
+- `EncounterPlanId`, `EncounterPlan`, saved-plan summaries, and planning facts
+- difficulty bands, thresholds, tuning choices, candidate diagnostics, and
+  generated alternatives
+- revisioned builder, initiative, combat, and result runtime state
+- ordered generated intents, prepared concrete roster summaries, generated
+  batch outcomes, and Encounter-number-to-plan mappings
+
+Public commands and foreign API results are translated before they enter
+Encounter policies or the write model. API carriers, repositories, persistence
+rows, and foreign internal models are not Encounter domain truth.
+
+## Write Model
+
+`EncounterPlan` is the Encounter write model and aggregate root. It owns:
+
+- stable plan identity
+- user-visible plan name and optional generated encounter label
+- ordered `EncounterPlanCreature` values containing creature identity,
+  quantity, and last-known display name
+- optional immutable generated origin identifying the preparation, generation
+  run, engine meaning, Encounter number, and normalized roster
+
+An `EncounterPlan` contains at least one creature. It does not embed creature
+statblocks, party members, initiative, combat HP, generated rewards, packing,
+audits, session scenes, or dungeon placement.
+
+Generated preparation carriers translate a complete proposed batch into
+ordinary `EncounterPlan` aggregates. They are not a second write model.
+
+## Derived And Runtime State
+
+Encounter derives:
+
+- active-party difficulty thresholds and daily-budget context
+- candidate pools constrained by filters, encounter tables, World Planner
+  sources, and finite stock caps
+- role hints, ranked alternatives, fallback advice, and generation diagnostics
+- party-specific planning facts for saved plans
+- prepared concrete generated-roster batches
+
+Generated alternatives and prepared batches remain transient until saved. The
+current builder, initiative, combat, and result session state is Encounter-owned
+runtime state, not persisted `EncounterPlan` truth and not view-owned mutable
+state.
+
+## Mutation Language
+
+Encounter supports:
+
+- generate encounter alternatives
+- save the current roster as an Encounter plan
+- load or list saved Encounter plans
+- prepare one ordered generated-intent batch as concrete rosters
+- commit one complete prepared batch as saved Encounter plans
+
+## Invariants
+
+- the active party is the balancing baseline for runtime generation
+- encounter math uses current public Party facts rather than copied Party truth
+- selected encounter tables replace creature-filter sourcing for that pass
+- selected World Planner sources may narrow encounter tables and stock caps but
+  do not transfer World Planner ownership
+- Auto difficulty and tuning resolve deterministically from the generation
+  seed and request meaning before alternatives are enumerated
+- a non-empty candidate pool with no viable roster is distinct from an empty
+  candidate pool
+- ranking is deterministic for the same inputs
+- saved plans contain at least one concrete creature identity with positive
+  quantity and never own creature statblocks
+- generated origin is unique for one engine meaning, preparation identity, and
+  Encounter number
+- every generated intent resolves to one concrete non-empty roster before any
+  plan from the batch becomes durable
+- the complete generated batch is all-or-nothing and an identical completed
+  retry denotes the same saved plans
+- generated origin never transfers reward, packing, audit, or session-scene
+  ownership into Encounter
+
+## Domain Policies
+
+- difficulty evaluation uses party thresholds and monster-count multipliers
+- candidate filtering may narrow by creature type, subtype, biome, selected
+  tables, World Planner sources, and finite stock
+- tuning may prefer different creature counts, XP spread, and statblock
+  diversity
+- Auto generation tries a neutral configuration and then a bounded seeded set
+  of alternatives
+- when no exact difficulty match exists but valid rosters do, the best-ranked
+  fallback is returned with an advisory
+- role hints are heuristic derived state and never persisted creature truth
+- saved plans preserve roster composition only; combat state is never plan
+  truth
+
+## Consistency Boundary
+
+One `EncounterPlan` is the manual-save consistency boundary. One generated
+batch is a larger all-or-nothing consistency boundary containing multiple
+ordinary Encounter plans with immutable generated origins. Opening a plan
+rebuilds runtime state from current creature detail and clears prior initiative,
+combat, result, and generated-alternative runtime state.
+
+## References
+
+- [Feature Requirements](../requirements/requirements-encounter.md)
+- [Encounter Persistence](../contract/contract-encounter-persistence.md)
+- [Encounter Saved Plans Contract](../contract/contract-encounter-saved-plans.md)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Architecture](../architecture/architecture-encounter.md)
+- [Encounter Runtime UI](../requirements/requirements-encounter-state-tab.md)

--- a/docs/encounter/requirements/requirements-encounter-state-tab.md
+++ b/docs/encounter/requirements/requirements-encounter-state-tab.md
@@ -1,0 +1,147 @@
+# Encounter Runtime State UI
+
+The Builder mode exposes difficulty, balance, amount, and diversity in an
+`Encounter abstimmen` section. The section is collapsed by default and writes
+only `EncounterTuningSettings`; Catalog pool filters remain unchanged.
+
+## Component Purpose
+
+The Encounter state tab owns the compact encounter dialog shown in the
+global `COCKPIT_STATE` pane when the active left-bar tab does not provide its
+own state content.
+
+The dialog visually mirrors the original Salt-Marcher encounter state-pane
+workflow in one local state-tab surface:
+
+- encounter creation
+- saved encounter open/save
+- initiative entry
+- combat tracking
+- combat result resolution
+- return to encounter creation
+
+The creature catalog browser and encounter filter/tuning controls are separate
+left-bar tab content. They publish add-creature, filter, difficulty intent, and
+generator tuning signals to this dialog through runtime session state.
+
+## Visible Surfaces
+
+Current state:
+
+- `Creation` shows the original compact encounter roster dialog: title row,
+  difficulty and party summary, difficulty meter, thresholds, adjusted XP,
+  roster cards, saved-plan actions, previous/next alternative controls, and
+  generate/start actions.
+- `Initiative` shows one editable initiative row for each party member and
+  encounter creature.
+- `Combat` shows round status, combat cards, HP bars, AC and initiative badges,
+  next-turn controls, and a two-step end-combat confirmation.
+- `Resolution` shows defeated-enemy selection, XP and loot summaries, reward
+  controls, and the action that returns to encounter planning. Its enemy list
+  is part of the page body, not a nested list window.
+
+The state pane uses centralized encounter selector roles for difficulty labels,
+the difficulty meter, roster cards, role badges, initiative rows, combat card
+states, HP bars, AC/init badges, edit popups, and result highlights. It reads
+active-party thresholds through the Encounter feature boundary and resolves
+creature details through the Creatures feature boundary.
+Encounter pages use the shared dialog-surface primitive so page actions stay in
+the fixed footer while oversized page bodies scroll.
+
+## Interactions
+
+- `Generieren` creates ranked encounter alternatives from the active party and
+  the latest catalog type, subtype, biome, difficulty, amount, balance, and
+  diversity selections. Auto difficulty or Auto tuning values are resolved by
+  the generator for that request and reported in the generation status line.
+  When catalog encounter tables are selected, generation uses those table IDs
+  instead of the type, subtype, and biome candidate source.
+- Previous and next controls sit in the generator action row and switch among
+  the currently generated alternatives.
+- `Speichern` stores the current roster as a saved encounter plan.
+- `Öffnen` shows saved encounter plans from the title row. Selecting one
+  replaces the builder roster, returns to Creation mode, and clears generated
+  alternatives, initiative, combat, and result state.
+- `Verlauf löschen` in the title row clears only transient generator history
+  and
+  generated labels. The current roster stays in Creation mode as a manual
+  encounter.
+- Catalog `+Add` actions append the selected creature to the runtime roster in
+  creation mode and add the selected creature as a reinforcement in active
+  combat.
+- Roster `+`, `-`, and remove controls adjust slot quantity or remove a slot;
+  a single undo action can restore the most recently removed slot.
+- A roster creature name opens the creature details inspector.
+- `Kampf starten` opens initiative entry when the roster has creatures.
+- `Alle würfeln` updates visible initiative spinner values.
+- Confirming initiative opens the combat tracker.
+- Combat internally keeps one entry per individual monster. A combat card may
+  still show a runtime mob projection when at least four alive monsters share
+  the same creature identity and initiative.
+- `Weiter` advances the active combat turn and round display.
+- `SC hinzufügen` opens a compact popup for active party members that are not
+  already in the running combat; each row accepts an initiative value before
+  adding that character to the turn order.
+- HP bars open a compact damage/heal popup.
+- Initiative badges open a compact set-initiative popup.
+- `Kampf beenden` requires a second confirmation before showing results.
+- `XP verteilen` awards the current per-player XP result to the active party.
+- `Zum Planer` closes the combat result screen and returns to encounter
+  planning.
+
+## Visible States
+
+- Empty roster: the creation view mirrors the original `+Add` placeholder and
+  can be populated through catalog `+Add` or `Generieren`.
+- Generated roster: difficulty, thresholds, adjusted XP, generator title, and
+  creature cards are visible.
+- Auto-resolved generation: the generated roster shows the resolved difficulty
+  through the difficulty label and adjusted XP summary.
+- Saved plan available: the title-row open action is enabled and shows the
+  saved plan name, generated label, and creature count.
+- Encounter-table loot conflict: the Catalog controls show `Loot-Konflikt`;
+  combat start remains available because loot assignment is not part of this
+  runtime surface.
+- Removed roster slot: a one-action undo notice is visible until another roster
+  or generator mutation replaces it.
+- Live combat: the active turn is highlighted and defeated monsters use the
+  dead-card style.
+- Combat reinforcement: catalog `+Add` creates a new combat monster without
+  mutating the creation roster, preserves the current active turn highlight,
+  and includes the reinforcement in result XP eligibility.
+- Missing combat party member: the add-SC action is disabled when every active
+  party member is already represented, and adding an SC preserves the current
+  active turn highlight.
+- Runtime mob combat: three or fewer matching monsters stay as individual
+  cards, four to ten matching monsters become one `xN` mob card, and larger
+  matching groups split into mob cards of four to ten members. Mob damage
+  spills into the lowest-HP members first, mob healing restores the lowest-HP
+  alive member, and mob initiative edits apply to every member in that mob
+  card.
+- All enemies defeated: the end-combat button receives accent emphasis.
+- Results awarded: the XP action becomes disabled and the status line confirms
+  the party award.
+
+## Acceptance Criteria
+
+- when the active left-bar tab does not claim `COCKPIT_STATE`, the global
+  Encounter state tab owns the compact encounter dialog in that pane
+- generation uses the active party plus the latest catalog filter, difficulty,
+  tuning, and encounter-table selections visible to the runtime session
+- opening a saved encounter plan replaces the current creation roster and
+  clears generated-alternative, initiative, combat, and result runtime state
+- the title-row `Verlauf löschen` action removes transient generation history
+  without
+  deleting the current roster
+- catalog `+Add` appends creatures in creation mode and adds reinforcements in
+  active combat without mutating saved encounter-plan persistence implicitly
+- combat start is unavailable until a non-empty roster exists
+- live combat keeps per-member runtime state even when the UI aggregates
+  matching monsters into mob cards for display
+- awarding XP disables the award action for the current result state and keeps
+  the return-to-planner action available
+
+## References
+
+- [Encounter Feature Spec](requirements-encounter.md)
+- [Encounter Domain Model](../domain/domain-encounter.md)

--- a/docs/encounter/requirements/requirements-encounter.md
+++ b/docs/encounter/requirements/requirements-encounter.md
@@ -1,0 +1,111 @@
+# Encounter Feature Spec
+
+## Goal
+
+Provide a runtime encounter builder that:
+
+- uses the active party as the balancing baseline
+- generates several encounter alternatives for one requested or automatically
+  resolved difficulty band
+- explains why an alternative fits the target
+- lets catalog creature rows build a manual encounter roster
+- saves and opens created encounter rosters as persistent encounter plans
+- can use selected encounter tables as curated generator sources
+- resolves one ordered group of Session Generation intents into concrete
+  creature rosters and makes the complete group available as saved plans
+
+## Non-Goals
+
+- saving initiative, combat HP, defeated state, XP-result state, or loot-result
+  state as part of an encounter plan
+- room-aware dungeon population
+- owning Session Generation runs, generated rewards, or Session Planner scenes
+
+## Primary User Flow
+
+1. The user opens the encounter state tab when the active left-bar tab is not
+   claiming the state pane.
+2. The state tab reads the active party and current creature filter options.
+3. The user selects Auto or an explicit difficulty and optional type, subtype,
+   biome filters, tuning controls, or encounter tables.
+4. The user generates encounter alternatives or manually adds catalog
+   creatures.
+5. The user switches among generated alternatives with previous/next controls.
+6. The user saves the current roster as an encounter plan, or opens a saved
+   plan into the builder.
+7. The user starts initiative and combat from the current builder roster.
+
+Generated preparation is a separate Session Planner-driven flow:
+
+1. Session Planner requests a complete ordered group of generated encounters.
+2. Encounter resolves every requested encounter into a concrete roster while
+   preserving request order.
+3. Success makes the complete group available as saved plans; failure leaves
+   the previously visible saved-plan set unchanged.
+
+## Expected Capabilities
+
+- show active-party thresholds for easy, medium, hard, and deadly encounters
+- show daily-budget context from the party feature
+- generate multiple ranked alternatives instead of one opaque result
+- support multi-select creature filters with visible active-filter chips
+- support generator tuning for creature amount, XP-spread balance, and
+  statblock diversity
+- support Auto difficulty and Auto tuning for amount, XP-spread balance, and
+  statblock diversity, with the resolved choices visible in diagnostics
+- return compact generation diagnostics with resolved difficulty, resolved
+  tuning, solution quality, search stop category, candidate-pool size,
+  attempt count, and candidate-evaluation count
+- return best fallback encounter options with an advisory when no exact target
+  difficulty can be generated from the available candidates
+- support encounter-table selection as an alternate generator source
+- support World Planner faction and location source IDs as generator
+  constraints, including table-source intersection and finite stock caps
+- show a non-blocking `Loot-Konflikt` warning when selected encounter tables
+  reference multiple linked loot-table IDs
+- expose creature composition, role hints, and generator highlights
+- allow catalog creature rows to be added directly to the current encounter
+  roster as runtime derived state
+- save the current roster as a persistent encounter plan
+- list saved encounter plans from the encounter title row
+- open a saved encounter plan into Creation mode and clear initiative, combat,
+  result, and generated-alternative runtime state
+- return concrete creature identities, quantities, display names, total count,
+  adjusted XP, and difficulty in every prepared roster summary
+- list and open generated rosters through the same saved-plan interaction as
+  manually saved rosters
+
+## Acceptance Criteria
+
+- saved encounter plans reopen with the same creature identities, quantities,
+  display names, and generated label while showing current creature detail
+- generated alternatives remain derived runtime output until explicitly saved
+- a party with no active members yields a clear empty-state message
+- generator output includes adjusted XP and a difficulty-band label
+- Auto generation exposes the resolved difficulty and tuning through result
+  diagnostics without changing the generated encounter roster ownership model
+- a non-empty candidate pool that cannot produce a composition yields
+  `NO_SOLUTION`; an empty candidate pool remains `NO_CREATURES`
+- previous and next actions switch generated alternatives in place
+- selecting encounter tables limits generated candidates to those tables and
+  ignores type, subtype, and biome filters for that generation run
+- selecting World Planner factions or a World Planner location constrains
+  generation to the source tables available through those sources and prevents
+  generated statblock counts from exceeding finite faction stock caps
+- opening a saved plan replaces the builder roster and returns the state tab to
+  Creation mode
+- generated preparation publishes every concrete roster in request order or
+  publishes none of them
+- invalid, unresolvable, or failed generated preparation leaves the previously
+  visible saved-plan set unchanged
+- retrying an identical completed preparation creates no visible duplicate
+  plans
+
+## References
+
+- [Encounter Runtime State UI](requirements-encounter-state-tab.md) (line 1)
+- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
+- [Encounter Persistence Contract](../contract/contract-encounter-persistence.md) (line 1)
+- [Encounter Table Feature Spec](../../encountertable/requirements/requirements-encountertable.md) (line 1)
+- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Architecture](../architecture/architecture-encounter.md)

--- a/docs/encountertable/README.md
+++ b/docs/encountertable/README.md
@@ -1,0 +1,29 @@
+# Encounter Table Feature README
+
+## Purpose
+
+The encounter table feature owns read-only access to authored encounter-table
+membership. It lets runtime encounter generation use curated creature pools
+without making the encounter generator own catalog persistence.
+
+## Documentation Set
+
+- [Encounter Table Spec](requirements/requirements-encountertable.md)
+- [Encounter Table Domain Model](domain/domain-encountertable.md)
+- [Encounter Table Persistence](contract/contract-encountertable-persistence.md)
+- [Encounter Feature Spec](../encounter/requirements/requirements-encounter.md)
+- [Catalog Tab UI](../creatures/requirements/requirements-creatures-catalog.md)
+
+## Scope
+
+In scope:
+
+- list encounter table summaries
+- expose linked loot-table identifiers as read-only warning context
+- load weighted encounter-generation candidates for selected table IDs
+
+Out of scope:
+
+- table editor and CRUD flows
+- loot-table assignment UI
+- persisted generated encounters

--- a/docs/encountertable/contract/contract-encountertable-persistence.md
+++ b/docs/encountertable/contract/contract-encountertable-persistence.md
@@ -1,0 +1,78 @@
+# Encounter Table Persistence
+
+This document is normative for the `encountertable` feature's persistence path.
+
+## Adapter Boundary
+
+- The encounter-table SQLite adapter satisfies feature-owned application ports
+  and remains private to the encounter-table composition entry point.
+- The application composition supplies `EncounterTableApi` explicitly; no
+  registry, discovery convention, port implementation, or adapter type is a
+  public boundary.
+- SQL rows and adapter failures MUST NOT cross `EncounterTableApi`.
+
+## Mandatory Schema
+
+- The feature-owned persistence schema declaration is the canonical in-code
+  schema owner.
+- The schema owns:
+  - `encounter_tables`
+  - `encounter_table_entries`
+  - `encounter_table_loot_links`
+
+Creature and loot-table identifiers are logical references. The Encounter
+Table schema MUST use foreign keys only between its own tables; it MUST NOT bind
+startup, deletion, or repair to a Creatures- or Loot-owned table.
+
+## Read Path Responsibilities
+
+- the shared platform owns connection lifecycle; the Encounter Table SQLite
+  adapter owns feature schema readiness, SQL, and row translation
+- one feature-owned read port separates application orchestration from SQLite
+  mechanics
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
+
+- schema readiness MUST be verified before encounter-table lookups return
+  successful results
+- malformed table rows, entry rows, or loot-link rows MUST become
+  storage-failure results instead of synthesized candidate truth
+- optional loot-link reads MAY be absent, but storage failures MUST surface
+  through encounter-table-owned result statuses rather than leaking SQLite
+  exceptions
+
+## Stability Rules
+
+- Target Encounter Table persistence returns only table-owned membership, creature
+  IDs, weights, summaries, and optional loot-link IDs. It MUST NOT read or join
+  Creatures-owned rows.
+- The application layer resolves creature facts through `CreaturesApi` and
+  combines them with table-owned weights for candidate results.
+- Optional loot links are warning context only and do not block encounter
+  generation.
+
+## Compatibility And Migration
+
+Compatibility obligations begin with the first released format.
+Before the first released format, Encounter Table supports exactly the current schema at
+owner version 1. One guarded initializer creates the complete target in an
+empty owner namespace. There is no predecessor import, partial-schema repair,
+copy/drop conversion, backfill, or cross-owner repair.
+
+The exact owner inventory covers every table, index, view, and trigger named
+with `encounter_table` or `idx_encounter_table`. An unversioned partial
+namespace, a recorded version-1 shape that differs from the exact current DDL,
+an adjacent retired owner object, or a newer owner version MUST fail without
+mutating rows, schema objects, or ledger state. Initialization failure MUST NOT
+fabricate a ledger entry. Until activation, unsupported development databases
+are reinitialized rather than migrated.
+
+
+## References
+
+- [Encounter Table Domain Model](../domain/domain-encountertable.md) (line 1)
+
+- [Encounter Table Feature Spec](../requirements/requirements-encountertable.md) (line 1)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/encountertable/domain/domain-encountertable.md
+++ b/docs/encountertable/domain/domain-encountertable.md
@@ -1,0 +1,74 @@
+# Encounter Table Domain Model
+
+## Context Role
+
+Context Role: Reference Catalog Context
+Context Name: EncounterTable
+
+- `encountertable` publishes authored encounter-table membership as a
+  read-only reference catalog for generator candidate pools.
+- It does not own creature truth or loot truth.
+- It exposes encounter-table summaries and weighted candidate rows through
+  `EncounterTableApi`.
+
+## Published Language
+
+`EncounterTableApi` owns encounter-table summaries, candidate rows, list
+results, and read status vocabulary.
+
+Published candidate rows carry creature snapshot fields needed by encounter
+generation plus the selected table weight. They do not expose table-entry
+mutation commands.
+
+## Application Boundary
+
+`EncounterTableApi` is the only public feature boundary. It offers typed
+operations equivalent to:
+
+- `loadSummaries(LoadEncounterTableSummariesQuery)`
+- `loadGenerationCandidates(LoadEncounterTableCandidatesQuery)`
+
+The application layer converts storage failures into `STORAGE_ERROR` results
+and does not leak adapter exceptions through the API.
+
+## Ubiquitous Language
+
+- Encounter Table: authored grouping of weighted creature entries used as a
+  generation source.
+- Table Summary: user-facing table identity and linked-loot context.
+- Candidate Row: read-only creature snapshot plus encounter-table weight.
+
+## Write Model And Derived State
+
+Write Model: Encounter Table-owned authored membership rows in SQLite
+
+`EncounterTableApi` exposes no mutation workflow unless observable product
+requirements add one; storage ownership does not imply a public write API.
+
+Derived state:
+
+- ordered table summaries for UI controls
+- weighted creature candidate snapshots for the encounter generator
+- linked loot-table conflict context for selected table combinations
+
+## Invariants
+
+- empty table selections produce no table candidates
+- weights are normalized to the supported `1..10` range
+- generation candidates respect the supplied XP ceiling
+- selected table lookup must not additionally apply creature type, subtype, or
+  biome filters
+
+## Foreign Boundaries
+
+Target Encounter Table persistence owns membership IDs, weights, summaries, and
+optional loot-link IDs only. The application layer resolves creature facts
+through `CreaturesApi` and combines them with table-owned weights. No Encounter
+Table target code may read or join Creatures-owned persistence, and no domain
+code reaches into creature or loot persistence directly.
+
+## References
+
+- [Encounter Table Persistence](../contract/contract-encountertable-persistence.md)
+- [Encounter Table Feature Spec](../requirements/requirements-encountertable.md)
+- [Encounter Feature Spec](../../encounter/requirements/requirements-encounter.md)

--- a/docs/encountertable/requirements/requirements-encountertable.md
+++ b/docs/encountertable/requirements/requirements-encountertable.md
@@ -1,0 +1,46 @@
+# Encounter Table Feature Spec
+
+## Goal
+
+Expose authored encounter tables as a read-only candidate source for runtime
+encounter generation.
+
+## Non-Goals
+
+- editing encounter tables
+- creating encounter-table entries
+- assigning loot tables
+- resolving or rolling loot
+
+## Expected Capabilities
+
+- load all encounter table summaries for Catalog controls
+- expose each table's optional linked loot-table ID
+- load generation candidates for selected table IDs with an XP ceiling
+- carry each candidate's table weight into encounter ranking
+- return an empty candidate list for empty table selections
+
+## User-Visible Behavior
+
+- selecting no encounter tables means the generator uses the normal monster
+  catalog source and current creature filters
+- selecting one or more encounter tables means generation uses only creatures
+  present in those selected tables
+- type, subtype, and biome filters do not additionally constrain selected
+  encounter-table generation
+- multiple selected tables with different linked loot-table IDs show a
+  non-blocking `Loot-Konflikt` warning
+
+## Acceptance Criteria
+
+- encounter-table data is exposed only through the Encounter Table feature
+  boundary
+- encounter-table generation lookup remains read-only
+- table selection does not create or persist encounter state
+- missing or broken encounter-table storage produces a storage-error result
+
+## References
+
+- [Encounter Table Domain Model](../domain/domain-encountertable.md) (line 1)
+- [Encounter Table Persistence](../contract/contract-encountertable-persistence.md) (line 1)
+- [Encounter Feature Spec](../../encounter/requirements/requirements-encounter.md) (line 1)

--- a/docs/hex/README.md
+++ b/docs/hex/README.md
@@ -1,0 +1,37 @@
+# Hex Feature Docs
+
+## Purpose
+
+The `hex` feature owns hex-map-specific user-facing behavior such as overworld
+travel, compact Hex travel readback, tile inspection, and hex editor behavior.
+The feature-neutral Travel capability selects that readback for the runtime
+`Reise` tab when the party occupies a Hex location.
+
+Generic shared map-canvas behavior remains canonical in `docs/maps/`.
+
+## Document Set
+
+### Requirements
+
+- [Hex Feature Requirements](./requirements/requirements-hex.md)
+- [Hex Travel Requirements](./requirements/requirements-hex-travel.md)
+- [Hex Travel State Requirements](./requirements/requirements-hex-travel-state.md)
+- [Hex Editor Requirements](./requirements/requirements-hex-editor.md)
+
+### Domain
+
+- [Hex Map Domain](./domain/domain-hex-map.md)
+
+### Contract
+
+- [Hex Persistence Contract](./contract/contract-hex-persistence.md)
+
+### Related Maps Docs
+
+- [Map Canvas Overview](../maps/README.md) (line 1)
+- [Maps Canvas Requirements](../maps/requirements/requirements-maps-canvas.md) (line 1)
+- [Hex Map Adoption Architecture](../maps/architecture/architecture-maps-hex-adoption.md) (line 1)
+
+## References
+
+- [Map Canvas Overview](../maps/README.md) (line 1)

--- a/docs/hex/contract/contract-hex-persistence.md
+++ b/docs/hex/contract/contract-hex-persistence.md
@@ -1,0 +1,117 @@
+# Hex Persistence Contract
+
+## Purpose
+
+This contract defines the stored SQLite truth required for authored Hex maps.
+It exists so Hex implementation can add persistence without borrowing Dungeon
+schema meaning or making adapter row shape the domain owner.
+
+## Owners And Consumers
+
+- Owner: Hex feature.
+- Producer: Hex editor write path.
+- Consumers: Hex editor readback and future Hex runtime map loading.
+
+## Scope Boundary
+
+This contract owns only authored Hex map persistence. It does not own Dungeon
+tables, generic map-canvas contracts, party roster persistence, compact
+`Reise` travel-state persistence, or migration from external map sources.
+
+## Stored Truth
+
+Hex persistence MUST store:
+
+- maps, including stable id, display name, and radius
+- tiles, including owning map id and axial coordinate
+- terrain overrides keyed by map and tile coordinate
+- markers keyed by map and marker id, with exactly one owning tile coordinate
+
+## Schema Semantics
+
+### Maps
+
+The map table MUST store one row per authored Hex map. A map row MUST include:
+
+- stable map id
+- nonblank name
+- radius from `0` through `99`
+
+### Tiles
+
+Tile rows MUST be scoped to one map. A tile coordinate is the single-layer
+axial coordinate `q,r`. Stored tile records MUST NOT introduce a Dungeon level,
+room, or topology reference.
+
+Hex runtime travel uses a derived stable tile id for party-owned overworld
+travel positions. That id is not stored in Hex tables; it is computed from the
+Hex axial coordinate and decoded by the Hex runtime readback. Hex persistence
+remains keyed by `map_id`, `q`, and `r`.
+
+### Terrain Overrides
+
+Terrain override rows MUST be scoped to one map and one tile coordinate. The
+terrain value MUST use the Hex terrain vocabulary exposed by the Hex editor
+requirements.
+
+### Markers
+
+Marker rows MUST include:
+
+- stable marker id inside the map
+- owning map id
+- owning tile coordinate `q,r`
+- nonblank name
+- marker type
+- optional note
+
+Marker type MUST be one of:
+
+- `SETTLEMENT`
+- `LANDMARK`
+- `DANGER`
+- `RESOURCE`
+
+Each marker row MUST belong to exactly one owning tile. A marker note MAY be
+stored as absent, null, or blank according to the chosen adapter convention, but
+that absence MUST round-trip as "no note" and MUST NOT change marker identity.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
+
+- Loading malformed marker type, blank marker name, invalid map radius, or
+  out-of-radius tile coordinates MUST fail visibly to the caller instead of
+  silently repairing stored truth.
+- Saving a map MUST preserve marker ownership and terrain overrides for tiles
+  that remain inside the map radius.
+- Shrinking a map radius MAY delete out-of-radius tile-owned data only after
+  the editor behavior has surfaced the destructive warning owned by
+  requirements.
+
+## Compatibility And Migration
+
+Compatibility obligations begin with the first released format.
+Before the first released format, Hex supports exactly the current schema at owner version
+1. A fresh owner namespace is initialized directly to that complete target.
+There is no predecessor import, hybrid-schema repair, copy/drop conversion,
+archive table, or cross-owner foreign-key rewrite.
+
+An unversioned partial namespace, a recorded version-1 shape that differs from
+the exact current DDL, an adjacent retired Hex object, or a newer owner version
+MUST fail closed. Failure MUST leave the schema, rows, and owner ledger
+unchanged; initialization failure MUST NOT fabricate a ledger entry. Until
+activation, unsupported development databases are reinitialized rather than
+migrated.
+
+The exact owner inventory covers every table, index, view, and trigger named
+with `hex_`, `idx_hex_`, or `sm_hex_`. Current Hex tables use foreign keys only
+inside the Hex owner. Other features retain Hex map or tile identifiers as
+logical references and MUST NOT cause Hex startup to inspect, repair, rename,
+or rewrite their schemas.
+
+
+## References
+
+- [Hex Domain](../domain/domain-hex-map.md)
+- [Hex Editor Requirements](../requirements/requirements-hex-editor.md)

--- a/docs/hex/domain/domain-hex-map.md
+++ b/docs/hex/domain/domain-hex-map.md
@@ -1,0 +1,94 @@
+# Hex Map Domain
+
+## Purpose
+
+This document owns the domain truth for authored Hex maps. Requirements own
+visible editor behavior, the persistence contract owns SQLite storage
+semantics, and architecture owns system boundaries.
+
+## Bounded Context
+
+The Hex context owns authored overworld-style hex maps used by Hex editor and
+Hex runtime surfaces. A Hex map is an authored map root with metadata,
+hex tiles, terrain overrides, and simple tile-owned markers.
+
+The Hex context does not own Dungeon topology, party roster truth, encounter
+simulation, campaign clocks, weather rules, or generic map-canvas rendering
+contracts. It does own the Hex-specific interpretation of party-owned
+overworld travel readback when the party location points at a Hex map.
+
+## Write Model
+
+- `HexMap` is the aggregate root for one authored map.
+- `HexTile` is the authored coordinate inside one map.
+- `HexTerrainOverride` records the authored terrain chosen for one tile when
+  the tile differs from default generation or empty-map state.
+- `HexMarker` is a simple authored marker owned by one tile.
+
+## Domain Vocabulary
+
+### Map
+
+A Hex map has a stable identity, a required display name, and a radius. Radius
+defines the set of valid tile coordinates for the authored map. V1 Hex maps
+support radius `0` through `99`; larger stored values are malformed domain
+truth and must fail visibly instead of being projected.
+
+### Tile
+
+A Hex tile belongs to exactly one Hex map. Tile identity is the map identity
+plus axial coordinate `q,r`. V1 Hex maps are single-layer maps; no level or
+Dungeon room coordinate participates in Hex tile identity.
+
+Party-owned overworld travel state carries only `mapId` plus a stable
+`tileId`. Hex translates that `tileId` to and from axial `q,r` through the
+Hex-owned stable tile-id convention. The convention is valid only for the V1
+maximum Hex radius `99`; invalid or out-of-radius ids do not become active Hex
+travel positions.
+
+### Terrain
+
+Terrain is authored per tile only when the editor stores an override. The V1
+terrain vocabulary is the editor palette from
+`docs/hex/requirements/requirements-hex-editor.md`.
+
+### Marker
+
+A Hex marker is a simple place marker. It has:
+
+- required stable marker identity inside its map
+- required nonblank name
+- required marker type
+- optional note
+- exactly one owning Hex tile
+
+The V1 marker types are:
+
+- `SETTLEMENT`
+- `LANDMARK`
+- `DANGER`
+- `RESOURCE`
+
+## Invariants
+
+- A Hex map name MUST be nonblank.
+- A Hex map radius MUST be nonnegative.
+- A Hex map radius MUST NOT exceed `99`.
+- A Hex tile MUST reference an existing Hex map.
+- A Hex tile coordinate MUST be inside the owning map radius.
+- A terrain override MUST reference exactly one valid Hex tile.
+- A marker MUST reference exactly one valid Hex tile.
+- A marker name MUST be nonblank after editor validation.
+- A marker type MUST be one of `SETTLEMENT`, `LANDMARK`, `DANGER`, or
+  `RESOURCE`.
+- A marker note MAY be absent or blank without changing marker identity or tile
+  ownership.
+- Hex markers MUST NOT reuse Dungeon feature-marker kinds, topology refs, or
+  runtime travel state.
+- Hex runtime readback MAY interpret party-owned overworld travel positions as
+  Hex coordinates only through the Hex stable tile-id convention.
+
+## References
+
+- [Hex Editor Requirements](../requirements/requirements-hex-editor.md)
+- [Hex Persistence Contract](../contract/contract-hex-persistence.md)

--- a/docs/hex/requirements/requirements-hex-editor.md
+++ b/docs/hex/requirements/requirements-hex-editor.md
@@ -1,0 +1,114 @@
+# Hex Editor Requirements
+
+## Goal
+
+Define the required editor workflow over committed hex-map truth so the user
+can manage maps, inspect tiles, paint terrain, and place simple authored
+markers without inventing a second map source of truth.
+
+## Non-Goals
+
+- interactive hex travel behavior
+- compact runtime `Reise` travel-state behavior
+- shared map-canvas contract design
+- persistence schema detail
+- hidden simulation or campaign rules that are not visible in the editor
+
+## Visible Structure
+
+- a shared shell catalog CRUD surface for selecting, creating, renaming, and
+  reloading Hex maps
+- compact tool controls for at least `Auswahl`, terrain painting, marker
+  placement, and party-token movement
+- main content as the shared hex map surface in editor mode
+- state content for selected map metadata, radius changes, active status,
+  selected tile details, and marker editing
+- terrain palette for the active paint tool
+- marker placement controls for name, type, and optional note in the state pane
+
+## Visible States
+
+- no map loaded
+- loaded editable hex map
+- selected tile with visible details
+- active terrain-paint mode
+- active marker-placement mode
+- selected marker with visible name, type, note when present, and owning tile
+- save or validation failure during map edits
+- destructive radius-change warning before data loss
+
+## Required Behavior
+
+- the editor MUST let the user create and edit hex maps
+- new map creation MUST use the shared catalog `Neu` flow and create a named
+  map with default radius `2`
+- map editing MUST support visible name and radius changes from the state pane
+- the Hex control panel MUST use the shared shell map layout pattern:
+  `CatalogCrudControlsView` as fixed catalog, compact Hex controls as the
+  flexible controls child, Hex rendering in `COCKPIT_MAIN`, and edit details in
+  `COCKPIT_STATE`
+- map radius MUST stay inside the supported `0` through `99` range
+- shrinking a map radius in a way that removes authored terrain or markers MUST
+  surface an explicit destructive warning before commit
+- the editor MUST support a selection tool for tile inspection
+- the editor MUST support a terrain-paint tool
+- the active terrain type MUST be visible while painting
+- the editor MUST support placing a simple marker on one selected or clicked
+  tile
+- marker creation MUST require a nonblank name
+- marker creation MUST require one marker type from the supported marker type
+  vocabulary
+- marker note text MUST be optional
+- every marker MUST belong to exactly one owning hex tile
+- marker feedback MUST be visible on the owning tile after placement
+- tile inspection MUST surface visible details for at least position, terrain,
+  elevation, biome, exploration state, and notes when those values are
+  available
+- tile inspection MUST expose markers owned by the selected tile when markers
+  are present
+- paint feedback MUST be visible on the map surface
+- failed save operations MUST surface a visible failure outcome instead of
+  silently discarding the edit
+
+## Supported Terrain Palette
+
+The editor terrain palette exposes these visible labels:
+
+- `Grasland`
+- `Wald`
+- `Gebirge`
+- `Wasser`
+- `Wüste`
+- `Sumpf`
+
+## Supported Marker Types
+
+The V1 marker vocabulary exposes these visible marker types:
+
+- `SETTLEMENT`
+- `LANDMARK`
+- `DANGER`
+- `RESOURCE`
+
+## Acceptance Criteria
+
+- The user can create a new map through the shared catalog `Neu` flow and
+  immediately see it as an editable radius-2 map.
+- The user can select a tile and inspect visible tile details.
+- The user can paint terrain and see the changed terrain on the map.
+- The user can place a named marker with a supported type on exactly one tile.
+- The user can add or omit a marker note without changing marker ownership.
+- Marker validation failure produces a visible error outcome when name or type
+  is missing.
+- Destructive radius shrink requires an explicit warning before commit.
+- Save failure produces a visible error outcome.
+- The visible Hex map surface remains available below the controls because the
+  map catalog and compact controls share the shell stack layout used by Dungeon
+  map screens.
+
+## References
+
+- [Hex Feature Requirements](./requirements-hex.md)
+- [Hex Domain](../domain/domain-hex-map.md)
+- [Hex Persistence Contract](../contract/contract-hex-persistence.md)
+- [Maps Canvas Requirements](../../maps/requirements/requirements-maps-canvas.md) (line 1)

--- a/docs/hex/requirements/requirements-hex-travel-state.md
+++ b/docs/hex/requirements/requirements-hex-travel-state.md
@@ -1,0 +1,61 @@
+# Hex Travel State Requirements
+
+## Goal
+
+Define the compact read-mostly travel-state surface shown in the runtime
+`Reise` tab for overworld or hex travel context.
+
+## Non-Goals
+
+- the interactive hex travel workspace
+- hex editor behavior
+- dungeon-specific travel context
+- shared map-canvas contract design
+
+## Visible Structure
+
+- one compact location row
+- one travel-status badge
+- a small key-value block for weather, time of day, and pace
+- one concise interaction or context hint
+
+## Required Behavior
+
+- when the active party is travelling on a hex map, the runtime tab labeled
+  `Reise` MUST show hex travel context rather than a generic placeholder
+- the surface MUST communicate current location or lack of location
+- the surface MUST communicate visible overworld travel context such as
+  weather, time of day, and pace
+- the surface MUST remain compact and read-mostly
+- the surface MUST NOT duplicate the interactive hex travel workspace
+- when no current hex location is available, the surface MUST show an explicit
+  empty state
+- the surface MUST consume an approved Hex runtime readback and MUST NOT infer
+  Hex travel context from editor-only map selection
+- movement commands MUST remain outside the compact state tab
+- Hex MUST publish its compact context as typed readback for the feature-neutral
+  Travel capability; Hex MUST NOT remain the permanent owner of the global
+  `travel` shell contribution
+
+## Visible States
+
+- no current location selected
+- active overworld or hex travel context
+- transient status change after movement
+- explicit no-context fallback while no matching Hex runtime readback exists
+
+## Acceptance Criteria
+
+- A user can read the core overworld travel context from the compact state
+  surface alone.
+- The surface remains clearly distinct from the full interactive travel view.
+- Lack of active hex travel context is shown explicitly.
+- Hex context appears only when an approved Hex runtime readback matches the
+  active party position.
+
+## References
+
+- [Hex Feature Requirements](./requirements-hex.md)
+- [Hex Travel Requirements](./requirements-hex-travel.md)
+- [Travel State Tab UI](../../project/requirements/requirements-travel-state-tab.md) (line 1)
+- [Travel Context Domain](../../travel/domain/domain-travel.md)

--- a/docs/hex/requirements/requirements-hex-travel.md
+++ b/docs/hex/requirements/requirements-hex-travel.md
@@ -1,0 +1,58 @@
+# Hex Travel Requirements
+
+## Goal
+
+Define the interactive runtime travel workflow over a committed hex map plus
+party-owned runtime position.
+
+## Non-Goals
+
+- compact travel-state surface behavior shown in the runtime `Reise` tab
+- hex editor behavior
+- shared map-canvas contract design
+- persistence schema detail
+
+## Visible Structure
+
+- controls that include the `Reisegruppe` movement tool
+- main content as the shared `Hex-Karte` map surface
+- one visible party token on the active hex
+- compact travel context in the runtime `Reise` state tab, including location,
+  weather, time of day, pace, and status
+
+## Visible States
+
+- no current location selected
+- active travel state with visible party token
+- updated location after token movement
+- blocked or invalid travel outcome without stale success text
+
+## Required Behavior
+
+- the travel surface MUST load a visible hex map and current party position
+- the surface MUST show the party token on the current tile when one exists
+- travel MUST support direct party-token movement across the hex map
+- the surface MUST communicate current location or context plus visible travel
+  status
+- the surface MUST communicate visible overworld travel context such as
+  weather, time of day, and pace when that information is available to the
+  surface
+- invalid or blocked movement MUST leave committed map truth unchanged and
+  surface a meaningful outcome
+- when no active location is available, the surface MUST show an explicit empty
+  state rather than implied valid travel context
+
+## Acceptance Criteria
+
+- A user can identify the current party tile on the map.
+- Using the `Reisegruppe` tool to choose a destination tile updates visible
+  travel context when the move resolves.
+- The travel surface stays focused on interactive map travel rather than
+  adding movement commands to the compact runtime `Reise` state tab.
+- Missing location context is shown explicitly.
+
+## References
+
+- [Hex Feature Requirements](./requirements-hex.md)
+- [Hex Travel State Requirements](./requirements-hex-travel-state.md)
+- [Maps Canvas Requirements](../../maps/requirements/requirements-maps-canvas.md) (line 1)

--- a/docs/hex/requirements/requirements-hex.md
+++ b/docs/hex/requirements/requirements-hex.md
@@ -1,0 +1,93 @@
+# Hex Feature Requirements
+
+## Goal
+
+Provide one hex-map workflow that lets a GM:
+
+- load and inspect an overworld-style hex map
+- track and move party travel on that map
+- read compact Hex travel state through the feature-neutral global travel-state
+  surface shown in the runtime `Reise` tab
+- edit map metadata and hex terrain without duplicating map truth
+
+## Non-Goals
+
+- dungeon topology or dungeon travel semantics
+- shared map-canvas contract design
+- faction, location, or campaign simulation rules that are not surfaced in the
+  user-facing feature
+- persistence schema detail
+
+## Primary Surfaces
+
+- hex map travel surface
+- compact Hex travel state shown in the runtime `Reise` tab
+- hex editor surface
+
+## Primary User Flows
+
+### Load And Inspect A Hex Map
+
+1. The user opens the hex map.
+2. The current party position or default tile is visible on the map.
+3. The user pans, zooms, and selects tiles to inspect visible details.
+
+### Travel Across The Hex Map
+
+1. The user opens the `Hex-Karte` surface.
+2. The party token is shown on the current tile.
+3. The user selects the `Reisegruppe` tool and clicks a destination hex.
+4. The visible party token and Hex travel readback update.
+
+### Read Compact Hex Travel State
+
+1. The user opens the global travel-state surface shown in the runtime
+   `Reise` tab.
+2. The surface shows compact overworld travel context such as location, status,
+   weather, time of day, and pace.
+
+### Edit The Hex Map
+
+1. The user opens the hex editor.
+2. The user selects a map and a tool.
+3. The user inspects a tile or paints terrain.
+4. The user edits map metadata such as name or radius when needed.
+
+## Visible Capabilities
+
+- hex map display with party token
+- tile selection and tile inspection
+- compact travel context for overworld travel
+- terrain paint workflow
+- map creation and metadata editing
+- simple tile-owned marker placement
+- destructive shrink warning when radius changes would remove authored tile
+  data
+
+## Acceptance Criteria
+
+- Travel, the runtime `Reise` travel-state surface, and the editor refer to
+  one visible hex-map feature concept rather than disconnected special cases.
+- The current party tile is understandable to the user on the map surface.
+- Tile inspection is visible and understandable when a tile is selected.
+- Hex travel context can be read from the `Hex-Karte` state panel and the
+  compact travel-state surface shown in the runtime `Reise` tab.
+- The compact `Reise` state tab consumes Hex runtime travel readback only; it
+  does not infer active travel from editor-only map selection.
+- Editing terrain or map metadata never requires the user to infer hidden map
+  state from implementation details.
+
+## Open Product Questions
+
+- Which tile details must always be shown versus only on demand?
+- How much overworld travel context belongs directly on the interactive travel
+  surface versus only in the runtime `Reise` tab?
+- Which non-marker editor capabilities belong after the first SaltMarcher Hex
+  editor milestone?
+
+## References
+
+- [Hex Travel Requirements](./requirements-hex-travel.md)
+- [Hex Travel State Requirements](./requirements-hex-travel-state.md)
+- [Hex Editor Requirements](./requirements-hex-editor.md)
+- [Maps Canvas Requirements](../../maps/requirements/requirements-maps-canvas.md) (line 1)

--- a/docs/items/README.md
+++ b/docs/items/README.md
@@ -1,0 +1,27 @@
+# Items Feature README
+
+## Purpose
+
+Items owns a local read-only reference catalog imported explicitly from the
+public D&D 5e SRD API. It does not own inventory, loot, assignment, crafting, or
+user-authored item state.
+
+## Documentation Set
+
+- [Items Catalog Requirements](requirements/requirements-items-catalog.md)
+- [Items Domain Model](domain/domain-items.md)
+- [Items Persistence And Import Contract](contract/contract-items-persistence.md)
+
+## Source Boundary
+
+The import is pinned to the public 2014 API at
+`https://www.dnd5eapi.co/api/2014`. The API requires no authentication and
+exposes GET-only reference data. SaltMarcher stores the imported projection
+locally and performs no network requests while browsing the Catalog. Network
+access exists only behind the explicit `ItemsImportApi` maintenance call.
+
+## References
+
+- [D&D 5e SRD API Introduction](https://5e-bits.github.io/docs/introduction)
+- [5e-database](https://github.com/5e-bits/5e-database)
+- [5e-database License](https://github.com/5e-bits/5e-database/blob/main/LICENSE.md)

--- a/docs/items/contract/contract-items-persistence.md
+++ b/docs/items/contract/contract-items-persistence.md
@@ -1,0 +1,121 @@
+# Items Persistence And Import Contract
+
+## Purpose And Consumers
+
+This persistence contract owns the local Items schema, compatibility rules,
+full-corpus import boundary, and read failure semantics. The Items application
+service is its consumer. Catalog presentation consumes only `ItemsCatalogApi`;
+it does not access SQLite or the public HTTP source.
+
+## Ownership And Compatibility
+
+Items owns the unambiguous current tables `items_catalog_entries` and
+`items_catalog_tags`. Stable source keys from the pinned `/api/2014` API are
+persisted as text identifiers. One direct schema initializer is registered as
+owner version `1` under `items` and consumed through one prepared
+`FeatureStoreHandle`; Items
+does not open a parallel connection lifecycle. Desktop composition constructs only the
+catalog-read adapter and application service. The separately composed operator import
+constructs its own HTTP source, import application service, and write adapter from one
+owner-bound `FeatureStoreMaintenance` capability. That capability supplies both the
+whole-database backup and the later Items write connection; ordinary provider reads cannot
+request either maintenance operation.
+
+Owner version `1` has one structural signature: exact entry and tag columns,
+`source_key` and `(item_source_key, tag)` primary keys, one cascading tag
+foreign key, and the five named query indexes. The entry columns are exactly
+the fields written by a validated current provider import: identity, display
+and classification facts, cost and weight, combat and description facts, and
+source version and URL. No migration identity or predecessor provenance is
+stored. Owner readiness checks the exact owner object inventory plus every
+declared column type, nullability, default, primary key, `CHECK`, foreign key,
+unique constraint, table flag, and named index before the handle becomes
+`READY`; platform
+startup also checks global integrity and foreign keys. Semantic rows remain an
+Items provider read/write concern and fail closed through typed Items results
+rather than a startup corpus scan.
+
+## Development Compatibility Boundary
+
+Compatibility obligations begin with the first released format.
+Before the first released format, Items supports no predecessor conversion, compatibility
+bridge, or schema fallback. The version `1` initializer creates the current
+tables and indexes directly only when no current or retired Items development
+table exists. Existing older, mixed, or incomplete development shapes return
+typed `INCOMPATIBLE` without copying, dropping, renaming, or otherwise mutating
+those tables and without affecting another provider's readiness. Such
+disposable development databases must be reinitialized and populated through a
+complete current provider import.
+
+After activation, a schema or pinned-source-version change requires a new
+explicit compatibility decision under the project persistence lifecycle. Where
+that decision keeps imported reference data replaceable, the replacement still
+requires a complete validated re-import rather than synthesized source facts.
+
+## Import Boundary
+
+The explicit `ItemsImportApi` capability reads only the public equipment and
+magic-item GET endpoints. It requires no account, cookie, token, or other
+secret. The desktop runtime and Items UI never invoke this capability and
+never transmit local database contents. An operator must invoke import as a
+separate maintenance action.
+
+Both indexes and every referenced detail are fetched and parsed before a domain
+batch validates completeness, unique keys, and pinned-source attribution.
+Only then does the importer initialize the Items schema and ask the shared
+SQLite lifecycle for a timestamped maintenance backup. The platform proves
+both the backup and a restored temporary copy with SQLite `integrity_check`.
+One later transaction replaces both prior Items-owned tables. A fetch, parse,
+validation, backup, restore-check, or SQL failure leaves the prior Items
+projection intact and returns a typed failure status.
+
+Required batch validation rejects an empty corpus, a missing equipment or
+magic-item feed, blank stable key, name, or category, duplicate stable keys,
+and source version or URL attribution outside the pinned source. Optional
+upstream fields remain absent rather than being synthesized.
+
+## Query Contract
+
+Catalog queries accept optional filters and a bounded page. Invalid bounds
+return an invalid-query result. Zero imported rows return an unavailable
+result. An unsupported schema returns an incompatible result. Storage failures
+return a storage-error result without changing published prior state.
+
+All catalog reads and explicit imports return `CompletionStage` results and
+schedule blocking work through the supplied `ExecutionLane`. SQLite and HTTP
+work therefore remain outside the JavaFX application thread; a future Catalog
+consumer may dispatch only the resulting immutable projection back to JavaFX.
+
+## Error And Compatibility Behavior
+
+- Missing or zero-row imported data returns `UNAVAILABLE`.
+- An unsupported or newer Items schema returns `INCOMPATIBLE` without mutation.
+- A recorded Items owner version above the current direct version is rejected during read-only
+  store qualification; the application reports `INCOMPATIBLE` while the owner rows, schema,
+  platform ledger, and complete SQLite file family remain unchanged.
+- Invalid cost bounds return `INVALID_QUERY` without querying rows.
+- Missing detail keys return `NOT_FOUND`.
+- SQLite failures return `STORAGE_ERROR`; execution-lane rejection returns
+  `EXECUTION_ERROR`.
+- Import distinguishes source, validation, backup, storage, and execution
+  failures. No failure status permits partial replacement.
+
+The current schema owner target is version `1`, created by its single direct
+initializer. Before the first released format, the initializer may be revised with the
+current target and never translates an earlier development shape. After the
+first released format, later compatible changes use a new Items-owned migration. Public
+API callers never infer compatibility from JDBC or table layout.
+
+
+## Attribution
+
+Every imported row retains source version and source URL. The Inspector shows
+that attribution. The project data source is the 5e-bits 5e-database/API; its
+repository is MIT licensed and identifies the underlying material as Open Game
+License 1.0a content.
+
+References:
+
+- [D&D 5e SRD API Introduction](https://5e-bits.github.io/docs/introduction)
+- [5e-database](https://github.com/5e-bits/5e-database)
+- [5e-database License](https://github.com/5e-bits/5e-database/blob/main/LICENSE.md)

--- a/docs/items/domain/domain-items.md
+++ b/docs/items/domain/domain-items.md
@@ -1,0 +1,60 @@
+# Items Domain Model
+
+## Context Role
+
+Context Role: Imported Reference Catalog Context
+
+Context Name: Items
+
+Items owns the complete, replaceable local reference projection of the pinned
+public equipment and magic-item corpus. It does not own inventory, loot,
+assignment, crafting, or user-authored item truth.
+
+## Published Language
+
+`ItemsCatalogApi` publishes item queries, typed catalog statuses, filter
+options, result pages, item rows, and item details. `ItemsImportApi` publishes
+the explicit full-corpus import result and its typed status.
+
+## Application Boundary
+
+The application boundary normalizes catalog queries and coordinates public
+source loading, batch validation, verified backup, and whole-catalog
+replacement. It translates domain catalog values into immutable API carriers;
+it does not create missing reference facts or expose persistence shape.
+
+## Write Model And Derived State
+
+The only write model is one validated full-corpus import batch. An
+item is identified by its stable source key and includes its name, equipment
+category, optional subcategory, magic status, optional rarity, attunement
+status, optional cost and weight, descriptive properties, and source URL.
+
+Derived state consists of distinct filter options, filtered and ordered result
+pages, and one selected item detail. Derived results never mutate imported
+truth.
+
+## Invariants
+
+- source keys are unique within the pinned source version
+- catalog records are read-only between complete imports
+- one import publishes either a complete replacement or no replacement
+- both the equipment and magic-item indexes and every referenced detail are
+  fetched and parsed before validation permits any database maintenance
+- equipment and magic-item feeds that describe the same source key produce one
+  deterministic record
+- absent source fields remain absent; they are not invented from display text
+- inventory ownership, loot assignment, and user-authored item changes belong
+  outside Items
+
+## Consistency Boundary
+
+One import batch is the consistency boundary: readers observe either the prior
+complete projection or the replacement complete projection. A catalog query or
+detail lookup is internally consistent for that single request; later requests
+may observe a newer completed import.
+
+## References
+
+- [Items Catalog](../requirements/requirements-items-catalog.md)
+- [Items Persistence And Import](../contract/contract-items-persistence.md)

--- a/docs/items/requirements/requirements-items-catalog.md
+++ b/docs/items/requirements/requirements-items-catalog.md
@@ -1,0 +1,47 @@
+# Items Catalog
+
+## Goal
+
+Provide a fast local reference list for public-SRD equipment and magic items
+inside the shared Catalog.
+
+Affected users are game masters who need local rules-reference facts while
+planning or running a session. Inventory management, loot generation,
+assignment, crafting, and authored item editing are non-goals.
+
+## Target Visible Behavior
+
+- `Items` appears directly after `Monster` in the Catalog content strip.
+- Name, category, subcategory, rarity, magic status, attunement status, and
+  cost can narrow the list.
+- Name, category, rarity, and cost can order the list.
+- Selecting an item opens description, properties, cost, weight, rarity,
+  attunement, damage or armor facts when available, and source attribution in
+  the Inspector.
+- Empty, invalid-filter, loading, unavailable-data, and storage-error states
+  are explicit; an incompatible local Items schema is distinguished from a
+  missing import.
+- The surface contains no create, edit, delete, loot generation, assignment,
+  or inventory action.
+
+## Primary Flow
+
+1. The game master opens `Items` in the shared Catalog.
+2. The surface reports loading and then either a local result page, an empty
+   result, unavailable imported data, an invalid filter, or a storage failure.
+3. The game master narrows or orders the local result page.
+4. Selecting a row shows its imported detail and source attribution in the
+   Inspector without changing global Encounter state.
+
+## Acceptance Criteria
+
+- browsing imported items performs no network request
+- Items content never replaces the global Encounter state pane
+- every displayed item is attributable to the pinned public source import
+- filtering, sorting, paging, and Inspector selection use only the local
+  imported projection
+- a missing import is an isolated Items unavailable state and does not break
+  other Catalog contents
+- an incompatible Items schema is an isolated Items failure and does not break
+  Monster or other provider-backed Catalog contents
+- no Item UI or application command mutates imported item truth

--- a/docs/maps/README.md
+++ b/docs/maps/README.md
@@ -1,0 +1,39 @@
+# Map Canvas Docs
+
+## Purpose
+
+`platform.ui.mapcanvas` owns feature-neutral camera, viewport, layered-canvas,
+cache, and technical pointer mechanisms that multiple map surfaces can use.
+This bundle defines those passive mechanisms and adopter translation.
+
+It is not a product feature, has no application lifecycle or feature API, and
+does not own adopter domain, persistence, or gameplay semantics.
+
+## Document Set
+
+### Requirements
+
+- [Maps Canvas Requirements](./requirements/requirements-maps-canvas.md)
+
+### Architecture
+
+- [Maps Canvas Architecture](./architecture/architecture-maps-canvas.md)
+- [Dungeon Map Adoption Architecture](./architecture/architecture-maps-dungeon-adoption.md)
+- [Hex Map Adoption Architecture](./architecture/architecture-maps-hex-adoption.md)
+
+### Contracts
+
+- [Maps Canvas Contract](./contract/contract-maps-canvas.md)
+- [Dungeon Map Surface Contract](./contract/contract-maps-dungeon-surface.md)
+
+## Adopters
+
+- Dungeon adopts the passive canvas through its feature-owned translation and
+  documents its behavior, contracts, and domain under `docs/dungeon/`.
+- Hex adopts the passive canvas through its feature-owned translation and
+  documents its behavior and domain under `docs/hex/`.
+
+## References
+
+- [Dungeon Feature Overview](../dungeon/README.md) (line 1)
+- [Hex Feature Overview](../hex/README.md) (line 1)

--- a/docs/maps/architecture/architecture-maps-canvas.md
+++ b/docs/maps/architecture/architecture-maps-canvas.md
@@ -1,0 +1,101 @@
+# Maps Canvas Architecture
+
+## Purpose And Concerns
+
+This specification defines reusable mechanisms owned by `platform.ui.mapcanvas`. It
+serves maintainers of map presentation and adopting features that translate
+their own map facts into canvas-native scenes.
+
+It answers:
+
+- where passive camera, drawing, hit-testing, and pointer capture belong
+- how an adopter supplies a scene without exposing its domain to Maps
+- how canvas input returns to an adopter without Maps learning adopter meaning
+- how the application composes the canvas and its adopters explicitly
+
+It does not own dungeon or hex behavior, coordinates, persistence, commands, or
+domain invariants.
+
+## Target Ownership
+
+```text
+platform/ui/mapcanvas/
+  camera and viewport values
+  bounded viewport caches
+  logical paint phases on one bounded JavaFX canvas host
+  technical scene, hit, and pointer values
+```
+
+The platform package is a feature-neutral mechanism boundary. JavaFX adapters
+may depend on it; it must not import any adopter API or implementation.
+
+## Boundaries
+
+- All scene geometry and pointer coordinates crossing the mechanism boundary are
+  canvas-native.
+- One immutable scene revision supplies both draw order and ordered hit evidence.
+- The JavaFX adapter renders the supplied scene and captures technical input. It
+  does not interpret dungeon-grid, hex-grid, editing, or travel meaning.
+- Camera, pan, zoom, viewport, resize, and reset behavior remain Maps-owned
+  passive presentation behavior.
+- Each adopter owns one translation boundary in its `adapter/javafx` package
+  between its feature API and canvas-native values.
+- Adopter domain and application packages never depend on JavaFX or Maps
+  presentation types.
+- Maps owns no SQLite state under the current contract.
+- Maps therefore has no SQLite adapter. Target roles follow owned capability;
+  empty form packages are forbidden.
+
+## Composition View
+
+`app` constructs adopter features. Their JavaFX adapters instantiate passive
+map-canvas mechanisms directly; the platform mechanism has no feature entry
+point, lifecycle, discovery, or service lookup.
+
+## Capability Paths
+
+### Surface Read
+
+`adopter API state -> adopter JavaFX translation -> platform map canvas`
+
+### Pointer Input
+
+`platform pointer sample -> adopter JavaFX translation -> adopter API command`
+
+### Draw And Hit
+
+`one canvas scene revision -> ordered draw primitives + ordered hit evidence -> bounded JavaFX canvas`
+
+Base, interaction, and actor paint remain separate invalidation phases. They
+share one backing surface so each open editor does not multiply a full-window
+pixel buffer; transient repaint replays the retained base phase first.
+
+The adopter translation boundary derives canvas-native geometry and stable hit
+references from adopter API state. It also translates a technical hit reference
+back to an adopter API command or query. Maps does not reconstruct either
+translation.
+
+## Decisions And Rationale
+
+- A feature-owned API keeps cross-feature dependencies compile-time visible.
+- One scene revision prevents draw and hit state from diverging.
+- One adopter translation boundary prevents competing coordinate and identity
+  mappings.
+- Explicit application composition exposes lifecycle and dependencies without a
+  runtime registry or classpath convention.
+- A JavaFX adapter, rather than a role-name convention, owns technical rendering
+  and input capture.
+
+Rejected target forms include shared adopter-native payloads, direct Maps access
+to adopter application services, multiple projection owners for one surface,
+and runtime discovery or service lookup.
+
+
+## References
+
+- [Maps Canvas Requirements](../requirements/requirements-maps-canvas.md)
+- [Maps Canvas Contract](../contract/contract-maps-canvas.md)
+- [Dungeon Map Adoption Architecture](architecture-maps-dungeon-adoption.md)
+- [Hex Map Adoption Architecture](architecture-maps-hex-adoption.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Application Composition Standard](../../project/architecture/patterns/application-composition.md)

--- a/docs/maps/architecture/architecture-maps-dungeon-adoption.md
+++ b/docs/maps/architecture/architecture-maps-dungeon-adoption.md
@@ -1,0 +1,104 @@
+# Dungeon Map Adoption Architecture
+
+## Purpose And Scope
+
+This specification defines how the Dungeon feature adopts the passive Maps
+canvas for editor and travel workspaces. It serves Dungeon, Maps, shell, and
+application-composition maintainers.
+
+It owns the structural translation between Dungeon API state and canvas-native scene
+and pointer types. Dungeon requirements own observable editor and travel
+behavior; Dungeon domain and persistence documents own authored truth and stored
+truth.
+
+## Ownership
+
+```text
+features/dungeon/
+  api/             Authored, Editor, and Travel capabilities and state
+  domain/          authored dungeon truth and invariants
+  application/     authored/catalog, editor-session, and travel orchestration
+  adapter/sqlite/  authored dungeon persistence
+  adapter/javafx/  shell contribution and Dungeon-to-Maps translation
+  <feature root>   Dungeon composition entry point used by app
+```
+
+The Dungeon JavaFX adapter may depend on `features.dungeon.api`,
+`shell.api`, and `platform.ui.mapcanvas`. It must not
+reach into Dungeon domain, application, or SQLite packages. The platform map
+canvas must not depend on any Dungeon package.
+
+## Composition And Dependencies
+
+`app` constructs platform persistence and the Dungeon entry point explicitly.
+Dungeon's JavaFX adapter instantiates the passive canvas mechanism and receives
+foreign feature APIs required by travel composition. Dungeon exposes its
+constructed shell contribution and public APIs back to `app`; internal
+repositories and adapters remain feature-private.
+
+No shell discovery, service locator, or implementation-name convention is part
+of this route.
+
+## Translation Boundary
+
+The Dungeon JavaFX adapter is the single owner of both directions:
+
+- Dungeon API state to one canvas-native scene revision
+- platform pointer and hit samples to typed Dungeon API inputs
+
+Dungeon-grid coordinates, topology identity, preview meaning, editing tools,
+selection, and travel actions remain Dungeon-owned. Canvas coordinates, camera,
+viewport, draw order, and technical hit capture remain Maps-owned.
+
+The adapter may derive render primitives, labels, overlays, markers, graph
+relations, and token anchors from immutable Dungeon API state. Those derived
+values are presentation state, never authored dungeon truth or persistence
+input.
+
+## Capability Paths
+
+### Authored And Editor Read
+
+`Dungeon API state -> Dungeon JavaFX translation -> platform map canvas`
+
+### Preview And Apply
+
+`platform pointer sample -> Dungeon JavaFX translation -> DungeonEditorIntent -> DungeonEditorApi -> immutable DungeonEditorState -> translated canvas scene`
+
+Preview and apply reuse the same authored operation vocabulary. Preview does not
+persist; apply commits only after Dungeon validation succeeds.
+
+### Travel
+
+`map-canvas pointer sample or travel control -> Dungeon JavaFX translation -> DungeonTravelApi -> immutable DungeonTravelState -> translated map-canvas scene`
+
+Party position remains owned by the Party feature and reaches Dungeon only
+through the Party API supplied during explicit composition.
+
+### Authored Catalog
+
+Map search, create, rename, delete, and selection use the catalog capability of
+`DungeonAuthoredApi`. Catalog behavior does not pass through the Maps canvas
+API.
+
+## Decisions And Rationale
+
+- Dungeon remains one feature with separate Authored, Editor, and Travel APIs;
+  authored catalog work belongs to `DungeonAuthoredApi`.
+- One JavaFX translation owner keeps dungeon-grid conversion and hit identity
+  consistent across editor and travel surfaces.
+- The platform canvas receives canvas-native presentation facts only; it never receives
+  Dungeon commands, aggregates, repositories, or persistence rows.
+- Render-ready state is derived in the JavaFX adapter from revisioned Dungeon API
+  state and must not become a second Dungeon publication or persistence model.
+- Cross-feature calls target APIs only and are injected by `app`.
+
+
+## References
+
+- [Maps Canvas Architecture](architecture-maps-canvas.md)
+- [Maps Canvas Contract](../contract/contract-maps-canvas.md)
+- [Dungeon Map Surface Contract](../contract/contract-maps-dungeon-surface.md)
+- [Dungeon Feature Overview](../../dungeon/README.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Application Composition Standard](../../project/architecture/patterns/application-composition.md)

--- a/docs/maps/architecture/architecture-maps-hex-adoption.md
+++ b/docs/maps/architecture/architecture-maps-hex-adoption.md
@@ -1,0 +1,58 @@
+# Hex Adoption of the Maps Capability
+
+## Purpose
+
+Hex is a shipped feature. This specification owns how its editor and travel
+surfaces adopt the platform map-canvas mechanism without leaking it into the
+Hex domain or duplicating coordinate and interaction truth.
+
+It does not own Hex gameplay, persistence, or the generic Maps contract.
+
+## Target Ownership
+
+- Hex lives below `features/hex` with `api`, `domain`, `application`,
+  `adapter/sqlite`, `adapter/javafx`, and an exact-root feature composition
+  package.
+- The reusable passive canvas mechanism lives in `platform.ui.mapcanvas`.
+- Hex's JavaFX adapter instantiates and translates that mechanism from injected
+  platform services. Runtime discovery, registries, and service locators are
+  forbidden.
+- The Hex JavaFX adapter is the only Hex role allowed to consume the map-canvas mechanism.
+  The Hex domain and application layers remain independent of JavaFX, canvas,
+  camera, viewport, and pointer mechanisms.
+
+## Scene And Interaction Boundary
+
+- One immutable, revisioned Maps scene supplies both drawing and hit testing.
+  A displayed frame and its hit results therefore describe the same revision.
+- Maps owns canvas coordinates, camera and viewport state, rendering mechanics,
+  and technical pointer input.
+- Maps returns an opaque hit identity from the displayed scene. It does not
+  manufacture Hex coordinates, selections, commands, or gameplay meaning.
+- The Hex JavaFX adapter translates Maps input and hit identities into typed Hex
+  application input. It is the only owner of `canvas <-> Hex` conversion.
+- Hex axial coordinates, snapping, selection, editing candidates, terrain,
+  markers, tokens, and travel meaning remain Hex-owned.
+- Hex must not reconstruct hit testing independently from the scene rendered by
+  Maps or encode Hex meaning into string identifiers.
+
+## Observable Behavior
+
+- The editor and travel surfaces reuse the same passive Maps capability while
+  retaining their distinct Hex workflows.
+- Terrain, markers, tokens, selection, and travel presentation are drawn and
+  hit-tested consistently for one scene revision.
+- Camera and viewport changes affect presentation only; they do not mutate Hex
+  gameplay state.
+- Hex persistence remains behind the Hex API and Hex SQLite adapter. Maps does
+  not read or write Hex records.
+
+## References
+
+- [Maps Canvas Architecture](./architecture-maps-canvas.md)
+- [Maps Canvas Contract](../contract/contract-maps-canvas.md)
+- [Hex Domain](../../hex/domain/domain-hex-map.md)
+- [Hex Requirements](../../hex/requirements/requirements-hex.md)
+- [Hex Persistence](../../hex/contract/contract-hex-persistence.md)
+- [Feature Boundaries](../../project/architecture/patterns/feature-boundaries.md)
+- [Application Composition](../../project/architecture/patterns/application-composition.md)

--- a/docs/maps/contract/contract-maps-canvas.md
+++ b/docs/maps/contract/contract-maps-canvas.md
@@ -1,0 +1,111 @@
+# Maps Canvas Contract
+
+## Purpose, Owners, And Consumers
+
+This technical contract defines canvas-native values exchanged through
+`platform.ui.mapcanvas`.
+
+- provider: platform map-canvas mechanism
+- consumers: adopting feature JavaFX adapters
+- non-owners: adopter domain, application, persistence, and gameplay semantics
+
+The API owns technical scene, camera, hit, and pointer semantics. It does not own
+dungeon-grid or hex-grid coordinates, adopter commands, adopter identities, or
+stored truth.
+
+## Contract Surface
+
+### Canvas Point
+
+Required fields:
+
+- finite `x`
+- finite `y`
+
+### Canvas Hit
+
+Required fields:
+
+- opaque adopter-provided `hitRef`
+- canvas-native hit primitive or area
+
+Optional fields:
+
+- opaque adopter-provided `selectionRef`
+
+References identify content only within the scene revision that carries them.
+Maps may return them to the producing adopter but must not interpret them.
+
+### Canvas Scene
+
+Required fields:
+
+- monotonically comparable scene revision
+- ordered draw primitives
+- ordered hit evidence derived from those primitives
+
+Optional families:
+
+- surfaces and boundaries
+- glyphs and text
+- relations
+- actors and markers
+- overlays
+- explicit empty-state presentation
+
+All geometry is canvas-native. Draw order and hit order come from the same
+immutable scene revision.
+
+### Canvas Pointer Sample
+
+Required fields:
+
+- phase: press, drag, release, move, or level-scroll
+- pressed buttons
+- modifiers
+- canvas point
+- scene revision observed during hit-testing
+
+Optional fields:
+
+- canvas hit
+- scroll delta when the phase carries scrolling
+
+One pointer-sample family covers all phases. This is an API payload decision,
+not a naming rule for adapter classes or callbacks.
+
+### Canvas Capability
+
+The capability accepts a current canvas scene and publishes technical pointer
+samples. Camera and viewport changes may publish canvas state but never mutate
+adopter truth.
+
+## Validation And Error Behavior
+
+- Non-finite coordinates or geometry are rejected at the map-canvas boundary.
+- A pointer sample without a hit still carries a valid canvas point and scene
+  revision.
+- A hit whose revision is stale or unknown is returned as no-hit; Maps does not
+  guess an adopter target.
+- Missing optional fields mean absence, not adopter-specific defaults.
+- An empty scene remains renderable and hittable as no-hit.
+- Duplicate scene revisions with different content are rejected.
+- Adapter failures must not mutate the last accepted scene or adopter state.
+
+## Compatibility And Versioning
+
+Internal Java types may change atomically with all consumers in one green slice.
+The semantic obligations in this contract remain stable: canvas-native exchange,
+one scene revision for draw and hit, opaque adopter identity, passive camera
+behavior, and no adopter meaning inside Maps.
+
+Adding optional primitive families is backward-compatible. Changing coordinate,
+revision, identity, or hit-order semantics requires an explicit contract
+migration with every adopter updated together.
+
+
+## References
+
+- [Maps Canvas Requirements](../requirements/requirements-maps-canvas.md)
+- [Maps Canvas Architecture](../architecture/architecture-maps-canvas.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/maps/contract/contract-maps-dungeon-surface.md
+++ b/docs/maps/contract/contract-maps-dungeon-surface.md
@@ -1,0 +1,176 @@
+# Dungeon Map Surface Contract
+
+## Purpose, Owners, And Consumers
+
+This feature-boundary contract defines the dungeon-native request and response
+families exposed from `features/dungeon/api` for committed map reads, editor
+preview and apply, selection inspection, catalog behavior, and travel sessions.
+
+- provider: Dungeon feature APIs
+- consumers: Dungeon JavaFX adapter and foreign features that need a documented
+  Dungeon capability
+- composition owner: `app`, which passes typed APIs explicitly
+
+Consumers depend only on `features.dungeon.api`; they do not import Dungeon
+domain, application, SQLite adapter, JavaFX adapter, or composition packages.
+The contract owns boundary semantics, not authored invariants or persistence
+schema.
+
+## Rules
+
+- Committed map reads and selection inspection use the owning Authored, Editor,
+  or Travel API for that workspace.
+- Preview and apply reuse one authored operation vocabulary. Preview never
+  persists authored truth.
+- Editor controls, map, selection, preview, inspector, and command outcome come
+  from one immutable `DungeonEditorState` revision.
+- Catalog work uses one catalog request and response family.
+- Runtime travel reads and moves use one travel-session command and immutable
+  state family.
+- Authored read, authored mutation, catalog, and travel remain distinct API
+  capabilities even when one Dungeon entry point provides them.
+- Public state is immutable and revisioned; a late result cannot replace newer
+  state.
+
+## Inbound Request Families
+
+### Authored Read And Selection
+
+Operations:
+
+- select or read a map
+- inspect a pointer-selected authored target
+
+Required context:
+
+- map id for map selection
+- typed pointer or selection sample for inspection
+
+Optional context:
+
+- topology ref, handle ref, and boundary target carried by the selection sample
+
+### Authored Mutation
+
+`DungeonEditorIntent` covers map selection, projection, overlay, tool family and
+options, narration, labels, stairs, transitions, markers, and pointer-driven
+authored work. Pointer intents carry `ToolFamily`, `ToolOptions`, and
+`PointerGesture` meaning translated from the displayed canvas revision.
+
+Preview and apply use the same typed command plan. Apply adds commit intent; it
+does not reconstruct a second edit vocabulary.
+
+### Catalog
+
+Operations:
+
+- search and list maps
+- create a map
+- rename a map
+- delete a map
+
+### Travel
+
+Actions:
+
+- `REFRESH`
+- `ACTION`
+- `MOVE_TO_CELL`
+- `SET_PROJECTION_LEVEL`
+- `SHIFT_PROJECTION_LEVEL`
+- `SET_OVERLAY`
+
+Required fields:
+
+- chosen action id for `ACTION`
+- target Dungeon cell for `MOVE_TO_CELL`
+- projection level for `SET_PROJECTION_LEVEL`
+- projection-level delta for `SHIFT_PROJECTION_LEVEL`
+- overlay settings for `SET_OVERLAY`
+
+Optional fields:
+
+- action id for `REFRESH`
+- projection level and overlay settings for `REFRESH` or `ACTION`
+
+## Outbound State And Result Families
+
+### Authored Read
+
+- committed `DungeonViewportSnapshot`
+- stable inspector facts carried by `DungeonEditorState` when selected
+- map revision and stable authored identities
+
+### Authored Mutation
+
+- immutable `DungeonEditorState`
+- accepted result with resulting revision and changed stable identities, or a
+  typed rejection reason with unchanged committed revision
+
+### Catalog
+
+- `List<DungeonMapSummary>`
+- mutation kind plus `DungeonMapId`
+
+### Travel
+
+- immutable `DungeonTravelState`
+- travel-session revision, available actions, projection level, overlays, and
+  party position needed by the workspace
+
+These names describe Dungeon API semantics. They require no model suffix or
+presentation projection class.
+
+## Maps Integration
+
+The Dungeon JavaFX adapter translates Dungeon API state into
+`platform.ui.mapcanvas` scene values and map-canvas pointer samples into
+Dungeon API requests.
+
+- Dungeon-grid coordinates and topology identity never enter Maps as domain
+  types.
+- Canvas geometry and hit areas never enter Dungeon authored or travel state.
+- Render primitives, labels, overlays, markers, relations, and token anchors are
+  derived presentation state and never persistence input.
+- One scene revision corresponds to one consumed Dungeon state revision.
+- Catalog requests bypass the canvas capability.
+
+## Validation And Error Behavior
+
+- Invalid authored edits publish a rejected `DungeonEditorCommandOutcome` with
+  unchanged committed truth and a stable typed rejection reason.
+- Invalid travel actions return unchanged authored truth and an immutable travel
+  result that reports rejection without inventing a move.
+- Preview must not persist authored truth.
+- Unknown map, topology, handle, selection, or action identities are rejected or
+  represented as absence according to the owning operation; adapters must not
+  synthesize replacements.
+- A travel action is addressed by stable action id, never by presentation-row
+  position. Direct movement and listed actions share one validation and outcome
+  path.
+- Missing optional result sections mean absence, not defaults invented by a
+  consumer.
+- A stale asynchronous result must not overwrite a newer Dungeon API revision.
+- Translation into canvas-native values must preserve Dungeon meaning but must not
+  mutate Dungeon state.
+
+## Compatibility, Migration, And Versioning
+
+Persisted dungeon truth and observable behavior retain their domain,
+persistence, and requirements owners. Internal Java API types may change with
+all consumers in one atomic green migration slice.
+
+Changing authored operation meaning, stable identities, commit semantics,
+catalog mutation semantics, or travel action meaning requires an explicit
+contract migration. Adding optional read fields is compatible when old consumers
+continue to distinguish absence from defaults.
+
+
+## References
+
+- [Maps Canvas Architecture](../architecture/architecture-maps-canvas.md)
+- [Dungeon Map Adoption Architecture](../architecture/architecture-maps-dungeon-adoption.md)
+- [Maps Canvas Contract](contract-maps-canvas.md)
+- [Dungeon Persistence Contract](../../dungeon/contract/contract-dungeon-persistence.md)
+- [Dungeon Domain Model](../../dungeon/domain/domain-dungeon.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/maps/requirements/requirements-maps-canvas.md
+++ b/docs/maps/requirements/requirements-maps-canvas.md
@@ -1,0 +1,76 @@
+# Maps Canvas Requirements
+
+## Goal
+
+Provide feature-neutral passive map-canvas mechanisms that Dungeon and Hex
+JavaFX surfaces reuse for rendering, hit-testing, camera behavior, viewport
+caching, and passive pointer capture.
+
+## Non-Goals
+
+- adopter domain invariants
+- adopter persistence rules
+- adopter-native payload vocabulary
+- adopter-specific gameplay behavior
+
+## Visible Structure
+
+- one workspace frame and canvas host
+- one rendered scene that can draw adopter-provided cells or tiles,
+  boundaries or edges, labels, markers, actor tokens, relations, and overlays
+- one passive camera and viewport owner
+- one passive pointer-capture surface
+- one adopter-independent empty or placeholder presentation
+
+## Required Behavior
+
+- the canvas MUST draw from one shared scene root
+- hit-testing MUST derive from the same scene the canvas draws
+- pan, zoom, resize, and reset-view behavior MUST remain passive presentation
+  behavior
+- empty-state and placeholder rendering MUST be possible without synthesizing
+  adopter-native map content
+- the canvas MUST support adopter-provided labels, markers, and runtime travel
+  tokens without turning them into canvas-owned domain meaning
+- the canvas MUST remain reusable for both square-grid and hex-grid adopters
+- the canvas MAY host different adopter-facing scene presentations, for
+  example tile-first or graph-like scenes, while keeping the same passive
+  interaction model
+- the canvas MUST NOT emit adopter-native coordinates, refs, commands, or
+  queries directly
+
+## Interactions
+
+- middle-pointer drag pans the camera
+- zoom and resize redraw against the current camera state
+- reset view restores the default camera state without changing adopter truth
+- pointer events remain passive and are delivered to the adopting feature
+  without acquiring adopter-specific meaning inside the canvas
+- pointer press, drag, release, move, and level-scroll capture remain
+  adopter-triggered outcomes rather than canvas-owned game actions
+- shell layout changes do not implicitly recenter the canvas
+
+## Visible States
+
+- explicit empty state when no map or scene is available
+- loaded scene state with adopter-provided geometry and overlays
+- camera changes that leave the rendered content stable until the adopter
+  changes the scene
+- adopter-owned overlay on or off states presented through the shared canvas
+- adopter-owned runtime marker states such as current token position
+
+## Acceptance Criteria
+
+- draw and hit reflect the same current scene
+- the camera remains scene-stable while pointer hits change
+- the passive canvas stays reusable across grid-based and hex-based adopters
+- the canvas can show empty, loaded, and overlay-bearing scenes without
+  inventing adopter-specific placeholder data
+- adopter-native coordinate conversion happens outside the passive canvas
+
+## References
+
+- [Maps Canvas Architecture](../architecture/architecture-maps-canvas.md) (line 1)
+- [Maps Canvas Contract](../contract/contract-maps-canvas.md) (line 1)
+- [Dungeon Map Adoption Architecture](../architecture/architecture-maps-dungeon-adoption.md) (line 1)
+- [Hex Map Adoption Architecture](../architecture/architecture-maps-hex-adoption.md) (line 1)

--- a/docs/party/README.md
+++ b/docs/party/README.md
@@ -1,0 +1,14 @@
+# Party Feature README
+
+## Purpose
+
+The party feature owns the Campaign Roster, its current-Party subset, character
+state, party persistence behavior, and the public backend boundary `PartyApi`.
+
+## Documentation Set
+
+- [Party Domain Model](domain/domain-party.md)
+- [Party Persistence](contract/contract-party-persistence.md)
+- [Party Dropdown Requirements](requirements/requirements-party-dropdown.md)
+- [Adventuring Day Dropdown Requirements](requirements/requirements-adventuring-day-dropdown.md)
+- [Adventuring Day Calculator Requirements](requirements/requirements-adventuring-day-calculator.md)

--- a/docs/party/contract/contract-party-persistence.md
+++ b/docs/party/contract/contract-party-persistence.md
@@ -1,0 +1,95 @@
+# Party Persistence
+
+This document is normative for the `party` feature's persistence path.
+
+## Adapter Boundary
+
+- The party SQLite adapter satisfies party-owned application ports and remains
+  private to the party composition entry point.
+- The application composition supplies `PartyApi` explicitly to consumers; no
+  registry, discovery convention, published mutable model, or adapter type is
+  a public boundary.
+- SQL rows, mappers, gateways, and schema helpers MUST NOT cross `PartyApi`.
+
+## Mandatory Schema
+
+- The feature-owned persistence schema declaration is the canonical in-code
+  schema owner.
+- The schema currently owns:
+  - `player_characters`
+  - `party_roster_metadata`
+- `player_characters` stores character-owned travel columns for dungeon and
+  overworld locations plus the party-token attachment flag. These columns are
+  part of character state, not a campaign-level travel table and not dungeon
+  authored truth.
+- owner startup creates the complete current schema directly as owner version
+  `1`, and only when the Party object namespace is empty
+- startup validates the exact table definitions and complete Party-owned object
+  inventory before the store becomes ready
+
+## Current Mapping
+
+Party persistence stores the character roster, membership, progression, combat
+profile, and character-specific runtime travel context in the party write
+model. That travel context is represented as scalar references to the owning
+space:
+
+- `name` is required; `player_name`, `level`, `passive_perception`, and `ac`
+  are nullable and preserve authored absence without sentinel values
+- a newly inserted Roster character defaults to inactive membership and no
+  party-token attachment; activation and attachment require later explicit
+  mutations
+
+- dungeon travel location stores map id, local owner id, local tile coordinate,
+  level, location kind, and heading
+- overworld travel location stores overworld map id and tile id
+- party-token attachment stores whether a character currently follows the
+  shared party token position
+
+The Party SQLite adapter maps those columns through private records into Party
+domain values. Dungeon persistence remains responsible for authored map
+truth only; it does not persist character positions.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
+
+- party writes MUST reject malformed character identity, roster, progression,
+  or travel-location payloads instead of silently persisting partial character
+  truth
+- a present level requires at least its rules-profile XP floor; XP since the
+  short rest cannot exceed XP since the long rest, and neither rest-progress
+  counter can exceed current XP
+- nullable optional facts MUST round-trip as SQL `NULL`; readers and writers
+  MUST NOT replace absence with level `1`, passive perception `10`, AC `10`, or
+  another compatibility/default value
+- dungeon and overworld travel references MUST be validated as party-owned
+  scalar location references rather than expanded into authored map truth
+- storage and schema failures MUST surface through Party API result statuses
+  rather than leaking SQLite exceptions to consumers
+- the required singleton metadata row MUST be present; reads do not reconstruct
+  it from character rows
+
+## Current Schema Lifecycle
+
+Compatibility obligations begin with the first released format.
+Before the first released format, only the current direct version-`1` schema is accepted.
+Unversioned partial, superseded, structurally damaged, adjacent-owner-object,
+and newer shapes fail closed without `ALTER`, repair, backfill, copy, drop,
+normalization, or a version claim. They must be discarded and recreated from
+the current product.
+
+## Stability Rules
+
+- The party roster write port remains an internal collaborator injected by the
+  party composition entry point.
+- Character-specific runtime state belongs in party persistence unless another
+  bounded context owns the character information itself.
+- Foreign features MUST use `PartyApi` for party commands and readback.
+
+
+## References
+
+- [Party Domain Model](../domain/domain-party.md) (line 1)
+- [Party Dropdown UI](../requirements/requirements-party-dropdown.md) (line 1)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/party/domain/domain-party.md
+++ b/docs/party/domain/domain-party.md
@@ -1,0 +1,128 @@
+# Party Domain Model
+
+## Context Role
+
+Context Role: Party Character State Context
+Context Name: Party
+
+- `party` is the Campaign Roster and current-Party character state context.
+- Its public boundary is `PartyApi`.
+- The feature owns party composition, party membership, XP progression,
+  rest-driven mutation rules, and character-specific runtime travel position.
+
+## Published Language
+
+`PartyApi` owns public party commands, results, snapshots, status enums,
+membership states, rest carriers, and adventuring-day calculation carriers.
+Character
+detail snapshots publish current XP, current-level XP floor, next-level XP
+threshold, and rest cadence facts so downstream views can render progression
+without depending on roster internals.
+
+The party domain MUST NOT depend on API carriers. The application boundary
+translates public carriers into roster values before delegating to the model.
+
+## Application Boundary
+
+The application boundary contains party use cases. Use cases load one
+`PartyRoster`, delegate mutation or query decisions to the roster model, and
+save through a feature-owned persistence port. The application layer publishes
+immutable, revisioned API state and mutation feedback through `PartyApi`.
+
+## Write Model
+
+The authored write model is the persisted Campaign Roster and character state:
+
+- stable character identity
+- optional player identity, level, and combat-profile facts
+- explicit current-Party membership state
+- XP and rest progression without inventing a missing authored level
+- character-specific travel location and whether that character is attached to
+  the party token
+
+## Aggregate Model
+
+Aggregate Root: PartyRoster
+
+`PartyRoster` is the transaction boundary for one party roster. It owns the
+character collection, next character identity, optional authored facts,
+membership assignment, XP
+awards and corrections, and rest-driven progression transitions.
+
+`PartyCharacter` is an identity-bearing child model. The Party domain owns
+identity, progress, combat profile, membership, rest type, travel position,
+and mutation status vocabulary; package and helper decomposition are internal
+implementation choices.
+
+## Commands And Invariants
+
+Commands entering the aggregate are:
+
+- create Roster character
+- update character
+- delete character
+- set membership
+- award XP or correct XP with a signed delta
+- perform rest
+- move characters to a dungeon or overworld travel location
+
+Core invariants:
+
+- character identity remains stable across roster mutations
+- character name is the only universal creation requirement; player, level,
+  passive perception, and Armor Class preserve exact presence or absence
+- character creation always produces an inactive Roster member detached from
+  Party travel and Scene participation
+- active and reserve membership is owned by the party aggregate, not by view
+  state, and changes only through the explicit membership command
+- XP and level progression remain internally consistent after award, signed
+  correction, and rest operations
+- editing identity or optional combat facts with the same authored level never
+  changes XP or rest progress; changing or clearing the authored level never
+  discards earned XP, while a raised level establishes at least that level's XP
+  floor
+- negative XP correction is capped at the current level's XP floor and reduces
+  rest-cadence XP counters by the applied correction amount without going below
+  zero
+- character-specific travel location is stored with the character, not in a
+  campaign-level model, shell session, dungeon map, or presentation model
+- the party token is derived from attached character travel state instead of
+  being a separate write model
+- adventuring-day budget and progress calculations use party-owned level and
+  rest-budget policies and are exposed through Party API read carriers; an
+  automatic calculation requiring level does not run with a missing level
+- external mutation enters through the owning roster aggregate
+
+## Consistency Model
+
+One roster mutation changes one `PartyRoster` aggregate instance and is saved
+by the party roster persistence repository. Other contexts consume party state
+through `PartyApi` instead of
+sharing roster internals.
+
+## Ubiquitous Language
+
+- `PartyRoster`: authored party aggregate.
+- `PartyCharacter`: identity-bearing character inside the roster.
+- `PartyMembership`: active or reserve participation state.
+- `PartyCharacterProgress`: level, XP, and rest-cadence progress.
+- `PartyCharacterTravelState`: character-owned runtime travel state and party
+  token attachment.
+- `PartyTravelLocation`: character travel target in a dungeon or overworld
+  space.
+- `PartyRestType`: short-rest or long-rest roster transition.
+
+## Architecture Constraints
+
+- party mutation rules stay on the roster model and related pure domain work
+- application orchestration remains thin and publishes state through `PartyApi`
+- the roster domain remains free of API-carrier dependencies
+- character-specific state, including dungeon and overworld travel position,
+  stays with the character-owned roster state
+- Dungeon travel changes party position through `PartyApi`; shell session state
+  and campaign-level models are not alternate owners
+
+## References
+
+- [Party Persistence](../contract/contract-party-persistence.md)
+- [Party UI](../requirements/requirements-party-dropdown.md)

--- a/docs/party/requirements/requirements-adventuring-day-calculator.md
+++ b/docs/party/requirements/requirements-adventuring-day-calculator.md
@@ -1,0 +1,54 @@
+# Adventuring Day Calculator
+
+## Component Purpose
+
+The Adventuring Day calculator appears inside the Adventuring Day dropdown. It
+presents the original-style budget and progress controls and shows calculation
+results for either the active party or custom level/count rows.
+
+Current state:
+
+- The calculator supports row editing, mode toggles, summary output, and timeline
+  output.
+- Active-party levels and calculated results come from the owning Party feature.
+- The calculator presentation does not define adventuring-day calculation rules.
+
+## Visible Surfaces
+
+- The calculator has no separate navigation destination.
+- It appears inside the Adventuring Day top-bar popup scroll area.
+
+## Interactions
+
+- Active-party mode follows the levels supplied by the owning dropdown.
+- Custom mode lets the user edit level/count rows locally without mutating the
+  party roster.
+- Budget mode shows daily XP thresholds and rest milestones.
+- Progress mode maps group XP to adventuring days, rest counts, level-up
+  summary, and timeline events.
+
+## Visible States
+
+- Active-party mode: calculator rows mirror the current active party levels.
+- Custom mode: edited rows remain local to the calculator surface.
+- Budget mode: daily thresholds and rest milestones are visible.
+- Progress mode: group XP produces day-progress, rest-count, and timeline
+  output.
+
+## Acceptance Criteria
+
+- the calculator remains contained in the Adventuring Day dropdown and has no
+  separate navigation destination
+- switching from active-party mode to direct row editing does not mutate the
+  party roster
+- budget mode exposes daily threshold and rest-milestone output for the current
+  rows
+- progress mode maps the entered XP amount into adventuring-day progress,
+  rest-count, level-up summary, and timeline events
+- adventuring-day calculations come from the owning Party feature, while the
+  calculator surface presents inputs and results without defining those rules
+
+## References
+
+- [Adventuring Day Top-Bar UI](requirements-adventuring-day-dropdown.md)
+- [Party Dropdown UI](requirements-party-dropdown.md)

--- a/docs/party/requirements/requirements-adventuring-day-dropdown.md
+++ b/docs/party/requirements/requirements-adventuring-day-dropdown.md
@@ -1,0 +1,65 @@
+# Adventuring Day Top-Bar UI
+
+## Component Purpose
+
+The Adventuring Day top-bar dropdown restores the original separate rest-budget
+trigger next to the Party trigger. It reads the active party's adventuring-day
+summary for the trigger and hosts the original-style adventuring-day calculator
+as a top-bar control panel.
+
+Current state:
+
+- The trigger reads the active party's rest-budget summary through the Party
+  feature boundary.
+- The dropdown renders the calculator surface with active-party and custom
+  party input modes.
+- Calculation decisions are requested through the Party feature boundary;
+  the JavaFX view owns controls and rendering only.
+
+## Visible Surfaces
+
+- `TOP_BAR` hosts the rest-budget trigger before the Party trigger.
+- The trigger shows `Rastbudget`, `Kein Rastbudget`, `Rastbudget nicht
+  verfügbar`, or `SR <xp> · LR <xp>` depending on read state.
+- The dropdown shows an `ADVENTURING DAY` header and a scrollable calculator
+  panel.
+- The calculator includes source controls (`Aktive Party`, `Zeile`, `Leeren`),
+  mode controls (`Budget`, `XP -> Tage`), a `Gesamt-XP` input in progress mode,
+  level/count rows, a summary card, and an `Etappen` timeline card.
+
+## Interactions
+
+- Opening the dropdown refreshes the active party's adventuring-day summary.
+- `Aktive Party` repopulates calculator rows from the active party levels.
+- Editing rows switches the calculator to custom party mode without mutating the
+  party roster.
+- `Budget` shows the daily budget and rest milestones for the current rows.
+- `XP -> Tage` shows adventuring-day progress, rest counts, level-up summary,
+  and timeline events for the entered group XP.
+
+## Visible States
+
+- Loading: the trigger can temporarily show that the rest-budget summary is
+  unavailable while it refreshes.
+- No budget: the trigger shows `Kein Rastbudget`.
+- Storage error: the trigger shows `Rastbudget nicht verfügbar`.
+- Loaded budget: the trigger shows `Rastbudget` or the compact `SR <xp> · LR
+  <xp>` summary and the dropdown exposes the calculator surface.
+
+## Acceptance Criteria
+
+- the top bar exposes a dedicated rest-budget trigger separate from the Party
+  trigger
+- opening the dropdown refreshes the current active-party adventuring-day
+  summary before showing stale results as final truth
+- `Aktive Party` reloads calculator rows from the active party without mutating
+  the underlying roster
+- editing rows moves the calculator into custom mode without persisting party
+  changes
+- budget and progress modes stay available inside the same dropdown surface and
+  reuse the shared calculator behavior
+
+## References
+
+- [Adventuring Day Calculator](requirements-adventuring-day-calculator.md)
+- [Party Dropdown UI](requirements-party-dropdown.md)

--- a/docs/party/requirements/requirements-party-dropdown.md
+++ b/docs/party/requirements/requirements-party-dropdown.md
@@ -1,0 +1,96 @@
+# Party Dropdown UI
+
+## Component Purpose
+
+The party dropdown is the top-bar surface for the Campaign Roster and its
+distinct current-Party subset. It lets the GM manage all Campaign PCs and
+explicitly change table participation without becoming a separate navigation
+tab.
+
+Current state: the dropdown reads the real party snapshot and adventuring-day
+summary, and mutation controls use the Party feature's public mutation API.
+
+## Visible Surfaces
+
+- The application top bar hosts the party dropdown trigger and dropdown content.
+- The dropdown trigger shows only party membership state: no-party text or the
+  active character count with average level. Adventuring-day rest-budget state
+  is shown by the separate Adventuring Day top-bar surface.
+- The dropdown content shows a `PARTY` header, active member rows and rest
+  actions plus a distinct `CHARAKTER-ROSTER` section containing every active or
+  inactive PC. Roster rows expose stable Roster IDs so namesakes remain
+  distinguishable. Search matches name, player, or Roster ID.
+- Active member rows are compact full-width two-line cards. The first line
+  shows character and player identity, current and next level, an overlaid
+  `current XP/next-level XP (%)` level-up meter, and popup-based XP correction.
+  The second line shows combat/rest metadata plus edit and remove affordances.
+- The Roster create/edit editor is a secondary anchored dropdown. Only the
+  character name is required; player, level, passive perception, and AC are
+  optional and can be cleared again. Edit mode identifies the PC by stable ID
+  and retains explicit delete confirmation. The editor stays open on validation
+  or storage failures and reports the field or mutation error inline.
+
+## Interactions
+
+- Opening the dropdown requests the current party snapshot from the Party
+  feature.
+- Roster search filters all Campaign PCs locally.
+- Creating a PC adds it only to the Roster. It does not activate current-Party
+  membership, attach the PC to the Party travel token, or assign a Scene.
+- Adding or removing current-Party membership is a separate explicit action on
+  an existing Roster PC. Create, edit, delete, XP correction, membership, rest,
+  and long-rest controls persist through the Party feature's public mutation
+  API and refresh the dropdown snapshot after successful mutations.
+- Clicking a character's level-up meter opens a compact XP popup. `+XP` awards
+  XP, while `-XP` corrects previously awarded XP without lowering the
+  character below the current level's XP floor.
+- Character editor submission requires a non-blank name and validates only
+  optional values that were entered. Failed validation does not close the
+  editor or mutate the Roster.
+- After successful party mutations, updated Party state is available when
+  Encounter surfaces refresh party-derived thresholds and combat baselines.
+- The trigger supports the party mnemonic and can be opened from the top bar
+  with `Alt+P` when focus is in the application.
+- Closing the dropdown leaves party domain state unchanged unless an explicit
+  mutation action has already completed.
+
+## Visible States
+
+- Loading: party summary content is temporarily unavailable while the snapshot
+  refreshes.
+- Empty: no active party members are available.
+- Loaded: member summaries and adventuring-day status are visible.
+- Storage error: the dropdown reports that party data could not be loaded.
+- Action feedback: a successful or warning-colored inline status explains the
+  mutation result.
+- Editor error: invalid editor input, missing characters, or failed storage
+  writes are shown inside the editor while the entered values remain available
+  for correction.
+
+## Acceptance Criteria
+
+- the Party dropdown remains a top-bar party surface and does not become a
+  separate navigation tab
+- opening the dropdown refreshes the current party snapshot before new
+  mutations are presented as final state
+- create, edit, remove, rest, and XP-correction actions persist only through
+  the Party feature's public mutation API
+- name-only creation succeeds, leaves every optional fact absent, and changes
+  neither current Party nor Scene/travel participation
+- duplicate names remain independently editable and visibly distinguishable by
+  stable Roster ID
+- clearing an optional player, level, passive-perception, or AC value restores
+  absence rather than a default or sentinel
+- current-Party membership changes only through a separate explicit action
+- failed editor validation keeps the editor open, preserves entered values, and
+  renders inline error feedback
+- after successful mutations, downstream Encounter refreshes observe the
+  updated party-derived thresholds and baselines
+- closing the dropdown without a completed mutation leaves party domain state
+  unchanged
+
+## References
+
+- [Adventuring Day Top-Bar UI](requirements-adventuring-day-dropdown.md)
+- [Party Domain Model](../domain/domain-party.md)
+- [Party Persistence](../contract/contract-party-persistence.md)

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,35 @@
+# Project Documentation
+
+This directory owns cross-feature canonical documentation. Feature-owned truth
+lives under `docs/<feature>/`; see [docs/README.md](../README.md).
+
+## Direction
+
+- [Vision](vision.md) -- who SaltMarcher is for, and what it is not.
+
+## Architecture
+
+- [Program Technical Needs](architecture/program-technical-needs.md) --
+  solution-neutral obligations and measurable quality scenarios derived from
+  the confirmed complete local GM-core needs.
+- [Source Architecture](architecture/source-architecture.md) -- target source
+  shape, boundaries, quality concerns, and migration relationship. Start here.
+- Patterns: [feature boundaries](architecture/patterns/feature-boundaries.md),
+  [application composition](architecture/patterns/application-composition.md),
+  [shell layer](architecture/patterns/shell-layer.md), and
+  [styling](architecture/patterns/styling.md).
+
+## Contracts
+
+- [Persistence Lifecycle](contract/persistence-lifecycle.md) -- shared SQLite
+  location, connection, version, backup, and recovery semantics.
+
+## Repo-Wide Requirements
+
+Behavior owned centrally rather than by one feature:
+[anchored popup](requirements/requirements-anchored-popup.md),
+[program capabilities](requirements/requirements-program-capabilities.md),
+[dialog surface](requirements/requirements-dialog-surface.md),
+[dropdown popup](requirements/requirements-dropdown-popup.md),
+[progress meter](requirements/requirements-progress-meter.md),
+[travel state tab](requirements/requirements-travel-state-tab.md).

--- a/docs/project/architecture/patterns/application-composition.md
+++ b/docs/project/architecture/patterns/application-composition.md
@@ -1,0 +1,47 @@
+# Application Composition Standard
+
+## Concern
+
+The application must reveal startup dependencies at compile time while the
+shell remains passive and feature behavior remains feature-owned.
+
+## Rules
+
+- `app` MUST construct platform services and feature entry points explicitly in
+  dependency order.
+- `app` MUST compose immutable installation and Campaign feature-storage
+  definitions into their owning persistence lifecycles and complete
+  owner-scoped storage preparation before constructing or starting any service
+  that can enqueue persistence work.
+- `app` may import a feature's exact composition-root package and public API;
+  it MUST NOT import that feature's domain, application, or adapter packages.
+- `app` MUST pass typed dependencies into feature and shell constructors.
+- Feature entry points MAY expose their public API and constructed shell
+  contributions to `app`; they MUST NOT expose internal repositories or
+  adapters as application-wide services.
+- Startup MUST register each shell contribution exactly once, preserve
+  deterministic ordering, and choose at most one default landing target.
+- Runtime classpath scanning, reflective contribution construction, suffix
+  discovery, service registries, and service locators are forbidden.
+- `app` MUST own lifecycle shutdown for executors, database resources, and the
+  JavaFX application. It MUST NOT own feature state or business decisions.
+- Installation services and the active Campaign graph MUST have separate
+  lifetimes. One installation-owned coordinator serializes Campaign activation,
+  prepares a survivor-capable core candidate, fences and drains prior writes,
+  commits the durable active-Campaign generation, publishes the new Campaign
+  shell root, and closes the prior runtime. Before the durable commit a failure
+  restores the prior runtime; after it, recovery rolls forward to the committed
+  Campaign. Candidate readiness uses semantic survivor readback plus a
+  non-payload transactional rollback probe; it never mutates user-authored
+  truth as a health check. The exact next durable feature mutation is qualified
+  on a disposable Campaign through the production route. Optional-capability
+  readiness cannot block core publication.
+- Startup phases are explicit: compose definitions, prepare storage, construct
+  services, start feature work, register shell contributions. Constructor or
+  composition side effects MUST NOT perform persistence work.
+
+## References
+
+- [Source Architecture](../source-architecture.md)
+- [Feature Boundary Standard](feature-boundaries.md)
+- [Shell Layer Standard](shell-layer.md)

--- a/docs/project/architecture/patterns/feature-boundaries.md
+++ b/docs/project/architecture/patterns/feature-boundaries.md
@@ -1,0 +1,60 @@
+# Feature Boundary Standard
+
+## Dependency Direction
+
+Each `features/<name>/` area may contain these roles:
+
+```text
+api              commands, results, immutable state, public capabilities
+domain           feature truth and invariants
+application      orchestration over domain and ports
+adapter/sqlite   persistence mechanics and translation, when stored truth exists
+adapter/resource bundled read-only resource loading and translation, when static reference data exists
+adapter/http     explicit remote protocol integration, when a feature owns external HTTP exchange
+adapter/javafx   presentation and shell contribution, when JavaFX UI exists
+<feature root>   composition entry point used only by app
+```
+
+Roles are capability-driven, not a required folder template. A feature MUST
+NOT create an empty adapter package merely to match this list.
+
+- Cross-feature dependencies originate only from application, JavaFX adapter,
+  or composition code and MUST target the provider's `api` package.
+- `api` MUST NOT depend on feature implementation packages. Observable API
+  contracts MAY use `platform.state` and `platform.ui` contracts; they MUST NOT
+  use JavaFX, JDBC, file I/O, or other platform capabilities.
+- `domain` MUST NOT depend on API carriers, application, adapters, feature
+  composition, SQL, JavaFX, shell, platform, or foreign-feature code.
+- `application` MAY depend on its API, domain, `platform.execution`,
+  `platform.state`, `platform.ui`, and `platform.diagnostics`; it MUST NOT
+  depend on adapters or shell code.
+- `adapter/sqlite` MAY implement feature-owned ports and use
+  `platform.persistence` plus `platform.diagnostics`. It MUST NOT depend on
+  JavaFX adapters.
+- `adapter/resource` MAY implement feature-owned ports and read bundled,
+  offline resources through JDK resource I/O. It MAY use
+  `platform.diagnostics`; it MUST NOT depend on application orchestration,
+  foreign features, JDBC, or JavaFX.
+- `adapter/http` MAY implement feature-owned ports and use JDK HTTP client APIs.
+  It MUST NOT depend on application orchestration, foreign features, JDBC,
+  local file I/O, JavaFX, or shell code. Remote calls are explicit use cases;
+  they MUST NOT run as constructor, startup, or UI-side effects.
+- `adapter/javafx` MAY depend on its feature API, domain values, and application
+  layer, foreign feature APIs, `shell.api`, and `platform.ui`. It MUST NOT reach
+  into a foreign domain, application, or adapter, SQLite packages, or other
+  platform capabilities.
+- The feature composition entry point MAY construct all packages of its own
+  feature, wire any platform capability, and receives foreign APIs explicitly
+  from `app`.
+- Boundary values remain typed: enums and value types cross as themselves;
+  string round-trips, duplicate enum vocabularies, and stringly typed `kind`
+  constants are forbidden where a type exists.
+- One representation serves one purpose. State is reshaped only at a real
+  consumer boundary that requires a different shape; forwarding duplicates and
+  parallel carrier models are not compatibility surfaces.
+
+## References
+
+- [Source Architecture](../source-architecture.md)
+- [Application Composition Standard](application-composition.md)
+- [Shell Layer Standard](shell-layer.md)

--- a/docs/project/architecture/patterns/shell-layer.md
+++ b/docs/project/architecture/patterns/shell-layer.md
@@ -1,0 +1,34 @@
+# Shell Layer Standard
+
+## Goal
+
+SaltMarcher uses a passive cockpit shell. The shell owns hosting, navigation,
+view activation, details/history, state-pane arbitration, and shell-scoped UI
+capabilities. Application startup and shutdown remain in `app`. The shell does
+not own feature logic, business behavior, or feature state mutation.
+
+## Shell Responsibilities
+
+- host left-bar, top-bar, main, details/history, and state-pane surfaces
+- activate and deactivate explicitly supplied bindings
+- expose public shell contracts under `shell/api/**`
+- provide shell-owned inspector, navigation, and session capabilities through
+  narrow shell contracts
+- keep concrete shell host internals private from feature code
+
+## Boundaries
+
+Features communicate with the shell only through `shell.api` contracts. The
+shell MUST NOT import concrete feature implementations, locate feature
+services, or store long-lived feature state. Concrete shell internals MAY use
+feature-neutral platform mechanisms such as UI dispatch and local diagnostics;
+public `shell.api` contracts MUST NOT expose platform implementation types.
+Those concrete dependencies target only `platform.ui` and
+`platform.diagnostics`.
+
+
+## References
+
+- [Source Architecture](../source-architecture.md)
+- [Feature Boundary Standard](feature-boundaries.md)
+- [Application Composition Standard](application-composition.md)

--- a/docs/project/architecture/patterns/styling.md
+++ b/docs/project/architecture/patterns/styling.md
@@ -1,0 +1,26 @@
+# Styling Standard
+
+## Goal
+
+SaltMarcher styling is authored centrally so feature code does not carry its
+own inline presentation system.
+
+## Rules
+
+- Approved application style rules and shared selector vocabulary live in
+  `resources/salt-marcher.css`.
+- `app` applies shared application styling from that stylesheet.
+- Active application code under `app/`, `shell/`, `platform/`, and `features/`
+  expresses ordinary node styling through explicit centralized style-class
+  selectors.
+- Active application code must not use `setStyle(...)`.
+- Passive views must not author ordinary node layout styling through local
+  padding, spacing, gap, or fixed visual-size setters.
+- Direct rendering is allowed for surfaces such as canvas drawing where CSS
+  selectors cannot express the rendered pixels directly.
+- Direct-rendered values should still be derived from centralized styling truth
+  rather than a local visual system.
+
+## References
+
+- [Source Architecture](../source-architecture.md)

--- a/docs/project/architecture/program-technical-needs.md
+++ b/docs/project/architecture/program-technical-needs.md
@@ -1,0 +1,603 @@
+# SaltMarcher Program Technical Needs
+
+## Purpose
+
+This document is the binding technical-needs input to a later greenfield target
+architecture. It translates confirmed product behavior into solution-neutral
+obligations, invariants, quality scenarios, and change scenarios. It does not
+select source modules, feature boundaries, APIs, schemas, storage mechanisms,
+frameworks, processes, or technologies.
+
+The input baseline is the `Active Target` in
+`docs/project/requirements/requirements-program-capabilities.md`, originally
+merged to `origin/main` by commit `9678b65f62857a26ceb494255eff465748aed299`
+on 2026-07-23 and extended by the confirmed 2026-07-26 in-game tutorial owner
+requirement. The project vision is an additional binding local constraint.
+Current implementation and prior design decisions were not derivation inputs.
+
+Target architecture, comparison with the current system, and migration planning
+remain later phases.
+
+## Stakeholders And Concerns
+
+| Stakeholder | Concern owned here |
+| --- | --- |
+| GM | Campaign truth, continuity during table play, recoverability, privacy, and explicit authority |
+| Product owner | Complete derivation from confirmed capabilities without invented behavior |
+| Architecture authors | Measurable constraints and change pressures without a preselected solution |
+| Implementers | Objective invariants and qualification profiles for later designs |
+| Reviewers | Bidirectional traceability, feasibility, failure containment, and absence of current-system anchoring |
+
+## Derivation Rules
+
+1. `MUST` is binding. `SHOULD` is binding unless a later architecture decision
+   demonstrates an equal or stronger outcome. `MAY` is optional.
+2. Every `TN-*` traces to a confirmed requirement. No
+   existing implementation fact is evidence for a need.
+3. Product behavior remains owned by the capability requirements. This document
+   owns only its technical consequences and does not restate behavior as a new
+   product source.
+4. A measurable scenario states stimulus, environment, affected truth, response,
+   measure, and proof route. Timing populations are never pooled across action,
+   operating system, profile, cold/warm state, or background-work category. Each
+   warm population uses 100 recorded runs after five unrecorded warm-up runs;
+   p95 is the 95th value in ascending order. Each cold run uses a new process and
+   a disjoint, never-read fixture copy; every cold population has 100 recorded
+   runs and no warm-up. A named timeout is
+   checked on every run. Correctness and privacy invariants permit zero
+   violations.
+5. Performance numbers are qualification targets, not claims about the current
+   program. The interaction thresholds are calibrated against the preserved
+   Nielsen response-time source. Workload sizes are dated synthetic lower-bound
+   qualification profiles, not product caps.
+6. Data integrity, GM authority, and privacy outrank live availability. Live
+   availability outranks background-work throughput. A lower-ranked outcome may
+   degrade only to protect a higher-ranked one, and the degradation MUST be
+   explicit.
+7. A current or future implementation may use any design that proves every
+   obligation and scenario. Terminology such as identity, checkpoint, authority,
+   atomic, or isolation describes observable semantics, not a chosen mechanism.
+8. No real users or legacy data exist before complete GM-core feature
+   completion. Pre-completion persisted formats and development data are
+   disposable and create no compatibility, conversion, migration, fallback, or
+   compatibility-shaped design obligation. `TN-18` and every clause concerning
+   prior released formats activate only when the completed product is approved
+   for first real use and its initial durable format is frozen. Current-format
+   restart, recovery, import, and export obligations remain active throughout
+   product development.
+
+## Reference Qualification Profiles
+
+These profiles make `ordinary`, `large`, and `exceptional` reproducible. They
+are deliberately conservative synthetic workloads assembled from the dimensions
+named by the capability baseline. Passing a profile does not authorize an
+artificial product limit.
+
+### Hardware And Display Profile `RP-H`
+
+- 4 logical CPU cores available to SaltMarcher, with the single-threaded profile
+  probe defined below meeting its stated thresholds;
+- 8 GiB memory available to the application and its local data work;
+- local solid-state storage sustaining 200 MB/s sequential reads and writes,
+  4 KiB random-read p95 at or below 2 ms, and durable 4 KiB write p95 at or
+  below 10 ms;
+- at least 100 GiB free local space before `RP-L` portability qualification;
+- no dedicated GPU and no server-class hardware;
+- one 1366 x 768 effective laptop viewport; one 1920 x 1080 display; two
+  heterogeneous displays; and a high-density display at 200% scale, including
+  window/focus movement between different scales;
+- network unavailable throughout core-operation qualification.
+
+The calibration record MUST include CPU score, storage measurements, exact OS
+and architecture, power mode, free space, and whether a population is cold or
+warm. The later architecture MAY support lower hardware. It MUST pass on `RP-H`
+for every version in the declared supported Linux, Windows, and macOS matrix
+without separately administered infrastructure.
+
+### Campaign Profile `RP-R` — Representative Long-Lived Campaign
+
+- 10,000 Campaign-owned objects numbered from 1. Objects 1 through 2,000 use
+  name `duplicate-ceiling(i/2)`, producing exactly 1,000 duplicate-name pairs;
+  the rest use `object-i`. Exactly 5,000 texts are 2 KiB, 4,000 are 4 KiB, 950
+  are 16 KiB, and 50 are 64 KiB, filled by repeating the UTF-8 byte sequence
+  `0123456789abcdef`. Object 1 references its next 100 cyclic successors,
+  objects 2 through 93 their next 7, and every other object its next 8. Thus
+  mean reference fan-out is exactly 8 and maximum fan-out is 100;
+- 100,000 numbered records: exactly 16,667 each of notes, history entries,
+  corrections, and ledger entries, plus 16,666 each of trade facts and travel
+  checkpoints. Record `i`
+  belongs to the active working set exactly when `i modulo 5 = 0`; its text is
+  `entry-i` and its owner is Campaign object
+  `1 + ((i - 1) modulo 10,000)`;
+- 20 Roster characters, 4 independently timed Running Scenes, 8 simultaneous
+  runtime masks, and 50 live participants, all numbered from 1. Participant `i`
+  belongs to Scene `1 + ((i - 1) modulo 4)`; mask `k` contains participants
+  whose number modulo 8 equals `k`, and participants 1 through 4 additionally
+  belong to every mask to exercise shared membership;
+- 100,000 numbered reusable definitions and 10,000 numbered scheduled
+  candidates. Candidates 1..2,500 are ineligible, 2,501..5,000 eligible without
+  a consequence, 5,001..7,500 eligible with a new consequence, and
+  7,501..10,000 eligible with an already-established result. The first 1,500
+  eligible candidates form five ordered levels of 300; every node after level
+  zero depends on previous-level offsets `j`, `j+1`, and `j+2` modulo 300,
+  producing depth 4 and fan-out 3. Party-danger boundaries follow eligible
+  ordinals 750, 3,750, and 6,750;
+- 20 maps with exactly 100,000 authored spatial facts each. Maps 1 through 10
+  are axial Hex rectangles with `q=0..399`, `r=0..249`; maps 11 through 20 are
+  Dungeon cell grids with `x=0..399`, `y=0..249` and orthogonal adjacency.
+  Facts sort by map, then second coordinate, then first coordinate. Map
+  scenarios use the first lexicographically ordered 256, 2,048, and 8,192
+  visible facts, 6 knowledge owners, 8 visible layers, 4 visibility modifiers,
+  and cold as well as warm assets. Boundary `i` occludes exactly when
+  `i modulo 4 = 0`. Knowledge owner `k` knows fact `i` exactly when
+  `i modulo 6 = k`; the 0%, 50%, and 100% overlap variants respectively use
+  disjoint sets, add the preceding three owners' sets, or give every owner the
+  union. Layers and modifiers are assigned by fact index modulo their count;
+  the three zoom tiers repeat round-robin. Single edit, regional edit, and
+  reveal affect the first 1, 2,048, and 8,192 visible facts;
+- 10 GiB across 10,000 intact local map, image, and audio files, where 1 MiB is
+  1,048,576 bytes: 9,000 files are 256 KiB, 900 are 4 MiB, 89 are 40 MiB, 10
+  are 33 MiB, and one is 500 MiB. File bytes repeat the SHA-256 digest of
+  `23072026:file-i` until the declared length; file type cycles map, image,
+  audio by `i modulo 3`. The p95 size is 4 MiB and the maximum is 500 MiB.
+  Missing/damaged media belongs to a separate
+  fault profile, never the intact round-trip profile;
+- a repeated 20-operation cycle: slots 1..12 alternate read and search, slots
+  13..17 are live mutations, slot 18 is a history query, slot 19 a ledger query,
+  and slot 20 a long-work operation whose mode cycles start, cancel, retry.
+  Target IDs advance modulo the relevant manifest count. Search text is the
+  target record/object text. Any remaining randomized choice uses seed
+  `23072026` and the deterministic generator below.
+
+### Campaign Profile `RP-L` — Extraordinary Large Campaign
+
+- 100,000 Campaign-owned objects, 1,000,000 combined note/history/ledger/
+  checkpoint entries, 100 Roster characters, 10 independently timed Running
+  Scenes, 50 simultaneous masks, 500 live participants, 250,000 reusable
+  definitions, 100,000 scheduled candidates, 100 maps, 20,000,000 authored
+  spatial facts, and 50 GiB across 50,000 intact media files;
+- only one dominant axis is multiplied at a time for the first pass, followed by
+  the combined profile needed to expose interaction effects.
+
+Numbered `RP-R` classes scale by prefixing each complete repeated cohort with
+its cohort number. `RP-L` repeats object and record cohorts ten times and map
+and media cohorts five times. Each `RP-L` map contains two prefixed copies of
+its `RP-R` spatial-fact cohort, yielding exactly 200,000 facts per map and
+20,000,000 total. Text, reference, operation, and media-byte construction
+repeats unchanged inside each cohort; cross-cohort references are absent unless
+a scenario explicitly declares them. Scheduled candidates repeat the `RP-R`
+cohort ten times with occurrence identity prefixed by cohort.
+
+### Campaign Profile `RP-X` — Exceptional Pressure
+
+`RP-X` qualifies each `RP-L` axis separately at ten times its declared count:
+Campaign objects, records, Roster characters, Scenes, masks, participants,
+reusable definitions, scheduled candidates, maps, spatial facts, media file
+count, and media bytes. It then qualifies the combined `RP-L` profile. Fault
+variants are exact: free destination capacity is one byte below the declared
+input-plus-output-plus-temporary preflight; each independently addressable data
+class receives one deterministic single-bit corruption; every supporting
+capability is absent in turn; memory pressure is raised until the next admitted
+operation would cross the resident-set ceiling; and three of four logical cores
+are saturated. Each fault runs alone and then in every compatible pair.
+
+All variants reserve at
+least one `RP-H` logical core or 25% CPU capacity, whichever is greater, for
+SaltMarcher. No background throughput SLA applies, but `TN-21` live-path budgets
+remain binding. Peak resident set size MUST stay within 75% of `RP-H` memory;
+temporary storage MUST be preflighted and MUST NOT exceed 120% of declared input
+plus output size; one capability MUST NOT retain more than one active and one
+pending long operation. The working-storage safety reserve is the greater of
+2 GiB or 5% of volume capacity. Admission or pressure failure is reported within
+1 s, before unsafe mutation. No injected failure may cause additional data loss:
+unaffected truth remains complete, and damaged units are recovered or disclosed
+only through salvage. Safe read, export to a destination with sufficient
+capacity, and retry remain available.
+
+### Profile Manifest And Calibration
+
+Manifest version `PTN-2026-07-23.1` is normative. Its fixture manifest is the
+exact `RP-R`/`RP-L`/`RP-X` data and construction algorithm in this document.
+It records counts, byte distributions, reference fan-out, active/archive ratio,
+operation distribution, scheduling intersections, dependency shape, visible
+spatial density/topology, asset state, and random seed. Scheduling variants use
+0%, 50%, and 100% eligibility in addition to the base 75%. At 0% every candidate
+is ineligible. At 50%, eligible ordinals contain 1,666 without consequence,
+1,667 new, and 1,667 established results. At 100%, those counts are 3,334,
+3,333, and 3,333. In every nonzero variant, its first 20% of eligible ordinals
+use five equal dependency levels and the same modulo-three construction; danger
+boundaries follow eligible ordinals at ceiling(10%), ceiling(50%), and
+ceiling(90%). `RP-L` repeats each exact `RP-R` scheduling cohort ten times. A
+timing result is invalid until an independent generator reproduces all manifest
+totals, intersections, and distributions.
+
+The deterministic generator is SplitMix64 with unsigned 64-bit wraparound:
+state increases by `0x9E3779B97F4A7C15`; `z=(z xor (z >> 30)) *
+0xBF58476D1CE4E5B9`; then `z=(z xor (z >> 27)) * 0x94D049BB133111EB`;
+the result is `z xor (z >> 31)`. Selection maps the unsigned result modulo the
+candidate count; unique selections redraw collisions. Its initial state is the
+declared seed.
+
+The CPU probe emits UTF-8 lines and includes process start, generation, digest,
+and process completion in its timing boundary. For one-based integer `i`, the
+scheduling line is `i,scene=(i modulo 10),period=floor(i/10)\n`; the spatial line
+is `i,q=(i modulo 2000),r=floor(i/2000)\n`. Decimal integers have no padding.
+SHA-256 consumes the exact byte stream. The `RP-H` thresholds are 0.5 s for
+100,000 scheduling records and 5 s for 2,000,000 spatial records. Storage
+calibration uses deterministic generator seed `23072026`, records its algorithm
+and version, and a new 64 MiB file. It first performs and durably synchronizes
+one sequential 64 MiB write, then one sequential 64 MiB read, then 200 generated
+non-overlapping 4 KiB writes each followed by durable synchronization, and
+finally 1,000 generated 4 KiB reads. Throughput covers the whole sequential
+operation; per-operation p95 follows the rule above. Every cold storage run
+creates a new file at a never-used path and uses disjoint offsets. The record
+names the exact OS build, filesystem, storage device, power mode, cache state,
+free space, and calibration implementation revision.
+
+Disposable feasibility probes on 2026-07-23 used Linux 6.19 x86-64 on an Intel
+i5-8365U (4 physical/8 logical cores) and streamed/digested 100,000 scheduling
+records in 0.20 s (`sha256:3f8ca7663718dadf8567654e4f3a10c2e79657a0ff9704f8896ada6bd2800931`)
+and 2,000,000 spatial records in 3.82 s
+(`sha256:d4124f10c047b1cfb7074e840b46822b809c289c2ef783b66a9eb51f7bb15394`)
+with about 4 MiB resident memory. These probes validate only
+that the qualification data volumes are inexpensive to generate; they are not
+current-system proof and do not substitute for end-to-end production-route
+qualification.
+
+### Metric Provenance
+
+| Metric family | Calibration basis | Verdict method |
+| --- | --- | --- |
+| 100 ms feedback, 1 s uninterrupted interaction, 10 s attention/interrupt | Preserved Nielsen response-time evidence | Per-action/per-environment p95 and timeout populations defined above |
+| `RP-R`/`RP-L` volume and operation mix | Synthetic lower-bound profile across every scale dimension named by the capability baseline; generation feasibility probe above | Manifest reproduction before timing; complete per-axis then combined qualification |
+| 1 s durability acknowledgement and zero acknowledged loss | Owner-confirmed automatic preservation plus 1 s uninterrupted-flow threshold | Crash/power fault after every acknowledged mutation |
+| 1 s warm switch, 5/10 s start/resume | Owner-confirmed immediate switching and live-table continuity; 1/10 s HCI thresholds | Separate warm-switch, cold-start, and crash-resume populations; add post-conversion only after `TN-18` activates |
+| 60 s recovery point; 5/20 min restore | Technical safety target for “almost never” losing work; transfer floor of the declared intact data volumes on `RP-H` | Storage-loss and full-restore drill including media |
+| 10/60 min export/import | Declared intact profile bytes, 200 MB/s storage floor, and natural-break progress/cancel requirement | Closed-manifest cross-OS round trip |
+| 60 s/15 min World catch-up | Exact scheduled-candidate mixes plus disposable 100,000-record generation probe; live work remains higher priority | Candidate/eligible/committed counts, live timings, retry and once-only oracle |
+| WCAG contrast, keyboard, color, and 200% scaling | Preserved WCAG 2.2 criteria applied as a technology-neutral measurement baseline | Measured contrast plus human workflow inspection on every display configuration |
+
+## Priority Model
+
+| Priority | Meaning |
+| --- | --- |
+| `P0` | Integrity, GM authority, privacy, or live-table continuity; blocks every target architecture |
+| `P1` | Required core quality or change capability; blocks activation unless its proof route exists |
+| `P2` | Explicitly parked or product-testing concern; recorded only to prevent accidental architectural commitment |
+
+## Technical-Need Catalog
+
+### Truth, Identity, Lifecycle, And History
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-01` | P0 | `SRC-F02`, `SRC-F03`, `SRC-F04`, `SRC-R03`, `SRC-S01`, `SRC-D02` | Every independently editable Campaign object, concrete Item, reusable definition, runtime context, historical subject, and recoverable target MUST have stable semantic identity independent of name, storage location, or display label. Copies and imports create independent Campaign-owned identity; trash/restore preserves recoverable identity. A copied Campaign object MUST NOT retain a Campaign-owned reference back to its source Campaign: referenced closure is copied, remapped to the target, omitted with disclosure, or resolved by the GM before completion. | Editing, deleting, copying, importing, restoring, or correcting one namesake changes no other namesake; an independent copy has no hidden source-Campaign dependency. | Duplicate-name and reference-closure property suite across Campaign, copy, import, trash, restore, and history paths; zero cross-target mutations. |
+| `TN-02` | P0 | `SRC-F01`, `SRC-F02`, `SRC-F03`, `SRC-L01`, `SRC-T01`, `SRC-R02`, `SRC-S01`, `SRC-D02`, `SRC-Q01`, `SRC-Q05` | State MUST have one unambiguous owning scope: installation-wide reusable definitions; Campaign-owned records, Roster, Party, and runtime; Session-owned planning Party; Scene-owned time and runtime; character-owned knowledge; and the explicitly selected owner for Shop or travelling content. The confirmed core has one local mutation authority; passive displays and other observers are read-only and cannot originate Campaign writes. Ownership is semantic and does not prescribe a module, store, or concurrency mechanism. | Switching, focus, planning, import, observer loss, or mutation in one scope cannot mutate another scope unless the capability requirement explicitly defines the handoff. | Ownership-transition, observer-write denial, and cross-Campaign non-interference suite. |
+| `TN-03` | P0 | `SRC-F04`, `SRC-P01`, `SRC-P02`, `SRC-P03`, `SRC-L02`, `SRC-D03`, `SRC-Q02` | Replaceable plans, unaccepted drafts, accepted World placements, resumable Running Scenes, temporary masks, explanatory history, recoverable trash, permanent deletion, and retained unavailable-capability data MUST remain distinct lifecycle classes. Promotion, completion, replacement, disablement, restore, and deletion MUST affect exactly the class named by the confirmed action. | Plan replacement cannot remove accepted placement; mask completion cannot end a Scene; capability removal cannot delete retained data. | Transition matrix with survivor/removal assertions after every lifecycle action and restart. |
+| `TN-04` | P0 | `SRC-F02`, `SRC-R05`, `SRC-D02`, `SRC-C04` | Current and future reads MAY follow the current reusable definition, while completed history MUST preserve the confirmed explanatory fact. Definition edits, deletion, trash, restore, or permanent loss MUST NOT recalculate completed facts; missing live identities remain intelligible as unknown or recoverable. | Current projection changes when a definition changes; already completed fact does not. | Complete-reference/edit/delete/restore test with semantic snapshots of current and historical projections. |
+| `TN-05` | P0 | `SRC-F04`, `SRC-L01`, `SRC-S01`, `SRC-D03` | Explicit deletion MUST remove current references and only the confirmed dependent runtime, preserve explanatory history, and never treat leaving a Scene as deletion. Recoverable owner-dependent relationships, including Shops, MUST restore coherently. After separate permanent deletion, application-controlled live, trash, recovery, staging, temporary, and retained-capability state MUST NOT reconstruct the deleted payload; permitted history retains only non-reconstructive explanatory facts and unknown identity. Prior GM-controlled exports are outside revocation and MUST be disclosed as such. | No live dangling reference; no implicit loss of persistent location content; no application-controlled resurrection after permanent deletion; history remains truthful. | Dependency-graph suite plus delete/crash/restart/recovery/export/import and unavailable-capability cases, including interrupted deletion. |
+| `TN-06` | P0 | `SRC-F04`, `SRC-R01`, `SRC-R03`, `SRC-R05`, `SRC-S02`, `SRC-S03`, `SRC-C01`, `SRC-C04` | History MUST preserve both confirmation order and effective in-world time. Meaningful confirmed consequences and linked corrections are ordinarily append-only; a correction changes current truth without rewriting the original fact. Travel undo and explicit target deletion are the only confirmed narrow removal exceptions and MUST remain visibly scoped. | Backdating, time reversal, correction, or definition change cannot silently reorder or rewrite confirmation history. | History oracle covering XP, HP/death, Party, travel, trade/restock, correction, backdating, deletion, and restart. |
+
+### Runtime Consistency, Time, And GM Authority
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-07` | P0 | `SRC-F03`, `SRC-L01`, `SRC-L02`, `SRC-T01`, `SRC-C02` | At most one current Party exists per Campaign; every active PC belongs to exactly one Running Scene and inactive PCs to none; one empty primary Scene remains when needed. Party/Scene membership changes are authoritative immediately and remove moved participants from masks even when dependent reconciliation is unavailable. | Authoritative membership changes once; only referencing contexts may become visibly pending; stale membership is never shown as current. | Failure injection during activation, deactivation, deletion, movement, empty-Scene cleanup, restart, and retry. |
+| `TN-08` | P0 | `SRC-L04`, `SRC-T03`, `SRC-Q05`, `SRC-C04` | Every Running Scene MUST have independent in-world time. Moving time backward or manually resolving reunion MUST NOT reverse World state, delete history, or roll back another Scene. Confirmation order and effective time MUST remain distinguishable. | Permuting Scene advancement, backdating, reversal, and reunion preserves established World facts. | Multi-Scene time permutation and restart suite. |
+| `TN-09` | P0 | `SRC-L04`, `SRC-T02`, `SRC-T03`, `SRC-S03`, `SRC-Q05` | A logical shared World, restock, weather, or autonomous consequence MUST have one stable occurrence identity and apply at most once across Scene order, retry, restart, reversal, or catch-up. Earlier Scenes reuse that established shared result. A Calendar event instead has stable definition identity and its relevance MUST be evaluated independently for each `(event, Scene, Scene time, Scene place)` context using the Campaign's authored month/day/week/year structure; relevance may coexist in several Scenes and never decides a narrative consequence. Any separately confirmed shared consequence arising from an event receives its own once-only occurrence. Party-danger resolution MUST pause for GM authority. | Shared-consequence applied count is exactly zero before eligibility and exactly one after confirmation; never greater than one. Calendar relevance matches every Scene context independently and changes only with authored calendar/event or that Scene's time/place. | Permutation/property suite asserting separate per-Scene relevance and shared-consequence counts over divergent Scene clocks/places, authored calendars, retry, restore, rule edits, and redo. |
+| `TN-10` | P0 | `SRC-P02`, `SRC-P03`, `SRC-R01`, `SRC-R02`, `SRC-R03`, `SRC-R04`, `SRC-R05`, `SRC-S02`, `SRC-C01` | Confirmed coupled outcomes MUST be all-or-nothing: Encounter completion with selected XP and carried-forward tracked outcome; purchase with stock and ledger acquisition; sale with stock and ledger fact; correction with current truth and linked history. Unsatisfied generation constraints yield no partial result. | Every injected failure exposes either complete old truth or complete new truth, never a hybrid. | Fault injection at every externally observable substep plus idempotent retry. |
+| `TN-11` | P0 | `SRC-L01`, `SRC-C02`, `SRC-C03` | Where the baseline makes a primary change authoritative before a dependent context, the primary change MUST persist once, affected dependents MUST be visibly pending, unaffected contexts MUST remain unchanged, stale state MUST NOT appear synchronized, and retry MUST converge without repeating the primary change. | One primary mutation, zero duplicate effects, exact affected-context set. | Scene-save/Encounter and Party/context failure matrix with restart and repeated retry. |
+| `TN-12` | P0 | `SRC-T02`, `SRC-T03`, `SRC-C04` | Every route point and interruption MUST be a committed checkpoint. Multi-level undo removes only the chosen segment and effects caused exclusively by it; later authoritative facts survive. Redo MUST NOT duplicate scheduled or historical consequences. | Undo/redo is causal, not time-wide rollback. | Property-based checkpoint graph with intervening edits, another Scene's later facts, restart, and redo. |
+| `TN-13` | P0 | `SRC-P02`, `SRC-T03`, `SRC-D02`, `SRC-Q05`, `SRC-C04` | The system MUST detect and expose contradictions without silently deciding for the GM: impossible generation blocks with explanation; earlier-time contradictions warn, remain allowed, and retain a conflict marker; definition import conflicts show consequences before explicit choice. A missing optional PC statistic blocks only the automatic workflow that requires it, identifies the missing input, and cannot make unrelated optional character data mandatory. | Conflict marker survives restart until explicit resolution; blocked actions produce no result; unrelated workflows remain available. | Decision-table tests for every conflict family, retain-both, explicit resolution, and each workflow-local PC prerequisite. |
+| `TN-14` | P0 | `SRC-P04`, `SRC-L04`, `SRC-T02`, `SRC-T05` | Manual overrides MUST have explicit precedence, persistence, and release semantics. Automation cannot overwrite an active GM decision; after release it resumes from current Scene context rather than stale pre-override context. | Manual value wins exactly while active; release recomputes from current inputs. | Override-before/during/after suite with focus change, Campaign switch, restart, and failure. |
+
+### Preservation, Recovery, Portability, And Scale
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-15` | P0 | `SRC-T02`, `SRC-D01`, `SRC-Q02`, `SRC-C02`, `SRC-C03` | Confirmed GM work MUST be preserved automatically. The UI MUST NOT present a mutation as stored until it is durable or explicitly show it as pending/unsafe. Acknowledged-work loss after crash or power loss is `0`; safe-state acknowledgement is at most 1 s p95 with a 10 s timeout on `RP-R`. | Every acknowledged change survives abrupt termination; every non-durable change was visibly identified before termination. | Kill/power-loss, denied-write, low-space, interrupted-write, and dependent-failure matrix after each representative mutation. |
+| `TN-16` | P0 | `SRC-F01`, `SRC-D01`, `SRC-Q02`, `SRC-C02`, `SRC-C03` | Warm Campaign switching, cold start, and crash resume are distinct populations; after `TN-18` activates, post-conversion start is a further distinct population. All applicable modes restore focus, Scenes, masks, travel checkpoints, overrides, queues, and pending reconciliation before readiness. A warm switch is ready within 1 s p95 and 10 s timeout; cold start and crash resume within 5 s p95 on `RP-R` and 10 s p95 on `RP-L`. Ready means the safely rendered focused Scene accepts and durably preserves a representative next mutation. | Clean start has 100% observable-state equivalence; abrupt restart differs only by visibly unacknowledged work. | Combinatorial state snapshot plus next-action comparison for each applicable start mode and supported OS. |
+| `TN-17` | P0 | `SRC-D01`, `SRC-Q02` | Damage MUST be detected and isolated at the granularity of one independently addressable Campaign object, reusable definition, asset, or runtime context. The newest uniquely safe recovery opens automatically with exact disclosure; ambiguous recovery asks the GM. Rolling recovery MUST offer a recoverable point no older than 60 s of confirmed work and complete full restore, including local media, within 5 min on `RP-R` or 20 min on `RP-L`. A disclosed salvage open/export MAY omit identified damaged units but MUST NOT be called a complete export. | Zero silent substitution; original damaged material remains unchanged until explicit recovery/deletion; unaffected data remains usable. | Corruption corpus, storage-loss simulation, full restore drill, and separate disclosed-salvage manifest. A backup counts only after restore verification. |
+| `TN-18` | P0 | `SRC-D02`, `SRC-Q02` | Once the completed product's initial durable format is frozen for first real use, updates and conversions MUST preserve Campaign and resumable state. A failed conversion MUST leave prior data untouched and usable by the prior compatible application. Pre-completion persisted formats and development data create no conversion or compatibility obligation. | After activation, failed conversion produces semantic and byte-level equivalence of the prior source where byte preservation is applicable. | After activation, fault every conversion phase, reopen with the prior released version, then qualify successful conversion, resume, and export. |
+| `TN-19` | P0 | `SRC-D02`, `SRC-Q01`, `SRC-Q02` | Complete export MUST be a closed, versioned transfer of Campaign data, intact assets, required reusable definitions, resumable state, trash needed for recovery, and retained optional-capability data. Every imported byte and reference is untrusted: validation is bounded before commit; import executes nothing, resolves no external resource or network reference, writes only owned import state, and stages shared-definition decisions without mutating existing truth. Import MUST be atomic, create a new independent Campaign, never merge Campaign-owned state, and resolve definition conflicts explicitly. Current-format round trip is always required. After the first-real-user/data cutover, each release MUST also import the immediately preceding released export format and declare any older supported formats. `RP-R` export/import MUST finish within 10 min and `RP-L` within 60 min on `RP-H`, with progress and cancellation. | Cross-platform round trip has semantic and intact-asset checksum equality; rejection/cancellation leaves both Campaign and shared definitions unchanged; no path escape, execution, network resolution, or unbounded amplification. | Every supported OS pairing, source-machine removal, manifest audit, current-format readback, and interruption/low-space/conflict, traversal, link, collision, compressed-bomb, oversized-count, malformed parser/media, external URI, and staged-definition failure cases. After cutover, add compatibility readback for every declared supported released format. |
+| `TN-20` | P1 | `SRC-T04`, `SRC-Q02` | The system MUST impose no artificial content cap. It MUST meet all live-path budgets on `RP-R`, complete and remain operable on `RP-L`, and obey the explicit `RP-X` pressure limits without truncation or corruption. Resource exhaustion MUST be reported before unsafe mutation; safe read, export to a destination with capacity, and retry remain available. | Completeness is 100% at every profile; process memory <=75% of `RP-H`, temporary storage <=120% of declared input plus output, and per-capability long-work queue <=1 active + 1 pending under `RP-X`. | Synthetic profile and pressure-decision qualification measuring latency, throughput, memory, temporary/storage growth, queue depth, completeness, and recovery. |
+
+### Responsiveness, Background Work, Spatial State, And Media
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-21` | P0 | `SRC-P04`, `SRC-L03`, `SRC-T01`, `SRC-R03`, `SRC-S01`, `SRC-Q01`, `SRC-Q02`, `EXT-NNG` | Direct manipulation MUST acknowledge within 100 ms p95. Frequent live actions and first useful cross-kind search results MUST complete within 1 s p95 and a 10 s timeout on `RP-R`; these absolute budgets remain unchanged under long work. The named vision paths remain context-preserving for pointer and keyboard alike: open the monster list in one semantic action, add a monster in one further action, and reach notes from an already open NPC or place in one action. Scene-focus changes update the safe passive-display projection within 1 s p95. | No interaction-thread stall exceeds 100 ms p95 or the 1 s timeout; no named frequent path exceeds its action count or leaves its working context. | Per-action timing and action-count journeys on `RP-H`, idle and under every long-work category. |
+| `TN-22` | P0 | `SRC-P02`, `SRC-T03`, `SRC-D02`, `SRC-Q02`, `EXT-NNG` | Generation, import/export, simulation, weather, maps, and World catch-up MUST be observable, cancellable where the baseline permits, and subordinate to live play. Work exceeding 1 s shows activity; work expected to exceed 10 s shows determinate progress when knowable and an explicit interrupt. Cancellation has one linearized terminal outcome: before commit it acknowledges within 1 s p95, exposes no new effect afterward, and leaves no live task, handle, queue entry, or unmarked temporary artifact after 10 s; after commit it reports completion rather than cancellation. At most one explicitly marked resumable artifact per capability may remain, within the `RP-X` temporary-space cap, visible for resume/replacement/explicit discard, and outside Campaign truth. Only independently accepted results survive. | No unaccepted Campaign/staging mutation; after 20 cancel cycles resident memory returns within 10% of the pre-cycle steady state and below the `RP-X` ceiling; live budgets remain within `TN-21`; retry duplicates no effect. | Repeated early/mid/commit-boundary cancel/failure suite measuring manifests, marked/unmarked temp storage, resident memory steady state, handles, task/queue count, CPU, restart, resume/discard, and retry. |
+| `TN-23` | P1 | `SRC-T03`, `SRC-Q02` | World catch-up MUST yield to live work, preserve exactly-once semantics, and process the `RP-R` scheduling profile within 60 s and `RP-L` within 15 min on `RP-H`. If Party involvement or a configured consequence boundary is reached, processing pauses before the prohibited consequence. | Established periods are reused; cancellation/restart creates no duplicate consequence; backlog remains visible. | Synthetic scheduling profile with Scene-order permutations, pause, cancellation, restart, and resource contention. |
+| `TN-24` | P0 | `SRC-L05`, `SRC-T04`, `SRC-Q01`, `SRC-Q04` | Durable per-character map knowledge, transient current perception, and GM-private truth MUST remain separate. The passive display is read-only and MUST expose only the focused Scene's permitted visual projection, never hidden/unknown live details, mechanics, text, or private notes. Viewport scenarios separately qualify pan/zoom, focus switch, single/regional edit, reveal, multi-character visibility, and cold/warm assets at every declared visible-density tier. | Prohibited information leaks: `0`; feedback <=100 ms p95 and complete safe projection <=1 s p95; focus/visibility change never displays a stale unsafe frame. | Exact viewport manifest plus multi-character knowledge/perception oracle under focus, movement, light, weather, elevation, hidden state, blank, replace, and display loss. |
+| `TN-25` | P1 | `SRC-P04`, `SRC-L04`, `SRC-T04`, `SRC-T05`, `SRC-Q02` | Weather computation MUST accept location, terrain, climate, Scene time, declared spatial/temporal resolution, structured effects, moving phenomena, and GM overrides while maintaining regional and temporal continuity within `TN-22`/`TN-23` budgets. No weather algorithm is selected here. The later rule/domain owner MUST publish model-specific maximum change per spatial and temporal step before a weather implementation can qualify; discontinuities require an authored event, input boundary, or override. | Same established inputs for the same authoritative period reuse one result; measured deltas remain within the published model bound or carry the explicit discontinuity cause. | Model-bound continuity/metamorphic tests over space, time, resolution, event edits, pause, override, and release. |
+| `TN-26` | P1 | `SRC-P04`, `SRC-L03`, `SRC-T05`, `SRC-Q02` | Local maps, images, audio, manual media precedence, and resumable media state MUST remain portable and intact. Missing, damaged, unsupported, or slow media MUST affect only that media capability and never block Scenes, Encounters, editing, preservation, or export of unaffected truth. | Core-workflow outage from a media fault: `0`; every affected asset is identified. | Asset fault matrix during playback, focus, restart, export/import, and low storage. |
+
+### Modularity, Extensions, Trust, Portability, And Inclusion
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-27` | P0 | `SRC-Q02`, `SRC-Q03` | Supporting capabilities MUST have explicit failure domains. Failure, cancellation, removal, replacement, or temporary absence of music, weather, maps, generation, or World progression MUST leave Running Scenes, Encounters, manual editing, preservation, and complete export usable; complete export retains the unavailable capability's opaque data, while only disclosed salvage may omit identified damage. Only behavior that directly requires the capability may be unavailable. From an observable provider failure or first access to a defective unit, the error is visible within 1 s; retry is explicit, retained data survives, and repeated faults stay within the `TN-22` steady-state envelope and `TN-21` live budgets. | Survivor-workflow outage, unaffected-state mutation, retained-data loss, and out-of-envelope repeated-fault growth are `0`; Campaign opening succeeds. | Capability-by-survivor fail/remove/replace/restore matrix with complete/salvage export manifests, live timings, sentinels, detection/retry, and resource-envelope measurement. |
+| `TN-28` | P1 | `SRC-P01`, `SRC-L02`, `SRC-L03`, `SRC-T01`, `SRC-T05`, `SRC-Q03`, `SRC-Q05` | A content kind, runtime mask, influence family, generator, importer, or presentation MUST be addable without semantic changes to unrelated capability-owned decisions, public behavior, or persisted meaning. An optional capability MUST be omittable, removable, or replaceable while preserving unrelated workflows and data. Declared integration wiring and compatibility adapters are allowed. Multiple masks and shared participants remain composable. Source-file topology, registration count, and touched-file count are not verdicts. | Unrelated acceptance scenarios and stored truth remain unchanged in present, absent, replaced, and restored states; existing unrelated owners requiring semantic change: `0`. | Change scenarios `CS-01` through `CS-06`, before/add/remove/replace semantic-digest conformance, compatibility qualification, and retained-data round trips. |
+| `TN-29` | P0 | `SRC-Q03` | Extensions MUST be explicitly installed, identified, disabled on fault/incompatibility, and denied Campaign-data, file, network, or other protected access by default. Every protected-access request MUST be disclosed before activation and remains denied until the GM explicitly consents to that exact extension identity/version, capability, data, destination, and action; installation alone is not consent. Grants MUST be inspectable and revocable. Disable, removal, revocation, update, reinstall, identity change, or a changed request takes effect before the next protected operation and cannot inherit stale authority silently; every protected sink checks current authority. Extensions MUST NOT bypass deletion, truthful history, privacy, confirmed-work, or passive-display boundaries. | Protected access before exact consent or outside current scope and successful safety-boundary bypasses are `0`; incompatible extension cannot rewrite Campaign data or block opening. | Permission matrix covering install without consent, denial, scope elevation, changed request, combined data+network grants, revoke-during-work, stale handles, disable/re-enable, update, reinstall, identity change, undeclared access, crash, damage, deletion, egress, and history rewrite. |
+| `TN-30` | P0 | `SRC-D02`, `SRC-Q01` | Core preparation and play MUST run offline, without hidden upload or default telemetry. Product runtime may create a local complete export or perform another precisely disclosed GM-initiated transfer whose payload and destination are confirmed; it MUST NOT perform background or broader egress. No core workflow may depend on a paid, cloud, external-analysis, or separately administered service. Linux, Windows, and macOS Campaign behavior MUST be portable and self-contained. | Unexplained product outbound attempts, broader-than-confirmed transfer, and mandatory external-service dependencies are `0`; every ordinary core workflow passes with network disabled. | Network-denied journey, product transfer disclosure/destination audit, clean-system install, dependency audit, and cross-platform portability matrix. |
+| `TN-31` | P1 | `SRC-L05`, `SRC-Q01`, `SRC-Q04`, `EXT-WCAG` | All core and extension-facing interface text MUST be localizable while Campaign-authored text remains arbitrary and unchanged by locale. Complete core workflows MUST be keyboard-operable without traps or timing-dependent keystrokes; required information MUST NOT rely on color alone; ordinary text contrast MUST be at least 4.5:1 and essential non-text controls/state at least 3:1; text/interface scaling to 200% MUST preserve content and functionality across the full `RP-H` display matrix. | Localizable identified strings: 100%; authored-text mutation: `0`; unreachable keyboard action, trap, lost content/function, or color-only fact: `0`; action counts obey `TN-21`. | Pseudo-localization with 40% expansion and Unicode corpus; locale/export round trip; keyboard-only workflow suite; mixed-DPI monitor movement; automated and human contrast/scale inspection. |
+| `TN-32` | P1 | `SRC-S03`, `SRC-Q02`, `SRC-Q03`, `SRC-Q05` | Time, randomness, permissions, cancellation, corruption, resource pressure, and downstream failure MUST be controllable and observable enough to reproduce every invariant through self-contained qualification with synthetic data and no mandatory external service. Random outcomes need not be identical in play, but their inputs, rule profile, and established result MUST be inspectable for diagnostics and retry safety. | Repeated qualification reaches the same invariant verdict; once-only effects and primary writes occur exactly once. | Deterministic synthetic inputs, controlled clocks/random sources/faults, production-route acceptance, and self-contained evaluation. |
+| `TN-38` | P1 | `SRC-Q06` | Every exposed capability MUST have an in-game tutorial. The derived update policy is exact: first installation and the first start of every distinct installed application version present the complete tutorial set for all capabilities exposed by that version; another start of the same version does not automatically repeat it. Every lesson can be skipped individually, and the remaining automatic run can be dismissed without completing it. Removed capabilities contribute no lesson; capabilities present again in a later installed version contribute their lesson with that version's complete set. Start, skip, and dismissal MUST NOT disable a capability or mutate Campaign truth. Cross-cutting offline, localization, keyboard, scaling, privacy, and failure-isolation obligations apply to the tutorial surface. | Exposed capabilities without a tutorial, queue mismatch against the complete current-version capability set, missed or repeated version start, required completion before ordinary use, Campaign mutation caused only by start/skip/dismissal, capability loss after skip, or tutorial-only network access: `0`. | Capability/tutorial coverage oracle; clean-install, same-version restart, and successive installed-version journeys with unchanged, added, changed, removed, and restored lessons; individual-skip and whole-run-dismissal journeys; Campaign semantic digest; offline, keyboard-only, pseudo-localization, scale, and tutorial-fault qualification. |
+
+### Rules Profile And Provenance
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-33` | P0 | `SRC-F02`, `SRC-P02`, `SRC-L04`, `SRC-R01`, `SRC-R02`, `SRC-R04`, `SRC-S03`, `SRC-D02`, `SRC-Q04`, `SRC-Q05`, `SRC-C01`, `EXT-DND2014` | Every automatic calculation derived from the binding D&D 5e 2014 profile MUST identify the local offline profile version, inputs, applicable rounding rule, and output, and MUST trace its published-rule derivation to the later authorized rule/domain owner. Travel, weather, restock, or other GM-authored calculations are outside this provenance clause unless they consume that rules profile. Product-confirmed rounding, including equal XP shares rounded up, is authoritative. | Same profile version and inputs yield the same exact result across OS, restart, import/export, and locale; no silent rule-profile refresh. | Versioned golden cases traced to preserved rule-owner evidence, boundary/rounding cases, offline execution, and profile/version readback. |
+
+### Workflow-Specific Correctness
+
+| ID | Priority | Sources | Obligation and rationale | Invariant or measure | Proof route |
+| --- | --- | --- | --- | --- | --- |
+| `TN-34` | P0 | `SRC-F04` | Name-only creation from a Running Scene MUST default to attaching the new object to that Scene and MUST offer an explicit opt-out before confirmation. Creation plus the chosen attachment outcome is one confirmed transition. | Confirming the default creates exactly one object attached to exactly the initiating Scene; opting out creates exactly one unattached object; failure creates neither partial outcome. | Production-route default/opt-out/failure/retry matrix with duplicate names and Scene switch during confirmation. |
+| `TN-35` | P0 | `SRC-R01` | XP granted to an inactive PC MUST create exactly one deferred informational notice. The notice MUST appear on that PC's next activation and clear only after that delivery is durably recorded; restart or retry cannot omit or duplicate it. | Deferred notice delivery count is `0` before the next activation and exactly `1` afterward. | Inactive award, repeated award, activation, crash-before/after-delivery, retry, and deactivate/reactivate sequence oracle. |
+| `TN-36` | P0 | `SRC-P04`, `SRC-L03`, `SRC-R03` | Note search MUST cover every Campaign object kind that can own notes, including notes edited in a Running Scene. A confirmed edit becomes part of the next search truth without stale or missing object classes. | For the exact manifest corpus, result identities equal the complete cross-kind oracle; a confirmed Scene edit is visible to the next search and first useful result obeys `TN-21`. | Per-kind seeded corpus, namesake, edit/search race, restart, locale, and archive/active-set production-route qualification. |
+| `TN-37` | P0 | `SRC-Q05` | For each Encounter Table evaluation, the supplied candidate set MUST equal that evaluation's contextually eligible entries and preserve every authored relative weight without making the narrative selection. A reusable entry may be eligible again in a later evaluation. | Candidate identities equal the evaluation-specific eligibility oracle; normalized authored weight ratios are exact and remain stable across restart and locale. | Fixed-input context, eligibility, identity, and exact normalized-weight conformance cases across repeated evaluations. |
+
+## Measurable Runtime Quality Scenarios
+
+| Scenario | Stimulus | Environment and affected truth | Required response and measure | Proof |
+| --- | --- | --- | --- | --- |
+| `QS-01 Live interaction` | GM focuses a Scene, moves a participant, changes HP, edits a note, invokes search, or follows a named frequent path | `RP-H` + `RP-R`, with and without each long-work category; current Campaign truth and projection | input feedback <=100 ms p95; completed action or first useful search result <=1 s p95 and 10 s timeout; absolute budget unchanged under background work; `TN-21` action counts pass | per-action production-route timing, action trace, and semantic-state oracle |
+| `QS-02 UI non-blocking` | generation, import, export, simulation, weather, or map work runs | focused Running Scene remains active | no interaction-thread stall >100 ms p95 or 1 s timeout; live workflow remains fully usable | separate per-workload population and recorded input latency |
+| `QS-03 Cancellation` | GM cancels long work at early, middle, and commit-boundary phases, repeatedly | accepted/unaccepted results, staging, marked/unmarked temp files, queues, and resources exist | one terminal outcome; acknowledgement <=1 s p95; no new effect after acknowledgement; cleanup <=10 s; accepted results remain; no unaccepted mutation; after 20 cycles memory is within 10% steady state and marked artifact count <=1 per capability | Campaign/staging manifest, temp/resource/handle/queue measurement, restart, resume/discard, and retry |
+| `QS-04 Preservation` | confirmed mutation followed by abrupt loss | normal and pressured `RP-R`; durable Campaign truth | acknowledged-work loss = 0; safe acknowledgement <=1 s p95 and 10 s timeout; unsafe work was visibly pending | crash/power/write-failure injection |
+| `QS-05 Warm switch` | GM switches Campaign with active Scenes, masks, travel, overrides, and pending reconciliation | warm `RP-R` and `RP-L` on each supported OS | 100% useful-state equivalence and safely rendered next mutation; ready <=1 s p95 and 10 s timeout | state snapshot and next-action comparison |
+| `QS-06 Start/resume` | clean cold start, crash restart, or, after `TN-18` activates, post-conversion start | `RP-R`/`RP-L`, each supported OS | 100% useful-state equivalence; ready <=5 s p95 `RP-R`, <=10 s p95 `RP-L`; progress visible after 1 s | separate cold/crash populations and, after activation, a separate conversion population; next-action comparison for each applicable mode |
+| `QS-07 Recovery` | full store or one independently addressable unit is damaged | unique safe recovery exists or choices are ambiguous | automatic unique recovery with exact disclosure; RPO <=60 s; complete restore including media <=5 min `RP-R`/20 min `RP-L`; salvage mode explicitly lists omissions | corruption corpus, complete restore and separate salvage-manifest drill |
+| `QS-08 Portability` | complete export/import across OS with source computer absent or crafted input supplied | all intact asset, definition, trash, optional-data, and runtime classes | semantic/asset equality 100%; independent Campaign; <=10 min `RP-R`/60 min `RP-L`; atomic cancel/reject; no path escape/execution/network/shared-state mutation | OS-pair round trip and adversarial import matrix |
+| `QS-09 Spatial display` | pan/zoom/focus, single/regional edit, reveal, visibility, weather, elevation, light, or hidden state change | every viewport density and cold/warm asset tier | feedback <=100 ms p95; complete safe projection <=1 s p95; prohibited leaks = 0 | exact viewport manifest, sustained interaction, memory peak, visibility and frame-safety oracle |
+| `QS-10 World catch-up` | independently timed Scenes cross none/some/all eligible, established, dependent, consequence-producing, and danger-bound candidates | exact `RP-R`/`RP-L` scheduling manifest | <=60 s `RP-R`, <=15 min `RP-L`; live budgets preserved; counts match manifest; each occurrence <=1; danger boundary pauses | controlled clocks, candidate/eligible/commit counts, cancel/restart and once-only oracle |
+| `QS-11 Capability failure` | each supporting capability faults once and repeatedly | explicit survivor matrix below | detection <=1 s from observable failure/first defective access; survivor journeys retain `TN-21`; confirmed/retained-data loss and out-of-envelope resource growth = 0; affected capability identified/retryable | per-capability survivor timings, sentinels, retained-data and resource-envelope audit |
+| `QS-12 Exceptional pressure` | low disk, memory pressure, CPU contention, damaged input, or oversized axis | pressure decision table below | `RP-X` ceilings and 1 s admission/error deadline pass; no truncation/corruption; safe read/export/retry survives | long-duration pressure and completeness/resource audit |
+| `QS-13 Accessibility/localization` | keyboard-only use, locale switch, 200% scale, color unavailable, or mixed-DPI display move | complete core across full `RP-H` display matrix | all workflows/action counts pass; no trap/loss; 4.5:1 text and 3:1 essential non-text contrast; no color-only fact; authored text unchanged | keyboard/action suite, contrast scan plus human review, pseudo-localization/display round trip |
+| `QS-14 Tutorial onboarding` | clean first installation, first start of a new installed application version, or same-version restart | exact complete exposed-capability/tutorial inventory for that installed version; no Campaign is open or one real Campaign is active | clean install and each new version present the complete current set exactly once; same-version restart does not; the GM can skip one lesson or dismiss the remaining run without completion; no Campaign truth changes and every capability remains ordinarily usable | installed-version matrix with unchanged/add/change/remove/restore manifest oracle, keyboard-only individual skip and whole-run dismissal, Campaign semantic digest, restart, offline execution, and tutorial-fault injection |
+
+## Change Scenarios
+
+| Scenario | Change stimulus | Required response and measure | Verification |
+| --- | --- | --- | --- |
+| `CS-01 Content kind` | Add a Campaign content kind with identity, notes, search, history, and export behavior. | Existing unrelated kinds, Campaign truth, and acceptance behavior remain semantically unchanged; any compatibility work is declared and qualified rather than judged by touched-file count. | Add/remove fixture kind and compare unrelated state/behavior/data. |
+| `CS-02 Runtime mask` | Add a mask which may coexist and share participants. | Scene continuity and participant authority remain unchanged; removing/moving a participant reconciles without modifying unrelated masks. | Two-mask conformance scenario plus failure/removal. |
+| `CS-03 Influence family` | Add a location/weather/time influence consumed by generation or ambience. | Existing influence semantics do not change; absence is neutral; addition/removal cannot corrupt accepted results or history. | Metamorphic before/add/remove comparison. |
+| `CS-04 Generator/importer` | Add or replace a generator or importer. | Unaccepted results remain isolated, cancellation is clean, accepted results use the same lifecycle and safety boundaries, and core manual workflows remain available. | Conformance, cancel, malformed-input, and replacement suite. |
+| `CS-05 Optional capability` | Omit, remove, replace, then restore music, weather, maps, or another supporting capability. | Campaign opens throughout; unrelated workflows/data are unchanged; retained data round-trips and becomes usable again. | Four-state capability matrix with semantic digests. |
+| `CS-06 Third-party presentation` | Add a presentation including a passive-display projection. | It receives only disclosed/consented data and cannot expose prohibited GM-private/mechanical state or write Campaign truth. | Adversarial permission and information-flow test. |
+
+## Cross-Workflow Invariants
+
+| Scenario | Required invariant set |
+| --- | --- |
+| Split-Scene time and World catch-up | `TN-08`, `TN-09`, `TN-13`, and `TN-23`: independent clocks, once-only shared consequences, persistent conflict visibility, live-first scheduling. |
+| Travel interruption and undo/redo | `TN-12`, `TN-15`, and `TN-22`: checkpoint is durable before further route progress, undo is causally bounded, retry/redo duplicates nothing. |
+| Encounter completion and XP | `TN-10`, `TN-06`, `TN-33`, and `TN-35`: one atomic confirmed outcome, explanatory history retained, versioned exact rounding, one deferred inactive-recipient notice. |
+| Shop restock, trade, and history | `TN-09`, `TN-10`, and `TN-06`: restock once, trade all-or-nothing, manual stock outside rule scope unchanged, explanatory fact retained. |
+| Crash during save or, after first-real-user/data cutover, update | `TN-15`, `TN-16`, and `TN-17`: no acknowledged loss, truthful pending state, and safe recovery. After activation, `TN-18` additionally requires that the prior released version remain usable after failed conversion. |
+| Corrupt individual data | `TN-17` and `TN-27`: affected identity isolated and disclosed; remaining Campaign and unrelated capabilities open. |
+| Complete Campaign import | `TN-01`, `TN-02`, `TN-19`, and `TN-33`: independent Campaign identity, closed asset/definition set, explicit conflicts, preserved rule provenance. |
+| Large maps and passive display | `TN-20`, `TN-21`, and `TN-24`: complete sparse/dense truth, responsive viewport, zero hidden/private leak. |
+| Faulty extension | `TN-27`, `TN-29`, and `TN-30`: extension disabled and identified, retained data intact, Campaign opens, no unauthorized access or egress. |
+
+## Failure-Mode Analysis
+
+| Hazard | Priority | Required detection | Required containment and proof |
+| --- | --- | --- | --- |
+| Confirmed-data loss | P0 | durability acknowledgement, integrity checks, restore drill | `TN-15`/`TN-17`; zero acknowledged loss, restore-tested recovery |
+| Silent partial success | P0 | all-or-nothing outcome oracle and pending-state reconciliation | `TN-10`/`TN-11`; no hybrid truth, explicit pending dependents |
+| Stale presentation shown as current | P0 | revision/freshness relationship observable without choosing its mechanism | `TN-11`/`TN-24`; stale state labeled or withheld, unsafe passive frame never shown |
+| Unauthorized data egress | P0 | outbound observation and permission audit | `TN-29`/`TN-30`; zero real-data egress and zero undisclosed access |
+| Duplicate time consequence | P0 | stable occurrence identity and applied-count audit | `TN-09`; count never exceeds one across retry, Scene order, or restart |
+| Live-game blockage | P0 | end-to-end latency and stall monitoring under workload | `TN-21`/`TN-22`; live budgets retained, long work yields/cancels |
+
+### Pressure Decision Table
+
+| Stimulus | Admission and bound | Workflows that MUST remain available | Recovery transition |
+| --- | --- | --- | --- |
+| Destination lacks declared input/output plus temporary-space budget | reject before mutation within 1 s; no staging growth | safe read, choose another destination, export there, retry | retry after capacity/destination change |
+| Local working storage reaches its safety reserve | reject new writes before unsafe acknowledgement; do not consume the reserve | safe read, export to a destination with capacity, retry | resume only after capacity is restored and integrity rechecked |
+| Memory pressure would exceed 75% of `RP-H` | yield/cancel background work before the limit; one active + one pending per capability | Running Scene, Encounter, manual edit, preservation, safe export | explicit retry resumes from accepted/checkpointed truth only |
+| CPU contention | background work yields; live `TN-21` budgets remain binding | all live/manual survivor journeys | backlog remains visible; process when capacity returns |
+| Oversized data axis | no silent truncation; paginate/defer/reject the affected long operation with complete count/disclosure | safe read, targeted manual work, preservation, export, retry | operation resumes without duplicate or omitted truth |
+| Damaged input/record/asset | isolate the named unit; no implicit substitute | unaffected Campaign, preservation, salvage export, retry/recovery | explicit recover/delete or complete restore |
+
+### Capability Failure Survivor Matrix
+
+All rows preserve Campaign opening and confirmed-work preservation. Initiating,
+observing, or cancelling complete export and every survivor journey obeys
+`TN-21`; export completion obeys `TN-19` and cancellation obeys `TN-22`.
+Complete export includes opaque retained failed-capability data. Only the
+separately labeled salvage route may omit an identified damaged unit.
+
+| Failed capability | Allowed unavailable behavior | Required survivors |
+| --- | --- | --- |
+| Music/ambience | automatic/manual playback and queue changes | Running Scenes, Encounters, notes, maps, travel, manual Campaign editing |
+| Weather | automatic weather progression and weather-derived calculation | Running Scenes, Encounters, manual time/place editing, manual overrides, travel inspection |
+| Maps/spatial projection | map rendering, spatial authoring, route calculation that requires the map | Running Scenes, Encounters, administrative place assignment, notes, preservation |
+| Generation | generation and regeneration | complete manual preparation, live Scene/Encounter work, accepted results |
+| World progression/autonomy | catch-up and unresolved autonomous consequence | live/manual work, manual time advancement with visible backlog, established prior consequences |
+| Optional extension/capability | only behavior requiring that provider | all core and other-capability workflows; retained provider data remains intact |
+
+## Requirement And Constraint Coverage
+
+Subsection IDs below cover every normative workflow subsection, including prose
+before its acceptance list. The catalog's `Sources` column names these exact
+subsection and constraint IDs; the acceptance table below records the separate
+criterion-to-need relation.
+
+| Source ID | Capability subsection | Technical needs |
+| --- | --- | --- |
+| `SRC-F01` | Campaign Lifecycle | `TN-02`, `TN-16` |
+| `SRC-F02` | Reusable And Campaign-Specific Knowledge | `TN-01`, `TN-02`, `TN-04`, `TN-33` |
+| `SRC-F03` | Roster, Current Party, And Planning Party | `TN-01`, `TN-02`, `TN-07` |
+| `SRC-F04` | Minimal Creation And Explicit Deletion | `TN-01`, `TN-03`, `TN-05`, `TN-06`, `TN-34` |
+| `SRC-P01` | Planning Workspace And Timeline | `TN-03`, `TN-28` |
+| `SRC-P02` | Assisted Generation | `TN-03`, `TN-10`, `TN-13`, `TN-22`, `TN-33` |
+| `SRC-P03` | Accepted World Content And Treasures | `TN-03`, `TN-10` |
+| `SRC-P04` | Weather, Music, And Notes | `TN-14`, `TN-21`, `TN-25`, `TN-26`, `TN-36` |
+| `SRC-L01` | Continuous Scene State And Party Splits | `TN-02`, `TN-05`, `TN-07`, `TN-11` |
+| `SRC-L02` | Masks And Prepared Monster Groups | `TN-03`, `TN-07`, `TN-28` |
+| `SRC-L03` | Live Search, Creation, Notes, And Music | `TN-21`, `TN-26`, `TN-28`, `TN-36` |
+| `SRC-L04` | Independent Time And Weather | `TN-08`, `TN-09`, `TN-14`, `TN-25`, `TN-33` |
+| `SRC-L05` | Passive Second Display | `TN-24`, `TN-31` |
+| `SRC-T01` | Places, Subplaces, And Scene Continuity | `TN-02`, `TN-07`, `TN-21`, `TN-28` |
+| `SRC-T02` | Travel, Interruptions, And Overrides | `TN-09`, `TN-12`, `TN-14`, `TN-15` |
+| `SRC-T03` | Independent Scene Time And World Progression | `TN-08`, `TN-09`, `TN-12`, `TN-13`, `TN-22`, `TN-23` |
+| `SRC-T04` | Hex Maps, Knowledge, And Visibility | `TN-20`, `TN-24`, `TN-25` |
+| `SRC-T05` | Climate, Weather, And Ambience | `TN-14`, `TN-25`, `TN-26`, `TN-28` |
+| `SRC-R01` | Encounter Consequences And XP | `TN-06`, `TN-10`, `TN-33`, `TN-35` |
+| `SRC-R02` | Rewards And Narrative Notes | `TN-02`, `TN-10`, `TN-33` |
+| `SRC-R03` | Character Loot Ledger | `TN-01`, `TN-06`, `TN-10`, `TN-21`, `TN-36` |
+| `SRC-R04` | Cumulative Loot Guidance | `TN-10`, `TN-33` |
+| `SRC-R05` | Corrections And History | `TN-04`, `TN-06`, `TN-10` |
+| `SRC-S01` | Shop Identity And Inventory | `TN-01`, `TN-02`, `TN-05`, `TN-21` |
+| `SRC-S02` | Trade And Character Ledger | `TN-06`, `TN-10` |
+| `SRC-S03` | Restock And Randomized Stock | `TN-06`, `TN-09`, `TN-32`, `TN-33` |
+| `SRC-D01` | Continuous Preservation And Resume | `TN-15`, `TN-16`, `TN-17` |
+| `SRC-D02` | Complete Campaign Portability | `TN-01`, `TN-02`, `TN-04`, `TN-13`, `TN-18`, `TN-19`, `TN-22`, `TN-30`, `TN-33` |
+| `SRC-D03` | Campaign Deletion | `TN-03`, `TN-05` |
+| `SRC-Q01` | Offline Desktop Operation And Trust | `TN-02`, `TN-19`, `TN-21`, `TN-24`, `TN-30`, `TN-31` |
+| `SRC-Q02` | Responsiveness, Scale, And Failure Isolation | `TN-03`, `TN-15`, `TN-16`, `TN-17`, `TN-18`, `TN-19`, `TN-20`, `TN-21`, `TN-22`, `TN-23`, `TN-25`, `TN-26`, `TN-27`, `TN-32` |
+| `SRC-Q03` | Modular Change And Third-Party Extensions | `TN-27`, `TN-28`, `TN-29`, `TN-32` |
+| `SRC-Q04` | Rules, Localization, Accessibility, And Displays | `TN-24`, `TN-31`, `TN-33` |
+| `SRC-Q05` | Calendar, Encounter Tables, Dice, And PC Data | `TN-02`, `TN-08`, `TN-09`, `TN-13`, `TN-28`, `TN-32`, `TN-33`, `TN-37` |
+| `SRC-Q06` | In-Game Capability Tutorials | `TN-21`, `TN-31`, `TN-38` |
+| `SRC-C01` | Complete Encounter Outcome | `TN-06`, `TN-10`, `TN-33` |
+| `SRC-C02` | Authoritative Party With Dependent Running Contexts | `TN-07`, `TN-11`, `TN-15`, `TN-16` |
+| `SRC-C03` | Scene Save Before Encounter Synchronization | `TN-11`, `TN-15`, `TN-16` |
+| `SRC-C04` | Explanatory Campaign History | `TN-04`, `TN-06`, `TN-08`, `TN-12`, `TN-13` |
+
+External sources contribute only the listed measurement or proof
+constraint; they do not own product behavior.
+
+| Constraint ID | Preserved source or owner | Technical needs or impact |
+| --- | --- | --- |
+| `EXT-NNG` | Nielsen Norman Group response-time evidence | `TN-21`, `TN-22` |
+| `EXT-WCAG` | W3C WCAG 2.2 | `TN-31` |
+| `EXT-DND2014` | preserved D&D Basic Rules 2014 evidence | `TN-33` |
+| `EXT-ARC42` | arc42 quality-scenario guidance | no independent technical need; supplies the scenario form |
+
+## Acceptance-Criterion Traceability
+
+Acceptance IDs follow source order. The summary is descriptive only; the linked
+capability requirement remains the behavior owner.
+
+| Acceptance ID | Summary | Technical needs or no separate impact |
+| --- | --- | --- |
+| `AC-F01` | name-only Campaign creation | `TN-01`, `TN-02`; no separate quality constraint beyond minimal valid identity |
+| `AC-F02` | immediate Campaign switch and exact runtime resume | `TN-02`, `TN-16`, `TN-21` |
+| `AC-F03` | manual Session without Party | `TN-02`, `TN-28`; no additional constraint |
+| `AC-F04` | Session expected Party cannot change table Party | `TN-02`, `TN-07` |
+| `AC-F05` | independent Campaign copy | `TN-01`, `TN-02` |
+| `AC-F06` | current definition, frozen completed fact | `TN-04`, `TN-33` |
+| `AC-F07` | manual note-first narrative records | `TN-28`; no autonomous-resolution need |
+| `AC-F08` | Scene creation default with opt-out | `TN-02`, `TN-10`, `TN-34` |
+| `AC-F09` | deletion removes current/dependent runtime, preserves history | `TN-03`, `TN-05`, `TN-06` |
+| `AC-F10` | one Campaign Roster with optional PC facts and no implicit Party membership | `TN-01`, `TN-02`, `TN-07` |
+| `AC-P01` | complete manual preparation | `TN-03`, `TN-28`; generation remains optional |
+| `AC-P02` | editable ordered timeline | `TN-03`, `TN-15` |
+| `AC-P03` | plan replacement preserves placements | `TN-03` |
+| `AC-P04` | impossible generation blocked with explanation | `TN-10`, `TN-13` |
+| `AC-P05` | independent generated result changes | `TN-03`, `TN-22`, `TN-27` |
+| `AC-P06` | placed content exposed without auto-start/award | `TN-03`, `TN-13` |
+| `AC-P07` | placed Treasure Items remain editable/movable | `TN-01`, `TN-10` |
+| `AC-P08` | weather requires no Session preparation | `TN-25`, `TN-27`; no separate persistence boundary |
+| `AC-P09` | focused Scene autoplay and manual precedence | `TN-14`, `TN-26` |
+| `AC-P10` | live note edit and cross-kind search | `TN-15`, `TN-21`, `TN-31`, `TN-36` |
+| `AC-L01` | empty primary Scene | `TN-07` |
+| `AC-L02` | each active PC in exactly one Scene | `TN-02`, `TN-07` |
+| `AC-L03` | split/reunite without implicit deletion | `TN-05`, `TN-07`, `TN-08` |
+| `AC-L04` | prepared group available without persistent Encounter | `TN-03`, `TN-28` |
+| `AC-L05` | coexisting masks/shared participants | `TN-07`, `TN-28` |
+| `AC-L06` | move removes participant from masks without block | `TN-07`, `TN-11` |
+| `AC-L07` | live search/add/lightweight creation | `TN-21`, `TN-28`, `TN-31` |
+| `AC-L08` | divergent Scene time without reversal | `TN-06`, `TN-08`, `TN-09` |
+| `AC-L09` | independent weather and override release | `TN-09`, `TN-14`, `TN-25` |
+| `AC-L10` | safe passive display | `TN-21`, `TN-24`, `TN-31` |
+| `AC-T01` | unified complete/partial subgroup travel | `TN-02`, `TN-07`, `TN-21` |
+| `AC-T02` | position/time advance to checkpoints | `TN-09`, `TN-12`, `TN-15` |
+| `AC-T03` | interruption without narrative decision | `TN-12`, `TN-13` |
+| `AC-T04` | override and causal undo/redo | `TN-08`, `TN-12`, `TN-14` |
+| `AC-T05` | reuse World behavior and expose conflict | `TN-09`, `TN-13`, `TN-23` |
+| `AC-T06` | coarse/fine Hex propagation | `TN-20`, `TN-24`, `TN-25` |
+| `AC-T07` | passive union of knowledge/perception | `TN-24` |
+| `AC-T08` | coherent weather/effects/notification | `TN-09`, `TN-25` |
+| `AC-T09` | manual ambience coexists with automation | `TN-14`, `TN-26` |
+| `AC-R01` | Encounter outcome, XP, Scene continues | `TN-06`, `TN-10`, `TN-33` |
+| `AC-R02` | XP rounding, derived level, correction history | `TN-06`, `TN-10`, `TN-33` |
+| `AC-R03` | one deferred XP information message | `TN-02`, `TN-09`, `TN-35` |
+| `AC-R04` | shared reward distribution, no auto-recipient | `TN-10`, `TN-13` |
+| `AC-R05` | manual narrative resolution | `TN-28`; no autonomous-resolution need |
+| `AC-R06` | searchable/correctable ledger and stacks | `TN-01`, `TN-06`, `TN-21` |
+| `AC-R07` | sold/given reminders and provenance | `TN-04`, `TN-06` |
+| `AC-R08` | cumulative loot compensation | `TN-10`, `TN-33` |
+| `AC-S01` | Shop ownership and stock identity | `TN-01`, `TN-02` |
+| `AC-S02` | owner reassignment or co-trash/restore | `TN-03`, `TN-05` |
+| `AC-S03` | Scene Shop availability | `TN-02`, `TN-21` |
+| `AC-S04` | atomic purchase without coin deduction | `TN-06`, `TN-10` |
+| `AC-S05` | atomic sale and counterparty | `TN-06`, `TN-10` |
+| `AC-S06` | manual/fixed/random restock | `TN-09`, `TN-28`, `TN-32` |
+| `AC-S07` | time rule once and scoped stock | `TN-09`, `TN-10` |
+| `AC-S08` | trade/restock history without extra notice | `TN-06`, `TN-09` |
+| `AC-D01` | automatic preservation and useful resume | `TN-15`, `TN-16` |
+| `AC-D02` | newest safe recovery and disclosure | `TN-17` |
+| `AC-D03` | complete source-independent restore | `TN-19`, `TN-30`, `TN-33` |
+| `AC-D04` | import creates independent Campaign | `TN-01`, `TN-02`, `TN-19` |
+| `AC-D05` | explicit shared-definition conflict choice | `TN-04`, `TN-13`, `TN-19` |
+| `AC-D06` | recoverable then permanent Campaign deletion | `TN-03`, `TN-05`, `TN-17` |
+| `AC-Q01` | offline core | `TN-30` |
+| `AC-Q02` | cross-platform self-contained Campaign | `TN-19`, `TN-30` |
+| `AC-Q03` | responsive live actions and cancellable long work | `TN-21`, `TN-22`, `TN-23` |
+| `AC-Q04` | supporting failure isolation | `TN-26`, `TN-27` |
+| `AC-Q05` | no unaccepted cancelled result | `TN-03`, `TN-22` |
+| `AC-Q06` | safe data through released update after cutover, damage, or missing capability | `TN-17`, `TN-18`, `TN-27` |
+| `AC-Q07` | remove/replace capability and restore data | `TN-27`, `TN-28` |
+| `AC-Q08` | extension access after disclosure/consent | `TN-29`, `TN-30` |
+| `AC-Q09` | incompatible extension cannot block or bypass safety | `TN-27`, `TN-29` |
+| `AC-Q10` | accessible efficient workflows | `TN-21`, `TN-31` |
+| `AC-Q11` | Calendar relevance without narrative decision | `TN-08`, `TN-09`, `TN-13` |
+| `AC-Q12` | Encounter Tables supply weighted candidates | `TN-28`, `TN-32`, `TN-37` |
+| `AC-Q13` | no general dice roller; internal randomness allowed | `TN-32`, `TN-33`; scope exclusion has no additional technical impact |
+| `AC-Q14` | workflow-specific PC statistics | `TN-02`, `TN-13`, `TN-28` |
+| `AC-Q15` | every capability has an in-game tutorial; install/update starts automatically and the experience is skippable | `TN-21`, `TN-31`, `TN-38` |
+| `AC-C01` | complete Encounter outcome | `TN-06`, `TN-10`, `TN-33` |
+| `AC-C02` | authoritative Party with pending dependents | `TN-07`, `TN-11`, `TN-15`, `TN-16` |
+| `AC-C03` | saved Scene with pending Encounter sync | `TN-11`, `TN-15`, `TN-16` |
+| `AC-C04` | explanatory history and narrow exceptions | `TN-04`, `TN-06`, `TN-12`, `TN-13` |
+
+## Reverse Traceability And Orphan Check
+
+Every `TN-*` above names at least one source subsection. `TN-15` through
+`TN-25` additionally instantiate the capability baseline's explicit instruction
+to establish measurable response, preservation, recovery, scale, map, and
+World-catch-up budgets during technical-needs derivation. `TN-31` uses WCAG only
+to make the owner-confirmed accessibility outcomes measurable; it does not add a
+web technology requirement. `TN-33` uses preserved D&D evidence only to require
+versioned, auditable offline rule truth; it does not adopt an external API or
+rule table.
+
+The forward tables cover every capability subsection and every acceptance
+criterion. There are no orphan technical needs and no unassigned confirmed
+acceptance criteria.
+
+## Deliberately Deferred Product Research
+
+The following does not block this `Active Target` because the baseline itself
+parks it or assigns it to later product testing:
+
+- exact music mood axes and categorization;
+- player-operated or remote-play products;
+- cross-map route planning convenience;
+- procedural Hex generation and autonomous faction simulation;
+- generic support for other game systems or D&D editions;
+- concrete D&D rule tables and formulas owned by the later rule/domain owner.
+
+This deferral MUST NOT be used to weaken the obligations above. In particular,
+weather remains constrained by inputs, continuity, spatial/temporal resolution,
+overrides, structured effects, and compute budgets, while its algorithm remains
+open.

--- a/docs/project/architecture/source-architecture.md
+++ b/docs/project/architecture/source-architecture.md
@@ -1,0 +1,364 @@
+# Source Architecture
+
+## Purpose And Concerns
+
+This specification serves maintainers changing features, persistence, the
+JavaFX shell, and application startup. It answers where behavior belongs, how
+features collaborate, and which boundaries protect UI responsiveness, local
+data, and diagnosability.
+
+SaltMarcher remains one local JavaFX desktop process and one Gradle application.
+Local persistence has one installation-owned store for the Campaign registry
+and reusable definitions plus one physically separate store per Campaign. Only
+one Campaign runtime is active in the shell at a time. The target is a modular
+monolith, not a distributed system or a set of Gradle subprojects.
+
+## Target Shape
+
+```text
+app/       explicit application composition and lifecycle
+shell/     passive JavaFX host and shell contracts
+platform/  execution, persistence, diagnostics, and state mechanisms
+features/  capability-driven feature roles and required adapters
+resources/ static resources and centralized application styling
+docs/      durable product, domain, contract, and architecture truth
+```
+
+Feature roles follow owned behavior rather than a mandatory folder template. A
+feature publishes `api` only for capabilities consumed outside its
+implementation, owns `domain` only for business truth and invariants, and owns
+`application` only for use-case orchestration. A feature with stored truth owns
+an `adapter/sqlite`; a feature with JavaFX presentation owns an
+`adapter/javafx`; bundled read-only reference data belongs in an
+`adapter/resource`; explicit remote protocol integration belongs in an
+`adapter/http`. Empty role packages are forbidden. Dungeon remains one
+feature and publishes separate Authored, Editor, and Travel APIs.
+
+## Permanent Boundaries
+
+- `app` MUST compose platform services, feature entry points, and shell
+  contributions explicitly and deterministically. It may depend on every
+  target root but MUST NOT own feature behavior or long-lived feature state.
+- `app` MUST give the installation lifetime and each active Campaign runtime
+  separate persistence and execution lifecycles. One installation-owned
+  activation coordinator serializes Campaign changes and owns the activation
+  generation, durable active-Campaign pointer, and runtime admission fence.
+- `shell` MUST remain independent from feature implementations. Features may
+  use `shell.api` contracts; the shell receives already constructed
+  contributions and MUST NOT locate feature services. Shell internals may use
+  feature-neutral platform mechanisms; `shell.api` contracts remain free of
+  platform implementation types.
+- `platform` MUST contain only feature-neutral mechanisms. It MUST NOT import
+  `app`, `shell`, or feature code. Its capability packages are
+  `platform.execution`, `platform.persistence`, `platform.diagnostics`,
+  `platform.state`, and `platform.ui`; new catch-all packages are forbidden.
+  Passive map camera, viewport, layered-canvas, cache, and technical pointer
+  mechanisms live in `platform.ui.mapcanvas`; they do not form a Maps feature
+  or own adopter coordinates and behavior.
+- A feature MUST expose cross-feature capabilities only from its `api` package.
+  Application, JavaFX adapter, and composition code may consume foreign APIs;
+  no consumer may import another feature's domain, application, adapters, or
+  composition entry point.
+- Feature domain roles MUST remain independent from `platform`. Observable API
+  contracts may use feature-neutral state and UI-dispatch contracts.
+  Application code may use execution, state, UI-dispatch, and diagnostics
+  contracts; SQLite adapters may use persistence and diagnostics; JavaFX
+  adapters may use UI contracts; HTTP adapters may use diagnostics; feature composition may wire any platform
+  capability.
+- Feature API calls that can touch persistence or files MUST be non-blocking.
+  JavaFX state changes MUST be dispatched explicitly to the UI thread.
+- Published feature state MUST be immutable and revisioned. A late asynchronous
+  result MUST NOT overwrite newer state.
+- Feature SQLite adapters own their stored truth and migration steps. Reusable
+  definitions and the Campaign registry use the installation store;
+  Campaign-owned truth uses only that Campaign's store. Cross-store references
+  use stable logical identities and MUST NOT depend on cross-database foreign
+  keys or duplicate mutable Campaign truth. Shared connection, integrity,
+  backup, and recovery mechanisms belong to `platform`. JDBC and SQLite driver
+  APIs are allowed only in feature SQLite adapters and `platform.persistence`.
+- Technical diagnostics MUST remain local and MUST NOT record feature payloads,
+  secrets, or user-authored content.
+
+The global compact travel context is owned by a feature-neutral Travel
+capability. It consumes Party position plus Dungeon and Hex API readbacks,
+publishes one immutable `TravelContextSnapshot`, and owns the single global
+`Reise` state contribution. Dungeon and Hex retain their movement semantics and
+detailed workspaces; `app` only composes these APIs.
+
+Internal Java types have no compatibility obligation while all consumers move
+atomically in one green slice. Persisted data and observable behavior retain
+their contract and requirement owners.
+
+## Tutorial Runtime Boundary
+
+The installation runtime owns one tutorial coordinator and its installation-
+scoped progress. Capability owners contribute immutable, versioned lesson
+definitions through explicit application composition; neither the shell nor
+the tutorial coordinator discovers feature implementations. A lesson targets
+semantic capability actions and owned product concepts rather than source
+packages, CSS selectors, persistence rows, or adapter details. An installed
+extension which exposes a capability contributes its lesson through the same
+restricted extension boundary and cannot gain additional Campaign, file, or
+network authority by doing so.
+
+The coordinator compares the installed application version with the last
+version whose automatic presentation began in this installation profile. First
+installation and the first start of every distinct installed version enqueue
+the complete lesson set contributed by all capabilities exposed by that
+version, including unchanged lessons. A same-version restart enqueues nothing
+automatically. Removed capabilities contribute nothing; an added, changed, or
+restored capability participates in the complete set of the next installed
+version in which it is present.
+
+Each lesson exposes an individual skip, and the automatic presentation exposes
+a separate action which dismisses all remaining lessons. Skip, dismissal, and
+completion state are installation-owned preferences, not Campaign truth and do
+not suppress the complete set after a later application update. Starting,
+skipping, or dismissing a tutorial cannot confirm a Campaign mutation, disable
+a capability, or change runtime authority. A
+tutorial may guide a real product action only after the GM invokes that action
+through its ordinary capability boundary and receives the ordinary durable
+feedback.
+
+Tutorial presentation is an in-product shell contribution which remains
+keyboard-operable, localizable, scalable, offline, and skippable without
+completion. It is isolated from an unavailable or faulty lesson so the
+underlying capability and the rest of the Campaign remain usable. Lesson
+versioning and deliberate replay are reversible technical conveniences, not
+owner-confirmed behavior.
+
+## Campaign Runtime Boundary
+
+An installation runtime owns shared reference capabilities, the Campaign
+registry, and a lifecycle/import coordinator. The coordinator owns bounded
+validation, staging, identity remapping, and atomic promotion of a complete
+Campaign package including its store and assets; feature owners retain their
+payload truth. Existing shared definitions and Campaigns remain unchanged
+until all required import choices and validation have succeeded.
+
+A Campaign runtime owns the Campaign-scoped feature components, their execution
+lanes, their SQLite lifecycle, and their bound shell contributions. Core
+readiness means preservation plus the required survivor journeys have valid
+semantic state, can open safely, and have a writable transactional persistence
+boundary. Before the durable pointer commit, candidate preparation qualifies
+the complete attached root structure, selected focused-Scene journey, survivor
+state, and non-payload rollback probe without admitting Campaign mutations. It
+MUST NOT perform a duplicate offscreen CSS/layout render as a substitute for
+the real publication path. Visible readiness is decided after whole-root
+publication by the safely rendered focused Scene and its exact next durable
+feature mutation through the same production composition and persistence route
+against a disposable Campaign. Candidate preparation MUST NOT create, alter,
+or delete user-authored truth merely to test readiness. An optional or
+supporting capability that fails readiness starts explicitly disabled or
+degraded and does not block the core shell. Runtime closure revokes later work
+on its first attempt and remains in `QUIESCING` after a release failure.
+Campaign-scoped components acquire foreign subscription handles only after the
+complete component aggregate owns them. A synchronous partial-start failure
+retains every acquired handle in that aggregate; retry resumes at the first
+unacquired handle, while runtime closure releases and, after release failure,
+retries only the retained handles. Each
+retry owns a fresh terminal result while skipping component, execution-lane,
+and database releases already proven successful; it reaches `CLOSED` and
+shuts down its closure executor only after the complete graph is released.
+
+Campaign activation is one serialized state transition:
+
+1. prepare a core-ready candidate without admitting Campaign mutations;
+2. close admission for the current runtime and drain every accepted mutation;
+3. durably commit the target Campaign and a new activation generation in the
+   installation registry; this commit is the linearization and crash-truth
+   point;
+4. publish the candidate's whole Campaign shell root and admit its generation;
+5. retire the detached runtime: close it, or retain the complete aggregate in
+   the coordinator's single bounded `PARKED` slot when the eligibility rules
+   below hold.
+
+Application and persistence boundaries reject a revoked runtime generation
+before commit. Failure before the registry commit reopens the unchanged prior
+runtime. Failure after that commit never reopens prior mutation authority: the
+coordinator keeps the UI in an explicit switching/recovery state and rolls
+forward to the durably selected Campaign. Restart follows the same durable
+selection.
+
+A user-directed switch out of recovery first rereads the durable pointer and
+derives one explicit replacement fallback aggregate: the retained prior when
+it is still durable, or the prepared target when that target was already
+committed. Every other recovery-owned aggregate must close before another
+candidate may be allocated. The fallback remains owned through replacement
+preparation, prior drain, and an ambiguous or timed-out pointer commit; it may
+retire only after the replacement pointer commit is confirmed. Its lifecycle
+mode is explicit: an active fallback drains once before replacement
+preparation, a parked fallback remains parked, and an already committed but
+not yet published fallback remains prepared rather than being treated as an
+active runtime. If the durable Campaign could not open at all, the explicit
+mode is durable-truth-only: there is no aggregate to drain or republish, so the
+coordinator may prepare one healthy alternative within the same ownership
+bound and commit it without reading or mutating the inaccessible Campaign
+store. Any rejection before that commit returns to the durable recovery state.
+A definite
+pre-commit rejection resumes admission and republishes that exact retained
+shell into the installation host because recovery publication detached and
+released the prior host reference. Resolving a contained pre-commit recovery
+does the same rather than claiming an active snapshot while the recovery desk
+is still visible. A committed replacement follows the normal roll-forward
+rule, including recovery after publication failure.
+
+Every contained preparation, drain, or pointer-commit stage retains its exact
+activation context: the prior aggregate, its drain outcome, and whether a
+recovery publication actually detached the prior root. Normal switching
+timeouts therefore let the host show a contained settling/recovery desk while
+retaining the exact published shell identity and accelerator surface. The host
+restores that same shell on `RESUMED` without falsely marking its publication
+lost or publishing it a second time. This contained desk presents the retained
+Campaign as healthy and available while the transition settles; it MUST NOT
+label or disable that Campaign as damaged. A retry, registry-read failure, or
+other recovery action while any contained stage remains nonterminal MUST stay
+`RECOVERY_UNAVAILABLE` and MUST NOT request visible recovery publication.
+Only a recovery-directed replacement republishes its detached fallback. A durable-truth-only replacement retains a non-recursive fallback
+of the damaged durable activation, Campaign identity, and path rather than a
+second recovery graph. If its late preparation or pointer commit settles
+definitively before commit, that exact damaged recovery truth is restored and
+a later healthy replacement remains possible without reading or changing the
+damaged Campaign bytes.
+
+Exact aggregate restoration requires either that no drain began or that the
+drain completed successfully. A terminal drain failure makes that in-memory
+aggregate unsafe to readmit: it remains an owned close obligation until close
+succeeds, while the durable Campaign truth remains selected and is rebuilt
+through the normal current-format open path. No replacement candidate may be
+allocated while that close remains unsettled.
+
+The coordinator records the prior aggregate's drain outcome explicitly as
+`NOT_STARTED`, `PAUSED`, `UNSAFE`, or `NOT_REQUIRED`. Only terminal successful
+completion moves an attempted drain to `PAUSED`; a synchronous exception or a
+timeout moves it to `UNSAFE` until a late terminal success proves `PAUSED`.
+Immediate or late terminal failure releases the uncommitted candidate, closes
+the unsafe prior under a retained obligation, never resumes or republishes that
+instance, and retains the unchanged durable Campaign truth for a cold rebuild
+after close settlement. A definite pre-commit rejection resumes a `PAUSED`
+fallback exactly once. Prepared and durable-truth-only fallbacks never receive
+that resume operation.
+
+Campaign switching replaces the whole Campaign shell root. The active shell
+does not discover services, mix contributions from another runtime, or
+coordinate state copying between runtimes. The coordinator MAY retain exactly
+one detached ownership aggregate containing its Campaign runtime, complete
+shell root, and accelerator map. That aggregate is `PARKED`: admission is
+drained and closed, it has no mutation authority, and it is absent from the
+installation-owned active `Scene`. A later activation always receives a fresh
+durable generation before the aggregate can regain admission authority.
+
+Parking is eligible only while the focused workspace has no delayed activation
+or deactivation lifecycle and every installation-owned reference consumed by
+the aggregate is immutable for the parked interval. The current eligibility
+rule is the focused primary Scene journey. Any mutable shared-definition route
+MUST invalidate or evict the parked aggregate before publishing its mutation;
+other focused workspaces use close-and-rebuild. Before reuse, the complete
+parked current-format store is checked in O(1) against the quiescent token
+captured after its admitted work drained: physical file identity, size,
+high-resolution modification time, and absence of WAL, SHM, and rollback
+journal sidecars. An unchanged token inherits the physical, foreign-key, and
+owner-schema integrity established at current-format open. Any detected main
+file change receives those complete checks through an immutable read-only
+SQLite connection; a sidecar appearance fails closed because an immutable
+main-file read cannot safely interpret it. Even a structurally valid external
+change invalidates the aggregate because its in-memory models may be stale; the
+coordinator closes it, fails before pointer commit, and a later retry rebuilds
+from the now-validated current bytes. Neither route creates, alters, or deletes
+database-family bytes. Failure closes the parked aggregate, preserves the
+active Campaign and target bytes, and fails before pointer commit.
+
+This change token is an ownership oracle for one local application process,
+not a defense against an actor with operating-system privileges who can rewrite
+bytes while spoofing file identity and timestamps. Files entering through an
+import or other untrusted boundary never inherit this oracle and require full
+bounded validation. A definite stale or other pre-commit rejection returns a
+borrowed parked aggregate to the slot and reopens only the confirmed prior
+authority. That origin survives delayed drain or ambiguous-commit recovery: a
+terminal pre-commit outcome or durable reread confirming the prior returns the
+loan, while a confirmed target or post-commit publication failure never caches
+the prior aggregate.
+
+Preparing a third distinct Campaign requires the parked aggregate to close
+successfully first. A failed eviction remains a slot-occupying close obligation
+and blocks further candidate preparation until it settles. The same gate
+applies to any incomplete close of a full Campaign candidate, so repeated
+close failure cannot accumulate runtime graphs outside the active-plus-one
+bound. A close obligation retains its matching never-committed reservation;
+neither cleanup nor replacement allocation may proceed until that exact close
+has settled successfully. Unresolved close or reservation-cleanup obligations
+also block a new Campaign identity reservation itself, so repeated close and
+delete failure cannot grow directories or invoke another candidate factory.
+Terminal close
+identity-deduplicates active, parked, recovery, and pending-close ownership.
+The steady ownership bound is therefore one active plus one parked Campaign
+runtime; recovery or incomplete close may replace normal progress but never
+authorizes another factory allocation beyond that bound.
+
+Candidate aggregate closure is itself idempotent. The coordinator retains only
+the currently active, parked, recovery, eviction, or unsettled-close identities;
+it MUST NOT keep an unbounded history of previously closed candidate graphs.
+Repeated close calls reuse an in-flight attempt or skip already completed
+release steps. The coordinator memoizes the one invocation wrapper and
+terminal stage in an identity-keyed pending attempt for each candidate; repeated submissions
+observe that exact stage, and only its terminal failure authorizes a fresh
+attempt under the same bounded close obligation. A serialized transition may additionally retain an
+identity set of successful close settlements only for the duration of that
+transition, so a just-settled retry and subsequent recovery containment cannot
+invoke close twice; the set is discarded before the next transition.
+
+Retrofitting selector columns into today's
+mixed global store, shadow snapshots, and dual live graphs are not accepted as
+Campaign boundaries; an owner-scoped store design may use internal
+discriminators only with independent isolation proof.
+
+The JavaFX `Scene` and its render host belong to the installation lifetime and
+remain stable across Campaign switches. This is a rendering and input host,
+not Campaign state: each activation installs the complete candidate `AppShell`
+as the stable host's sole root and completely replaces the host accelerators.
+No inactive Campaign node remains in the active `Scene`; an eligible parked
+root stays detached inside its complete coordinator-owned aggregate.
+Qualification therefore reasons about the candidate root while visible
+readiness is observed only after that root is attached to the
+installation-owned `Scene` for two consecutive JavaFX pulses with positive
+on-screen bounds. A pulse with a different root or non-positive bounds resets
+the sequence. The publication coordinator and candidate jointly own that
+readiness attempt as a cancellable lifecycle resource. Successful readiness,
+phase timeout, publication revocation, whole-root replacement, recovery
+publication, candidate close, host close, and window disposal all terminate
+its pulse source and release its reference to the candidate root before the
+detached aggregate can be retained or closed. Candidate-route render
+qualification treats JavaFX CSS conversion warnings from the published root's
+stylesheet as failures rather than accepting a visibly degraded shell.
+When publication authority is revoked after a root swap may have begun, the
+root-swap invocation must settle first, then the owned readiness cancellation
+must settle, and only then may the installation host publish recovery. Late
+readiness completion has no activation authority and shares the already-owned
+recovery publication rather than initiating another root change.
+Entering recovery stages the coordinator-owned aggregate and its prior
+publication truth before asking the host to replace the root. The coordinator
+may set `publicationLost` only after the host confirms that recovery is visible;
+an exceptional or timed-out recovery publication retains the previous shell,
+identity, accelerator references, and restoration truth until later completion
+is confirmed.
+
+## Rationale
+
+Vertical ownership keeps one behavior change local to its feature. Explicit
+composition makes dependencies visible to the compiler. Physical Campaign
+store separation gives switching, recovery, and export a Campaign-sized
+containment boundary while the lifecycle coordinator preserves cross-store
+consistency. Non-blocking I/O keeps the JavaFX event thread responsive.
+Versioned persistence and local diagnostics make failures recoverable without
+transmitting user data.
+
+Generic classpath discovery, a shell-owned service locator, horizontal
+domain/view/data roots, and package-form compatibility were rejected because
+they hide dependencies, fragment ownership, and make safe migration harder.
+
+## References
+
+- [Feature Boundary Standard](patterns/feature-boundaries.md)
+- [Application Composition Standard](patterns/application-composition.md)
+- [Shell Layer Standard](patterns/shell-layer.md)
+- [Styling Standard](patterns/styling.md)

--- a/docs/project/contract/persistence-lifecycle.md
+++ b/docs/project/contract/persistence-lifecycle.md
@@ -1,0 +1,211 @@
+# Persistence Lifecycle
+
+## Purpose And Boundary
+
+SaltMarcher uses one installation-owned SQLite database plus one physically
+separate SQLite database per Campaign. Platform persistence owns physical file
+safety, connection configuration, each file's feature-version ledger,
+owner-scoped preparation, backup, and recovery. Feature SQLite adapters own
+their stored truth, target schema signatures, semantic row validation, and
+migration bodies. Installation-owned registry and reusable definitions never
+share a database with Campaign-owned truth.
+
+`app` composes immutable `FeatureStoreDefinition` values before it constructs
+feature services. Preparation returns one `FeatureStoreReadiness` per owner.
+Ready features receive only their `FeatureStoreHandle`; they never receive the
+global registry or another owner's plan. An explicit reference-data maintenance
+route may additionally receive its owner's separate `FeatureStoreMaintenance`
+capability. That single capability creates the verified recovery point and opens the
+subsequent write connection from the same database lifecycle. It is never composed into
+normal desktop startup. Ordinary handles do not expose backup operations.
+
+API, domain, application, JavaFX, Catalog, and shell code do not access JDBC,
+database files, or migration types.
+
+## Location And Connection
+
+The installation store is `installation.sqlite` below:
+
+- `$XDG_DATA_HOME/salt-marcher/` when `XDG_DATA_HOME` is non-blank;
+- `${user.home}/.local/share/salt-marcher/` otherwise.
+
+Campaign stores live below the sibling `campaigns/` directory, one reserved
+SQLite file per stable Campaign identity. Desktop startup opens only the
+installation store and the durably selected Campaign store. It never opens the
+former mixed-store filename `game.db`.
+
+Every writable connection enables and verifies WAL mode, enables foreign keys,
+uses a 5000 ms busy timeout, and uses SQLite `NORMAL` synchronous mode.
+Connections are operation-scoped and closed by the owning adapter.
+
+Opening a handle connection validates only platform compatibility and that
+handle's prepared owner. It MUST NOT iterate, validate, or migrate other
+registered owners. Opening an unprepared handle fails without creating or
+mutating the database.
+
+## Definitions, Preparation, And Readiness
+
+`FeatureStoreDefinition` contains one stable lowercase owner key, target
+version, contiguous monotonic migration steps beginning at `1`, and a final
+owner validator. Definitions are immutable after composition. Registering or
+discovering a migration as a side effect of opening a connection is forbidden.
+
+Before feature services start, the coordinator:
+
+1. loads the driver and verifies the primary database or initializes an empty one
+2. validates the exact direct current-v1 platform ledger and its complete bound
+   object inventory through an immutable read-only connection before reading any
+   owner version when the source has no sidecar
+3. rejects a malformed or newer platform globally without replacement, downgrade,
+   WAL activation, or source transaction
+4. validates every already-current or newer owner immutable read-only; an existing
+   rollback-journal family is first materialized as one coherent disposable inspection,
+   while a complete WAL-plus-SHM family is byte-copied without opening the source and
+   materialized only from that copy; pending direct initialization prepares all owners
+   on a disposable copy before source access
+5. creates and restore-tests one verified pre-mutation snapshot only when at least
+   one pending owner qualified successfully on that copy
+6. prepares only those qualified pending owners against the source, in deterministic
+   composition order and one transaction per owner
+7. validates the owner's exact target DDL and complete bound object inventory,
+   physical integrity, and foreign keys before each commit
+8. returns immutable readiness for every owner
+
+Owner-table dependencies, owned prefixes, and forbidden object names are matched
+case-insensitively with locale-independent normalization. Because SQLite accepts
+single-quoted identifiers in identifier positions, a single-quoted owner table in
+stored view or trigger DDL is treated fail-closed as an owner dependency rather than
+ignored as a string literal.
+
+Readiness is:
+
+- `READY`: the owner version and declared table, column, primary-key, required
+  foreign-key, and required-index signatures match the supported target, and
+  global physical and foreign-key integrity succeeded
+- `MIGRATION_FAILED`: a supported migration or owner validation rolled back
+- `NEWER_SCHEMA`: stored owner version is newer than this application
+- `INCOMPATIBLE`: the sidecar family cannot be interpreted safely as one isolated
+  source state, including WAL without SHM, SHM without WAL, mixed journal families,
+  non-physical sidecars, or a family that changes while it is copied
+- `CORRUPT`: physical integrity prevents safe access
+
+`MIGRATION_FAILED` and `NEWER_SCHEMA` fail closed for that owner only. They do
+not prevent unrelated ready handles from opening connections. Physical database
+corruption, an incompatible sidecar family, and a newer platform version remain
+global because no safe shared file access exists. Incompatibility is not evidence
+of physical corruption and never authorizes recovery, quarantine, or replacement.
+
+A table declaration is exact by default. A read-only provider MAY instead
+declare a required column projection when additional provider-owned columns are
+compatible and must remain untouched. That opt-in still fails on every missing
+required column and on mismatched declared keys or indexes; it does not weaken
+exact declarations for application-owned schemas.
+
+No feature may enqueue a persistence operation before its readiness is known.
+An unavailable feature exposes its existing typed storage or availability
+result and performs no write.
+
+Startup readiness does not scan the feature corpus for semantic row validity.
+Providers validate semantic rows on their normal typed read/write routes and
+fail closed through their feature-owned error contract.
+
+## Migration Contract
+
+`PRAGMA user_version` owns the platform format. `sm_schema_versions` maps one
+owner to its current feature version. Platform version `1` has one direct
+canonical shape: `owner TEXT PRIMARY KEY` and `version INTEGER NOT NULL
+CHECK(version >= 0)`, with no additional column, index, view, or trigger bound
+to that ledger. A missing key/check, additional column, trigger, or otherwise
+duplicate-capable ledger is a global incompatible platform shape and is not
+repaired.
+
+Each future released-format migration:
+
+- runs once inside the coordinator-owned owner transaction
+- is idempotent but never changes auto-commit, commits, or updates the ledger itself
+- reads and writes only its feature's stored truth
+- recognizes every supported predecessor through explicit structural validation
+- aborts before destructive work when the stored signature is unknown
+- copies and validates replacement rows before dropping or renaming predecessor tables
+
+Compatibility obligations begin with the first released format.
+Before the first released format, the current cut has no compatibility reader, mixed-store
+conversion, or predecessor-format migration obligation. After the first released format,
+`TN-18` governs update/conversion preservation and failure rollback, while
+`TN-19` governs versioned export/import compatibility. Those future translators
+must be explicit and qualified; they do not justify retaining an unused current
+development storage topology.
+
+The coordinator records the new owner version only after the migration action
+and final target-signature validator succeed. Failure rolls back schema, rows,
+and owner version for that transaction.
+
+An already recorded version never changes meaning. Supporting another legacy
+shape requires a new migration or an explicitly versioned predecessor
+translator, not rewriting a released step.
+
+## Backup And Recovery
+
+Before first mutation of an existing healthy database, platform persistence
+runs full `integrity_check` and `foreign_key_check`, creates one coherent
+snapshot, verifies it, copies it to an isolated restore probe, verifies the
+probe, and only then permits owner migration. A live WAL-plus-SHM family is copied
+under matching before/after family tokens and materialized with SQLite snapshot
+semantics only from that isolated copy; a sidecar-free quiescent main file is copied
+under matching before/after identity tokens. Qualification therefore cannot activate
+WAL, create SHM, checkpoint, or remove a sidecar on the source.
+
+The local backup name embeds the compatible platform version. Migration failure
+never replaces the primary with a backup and never deletes the verified backup.
+
+If the primary is physically corrupt and its sidecar family was first classified as
+safe to interpret, the lifecycle may restore the highest
+verified backup whose platform version is supported. Before quarantine, it copies
+each candidate in newest-first order to an isolated recovery file, validates the exact
+platform manifest, prepares and validates every registered owner there, and requires
+all owner readiness to be current. A malformed ledger or owner manifest therefore
+leaves the complete primary family byte-for-byte authoritative and creates no
+quarantine. Only a fully qualified copy permits preservation of the corrupt family
+under a local quarantine name; the installed copy is validated again and the backup
+is kept. Unknown newer versions are not
+corruption and never trigger recovery. An orphan SHM, WAL without SHM, mixed
+journal family, or changing source family fails closed byte-for-byte even when a
+valid backup exists; those conditions never enter physical-corruption recovery.
+
+An explicit feature maintenance operation that replaces reference data requests
+a feature-named maintenance backup through its separately injected maintenance
+capability immediately before its transaction. The same capability supplies the later
+owner connection, so composition cannot back up one physical database and mutate another.
+It exposes only an opaque receipt; it cannot reveal the physical path or another owner's
+definition. Startup does not receive maintenance authority and does not perform external
+imports or paid/network work.
+
+## Execution And Shutdown
+
+The persistence lifecycle does not impose one global application execution
+queue. Independent reads may use a bounded I/O executor. A feature that requires
+ordered mutations owns a serial mutation lane or transaction boundary for that
+truth.
+
+Shutdown first prevents new application work, then drains feature executors,
+then closes the persistence lifecycle. A closed or unready handle rejects work
+with a typed local failure and never opens JDBC.
+
+## Errors, Privacy, And Recovery
+
+Technical diagnostics use stable ids, owner key, operation class, readiness,
+and failure class only. They do not contain paths, SQL, exception messages,
+secrets, or user-authored content and are not transmitted.
+
+Real-data migration requires a restore-tested backup and rehearsal against an
+isolated copy. The operator snapshot uses SQLite's online
+snapshot semantics, is stored with owner-only permissions, and is copied again for the
+destructive rehearsal. The rehearsal executable requires an explicit absolute copy path
+and rejects the installed application-data directory.
+
+## References
+
+- [Source Architecture](../architecture/source-architecture.md)
+- [Application Composition](../architecture/patterns/application-composition.md)
+- [Catalog Architecture](../../catalog/architecture/architecture-catalog.md)
+- Feature persistence contracts under `docs/<feature>/contract/`

--- a/docs/project/requirements/requirements-anchored-popup.md
+++ b/docs/project/requirements/requirements-anchored-popup.md
@@ -1,0 +1,31 @@
+# Anchored Popup
+
+## Component Purpose
+
+The anchored popup centralizes JavaFX popup hosting, visibility, placement,
+offset, width, focus restoration, auto-hide, and Escape handling.
+
+## Rules
+
+- Owning features build popup content and handle feature actions.
+- Use below placement for small inline popups and trailing placement for top-bar
+  dropdowns aligned to the trigger's right edge.
+- Use the shared dialog surface for form-like popups with headers and fixed
+  actions.
+- The popup host must not own feature or business actions.
+
+## Acceptance Criteria
+
+- the shared host centralizes popup mechanics instead of repeating
+  anchoring, hide-on-Escape, auto-hide, and focus-return logic in feature Views
+- owning features retain popup content and action ownership
+- small inline popups use below placement, while trailing top-bar popups use
+  trailing placement
+- dialog-like popup content uses the shared dialog surface instead of duplicating
+  header and footer layout in each caller
+- popup visibility and placement remain host state, not feature truth
+
+## References
+
+- [Dialog Surface](requirements-dialog-surface.md)
+- [Reusable Top-Bar Dropdown Popup](requirements-dropdown-popup.md)

--- a/docs/project/requirements/requirements-dialog-surface.md
+++ b/docs/project/requirements/requirements-dialog-surface.md
@@ -1,0 +1,37 @@
+# Dialog Surface
+
+## Component Purpose
+
+The shared surface centralizes dialog-like layout for embedded state-tab surfaces
+and popup content. JavaFX section composition stays in the owning surface,
+while the surface owns header visibility, footer visibility, and body scroll
+policy.
+
+## Rules
+
+- Use scrolling when the whole body may
+  exceed the available height.
+- Keep action buttons in the footer so navigation remains visible.
+- Do not put feature services, domain objects, or command decisions in this
+  primitive.
+- Use the shared anchored-popup host when a dialog surface appears in a JavaFX
+  popup.
+- The primitive must not own feature callbacks or domain-facing behavior.
+
+## Acceptance Criteria
+
+- the shared surface centralizes dialog-like layout instead of duplicating
+  header, body, and fixed-footer structure in each embedded state or popup
+  surface
+- large dialog bodies scroll so the
+  footer actions remain visible
+- feature services, domain objects, and command decisions stay outside this
+  primitive
+- layout state remains presentation state rather than feature truth
+- popup-hosted dialog content uses the shared anchored host rather than opening
+  raw JavaFX popups directly from feature layout code
+
+## References
+
+- [Anchored Popup](requirements-anchored-popup.md)
+- [Travel State Tab UI](requirements-travel-state-tab.md)

--- a/docs/project/requirements/requirements-dropdown-popup.md
+++ b/docs/project/requirements/requirements-dropdown-popup.md
@@ -1,0 +1,37 @@
+# Reusable Top-Bar Dropdown Popup
+
+## Component Purpose
+
+The dropdown popup centralizes reusable top-bar trigger, accessibility,
+anchoring, and open/close behavior.
+
+Current state:
+
+- the popup aligns to the trailing edge of its trigger
+- the owning feature supplies trigger text, accessibility text, tooltip,
+  content, width, and action handling
+
+## Visible Surfaces
+
+- The popup does not add a standalone shell surface.
+- Top-bar dropdowns reuse the popup behavior and align to the trailing edge of
+  their trigger button.
+
+## Interactions
+
+- If the popup is open, invoking the trigger closes it.
+- If the popup is closed, invoking the trigger opens the trailing popup and
+  informs the owning feature.
+
+## Acceptance Criteria
+
+- the dropdown popup behavior remains reusable by owning top-bar dropdowns
+  without adding a standalone shell surface
+- invoking the trigger toggles popup visibility for the owning dropdown root
+- each owning dropdown shows its supplied popup content and exposes its supplied
+  feature actions
+- the popup aligns to the trailing edge of its trigger
+
+## References
+
+- [Anchored Popup](requirements-anchored-popup.md)

--- a/docs/project/requirements/requirements-program-capabilities.md
+++ b/docs/project/requirements/requirements-program-capabilities.md
@@ -1,0 +1,919 @@
+# SaltMarcher Program Capability Requirements
+
+## Goal
+
+Define one coherent needs baseline for preparing, running, and following up on a
+local tabletop Campaign before deriving technical needs or deciding feature,
+module, persistence, integration, or technology boundaries.
+
+The [Project Vision](../vision.md) remains the owner of users, top-level jobs,
+and product non-goals. This document owns confirmed observable behavior that
+spans or precedes individual feature requirements.
+
+## Scope Boundary
+
+- The binding horizon is the complete local GM-operated core product.
+- Player-operated applications, remote play, and unspecified distant
+  extensions are parked and cannot constrain the core architecture.
+- A passive GM-controlled second-monitor output remains eligible for the core
+  because it accepts no player input.
+- Current code, feature names, feature requirements, architecture, and storage
+  are not target constraints.
+- No real users or legacy data exist before the complete GM core reaches
+  feature completion. Development data and pre-completion persisted formats are
+  disposable and create no compatibility, conversion, migration, or fallback
+  obligation. This premise ends only when the completed product is approved for
+  first real use and its initial durable data format is frozen. Current-format
+  restart, recovery, import, and export outcomes remain required before then.
+
+## Non-Goals
+
+- choosing source modules, feature boundaries, APIs, schemas, databases,
+  transaction mechanisms, frameworks, or other technologies
+- scheduling implementation or preserving current implementation behavior that
+  the owner has not confirmed as need
+
+## Derivation Boundary
+
+This Active Target is the binding product input to the next phase: deriving the
+technical needs implied by these observable capabilities. It does not choose an
+architecture, technology, contract, persistence model, source layout, or
+delivery sequence. Greenfield target architecture, comparison with the current
+system, and migration planning remain later phases and may begin only after the
+technical needs have been made explicit.
+
+## Confirmed Workflow: Campaign Foundation And Knowledge
+
+### Campaign Lifecycle
+
+The GM can create a Campaign with only a name and keep several Campaigns in
+SaltMarcher. Switching happens immediately through options or settings. Running
+Scene, Encounter, and travel state in the Campaign being left remains preserved
+and resumes when the GM returns; switching requires no warning, confirmation,
+or prior closure.
+
+### Reusable And Campaign-Specific Knowledge
+
+Rules, general Creature data, and Item definitions are reusable references
+across Campaigns. PCs, NPCs, places, factions, quests, rumours, possessions, and
+concrete Item instances belong to one Campaign. A Campaign-specific object may
+be copied into another Campaign, where it becomes fully independent. Objects of
+the same kind may share a name.
+
+Quests, rumours, and similarly complex narrative concepts are lightweight,
+note-first GM records which may be attached to places, factions, or NPCs.
+SaltMarcher does not require encoded completion conditions, NPC trigger graphs,
+or automatic resolution; the GM resolves the record manually.
+
+Campaign content references reusable definitions rather than owning copies.
+Current and future play reads the current definition. Updating a definition does
+not retroactively recalculate completed Scenes or their historical facts.
+
+### Roster, Current Party, And Planning Party
+
+Each Campaign has one `Roster` containing every Campaign PC, whether currently
+participating or not. At most one current `Party` contains those Roster
+characters whose players currently participate at the table. Groups assigned
+to different Running Scenes are subdivisions of that Party, not separate
+Parties.
+
+A Session may be authored without a Party. Before generation, the GM selects a
+planning-only expected Party from the Roster. This selection enables planning
+calculations but neither is nor changes the current table Party.
+
+### Minimal Creation And Explicit Deletion
+
+A Campaign object requires only a name; every other property is optional and may
+be completed later. When the GM creates an object from a Running Scene, the
+creation dialog attaches it to that Scene by default and lets the GM opt out.
+
+Explicit deletion removes an object from preparation, Running Scenes, and
+Running Encounters, including runtime state that depends on it. Completed
+history retains the historical fact but displays the missing identity as
+`[UNKNOWN]`. If the object remains recoverable in trash, the history may link to
+that recoverable object.
+
+### Acceptance Criteria
+
+- the GM can create a usable empty Campaign by entering only a name
+- the GM can switch Campaigns immediately and later resume the exact Running
+  Scene, Encounter, and travel state left in each Campaign
+- a Session can be manually authored without selecting any Party
+- generation uses a Session-owned expected Party selected from the Roster and
+  does not change the current table Party
+- copying Campaign-specific content into another Campaign creates an
+  independently editable object
+- a changed reusable definition affects current and future reads without
+  changing completed Scene facts
+- the GM can attach a note-first Quest or rumour to a place, faction, or NPC and
+  resolve it manually without authoring automated completion conditions
+- name-only creation from a Running Scene attaches there by default and exposes
+  an opt-out before confirmation
+- explicit deletion removes current references and dependent Encounter runtime
+  while completed history keeps its fact with an unknown or recoverable-trash
+  reference
+- the GM can manage the Campaign's one Roster of independently identified PCs,
+  leave every optional statistic unset, and do so without silently adding a PC
+  to the current Party
+
+## Confirmed Workflow: Session Preparation And Supporting Content
+
+### Planning Workspace And Timeline
+
+`Session` is an unnamed, date-independent planning workspace rather than a
+Campaign content object. It holds one current plan that the GM may reuse or
+replace. The plan is an ordered timeline of expected Scene occurrences. Each
+entry may contain notes and reference zero or one location; the same location
+may appear in several entries. The GM can add, remove, reorder, and annotate
+entries at any time.
+
+Timeline entries are not stored Scenes. A Scene exists only as resumable runtime
+state. The primary Running Scene is always available in the Scene tab and only
+changes its contents; the GM neither starts nor ends it. Splitting characters
+out of that Scene creates additional Running Scenes.
+
+The GM can prepare the complete timeline, monster groups, treasures, and
+location placements manually without a planning Party, Adventure Day, name,
+date, or generation.
+
+### Assisted Generation
+
+Generation uses a planning-only expected Party selected from the Roster and
+does not change the current table Party. It requires an Adventure Day. For the
+selected characters and levels, the Adventure Day provides the DMG-guided
+Encounter amount, XP budget, and loot budget used to create monster groups and
+treasures.
+
+The GM may optionally provide a desired Scene count and select locations,
+factions, NPCs, Items, or other Campaign content. Every selected object is a
+binding constraint and must occur in the suggested Scenes. SaltMarcher may add
+other existing or newly created Campaign content. Before generation it checks
+whether all constraints fit the Adventure Day. If not, it explains the conflict
+and disables generation instead of producing a partial result.
+
+Generation returns a timeline with concrete monster groups and treasures. The
+GM can edit, regenerate, reject, accept, and place each result independently.
+Regenerating one result leaves every other result, manual edit, placement, and
+timeline change untouched.
+
+### Accepted World Content And Treasures
+
+Placing a monster group or treasure accepts it as persistent World content. It
+remains editable and survives replacement of the current plan. Replacing the
+plan removes its timeline, timeline notes, and unaccepted drafts without
+changing any accepted placement.
+
+When the Party reaches a prepared location, its placed monster groups and
+treasures appear in the Running Scene UI. SaltMarcher does not begin combat or
+award anything automatically; the GM decides what happens.
+
+A treasure may contain Items, including coins, trade goods, magic Items,
+equipment, and other possessions. The GM can independently add, remove,
+replace, and edit each Item before or after placement and move Items between
+treasures and locations.
+
+### Weather, Music, And Notes
+
+Weather is not Session preparation. It develops autonomously from location
+terrain and other available climate data; its live behavior follows the
+confirmed Scene-time, climate, and override requirements below.
+
+Songs are stored locally. When adding a song, the GM assigns mood, intensity,
+vibe tags, and genre and can manage that data later. Scene sliders supply mood
+and intensity input; locations, NPCs, factions, monsters, and other Scene
+content contribute vibe tags and genres. The exact mood axes and categorization
+model remain subject to product testing.
+
+The GM may enable or disable autoplay. When enabled, the currently focused
+Running Scene drives the automatically generated music queue. Scene changes
+update that queue, and a song that no longer fits fades out gradually. Manual
+stop, skip, back, selection, queue, and loop actions take precedence until the
+manual choice ends, after which autoplay resumes if still enabled.
+
+Every authored or generated object may carry free-form GM notes. Notes relevant
+to a Running Scene are visible and editable there, and the GM can search notes
+across every kind of object.
+
+### Acceptance Criteria
+
+- the GM can build all preparation manually in an unnamed, undated planning
+  workspace without choosing a Party or using generation
+- the GM can freely edit and reorder a timeline whose entries each reference
+  zero or one location
+- replacing the current plan removes only its timeline and unaccepted work and
+  preserves all accepted World placements
+- generation remains unavailable with an explanation when its binding inputs
+  cannot fit the selected Party's Adventure Day
+- a generated monster group or treasure can be changed or regenerated without
+  changing any other generated or manual preparation
+- reaching a prepared location exposes placed content without starting or
+  awarding it automatically
+- treasure Items remain individually editable and movable after placement
+- weather requires no Session preparation
+- the focused Running Scene drives optional autoplay while manual music
+  controls take precedence
+- the GM can edit relevant notes in a Running Scene and search notes across all
+  object kinds
+
+## Confirmed Workflow: Live Table Play
+
+### Continuous Scene State And Party Splits
+
+The primary Running Scene is always available as mutable runtime state in the
+Scene workspace; the GM neither creates nor completes it. A Scene has zero or
+one current location. Split Scenes need no name or label.
+
+Every active Party character belongs to exactly one Running Scene. Activating a
+Roster character assigns that character to the GM-focused Scene. Inactive
+Roster characters belong to no Scene and retain their last location and other
+state.
+
+The GM uses the same action to move selected characters into a new or existing
+Scene. An empty Scene is removed and a remaining populated Scene becomes the
+primary Scene. If the current Party is empty, one empty primary Scene remains
+available.
+
+Changing a Scene's location replaces its location-derived NPCs, Features,
+treasures, monster groups, and other content. The GM may instead pin any
+Scene-capable content to that Scene or assign it to travel with exactly one
+Party subgroup. Content that leaves or outlives a Scene remains at its location
+and is never implicitly deleted.
+
+### Masks And Prepared Monster Groups
+
+Persistent preparation creates editable monster groups at locations, not
+Encounters. At a Scene's current location, the GM selects individual monsters
+or groups and Scene participants to start an Encounter.
+
+Encounter, Chase, and possible future masks add focused runtime behavior over
+the continuously visible Scene. Several masks of the same or different types
+may coexist, and one PC, NPC, or monster may participate in several masks.
+Moving a character to another Scene removes that character from every mask
+without blocking the move.
+
+The GM ends an Encounter through the confirmed completion workflow. Its
+confirmed consequences apply while the Running Scene continues.
+
+### Live Search, Creation, Notes, And Music
+
+The GM can search all content without leaving the Scene and add a result
+directly to it. The GM can also create lightweight, note-first Campaign content
+there, including NPCs, locations, factions, Quests, rumours, and similar
+objects. Complete data records such as Items and monsters remain outside
+Scene-local creation.
+
+Relevant object notes remain visible and editable in the Scene, while notes
+across every object kind remain searchable. The focused Scene drives optional
+music autoplay. Scene changes update the queue, obsolete songs fade out, and
+the GM's manual player actions take precedence.
+
+### Independent Time And Weather
+
+Every Scene advances its own time through travel, exploration, and mask
+activity. Encounter and Chase rounds last six seconds. Travel duration is
+calculated from applicable factors. The GM may override any input factor, the
+final duration, or both; a final-duration override is authoritative while it
+remains active. The GM chooses exploration duration.
+
+The GM may increment Scene time forward or backward. When groups with different
+times reunite, the GM manually chooses their temporal resolution. Moving
+temporal focus backward never deletes history, reverses World state, or rolls
+back another Scene. A fact recorded later at the table may carry an earlier
+in-world time and is treated as having happened then. Only an explicit deletion
+operation removes its selected target.
+
+Weather advances independently from each Scene's time, location, terrain, and
+climate data. A GM override remains until the GM disables it, after which
+autonomous weather resumes.
+
+### Passive Second Display
+
+The passive second display immediately follows the focused Scene. During travel
+it automatically shows the map; at a location it automatically shows background
+art. The map combines the durable map knowledge of all characters in the
+focused Scene. Current visibility is the union of what at least one of those
+characters can perceive and updates with position, line of sight, light,
+hidden state, weather, elevation, and similar visibility changes.
+
+NPC artwork appears only when highlighted by the GM. During an Encounter or
+Chase, the GM may enable automatic artwork for the current actor. The display
+contains only maps and NPC or location artwork; it never exposes mechanics,
+text, or private notes. The GM can blank it or manually replace the automatic
+visual at any time.
+
+### Acceptance Criteria
+
+- one empty primary Scene remains usable when no Party character is active
+- every active Party character appears in exactly one Scene, and activation
+  assigns that character to the focused Scene
+- the GM can split and reunite the Party through the same character-move action
+  without implicitly deleting content left at a location
+- entering a location makes its prepared monster groups available without
+  creating or starting a persistent Encounter
+- several masks and shared mask participants may coexist while the Scene
+  remains continuously usable
+- moving a character to another Scene removes that character from every mask
+  without blocking the move
+- the GM can search all content, add a result, and create note-first Campaign
+  content without leaving the Scene
+- split Scenes may advance to different times, and their later reunification
+  never deletes history or reverses confirmed World state
+- automatic weather follows each Scene independently and resumes when the GM
+  releases a manual override
+- the passive second display switches with Scene focus, distinguishes current
+  perception from remembered knowledge without revealing unknown or hidden
+  live details, never exposes textual or mechanical state, and can be blanked
+  or replaced by the GM
+
+## Confirmed Workflow: Spatial Travel And Campaign-Time Progression
+
+### Places, Subplaces, And Scene Continuity
+
+Travel is one live GM workflow for the focused Scene across ordinary places,
+Hex maps, and Dungeons. A full place is a Scene boundary. Subplaces, Dungeon
+navigation areas, and exact cells refine position within that Scene without
+creating another one. Characters at different full places require different
+Scenes.
+
+Moving only part of a Scene's Party subgroup to another full place creates or
+joins another Scene. Moving the complete subgroup changes the existing Scene's
+place. Places may be nested on Hex and Dungeon maps. The GM may assign an
+unmapped place administratively, but that action is not travel and advances no
+time automatically.
+
+Weather, music tags, ambience context, and loot-, Encounter-, and
+faction-appearance factors may flow from containing places into children. The
+GM chooses additive or replacing behavior separately for each factor family
+and place; additive behavior is the default.
+
+### Travel, Interruptions, And Overrides
+
+For adjacent movement the GM selects a destination. For a longer journey the
+GM selects travel points and uses a route within the current map. Cross-map
+route planning is optional future convenience rather than binding core scope.
+
+Travel advances position, Scene time, weather, tracks, perception, events, and
+applicable autonomous World behavior. The GM may pause, resume, reroute, end,
+or change the real-time presentation speed without changing in-world duration.
+Every route point and interruption is a committed checkpoint.
+
+Events, Traps, relevant tracks, and perceived NPCs stop further route progress
+at a checkpoint for GM inspection. Perceiving an NPC exposes it in the Scene
+but does not start an Encounter without explicit GM confirmation.
+
+The GM may override any travel-duration input, the calculated final duration,
+or both. While present, a final-duration override wins over all inputs. The GM
+may undo and redo several travel checkpoints. Undo removes the journey segment
+and every result introduced only by that segment, while preserving facts
+already established by a later authoritative Scene.
+
+### Independent Scene Time And World Progression
+
+Split Scenes advance independently. Autonomous World behavior for one
+in-world period occurs once and is reused when an earlier Scene reaches that
+period. The furthest-advanced Scene is authoritative for shared World facts.
+
+The target outcome is that the complete Campaign World progresses with
+GM-confirmed campaign time. Optional Actor Autonomy remains individually
+GM-enabled and bounded. Party involvement pauses before autonomous danger
+resolution; permitted non-Party behavior may continue. Computation strategy
+and scale handling remain later technical decisions rather than product-scope
+reductions.
+
+The GM normally avoids introducing an earlier-time contradiction. If a change
+would conflict with already dependent later history, SaltMarcher warns but
+allows it, marks the affected history as conflicting, and lets the GM resolve
+it manually. The marker remains until the GM explicitly confirms resolution.
+
+### Hex Maps, Knowledge, And Visibility
+
+SaltMarcher supports several continuous Hex maps. Each has no fixed authored
+extent and provides predetermined mouse-wheel zoom levels from local
+three-mile Hexes to world scale. Coarse facts supply finer defaults; detailed
+edits recalculate their coarse aggregate.
+
+The GM can author terrain, rivers, roads, cliffs, ravines, location markers,
+assets, and faction influence; import and export maps; and control Fog of War,
+unknown regions, and manual reveal. Weather and elevation influence sight
+distance. Procedural Hex generation and autonomous faction simulation are
+distant extensions.
+
+Map knowledge belongs to individual characters. The passive map for the
+focused Scene shows the union of its characters' knowledge. A general GM
+reveal action adds selected knowledge to relevant characters without requiring
+character-to-character transfer bookkeeping.
+
+### Climate, Weather, And Ambience
+
+A Hex map has a quick fallback climate plus paintable or otherwise modulatable
+regional climate zones. Seasonal baselines and coherent moving phenomena
+produce gradual, geographically sensible weather without unrelated random
+weather per Hex or burdensome meteorological setup. The GM may author weather
+events with an affected area, type, intensity, movement, time extent, notes,
+and mechanical effects and may pause, edit, or end them.
+
+Structured weather effects initially cover visibility, travel, perception,
+temperature, ambience, and music. Combat-facing effects may remain prominent
+notes for GM adjudication. A mechanically relevant weather change updates its
+effects and creates a Scene-associated notification which remains until the
+weather ends or the GM dismisses it; it does not itself stop travel. New
+influence families, such as creature preferences for weather or time of day,
+remain locally extensible needs.
+
+Music and ambience use locally managed and categorized files. Weather and
+environment layers combine automatically, and SaltMarcher balances the mix.
+The GM may add sounds to or suppress sounds from the automatic selection.
+Those choices persist until released, after which automation resumes from the
+Scene's current place, weather, and time.
+
+### Acceptance Criteria
+
+- the GM can move a complete or partial Scene subgroup through one travel
+  workflow without leaving the Scene workspace
+- adjacent movement and routed travel advance position and in-world time
+  together to explicit checkpoints
+- an event, Trap, relevant track, or perceived NPC stops further progress for
+  GM inspection without deciding its fictional outcome
+- the GM can override travel factors or final duration and can undo and redo
+  several checkpoints without erasing facts already established by a later
+  authoritative Scene
+- split Scenes reuse World behavior already processed for the same in-world
+  period and expose conflicts for manual resolution rather than silently
+  rewriting established history
+- coarse and fine Hex-map edits propagate across zoom levels while preserving
+  GM control over terrain, routes, locations, influence, visibility, and reveal
+- the focused Scene's passive map shows only the union of its characters'
+  knowledge and current perception
+- weather changes coherently across regions and time, applies its structured
+  effects, and keeps a dismissible notification visible while mechanically
+  relevant
+- manual ambience additions and suppressions coexist with automatic selection
+  and balancing until the GM releases them
+
+## Confirmed Workflow: Follow-Up, Progression, And Reward Ledger
+
+### Encounter Consequences And XP
+
+Ending an Encounter carries forward tracked HP, rule-derived deaths, and XP
+while the Running Scene continues. Conditions, capture, location, resource use,
+notes, and other narrative consequences remain ordinary GM edits rather than
+inferred completion results.
+
+A dead PC or NPC remains as a dead character in the Roster or at its place, may
+be revived by the GM, and is never automatically deleted.
+
+Encounter XP defaults to participating PCs in the initiative order. The GM may
+add or remove recipients before distribution. SaltMarcher divides XP equally
+and rounds each individual share up. Crossing an XP threshold immediately
+changes the character's derived level state without GM confirmation.
+
+An XP correction immediately recalculates derived level state while history
+retains the original award and linked correction. If an inactive character
+receives XP, the GM is informed once when that character is next activated;
+the information then clears automatically.
+
+### Rewards And Narrative Notes
+
+Encounter and manually resolved Quest rewards use one GM-facing distribution
+dialog. A Treasure may be distributed partially or completely, and
+undistributed Items may remain with the Treasure or at its place. The GM chooses
+every Item recipient; SaltMarcher does not choose one automatically.
+
+Quests, rumours, and similarly complex narrative concepts are lightweight
+records attached to places, factions, or NPCs. They contain open-or-closed
+state, free text, optional structured Rewards, and, for a Quest, a structured
+contributor set. A new Quest begins without contributors unless its creation
+context supplies selected characters.
+
+SaltMarcher does not model Quest completion conditions, NPC trigger graphs, or
+automatic narrative resolution. The GM resolves the note manually. Structured
+narrative Rewards are XP and Items, where Items include coins, equipment, trade
+goods, magic Items, and other concrete goods. Quest contributors default the
+XP recipient set, which remains GM-adjustable; XP follows the same equal
+rounded-up distribution rule as Encounter XP.
+
+### Character Loot Ledger
+
+Awarded and purchased Items appear in a searchable and filterable
+character-specific loot ledger. It is a GM reminder and Reward-accounting
+surface, not a player-operated or rules-complete inventory simulation. Awarded
+Items count as received loot; purchased Items carry their purchase source but
+do not. The GM may add, remove, or correct ledger Items manually without a
+Reward source. Coins, trade goods, and equivalent Items support quantity stacks
+which may be split and merged.
+
+`Received`, `given away`, and `sold` are non-mechanical reminders. Sold or
+given-away awarded Items remain visible and continue to count as received loot.
+A sale or handoff records a structured counterparty link to an existing Shop,
+NPC, place, or faction when available, plus optional free text. A sale also
+records its actual price, which becomes authoritative for final loot valuation
+when that Item counts as received loot. A separate per-instance value override
+is not required.
+
+Item provenance records available Treasure, Encounter or Quest, Scene or
+place, in-world time, and award time, with optional free-form provenance for
+manual and exceptional cases.
+
+### Cumulative Loot Guidance
+
+Expected loot follows a versioned D&D 5e 2014 rule profile based on the owner's
+confirmed DMG guidance: character-level expectations produce a loot-per-XP
+value. Session planning compares cumulative received loot with cumulative
+expected loot for all XP the characters have received so far.
+
+Session generation automatically adjusts proposed Rewards to compensate for
+the cumulative loot surplus or deficit. The GM retains the previously confirmed
+ability to inspect and edit each proposed Reward independently. The exact
+published-rule derivation remains a later source-backed rule decision rather
+than an assumed formula in this requirements document.
+
+### Corrections And History
+
+A later correction immediately updates current Item, XP, HP, death, or other
+corrected truth while explanatory history retains the original fact and a
+linked correction. Existing explicit-deletion and travel-undo exceptions remain
+governed by their previously confirmed behavior.
+
+### Acceptance Criteria
+
+- Encounter completion preserves tracked HP, derives death, distributes XP to
+  a GM-adjustable participant set, and leaves the Running Scene active
+- equal XP shares round up, threshold-derived level state updates immediately,
+  and a correction retains its linked explanatory history
+- an inactive XP recipient produces one information message on next activation
+- Encounter and manually resolved Quest Rewards use the same distribution
+  interaction without automatic Item-recipient selection
+- Quests and rumours remain manually resolved note-first records without
+  completion-condition or NPC-trigger automation
+- the GM can search and filter each character's Item ledger, correct it
+  manually, and split or merge quantity stacks
+- sold and given-away Items remain visible as non-mechanical reminders and keep
+  their provenance, counterparty, and applicable sale information
+- Session generation compensates proposed Rewards for the cumulative difference
+  between expected loot for received XP and actual received loot
+
+## Confirmed Workflow: Shops And Trade
+
+### Shop Identity And Inventory
+
+A Shop is a named Campaign record with one structured inventory and belongs to
+exactly one NPC or exactly one place. Its inventory contains quantity stacks of
+reusable Item definitions and individual concrete or unique Items. An entry
+records its current quantity, the price charged when the Party buys, the price
+paid when the Shop buys, and optional notes.
+
+The GM may add, remove, and edit Shop stock manually at any time. When the
+owning NPC is present in a Running Scene or the owning place is the Scene's
+current place, the Shop is available directly from that Scene.
+
+Deleting the Shop's owning NPC or place warns the GM and offers reassignment.
+If the GM proceeds without reassigning it, the Shop moves into recoverable trash
+with the owner. Restoring the owner restores the Shop relationship. Completed
+trade history remains explanatory regardless of deletion or restore.
+
+### Trade And Character Ledger
+
+One trade interaction updates Shop stock and the character loot ledger
+together. On purchase, the GM selects the receiving character, Shop stock
+decreases, and the acquired Item enters that character's ledger.
+
+A purchased Item is marked as a purchase and does not count as received loot
+in cumulative loot guidance. SaltMarcher records the paid price but does not
+automatically deduct coins from the character ledger.
+
+When a character sells an Item to the Shop, Shop stock increases and the
+character ledger records the sold state, actual price, and Shop or owning NPC
+as counterparty according to the existing sale rules.
+
+### Restock And Randomized Stock
+
+The GM can restock manually and can define automatic rules triggered by elapsed
+Campaign time or configured calendar events. A fixed rule may refill an entry
+to a target quantity or add a configured quantity.
+
+Randomized restock uses GM-configured weighted Item tables or filters such as
+type, rarity, value, and tags. A configured automatic restock may update stock
+without per-run preview or confirmation.
+
+Time-based restock runs once according to authoritative Campaign time even when
+several Scenes reach the trigger. It leaves manually added stock unchanged
+unless an explicit restock rule manages that stock.
+
+Purchases, sales, and automatic restocks remain in explanatory Campaign
+history. Automatic restock creates no separate notification.
+
+### Acceptance Criteria
+
+- a named Shop belongs to one NPC or one place and exposes stacks and unique
+  Items with quantities, both trade prices, and optional notes
+- deleting the owning NPC or place offers Shop reassignment and otherwise moves
+  the Shop into recoverable trash with a restorable relationship
+- the Scene exposes a Shop when its owning NPC is present or its owning place
+  is current
+- one purchase decreases Shop stock and records the selected character's
+  acquisition without counting it as received loot or deducting coins
+- one sale increases Shop stock and records the character's actual sale price
+  and counterparty
+- the GM can restock manually and configure target-quantity, additive, and
+  randomized restock rules
+- a time-based rule runs once at authoritative Campaign time and does not alter
+  manually added stock outside its explicit scope
+- trade and restock remain visible in history without an additional automatic-
+  restock notification
+
+## Confirmed Workflow: Local Data Lifecycle
+
+### Continuous Preservation And Resume
+
+SaltMarcher preserves confirmed GM work automatically as soon as practical.
+Normal use does not depend on a manual Save action, should almost never lose
+confirmed work, and does not impose unnecessary user-visible load.
+
+After restart, SaltMarcher restores as much of the prior useful working state
+as possible, including the active Campaign, focused Running Scene, and live
+Encounter, Chase, and Travel contexts. There is no product-level list of
+runtime state which SaltMarcher deliberately discards on restart.
+
+Backup schedules, retention, snapshot controls, restore granularity, and
+persistence mechanisms remain technical decisions. The required outcome is
+recovery of Campaign work and local assets without requiring the GM to
+understand or operate backup internals.
+
+When local data is damaged, SaltMarcher automatically opens the newest uniquely
+safe recoverable state, tells the GM what it recovered and what could not be
+preserved, and asks the GM to choose only when no single recovery choice is
+clearly safe.
+
+### Complete Campaign Portability
+
+A complete Campaign export includes Campaign data, maps, images, local audio,
+required reusable Creature, Item, and rule definitions, and resumable working
+state. Partial Campaign export is not required.
+
+On another compatible SaltMarcher installation, that export restores the same
+Campaign content, local assets, and resumable state without access to the
+original computer. Import always creates a new independent Campaign and never
+merges Campaign content into an existing Campaign.
+
+Campaign-owned data remains isolated between Campaigns. Large reusable Monster,
+Item, rule, and similar reference collections are installation-wide and shared
+between Campaigns rather than duplicated per Campaign.
+
+If an imported Campaign requires a missing shared definition, the definition
+joins the shared collection. If an imported definition conflicts with an
+existing one, the GM explicitly chooses whether to discard either variant or
+retain both as separate definitions. SaltMarcher shows the consequences for
+the imported and existing Campaigns before applying that decision and never
+chooses silently.
+
+Managing Monster and Item definitions, including whole-data-set refresh, is a
+late quality-of-life feature rather than a core need. If definitions are
+changed later, current and future reads use their current definition while
+completed history remains unchanged.
+
+### Campaign Deletion
+
+Deleting a Campaign moves its complete data into recoverable trash. Permanent
+deletion requires a separate explicit GM action.
+
+### Acceptance Criteria
+
+- confirmed work persists without a manual Save action and survives normal
+  restart with the useful runtime state restored wherever possible
+- damaged local data automatically opens the newest uniquely safe recovery,
+  discloses any loss, and asks only when recovery is ambiguous
+- a complete export restores the same Campaign, assets, definitions, and
+  resumable state on another compatible installation without the source
+  computer
+- import creates a new Campaign without merging Campaign-owned data into an
+  existing Campaign
+- a shared-definition conflict requires an informed explicit GM decision and
+  may retain both definitions independently
+- Campaign deletion remains recoverable until the GM separately requests
+  permanent deletion
+
+## Confirmed Program-Wide Quality And Product Boundaries
+
+### Offline Desktop Operation And Trust
+
+The complete local GM core works offline when its required rules, media, and
+Campaign data are present locally. Network use occurs only through explicit
+imports, downloads, GM-approved extension permissions, or future online
+capabilities.
+
+Linux, Windows, and macOS are supported desktop targets with portable Campaign
+behavior across them. The GM installs a self-contained application without
+separately administering a database server, web server, runtime, or other
+infrastructure. It runs fluidly on an ordinary current laptop without requiring
+a dedicated GPU or server hardware.
+
+One local GM is the sole Campaign writer in the confirmed core. The passive
+second display reads live state; concurrent multi-process, multi-computer, or
+multi-user Campaign editing is not required.
+
+Campaign data, notes, maps, images, audio, and usage data leave the computer
+only through a concrete, understandable GM action. There is no mandatory cloud
+dependency, hidden upload, or telemetry enabled by default.
+
+### Responsiveness, Scale, And Failure Isolation
+
+Ordinary live-play actions respond without perceptible delay. Longer
+generation, import, and simulation work is visible and cancellable and does not
+make the Running Scene unusable. Resource-intensive simulation adapts to
+available resources rather than blocking live play.
+
+SaltMarcher supports practically large, long-lived Campaigns without artificial
+content limits. Under exceptional load it degrades predictably instead of
+truncating data or failing unpredictably. Representative Campaign sizes and
+measurable response budgets are established during technical-needs derivation
+and verified with realistic scenarios rather than guessed by the GM.
+
+Failure of supporting music, weather, maps, generation, or World progression
+affects only that capability. Running Scenes, Encounters, manual editing, and
+preservation of confirmed work remain usable, with a clear error and retry for
+the affected function.
+
+Cancellation or failure of a long operation keeps only independently accepted
+results; unconfirmed partial results are discarded cleanly. If new work cannot
+be persisted safely, SaltMarcher reports that immediately and never presents it
+as stored. Safe reading, export, and retry remain available.
+
+After the completed product's initial durable data format is frozen for first
+real use, application updates preserve Campaigns and resumable runtime state. A
+failed data conversion leaves prior data untouched and usable with the prior
+compatible application version. Before that cutover, development data and
+pre-completion formats create no update-compatibility or conversion obligation.
+Damage to one record does not prevent the remaining Campaign from opening:
+SaltMarcher isolates and identifies the record and offers recovery or explicit
+deletion.
+
+Data belonging to a disabled, missing, or temporarily unavailable capability
+remains intact, stays in complete exports, and becomes usable again when the
+capability returns.
+
+### Modular Change And Third-Party Extensions
+
+Capability areas can be added, omitted, removed, or replaced without breaking
+unrelated workflows or Campaign data. New runtime masks, content kinds,
+influences, and supporting systems can integrate without rebuilding existing
+features.
+
+The GM can install third-party extensions, plugins, or scripts. Every extension
+is installed explicitly and discloses requested Campaign-data, file, network,
+and other access before activation. Extensions have no default network or
+unrestricted file access; additional permissions require explicit GM consent.
+
+A faulty, damaged, missing, or update-incompatible extension is disabled and
+identified without preventing SaltMarcher or the Campaign from opening. Its
+data remains intact, and application updates do not let an incompatible
+extension rewrite Campaign data.
+
+Extensions may add content kinds, runtime masks, generators, importers, and
+presentations. They cannot silently bypass explicit deletion, local data
+control, truthful history, or another confirmed safety boundary.
+
+### Rules, Localization, Accessibility, And Displays
+
+D&D 5e 2014 is the only binding core rules profile. Supporting several D&D
+versions or other game systems is parked as very late quality-of-life work and
+does not require a generic multi-system core now.
+
+The interface is localizable for additional languages. Campaign-authored text
+remains arbitrary user content independent of interface language.
+
+The complete core supports keyboard operation, scalable text and interface,
+sufficient contrast, and information which does not rely on color alone. These
+alternatives do not clutter the default interface or slow its low-friction
+workflows. The interface remains usable at common laptop resolutions, on
+high-density displays, and across multiple monitors. Touch, mobile, and
+smartphone layouts are not core targets.
+
+### Calendar, Encounter Tables, Dice, And PC Data
+
+Each Campaign has a configurable fantasy calendar with authored month lengths,
+day length, weekdays, and year counting. The GM can author calendar events such
+as holidays. Events may be bound to time, place, or both and become relevant
+according to each Running Scene's time and location without automatically
+deciding narrative consequences.
+
+Named, GM-editable Encounter Tables contain weighted Monster or group entries.
+Factions, places, and other context use them as foundational sources for
+Encounter candidate pools and generation, alongside applicable contextual
+influences.
+
+SaltMarcher has no general-purpose GM dice roller. Ordinary table dice stay
+physical; automatic generators and simulations may use internal randomness.
+
+A PC tracks every structured statistic required by enabled automatic systems.
+Only its name is universally required; an automatic workflow may require its
+relevant optional statistics before running. SaltMarcher does not thereby
+become a complete character-sheet, spell, class-feature, or rules-complete
+inventory manager.
+
+### In-Game Capability Tutorials
+
+Every capability exposed by the product has an in-game tutorial. Tutorials
+begin automatically on first installation and after an update. The
+automatically begun tutorial experience is optional and can be skipped without
+requiring the GM to complete it.
+
+### Acceptance Criteria
+
+- ordinary core preparation and play remain usable without network access
+- the same complete Campaign can be used across supported desktop systems
+  without separately administered infrastructure
+- common live actions remain responsive while long operations expose progress,
+  cancellation, and non-blocking behavior
+- a supporting-capability failure leaves unrelated live and manual workflows
+  usable and retains confirmed work
+- cancelled work leaks no unaccepted partial result into Campaign truth
+- after the initial real-use data-format cutover, updates preserve the last safe
+  prior Campaign data; damaged individual records and missing capabilities
+  preserve the last safe unaffected Campaign data at every stage
+- an optional capability can be removed or replaced without breaking unrelated
+  workflows, and its retained data returns with the capability
+- an extension obtains network, file, or Campaign-data access only after
+  explicit disclosure and GM consent
+- an incompatible extension cannot block Campaign opening or silently bypass
+  deletion, privacy, or history boundaries
+- keyboard, scaling, contrast, and non-color alternatives preserve the same
+  efficient workflows across supported display configurations
+- Calendar events respond to applicable Scene time and place without executing
+  a narrative decision automatically
+- Encounter Tables can provide weighted candidates to factions, places, and
+  generation
+- ordinary dice rolling remains outside SaltMarcher while automatic systems may
+  randomize internally
+- an automatic PC workflow clearly requires its missing relevant statistics
+  without making unrelated optional character data mandatory
+- every exposed capability has an in-game tutorial; first installation and an
+  update start tutorials automatically, while the GM can skip the automatic
+  tutorial experience without completing it
+
+## Confirmed Cross-Workflow Behavior
+
+### Complete Encounter Outcome
+
+The GM confirms one complete Encounter outcome. Encounter completion and the
+selected participant XP distribution become effective together or remain
+wholly unchanged. Tracked HP and rule-derived deaths carry forward; SaltMarcher
+does not infer named-NPC lifecycle, finite-stock, condition, capture, location,
+resource-use, or other narrative consequences from completion. The associated
+Running Scene remains active. Reward distribution, character loot ledger,
+progression, and correction behavior follow the confirmed follow-up workflow
+above.
+
+### Authoritative Party With Dependent Running Contexts
+
+Party activation, deactivation, or deletion is authoritative immediately and is
+not rolled back by an unavailable Running Scene or Encounter. Activation
+assigns the character to the focused Running Scene; deactivated or deleted
+characters immediately stop counting as current Party members and leave their
+Running Scene and masks according to the confirmed live-play behavior above.
+
+Only Running Scenes that reference the changed character and their Encounters
+reconcile. Until reconciliation succeeds, affected contexts are visibly pending
+and stale Encounter context is not presented as synchronized. Initialization,
+refresh, and explicit retry resume the saved work without repeating the Party
+change. Unaffected contexts do not change.
+
+### Scene Save Before Encounter Synchronization
+
+A valid Running Scene change remains saved and usable when its Encounter cannot
+accept the corresponding context. The exact Scene state remains visibly pending,
+stale Encounter context is never presented as synchronized, and retry continues
+from the saved Scene change.
+
+### Explanatory Campaign History
+
+The GM can inspect an ordinarily immutable chronological history of meaningful
+confirmed Campaign consequences, including campaign-time progression, travel,
+Encounter completion, XP, Party membership, manually confirmed NPC or
+finite-stock effects, and GM corrections.
+
+A correction appends a linked entry rather than rewriting prior history. The
+history is not required to replay the Campaign, reconstruct every intermediate
+application state, or restore an arbitrary whole-Campaign snapshot.
+
+Moving a Scene's in-world time backward or manually resolving different Scene
+times never deletes history or reverses confirmed World consequences. A fact
+recorded later at the table may carry an earlier in-world time and is treated
+as having happened then. Travel undo is the narrow exception described above:
+it removes the undone segment and results introduced only by it. An explicit
+GM deletion may remove its selected target even when that produces marked
+history conflicts which the GM must later resolve.
+
+## Baseline State
+
+The baseline covers all eight identified workflows plus structured Shop
+inventory. Shop purchases and counterparties remain consistent with the
+character ledger, and deleting an owner neither orphans nor silently deletes
+the Shop. No unresolved product decision remains in the needs baseline.
+
+Exact responsiveness and scale budgets, the detailed weather model, the
+published-rule derivation, persistence and backup mechanisms, and extension
+technology remain later technical or product decisions. They do not change the
+observable needs recorded here and do not
+block technical-needs derivation.
+
+- [Project Vision](../vision.md)

--- a/docs/project/requirements/requirements-progress-meter.md
+++ b/docs/project/requirements/requirements-progress-meter.md
@@ -1,0 +1,52 @@
+# Progress Meter
+
+## Component Purpose
+
+The reusable meter renders a compact track, filled region, centered text overlay,
+optional tooltip, and optional amount popup in one JavaFX control.
+
+The meter presents values supplied by its owning feature and keeps only local
+popup interaction state such as the current amount draft. It does not calculate
+HP, XP, thresholds, labels, readiness, or other business state.
+
+## Visible Surfaces
+
+- The control shows a track, a filled region, centered text overlay, and an
+  optional tooltip.
+- When amount actions are enabled, the control can open a compact popup for
+  signed or unsigned adjustments.
+
+## Interactions
+
+- Owning features provide projected text, fraction, accessible text, sizing
+  style, fill style, tooltip text, initial amount, and action metadata through
+  the meter's public presentation input.
+- Popup-based amount actions report amount snapshots to the owning feature
+  instead of mutating feature state.
+- The meter may appear anywhere a reusable progress display is needed without
+  becoming a separate navigation destination.
+
+## Visible States
+
+- No popup: the control shows only the passive meter surface.
+- Tooltip available: the control exposes projected tooltip text.
+- Amount popup available: the control can open the compact adjustment popup.
+- Disabled action state: the control renders the passive meter without
+  mutating any owning feature state directly.
+
+## Acceptance Criteria
+
+- the progress meter remains passive and does not own
+  business calculations for HP, XP, thresholds, or readiness
+- owning features supply all projected business meaning, while the meter owns
+  only rendering and widget-local layout
+- amount actions report snapshots to the owning feature instead of mutating
+  domain state directly inside the meter
+- popup draft and availability remain local interaction state and do not become
+  feature truth
+- popup-based amount editing follows the shared anchored-popup behavior for
+  placement, dismissal, and focus return
+
+## References
+
+- [Anchored Popup](requirements-anchored-popup.md)

--- a/docs/project/requirements/requirements-travel-state-tab.md
+++ b/docs/project/requirements/requirements-travel-state-tab.md
@@ -1,0 +1,63 @@
+# Reise-State-Tab UI
+
+## Component Purpose
+
+The Reise-State-Tab is the lower-right global runtime tab labeled `Reise` next
+to the Encounter state tab. It is independent from navigable interactive
+travel workspaces.
+
+- One feature-neutral Travel capability consumes Party position plus approved
+  Dungeon and Hex readbacks, selects the matching live context, and owns the
+  single global `Reise` contribution.
+- Feature-owned travel contexts keep their behavior requirements in their
+  feature requirement docs; this project-wide document owns only the shared
+  global state-tab shell behavior and the no-context-to-live-context selection
+  rule.
+
+## Visible Surfaces
+
+- `COCKPIT_STATE` contains the content of the runtime tab labeled `Reise` when
+  that tab is selected in the global state-tab strip.
+- The explicit no-context state shows that no matching live travel context is
+  currently available.
+- When a live travel readback is available, the same compact state-tab surface
+  shows feature-owned travel context while staying distinct from the
+  interactive travel workspace.
+
+## Interactions
+
+- Selecting the runtime tab labeled `Reise` switches the global state pane
+  from Encounter content to the selected travel context or explicit no-context
+  state.
+- The live compact state-tab surface remains read-mostly. Travel movement and
+  editing commands belong in the owning interactive travel or editor surface.
+
+## Visible States
+
+- Selected: the lower-right state pane shows the matching compact travel
+  context or an explicit no-context state.
+- Not selected: the global state pane continues to show the currently selected
+  state tab instead of travel content.
+- No context: no approved readback matches the active Party position.
+- Live context: the lower-right state pane shows compact readback from the
+  owning travel feature and keeps movement commands out of the state tab.
+
+## Acceptance Criteria
+
+- the Reise-State-Tab is a global runtime state-tab surface independent from
+  the navigable Travel left-bar tab
+- selecting the runtime tab labeled `Reise` swaps the state pane from
+  Encounter content to compact travel content
+- the no-context and live compact states remain command-free in this surface
+- a feature-owned live travel context can appear only through an approved
+  readback surface and without adding movement commands to this state tab
+- Dungeon and Hex MUST NOT register separate global `travel` contribution keys;
+  the feature-neutral Travel capability owns exactly one contribution and an
+  explicit no-context fallback
+
+## References
+
+- [Encounter Runtime State UI](../../encounter/requirements/requirements-encounter-state-tab.md)
+- [Hex Travel State Requirements](../../hex/requirements/requirements-hex-travel-state.md)
+- [Dungeon Travel State Requirements](../../dungeon/requirements/requirements-dungeon-travel-state.md)
+- [Travel Context Domain](../../travel/domain/domain-travel.md)

--- a/docs/project/vision.md
+++ b/docs/project/vision.md
@@ -1,0 +1,53 @@
+# SaltMarcher Vision
+
+## Users
+
+SaltMarcher is for a DnD 5e GM who prepares, runs, and follows up on their
+own table. The primary user is the GM at the table, not players, remote
+participants, or a shared player-facing audience.
+
+## Jobs
+
+- A GM can create and find campaign objects such as NPCs, places, items,
+  factions, monsters, and similar reference material.
+- A GM can prepare a session with scenes, linked places, NPCs, and factions,
+  then generate encounter or loot suggestions that fit that preparation.
+- A GM can run the table by tracking initiative, monster HP, turn position,
+  notes, time, calendar events, music, and prepared scenes without interrupting
+  the active encounter or scene.
+- A GM can use hex or dungeon maps to understand where the party is and what is
+  located where during travel.
+- A GM can follow up after a session by reviewing logged events, visited
+  places, encountered NPCs, awarded items, encounter outcomes, and changed
+  campaign facts.
+- A GM can quickly look up rules, monster information, items, and other
+  reference material.
+
+## Non-Goals
+
+- SaltMarcher is not a dice chat.
+- SaltMarcher does not replace physical table tools such as battle maps,
+  miniatures, or dice.
+- SaltMarcher is not a player-operated app or shared control surface. A passive
+  second-monitor output may present GM-selected, party-known information without
+  accepting player input.
+- SaltMarcher is not a remote-play platform.
+- SaltMarcher does not ordinarily decide rules or make campaign decisions. The
+  GM always has the last word.
+- GM-enabled NPC and monster autonomy is the explicit exception: during
+  confirmed campaign time it may choose and execute bounded jobs and resolve
+  non-party conflicts within configured consequence limits. Party involvement
+  and decisions outside those limits return control to the GM.
+- SaltMarcher does not autonomously generate NPCs, places, or campaign content
+  without the GM's knowledge and decision.
+
+## Quality Bar
+
+- Table use must not interrupt or lose the current running state.
+- Frequent table actions should take very few clicks: for example, opening the
+  monster list in one click and adding a monster in one more click.
+- Notes on an open NPC or place should be immediately reachable.
+- Generator output must remain directly adjustable: the GM can remove monsters,
+  add monsters, or regenerate the encounter.
+
+## References

--- a/docs/scene/README.md
+++ b/docs/scene/README.md
@@ -1,0 +1,22 @@
+# Runtime Scene Feature
+
+## Purpose
+
+`scene` owns the GM's running-scene workspace: which scene is focused, which
+active PCs are in each scene, and which World Planner NPC and location
+references are currently present. Encounter remains the owner of builder,
+initiative, combat, and result state.
+
+## Documents
+
+- [Requirements](requirements/requirements-scene.md)
+- [Domain](domain/domain-scene.md)
+- [Architecture](architecture/architecture-scene.md)
+- [Persistence](contract/contract-scene-persistence.md)
+
+## References
+
+- [Session Planner](../sessionplanner/README.md)
+- [Encounter](../encounter/README.md)
+- [World Planner](../worldplanner/README.md)
+- [Party](../party/README.md)

--- a/docs/scene/architecture/architecture-scene.md
+++ b/docs/scene/architecture/architecture-scene.md
@@ -1,0 +1,73 @@
+# Runtime Scene Architecture
+
+## Entity And Concerns
+
+This specification serves maintainers of the GM runtime workspace, Encounter
+state switching, and Scene persistence. It answers how parallel scenes share
+foreign facts without sharing mutable feature internals and how restart-safe
+combat remains Encounter-owned.
+
+## Current Shape
+
+Scene is one vertical feature under `features/scene`. Its `api` publishes the
+asynchronous command boundary and immutable model, `domain` owns the running
+workspace, `application` orchestrates foreign facts and the synchronization
+saga, `adapter/sqlite` persists Scene-owned truth, and `adapter/javafx`
+contributes controls and main content to the passive shell. `SceneFeature` is
+the only composition entry point used by `app`.
+
+## Context View
+
+```text
+Party API ----------------\
+World Planner API ---------+--> Scene application --> Scene SQLite adapter
+Session Planner API -------/          |
+                                      +--> Encounter runtime-context API
+                                                 |
+                                                 +--> Encounter-owned runtime
+```
+
+Scene consumes `ActivePartyModel`, `WorldPlannerSnapshotModel`,
+`PreparedSceneCatalogModel`, `CreatureReferenceIndexModel`, and
+`EncounterRuntimeContextApi` only from the providers' `api` packages. It MUST
+NOT read foreign repositories, issue creature Catalog page queries, or persist
+copied foreign details. Encounter accepts opaque context identifiers and MUST
+NOT depend on Scene types.
+
+## Decisions
+
+- Runtime scenes are separate from authored Session Planner scenes because
+  planning edits and live play have different consistency and lifecycle needs.
+- A prepared scene import creates a new Scene-owned copy on every invocation.
+  Provenance remains visible, but no live link back to Session Planner exists.
+- Encounter sessions are keyed and persisted by Encounter because moving their
+  mutable combat internals into Scene would split Encounter ownership.
+- Scene commands and persistence work run asynchronously on the shared
+  `ExecutionLane`; `SceneModel.current()` reads published memory and performs no
+  persistence or foreign I/O.
+- Creature choices and mob labels come from the app-refreshed immutable,
+  revisioned creature reference index. Scene subscribes to that index but does
+  not own its refresh lifecycle, so Scene activation cannot replace a Catalog
+  search result.
+- Scene saves the workspace with `encounterSynchronized=false` before sending a
+  complete revisioned context snapshot. Only an accepted Encounter revision is
+  saved as synchronized. Initialization and refresh retry a pending snapshot.
+  This makes recovery after a partial local failure idempotent and observable.
+- The Scene JavaFX contribution uses controls and main slots but no state slot,
+  preserving simultaneous access to the Encounter state tab.
+
+Rejected alternatives are one global Encounter, live-linked planner scenes,
+and Scene-owned combat snapshots. Each would prevent independent party-split
+state or duplicate another feature's truth.
+
+## Consistency
+
+SQLite writes are transactional inside each owner. Cross-feature synchronization
+is a retryable saga rather than an atomic transaction.
+
+## References
+
+- [Source Architecture](../../project/architecture/source-architecture.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)
+- [Scene Requirements](../requirements/requirements-scene.md)
+- [Scene Persistence Contract](../contract/contract-scene-persistence.md)

--- a/docs/scene/contract/contract-scene-persistence.md
+++ b/docs/scene/contract/contract-scene-persistence.md
@@ -1,0 +1,72 @@
+# Runtime Scene Persistence Contract
+
+## Purpose, Owners, And Consumers
+
+The Scene SQLite adapter persists only Scene-owned workspace truth. Consumers
+use `SceneApi` and `SceneModel`; SQL records do not cross the feature. Party,
+World Planner, Session Planner, and Encounter retain ownership of their own
+payloads and lifecycle.
+
+## Stored Truth
+
+- `scene_workspace`: workspace revision, next scene ID, Standardszene ID,
+  focused scene ID, synchronization marker, and status text
+- `scene_running_scene`: stable scene ID, title, notes, optional planner
+  provenance values, optional initial Encounter plan ID, optional World Planner
+  location ID, and order
+- `scene_party_member`: ordered Party character foreign IDs
+- `scene_npc`: ordered World Planner NPC foreign IDs
+- `scene_mob`: ordered Scene-owned assignments of Creature catalog foreign IDs
+  and their positive group counts; Creature facts remain Creatures-owned
+- `scene_participant_state`: Scene-owned per-scene defeated state and quick
+  notes for an assigned PC, NPC, or mob, keyed by participant kind and the
+  corresponding foreign ID; it does not own that participant's source facts
+
+Party details, World Planner details, disposition, creature statblocks, and
+Encounter workflow state MUST NOT be stored in Scene tables.
+
+## Validation And Errors
+
+Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
+
+Scene IDs and all present foreign references MUST be positive. The database
+enforces one row per scene assignment plus global uniqueness of both PC and NPC
+assignment. Location IDs are not unique because multiple scenes may reference
+the same location. The only foreign keys target Scene-owned scene rows; foreign
+feature IDs MUST NOT receive cross-owner foreign keys.
+
+Writes replace one complete workspace in a transaction. Failed writes retain
+the last committed workspace and complete the command with `STORAGE_ERROR`.
+Failed Encounter synchronization is not a Scene storage failure: the committed
+workspace remains available with `encounter_synchronized=0` and is retried by
+initialization or refresh.
+
+## Consistency And Boundary Semantics
+
+Each logical Scene mutation increments the workspace revision. Scene persists
+the new revision as unsynchronized before invoking Encounter. An `APPLIED`
+result, or a `STALE_IGNORED` result whose accepted revision covers the sent
+revision, may mark that same current revision synchronized. A late completion
+MUST NOT overwrite a newer Scene revision.
+
+## Compatibility And Migration
+
+Before the first released format,
+`scene` supports exactly the complete current schema at owner version 1. One
+guarded initializer creates all six Scene tables in a fresh owner namespace.
+There is no additive v1-v3 build-up, predecessor repair, backfill, or workspace
+translation.
+
+The exact owner inventory covers every table, index, view, and trigger named
+with `scene_` or `idx_scene_`. An unversioned partial namespace, a recorded
+version-1 shape that differs from the exact current DDL, an adjacent retired
+Scene object, or a newer owner version MUST fail without mutating stored rows,
+schema objects, or ledger state. Initialization failure MUST NOT fabricate a
+ledger entry. Unsupported development databases are reinitialized rather than
+migrated before the first released format.
+
+Missing World Planner records remain visible as unresolved stable references
+until the GM removes or replaces them; inactive Party members are removed
+during refresh. These are current reference semantics, not schema-compatibility
+bridges. Foreign feature IDs remain logical values without cross-owner foreign
+keys or repair.

--- a/docs/scene/domain/domain-scene.md
+++ b/docs/scene/domain/domain-scene.md
@@ -1,0 +1,61 @@
+# Runtime Scene Domain Model
+
+## Context Role
+
+Context Name: Scene
+
+Scene owns running-scene composition and focus. It does not own Party
+characters, World Planner NPC/location details, prepared session records,
+creature statblocks, or Encounter workflow state.
+
+## Write Model
+
+`SceneWorkspace` is the aggregate root. It owns a monotonically increasing
+revision, the Standardszene ID, the focused-scene ID, scene identity allocation,
+and the collection of `RunningScene` records.
+
+Each `RunningScene` owns its title, notes, optional Session Planner provenance,
+an optional initial Encounter-plan reference, one optional World Planner
+location reference, ordered PC references, and ordered World Planner NPC
+references. Foreign IDs are references, not copied foreign entities.
+
+## Invariants
+
+- At least one scene always exists.
+- Standardszene and focused scene always identify existing scenes.
+- Standardszene cannot be deleted.
+- A PC reference can occur in at most one running scene.
+- An NPC reference can occur in at most one running scene.
+- A running scene has zero or one location and any number of NPC references.
+- Multiple running scenes may reference the same location.
+- Every prepared-scene import creates a new independent copy with provenance;
+  importing the same prepared source again is valid and creates another copy.
+
+## Published Language
+
+`SceneModel` publishes immutable scene cards, resolved foreign choices,
+prepared-scene choices, synchronization status, and workspace revision.
+`SceneCommand` owns initialization, refresh, and all mutations. Typed mutation
+results distinguish invalid input, missing references, Standardszene
+protection, and storage error.
+
+The application boundary translates active Party summaries, World Planner
+NPC/location summaries, and prepared Session Planner sources into Scene
+commands and projections. These translations are derived facts and do not
+become Scene-owned entities.
+
+## Consistency
+
+One `SceneWorkspace` mutation and its SQLite save form the Scene consistency
+boundary. Scene persistence is authoritative for context membership. Encounter
+receives an idempotent full-workspace synchronization carrying opaque context
+IDs and foreign IDs after the Scene save. The persisted synchronization marker
+is derived operational state and does not transfer Encounter ownership.
+Foreign names, levels, lifecycle, and disposition are re-read from their owning
+features. Refresh removes Party IDs that are no longer active.
+
+## References
+
+- [Scene Requirements](../requirements/requirements-scene.md)
+- [Scene Architecture](../architecture/architecture-scene.md)
+- [Scene Persistence Contract](../contract/contract-scene-persistence.md)

--- a/docs/scene/requirements/requirements-scene.md
+++ b/docs/scene/requirements/requirements-scene.md
@@ -1,0 +1,74 @@
+# Runtime Scene Requirements
+
+## Goal
+
+Give the GM one runtime tab for maintaining parallel running scenes, switching
+between split-party contexts, and keeping the matching Encounter session in
+view.
+
+The affected user is the GM during live play. Scene owns runtime composition
+and focus; Party, World Planner, Session Planner, and Encounter remain the
+owners of the referenced content.
+
+## Non-Goals
+
+- editing Party, World Planner, creature, or saved Encounter truth
+- writing runtime changes back into Session Planner scenes
+- allowing more than one location in a running scene
+
+## Primary Flow
+
+1. On first use, a Standardszene exists and contains every currently active PC.
+2. The GM creates another scene or loads a prepared Session Planner scene.
+3. PCs are moved between scenes; one PC can be in at most one running scene.
+4. The GM selects one World Planner location and any number of World Planner
+   NPCs for the focused scene.
+5. Switching scenes immediately switches the visible Encounter session.
+6. Every scene and Encounter session is restored after an application restart.
+
+Each prepared-scene import creates a new copy of title, notes, location,
+participant references, linked saved Encounter plan, and source provenance.
+Only active, currently unassigned participants are copied. The same prepared
+scene can be imported repeatedly; later planner edits do not update any runtime
+copy.
+
+## Visible Behavior
+
+- The Standardszene cannot be deleted but can be renamed.
+- Newly activated PCs appear as unassigned instead of moving automatically.
+- Inactive PCs are removed from their running scene on refresh.
+- Assigning a PC or NPC to another scene moves that reference atomically; it is
+  never shown in two scenes.
+- Each scene has at most one location, while the same location may be used by
+  several scenes.
+- Friendly NPCs enter the scene Encounter as allies, hostile NPCs as enemies,
+  and neutral NPCs remain visible context without joining combat.
+- The scene location automatically constrains later Encounter generation.
+- PC and NPC changes during initiative or combat reconcile immediately while
+  retaining existing initiative, HP, round, and active turn where applicable.
+- A failed Encounter synchronization is visible as pending. The saved Scene
+  workspace remains usable, while stale Encounter context MUST NOT be presented
+  as synchronized. Initialization and refresh retry the saved revision.
+- Storage failure is visible and does not publish an unsaved workspace as the
+  durable result.
+
+## Acceptance Criteria
+
+- A logical `no scene` state cannot be produced through the UI or domain API.
+- Construction and `SceneModel.current()` perform no persistence or foreign
+  I/O; initialization and commands complete asynchronously.
+- Split scenes keep independent Builder, Initiative, Combat, and Result state.
+- XP balancing and awards use only PCs assigned to that scene.
+- Scene persistence stores foreign IDs, not copied Party or World Planner data.
+- A failed post-save Encounter synchronization leaves the persisted Scene
+  revision marked unsynchronized, and a later initialization or refresh can
+  mark that revision synchronized.
+- A restart restores focus, scene contents, generated alternatives, initiative,
+  combatants, HP, round, turn, result, and XP-award status.
+- The Scene tab leaves the global Encounter state pane visible.
+
+## References
+
+- [Scene Domain](../domain/domain-scene.md)
+- [Scene Architecture](../architecture/architecture-scene.md)
+- [Scene Persistence Contract](../contract/contract-scene-persistence.md)

--- a/docs/sessiongeneration/README.md
+++ b/docs/sessiongeneration/README.md
@@ -1,0 +1,14 @@
+# Session Generation Feature
+
+## Document Set
+
+- [Requirements](requirements/requirements-session-generation.md)
+- [Domain](domain/domain-session-generation.md)
+- [API And Persistence Contract](contract/contract-session-generation.md)
+- [Architecture](architecture/architecture-session-generation.md)
+
+## Neighboring Owners
+
+- [Session Planner](../sessionplanner/README.md)
+- [Encounter](../encounter/README.md)
+- [Source Architecture](../project/architecture/source-architecture.md)

--- a/docs/sessiongeneration/architecture/architecture-session-generation.md
+++ b/docs/sessiongeneration/architecture/architecture-session-generation.md
@@ -1,0 +1,163 @@
+# Session Generation Architecture
+
+## Purpose
+
+Session Generation provides deterministic encounter-and-reward computation as
+one UI-free capability. It must remain independently usable, preserve the staged
+reference behavior, expose structured loot, and avoid using SQLite round trips
+as workflow transport.
+
+## Stakeholders And Concerns
+
+- Session Planner needs a complete deterministic value that can continue
+  directly into preparation and can later be made durable idempotently.
+- Encounter needs ordered structured intents without reward or persistence
+  internals.
+- Session Generation maintainers need pure stage seams, stable catalog meaning,
+  and normalized immutable storage.
+
+This document owns execution, dependency direction, publication semantics, and
+architecture quality targets. Observable result behavior belongs to
+requirements; run truth belongs to the domain; API and storage semantics belong
+to the contract.
+
+## Target Topology
+
+```text
+features/sessiongeneration/api/
+features/sessiongeneration/domain/
+features/sessiongeneration/application/
+features/sessiongeneration/adapter/resource/
+features/sessiongeneration/adapter/sqlite/
+features/sessiongeneration/SessionGenerationFeature
+resources/sessiongeneration/
+```
+
+`SessionGenerationFeature` receives bounded CPU execution, I/O execution,
+persistence, and local diagnostics from application composition. It publishes
+one `SessionGenerationApi` and no JavaFX or shell contribution.
+
+## Runtime
+
+```text
+Session Planner preparation
+  -> SessionGenerationApi.draft
+  -> cached immutable catalog snapshot
+  -> pure staged GenerationEngine
+  -> GeneratedRunDraft in memory
+  -> SessionGenerationApi.commit
+  -> one atomic normalized write
+```
+
+The successful draft continues directly into Encounter drafting and Session
+Planner assembly. Commit adds durability once the full prepared session is
+valid. It never requires a save, reload, and equality comparison in the hot
+path.
+
+## Publication Semantics
+
+The API publishes only complete immutable operation results. `draft` publishes
+either one complete `GeneratedRunDraft` or one typed failure; no stage result or
+partially populated reward collection crosses the boundary. `commit` publishes
+the durable identity for exactly the submitted semantic draft. `load` and
+reward batch reads publish immutable typed values with stable request ordering.
+
+Session Generation publishes no view state and initiates no consumer refresh.
+The calling application owns cancellation and whether a late result is still
+eligible for use. Cancellation prevents avoidable remaining work but never
+turns a partial stage value into a public success.
+
+## Pipeline
+
+The engine retains pure typed stage seams for session context, encounter target
+allocation, candidate construction and selection, treasure planning, loot
+resolution, packing, output, and audits. Each stage consumes immutable values
+and returns immutable values. The engine performs no API mapping, persistence,
+resource loading, clock access, diagnostics, or foreign-feature call.
+
+The application layer validates API input, obtains one already-validated
+catalog snapshot, invokes the engine on CPU execution, assigns stable run
+identity and content fingerprint after hard audits, and maps the result. The
+persistence adapter validates and writes the same semantic candidate; it does
+not rerun generation rules.
+
+## Catalog Lifecycle
+
+One catalog artifact is validated and cached by `(catalogVersion,
+catalogContentHash)`. Concurrent requests share the immutable snapshot. Artifact
+loading runs once per version and never occurs inside a SQLite transaction.
+A failed refresh cannot replace the last valid snapshot for an already pinned
+version.
+
+## Boundaries
+
+- API uses JDK and feature-neutral async values only.
+- Domain depends on no API, SQL, JavaFX, platform, or foreign feature.
+- Application depends inward on domain and outward on feature-owned ports.
+- Resource and SQLite adapters implement those ports and contain no generation
+  policy.
+- Composition is the only construction point.
+- Session Generation does not call Session Planner, Party, Creatures, or
+  Encounter.
+- Concrete creature selection remains Encounter-owned.
+
+Forbidden shortcuts include direct foreign database reads, Encounter
+repositories, JavaFX controls, shell service lookup, mutable global catalog
+state, JSON run persistence, opaque formatted-text output, and one monolithic
+generator method hiding stage boundaries.
+
+## Execution And Performance
+
+Pure drafting runs on bounded CPU execution. Catalog and SQLite work run on I/O
+execution. Transactions contain only validation against prepared rows and
+database writes. Multiple independent generation drafts are not globally
+serialized; caller cancellation stops avoidable stage work.
+
+The application publishes stage duration and candidate cardinality diagnostics
+without content. Separate engine and I/O measurements prevent slow persistence
+from being misdiagnosed as generation cost.
+
+Measurable architecture targets are:
+
+- `draft` performs zero SQLite operations and runs generation only on bounded
+  CPU execution; catalog loading and all persistence run on I/O execution
+- requests are not globally serialized; parallelism is bounded by the supplied
+  executors and transactions contain no catalog load or generation search
+- catalog validation happens at most once per catalog content identity before
+  reuse of its immutable snapshot
+- commit, load, and reward hydration use query families bounded by operation,
+  never one query per encounter, treasure, item line, or packing row
+- the Golden input produces the same deterministic engine result, while the
+  shared warmed three-Encounter reference workload records catalog, engine,
+  commit, and reward-read stages separately and remains inside the Session
+  Planner 2-second p95 end-to-end target over 20 runs
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- Session Generation remains a separate UI-free feature because deterministic
+  reward truth, catalog identity, audits, and immutable run history have one
+  lifecycle.
+- The engine uses pure typed stages so parity and performance are attributable
+  to named computation boundaries.
+- Draft and commit are separate operations so a complete prepared session can
+  be validated before a run becomes durable.
+- Runs use normalized immutable persistence and idempotent content-checked
+  commit so structured rewards and reproducibility survive one rendering.
+
+Rejected alternatives:
+
+- saving and reloading a run as in-process workflow transport
+- a monolithic generator that hides stage values and audit boundaries
+- JavaFX publication or a second generation UI
+- a remote generator service, rules plugin framework, event bus, shared
+  cross-feature transaction, or compensating deletion
+- compatibility with unadopted proof-of-concept schemas or Java carriers
+
+## Sources
+
+- [Requirements](../requirements/requirements-session-generation.md)
+- [Domain](../domain/domain-session-generation.md)
+- [Contract](../contract/contract-session-generation.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/sessiongeneration/contract/contract-session-generation.md
+++ b/docs/sessiongeneration/contract/contract-session-generation.md
@@ -1,0 +1,126 @@
+# Session Generation API And Persistence Contract
+
+## Owner And Consumers
+
+Session Generation owns this boundary and all stored generation-run truth.
+Session Planner is the primary consumer. Only Session Generation writes its
+normalized run schema. Encounter consumes encounter intents only through the
+Session Planner preparation workflow and never writes generation storage.
+
+## Non-Blocking API
+
+`SessionGenerationApi` exposes:
+
+```text
+draft(GenerationRequest) -> GenerationDraftResponse
+commit(CommitGenerationRunCommand) -> GenerationRunResponse
+load(GenerationRunId) -> GenerationRunResponse
+loadRewards(GenerationRewardBatchQuery) -> GenerationRewardBatchResponse
+```
+
+Every operation completes asynchronously and performs no file or SQLite work
+on the JavaFX thread.
+
+`GenerationRequest` contains one opaque preparation identity, ordered unique
+party-level counts, exact adventure-day fraction, optional encounter count, and
+seed. It contains no SQL, JavaFX, Session Planner persistence, or foreign
+domain carriers.
+
+A successful draft response contains one complete structured
+`GeneratedRunDraft` with stable run identity and normalized content
+fingerprint. Commit accepts that draft, validates it again, and returns its
+durable identity. Load returns the immutable structured run. Batch reward reads
+accept unique run-and-treasure identities and preserve request order.
+
+Public statuses distinguish success, invalid request, not found, catalog
+failure, generation failure, identity conflict, and storage failure. A
+non-success result contains no partial draft, run, or reward list.
+
+## Draft Identity And Commit
+
+Run identity is assigned only after a complete draft passes hard audits and is
+stable for preparation identity, engine version, and catalog content hash. The
+content fingerprint covers normalized inputs and every semantic persisted
+child in stable order. It excludes creation time and optional formatted text.
+
+Commit is idempotent:
+
+- a new identity and valid draft insert the root and every child once
+- an existing identity with the same fingerprint and reconstructed semantic
+  value returns success without rewriting rows
+- an existing identity with different content returns `IDENTITY_CONFLICT`
+- no consumer must load the just-committed run to continue the same workflow
+
+## Normalized Persistence
+
+The persistence lifecycle owner key remains `session-generation`.
+Owner startup readiness validates the feature-declared target schema signature;
+semantic row validation remains on typed repository read/write paths and fails
+closed through this feature contract.
+
+The logical schema stores:
+
+- run identity, content fingerprint, engine version, catalog version and
+  content hash, seed, exact adventure-day fraction, session summary, reward
+  summary, and optional formatted output
+- normalized party-level counts
+- ordered encounter targets, encounters, and selected role/CR blocks
+- ordered treasures, concrete loot item lines, and packing rows
+- ordered typed warnings and audits
+
+Every child uses the run identity plus generation-local identity and explicit
+ordering where order affects behavior. Exact decimals are lossless; money uses
+copper-piece units; enums use constrained canonical codes. Composite foreign
+keys prevent cross-run anchors and packing references.
+
+The schema MUST NOT store JSON aggregates, Java serialization, delimiter-packed
+records, copied catalog families, unselected candidate search space, or
+formatted text as the only representation of structured facts.
+
+One run and all children insert in one transaction. A failure leaves no visible
+partial root. Load reconstructs typed values and fails on corrupt, orphaned,
+duplicate, unknown-enum, fingerprint-mismatched, or out-of-order rows.
+
+## Catalog Boundary
+
+The shipped catalog remains a read-only versioned artifact. Its content hash is
+SHA-256 over catalog version plus the canonical filename-sorted inventory,
+dimensions, and per-file hashes. Resource validation is all-or-nothing and
+includes required families, identities, vocabularies, ordering, and
+cross-references before one immutable snapshot is cached.
+
+Runs pin catalog version and content hash. Source URL and source-file hash are
+provenance and do not replace runtime artifact identity.
+
+## Precompletion Schema Lifecycle
+
+Before full feature completion there is no released Session Generation data to
+preserve. Owner startup creates the complete normalized schema directly as
+owner version `1`, only on an empty `session_generation_*` namespace, and
+validates the exact table, relationship, constraint, implicit-index, and
+owner-object inventory.
+
+Every current run stores a non-null content fingerprint. Reads validate that
+fingerprint against reconstructed typed rows; no predecessor row without the
+fingerprint is accepted and no fingerprint is derived as a compatibility
+fallback.
+
+Unversioned partial, predecessor, structurally damaged,
+adjacent-owner-object, and newer shapes fail closed unchanged. Startup performs
+no `ALTER`, repair, backfill, copy, drop, legacy write, or version claim. Such
+precompletion databases, proof-of-concept schemas, files, JSON shapes, Java
+carriers, and tables are discarded and recreated from the current product.
+
+## Diagnostics And Errors
+
+Diagnostics may record operation, stable run or catalog identity, stage,
+duration, cardinality, and failure class. They exclude generated item text,
+authored session content, SQL, exception payloads, secrets, and local paths.
+Public messages are display-safe.
+
+
+## Sources
+
+- [Shared Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
+- [Domain](../domain/domain-session-generation.md)
+- [Source Architecture](../../project/architecture/source-architecture.md)

--- a/docs/sessiongeneration/domain/domain-session-generation.md
+++ b/docs/sessiongeneration/domain/domain-session-generation.md
@@ -1,0 +1,97 @@
+# Session Generation Domain Model
+
+## Context Role And Ownership
+
+Context Name: `SessionGeneration`
+
+Context Role: Generated Proposal Context
+
+The context owns normalized generation input, deterministic generation policy,
+encounter intents, rewards, packing, warnings, audits, immutable generated
+runs, and the versioned reference-catalog meaning recorded by those runs. It
+owns neither authored sessions nor concrete creatures, Encounter rosters, or
+saved Encounter plans.
+
+## Published Language
+
+The public language contains typed values for:
+
+- `GenerationRunId`, normalized generation input, and seed
+- session summary, encounter target, encounter intent, and CR-and-role block
+- treasure plan, loot item line, packing row, and reward summary
+- warning and audit outcome
+- engine version, catalog version, and catalog content hash
+
+Closed vocabulary crosses the boundary as enums or value types. Versions are
+audit metadata, not user-selectable ruleset labels.
+
+## Write Model And Derived State
+
+`GeneratedRun` is the immutable Session Generation write model. It owns:
+
+- stable run identity and normalized input
+- catalog and engine identity
+- ordered encounter targets and encounter intents
+- ordered treasures, item lines, packing rows, and reward summary
+- optional formatted output, typed warnings, and audits
+
+There is no update command. A changed request produces a different run.
+
+`GeneratedRunDraft` is transient derived state containing the same semantic
+generation result before it becomes durable. It is complete and immutable but
+is not stored truth and cannot be observed as a partial `GeneratedRun`.
+
+Encounter intents describe CR, role, XP, and quantity requirements. They do not
+contain selected creature identity and never claim to be a concrete Encounter.
+Reward detail remains Session Generation truth; consumers retain stable
+references and resolve detail through Session Generation.
+
+## Deterministic Engine
+
+`GenerationEngine` is a pure policy over normalized `GenerationInput` and one
+immutable `ReferenceCatalogSnapshot`. Its named stages are:
+
+1. session context
+2. encounter target allocation
+3. encounter intent construction and selection
+4. treasure planning
+5. non-magic and magic item resolution
+6. packing
+7. reward aggregation and formatting
+8. warnings and hard audits
+
+The same normalized input, engine version, and catalog content hash produce the
+same domain values. Wall-clock time, locale defaults, database order, hash
+iteration, and volatile randomness cannot influence output.
+
+## Invariants
+
+- party levels are unique and from 1 through 20; counts are non-negative and
+  total count is positive
+- explicit encounter count is 1 through 10
+- encounter numbers and targets are contiguous and ordered from 1
+- encounter targets sum exactly to the session XP target
+- every encounter target has one non-empty structured intent
+- treasure, item-line, packing-row, and audit identities are unique within a
+  run or draft
+- at most one quest treasure and at most one treasure per Encounter anchor
+  exist
+- non-magic slot totals and magic counts equal the calculated targets
+- every item line has one valid packing result
+- hard audit failure prevents an applicable draft or run
+- one run identity denotes exactly one normalized semantic result
+- exact catalog-row selection is not a cross-version invariant
+
+The complete encounter candidate search space is transient stage state. Only
+selected intents and candidate-coverage audits become run truth.
+
+## Consistency Boundary
+
+One `GeneratedRun` and all of its owned values form one immutable consistency
+boundary. A run pins engine version, catalog version, and catalog content hash
+and remains self-contained after creation.
+
+## Sources
+
+- [Requirements](../requirements/requirements-session-generation.md)
+- [Contract](../contract/contract-session-generation.md)

--- a/docs/sessiongeneration/requirements/requirements-session-generation.md
+++ b/docs/sessiongeneration/requirements/requirements-session-generation.md
@@ -1,0 +1,104 @@
+# Session Generation Requirements
+
+## Goal And Scope
+
+Given normalized party levels, an adventure-day fraction, optional encounter
+count, and seed, Session Generation MUST produce one deterministic structured
+result containing encounter intents, rewards, packing, warnings, and audits.
+After the result is saved and reopened, its structured meaning MUST be
+equivalent to the result first presented for the same generation.
+
+Session Planner is the primary consumer. Encounter converts generated encounter
+intents into concrete rosters. Session Generation does not own UI, authored
+sessions, Party members, creature facts, or saved Encounter plans.
+
+## User-Observable Result
+
+Through Session Planner, a successful generation contributes:
+
+- ordered encounter targets and typed role/CR composition intents
+- generated reward channels and encounter anchors
+- concrete generated item lines with quantity, value, magic, curse, and packing
+  facts when applicable
+- display summaries, warnings, and audit outcome
+- stable run and treasure identities used by the prepared session
+
+Generated loot is structured result data. Formatted text is an optional derived
+rendering and MUST NOT be the only reward output. Engine and catalog versions
+are audit metadata, not user-selectable ruleset controls.
+
+## Inputs And Validation
+
+Party levels are unique and from 1 through 20. Counts are non-negative and sum
+to a positive party size. The adventure-day fraction is an exact non-negative
+decimal. An explicit encounter count is from 1 through 10; omission activates
+deterministic automatic calculation. The seed is explicit.
+
+Invalid input produces no result. Catalog, generation, and saving failures are
+distinguishable and expose no partial result.
+
+## Adopted Rule-Parity Profile
+
+The target retains the executed rule groups in sections 3 through 15 of the
+preserved owner-provided reference as the `saltmarcher-v1` behavior profile.
+This is stage and invariant parity, not spreadsheet-row or exact-item parity.
+
+The engine MUST preserve:
+
+- request normalization, session XP, gold pools, magic targets, treasure count,
+  and non-magic slot calculation
+- exact-sum encounter target allocation, role bands, patterns, effective
+  monster count, ranking, seeded choice, difficulty labels, and bossiness
+- normal and overstock budgets, channel caps, theme and magic distribution,
+  descending slots, dynamic line budgets, loot roles, candidate tolerances,
+  bulk behavior, coins, adorned/useful/flavor items, magic, enspelling, curses,
+  packing, and formatting
+- positive modulo, explicit stable ordering, deterministic selection, typed
+  fallbacks, hard audits, and budget tolerances
+
+SaltMarcher owns catalog content. The engine may use stable keyed entropy and
+different active catalog rows. Exact selected candidates, items, containers,
+monetary totals, formatted text, spreadsheet row identities, and per-cell seed
+multipliers are outside compatibility.
+
+## Golden Acceptance Boundary
+
+For two level-3 players, two level-4 players, adventure-day fraction `0.6`,
+explicit encounter count `3`, and seed `179974`, the required Golden output is:
+
+```text
+encounterTargets = [680, 1000, 1800]
+```
+
+No exact encounter candidate, creature roster, loot item, packing choice, or
+formatted-text snapshot is Golden compatibility.
+
+## Result Completeness And Stability
+
+- generation completes asynchronously without blocking the visible planner
+- success exposes one complete structured result; consumers never observe an
+  intermediate encounter-only or reward-only result
+- failed hard audits prevent success; non-blocking fallbacks remain visible as
+  typed warnings
+- saved and reopened results retain the same encounters, rewards, packing,
+  warnings, audits, seed, and recorded engine/catalog meaning
+- repeating an already completed request does not create visible duplicates
+- reward details remain available as structured fields rather than only as
+  formatted text
+
+## Acceptance Criteria
+
+- equal normalized input, engine version, and catalog content hash produce
+  equal structured results
+- encounter targets sum exactly to session XP
+- every applicable result retains seed, versions, content hash, structured
+  encounters, rewards, packing, warnings, and audits
+- concrete item lines survive save and reopen as typed fields with equivalent
+  meaning
+- failed generation or saving exposes no partial generated result
+- the Golden input produces exactly `[680, 1000, 1800]`
+
+## Sources
+
+- [Session Planner Requirements](../../sessionplanner/requirements/requirements-session-planner.md)
+- [Encounter Requirements](../../encounter/requirements/requirements-encounter.md)

--- a/docs/sessionplanner/README.md
+++ b/docs/sessionplanner/README.md
@@ -1,0 +1,26 @@
+# Session Planner Feature
+
+## Reading Order
+
+1. Read [Requirements](requirements/requirements-session-planner.md) for the
+   observable preparation flow and compact workspace.
+2. Read [Domain](domain/domain-session-planner.md) for authored truth and
+   invariants.
+3. Read [Persistence Contract](contract/contract-session-planner-persistence.md)
+   for stored references and write behavior.
+4. Read [Architecture](architecture/architecture-session-planner.md) for the
+   preparation workflow, workspace snapshot, concurrency, and performance
+   decisions.
+
+## Document Set
+
+- [Requirements](requirements/requirements-session-planner.md)
+- [Domain](domain/domain-session-planner.md)
+- [Persistence Contract](contract/contract-session-planner-persistence.md)
+- [Architecture](architecture/architecture-session-planner.md)
+
+## Neighboring Owners
+
+- [Session Generation](../sessiongeneration/README.md)
+- [Encounter](../encounter/README.md)
+- [Party](../party/README.md)

--- a/docs/sessionplanner/architecture/architecture-session-planner.md
+++ b/docs/sessionplanner/architecture/architecture-session-planner.md
@@ -1,0 +1,271 @@
+# Session Planner Architecture
+
+## Objective
+
+The target supports one responsive preparation command that publishes concrete
+Encounter rosters, structured rewards, and one coherent editable workspace
+revision. Persistence is durable truth rather than in-process transport, and
+latency stays bounded by provider family rather than saved or generated row
+count.
+
+## Stakeholders And Concerns
+
+- Game masters need one responsive action, coherent progress, and one complete
+  editable result.
+- Session Planner maintainers need one orchestration owner, explicit foreign
+  seams, and no persistence transport hidden in the workflow.
+- Session Generation, Encounter, Party, and World Planner maintainers need their
+  truth accessed only through their public APIs.
+
+This document owns structural and quality decisions for preparation and
+workspace publication. Product outcomes belong to requirements, write-model
+truth to domain documents, and payload or persistence semantics to contracts.
+
+## Target Topology
+
+```text
+features/sessionplanner/api/
+features/sessionplanner/domain/
+features/sessionplanner/application/
+features/sessionplanner/adapter/sqlite/
+features/sessionplanner/adapter/javafx/
+features/sessionplanner/SessionPlannerFeature
+```
+
+Session Planner remains one feature in the local modular monolith. It receives
+`PartyApi`, `EncounterApi`, `SessionGenerationApi`, and `WorldPlannerApi`
+explicitly from application composition. It exposes `SessionPlannerApi`, one
+workspace snapshot publication, prepared-scene publication, and passive shell
+contributions.
+
+## One Workspace State
+
+`SessionPlannerWorkspaceSnapshot` is the sole view-facing planner state. One
+revision contains:
+
+- session catalog and current session
+- resolved participant summaries and budget
+- ordered scene summaries and selected-scene detail
+- linked Encounter summaries and structured generated rewards
+- the selected-scene saved-plan search request epoch and typed transient state
+- preparation status and stage progress
+- display-safe missing-reference and failure states
+
+`SessionPlannerWorkspaceAssembler` loads one planner snapshot, collects foreign
+IDs, performs one batch read per owning feature, and joins immutable results in
+memory. The JavaFX adapter renders that revision and dispatches typed intents;
+it performs no provider calls, persistence, orchestration, or independent
+projection refresh.
+
+Publication is latest-revision-wins. One authored mutation or foreign-provider
+revision schedules at most one coalesced assembly. Scene, participant, controls,
+and state-panel views do not subscribe to separate planner projections.
+
+The reusable selected-scene inspector carries the published source Session
+revision into scene and manual-note drafts. Dirty scene and keyed note editors
+survive same-scene publications, including focus and caret. A control rebases its
+guard only while authoritative text still equals its loaded baseline; conflicting
+truth preserves the older guard so the next save rejects as stale. Matching
+coherent publication alone clears a submitted draft.
+
+Catalog switching sends at most one typed select command. When a scene draft is
+dirty, that command carries the guarded source edit; the authored lane saves it
+and switches the pointer without publishing an intermediate source workspace.
+
+Saved-plan search follows the same single-writer rule. JavaFX dispatches a
+typed query and only renders the search state inside
+`SessionPlannerWorkspaceSnapshot`; it does not filter cached plans. The
+publication coordinator owns the query epoch, publishes searching and terminal
+states, and accepts a completion only when the captured session identity,
+source revision, and selected scene still match. Underlength input is resolved
+locally with zero provider calls. Valid search hydrates the union of at most
+eight returned hit identities and the already-linked plan identities in one
+Encounter summary batch, then restores exact result order in memory.
+
+## Publication Semantics
+
+The application publishes one immutable workspace value at a time. Each value
+contains the source `SessionRevision`, one monotonically increasing publication
+revision, and the preparation status that applies to that source revision.
+Assembly begins from a captured planner snapshot; foreign results are joined
+only if that capture is still current. Completion from a stale capture is
+discarded and cannot overwrite a newer publication.
+
+Authored intents carry a Session identity and source revision from the JavaFX
+event boundary through the serial authored lane. Generate binds this target
+before asynchronous work begins; preparation loads that exact root, preserves
+it through replacement confirmation, and rechecks it before the final commit.
+Search and preparation are invalidated only when that target matches their active source. A successful
+non-current mutation triggers a catalog reassembly against an authoritative
+Current read and retains the active Session's search and preparation state.
+
+An in-progress or failed preparation updates status around the last stable
+authored workspace. Only a successful final Session Planner commit may publish
+new authored prepared content. JavaFX applies a complete immutable value in one
+dispatch and never combines sections from different revisions.
+
+## Prepare Session Use Case
+
+```text
+JavaFX Generate intent
+  -> SessionPlannerApi.prepareSession(command)
+  -> capture plan revision + generation inputs + preparation identity
+  -> SessionGenerationApi.draft(request)
+  -> EncounterApi.prepareGeneratedBatch(batch)
+  -> validate PreparedSessionDraft
+  -> commit generation run || commit Encounter plan batch
+  -> replace SessionPlan references
+  -> assemble and publish one workspace revision
+```
+
+The two foreign commits may run concurrently after complete in-memory
+validation. Session Planner commits only after both succeed. The preparation
+identity is derived from session identity, source revision, normalized inputs,
+and seed; Session Generation and Encounter retain it with their content
+fingerprints. A planner write failure therefore leaves reusable immutable
+foreign artifacts rather than triggering compensating deletion.
+
+Preparation never uses persistence as message transport. The generated draft
+and concrete Encounter roster drafts remain typed in-memory values until the
+commit stage. Session Generation validates again at its write boundary;
+Encounter validates the full concrete batch before its transaction.
+
+## Responsibility Boundaries
+
+Session Planner owns:
+
+- the user command, replacement confirmation, captured fingerprint, progress,
+  cancellation, orchestration, and final planner mutation
+- planner-owned session and workspace state
+- translating foreign results into planner references
+
+Session Generation owns:
+
+- deterministic encounter intents, reward generation, audits, catalog
+  identity, immutable generation-run persistence, and typed reward reads
+
+Encounter owns:
+
+- one batch creature-candidate snapshot, concrete roster selection, encounter
+  math, saved-plan validation, and atomic idempotent plan persistence
+
+Party and World Planner own their facts. No feature imports another feature's
+implementation package or repository.
+
+## Execution And Cancellation
+
+- the JavaFX dispatcher only captures intents and applies completed immutable
+  snapshots
+- pure generation and Encounter draft construction run on bounded CPU work
+- resource and SQLite work run on I/O execution; database transactions remain
+  short and contain no generation search
+- no global serial lane encloses the whole preparation workflow
+- only the final active-attempt check, current Session identity/revision
+  recheck, synchronized Planner-commit point of no return, and
+  `commitPreparedSession` share the authored FIFO writer lane with ordinary
+  Planner mutations; command assembly and all foreign work remain outside it
+- each request has a cancellation token and captured fingerprint
+- a newer request, session switch, or relevant authored revision cancels or
+  invalidates older work
+- late completion may contribute diagnostics but cannot publish or commit
+  against a stale fingerprint
+- `saving` remains cancellable while the two immutable, idempotent foreign
+  commits finish; cancellation retains those artifacts and skips the Planner
+  write without compensation
+- after both foreign commits and command assembly, the coordinator submits the
+  final task to the authored writer lane; on that lane it first rechecks the
+  active attempt and current Session identity and revision, then enters one
+  synchronized final Planner-commit point of no return immediately before
+  `commitPreparedSession`
+- entering that boundary atomically verifies the attempt is still latest,
+  marks it non-cancellable, and republishes the same attempt and Session as
+  `saving` with cancellation disabled; failure to enter skips the Planner store
+- cancellation after that boundary is a strict no-op and cannot suppress the
+  Planner store's `ready`, `invalid`, or `failed` outcome; newer-attempt and
+  authored invalidation rules remain authoritative
+
+Stage timings record stable request identity, stage, duration, candidate count,
+and query count only. Diagnostics exclude authored text, creature payloads,
+generated item text, SQL, and local paths.
+
+## Compact JavaFX Composition
+
+The accepted master-detail timeline remains. The controls adapter renders one
+horizontal preparation toolbar with progressive disclosure for participant
+detail. Saved-plan search belongs to the selected-scene inspector. The Generate
+button and progress share the toolbar; there is no separate preparation card or
+Apply control. Generated rewards use structured cards, while manual loot notes
+use a separate presentation type.
+
+## Performance Model
+
+The hot path has bounded service calls:
+
+- one Party resolution read
+- one immutable Session Generation catalog snapshot per catalog version
+- one Encounter candidate batch read for all generated intents
+- one generation-run transaction and one Encounter-plan batch transaction
+- one Session Planner replacement transaction
+- one batch workspace assembly after commit
+
+It forbids per-slot creature queries, per-creature detail reads, loading every
+saved Encounter plan to render controls, repeated full Session catalogs during
+one assembly, save-then-reload equality checks, and independent projection
+fan-out.
+
+Measurable architecture targets are:
+
+- Generate dispatch and immutable snapshot application are the only
+  preparation work allowed on the JavaFX thread; in-progress publication is
+  eligible for the next pulse.
+- one workspace assembly performs one planner read and at most one batch read
+  each from Party, Encounter, Session Generation, and World Planner, independent
+  of scene, saved-plan, reward, slot, and roster-member cardinality
+- ordinary workspace assembly never reads the global Encounter saved-plan
+  catalog. Search reads one bounded root statement and publishes at most eight
+  hits; Encounter summary hydration uses a fixed six-statement temp-relation
+  read independent of result and roster cardinality
+- Session Generation reward hydration uses one connection-scoped temporary
+  request relation and five actual statement executions for non-empty batches,
+  independent of 1, 401, or 800 reward references; caller order, duplicates,
+  and missing identities are reconstructed in memory
+- the warmed reference workload is two level-3 and two level-4 participants,
+  `0.6` adventure days, and three encounters over 20 runs; the complete editable
+  publication must satisfy the 2-second p95 product target
+- catalog initialization, migration, and cold caches are measured separately;
+  each CPU, foreign-read, commit, assembly, and JavaFX-apply stage records its
+  own duration and query count
+
+## Durable Decisions And Rejected Alternatives
+
+Chosen decisions:
+
+- `prepareSession` is the sole preparation use case; it validates one complete
+  typed in-memory preparation before durable commits.
+- The master-detail workspace renders one revisioned workspace snapshot.
+- Encounter preparation produces concrete rosters from one batch candidate
+  boundary; abstract slots are not a planner result.
+- Generated reward truth remains in Session Generation and is batch-projected
+  into Session Planner through stable references.
+- Revision guards, idempotent foreign commits, and one final optimistic planner
+  commit provide retry safety without shared storage ownership.
+
+Rejected alternatives:
+
+- backend preview/apply and save/reload workflow transport
+- multiple independently refreshed planner projections
+- copied foreign reward, creature, Party, or World Planner truth
+- a shared cross-feature transaction, workflow database, saga store, or event
+  bus
+- a remote generator service, dynamic rules plugin system, or second generation
+  UI
+
+
+## References
+
+- [Requirements](../requirements/requirements-session-planner.md)
+- [Domain](../domain/domain-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
+- [Session Generation Architecture](../../sessiongeneration/architecture/architecture-session-generation.md)
+- [Encounter Generated Preparation](../../encounter/contract/contract-encounter-generated-import.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/sessionplanner/contract/contract-session-planner-persistence.md
+++ b/docs/sessionplanner/contract/contract-session-planner-persistence.md
@@ -1,0 +1,190 @@
+# Session Planner Persistence Contract
+
+## Owner And Boundary
+
+The Session Planner SQLite adapter is the only writer of planner-owned session
+records. It implements a feature-owned application port and remains private to
+`SessionPlannerFeature`. SQL records, schema carriers, repositories, and
+adapter failures never cross `SessionPlannerApi`.
+
+## Final Prepared-Session Commit Operation
+
+The application port exposes one final replacement operation:
+
+```text
+commitPreparedSession(CommitPreparedSessionCommand)
+  -> CommitPreparedSessionResult
+```
+
+`CommitPreparedSessionCommand` contains:
+
+- target `SessionPlanId` and `expectedRevision`
+- stable preparation identity and normalized prepared-content fingerprint
+- the complete replacement scene order, rests, selection, manual loot notes,
+  and generated reward references
+- already-committed generation-run identity and the complete ordered mapping of
+  generated Encounter numbers to Encounter-plan identities
+
+It contains no foreign domain object, repository carrier, progress state, or
+partially prepared content.
+
+`CommitPreparedSessionResult` is exactly one of:
+
+- `SUCCESS(previousRevision, committedRevision, committedSession)`
+- `INVALID(validationErrors)`
+- `STALE(expectedRevision, currentRevision)`
+- `NOT_FOUND(sessionPlanId)`
+- `STORAGE_FAILURE(displaySafeMessage)`
+
+`SUCCESS` advances the revision exactly once. Every non-success result writes
+nothing. In particular, `STALE` is the optimistic-revision outcome and never
+silently retries against `currentRevision`.
+
+## Stored Truth
+
+The normalized session record stores:
+
+- stable session identity, display name, and revision
+- the current-session pointer
+- session-local participant references
+- exact adventure-day fraction
+- ordered scenes with title, notes, optional World Planner location ID, and
+  optional Encounter-plan ID
+- allocation data for encounter-linked scenes
+- selected scene identity
+- rests between scenes
+- manual loot notes
+- ordered generated reward references with scene ID, typed generation-run ID,
+  treasure ID, and last-known display label
+
+It MUST NOT store party membership or character detail, Encounter rosters,
+creature facts, copied World Planner detail, generated item lines, reward
+values, packing rows, audits, catalog rows, generation drafts, preparation
+fingerprints, or progress state.
+
+Saved-plan query text, request epochs, result identities, overflow state, and
+search failures are runtime publication state and are not persisted. The
+Session Planner store contains only the attached Encounter-plan reference; it
+does not cache or mirror the Encounter saved-plan catalog.
+
+`lastKnownLabel` is a display fallback for an unavailable foreign reward. It is
+not reward truth and MUST NOT replace a successful typed reward projection.
+
+## Reference Rules
+
+- foreign identities are stored as typed stable references, not cross-feature
+  SQLite foreign keys
+- every reward reference names an existing scene in the same session
+- Encounter-channel rewards reference their generated encounter scene
+- quest and environment rewards reference encounter-free scenes
+- a missing foreign object remains visibly unavailable; Session Planner does
+  not recreate it from copied data
+- deleting or editing a scene removes or changes only planner-owned references
+- attaching, replacing, and detaching an Encounter reference preserve generated
+  reward references; only deletion of their owning scene prunes them
+- Session Planner never cascades deletion into Party, Encounter, World Planner,
+  or Session Generation storage
+
+## Writes And Revisions
+
+Every authored command uses optimistic revision validation. A successful write
+replaces the root and affected child collections in one Session Planner
+transaction, advances the revision once, and returns the committed snapshot.
+A stale revision or invalid payload writes nothing.
+
+Every authored command carries one authored target consisting of Session
+identity and expected revision. This includes `PrepareSessionCommand`: it loads
+and validates that exact root before any foreign preparation, preserves the
+target through replacement confirmation, and applies the final compare-and-swap
+only to that target. Reference-bearing commands additionally carry and validate
+their scene, note, participant, rest-gap, or foreign-plan identity. The adapter
+never substitutes the current-session pointer as a read or write target.
+
+Delete is one guarded Session Planner transaction. It deletes only with
+`session_id` plus expected revision, updates the current pointer only when that
+exact current root was deleted, and creates and selects a seeded replacement in
+the same transaction when no Session remains. Stale and missing outcomes write
+nothing. After success the application reads Current authoritatively before it
+publishes.
+
+A catalog switch with a dirty scene draft is one authored-lane operation. It
+prevalidates the target Session, compare-and-swap saves the source draft, then
+switches the pointer and publishes only the target workspace. Any source
+validation or save failure leaves the pointer unchanged. If pointer switching
+fails after the source save, the source edit remains durable and the source
+workspace remains visible with a display-safe failure.
+
+`commitPreparedSession` is one replacement write. It preserves session
+identity, display name, participants, and adventure-day fraction while
+atomically replacing generated scenes, rests, manual loot notes, reward
+references, selection, and revision. The command accepts only already-persisted
+generation-run and Encounter-plan identities returned by their owning APIs.
+
+Before any write, the adapter validates target identity and revision, the
+prepared-content fingerprint, exact decimals, contiguous ordering, positive
+foreign identities, unique scene and reward keys, valid rest gaps,
+scene-local reward references, a complete Encounter-number mapping, and all
+optional reference shapes. Partial child replacement is forbidden.
+
+## Cross-Feature Retry
+
+Session Generation and Encounter commits precede the Session Planner write and
+are idempotent by deterministic origin plus content fingerprint. If the planner
+write fails, their immutable artifacts remain valid foreign truth. Retrying the
+same preparation reuses them; it does not create duplicates or delete them as
+compensation.
+
+This contract deliberately does not create a cross-feature transaction or a
+workflow journal in Session Planner persistence. In-flight preparation state is
+runtime state. A process restart may require the user to request preparation
+again; idempotency makes that retry safe.
+
+## Migration And Compatibility
+
+Compatibility obligations begin with the first released format.
+Before the first released format, the Session Planner owner's only supported schema is the
+current target at owner version 1. One direct initializer creates every current
+table and index, including manual loot notes and generated reward references.
+It never creates, reads, copies, repairs, or drops a loot-placeholder table or
+another development-only predecessor shape.
+
+An empty store initializes transactionally and reaches the exact current target.
+Any pre-existing incomplete or superseded development shape fails closed without
+schema repair, data conversion, destructive cleanup, or owner-version rewrite.
+The exact target includes the complete owner object inventory, column types,
+nullability and defaults, primary and unique constraints, checks, indexes, and
+all Session-Planner-internal cascading relationships. An adjacent retired owner
+object at recorded version 1 is therefore incompatible rather than ignored.
+Initializer or final-signature failure rolls back every table, index, row, and
+owner-version change made by that attempt. Current-format sessions, manual notes,
+and generated reward references remain readable across ordinary restart and the
+platform-owned backup/recovery lifecycle.
+
+After activation, subsequent owner versions become immutable predecessor
+contracts. A future migration must then preserve every supported shape through
+the shared backup, validation, rollback, and recovery boundary; it must not
+rewrite version 1.
+
+Real user data is never deleted or rewritten destructively without the
+owner-approved backup boundary.
+
+## Error Contract
+
+Owner startup readiness validates the exact feature-declared version-1 target
+signature through a separate non-mutating reference schema. It does not repair
+a mismatched structure. Semantic row validation
+remains on typed provider read/write paths and fails closed through the feature
+contract.
+
+Validation errors identify the invalid command field or invariant without
+echoing authored content. Failure messages are display-safe and contain no SQL,
+exception text, paths, generated item payloads, or authored notes. A failure
+leaves the last stable workspace revision visible.
+
+## References
+
+- [Domain](../domain/domain-session-planner.md)
+- [Architecture](../architecture/architecture-session-planner.md)
+- [Shared Persistence Lifecycle](../../project/contract/persistence-lifecycle.md)
+- [Session Generation Contract](../../sessiongeneration/contract/contract-session-generation.md)
+- [Encounter Generated Preparation](../../encounter/contract/contract-encounter-generated-import.md)

--- a/docs/sessionplanner/domain/domain-session-planner.md
+++ b/docs/sessionplanner/domain/domain-session-planner.md
@@ -1,0 +1,118 @@
+# Session Planner Domain Model
+
+## Context Role And Ownership
+
+Context Name: `SessionPlanner`
+
+Context Role: Authored Session Preparation Context
+
+Session Planner owns the editable preparation record for one session. Party,
+Encounter, Creatures, World Planner, and Session Generation retain their own
+truth. Session Planner records stable references to foreign truth without
+copying that truth into its model.
+
+## Published Language
+
+The feature publishes:
+
+- `SessionPlanId`, `SessionSceneId`, and optimistic `SessionRevision`
+- session catalog summaries and authored-session commands
+- `PrepareSessionCommand` and `PreparationStatus`
+- one immutable, revisioned `SessionPlannerWorkspaceSnapshot`
+- one revisioned prepared-scene catalog for Scene consumers
+
+SQL rows, repositories, JavaFX controls, and foreign internal models are not
+part of the published language.
+
+## Write Model
+
+`SessionPlan` is the sole Session Planner write model and aggregate root. It
+owns:
+
+- stable identity, display name, and revision
+- session-local participant references
+- exact encounter-day fraction
+- ordered scenes with title, notes, and optional World Planner location ID
+- optional Encounter plan ID and planner-owned allocation per scene
+- selected scene identity
+- rests between scenes
+- manual loot notes
+- ordered generated reward references consisting of scene ID, generation-run
+  ID, treasure ID, and a last-known display fallback
+
+It does not embed party details, Encounter rosters, creature details, World
+Planner records, generated item lines, packing rows, audits, or engine metadata.
+Preparation work that has not replaced the aggregate is transient derived
+state, never a second write model or authored truth.
+
+## Mutation Language And Invariants
+
+Mutation language covers:
+
+- create, open, rename, or delete a session
+- add or remove a session participant reference
+- add, edit, remove, or reorder a scene
+- attach or detach one saved Encounter plan
+- change one linked-scene allocation
+- set or clear one rest in a scene gap
+- add, update, or remove one authored manual loot note within its owning scene
+- select one scene
+- replace prepared content as one complete authored mutation
+
+Core invariants:
+
+- the current pointer names one existing persisted session
+- a session revision changes for every authored mutation
+- participant references are unique within a session
+- scene identities and order are unique within a session
+- rests exist only between adjacent scenes
+- each scene references at most one Encounter plan and one World Planner
+  location
+- generated reward references name an existing session scene and one positive
+  treasure identity in one non-blank generation run
+- encounter-channel rewards reference their generated Encounter scene; quest
+  and environment rewards reference encounter-free scenes
+- manual loot notes never masquerade as generated reward detail
+- attaching, replacing, or detaching a saved Encounter plan preserves every
+  generated reward reference; deleting a scene alone prunes the manual notes and
+  generated reward references owned by that scene
+- a manual-note identity is session-local and every note mutation identifies
+  both its owning scene and the exact Session revision it was authored from
+- every authored mutation and preparation request, including catalog rename,
+  delete, Generate, and replacement confirmation, carries the exact Session
+  identity and revision visible at intent time; Current is a read and
+  navigation pointer, never an implicit write target
+- incomplete preparation never mutates `SessionPlan`
+- prepared-content replacement applies to the exact session identity and
+  revision it read; concurrent authored edits reject the replacement
+- removing a scene removes its planner-owned reward references without deleting
+  foreign generated runs or saved Encounter plans
+
+## Derived State
+
+Session Planner derives, without creating another write model:
+
+- participant summaries and planning readiness
+- budget, planned XP, remaining or exceeded XP, and rest guidance
+- ordered scene summaries and selected-scene detail
+- linked and attachable Encounter summaries
+- hydrated generated rewards and manual loot-note presentation
+- preparation lifecycle, stage, warnings, and retry availability
+
+All presentation sections for one published view describe the same source
+`SessionRevision`.
+
+## Consistency Boundary
+
+One `SessionPlan` mutation is the Session Planner consistency boundary. Foreign
+generated runs and saved Encounter plans remain immutable truth in their owning
+contexts even when a planner reference is absent or later removed. Session
+Planner never compensates by deleting that foreign truth.
+
+## References
+
+- [Requirements](../requirements/requirements-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
+- [Architecture](../architecture/architecture-session-planner.md)
+- [Encounter Domain](../../encounter/domain/domain-encounter.md)
+- [Session Generation Domain](../../sessiongeneration/domain/domain-session-generation.md)

--- a/docs/sessionplanner/requirements/requirements-session-planner.md
+++ b/docs/sessionplanner/requirements/requirements-session-planner.md
@@ -1,0 +1,185 @@
+# Session Planner Requirements
+
+## Goal
+
+Give a game master one compact workspace for authoring and preparing a session.
+The planner MUST support manual planning and one-click deterministic preparation
+that produces editable scenes with concrete saved encounters and structured
+generated rewards.
+
+## Authored Planning
+
+The user can:
+
+- create, open, rename, and delete persisted session plans
+- add or remove session participants without changing Party membership
+- set the adventure-day fraction used for planning
+- add, edit, remove, and reorder session-owned scenes
+- give a scene a title, notes, and optional World Planner location
+- attach or detach one saved Encounter plan through an action on the selected
+  scene
+- allocate encounter budget per encounter-linked scene
+- see session XP budget, planned XP, remaining or exceeded XP, and recommended
+  rests
+- place short and long rests only between adjacent scenes
+- create, edit, and remove authored manual loot notes without presenting them
+  as generated loot
+- select a scene and edit all planner-owned fields after generation
+
+Scenes exist independently of encounters. Encounter rosters, creature details,
+party members, locations, and generated reward contents remain owned by their
+source features.
+
+Every authored action, including Generate and destructive-replacement
+confirmation, is bound to the Session identity and revision displayed when the
+user triggered it. A delayed, stale, removed, or non-current target is never
+redirected through the current-session pointer. Successful edits of a
+non-current Session refresh catalog truth without replacing, invalidating, or
+publishing over the active Session's search and preparation state.
+
+## Compact Workspace
+
+The Session Planner is one master-detail workspace:
+
+- the main area shows the ordered scene list and the selected scene inspector
+- the controls slot uses one compact preparation toolbar rather than nested
+  cards
+- session selection and session actions, participant summary, adventure-day
+  input, optional encounter count, Generate, progress, and failure status fit
+  in that toolbar
+- participant detail may expand on demand without permanently consuming the
+  controls slot
+- saved Encounter plans are searched and attached from the selected scene;
+  the controls slot does not render the full saved-plan catalog
+- blank and one-character saved-plan queries perform no Encounter read; a
+  qualifying query shows searching, ready-empty, bounded results, overflow, or
+  failure state in that inspector
+- at most eight saved-plan results are visible. Only those result identities
+  and already-linked plan identities may be hydrated with concrete Encounter
+  summaries; the global catalog is never joined into the workspace
+- the state slot shows a compact budget and selection summary
+- generated rewards appear as structured reward cards in their owning scene;
+  manual loot notes remain visually and semantically distinct
+- attaching, replacing, or detaching a saved Encounter changes only that scene's
+  Encounter reference; generated reward references remain until their owning
+  scene is deleted
+- opening another catalog Session atomically saves a dirty selected-scene draft
+  against its displayed Session revision before switching. A stale, removed, or
+  invalid source keeps the old Session and draft visible with an actionable
+  failure; the draft is never copied into the target Session
+- deleting a Session validates its displayed revision and updates deletion,
+  fallback selection, and any required empty-catalog replacement atomically;
+  stale or missing targets write nothing, while deleting a non-current Session
+  preserves the active pointer
+
+The Generate action MUST remain available without exposing a ruleset selector,
+engine version, catalog version, or an intermediate Apply button.
+
+## Session Preparation Flow
+
+1. The user selects a session and requests generation. The request retains that
+   exact Session identity and revision through loading, confirmation, and the
+   final replacement check.
+2. If replacing existing scenes, rests, generated reward references, or manual
+   loot notes would be destructive, the planner asks for explicit confirmation
+   before work starts. An empty session needs no confirmation.
+3. Preparation runs asynchronously. The existing workspace remains usable and
+   shows stage progress while encounters and rewards are prepared.
+4. Success publishes the complete generated session as the current editable
+   planner state without an intermediate preview or second Apply action.
+
+Cancellation remains available through the `saving` stage while the immutable,
+idempotent Session Generation and Encounter commits finish. It prevents the
+final Session Planner replacement but does not delete or compensate those
+foreign artifacts. After the final current-session identity and revision check
+passes and the final Planner commit begins, cancellation is no longer available
+and has no effect. Concurrent cancellation cannot suppress that commit's
+`ready`, `invalid`, or `failed` outcome.
+
+If the selected session or relevant inputs change while preparation is
+running, the older result MUST NOT replace the newer authored state. Invalid
+input, generation failure, encounter resolution failure, or saving failure
+leaves the existing session unchanged and exposes an actionable stage status.
+A retry of the same request MUST NOT create visible duplicate runs, Encounter
+plans, scenes, or rewards.
+
+## Generated Output
+
+Every generated encounter scene MUST reference a real Encounter-owned saved
+plan whose concrete roster contains stable creature identities and quantities.
+The scene shows at least the plan label, difficulty, adjusted XP, creature
+count, and concrete roster summary.
+
+Every generated reward MUST be visible as structured Session Generation truth,
+including its channel and generated item lines with quantities. Value, magic,
+curse, and packing facts are shown when present. Encounter-channel rewards
+attach to their generated encounter scene. Quest and environment rewards use
+encounter-free scenes. A generated reward MUST NOT be projected as a manual
+loot placeholder or reduced to a last-known label while its source is
+available.
+
+Generated scenes and planner-owned metadata are editable after preparation.
+Editing or removing a scene does not mutate or delete the immutable generation
+run or Encounter-owned saved plan.
+
+## Visible Preparation States
+
+- `idle`: no preparation is running
+- `confirming-replacement`: destructive replacement awaits the user's choice
+- `generating`: Session Generation is computing encounters and rewards
+- `resolving-encounters`: concrete Encounter rosters are being prepared
+- `saving`: the complete prepared result is being saved
+- `ready`: the authored session contains the completed result
+- `invalid`: current inputs cannot produce a session
+- `failed`: a stage failed and authored truth is unchanged
+
+The last stable workspace remains visible in every non-ready state.
+
+## Non-Goals
+
+- editing Encounter rosters or creature statblocks inside Session Planner
+- mutating Party membership
+- copying foreign domain internals into Session Planner persistence
+- exposing generation rulesets or catalog versions as user controls
+- a second generation tab or a long-lived preview workflow
+- deriving a gold budget from provisional heuristics
+
+## Performance Acceptance
+
+- Generate shows visible in-progress feedback by the next UI pulse and does not
+  freeze editing, selection, scrolling, or cancellation while work continues.
+- A newer preparation request or relevant session edit remains authoritative;
+  late completion from older work never replaces the visible workspace.
+- A saved-plan search result is published only while its request epoch, source
+  session and revision, and selected scene still match. A newer query, authored
+  intent, successful mutation, session switch, or selected-scene change makes
+  older completion ineligible to publish.
+- On the warmed reference desktop fixture, the canonical input of two level-3
+  and two level-4 participants, `0.6` adventure days, and three encounters MUST
+  publish the completed editable session within 2 seconds at p95 over 20 runs.
+  First-use initialization and schema migration are outside this warmed target.
+
+## Acceptance Criteria
+
+- the Session Planner is a dedicated left-bar tab with the compact
+  master-detail structure above
+- manual planning survives close and reopen
+- linked Encounter plans contribute real adjusted XP; blank scenes contribute
+  none
+- one Generate action produces concrete saved Encounter rosters and structured
+  generated rewards without a second Apply action
+- destructive replacement requires confirmation; failed or stale preparation
+  changes no authored session content
+- retry does not expose duplicate or partial generated content
+- the UI stays responsive and meets the warmed reference-fixture target
+- selected-scene saved-plan search is demand-driven, publishes at most eight
+  results plus overflow, preserves the inspector field while revisions apply,
+  and never reintroduces a full-catalog workspace load
+
+## References
+
+- [Domain](../domain/domain-session-planner.md)
+- [Persistence Contract](../contract/contract-session-planner-persistence.md)
+- [Architecture](../architecture/architecture-session-planner.md)
+- [Session Generation Requirements](../../sessiongeneration/requirements/requirements-session-generation.md)
+- [Encounter Requirements](../../encounter/requirements/requirements-encounter.md)

--- a/docs/travel/README.md
+++ b/docs/travel/README.md
@@ -1,0 +1,19 @@
+# Travel Docs
+
+## Purpose
+
+Travel owns selection and publication of one compact global runtime context for
+the active party. Dungeon and Hex retain their authored truth, movement rules,
+detailed travel workspaces, and feature-specific visible behavior. Party retains
+persisted runtime position.
+
+## Documentation Set
+
+- [Travel Context Domain](domain/domain-travel.md)
+
+## References
+
+- [Hex Feature Docs](../hex/README.md)
+- [Dungeon Feature Docs](../dungeon/README.md)
+- [Party Feature README](../party/README.md)
+- [Global Travel State Requirements](../project/requirements/requirements-travel-state-tab.md)

--- a/docs/travel/domain/domain-travel.md
+++ b/docs/travel/domain/domain-travel.md
@@ -1,0 +1,59 @@
+# Travel Context Domain
+
+## Context Role
+
+Context Role: Active Party Travel Context
+Context Name: Travel
+
+Travel is a read-only orchestration feature. It consumes party-owned runtime
+position and feature-owned Dungeon or Hex travel readback, selects the matching
+context, and publishes one compact global state. It owns no authored map truth,
+party position, route validation, movement command, or persistence.
+
+## Published Language
+
+`TravelContextSnapshot` is immutable and revisioned. It contains:
+
+- context kind: none, Dungeon, or Hex
+- location or map label
+- area or local-context label when available
+- tile or coordinate text
+- heading or equivalent movement orientation when available
+- movement status and concise hint
+- source revision and selected party-position revision
+
+Feature-owned APIs publish typed compact readback; Travel does not parse display
+text from editor state or inspect feature persistence.
+
+## Ownership And Composition
+
+- `features/travel` owns `TravelContextApi`, context selection, and the single
+  global `Reise` shell contribution
+- `features/party` owns active party identity and persisted runtime position
+- `features/dungeon` owns Dungeon movement semantics and compact Dungeon
+  readback
+- `features/hex` owns Hex movement semantics and compact Hex readback
+- `app` injects Party, Dungeon, and Hex APIs into Travel explicitly
+
+Travel has no SQLite adapter. Its current state is rebuilt from injected live
+readbacks and is not restored as separate truth.
+
+## Invariants
+
+- exactly one global travel context is published for one active party-position
+  revision
+- a valid Dungeon position selects Dungeon context; a valid Hex or overworld
+  position selects Hex context; absence or unresolved position selects explicit
+  no-context state
+- active editor selection never chooses the global travel context
+- stale source readback never replaces a newer party-position revision
+- the compact context is read-only and never dispatches movement
+- Dungeon and Hex do not register competing global `travel` contribution keys
+
+## References
+
+- [Travel Docs](../README.md)
+- [Global Travel State Requirements](../../project/requirements/requirements-travel-state-tab.md)
+- [Dungeon Travel State Requirements](../../dungeon/requirements/requirements-dungeon-travel-state.md)
+- [Hex Travel State Requirements](../../hex/requirements/requirements-hex-travel-state.md)
+- [Party Domain](../../party/domain/domain-party.md)

--- a/docs/worldplanner/README.md
+++ b/docs/worldplanner/README.md
@@ -1,0 +1,38 @@
+# World Planner Feature Docs
+
+## Purpose
+
+The `worldplanner` feature owns authored campaign-world planning records for
+NPCs, factions, and locations.
+
+It stores World Planner-owned notes, lifecycle state, relationships, and source
+constraints. It references creature statblocks and encounter tables through
+their owning public boundaries, and exposes location choices for later
+Session Planner-owned integration. It does not own creature statblocks,
+encounter rosters, party truth, combat runtime state, session records, dungeon
+maps, or hex maps.
+
+## Document Set
+
+### Requirements
+
+- [World Planner Requirements](./requirements/requirements-world-planner.md)
+
+### Architecture
+
+- [World Planner Architecture](./architecture/architecture-world-planner.md)
+
+### Contract
+
+- [World Planner Persistence Contract](./contract/contract-world-planner-persistence.md)
+
+### Domain
+
+- [World Planner Domain Model](./domain/domain-world-planner.md)
+
+## References
+
+- [Creatures Feature Overview](../creatures/README.md) (line 1)
+- [Encounter Feature Overview](../encounter/README.md) (line 1)
+- [Encounter Table Feature Overview](../encountertable/README.md) (line 1)
+- [Session Planner Feature Overview](../sessionplanner/README.md) (line 1)

--- a/docs/worldplanner/architecture/architecture-world-planner.md
+++ b/docs/worldplanner/architecture/architecture-world-planner.md
@@ -1,0 +1,60 @@
+# World Planner Architecture
+
+## Entity And Concerns
+
+This specification serves maintainers of World Planner authored state,
+persistence, JavaFX presentation, and Encounter or Session Planner integration.
+It defines ownership and collaboration without prescribing the legacy package
+or runtime-registry form.
+
+World Planner owns authored NPC, faction, location, lifecycle, note, source
+constraint, membership, and inventory-limit truth. It does not own creature
+statblocks, encounter tables, encounter runtime state, party truth, or session
+records.
+
+## Target Topology
+
+```text
+features/worldplanner/api/
+features/worldplanner/domain/
+features/worldplanner/application/
+features/worldplanner/adapter/sqlite/
+features/worldplanner/adapter/javafx/
+features/worldplanner/WorldPlannerFeature
+```
+
+`WorldPlannerFeature` receives `CreaturesApi` and `EncounterTableApi` from the
+application composition and exposes `WorldPlannerApi` plus constructed shell
+contributions.
+
+World Planner does not own shell navigation. Its JavaFX adapter contributes the
+NPC, faction, and location Catalog contents and Inspector editors to the shared
+Catalog shell contribution. The global Encounter state pane remains owned by
+Encounter.
+
+## Boundaries
+
+- `WorldPlannerApi` owns typed commands, results, immutable revisioned state,
+  and location or source-availability queries.
+- Domain code owns World Planner invariants and has no JavaFX, SQL, shell, or
+  foreign-feature dependencies.
+- Application code translates foreign API facts into World Planner values and
+  orchestrates domain and persistence ports.
+- The SQLite adapter persists only World Planner-owned truth and stable foreign
+  references.
+- The JavaFX adapter depends on `WorldPlannerApi`, `shell.api`, and
+  feature-neutral platform UI contracts only.
+- Encounter and Session Planner consume World Planner facts only through
+  `WorldPlannerApi`; candidate combat loss remains an explicit confirmation
+  workflow.
+
+Persistence-backed calls are non-blocking. Successful state publication occurs
+on the UI dispatcher and late results cannot replace a newer revision.
+
+
+## References
+
+- [World Planner Requirements](../requirements/requirements-world-planner.md)
+- [World Planner Domain Model](../domain/domain-world-planner.md)
+- [World Planner Persistence Contract](../contract/contract-world-planner-persistence.md)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/worldplanner/contract/contract-world-planner-persistence.md
+++ b/docs/worldplanner/contract/contract-world-planner-persistence.md
@@ -1,0 +1,106 @@
+# World Planner Persistence Contract
+
+## Purpose
+
+This contract defines the persisted storage boundary for the `worldplanner`
+feature.
+
+World Planner persistence stores only World Planner-authored NPC, faction,
+location, lifecycle, note, link, source-constraint, and inventory-limit truth.
+
+## Adapter Boundary
+
+- The World Planner SQLite adapter satisfies feature-owned application ports
+  and remains private to the World Planner composition entry point.
+- The application composition supplies `WorldPlannerApi` explicitly;
+  registry, discovery, mutable published models, repositories, gateways,
+  mappers, schema classes, and source records are not public boundaries.
+- SQL records and adapter failures MUST NOT cross `WorldPlannerApi`.
+
+## Stored Truth
+
+World Planner persistence stores:
+
+- NPC identity, display name, creature statblock reference, lifecycle status,
+  appearance notes, behavior notes, history notes, general notes, and bounded
+  PC-disposition modifier
+- faction identity, display name, notes, primary encounter-table reference,
+  bounded PC-disposition base, and NPC membership
+- faction statblock inventory limit rows, including whether a statblock is
+  finite or unlimited
+- location identity, display name, notes, linked factions, and linked
+  encounter tables
+
+World Planner persistence does not store:
+
+- creature statblock fields
+- encounter-table membership rows
+- post-combat runtime state or pending loss-confirmation workflows
+- saved encounter-plan rosters
+- party membership or character details
+- combat HP, initiative, turn order, or runtime result state
+- dungeon map or hex map truth
+- Session Planner records, notes, or selected session truth
+
+## Reference Rules
+
+- NPC statblocks are stored as stable creature IDs.
+- Faction and location encounter sources are stored as stable encounter-table
+  IDs.
+- Later Session Planner-owned integration may store location references in
+  Session Planner, not copied location data in World Planner.
+- Foreign truth must be re-read through the owning public boundary when a
+  World Planner projection needs display facts.
+- Missing optional source constraints mean unconstrained.
+- Missing statblock inventory limits mean unlimited.
+- Explicit finite inventory limit `0` means none available for that statblock.
+- NPC membership rows enforce at most one faction for each NPC.
+
+## Validation And Error Behavior
+
+Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
+
+- Writes must reject malformed NPC, faction, location, creature statblock, or
+  encounter-table references.
+- Writes must reject duplicate membership or duplicate link rows instead of
+  silently persisting ambiguous truth.
+- NPC deletion must remove faction membership in the same saved state.
+- Faction deletion must remove location links in the same saved state.
+- Removing a relationship must leave both referenced records intact.
+- Disposition values must remain between `-50` and `+50`.
+- Finite inventory limits must be non-negative.
+- A faction must not persist more than one primary encounter-table reference.
+- Candidate combat losses must not mutate durable NPC lifecycle or faction
+  stock until user confirmation is recorded.
+- Storage and schema failures must surface through World Planner API result
+  statuses instead of leaking SQLite exceptions to consumers.
+- Failed writes must leave the last stable revisioned World Planner API state
+  visible.
+
+## Current Schema Lifecycle
+
+World Planner is a feature-owned persistence surface. It does not migrate
+existing Session Planner, Encounter, EncounterTable, Creatures, Party, Dungeon,
+or Hex tables in the current backend slice.
+
+Compatibility obligations begin with the first released format.
+Before the first released format, owner startup creates the complete current schema
+directly as owner version `1`, only on an empty World Planner namespace, and
+validates its exact table, relationship, constraint, index, and owner-object
+inventory.
+
+Unversioned partial, superseded, structurally damaged, adjacent-owner-object,
+and newer shapes fail closed unchanged. Startup performs no `ALTER`, repair,
+membership normalization, copy, drop, or version claim. Until activation,
+unsupported development databases are discarded and recreated from the current
+product.
+
+Later Session Planner-owned references to World Planner locations belong to the
+Session Planner persistence contract and do not change this owner boundary.
+
+
+## References
+
+- [World Planner Domain Model](../domain/domain-world-planner.md) (line 1)
+- [World Planner Architecture](../architecture/architecture-world-planner.md) (line 1)
+- [Feature Boundary Standard](../../project/architecture/patterns/feature-boundaries.md)

--- a/docs/worldplanner/domain/domain-world-planner.md
+++ b/docs/worldplanner/domain/domain-world-planner.md
@@ -1,0 +1,138 @@
+# World Planner Domain Model
+
+## Context Role
+
+Context Role: Roster Truth Context
+Context Name: WorldPlanner
+
+- `worldplanner` owns authored NPC, faction, and location planning truth.
+- Its public boundary is `WorldPlannerApi`.
+- It reads creature, encounter-table, and Encounter-owned combat/result facts
+  through public boundaries, and exposes location choices for later
+  Session Planner-owned integration.
+- It does not own creature statblocks, encounter-table membership, saved
+  encounter rosters, party membership, combat runtime state, dungeon map truth,
+  or hex map truth.
+
+## Published Language
+
+`WorldPlannerApi` owns command carriers and immutable read state for:
+
+- NPC catalog and detail readback
+- faction catalog, membership, inventory, and encounter-source readback
+- location catalog, faction links, and encounter-table links
+- NPC lifecycle readback and reactivation
+
+Published carriers remain thinner than the internal authored model. They carry
+stable IDs and display data, not copied foreign statblocks or encounter
+rosters.
+
+## Write Model
+
+World Planner has three authored aggregate centers.
+
+`WorldNpc` owns:
+
+- stable NPC identity
+- display name
+- creature statblock reference
+- appearance, behavior, history, and notes
+- lifecycle status: active or defeated
+- optional last known faction/location references
+- a bounded `-50..+50` disposition modifier toward the PCs
+
+`WorldFaction` owns:
+
+- stable faction identity
+- display name and notes
+- one primary encounter-table reference
+- NPC memberships
+- optional finite statblock inventory limits
+- a bounded `-50..+50` base disposition toward the PCs
+
+`WorldLocation` owns:
+
+- stable location identity
+- display name and notes
+- linked faction references
+- location-owned encounter-table references
+
+## Derived State
+
+World Planner derives:
+
+- available NPCs by faction, location, and lifecycle status
+- effective authored encounter-table sources for a faction or location
+- finite and unlimited statblock availability for encounter generation
+
+Derived state is recalculated from World Planner authored state and foreign
+public reads. It is not stored as copied creature, encounter, party, dungeon,
+or hex truth.
+
+Encounter result integration derives confirmed named-NPC losses from
+Encounter-owned combat/result state and writes only durable World Planner NPC
+lifecycle. Later integration waves may derive additional stock-only loss
+candidates and Session Planner-facing location choices from this authored
+state.
+
+## Commands And Invariants
+
+Commands entering the model include:
+
+- create, rename, edit, and delete NPC
+- set NPC statblock reference
+- update NPC notes
+- mark NPC defeated
+- reactivate NPC
+- create, rename, edit, and delete faction
+- set faction primary encounter table
+- add or remove faction NPC membership
+- set or clear faction statblock inventory limit
+- create, rename, edit, and delete location
+- add or remove location faction link
+- add or remove location encounter-table link
+- confirm post-combat losses
+
+Core invariants:
+
+- one NPC belongs to at most one faction
+- effective PC disposition is the clamped faction base plus NPC modifier;
+  `<= -15` is hostile, `>= +15` friendly, and the values between are neutral
+
+- NPC statblock references point to creature-owned statblocks and do not copy
+  creature truth.
+- A named NPC can be active or defeated. Reactivation returns it to active
+  availability.
+- A defeated named NPC is excluded from available NPC and faction stock views.
+- Missing statblock inventory limits mean unlimited.
+- A finite statblock inventory limit is a cap for generated encounter counts.
+- Explicit source constraints intersect candidate sources; unset constraints
+  are unconstrained.
+- Combat runtime may propose losses, but only World Planner confirmation
+  changes durable NPC lifecycle or faction stock state.
+- Session Planner-owned integrations may reference World Planner locations
+  through stable IDs. World Planner does not define Session Planner records.
+
+## Consistency Boundaries
+
+- Creatures owns statblock data. World Planner stores only creature IDs and
+  re-reads creature display facts through the Creatures public boundary.
+- EncounterTable owns authored table membership. World Planner stores only
+  encounter-table IDs and uses table readbacks as source constraints.
+- Encounter owns generation policy, saved encounter-plan roster truth, and
+  combat runtime state. World Planner owns only durable NPC lifecycle and
+  inventory effects confirmed from combat results.
+- Session Planner owns its session-planning records and selected session
+  state. Future location use in those records belongs to the Session Planner
+  owner and may reference World Planner locations through stable IDs.
+- Party, Dungeon, and Hex own their own travel or map concepts. World Planner
+  locations are campaign planning locations unless a later owner document
+  defines an explicit integration.
+
+## References
+
+- [World Planner Requirements](../requirements/requirements-world-planner.md) (line 1)
+- [World Planner Architecture](../architecture/architecture-world-planner.md) (line 1)
+- [World Planner Persistence Contract](../contract/contract-world-planner-persistence.md) (line 1)
+- [Creatures Domain Model](../../creatures/domain/domain-creatures.md) (line 1)
+- [Encounter Domain Model](../../encounter/domain/domain-encounter.md) (line 1)

--- a/docs/worldplanner/requirements/requirements-world-planner.md
+++ b/docs/worldplanner/requirements/requirements-world-planner.md
@@ -1,0 +1,121 @@
+# World Planner Requirements
+
+## Goal
+
+Provide authored campaign-world records through the shared Catalog and
+Inspector surfaces so the user can:
+
+- create and maintain NPCs linked to existing creature statblocks
+- record NPC appearance, behavior, history, and notes
+- organize NPCs into factions
+- define faction encounter-table and optional statblock inventory limits
+- define locations and link them to factions and encounter tables
+- use factions and locations as encounter-generation source constraints
+- add NPCs to combat through the Encounter state tab
+- confirm combat losses manually and reactivate defeated NPCs later
+- expose World Planner location choices for later Session Planner-owned
+  integration
+
+## Non-Goals
+
+- editing creature statblocks or importing creature truth into World Planner
+- editing encounter tables
+- persisting encounter runtime combat state inside World Planner
+- storing party membership, dungeon map truth, or hex map truth
+- replacing saved encounter plans, the Encounter state tab, or the Session
+  Planner session record
+
+## Primary User Flows
+
+1. The user opens the Catalog and selects `NPCs`, `Fraktionen`, or `Orte`.
+2. Selection opens the record's details and existing editing actions in the
+   Inspector.
+3. The user creates NPCs and selects an existing creature statblock for each
+   NPC.
+4. The user records appearance, behavior, history, and notes for NPCs.
+5. The user creates factions, assigns one primary encounter table, and adds any
+   number of NPCs.
+6. The user optionally sets finite faction stock limits per creature
+   statblock. Missing limits mean unlimited stock.
+7. The user creates locations, links factions, and attaches location-owned
+   encounter tables.
+8. The user chooses factions or a location in the Catalog to limit
+   random encounter generation.
+9. The user adds NPCs to combat.
+10. At combat end, the Encounter state tab shows candidate losses and the user
+   confirms which losses should update World Planner state.
+11. Defeated NPCs stop counting as available until the user reactivates them.
+12. Later Session Planner-owned work can read World Planner location choices
+   through a public boundary without World Planner defining session records.
+
+## Source Constraint Behavior
+
+- Unset faction, location, or table filters mean unconstrained for that source
+  dimension.
+- Explicit source constraints combine by intersection of available candidate
+  sources.
+- A location contributes its own encounter tables plus tables reachable through
+  linked factions.
+- A faction contributes its primary encounter table and its NPC or statblock
+  inventory.
+- A finite faction inventory limit caps the generated count for that creature
+  statblock.
+- Missing faction inventory limits are unlimited by default.
+- A generator request that cannot satisfy finite inventory caps must return a
+  clear no-solution state instead of exceeding owned stock.
+
+## Expected Capabilities
+
+- list, create, rename, edit, and delete World Planner NPCs, factions, and
+  locations
+- show NPC details in the shell details/Inspector area
+- select statblocks only from the existing Creatures public boundary
+- add or remove NPCs from factions without mutating creature truth
+- configure faction stock as finite or unlimited per creature statblock
+- configure location-to-faction and location-to-table links
+- remove faction membership and location links without deleting the referenced
+  provider records
+- select factions and locations in encounter-generation controls
+- add an NPC to combat while preserving its World Planner identity
+- show a post-combat loss confirmation before durable NPC or inventory state
+  changes
+- reactivate a defeated named NPC
+- expose location choices through a public boundary for future
+  Session Planner-owned integration
+- store faction disposition and NPC modifiers toward the PCs so runtime scenes
+  can derive friendly, neutral, and hostile Encounter roles
+
+## Acceptance Criteria
+
+- World Planner persists authored NPC, faction, location, lifecycle, notes,
+  links, and inventory-limit truth as its own feature state.
+- the shell exposes no separate World Planner left-bar entry and no World
+  Planner-owned state pane
+- Catalog list selection opens World Planner details and existing editing
+  actions in the Inspector while the global Encounter state remains visible
+- NPCs store creature statblock references, not copied statblock fields.
+- Factions can contain any number of NPCs and one primary encounter table.
+- Faction statblock limits are optional and unlimited by default.
+- Encounter generation cannot generate more finite-stock creatures of a
+  statblock than the selected faction or location source owns.
+- Location-constrained generation uses only encounter tables available through
+  the selected location.
+- Combat does not mutate durable World Planner state until the user confirms
+  the loss summary after combat.
+- Defeated named NPCs are unavailable for generation and selection until
+  reactivated.
+- World Planner exposes location references without storing or defining
+  Session Planner-owned records.
+- an NPC belongs to at most one faction and its effective disposition is the
+  clamped sum of faction base and NPC modifier
+- deleting an NPC removes its faction membership; deleting a faction removes
+  its location links; deleting a location removes only the location
+- Creature statblocks, encounter-table membership, encounter rosters, party
+  members, combat HP, dungeon maps, and hex maps stay in their owning
+  contexts.
+
+## References
+
+- [World Planner Domain Model](../domain/domain-world-planner.md) (line 1)
+- [World Planner Architecture](../architecture/architecture-world-planner.md) (line 1)
+- [World Planner Persistence Contract](../contract/contract-world-planner-persistence.md) (line 1)


### PR DESCRIPTION
Restores only product requirements, domain documentation, contracts, architecture, and repository usage documentation after PR #571 removed them together with governance. Process metadata, workflows, harnesses, tests, tools, agent instructions, and skill references remain deleted. Relative documentation links and whitespace are clean. Product build: ./gradlew build --console=plain (green).