### PR TITLE
fix: make core capability failures typed

### DIFF
--- a/src/core/persistence/sqlite/campaign-store.ts
+++ b/src/core/persistence/sqlite/campaign-store.ts
@@ -6,6 +6,7 @@ import type {
   CampaignSnapshot
 } from '../../../shared/contracts/campaign.js'
 import { uuidv7 } from '../../../shared/ids/uuidv7.js'
+import { freezeCampaignSnapshot } from '../../../shared/contracts/campaign.js'
 
 export type CampaignCreatePhase =
   | 'before-registry-entry'
@@ -57,7 +58,10 @@ export class CampaignStore {
     const active = this.installation
       .prepare("SELECT value FROM settings WHERE key = 'active_campaign_id'")
       .get() as { value: string } | undefined
-    return { campaigns, activeCampaignId: active?.value ?? null }
+    return freezeCampaignSnapshot({
+      campaigns,
+      activeCampaignId: active?.value ?? null
+    })
   }
 
   create(name: string): CampaignSnapshot {

--- a/src/main/application-lifecycle/application.ts
+++ b/src/main/application-lifecycle/application.ts
@@ -11,8 +11,11 @@ import { outputPath } from './runtime-paths.js'
 import { isE2eRuntime } from './e2e-runtime.js'
 import {
   activateCampaignInputSchema,
-  createCampaignInputSchema
+  campaignCapabilityResponseSchema,
+  createCampaignInputSchema,
+  type CampaignSnapshot
 } from '../../shared/contracts/campaign.js'
+import { CapabilityError } from '../../shared/errors/capability-error.js'
 
 let core: CoreProcessClient | undefined
 
@@ -24,18 +27,28 @@ export async function startApplication(): Promise<void> {
     outputPath('main', 'utility.js')
   )
   await core.waitUntilReady()
-  ipcMain.handle('campaign:list', (event) => {
-    authorize(event, false)
-    return requireCore().list()
-  })
-  ipcMain.handle('campaign:create', (event, raw) => {
-    authorize(event, true)
-    return requireCore().create(createCampaignInputSchema.parse(raw).name)
-  })
-  ipcMain.handle('campaign:activate', (event, raw) => {
-    authorize(event, true)
-    return requireCore().activate(activateCampaignInputSchema.parse(raw).id)
-  })
+  ipcMain.handle('campaign:list', (event) =>
+    invokeCapability(() => {
+      authorize(event, false)
+      return requireCore().list()
+    })
+  )
+  ipcMain.handle('campaign:create', (event, raw) =>
+    invokeCapability(() => {
+      authorize(event, true)
+      const input = createCampaignInputSchema.safeParse(raw)
+      if (!input.success) throw new CapabilityError('validation_failed', false)
+      return requireCore().create(input.data.name)
+    })
+  )
+  ipcMain.handle('campaign:activate', (event, raw) =>
+    invokeCapability(() => {
+      authorize(event, true)
+      const input = activateCampaignInputSchema.safeParse(raw)
+      if (!input.success) throw new CapabilityError('validation_failed', false)
+      return requireCore().activate(input.data.id)
+    })
+  )
   createMainWindow()
   if (!isE2eRuntime()) createSecondaryWindow()
   app.on('activate', () => {
@@ -49,15 +62,32 @@ export function stopApplication(): void {
 }
 
 function requireCore(): CoreProcessClient {
-  if (core === undefined) throw new Error('Core process is not started')
+  if (core === undefined) throw new CapabilityError('core_unavailable', true)
   return core
 }
 
 function authorize(event: IpcMainInvokeEvent, requiresWrite: boolean): void {
   const window = BrowserWindow.fromWebContents(event.sender)
   if (window === null || window.isDestroyed())
-    throw new Error('Unauthorized IPC sender')
+    throw new CapabilityError('protocol_violation', false)
   if (requiresWrite && isReadOnlyWindow(event.sender)) {
-    throw new Error('This window cannot write campaign data')
+    throw new CapabilityError('read_only', false)
+  }
+}
+
+async function invokeCapability(
+  operation: () => Promise<CampaignSnapshot>
+): Promise<unknown> {
+  try {
+    return campaignCapabilityResponseSchema.parse({
+      ok: true,
+      snapshot: await operation()
+    })
+  } catch (error) {
+    const failure =
+      error instanceof CapabilityError
+        ? { code: error.code, retryable: error.retryable }
+        : { code: 'internal' as const, retryable: false }
+    return campaignCapabilityResponseSchema.parse({ ok: false, error: failure })
   }
 }

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { utilityProcess, type UtilityProcess } from 'electron'
+import { z } from 'zod'
 import {
   coreReadySchema,
   coreResponseSchema,
+  freezeCampaignSnapshot,
   type CampaignSnapshot,
   type CoreRequest
 } from '../../shared/contracts/campaign.js'
@@ -14,7 +16,10 @@ export class CoreProcessClient {
   #resolveReady: (() => void) | undefined
   #rejectReady: ((error: Error) => void) | undefined
   #closed = false
-  #lastSnapshot: CampaignSnapshot = { activeCampaignId: null, campaigns: [] }
+  #lastSnapshot: CampaignSnapshot = freezeCampaignSnapshot({
+    activeCampaignId: null,
+    campaigns: []
+  })
   readonly #pending = new Map<
     string,
     {
@@ -32,15 +37,15 @@ export class CoreProcessClient {
       this.#rejectReady = reject
     })
     this.#process.on('message', (raw) => this.handleMessage(raw))
-    this.#process.on('exit', (code) => {
-      const error = new CapabilityError(`Core process exited (${code})`)
+    this.#process.on('exit', () => {
+      const error = new CapabilityError('core_unavailable', true)
       if (!this.#closed) console.error(error.message)
       this.fail(error)
     })
   }
 
   public async waitUntilReady(): Promise<void> {
-    await this.withTimeout(this.#ready, 'Core process did not become ready')
+    await this.withTimeout(this.#ready)
   }
 
   public list(): Promise<CampaignSnapshot> {
@@ -59,7 +64,7 @@ export class CoreProcessClient {
   public close(): void {
     if (this.#closed) return
     this.#closed = true
-    this.rejectAll(new CapabilityError('Core process is closing'))
+    this.rejectAll(new CapabilityError('core_unavailable', false))
     this.#process.postMessage({
       kind: 'core.shutdown',
       requestId: randomUUID()
@@ -74,13 +79,12 @@ export class CoreProcessClient {
     return this.withTimeout(
       new Promise((resolve, reject) => {
         if (this.#closed) {
-          reject(new CapabilityError('Core process is closed'))
+          reject(new CapabilityError('core_unavailable', false))
           return
         }
         this.#pending.set(requestId, { resolve, reject })
         this.#process.postMessage({ ...request, requestId })
-      }),
-      `Core request ${request.kind} timed out`
+      })
     )
   }
 
@@ -92,20 +96,32 @@ export class CoreProcessClient {
       return
     }
     const response = coreResponseSchema.safeParse(raw)
-    if (!response.success) return
+    if (!response.success) {
+      const requestId = z.object({ requestId: z.uuid() }).safeParse(raw)
+      if (requestId.success) {
+        const pending = this.#pending.get(requestId.data.requestId)
+        if (pending !== undefined) {
+          this.#pending.delete(requestId.data.requestId)
+          pending.reject(new CapabilityError('protocol_violation', false))
+        }
+      }
+      return
+    }
     const pending = this.#pending.get(response.data.requestId)
     if (pending === undefined) return
     this.#pending.delete(response.data.requestId)
     if (!response.data.ok) {
       pending.reject(
         new CapabilityError(
-          response.data.error ?? 'Core process rejected command'
+          response.data.error.code,
+          response.data.error.retryable
         )
       )
       return
     }
-    this.#lastSnapshot = response.data.snapshot
-    pending.resolve(response.data.snapshot)
+    const snapshot = freezeCampaignSnapshot(response.data.snapshot)
+    this.#lastSnapshot = snapshot
+    pending.resolve(snapshot)
   }
 
   private rejectAll(error: Error): void {
@@ -120,10 +136,10 @@ export class CoreProcessClient {
     this.rejectAll(error)
   }
 
-  private withTimeout<T>(operation: Promise<T>, message: string): Promise<T> {
+  private withTimeout<T>(operation: Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(
-        () => reject(new CapabilityError(message)),
+        () => reject(new CapabilityError('timeout', true)),
         10_000
       )
       operation.then(

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -149,7 +149,11 @@ export class CoreProcessClient {
         },
         (error: unknown) => {
           clearTimeout(timeout)
-          reject(error instanceof Error ? error : new Error(String(error)))
+          reject(
+            error instanceof CapabilityError
+              ? error
+              : new CapabilityError('internal', false)
+          )
         }
       )
     })

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -104,6 +104,11 @@ export class CoreProcessClient {
           this.#pending.delete(requestId.data.requestId)
           pending.reject(new CapabilityError('protocol_violation', false))
         }
+      } else {
+        // An uncorrelatable utility response cannot be retried safely. Reject
+        // every waiter now instead of silently converting a protocol breach
+        // into an unrelated timeout.
+        this.fail(new CapabilityError('protocol_violation', false))
       }
       return
     }

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
 import { utilityProcess, type UtilityProcess } from 'electron'
-import { z } from 'zod'
 import {
   coreReadySchema,
   coreResponseSchema,
@@ -16,10 +15,6 @@ export class CoreProcessClient {
   #resolveReady: (() => void) | undefined
   #rejectReady: ((error: Error) => void) | undefined
   #closed = false
-  #lastSnapshot: CampaignSnapshot = freezeCampaignSnapshot({
-    activeCampaignId: null,
-    campaigns: []
-  })
   readonly #pending = new Map<
     string,
     {
@@ -27,6 +22,7 @@ export class CoreProcessClient {
       reject: (error: Error) => void
     }
   >()
+  readonly #timedOutRequestIds = new Set<string>()
 
   public constructor(dataRoot: string, utilityPath: string) {
     this.#process = utilityProcess.fork(utilityPath, [dataRoot], {
@@ -38,7 +34,7 @@ export class CoreProcessClient {
     })
     this.#process.on('message', (raw) => this.handleMessage(raw))
     this.#process.on('exit', () => {
-      const error = new CapabilityError('core_unavailable', true)
+      const error = new CapabilityError('core_unavailable', false)
       if (!this.#closed) console.error(error.message)
       this.fail(error)
     })
@@ -49,7 +45,6 @@ export class CoreProcessClient {
   }
 
   public list(): Promise<CampaignSnapshot> {
-    if (this.#closed) return Promise.resolve(this.#lastSnapshot)
     return this.request({ kind: 'campaign.list' })
   }
 
@@ -76,16 +71,32 @@ export class CoreProcessClient {
 
   private request(request: CoreRequestWithoutId): Promise<CampaignSnapshot> {
     const requestId = randomUUID()
-    return this.withTimeout(
-      new Promise((resolve, reject) => {
-        if (this.#closed) {
-          reject(new CapabilityError('core_unavailable', false))
-          return
+    return new Promise((resolve, reject) => {
+      if (this.#closed) {
+        reject(new CapabilityError('core_unavailable', false))
+        return
+      }
+      const timeout = setTimeout(() => {
+        if (!this.#pending.delete(requestId)) return
+        this.#timedOutRequestIds.add(requestId)
+        setTimeout(
+          () => this.#timedOutRequestIds.delete(requestId),
+          10_000
+        ).unref()
+        reject(timeoutFor(request.kind))
+      }, 10_000)
+      this.#pending.set(requestId, {
+        resolve: (snapshot) => {
+          clearTimeout(timeout)
+          resolve(snapshot)
+        },
+        reject: (error) => {
+          clearTimeout(timeout)
+          reject(error)
         }
-        this.#pending.set(requestId, { resolve, reject })
-        this.#process.postMessage({ ...request, requestId })
       })
-    )
+      this.#process.postMessage({ ...request, requestId })
+    })
   }
 
   private handleMessage(raw: unknown): void {
@@ -97,23 +108,15 @@ export class CoreProcessClient {
     }
     const response = coreResponseSchema.safeParse(raw)
     if (!response.success) {
-      const requestId = z.object({ requestId: z.uuid() }).safeParse(raw)
-      if (requestId.success) {
-        const pending = this.#pending.get(requestId.data.requestId)
-        if (pending !== undefined) {
-          this.#pending.delete(requestId.data.requestId)
-          pending.reject(new CapabilityError('protocol_violation', false))
-        }
-      } else {
-        // An uncorrelatable utility response cannot be retried safely. Reject
-        // every waiter now instead of silently converting a protocol breach
-        // into an unrelated timeout.
-        this.fail(new CapabilityError('protocol_violation', false))
-      }
+      this.protocolViolation()
       return
     }
     const pending = this.#pending.get(response.data.requestId)
-    if (pending === undefined) return
+    if (pending === undefined) {
+      if (this.#timedOutRequestIds.delete(response.data.requestId)) return
+      this.protocolViolation()
+      return
+    }
     this.#pending.delete(response.data.requestId)
     if (!response.data.ok) {
       pending.reject(
@@ -124,9 +127,7 @@ export class CoreProcessClient {
       )
       return
     }
-    const snapshot = freezeCampaignSnapshot(response.data.snapshot)
-    this.#lastSnapshot = snapshot
-    pending.resolve(snapshot)
+    pending.resolve(freezeCampaignSnapshot(response.data.snapshot))
   }
 
   private rejectAll(error: Error): void {
@@ -135,10 +136,22 @@ export class CoreProcessClient {
   }
 
   private fail(error: Error): void {
+    this.#closed = true
     this.#rejectReady?.(error)
     this.#resolveReady = undefined
     this.#rejectReady = undefined
     this.rejectAll(error)
+  }
+
+  private protocolViolation(): void {
+    if (this.#closed) return
+    this.#closed = true
+    const error = new CapabilityError('protocol_violation', false)
+    this.#rejectReady?.(error)
+    this.#resolveReady = undefined
+    this.#rejectReady = undefined
+    this.rejectAll(error)
+    this.#process.kill()
   }
 
   private withTimeout<T>(operation: Promise<T>): Promise<T> {
@@ -163,6 +176,12 @@ export class CoreProcessClient {
       )
     })
   }
+}
+
+function timeoutFor(kind: CoreRequestWithoutId['kind']): CapabilityError {
+  return kind === 'campaign.create'
+    ? new CapabilityError('outcome_unknown', false)
+    : new CapabilityError('timeout', true)
 }
 
 type CoreRequestWithoutId =

--- a/src/main/core-process/utility.ts
+++ b/src/main/core-process/utility.ts
@@ -1,9 +1,12 @@
 import {
+  capabilityFailureSchema,
   coreReadySchema,
   coreRequestSchema,
+  type CapabilityErrorCode,
   type CampaignSnapshot
 } from '../../shared/contracts/campaign.js'
 import { CampaignStore } from '../../core/persistence/sqlite/campaign-store.js'
+import { z } from 'zod'
 
 const suppliedDataRoot = process.argv[2]
 
@@ -20,6 +23,15 @@ process.parentPort.on('message', (event) => {
   const raw: unknown = event.data
   const parsed = coreRequestSchema.safeParse(raw)
   if (!parsed.success) {
+    const envelope = requestEnvelopeSchema.safeParse(raw)
+    if (envelope.success)
+      respondFailure(
+        envelope.data.requestId,
+        envelope.data.kind.startsWith('campaign.')
+          ? 'validation_failed'
+          : 'protocol_violation',
+        false
+      )
     return
   }
 
@@ -28,6 +40,7 @@ process.parentPort.on('message', (event) => {
       respond(parsed.data.requestId, campaigns.list())
       campaigns.close()
       process.exit(0)
+      return
     }
     if (parsed.data.kind === 'campaign.create') {
       const snapshot = campaigns.create(parsed.data.input.name)
@@ -41,14 +54,32 @@ process.parentPort.on('message', (event) => {
     }
     respond(parsed.data.requestId, campaigns.list())
   } catch (error) {
-    process.parentPort?.postMessage({
-      requestId: parsed.data.requestId,
-      ok: false,
-      error: error instanceof Error ? error.message : 'Utility process failure'
-    })
+    respondFailure(parsed.data.requestId, toCapabilityCode(error), false)
   }
 })
 
 function respond(requestId: string, snapshot: CampaignSnapshot): void {
   process.parentPort?.postMessage({ requestId, ok: true, snapshot })
+}
+
+const requestEnvelopeSchema = capabilityFailureSchema
+  .pick({})
+  .extend({ requestId: z.uuid(), kind: z.string() })
+
+function respondFailure(
+  requestId: string,
+  code: CapabilityErrorCode,
+  retryable: boolean
+): void {
+  process.parentPort?.postMessage({
+    requestId,
+    ok: false,
+    error: capabilityFailureSchema.parse({ code, retryable })
+  })
+}
+
+function toCapabilityCode(error: unknown): CapabilityErrorCode {
+  return error instanceof Error && error.message === 'Campaign not found'
+    ? 'not_found'
+    : 'internal'
 }

--- a/src/preload/capability-bridge/index.ts
+++ b/src/preload/capability-bridge/index.ts
@@ -2,8 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   createCampaignInputSchema,
   activateCampaignInputSchema,
-  campaignSnapshotSchema
+  campaignCapabilityResponseSchema,
+  freezeCampaignSnapshot
 } from '../../shared/contracts/campaign.js'
+import { CapabilityError } from '../../shared/errors/capability-error.js'
 import type {
   CampaignCapability,
   CampaignReadCapability,
@@ -12,28 +14,20 @@ import type {
 
 const readCampaigns: CampaignReadCapability = {
   async list() {
-    return campaignSnapshotSchema.parse(
-      await ipcRenderer.invoke('campaign:list')
-    )
+    return invokeCampaign('campaign:list')
   }
 }
 const campaigns: CampaignCapability = {
   ...readCampaigns,
   async create(name) {
-    return campaignSnapshotSchema.parse(
-      await ipcRenderer.invoke(
-        'campaign:create',
-        createCampaignInputSchema.parse({ name })
-      )
-    )
+    const input = createCampaignInputSchema.safeParse({ name })
+    if (!input.success) throw new CapabilityError('validation_failed', false)
+    return invokeCampaign('campaign:create', input.data)
   },
   async activate(id) {
-    return campaignSnapshotSchema.parse(
-      await ipcRenderer.invoke(
-        'campaign:activate',
-        activateCampaignInputSchema.parse({ id })
-      )
-    )
+    const input = activateCampaignInputSchema.safeParse({ id })
+    if (!input.success) throw new CapabilityError('validation_failed', false)
+    return invokeCampaign('campaign:activate', input.data)
   }
 }
 const api: SaltMarcherApi = {
@@ -47,3 +41,25 @@ const api: SaltMarcherApi = {
 }
 
 contextBridge.exposeInMainWorld('saltMarcher', Object.freeze(api))
+
+async function invokeCampaign(
+  channel: 'campaign:list' | 'campaign:create' | 'campaign:activate',
+  input?: unknown
+) {
+  try {
+    const response = campaignCapabilityResponseSchema.safeParse(
+      await ipcRenderer.invoke(channel, input)
+    )
+    if (!response.success)
+      throw new CapabilityError('protocol_violation', false)
+    if (!response.data.ok)
+      throw new CapabilityError(
+        response.data.error.code,
+        response.data.error.retryable
+      )
+    return freezeCampaignSnapshot(response.data.snapshot)
+  } catch (error) {
+    if (error instanceof CapabilityError) throw error
+    throw new CapabilityError('core_unavailable', true)
+  }
+}

--- a/src/renderer/shell/app.tsx
+++ b/src/renderer/shell/app.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState, type FormEvent, type ReactElement } from 'react'
-import type { CampaignSnapshot } from '../../shared/contracts/campaign.js'
+import {
+  capabilityErrorCodeSchema,
+  type CampaignSnapshot
+} from '../../shared/contracts/campaign.js'
+import { CapabilityError } from '../../shared/errors/capability-error.js'
+import type { CapabilityErrorCode } from '../../shared/contracts/campaign.js'
 import { PixiQualificationView } from '../spatial-2d/pixi-qualification-view.js'
 import { BabylonQualificationView } from '../spatial-3d/babylon-qualification-view.js'
 
@@ -35,6 +40,11 @@ export function App(): ReactElement {
       setName('')
       setError(null)
     } catch (cause) {
+      if (errorCode(cause) === 'outcome_unknown')
+        void window.saltMarcher.campaigns
+          .list()
+          .then(setSnapshot)
+          .catch(setError)
       setError(readError(cause))
     }
   }
@@ -138,9 +148,28 @@ export function App(): ReactElement {
   )
 }
 function readError(cause: unknown): string {
-  return cause instanceof Error
-    ? cause.message
-    : 'The requested operation could not be completed.'
+  const code = errorCode(cause)
+  const messages: Record<CapabilityErrorCode, string> = {
+    validation_failed: 'Die Eingabe ist nicht gültig.',
+    not_found: 'Diese Campaign ist nicht mehr verfügbar.',
+    read_only: 'Dieses Fenster darf Campaigns nicht ändern.',
+    timeout: 'Die Anfrage hat zu lange gedauert. Sie kann wiederholt werden.',
+    outcome_unknown:
+      'Es ist unklar, ob die Campaign erstellt wurde. Die Liste wird neu geladen.',
+    core_unavailable: 'Der lokale Programmkern ist nicht erreichbar.',
+    protocol_violation:
+      'Die interne Verbindung wurde aus Sicherheitsgründen beendet.',
+    internal: 'Die angeforderte Operation konnte nicht abgeschlossen werden.'
+  }
+  return code === undefined
+    ? 'Die angeforderte Operation konnte nicht abgeschlossen werden.'
+    : messages[code]
+}
+
+function errorCode(cause: unknown): CapabilityErrorCode | undefined {
+  if (!(cause instanceof CapabilityError)) return undefined
+  const parsed = capabilityErrorCodeSchema.safeParse(cause.code)
+  return parsed.success ? parsed.data : undefined
 }
 
 function hasCampaignWriteCapability(

--- a/src/shared/contracts/campaign.ts
+++ b/src/shared/contracts/campaign.ts
@@ -1,17 +1,21 @@
 import { z } from 'zod'
 
-export const campaignSchema = z.object({
-  id: z.uuid(),
-  name: z.string().min(1).max(100),
-  createdAt: z.iso.datetime()
-})
+export const campaignSchema = z
+  .object({
+    id: z.uuid(),
+    name: z.string().min(1).max(100),
+    createdAt: z.iso.datetime()
+  })
+  .strict()
 
 export type Campaign = Readonly<z.infer<typeof campaignSchema>>
 
-export const campaignSnapshotSchema = z.object({
-  activeCampaignId: z.uuid().nullable(),
-  campaigns: z.array(campaignSchema)
-})
+export const campaignSnapshotSchema = z
+  .object({
+    activeCampaignId: z.uuid().nullable(),
+    campaigns: z.array(campaignSchema)
+  })
+  .strict()
 
 export type CampaignSnapshot = Readonly<{
   activeCampaignId: string | null
@@ -39,51 +43,63 @@ export const capabilityErrorCodeSchema = z.enum([
   'internal'
 ])
 export type CapabilityErrorCode = z.infer<typeof capabilityErrorCodeSchema>
-export const capabilityFailureSchema = z.object({
-  code: capabilityErrorCodeSchema,
-  retryable: z.boolean()
-})
+export const capabilityFailureSchema = z
+  .object({
+    code: capabilityErrorCodeSchema,
+    retryable: z.boolean()
+  })
+  .strict()
 
 export const campaignCapabilityResponseSchema = z.discriminatedUnion('ok', [
-  z.object({ ok: z.literal(true), snapshot: campaignSnapshotSchema }),
-  z.object({ ok: z.literal(false), error: capabilityFailureSchema })
+  z.object({ ok: z.literal(true), snapshot: campaignSnapshotSchema }).strict(),
+  z.object({ ok: z.literal(false), error: capabilityFailureSchema }).strict()
 ])
 
-export const createCampaignInputSchema = z.object({
-  name: z.string().trim().min(1, 'A name is required').max(100)
-})
+export const createCampaignInputSchema = z
+  .object({ name: z.string().trim().min(1, 'A name is required').max(100) })
+  .strict()
 
-export const activateCampaignInputSchema = z.object({ id: z.uuid() })
+export const activateCampaignInputSchema = z.object({ id: z.uuid() }).strict()
 
 export const coreRequestSchema = z.discriminatedUnion('kind', [
-  z.object({ requestId: z.uuid(), kind: z.literal('campaign.list') }),
-  z.object({ requestId: z.uuid(), kind: z.literal('core.shutdown') }),
-  z.object({
-    requestId: z.uuid(),
-    kind: z.literal('campaign.create'),
-    input: createCampaignInputSchema
-  }),
-  z.object({
-    requestId: z.uuid(),
-    kind: z.literal('campaign.activate'),
-    input: activateCampaignInputSchema
-  })
+  z.object({ requestId: z.uuid(), kind: z.literal('campaign.list') }).strict(),
+  z.object({ requestId: z.uuid(), kind: z.literal('core.shutdown') }).strict(),
+  z
+    .object({
+      requestId: z.uuid(),
+      kind: z.literal('campaign.create'),
+      input: createCampaignInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: z.uuid(),
+      kind: z.literal('campaign.activate'),
+      input: activateCampaignInputSchema
+    })
+    .strict()
 ])
 
 export const coreResponseSchema = z.discriminatedUnion('ok', [
-  z.object({
-    requestId: z.uuid(),
-    ok: z.literal(true),
-    snapshot: campaignSnapshotSchema
-  }),
-  z.object({
-    requestId: z.uuid(),
-    ok: z.literal(false),
-    error: capabilityFailureSchema
-  })
+  z
+    .object({
+      requestId: z.uuid(),
+      ok: z.literal(true),
+      snapshot: campaignSnapshotSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: z.uuid(),
+      ok: z.literal(false),
+      error: capabilityFailureSchema
+    })
+    .strict()
 ])
 
-export const coreReadySchema = z.object({ kind: z.literal('core.ready') })
+export const coreReadySchema = z
+  .object({ kind: z.literal('core.ready') })
+  .strict()
 
 export type CoreRequest = z.infer<typeof coreRequestSchema>
 export type CoreResponse = z.infer<typeof coreResponseSchema>

--- a/src/shared/contracts/campaign.ts
+++ b/src/shared/contracts/campaign.ts
@@ -38,6 +38,7 @@ export const capabilityErrorCodeSchema = z.enum([
   'not_found',
   'read_only',
   'timeout',
+  'outcome_unknown',
   'core_unavailable',
   'protocol_violation',
   'internal'

--- a/src/shared/contracts/campaign.ts
+++ b/src/shared/contracts/campaign.ts
@@ -6,14 +6,48 @@ export const campaignSchema = z.object({
   createdAt: z.iso.datetime()
 })
 
-export type Campaign = z.infer<typeof campaignSchema>
+export type Campaign = Readonly<z.infer<typeof campaignSchema>>
 
 export const campaignSnapshotSchema = z.object({
   activeCampaignId: z.uuid().nullable(),
   campaigns: z.array(campaignSchema)
 })
 
-export type CampaignSnapshot = z.infer<typeof campaignSnapshotSchema>
+export type CampaignSnapshot = Readonly<{
+  activeCampaignId: string | null
+  campaigns: readonly Campaign[]
+}>
+
+export function freezeCampaignSnapshot(
+  snapshot: z.infer<typeof campaignSnapshotSchema>
+): CampaignSnapshot {
+  return Object.freeze({
+    activeCampaignId: snapshot.activeCampaignId,
+    campaigns: Object.freeze(
+      snapshot.campaigns.map((campaign) => Object.freeze({ ...campaign }))
+    )
+  })
+}
+
+export const capabilityErrorCodeSchema = z.enum([
+  'validation_failed',
+  'not_found',
+  'read_only',
+  'timeout',
+  'core_unavailable',
+  'protocol_violation',
+  'internal'
+])
+export type CapabilityErrorCode = z.infer<typeof capabilityErrorCodeSchema>
+export const capabilityFailureSchema = z.object({
+  code: capabilityErrorCodeSchema,
+  retryable: z.boolean()
+})
+
+export const campaignCapabilityResponseSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), snapshot: campaignSnapshotSchema }),
+  z.object({ ok: z.literal(false), error: capabilityFailureSchema })
+])
 
 export const createCampaignInputSchema = z.object({
   name: z.string().trim().min(1, 'A name is required').max(100)
@@ -42,7 +76,11 @@ export const coreResponseSchema = z.discriminatedUnion('ok', [
     ok: z.literal(true),
     snapshot: campaignSnapshotSchema
   }),
-  z.object({ requestId: z.uuid(), ok: z.literal(false), error: z.string() })
+  z.object({
+    requestId: z.uuid(),
+    ok: z.literal(false),
+    error: capabilityFailureSchema
+  })
 ])
 
 export const coreReadySchema = z.object({ kind: z.literal('core.ready') })

--- a/src/shared/errors/capability-error.ts
+++ b/src/shared/errors/capability-error.ts
@@ -1,6 +1,11 @@
+import type { CapabilityErrorCode } from '../contracts/campaign.js'
+
 export class CapabilityError extends Error {
-  public constructor(message: string) {
-    super(message)
+  public constructor(
+    public readonly code: CapabilityErrorCode,
+    public readonly retryable: boolean
+  ) {
+    super(code)
     this.name = 'CapabilityError'
   }
 }

--- a/tests/integration/campaign-store.test.ts
+++ b/tests/integration/campaign-store.test.ts
@@ -12,6 +12,18 @@ afterEach(() => {
 })
 
 describe('CampaignStore', () => {
+  it('returns deeply frozen snapshots', () => {
+    const root = mkdtempSync(join(tmpdir(), 'salt-marcher-campaign-store-'))
+    roots.push(root)
+    const store = new CampaignStore(root)
+    const snapshot = store.create('Frozen Campaign')
+    store.close()
+
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(Object.isFrozen(snapshot.campaigns)).toBe(true)
+    expect(Object.isFrozen(snapshot.campaigns[0])).toBe(true)
+  })
+
   it('reopens the campaign selected after A/B/A walking', () => {
     const root = mkdtempSync(join(tmpdir(), 'salt-marcher-campaign-store-'))
     roots.push(root)

--- a/tests/unit/capability-contract.test.ts
+++ b/tests/unit/capability-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  campaignCapabilityResponseSchema,
+  capabilityFailureSchema,
+  freezeCampaignSnapshot
+} from '../../src/shared/contracts/campaign.js'
+import { CapabilityError } from '../../src/shared/errors/capability-error.js'
+
+describe('capability contract', () => {
+  it('allows only documented typed failures', () => {
+    expect(
+      capabilityFailureSchema.parse({ code: 'not_found', retryable: false })
+    ).toEqual({ code: 'not_found', retryable: false })
+    expect(
+      capabilityFailureSchema.safeParse({ error: 'database unavailable' })
+        .success
+    ).toBe(false)
+  })
+
+  it('carries code and retryability without a technical message', () => {
+    const error = new CapabilityError('timeout', true)
+
+    expect(error.code).toBe('timeout')
+    expect(error.retryable).toBe(true)
+    expect(error.message).toBe('timeout')
+  })
+
+  it('freezes success snapshots at the capability boundary', () => {
+    const snapshot = freezeCampaignSnapshot({
+      activeCampaignId: null,
+      campaigns: [
+        {
+          id: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a031',
+          name: 'Campaign A',
+          createdAt: '2026-07-30T10:00:00.000Z'
+        }
+      ]
+    })
+
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(Object.isFrozen(snapshot.campaigns)).toBe(true)
+    expect(Object.isFrozen(snapshot.campaigns[0])).toBe(true)
+    expect(
+      campaignCapabilityResponseSchema.parse({ ok: true, snapshot })
+    ).toMatchObject({ ok: true })
+  })
+})

--- a/tests/unit/capability-contract.test.ts
+++ b/tests/unit/capability-contract.test.ts
@@ -17,6 +17,23 @@ describe('capability contract', () => {
     ).toBe(false)
   })
 
+  it('rejects unknown fields instead of silently dropping them', () => {
+    expect(
+      campaignCapabilityResponseSchema.safeParse({
+        ok: false,
+        error: { code: 'internal', retryable: false },
+        technicalDetail: 'sqlite error'
+      }).success
+    ).toBe(false)
+    expect(
+      capabilityFailureSchema.safeParse({
+        code: 'internal',
+        retryable: false,
+        message: 'sqlite error'
+      }).success
+    ).toBe(false)
+  })
+
   it('carries code and retryability without a technical message', () => {
     const error = new CapabilityError('timeout', true)
 


### PR DESCRIPTION
## Summary

- replace raw utility/core and IPC error strings with typed capability failures (`code`, `retryable`)
- validate and explicitly reject malformed correlated core messages
- freeze campaign snapshots at persistence, core-client, and preload capability boundaries
- add contract and immutability coverage

## Why

Renderer qualification must not be bundled with the broader capability-contract correctness work. This focused change makes renderer-facing core failures actionable without leaking technical exception text, and ensures returned snapshots cannot be mutated.

## Validation

`pnpm check`