### PR TITLE
test: make RP-H qualification evidence executable

### DIFF
--- a/docs/project/evidence/README.md
+++ b/docs/project/evidence/README.md
@@ -15,6 +15,19 @@ with a derived p95. Then validate the completed artifact:
 pnpm qualify:render:validate docs/project/evidence/<dated-file>.json
 ```
 
+Before the render run, create the structured calibration record with:
+
+```
+pnpm qualify:rp-h --output .tmp/rp-h-calibration.json --power-mode <mode> --dedicated-gpu false --server-class-hardware false --filesystem <name> --storage-device <name> --cache-state <state>
+```
+
+The command records the specified CPU streams, the 64 MiB sequential and 4 KiB
+storage populations, its implementation revision, and a calculated RP-H
+verdict. Copy the complete record into `environment.calibration`; the two
+hardware-class flags require operator confirmation because they cannot be
+determined portably. A failed calibration is valid only in a `status: "fail"`
+render evidence record.
+
 M1 covers one RP-H reference machine at normal display and 200% scaling. The
 M6 cross-platform accessibility matrix owns the broader OS, mixed-DPI, and
 monitor-change coverage.

--- a/docs/project/evidence/m1-render-qualification-template.json
+++ b/docs/project/evidence/m1-render-qualification-template.json
@@ -2,24 +2,23 @@
   "$comment": "Copy this worksheet to a dated file and replace every placeholder. It intentionally fails validation until the complete M1 measurement is recorded.",
   "status": "fail",
   "commit": null,
-  "fixtureVersion": "m1-render-qualification-v2",
+  "fixtureVersion": "m1-render-qualification-v3",
   "packageSha256": null,
   "recordedAt": null,
   "environment": {
     "operatingSystem": null,
     "architecture": null,
     "electronVersion": null,
-    "cpuCalibration": null,
-    "storageMeasurement": null,
+    "calibration": null,
     "powerMode": null,
     "freeSpaceGiB": null,
     "displayWidth": 1366,
     "displayHeight": 768,
-    "renderingBackend": "webgl2",
+    "renderingBackend": null,
     "webglVersion": null,
     "gpuModel": null,
     "gpuDriver": null,
-    "softwareRendering": false
+    "softwareRendering": null
   },
   "populations": {
     "normal": {

--- a/docs/project/evidence/m1-render-qualification.schema.json
+++ b/docs/project/evidence/m1-render-qualification.schema.json
@@ -15,7 +15,7 @@
     },
     "fixtureVersion": {
       "type": "string",
-      "const": "m1-render-qualification-v2"
+      "const": "m1-render-qualification-v3"
     },
     "packageSha256": {
       "type": "string",
@@ -41,13 +41,189 @@
           "type": "string",
           "minLength": 1
         },
-        "cpuCalibration": {
-          "type": "string",
-          "minLength": 1
-        },
-        "storageMeasurement": {
-          "type": "string",
-          "minLength": 1
+        "calibration": {
+          "type": "object",
+          "properties": {
+            "implementationRevision": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "operatingSystem": {
+              "type": "string",
+              "minLength": 1
+            },
+            "architecture": {
+              "type": "string",
+              "minLength": 1
+            },
+            "powerMode": {
+              "type": "string",
+              "minLength": 1
+            },
+            "freeSpaceGiB": {
+              "type": "number",
+              "minimum": 0
+            },
+            "logicalCpuCores": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "memoryAvailableGiB": {
+              "type": "number",
+              "minimum": 0
+            },
+            "dedicatedGpu": {
+              "type": "boolean"
+            },
+            "serverClassHardware": {
+              "type": "boolean"
+            },
+            "cpu": {
+              "type": "object",
+              "properties": {
+                "scheduling": {
+                  "type": "object",
+                  "properties": {
+                    "records": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "elapsedMs": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "sha256": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{64}$"
+                    }
+                  },
+                  "required": [
+                    "records",
+                    "elapsedMs",
+                    "sha256"
+                  ],
+                  "additionalProperties": false
+                },
+                "spatial": {
+                  "type": "object",
+                  "properties": {
+                    "records": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "elapsedMs": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "sha256": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{64}$"
+                    }
+                  },
+                  "required": [
+                    "records",
+                    "elapsedMs",
+                    "sha256"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "scheduling",
+                "spatial"
+              ],
+              "additionalProperties": false
+            },
+            "storage": {
+              "type": "object",
+              "properties": {
+                "filesystem": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "storageDevice": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "cacheState": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "fileBytes": {
+                  "type": "number",
+                  "const": 67108864
+                },
+                "randomAlgorithm": {
+                  "type": "string",
+                  "const": "splitmix64-v1"
+                },
+                "randomSeed": {
+                  "type": "number",
+                  "const": 23072026
+                },
+                "sequentialWriteBytesPerSecond": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "sequentialReadBytesPerSecond": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "durableRandomWriteMs": {
+                  "minItems": 200,
+                  "maxItems": 200,
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                },
+                "randomReadMs": {
+                  "minItems": 1000,
+                  "maxItems": 1000,
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                }
+              },
+              "required": [
+                "filesystem",
+                "storageDevice",
+                "cacheState",
+                "fileBytes",
+                "randomAlgorithm",
+                "randomSeed",
+                "sequentialWriteBytesPerSecond",
+                "sequentialReadBytesPerSecond",
+                "durableRandomWriteMs",
+                "randomReadMs"
+              ],
+              "additionalProperties": false
+            },
+            "passes": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "implementationRevision",
+            "operatingSystem",
+            "architecture",
+            "powerMode",
+            "freeSpaceGiB",
+            "logicalCpuCores",
+            "memoryAvailableGiB",
+            "dedicatedGpu",
+            "serverClassHardware",
+            "cpu",
+            "storage",
+            "passes"
+          ],
+          "additionalProperties": false
         },
         "powerMode": {
           "type": "string",
@@ -67,11 +243,11 @@
         },
         "renderingBackend": {
           "type": "string",
-          "const": "webgl2"
+          "minLength": 1
         },
         "webglVersion": {
           "type": "string",
-          "pattern": "^WebGL 2.*"
+          "minLength": 1
         },
         "gpuModel": {
           "type": "string",
@@ -82,16 +258,14 @@
           "minLength": 1
         },
         "softwareRendering": {
-          "type": "boolean",
-          "const": false
+          "type": "boolean"
         }
       },
       "required": [
         "operatingSystem",
         "architecture",
         "electronVersion",
-        "cpuCalibration",
-        "storageMeasurement",
+        "calibration",
         "powerMode",
         "freeSpaceGiB",
         "displayWidth",
@@ -400,66 +574,76 @@
         "pixi": {
           "type": "object",
           "properties": {
-            "lossRequested": {
-              "type": "boolean",
-              "const": true
+            "requestedCycles": {
+              "type": "integer",
+              "minimum": 20,
+              "maximum": 9007199254740991
             },
-            "lossObserved": {
-              "type": "boolean",
-              "const": true
+            "observedLossCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "restorationObserved": {
-              "type": "boolean",
-              "const": true
+            "restoredCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "rerendered": {
-              "type": "boolean",
-              "const": true
+            "rerenderedCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "nextInteractionSucceeded": {
-              "type": "boolean",
-              "const": true
+            "nextInteractionSucceededCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             }
           },
           "required": [
-            "lossRequested",
-            "lossObserved",
-            "restorationObserved",
-            "rerendered",
-            "nextInteractionSucceeded"
+            "requestedCycles",
+            "observedLossCycles",
+            "restoredCycles",
+            "rerenderedCycles",
+            "nextInteractionSucceededCycles"
           ],
           "additionalProperties": false
         },
         "babylon": {
           "type": "object",
           "properties": {
-            "lossRequested": {
-              "type": "boolean",
-              "const": true
+            "requestedCycles": {
+              "type": "integer",
+              "minimum": 20,
+              "maximum": 9007199254740991
             },
-            "lossObserved": {
-              "type": "boolean",
-              "const": true
+            "observedLossCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "restorationObserved": {
-              "type": "boolean",
-              "const": true
+            "restoredCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "rerendered": {
-              "type": "boolean",
-              "const": true
+            "rerenderedCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             },
-            "nextInteractionSucceeded": {
-              "type": "boolean",
-              "const": true
+            "nextInteractionSucceededCycles": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
             }
           },
           "required": [
-            "lossRequested",
-            "lossObserved",
-            "restorationObserved",
-            "rerendered",
-            "nextInteractionSucceeded"
+            "requestedCycles",
+            "observedLossCycles",
+            "restoredCycles",
+            "rerenderedCycles",
+            "nextInteractionSucceededCycles"
           ],
           "additionalProperties": false
         }
@@ -475,17 +659,17 @@
       "properties": {
         "rendererCycles": {
           "type": "integer",
-          "minimum": 20,
+          "minimum": 0,
           "maximum": 9007199254740991
         },
         "pixiContextLossCycles": {
           "type": "integer",
-          "minimum": 20,
+          "minimum": 0,
           "maximum": 9007199254740991
         },
         "babylonContextLossCycles": {
           "type": "integer",
-          "minimum": 20,
+          "minimum": 0,
           "maximum": 9007199254740991
         },
         "processMemoryBytesBefore": {
@@ -562,12 +746,10 @@
       "type": "object",
       "properties": {
         "keyboardJourneyPassed": {
-          "type": "boolean",
-          "const": true
+          "type": "boolean"
         },
         "textAlternativePassed": {
-          "type": "boolean",
-          "const": true
+          "type": "boolean"
         },
         "screenReader": {
           "type": "object",
@@ -581,8 +763,7 @@
               "minLength": 1
             },
             "journeyPassed": {
-              "type": "boolean",
-              "const": true
+              "type": "boolean"
             }
           },
           "required": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:smoke": "corepack pnpm build && electron out/main/index.js --smoke-test --no-sandbox",
     "test:packaged-smoke": "corepack pnpm package && tsx scripts/packaged-smoke.ts",
     "test:e2e": "corepack pnpm build && wdio run wdio.conf.ts --suite create && wdio run wdio.conf.ts --suite restart",
+    "qualify:rp-h": "tsx scripts/qualify-rp-h.ts",
     "qualify:render:validate": "tsx scripts/validate-render-qualification.ts",
     "qualify:render:artifacts": "tsx scripts/generate-render-qualification-artifacts.ts",
     "qualify:render:artifacts:check": "tsx scripts/check-render-qualification-artifacts.ts",

--- a/scripts/qualify-rp-h.ts
+++ b/scripts/qualify-rp-h.ts
@@ -1,0 +1,234 @@
+import {
+  closeSync,
+  fsyncSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  statfsSync,
+  writeFileSync,
+  writeSync
+} from 'node:fs'
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { arch, availableParallelism, freemem, platform, release } from 'node:os'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { performance } from 'node:perf_hooks'
+import {
+  rpHCalibrationPasses,
+  type RpHCalibration
+} from '../src/shared/qualification/render-evidence.js'
+
+const MEBIBYTE = 1024 * 1024
+const GIBIBYTE = 1024 * MEBIBYTE
+const fileBytes = 64 * MEBIBYTE
+const blockBytes = 4096
+let splitMixState = 23072026n
+
+const args = new Map<string, string>()
+for (let index = 2; index < process.argv.length; index += 2) {
+  const key = process.argv[index]
+  const value = process.argv[index + 1]
+  if (key === undefined || value === undefined || !key.startsWith('--')) usage()
+  args.set(key.slice(2), value)
+}
+const output = args.get('output')
+if (output === undefined) usage()
+
+const calibrationDirectory = mkdtempSync(join(tmpdir(), 'salt-marcher-rp-h-'))
+try {
+  const calibration: Omit<RpHCalibration, 'passes'> = {
+    implementationRevision: createHash('sha256')
+      .update(readFileSync(new URL(import.meta.url)))
+      .digest('hex'),
+    operatingSystem: `${platform()} ${release()}`,
+    architecture: arch(),
+    powerMode: args.get('power-mode') ?? 'unknown',
+    freeSpaceGiB: freeSpaceGiB(calibrationDirectory),
+    logicalCpuCores: availableParallelism(),
+    memoryAvailableGiB: freemem() / GIBIBYTE,
+    dedicatedGpu: booleanArgument('dedicated-gpu'),
+    serverClassHardware: booleanArgument('server-class-hardware'),
+    cpu: {
+      scheduling: cpuProbe('scheduling', 100_000),
+      spatial: cpuProbe('spatial', 2_000_000)
+    },
+    storage: storageProbe(calibrationDirectory)
+  }
+  const evidence = {
+    ...calibration,
+    passes: rpHCalibrationPasses(calibration as RpHCalibration)
+  }
+  writeFileSync(resolve(output), `${JSON.stringify(evidence, null, 2)}\n`)
+  console.log(
+    `RP-H calibration ${evidence.passes ? 'passed' : 'failed'}: ${output}`
+  )
+} finally {
+  rmSync(calibrationDirectory, { recursive: true, force: true })
+}
+
+function usage(): never {
+  console.error(
+    'Usage: pnpm qualify:rp-h --output <calibration.json> [--power-mode <mode>] [--dedicated-gpu true|false] [--server-class-hardware true|false] [--filesystem <name>] [--storage-device <name>] [--cache-state <state>]'
+  )
+  process.exit(1)
+}
+
+function booleanArgument(name: string): boolean {
+  const value = args.get(name)
+  if (value === 'true') return true
+  if (value === 'false') return false
+  // Hardware class cannot be inferred portably. Unknown is deliberately
+  // conservative: it prevents a pass until the operator records the fact.
+  return true
+}
+
+function freeSpaceGiB(path: string): number {
+  const stats = statfsSync(path)
+  return (Number(stats.bavail) * Number(stats.bsize)) / GIBIBYTE
+}
+
+function cpuProbe(
+  kind: 'scheduling' | 'spatial',
+  records: number
+): {
+  records: number
+  elapsedMs: number
+  sha256: string
+} {
+  const started = performance.now()
+  const child = spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', cpuProbeProgram(kind, records)],
+    { encoding: 'utf8' }
+  )
+  if (child.status !== 0) throw new Error(child.stderr || 'CPU probe failed')
+  return {
+    records,
+    elapsedMs: performance.now() - started,
+    sha256: child.stdout.trim()
+  }
+}
+
+function cpuProbeProgram(
+  kind: 'scheduling' | 'spatial',
+  records: number
+): string {
+  const line =
+    kind === 'scheduling'
+      ? '`${index},scene=${index % 10},period=${Math.floor(index / 10)}\\n`'
+      : '`${index},q=${index % 2000},r=${Math.floor(index / 2000)}\\n`'
+  return `import { createHash } from 'node:crypto'; const hash = createHash('sha256'); for (let index = 1; index <= ${records}; index += 1) hash.update(${line}); process.stdout.write(hash.digest('hex'));`
+}
+
+function storageProbe(directory: string): RpHCalibration['storage'] {
+  const path = join(directory, 'storage-calibration.bin')
+  const sequential = deterministicBuffer(fileBytes)
+  const descriptor = openSync(path, 'w+')
+  try {
+    const writeStarted = performance.now()
+    writeAll(descriptor, sequential, 0)
+    fsyncSync(descriptor)
+    const sequentialWriteBytesPerSecond =
+      (fileBytes * 1000) / (performance.now() - writeStarted)
+    const readBuffer = Buffer.allocUnsafe(fileBytes)
+    const readStarted = performance.now()
+    readAll(descriptor, readBuffer, 0)
+    const sequentialReadBytesPerSecond =
+      (fileBytes * 1000) / (performance.now() - readStarted)
+    const offsets = nonOverlappingOffsets(200, fileBytes / blockBytes)
+    const block = deterministicBuffer(blockBytes)
+    const durableRandomWriteMs = offsets.map((offset) => {
+      const started = performance.now()
+      writeAll(descriptor, block, offset * blockBytes)
+      fsyncSync(descriptor)
+      return performance.now() - started
+    })
+    const randomReadMs = Array.from({ length: 1000 }, () => {
+      const started = performance.now()
+      readAll(
+        descriptor,
+        block,
+        Number(nextRandom() % BigInt(fileBytes / blockBytes)) * blockBytes
+      )
+      return performance.now() - started
+    })
+    return {
+      filesystem: args.get('filesystem') ?? 'unknown',
+      storageDevice: args.get('storage-device') ?? 'unknown',
+      cacheState: args.get('cache-state') ?? 'unknown',
+      fileBytes,
+      randomAlgorithm: 'splitmix64-v1',
+      randomSeed: 23072026,
+      sequentialWriteBytesPerSecond,
+      sequentialReadBytesPerSecond,
+      durableRandomWriteMs,
+      randomReadMs
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+function writeAll(descriptor: number, buffer: Buffer, position: number): void {
+  let written = 0
+  while (written < buffer.length) {
+    const count = writeSync(
+      descriptor,
+      buffer,
+      written,
+      buffer.length - written,
+      position + written
+    )
+    if (count === 0)
+      throw new Error('Storage calibration write made no progress')
+    written += count
+  }
+}
+
+function readAll(descriptor: number, buffer: Buffer, position: number): void {
+  let read = 0
+  while (read < buffer.length) {
+    const count = readSync(
+      descriptor,
+      buffer,
+      read,
+      buffer.length - read,
+      position + read
+    )
+    if (count === 0) throw new Error('Storage calibration read ended early')
+    read += count
+  }
+}
+
+function nextRandom(): bigint {
+  splitMixState = BigInt.asUintN(64, splitMixState + 0x9e3779b97f4a7c15n)
+  let value = splitMixState
+  value = BigInt.asUintN(64, (value ^ (value >> 30n)) * 0xbf58476d1ce4e5b9n)
+  value = BigInt.asUintN(64, (value ^ (value >> 27n)) * 0x94d049bb133111ebn)
+  return BigInt.asUintN(64, value ^ (value >> 31n))
+}
+
+function nonOverlappingOffsets(count: number, blocks: number): number[] {
+  const selected = new Set<number>()
+  while (selected.size < count)
+    selected.add(Number(nextRandom() % BigInt(blocks)))
+  return [...selected]
+}
+
+function deterministicBuffer(length: number): Buffer {
+  const digest = createHash('sha256')
+    .update('salt-marcher-rp-h-calibration')
+    .digest()
+  const output = Buffer.allocUnsafe(length)
+  for (let offset = 0; offset < output.length; offset += digest.length)
+    digest.copy(
+      output,
+      offset,
+      0,
+      Math.min(digest.length, output.length - offset)
+    )
+  return output
+}

--- a/src/shared/qualification/render-evidence.ts
+++ b/src/shared/qualification/render-evidence.ts
@@ -21,19 +21,63 @@ const resultsSchema = z
 
 const recoverySchema = z
   .object({
-    lossRequested: z.literal(true),
-    lossObserved: z.literal(true),
-    restorationObserved: z.literal(true),
-    rerendered: z.literal(true),
-    nextInteractionSucceeded: z.literal(true)
+    requestedCycles: z.number().int().min(20),
+    observedLossCycles: z.number().int().nonnegative(),
+    restoredCycles: z.number().int().nonnegative(),
+    rerenderedCycles: z.number().int().nonnegative(),
+    nextInteractionSucceededCycles: z.number().int().nonnegative()
   })
   .strict()
+
+const calibrationRunSchema = z
+  .object({
+    records: z.number().int().positive(),
+    elapsedMs: z.number().finite().nonnegative(),
+    sha256: z.string().regex(/^[0-9a-f]{64}$/)
+  })
+  .strict()
+const rpHCalibrationSchema = z
+  .object({
+    implementationRevision: z.string().regex(/^[0-9a-f]{64}$/),
+    operatingSystem: z.string().min(1),
+    architecture: z.string().min(1),
+    powerMode: z.string().min(1),
+    freeSpaceGiB: z.number().finite().nonnegative(),
+    logicalCpuCores: z.number().int().nonnegative(),
+    memoryAvailableGiB: z.number().finite().nonnegative(),
+    dedicatedGpu: z.boolean(),
+    serverClassHardware: z.boolean(),
+    cpu: z
+      .object({
+        scheduling: calibrationRunSchema,
+        spatial: calibrationRunSchema
+      })
+      .strict(),
+    storage: z
+      .object({
+        filesystem: z.string().min(1),
+        storageDevice: z.string().min(1),
+        cacheState: z.string().min(1),
+        fileBytes: z.literal(64 * 1024 * 1024),
+        randomAlgorithm: z.literal('splitmix64-v1'),
+        randomSeed: z.literal(23072026),
+        sequentialWriteBytesPerSecond: z.number().finite().nonnegative(),
+        sequentialReadBytesPerSecond: z.number().finite().nonnegative(),
+        durableRandomWriteMs: z.array(sampleSchema).length(200),
+        randomReadMs: z.array(sampleSchema).length(1000)
+      })
+      .strict(),
+    passes: z.boolean()
+  })
+  .strict()
+
+export type RpHCalibration = z.infer<typeof rpHCalibrationSchema>
 
 export const renderQualificationEvidenceSchema = z
   .object({
     status: z.enum(['pass', 'fail']),
     commit: z.string().regex(/^[0-9a-f]{40}$/),
-    fixtureVersion: z.literal('m1-render-qualification-v2'),
+    fixtureVersion: z.literal('m1-render-qualification-v3'),
     packageSha256: z.string().regex(/^[0-9a-f]{64}$/),
     recordedAt: z.iso.datetime(),
     environment: z
@@ -41,17 +85,16 @@ export const renderQualificationEvidenceSchema = z
         operatingSystem: z.string().min(1),
         architecture: z.string().min(1),
         electronVersion: z.string().min(1),
-        cpuCalibration: z.string().min(1),
-        storageMeasurement: z.string().min(1),
+        calibration: rpHCalibrationSchema,
         powerMode: z.string().min(1),
         freeSpaceGiB: z.number().finite().nonnegative(),
         displayWidth: z.literal(1366),
         displayHeight: z.literal(768),
-        renderingBackend: z.literal('webgl2'),
-        webglVersion: z.string().startsWith('WebGL 2'),
+        renderingBackend: z.string().min(1),
+        webglVersion: z.string().min(1),
         gpuModel: z.string().min(1),
         gpuDriver: z.string().min(1),
-        softwareRendering: z.literal(false)
+        softwareRendering: z.boolean()
       })
       .strict(),
     populations: z
@@ -62,9 +105,9 @@ export const renderQualificationEvidenceSchema = z
       .strict(),
     resources: z
       .object({
-        rendererCycles: z.number().int().min(20),
-        pixiContextLossCycles: z.number().int().min(20),
-        babylonContextLossCycles: z.number().int().min(20),
+        rendererCycles: z.number().int().nonnegative(),
+        pixiContextLossCycles: z.number().int().nonnegative(),
+        babylonContextLossCycles: z.number().int().nonnegative(),
         processMemoryBytesBefore: z
           .array(z.number().int().nonnegative())
           .min(3),
@@ -82,13 +125,13 @@ export const renderQualificationEvidenceSchema = z
       .strict(),
     accessibility: z
       .object({
-        keyboardJourneyPassed: z.literal(true),
-        textAlternativePassed: z.literal(true),
+        keyboardJourneyPassed: z.boolean(),
+        textAlternativePassed: z.boolean(),
         screenReader: z
           .object({
             reader: z.string().min(1),
             version: z.string().min(1),
-            journeyPassed: z.literal(true)
+            journeyPassed: z.boolean()
           })
           .strict()
       })
@@ -100,10 +143,36 @@ export type RenderQualificationEvidence = z.infer<
   typeof renderQualificationEvidenceSchema
 >
 
+export function rpHCalibrationPasses(calibration: RpHCalibration): boolean {
+  return (
+    calibration.logicalCpuCores >= 4 &&
+    calibration.memoryAvailableGiB >= 8 &&
+    calibration.powerMode !== 'unknown' &&
+    !calibration.dedicatedGpu &&
+    !calibration.serverClassHardware &&
+    calibration.cpu.scheduling.records === 100_000 &&
+    calibration.cpu.scheduling.elapsedMs <= 500 &&
+    calibration.cpu.spatial.records === 2_000_000 &&
+    calibration.cpu.spatial.elapsedMs <= 5_000 &&
+    calibration.storage.filesystem !== 'unknown' &&
+    calibration.storage.storageDevice !== 'unknown' &&
+    calibration.storage.cacheState !== 'unknown' &&
+    calibration.storage.sequentialWriteBytesPerSecond >= 200_000_000 &&
+    calibration.storage.sequentialReadBytesPerSecond >= 200_000_000 &&
+    p95(calibration.storage.randomReadMs) <= 2 &&
+    p95(calibration.storage.durableRandomWriteMs) <= 10
+  )
+}
+
 export function validateRenderQualificationEvidence(
   raw: unknown
 ): RenderQualificationEvidence {
   const evidence = renderQualificationEvidenceSchema.parse(raw)
+  if (
+    evidence.environment.calibration.passes !==
+    rpHCalibrationPasses(evidence.environment.calibration)
+  )
+    throw new Error('RP-H calibration has an incorrect verdict')
   const expectedBudgets = {
     pixiPan: 16,
     babylonCamera: 16,
@@ -122,7 +191,17 @@ export function validateRenderQualificationEvidence(
       if (result.passes !== measuredP95 <= budget)
         throw new Error(`${name} has an incorrect verdict`)
     }
+  const recoveryPasses = Object.values(evidence.contextLoss).every(
+    (recovery) =>
+      recovery.observedLossCycles >= recovery.requestedCycles &&
+      recovery.restoredCycles >= recovery.requestedCycles &&
+      recovery.rerenderedCycles >= recovery.requestedCycles &&
+      recovery.nextInteractionSucceededCycles >= recovery.requestedCycles
+  )
   const resourcesPass =
+    evidence.resources.rendererCycles >= 20 &&
+    evidence.resources.pixiContextLossCycles >= 20 &&
+    evidence.resources.babylonContextLossCycles >= 20 &&
     evidence.resources.listenerCountBefore ===
       evidence.resources.listenerCountAfter &&
     evidence.resources.canvasCountBefore ===
@@ -132,13 +211,26 @@ export function validateRenderQualificationEvidence(
       Math.min(...evidence.resources.processMemoryBytesBefore) * 1.1 &&
     Math.max(...evidence.resources.processMemoryBytesAfterSettling) <
       evidence.resources.rpHMemoryBudgetBytes * 0.75
+  const backendPasses =
+    evidence.environment.renderingBackend === 'webgl2' &&
+    evidence.environment.webglVersion.startsWith('WebGL 2') &&
+    !evidence.environment.softwareRendering
+  const accessibilityPasses =
+    evidence.accessibility.keyboardJourneyPassed &&
+    evidence.accessibility.textAlternativePassed &&
+    evidence.accessibility.screenReader.journeyPassed
   const allPassed =
     Object.values(evidence.populations).every((configuration) =>
       Object.values(configuration).every((population) => population.passes)
-    ) && resourcesPass
+    ) &&
+    rpHCalibrationPasses(evidence.environment.calibration) &&
+    backendPasses &&
+    recoveryPasses &&
+    resourcesPass &&
+    accessibilityPasses
   if ((evidence.status === 'pass') !== allPassed)
     throw new Error(
-      'Top-level status does not match performance, recovery, resource, and accessibility verdicts'
+      'Top-level status does not match calibration, performance, backend, recovery, resource, and accessibility verdicts'
     )
   return evidence
 }
@@ -165,24 +257,23 @@ export function renderQualificationTemplate(): object {
       'Copy this worksheet to a dated file and replace every placeholder. It intentionally fails validation until the complete M1 measurement is recorded.',
     status: 'fail',
     commit: null,
-    fixtureVersion: 'm1-render-qualification-v2',
+    fixtureVersion: 'm1-render-qualification-v3',
     packageSha256: null,
     recordedAt: null,
     environment: {
       operatingSystem: null,
       architecture: null,
       electronVersion: null,
-      cpuCalibration: null,
-      storageMeasurement: null,
+      calibration: null,
       powerMode: null,
       freeSpaceGiB: null,
       displayWidth: 1366,
       displayHeight: 768,
-      renderingBackend: 'webgl2',
+      renderingBackend: null,
       webglVersion: null,
       gpuModel: null,
       gpuDriver: null,
-      softwareRendering: false
+      softwareRendering: null
     },
     populations: {
       normal: pendingConfiguration,
@@ -213,5 +304,5 @@ export function renderQualificationTemplate(): object {
 
 function p95(samples: readonly number[]): number {
   const ordered = [...samples].sort((left, right) => left - right)
-  return ordered[94] ?? 0
+  return ordered[Math.ceil(ordered.length * 0.95) - 1] ?? 0
 }

--- a/tests/unit/render-evidence.test.ts
+++ b/tests/unit/render-evidence.test.ts
@@ -8,7 +8,7 @@ const samples = Array.from({ length: 100 }, () => 1)
 
 function evidence(): RenderQualificationEvidence {
   const result = (budgetMs: number) => ({
-    samples,
+    samples: [...samples],
     p95Ms: 1,
     budgetMs,
     passes: true
@@ -16,15 +16,49 @@ function evidence(): RenderQualificationEvidence {
   return {
     status: 'pass',
     commit: 'a'.repeat(40),
-    fixtureVersion: 'm1-render-qualification-v2',
+    fixtureVersion: 'm1-render-qualification-v3',
     packageSha256: 'b'.repeat(64),
     recordedAt: '2026-07-30T00:00:00.000Z',
     environment: {
       operatingSystem: 'Linux',
       architecture: 'x64',
       electronVersion: '43.2.0',
-      cpuCalibration: 'recorded',
-      storageMeasurement: 'recorded',
+      calibration: {
+        implementationRevision: 'c'.repeat(64),
+        operatingSystem: 'Linux',
+        architecture: 'x64',
+        powerMode: 'balanced',
+        freeSpaceGiB: 100,
+        logicalCpuCores: 4,
+        memoryAvailableGiB: 8,
+        dedicatedGpu: false,
+        serverClassHardware: false,
+        cpu: {
+          scheduling: {
+            records: 100_000,
+            elapsedMs: 500,
+            sha256: 'd'.repeat(64)
+          },
+          spatial: {
+            records: 2_000_000,
+            elapsedMs: 5_000,
+            sha256: 'e'.repeat(64)
+          }
+        },
+        storage: {
+          filesystem: 'ext4',
+          storageDevice: 'test',
+          cacheState: 'warm',
+          fileBytes: 64 * 1024 * 1024,
+          randomAlgorithm: 'splitmix64-v1',
+          randomSeed: 23072026,
+          sequentialWriteBytesPerSecond: 200_000_000,
+          sequentialReadBytesPerSecond: 200_000_000,
+          durableRandomWriteMs: Array.from({ length: 200 }, () => 1),
+          randomReadMs: Array.from({ length: 1000 }, () => 1)
+        },
+        passes: true
+      },
       powerMode: 'balanced',
       freeSpaceGiB: 100,
       displayWidth: 1366,
@@ -50,20 +84,8 @@ function evidence(): RenderQualificationEvidence {
       }
     },
     contextLoss: {
-      pixi: {
-        lossRequested: true,
-        lossObserved: true,
-        restorationObserved: true,
-        rerendered: true,
-        nextInteractionSucceeded: true
-      },
-      babylon: {
-        lossRequested: true,
-        lossObserved: true,
-        restorationObserved: true,
-        rerendered: true,
-        nextInteractionSucceeded: true
-      }
+      pixi: completeRecovery(),
+      babylon: completeRecovery()
     },
     resources: {
       rendererCycles: 20,
@@ -102,4 +124,79 @@ describe('render qualification evidence', () => {
       'incorrect p95'
     )
   })
+
+  it.each([
+    [
+      'RP-H calibration',
+      (record: RenderQualificationEvidence) => {
+        record.environment.calibration.passes = false
+        record.environment.calibration.memoryAvailableGiB = 4
+      }
+    ],
+    [
+      'performance',
+      (record: RenderQualificationEvidence) => {
+        record.populations.normal.pixiPan.samples.splice(
+          94,
+          6,
+          ...Array.from({ length: 6 }, () => 17)
+        )
+        record.populations.normal.pixiPan.p95Ms = 17
+        record.populations.normal.pixiPan.passes = false
+      }
+    ],
+    [
+      'backend',
+      (record: RenderQualificationEvidence) =>
+        (record.environment.renderingBackend = 'webgl')
+    ],
+    [
+      'software rendering',
+      (record: RenderQualificationEvidence) =>
+        (record.environment.softwareRendering = true)
+    ],
+    [
+      'recovery',
+      (record: RenderQualificationEvidence) =>
+        (record.contextLoss.pixi.restoredCycles = 19)
+    ],
+    [
+      'resources',
+      (record: RenderQualificationEvidence) =>
+        (record.resources.meshCountAfter = 2)
+    ],
+    [
+      'keyboard journey',
+      (record: RenderQualificationEvidence) =>
+        (record.accessibility.keyboardJourneyPassed = false)
+    ],
+    [
+      'screenreader journey',
+      (record: RenderQualificationEvidence) =>
+        (record.accessibility.screenReader.journeyPassed = false)
+    ]
+  ])('accepts a complete fail record for %s', (_name, mutate) => {
+    const failed = evidence()
+    mutate(failed)
+    failed.status = 'fail'
+    expect(validateRenderQualificationEvidence(failed).status).toBe('fail')
+  })
+
+  it('rejects a forged RP-H calibration verdict', () => {
+    const forged = evidence()
+    forged.environment.calibration.passes = false
+    expect(() => validateRenderQualificationEvidence(forged)).toThrow(
+      'incorrect verdict'
+    )
+  })
 })
+
+function completeRecovery() {
+  return {
+    requestedCycles: 20,
+    observedLossCycles: 20,
+    restoredCycles: 20,
+    rerenderedCycles: 20,
+    nextInteractionSucceededCycles: 20
+  }
+}


### PR DESCRIPTION
## What changed

Makes the M1 RP-H rendering-evidence preflight executable without claiming a hardware qualification.

- Adds `pnpm qualify:rp-h --output …`, which records structured CPU and storage raw measurements, environment fields, hashes, and a machine-calculated RP-H verdict.
- Extends the evidence contract so each relevant failure class can be captured in a valid `status: "fail"` record: calibration, performance, backend/software rendering, recovery, resources, keyboard, and screen reader.
- Generates the checked-in JSON Schema and worksheet from the Zod contract, with the artifact checker ensuring they stay synchronized.

## Scope

This PR contains only the RP-H/evidence preflight. It includes no real hardware evidence, performance fixes, framework changes, or M2 product work.

## Validation

- `corepack pnpm check`

A passing preflight is not a claim that RP-H hardware qualification has been completed; the recorded packaged-app evidence remains required.