### PR TITLE
feat: add live session encounter workflow

### DIFF
--- a/docs/encounter/contract/contract-encounter-builder-inputs.md
+++ b/docs/encounter/contract/contract-encounter-builder-inputs.md
@@ -32,6 +32,18 @@ filters and Encounter-owned generation tuning.
   pool filters
 - all visible pool filters constrain candidate loading; selected Encounter
   tables are intersected with the filtered creature pool
+- choices within one source dimension form a union; explicitly selected table,
+  faction, and location dimensions intersect by creature ID
+- a location contributes direct tables and the primary tables of linked
+  factions; direct location-table membership is unlimited while faction
+  inventory may cap quantities
+- finite caps intersect by taking the smallest cap; any unlimited contribution
+  makes a unioned dimension unlimited
+- no effective table activates a visible catalog fallback, while an effective
+  but empty/filtered/capped pool returns no solution
+- summed weights rank unioned choices; intersections retain the lowest weight,
+  and deterministic seed selection uses weights only between otherwise
+  comparable balancing options
 - it does not expose saved plans, roster cards, initiative rows, combat
   runtime, or result state
 - it does not expose foreign creature, party, or encounter-table internals

--- a/docs/encounter/requirements/requirements-encounter-state-tab.md
+++ b/docs/encounter/requirements/requirements-encounter-state-tab.md
@@ -1,147 +1,50 @@
 # Encounter Runtime State UI
 
-The Builder mode exposes difficulty, balance, amount, and diversity in an
-`Encounter abstimmen` section. The section is collapsed by default and writes
-only `EncounterTuningSettings`; Catalog pool filters remain unchanged.
-
 ## Component Purpose
 
-The Encounter state tab owns the compact encounter dialog shown in the
-global `COCKPIT_STATE` pane when the active left-bar tab does not provide its
-own state content.
+The global scenario pane is selected through a dropdown. Its current entries
+are `Encounter` and `Reise`; the selector is extensible without exposing fake
+future options. `Reise` renders the feature-neutral read-only Travel state.
 
-The dialog visually mirrors the original Salt-Marcher encounter state-pane
-workflow in one local state-tab surface:
-
-- encounter creation
-- saved encounter open/save
-- initiative entry
-- combat tracking
-- combat result resolution
-- return to encounter creation
-
-The creature catalog browser and encounter filter/tuning controls are separate
-left-bar tab content. They publish add-creature, filter, difficulty intent, and
-generator tuning signals to this dialog through runtime session state.
+Encounter contains no generator or mutable planning roster. It consumes only
+groups already present in the focused runtime Scene.
 
 ## Visible Surfaces
 
-Current state:
+- `Selection` shows the assigned Scene Party, checkboxes for Scene groups, live
+  difficulty output, and the Initiative action.
+- `Initiative` shows one editable row for every participating PC and monster.
+- `Combat` shows round, active turn, HP, AC, initiative, and end confirmation.
+- `Resolution` shows defeated-enemy selection, XP controls, the no-loot notice,
+  one idempotent award action, and return to Selection.
+- `Reise` shows either an approved compact Dungeon/Hex readback or the explicit
+  `Kein aktiver Reisekontext` state. It exposes no movement commands.
 
-- `Creation` shows the original compact encounter roster dialog: title row,
-  difficulty and party summary, difficulty meter, thresholds, adjusted XP,
-  roster cards, saved-plan actions, previous/next alternative controls, and
-  generate/start actions.
-- `Initiative` shows one editable initiative row for each party member and
-  encounter creature.
-- `Combat` shows round status, combat cards, HP bars, AC and initiative badges,
-  next-turn controls, and a two-step end-combat confirmation.
-- `Resolution` shows defeated-enemy selection, XP and loot summaries, reward
-  controls, and the action that returns to encounter planning. Its enemy list
-  is part of the page body, not a nested list window.
+## Interactions And States
 
-The state pane uses centralized encounter selector roles for difficulty labels,
-the difficulty meter, roster cards, role badges, initiative rows, combat card
-states, HP bars, AC/init badges, edit popups, and result highlights. It reads
-active-party thresholds through the Encounter feature boundary and resolves
-creature details through the Creatures feature boundary.
-Encounter pages use the shared dialog-surface primitive so page actions stay in
-the fixed footer while oversized page bodies scroll.
-
-## Interactions
-
-- `Generieren` creates ranked encounter alternatives from the active party and
-  the latest catalog type, subtype, biome, difficulty, amount, balance, and
-  diversity selections. Auto difficulty or Auto tuning values are resolved by
-  the generator for that request and reported in the generation status line.
-  When catalog encounter tables are selected, generation uses those table IDs
-  instead of the type, subtype, and biome candidate source.
-- Previous and next controls sit in the generator action row and switch among
-  the currently generated alternatives.
-- `Speichern` stores the current roster as a saved encounter plan.
-- `Öffnen` shows saved encounter plans from the title row. Selecting one
-  replaces the builder roster, returns to Creation mode, and clears generated
-  alternatives, initiative, combat, and result state.
-- `Verlauf löschen` in the title row clears only transient generator history
-  and
-  generated labels. The current roster stays in Creation mode as a manual
-  encounter.
-- Catalog `+Add` actions append the selected creature to the runtime roster in
-  creation mode and add the selected creature as a reinforcement in active
-  combat.
-- Roster `+`, `-`, and remove controls adjust slot quantity or remove a slot;
-  a single undo action can restore the most recently removed slot.
-- A roster creature name opens the creature details inspector.
-- `Kampf starten` opens initiative entry when the roster has creatures.
-- `Alle würfeln` updates visible initiative spinner values.
-- Confirming initiative opens the combat tracker.
-- Combat internally keeps one entry per individual monster. A combat card may
-  still show a runtime mob projection when at least four alive monsters share
-  the same creature identity and initiative.
-- `Weiter` advances the active combat turn and round display.
-- `SC hinzufügen` opens a compact popup for active party members that are not
-  already in the running combat; each row accepts an initiative value before
-  adding that character to the turn order.
-- HP bars open a compact damage/heal popup.
-- Initiative badges open a compact set-initiative popup.
-- `Kampf beenden` requires a second confirmation before showing results.
-- `XP verteilen` awards the current per-player XP result to the active party.
-- `Zum Planer` closes the combat result screen and returns to encounter
-  planning.
-
-## Visible States
-
-- Empty roster: the creation view mirrors the original `+Add` placeholder and
-  can be populated through catalog `+Add` or `Generieren`.
-- Generated roster: difficulty, thresholds, adjusted XP, generator title, and
-  creature cards are visible.
-- Auto-resolved generation: the generated roster shows the resolved difficulty
-  through the difficulty label and adjusted XP summary.
-- Saved plan available: the title-row open action is enabled and shows the
-  saved plan name, generated label, and creature count.
-- Encounter-table loot conflict: the Catalog controls show `Loot-Konflikt`;
-  combat start remains available because loot assignment is not part of this
-  runtime surface.
-- Removed roster slot: a one-action undo notice is visible until another roster
-  or generator mutation replaces it.
-- Live combat: the active turn is highlighted and defeated monsters use the
-  dead-card style.
-- Combat reinforcement: catalog `+Add` creates a new combat monster without
-  mutating the creation roster, preserves the current active turn highlight,
-  and includes the reinforcement in result XP eligibility.
-- Missing combat party member: the add-SC action is disabled when every active
-  party member is already represented, and adding an SC preserves the current
-  active turn highlight.
-- Runtime mob combat: three or fewer matching monsters stay as individual
-  cards, four to ten matching monsters become one `xN` mob card, and larger
-  matching groups split into mob cards of four to ten members. Mob damage
-  spills into the lowest-HP members first, mob healing restores the lowest-HP
-  alive member, and mob initiative edits apply to every member in that mob
-  card.
-- All enemies defeated: the end-combat button receives accent emphasis.
-- Results awarded: the XP action becomes disabled and the status line confirms
-  the party award.
+- Selecting or deselecting a Scene group recomputes base XP, adjusted XP,
+  creature count, Party thresholds, and difficulty without persistence.
+- Initiative is disabled until at least one assigned active PC and one complete,
+  available Scene group are selected.
+- `Alle würfeln`, initiative editing, Combat turn progression, HP changes,
+  confirmed Combat end, result configuration, and XP award retain their
+  existing behavior.
+- Switching between Encounter and Reise hides only the pane. It never clears
+  Initiative, Combat, or Resolution.
+- With no Scene groups, the pane directs the GM to create or generate a group in
+  the focused Scene.
 
 ## Acceptance Criteria
 
-- when the active left-bar tab does not claim `COCKPIT_STATE`, the global
-  Encounter state tab owns the compact encounter dialog in that pane
-- generation uses the active party plus the latest catalog filter, difficulty,
-  tuning, and encounter-table selections visible to the runtime session
-- opening a saved encounter plan replaces the current creation roster and
-  clears generated-alternative, initiative, combat, and result runtime state
-- the title-row `Verlauf löschen` action removes transient generation history
-  without
-  deleting the current roster
-- catalog `+Add` appends creatures in creation mode and adds reinforcements in
-  active combat without mutating saved encounter-plan persistence implicitly
-- combat start is unavailable until a non-empty roster exists
-- live combat keeps per-member runtime state even when the UI aggregates
-  matching monsters into mob cards for display
-- awarding XP disables the award action for the current result state and keeps
-  the return-to-planner action available
+- the dropdown visibly offers Encounter and Reise
+- Encounter exposes no Generate, tuning, saved-plan, Catalog-add, reinforcement,
+  or roster quantity controls
+- evaluation and Combat preparation reject stale or foreign Scene group IDs
+- active Combat state survives both dropdown switching and application restart
+- Reise remains read-only and reports no context honestly when none exists
 
 ## References
 
 - [Encounter Feature Spec](requirements-encounter.md)
-- [Encounter Domain Model](../domain/domain-encounter.md)
+- [Runtime Scene Requirements](../../scene/requirements/requirements-scene.md)
+- [Travel State UI](../../project/requirements/requirements-travel-state-tab.md)

--- a/docs/encounter/requirements/requirements-encounter.md
+++ b/docs/encounter/requirements/requirements-encounter.md
@@ -2,109 +2,61 @@
 
 ## Goal
 
-Provide a runtime encounter builder that:
+Provide difficulty evaluation, Initiative, Combat, and Resolution for a
+selected subset of groups belonging to the focused runtime Scene. Encounter
+uses only PCs assigned to that Scene and never creates or edits Scene groups.
 
-- uses the active party as the balancing baseline
-- generates several encounter alternatives for one requested or automatically
-  resolved difficulty band
-- explains why an alternative fits the target
-- lets catalog creature rows build a manual encounter roster
-- saves and opens created encounter rosters as persistent encounter plans
-- can use selected encounter tables as curated generator sources
-- resolves one ordered group of Session Generation intents into concrete
-  creature rosters and makes the complete group available as saved plans
+The pure evaluation and generation rules remain Encounter calculation
+capabilities, but the interactive workflow belongs to Scene: Scene supplies its
+assigned Party, optional Location, current group draft, generation mode,
+creature filters, and tuning, then receives one complete transient roster.
+Saving it is a Scene command and does not create Encounter runtime state.
 
 ## Non-Goals
 
-- saving initiative, combat HP, defeated state, XP-result state, or loot-result
-  state as part of an encounter plan
-- room-aware dungeon population
-- owning Session Generation runs, generated rewards, or Session Planner scenes
+- generator, roster editor, saved-plan browser, or Catalog-add action in the
+  Encounter runtime pane
+- copying Scene groups into a second mutable planning roster
+- persisting an unaccepted Scene group proposal
+- owning Party, Scene, Creature, Location, or Travel truth
 
-## Primary User Flow
+## Primary Flow
 
-1. The user opens the encounter state tab when the active left-bar tab is not
-   claiming the state pane.
-2. The state tab reads the active party and current creature filter options.
-3. The user selects Auto or an explicit difficulty and optional type, subtype,
-   biome filters, tuning controls, or encounter tables.
-4. The user generates encounter alternatives or manually adds catalog
-   creatures.
-5. The user switches among generated alternatives with previous/next controls.
-6. The user saves the current roster as an encounter plan, or opens a saved
-   plan into the builder.
-7. The user starts initiative and combat from the current builder roster.
-
-Generated preparation is a separate Session Planner-driven flow:
-
-1. Session Planner requests a complete ordered group of generated encounters.
-2. Encounter resolves every requested encounter into a concrete roster while
-   preserving request order.
-3. Success makes the complete group available as saved plans; failure leaves
-   the previously visible saved-plan set unchanged.
+1. The GM selects `Encounter` in the global scenario dropdown.
+2. Encounter reads the focused Scene, its assigned active PCs, and its groups.
+3. The GM selects one or more Scene groups.
+4. Every selection change publishes Party thresholds, creature count, base XP,
+   adjusted XP, difficulty, and a startability message.
+5. A valid selection is snapshotted into Initiative; Combat then owns its
+   individual runtime HP, initiative, round, turn, and result state.
+6. Resolution may award XP once to the participating Scene Party and returns to
+   group selection without changing Scene groups.
 
 ## Expected Capabilities
 
-- show active-party thresholds for easy, medium, hard, and deadly encounters
-- show daily-budget context from the party feature
-- generate multiple ranked alternatives instead of one opaque result
-- support multi-select creature filters with visible active-filter chips
-- support generator tuning for creature amount, XP-spread balance, and
-  statblock diversity
-- support Auto difficulty and Auto tuning for amount, XP-spread balance, and
-  statblock diversity, with the resolved choices visible in diagnostics
-- return compact generation diagnostics with resolved difficulty, resolved
-  tuning, solution quality, search stop category, candidate-pool size,
-  attempt count, and candidate-evaluation count
-- return best fallback encounter options with an advisory when no exact target
-  difficulty can be generated from the available candidates
-- support encounter-table selection as an alternate generator source
-- support World Planner faction and location source IDs as generator
-  constraints, including table-source intersection and finite stock caps
-- show a non-blocking `Loot-Konflikt` warning when selected encounter tables
-  reference multiple linked loot-table IDs
-- expose creature composition, role hints, and generator highlights
-- allow catalog creature rows to be added directly to the current encounter
-  roster as runtime derived state
-- save the current roster as a persistent encounter plan
-- list saved encounter plans from the encounter title row
-- open a saved encounter plan into Creation mode and clear initiative, combat,
-  result, and generated-alternative runtime state
-- return concrete creature identities, quantities, display names, total count,
-  adjusted XP, and difficulty in every prepared roster summary
-- list and open generated rosters through the same saved-plan interaction as
-  manually saved rosters
+- reject stale Scene revisions and group IDs outside the focused Scene
+- reject unavailable creatures, an empty group selection, or an empty assigned
+  Party before Initiative
+- preserve selected Scene group identities as Combat provenance
+- keep a running Combat unchanged when a source Scene group is later edited
+- reconcile assigned PC changes while retaining initiative, HP, round, and
+  active turn where applicable
+- aggregate matching monsters into the specified runtime mob cards while
+  retaining per-individual HP
+- expose the explicit no-loot state until the Loot owner is available
 
 ## Acceptance Criteria
 
-- saved encounter plans reopen with the same creature identities, quantities,
-  display names, and generated label while showing current creature detail
-- generated alternatives remain derived runtime output until explicitly saved
-- a party with no active members yields a clear empty-state message
-- generator output includes adjusted XP and a difficulty-band label
-- Auto generation exposes the resolved difficulty and tuning through result
-  diagnostics without changing the generated encounter roster ownership model
-- a non-empty candidate pool that cannot produce a composition yields
-  `NO_SOLUTION`; an empty candidate pool remains `NO_CREATURES`
-- previous and next actions switch generated alternatives in place
-- selecting encounter tables limits generated candidates to those tables and
-  ignores type, subtype, and biome filters for that generation run
-- selecting World Planner factions or a World Planner location constrains
-  generation to the source tables available through those sources and prevents
-  generated statblock counts from exceeding finite faction stock caps
-- opening a saved plan replaces the builder roster and returns the state tab to
-  Creation mode
-- generated preparation publishes every concrete roster in request order or
-  publishes none of them
-- invalid, unresolvable, or failed generated preparation leaves the previously
-  visible saved-plan set unchanged
-- retrying an identical completed preparation creates no visible duplicate
-  plans
+- evaluation is read-only and changes immediately with the selected group set
+- adjusted XP uses the selected Scene groups and only assigned active PCs
+- Combat cannot be started from Catalog rows, generator output, saved plans, or
+  foreign Scene groups
+- Initiative, Combat, Resolution, XP-award status, and selected source group IDs
+  survive restart
+- switching the scenario dropdown to `Reise` does not stop a running Encounter
 
 ## References
 
-- [Encounter Runtime State UI](requirements-encounter-state-tab.md) (line 1)
-- [Encounter Domain Model](../domain/domain-encounter.md) (line 1)
-- [Encounter Persistence Contract](../contract/contract-encounter-persistence.md) (line 1)
-- [Encounter Table Feature Spec](../../encountertable/requirements/requirements-encountertable.md) (line 1)
-- [Generated Preparation Contract](../contract/contract-encounter-generated-import.md)
+- [Encounter Runtime State UI](requirements-encounter-state-tab.md)
+- [Encounter Domain Model](../domain/domain-encounter.md)
+- [Runtime Scene Requirements](../../scene/requirements/requirements-scene.md)

--- a/docs/encountertable/contract/contract-encountertable-persistence.md
+++ b/docs/encountertable/contract/contract-encountertable-persistence.md
@@ -16,9 +16,10 @@ This document is normative for the `encountertable` feature's persistence path.
 - The feature-owned persistence schema declaration is the canonical in-code
   schema owner.
 - The schema owns:
-  - `encounter_tables`
-  - `encounter_table_entries`
-  - `encounter_table_loot_links`
+  - `encounter_table`
+  - `encounter_table_entry`
+  - `encounter_table_loot_link`
+  - `encounter_table_metadata`
 
 Creature and loot-table identifiers are logical references. The Encounter
 Table schema MUST use foreign keys only between its own tables; it MUST NOT bind
@@ -30,6 +31,15 @@ startup, deletion, or repair to a Creatures- or Loot-owned table.
   adapter owns feature schema readiness, SQL, and row translation
 - one feature-owned read port separates application orchestration from SQLite
   mechanics
+
+## Write And Delete Responsibilities
+
+- table snapshots carry an optimistic revision; stale mutations fail without
+  changing rows
+- entries use stable creature logical references, unique table membership,
+  ordered positions, and weights from `1..10`
+- deleting a table removes its entries and loot link, removes World Planner
+  location links, and clears matching faction primary references atomically
 
 ## Validation And Error Behavior
 

--- a/docs/encountertable/domain/domain-encountertable.md
+++ b/docs/encountertable/domain/domain-encountertable.md
@@ -6,7 +6,7 @@ Context Role: Reference Catalog Context
 Context Name: EncounterTable
 
 - `encountertable` publishes authored encounter-table membership as a
-  read-only reference catalog for generator candidate pools.
+  campaign-local authored catalog for generator candidate pools.
 - It does not own creature truth or loot truth.
 - It exposes encounter-table summaries and weighted candidate rows through
   `EncounterTableApi`.
@@ -42,8 +42,8 @@ and does not leak adapter exceptions through the API.
 
 Write Model: Encounter Table-owned authored membership rows in SQLite
 
-`EncounterTableApi` exposes no mutation workflow unless observable product
-requirements add one; storage ownership does not imply a public write API.
+`EncounterTableApi` exposes immutable revisioned snapshots plus create, update,
+and delete commands for table metadata and weighted membership.
 
 Derived state:
 
@@ -53,11 +53,12 @@ Derived state:
 
 ## Invariants
 
-- empty table selections produce no table candidates
+- no effective table produces an explicit catalog fallback; an effective empty
+  table produces an empty candidate pool
 - weights are normalized to the supported `1..10` range
 - generation candidates respect the supplied XP ceiling
-- selected table lookup must not additionally apply creature type, subtype, or
-  biome filters
+- the Encounter application layer intersects table membership with every
+  visible creature filter
 
 ## Foreign Boundaries
 

--- a/docs/encountertable/requirements/requirements-encountertable.md
+++ b/docs/encountertable/requirements/requirements-encountertable.md
@@ -2,19 +2,19 @@
 
 ## Goal
 
-Expose authored encounter tables as a read-only candidate source for runtime
-encounter generation.
+Let campaign authors create and maintain weighted encounter tables and use them
+as candidate sources for Scene-group generation.
 
 ## Non-Goals
 
-- editing encounter tables
-- creating encounter-table entries
 - assigning loot tables
 - resolving or rolling loot
 
 ## Expected Capabilities
 
-- load all encounter table summaries for Catalog controls
+- list, create, edit, and delete campaign-local encounter tables
+- edit name, description, and unique weighted creature entries (`1..10`)
+- load all encounter table summaries for Catalog and generator controls
 - expose each table's optional linked loot-table ID
 - load generation candidates for selected table IDs with an XP ceiling
 - carry each candidate's table weight into encounter ranking
@@ -22,12 +22,18 @@ encounter generation.
 
 ## User-Visible Behavior
 
-- selecting no encounter tables means the generator uses the normal monster
-  catalog source and current creature filters
+- table creation and editing reuse the Scene group-management surface: the
+  same filtered creature catalog is shown on the left and the selected or new
+  table draft is shown on the right
+- the Catalog keeps its table overview; selecting or creating a table opens
+  that shared manager
+- a faction may open the same table manager above its own editor; saving a new
+  table returns to the unchanged faction draft and selects the new table
+- selecting no effective encounter tables means the generator visibly falls
+  back to the normal monster catalog source and current creature filters
 - selecting one or more encounter tables means generation uses only creatures
   present in those selected tables
-- type, subtype, and biome filters do not additionally constrain selected
-  encounter-table generation
+- all standard creature filters additionally constrain selected table sources
 - multiple selected tables with different linked loot-table IDs show a
   non-blocking `Loot-Konflikt` warning
 
@@ -35,9 +41,13 @@ encounter generation.
 
 - encounter-table data is exposed only through the Encounter Table feature
   boundary
-- encounter-table generation lookup remains read-only
+- writes are optimistic and revision checked
+- deleting a table removes location links and clears matching faction primary
+  table references and their derived inventory limits in the same database
+  transaction
 - table selection does not create or persist encounter state
-- missing or broken encounter-table storage produces a storage-error result
+- an effective empty table or a table emptied by filters produces a clear
+  no-solution result, not a catalog fallback
 
 ## References
 

--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -95,3 +95,42 @@ M1 cannot yet be accepted until the recorded integrated-GPU qualification and
 accessibility evidence is attached. This is a gate, not a reason to weaken the
 16-ms/50-ms budgets. Store reproducible measurements in
 `docs/project/evidence/`; track current CI state in the relevant pull request.
+
+## Approved vertical slice in progress
+
+The first running-play slice crosses the roadmap labels deliberately without
+claiming completion of M3 or M5. Its approved expansion contains:
+
+- the complete Party roster dropdown, Party membership, progression, rests,
+  and the separate Adventuring Day top-bar calculator
+- the productive Monster section of the common Catalog, backed by a versioned
+  local SRD 5.1 resource; the other Catalog sections remain later slices
+- one focused persistent runtime Scene with explicit PC assignments and named
+  GM creature groups; one two-pane builder combines the shared filtered
+  creature catalog, transient manual editing, live balancing, and fill-or-
+  replace generation before an explicit Scene save
+- a scenario dropdown for Encounter and read-only Reise; Encounter consumes
+  only selected Scene groups and owns difficulty evaluation, Initiative,
+  Combat, and Resolution, with the explicit no-loot state until Loot migrates
+- a persistent four-panel Session surface with one shared column divider and
+  an independent right-side Details/Scenario divider, focused-scene control,
+  scene-local detail history, inline statblocks, and an honest provider-ready
+  map/route-planning shell; Combat is persisted independently per running Scene
+- campaign-local World Planner location and faction CRUD plus authored
+  Encounter Tables in Catalog; locations link factions and tables, factions
+  own disposition, a primary table and optional finite inventory caps, while
+  Scene stores only a stable focused-location reference
+- one shared source resolver supplies both the visible Monster catalog and the
+  Scene-group generator with union-within/intersection-across semantics,
+  weighted deterministic ranking, finite caps, and explicit fallback/no-
+  solution behavior
+- Scene groups and Encounter Tables share one two-pane creature-collection
+  manager component rather than parallel look-alike dialogs; faction stock is
+  edited only from the selected table's creature membership
+
+Encounter-table, faction, and location filter controls appear only when their
+owning providers publish real options. NPC membership, loot links, and stock
+consumption remain later work. The slice uses only secure typed capabilities
+and utility-process-owned feature stores; it does not introduce copied creature
+truth, a Java compatibility layer, or claim that the open M1 qualification
+gate is complete.

--- a/docs/project/architecture/m1-render-qualification.md
+++ b/docs/project/architecture/m1-render-qualification.md
@@ -52,6 +52,17 @@ On the M1 reference machine, record:
    teardown. A non-settled result is a failed resource observation, not a
    value to normalize away.
 
+The packaged application exports these machine observations as a
+versioned `m1-runtime-observation-v1` JSON download. A download made after the
+four complete timing populations contains their raw samples, the selected
+configuration, display/DPR, concrete Pixi and Babylon WebGL version/renderer
+strings, Electron GPU feature status, active driver devices, and the
+software-rendering verdict. A post-resource-run download additionally contains
+the complete resource result and both working-set sample sets. The operator
+must use separate fresh processes and separate downloads for normal and 200%
+display scaling; the only manual M1 record is keyboard/text-alternative and
+screen-reader acceptance.
+
 The CI evidence route is `pnpm check`, `pnpm package`, and on Linux
 `xvfb-run -a pnpm test:e2e`. The E2E journey creates Campaign A, creates
 Campaign B, returns to A, then starts a second Electron process with the same

--- a/docs/project/evidence/README.md
+++ b/docs/project/evidence/README.md
@@ -41,3 +41,31 @@ only a completed `pass` or `fail` artifact is admissible acceptance evidence.
 The schema and worksheet are generated from the executable Zod contract; run
 `pnpm qualify:render:artifacts` after changing it, and
 `pnpm qualify:render:artifacts:check` verifies the checked-in copies.
+
+## Runtime observations from the packaged app
+
+The rendering-qualification screen exports a versioned
+`m1-runtime-observation-v1` JSON file. It is the source for every non-manual
+renderer observation in the final evidence record: the four raw timing
+populations, display dimensions and DPR, both actual WebGL canvas versions and
+unmasked renderers, Chromium GPU feature status and active driver devices,
+software-rendering verdict, cumulative recovery milestones, and the complete
+resource-cycle result including working-set samples.
+
+For each configuration, start a **new app process** from the AppImage. Select
+the matching configuration only after confirming the display setup, perform
+five warm-ups and 100 recorded actions for each population, and download one
+complete runtime observation. Do this once for `normal` and, after changing to
+200% scaling and confirming the effective 1366 × 768 display, once for
+`scale200Percent`; never combine their populations.
+
+In the normal-display process also exercise each context-loss control 20 times,
+perform its indicated follow-up interaction after every restoration, then run
+the 20 renderer build/dispose cycles. Download the observation again after the
+resource run: its `resources` record includes the three working-set samples on
+each side and the concrete canvas, mesh, and listener counts before and after.
+If the process is interrupted, the scaling is wrong, a resource result is not
+settled, or a population is incomplete, discard that affected observation and
+repeat it in a fresh process. The only fields not supplied by observations are
+the keyboard journey, text-alternative journey, and screen-reader name,
+version, and result.

--- a/docs/scene/contract/contract-scene-persistence.md
+++ b/docs/scene/contract/contract-scene-persistence.md
@@ -16,14 +16,16 @@ payloads and lifecycle.
   location ID, and order
 - `scene_party_member`: ordered Party character foreign IDs
 - `scene_npc`: ordered World Planner NPC foreign IDs
-- `scene_mob`: ordered Scene-owned assignments of Creature catalog foreign IDs
-  and their positive group counts; Creature facts remain Creatures-owned
+- `scene_group` and `scene_group_entry`: ordered, named Scene-owned groups of
+  Creature catalog foreign IDs and positive quantities; Creature facts remain
+  Creatures-owned
 - `scene_participant_state`: Scene-owned per-scene defeated state and quick
   notes for an assigned PC, NPC, or mob, keyed by participant kind and the
   corresponding foreign ID; it does not own that participant's source facts
 
-Party details, World Planner details, disposition, creature statblocks, and
-Encounter workflow state MUST NOT be stored in Scene tables.
+Party details, World Planner details, disposition, creature statblocks,
+generator drafts and suggestions, and Encounter workflow state MUST NOT be
+stored in Scene tables.
 
 ## Validation And Errors
 

--- a/docs/scene/domain/domain-scene.md
+++ b/docs/scene/domain/domain-scene.md
@@ -15,9 +15,9 @@ revision, the Standardszene ID, the focused-scene ID, scene identity allocation,
 and the collection of `RunningScene` records.
 
 Each `RunningScene` owns its title, notes, optional Session Planner provenance,
-an optional initial Encounter-plan reference, one optional World Planner
-location reference, ordered PC references, and ordered World Planner NPC
-references. Foreign IDs are references, not copied foreign entities.
+one optional World Planner location reference, ordered PC references, ordered
+World Planner NPC references, and ordered named creature groups. A group owns
+positive quantities of Creature catalog references, never copied statblocks.
 
 ## Invariants
 
@@ -27,6 +27,7 @@ references. Foreign IDs are references, not copied foreign entities.
 - A PC reference can occur in at most one running scene.
 - An NPC reference can occur in at most one running scene.
 - A running scene has zero or one location and any number of NPC references.
+- A running scene may have any number of named, non-empty creature groups.
 - Multiple running scenes may reference the same location.
 - Every prepared-scene import creates a new independent copy with provenance;
   importing the same prepared source again is valid and creates another copy.
@@ -53,6 +54,14 @@ IDs and foreign IDs after the Scene save. The persisted synchronization marker
 is derived operational state and does not transfer Encounter ownership.
 Foreign names, levels, lifecycle, and disposition are re-read from their owning
 features. Refresh removes Party IDs that are no longer active.
+
+Group editing and generation form one transient Scene application workflow. It
+supplies the current draft plus Scene context to the pure Encounter evaluation
+and generation rules and publishes one immutable full-roster result. Fill
+generation treats existing draft entries as fixed input; replacement generation
+starts from an empty roster. Only explicit save creates or updates Scene-owned
+group truth; filters, tuning, diagnostics, and an unaccepted draft are not
+persisted.
 
 ## References
 

--- a/docs/scene/requirements/requirements-scene.md
+++ b/docs/scene/requirements/requirements-scene.md
@@ -23,8 +23,10 @@ owners of the referenced content.
 3. PCs are moved between scenes; one PC can be in at most one running scene.
 4. The GM selects one World Planner location and any number of World Planner
    NPCs for the focused scene.
-5. Switching scenes immediately switches the visible Encounter session.
-6. Every scene and Encounter session is restored after an application restart.
+5. The GM creates or edits named creature groups in one catalog-backed builder
+   and may manually compose, fill, or replace its transient roster.
+6. Switching scenes immediately switches the visible Encounter session.
+7. Every persisted scene and Encounter session is restored after restart.
 
 Each prepared-scene import creates a new copy of title, notes, location,
 participant references, linked saved Encounter plan, and source provenance.
@@ -44,6 +46,14 @@ copy.
 - Friendly NPCs enter the scene Encounter as allies, hostile NPCs as enemies,
   and neutral NPCs remain visible context without joining combat.
 - The scene location automatically constrains later Encounter generation.
+- `Gruppen managen` combines the filtered Creature catalog with one transient
+  group draft. Manual changes and generation are evaluated immediately against
+  the assigned Party.
+- `Auffüllen` preserves the current roster as its generation basis, while `Neu
+  generieren` replaces it. Both use optional location, catalog filters, tuning,
+  and a deterministic seed. An unsaved result is discarded only after
+  confirmation and never survives restart.
+- Encounter may select only persisted groups from the focused Scene.
 - PC and NPC changes during initiative or combat reconcile immediately while
   retaining existing initiative, HP, round, and active turn where applicable.
 - A failed Encounter synchronization is visible as pending. The saved Scene
@@ -63,8 +73,8 @@ copy.
 - A failed post-save Encounter synchronization leaves the persisted Scene
   revision marked unsynchronized, and a later initialization or refresh can
   mark that revision synchronized.
-- A restart restores focus, scene contents, generated alternatives, initiative,
-  combatants, HP, round, turn, result, and XP-award status.
+- A restart restores focus, scene contents, initiative, combatants, HP, round,
+  turn, result, and XP-award status, but not an unaccepted group proposal.
 - The Scene tab leaves the global Encounter state pane visible.
 
 ## References

--- a/docs/session/README.md
+++ b/docs/session/README.md
@@ -1,0 +1,11 @@
+# Live Session Feature
+
+The Live Session workspace is the campaign's running-play surface. It keeps the
+Party, GM-authored creature groups, and the active scenario visible in one
+workspace. It is distinct from authored Session Planner records.
+
+- [Requirements](requirements/requirements-live-session.md)
+- [Domain](domain/domain-live-session.md)
+- [Persistence](contract/contract-live-session-persistence.md)
+- [Party](../party/README.md)
+- [Encounter](../encounter/README.md)

--- a/docs/session/contract/contract-live-session-persistence.md
+++ b/docs/session/contract/contract-live-session-persistence.md
@@ -1,0 +1,29 @@
+# Live Session Persistence
+
+The utility process alone opens campaign SQLite. Feature-owned adapters own
+their SQL and prepared statements.
+
+Live Session stores metadata, group headers, and group entries. Party stores
+the seeded Roster, membership, XP, and applied Combat award identities.
+Encounter stores one Zod-validated Combat memento per Scene identity. Focusing
+another Scene changes the projected Combat but never clears or overwrites the
+previous Scene's memento.
+
+The stored Combat memento includes phase, source groups, initiative sources,
+individual combatants, card membership, current HP, turn order, active turn,
+round, Resolution selection, sliders, and award status. Readback validates the
+complete memento before publication.
+
+An XP award first records the Combat identity in Party's idempotency set. A
+retry with the same identity changes no XP. Session and Encounter never write
+Party rows directly.
+
+Before the first released data format, feature initializers create the current
+schema directly. They do not introduce a generic ORM or expose SQLite carriers
+through public contracts.
+
+The shared column width, right-side Details/Scenario divider, and Details/Karte
+tab are validated shell preferences stored by Electron main below `userData`.
+Renderer code accesses them only through the restricted preload capability and
+never reads files or browser storage directly. Retired topology preferences
+retain their former column width and right-side divider when first read.

--- a/docs/session/domain/domain-live-session.md
+++ b/docs/session/domain/domain-live-session.md
@@ -1,0 +1,31 @@
+# Live Session Domain
+
+## Ownership
+
+`LiveSession` projects the focused Scene into one four-panel running-play
+workspace. Scene owns focus and ordered, named creature groups; Live Session
+owns neither Party membership nor creature facts.
+
+Party publishes the current Roster, membership, and XP through `PartyApi`.
+Creatures publishes current statblocks. Encounter owns the active Combat
+memento, including Initiative, individual combatants, HP, turn, round, and
+Resolution state.
+
+## Invariants
+
+- group identity and order remain stable
+- a group has a non-blank name and at least one positive creature quantity
+- group entries contain references only; current display and Combat facts are
+  resolved through Creatures
+- a Combat is keyed by Scene identity and captures its selected group
+  identities and runtime combat profiles
+- Resolution awards XP to the current active Party through an idempotent Combat
+  identity
+- finishing Combat clears only Encounter runtime state
+
+Detail history and selected scenario are renderer state scoped by Scene. Panel
+column width, right-side divider height, and selected Details/Karte tab are
+app-wide shell preferences, not campaign domain state.
+
+All public snapshots are immutable and revisioned. Mutations reject stale
+revisions instead of silently targeting newer state.

--- a/docs/session/requirements/requirements-live-session.md
+++ b/docs/session/requirements/requirements-live-session.md
@@ -1,0 +1,100 @@
+# Live Session Requirements
+
+## Goal
+
+Provide one running-play shell per campaign. The workspace shows the focused
+runtime Scene and a scenario selector without navigating away from the Session
+tab. Scene owns runtime composition; Session does not own a second group list.
+
+## Focused Scene
+
+- The Standardszene exists on first use. The control panel switches the focused
+  scene when multiple simultaneous scenes exist. Groups, detail navigation,
+  selected scenario, and running Combat remain scoped to their scene.
+- Only active PCs explicitly assigned to the focused Scene form its Party.
+- The Party card lets the GM assign active, unassigned PCs to the focused Scene
+  and remove assigned PCs from it.
+- `Gruppen managen` opens one GM dialog for creating and editing groups. The
+  left pane contains the Creature catalog with name, CR, size, type, subtype,
+  biome, and alignment filters. The right pane selects an existing Scene group
+  or starts a new draft.
+- Catalog rows add monsters to the draft explicitly. The draft supports
+  quantity changes and removal and requires a group name plus at least one
+  available creature with a positive quantity before saving.
+- Every draft change shows base XP, adjusted XP, Party thresholds, creature
+  count, difficulty, and status without persisting the draft.
+- One group may contain several creature identities. Scene stores stable
+  creature references and quantities, not copied statblocks.
+- Groups can be edited and deleted in the focused Scene.
+- A missing creature remains visibly unavailable and cannot enter combat.
+
+The same dialog exposes the Encounter tuning language. `Auffüllen` preserves
+the current draft and adds filtered creatures until the requested difficulty
+band is reached; an already sufficient or stronger group remains unchanged.
+`Neu generieren` replaces only the draft roster. Both operations receive the
+focused Scene, assigned Party, optional Location, current draft, filters, and
+tuning. Generator results remain transient until explicitly saved and do not
+survive restart. Switching groups or closing a dirty draft requires explicit
+discard confirmation.
+
+## Four-panel workspace
+
+- The upper-left control panel owns `Gruppen managen`, scene focus, and the
+  location selector. It assigns one current World Planner location or clears
+  the assignment without changing the Detail history.
+- The lower-left group panel and lower-right scenario panel retain their
+  running-play behavior.
+- The upper-right panel switches between Details and Karte. Details has a
+  scene-local backward/forward history and renders creature statblocks inline;
+  later described scene objects use the same history surface.
+- Karte is a provider-ready route-planning shell. It does not fabricate a map,
+  locations, or routes when Hex/Dungeon has not published a context.
+- The control panel uses only its required height and the group panel receives
+  the remaining left-column space. One shared vertical divider changes both
+  left/right panel widths. A separate horizontal divider changes only the
+  Details/Scenario split on the right. Both dimensions are stored app-wide in
+  Electron user data.
+
+## Combat Scenario
+
+1. The GM selects `Encounter` from the scenario dropdown. `Reise` is the other
+   current option and publishes a read-only no-context state until an approved
+   Dungeon or Hex readback exists.
+2. The GM selects one or more groups belonging to the focused Scene. The
+   assigned Scene Party is always selected.
+3. Every selection change shows base XP, adjusted XP, Party thresholds and the
+   resulting difficulty. At least one available group and one assigned active
+   Party member are required to prepare Initiative.
+4. Initiative values can be edited or rolled before Combat starts.
+5. Combat exposes turn and round progression, editable initiative, monster HP,
+   damage, healing, and a confirmed end action.
+6. Resolution exposes defeated-enemy selection, defeat threshold, XP fraction,
+   per-player XP, one idempotent Party award, and the current no-loot notice.
+7. Completing Resolution returns the scenario panel to selection while keeping
+   the Scene and its groups unchanged.
+
+Matching monsters retain individual runtime HP. The view shows up to three as
+individual cards, four to ten as one mob, and larger counts in mobs of four to
+ten. Mob damage spills through lowest-HP living members; healing restores the
+lowest-HP living member.
+
+Party membership changes are visible immediately. During Initiative or Combat,
+SC combatants are reconciled while the active turn is retained where possible.
+
+## Acceptance
+
+- a new campaign exposes four inactive test Roster characters exactly once
+- membership is controlled from the top-bar Party surface, not a Party tab
+- a multi-creature Scene group survives restart and remains campaign-local
+- one builder creates a new group, updates an existing group in place, and
+  never persists a discarded manual or generated draft
+- Initiative, Combat, and Resolution resume exactly after restart
+- switching scene focus hides another scene's Combat and restores it unchanged
+  when that scene is focused again
+- creating or renaming a World Planner location updates the selector; deleting
+  an assigned location leaves an explicit unresolved reference until the GM
+  replaces or clears it
+- the assigned Scene Party and at least one selected Scene group are required
+  to start
+- the same Combat identity cannot award XP twice
+- completing Combat never leaves the Session workspace

--- a/docs/worldplanner/contract/contract-world-planner-persistence.md
+++ b/docs/worldplanner/contract/contract-world-planner-persistence.md
@@ -31,6 +31,11 @@ World Planner persistence stores:
 - location identity, display name, notes, linked factions, and linked
   encounter tables
 
+The active Electron slice materializes location and faction metadata, faction
+inventory, location-to-faction links, and location-to-table links. Foreign
+creature and encounter-table IDs remain logical references; cross-owner
+referential cleanup is orchestrated in one utility-process transaction.
+
 World Planner persistence does not store:
 
 - creature statblock fields
@@ -54,6 +59,9 @@ World Planner persistence does not store:
 - Missing optional source constraints mean unconstrained.
 - Missing statblock inventory limits mean unlimited.
 - Explicit finite inventory limit `0` means none available for that statblock.
+- A faction inventory row is valid only while the creature belongs to that
+  faction's primary encounter table. Changing or deleting the reference and
+  removing a table entry prune invalid rows in the same transaction.
 - NPC membership rows enforce at most one faction for each NPC.
 
 ## Validation And Error Behavior
@@ -69,6 +77,8 @@ Owner startup readiness validates the feature-declared target schema signature; 
 - Removing a relationship must leave both referenced records intact.
 - Disposition values must remain between `-50` and `+50`.
 - Finite inventory limits must be non-negative.
+- Inventory writes without a primary table or for creatures outside that table
+  must fail validation.
 - A faction must not persist more than one primary encounter-table reference.
 - Candidate combat losses must not mutate durable NPC lifecycle or faction
   stock until user confirmation is recorded.

--- a/docs/worldplanner/requirements/requirements-world-planner.md
+++ b/docs/worldplanner/requirements/requirements-world-planner.md
@@ -19,7 +19,7 @@ Inspector surfaces so the user can:
 ## Non-Goals
 
 - editing creature statblocks or importing creature truth into World Planner
-- editing encounter tables
+- NPC creation and combat-loss workflows in the current Electron slice
 - persisting encounter runtime combat state inside World Planner
 - storing party membership, dungeon map truth, or hex map truth
 - replacing saved encounter plans, the Encounter state tab, or the Session
@@ -36,7 +36,8 @@ Inspector surfaces so the user can:
 5. The user creates factions, assigns one primary encounter table, and adds any
    number of NPCs.
 6. The user optionally sets finite faction stock limits per creature
-   statblock. Missing limits mean unlimited stock.
+   statblock from the faction's primary encounter table. Missing limits mean
+   unlimited stock; unrelated statblocks cannot be added directly.
 7. The user creates locations, links factions, and attaches location-owned
    encounter tables.
 8. The user chooses factions or a location in the Catalog to limit
@@ -58,6 +59,9 @@ Inspector surfaces so the user can:
   linked factions.
 - A faction contributes its primary encounter table and its NPC or statblock
   inventory.
+- The editable faction inventory consists only of creatures in its current
+  primary encounter table. Changing tables preserves limits for shared
+  creatures and removes all other limits.
 - A finite faction inventory limit caps the generated count for that creature
   statblock.
 - Missing faction inventory limits are unlimited by default.
@@ -72,6 +76,8 @@ Inspector surfaces so the user can:
 - select statblocks only from the existing Creatures public boundary
 - add or remove NPCs from factions without mutating creature truth
 - configure faction stock as finite or unlimited per creature statblock
+- create a missing encounter table from above the faction editor without
+  losing the faction draft; the saved table becomes the selected primary table
 - configure location-to-faction and location-to-table links
 - remove faction membership and location links without deleting the referenced
   provider records
@@ -96,6 +102,8 @@ Inspector surfaces so the user can:
 - NPCs store creature statblock references, not copied statblock fields.
 - Factions can contain any number of NPCs and one primary encounter table.
 - Faction statblock limits are optional and unlimited by default.
+- Faction inventory limits outside the selected primary encounter table are
+  rejected; removing table entries prunes affected limits atomically.
 - Encounter generation cannot generate more finite-stock creatures of a
   statblock than the selected faction or location source owns.
 - Location-constrained generation uses only encounter tables available through
@@ -113,6 +121,15 @@ Inspector surfaces so the user can:
 - Creature statblocks, encounter-table membership, encounter rosters, party
   members, combat HP, dungeon maps, and hex maps stay in their owning
   contexts.
+
+## Active Electron Slice
+
+The current Electron slice implements campaign-local location and faction CRUD
+through Catalog. Locations link any number of factions and direct encounter
+tables. Factions own notes, disposition, an optional primary encounter table,
+and optional finite creature inventory caps. These sources constrain both the
+visible monster catalog and Scene-group generation. NPC membership and durable
+combat-loss workflows remain deferred.
 
 ## References
 

--- a/scripts/import-srd-creatures.ts
+++ b/scripts/import-srd-creatures.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+const source =
+  'https://api.open5e.com/v1/monsters/?document__slug=wotc-srd&limit=500'
+const target = resolve('src/core/creatures/srd-5.1.generated.json')
+
+const xpByCr = new Map<number, number>([
+  [0, 10],
+  [0.125, 25],
+  [0.25, 50],
+  [0.5, 100],
+  [1, 200],
+  [2, 450],
+  [3, 700],
+  [4, 1100],
+  [5, 1800],
+  [6, 2300],
+  [7, 2900],
+  [8, 3900],
+  [9, 5000],
+  [10, 5900],
+  [11, 7200],
+  [12, 8400],
+  [13, 10000],
+  [14, 11500],
+  [15, 13000],
+  [16, 15000],
+  [17, 18000],
+  [18, 20000],
+  [19, 22000],
+  [20, 25000],
+  [21, 33000],
+  [22, 41000],
+  [23, 50000],
+  [24, 62000],
+  [25, 75000],
+  [26, 90000],
+  [27, 105000],
+  [28, 120000],
+  [29, 135000],
+  [30, 155000]
+])
+
+const response = await fetch(source)
+if (!response.ok) throw new Error(`SRD import failed: ${response.status}`)
+const payload = (await response.json()) as {
+  results: Record<string, unknown>[]
+}
+
+const creatures = payload.results
+  .map((raw) => {
+    const cr = Number(raw['cr'])
+    const dexterity = Number(raw['dexterity'])
+    const proficiencies = (raw['proficiencies'] ?? []) as {
+      value?: number
+      proficiency?: { name?: string }
+    }[]
+    const labeled = (prefix: string) =>
+      proficiencies
+        .filter((entry) => entry.proficiency?.name?.startsWith(prefix))
+        .map(
+          (entry) =>
+            `${entry.proficiency?.name?.slice(prefix.length) ?? ''} ${signed(entry.value ?? 0)}`
+        )
+        .join(', ')
+    const armor = raw['armor_class']
+    const armorClass = Array.isArray(armor)
+      ? Number((armor[0] as { value?: number } | undefined)?.value ?? 0)
+      : Number(armor)
+    const actions = normalizeActions(raw['actions'])
+    const traits = normalizeActions(raw['special_abilities'])
+    return {
+      id: String(raw['slug']),
+      name: String(raw['name']),
+      cr,
+      challengeRating: String(raw['challenge_rating']),
+      xp: xpByCr.get(cr) ?? 0,
+      type: title(String(raw['type'])),
+      subtype: title(scalarText(raw['subtype'])),
+      size: String(raw['size']),
+      alignment: title(String(raw['alignment'])),
+      biomes: ((raw['environments'] ?? []) as unknown[]).map(String).sort(),
+      ac: armorClass,
+      hp: Number(raw['hit_points']),
+      hitDice: scalarText(raw['hit_dice']),
+      speed: speedText(raw['speed']),
+      initiative: Math.floor((dexterity - 10) / 2),
+      abilities: {
+        str: Number(raw['strength']),
+        dex: dexterity,
+        con: Number(raw['constitution']),
+        int: Number(raw['intelligence']),
+        wis: Number(raw['wisdom']),
+        cha: Number(raw['charisma'])
+      },
+      senses: objectText(raw['senses']),
+      languages: scalarText(raw['languages']),
+      savingThrows: labeled('Saving Throw: '),
+      skills: objectText(raw['skills']) || labeled('Skill: '),
+      damageVulnerabilities: listText(raw['damage_vulnerabilities']),
+      damageResistances: listText(raw['damage_resistances']),
+      damageImmunities: listText(raw['damage_immunities']),
+      conditionImmunities: listText(raw['condition_immunities']),
+      traits,
+      actions,
+      legendaryActions: normalizeActions(raw['legendary_actions']),
+      details:
+        scalarText(raw['desc']).trim() ||
+        traits[0]?.description ||
+        actions[0]?.description ||
+        ''
+    }
+  })
+  .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
+
+const sourceHash = createHash('sha256')
+  .update(JSON.stringify(payload.results))
+  .digest('hex')
+const document = {
+  manifest: {
+    catalogVersion: 'srd-5.1-open5e-wotc-srd-2026-08-01',
+    source,
+    sourceHash,
+    sourceDocument: 'Dungeons & Dragons System Reference Document 5.1',
+    license: 'CC-BY-4.0',
+    attribution:
+      'This work includes material from the System Reference Document 5.1 by Wizards of the Coast LLC, available under CC-BY-4.0.'
+  },
+  creatures
+}
+
+await mkdir(dirname(target), { recursive: true })
+await writeFile(target, `${JSON.stringify(document, null, 2)}\n`, 'utf8')
+
+function normalizeActions(
+  value: unknown
+): { name: string; description: string }[] {
+  if (!Array.isArray(value)) return []
+  return value.map((entry) => {
+    const action = entry as Record<string, unknown>
+    return {
+      name: scalarText(action['name']),
+      description: scalarText(action['desc'])
+    }
+  })
+}
+
+function title(value: string): string {
+  return value.replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function signed(value: number): string {
+  return value >= 0 ? `+${value}` : String(value)
+}
+
+function speedText(value: unknown): string {
+  if (!value || typeof value !== 'object') return scalarText(value)
+  return Object.entries(value as Record<string, unknown>)
+    .map(([mode, distance]) => `${title(mode)} ${scalarText(distance)}`)
+    .join(', ')
+}
+
+function objectText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (!value || typeof value !== 'object') return ''
+  return Object.entries(value as Record<string, unknown>)
+    .map(
+      ([name, fact]) =>
+        `${title(name.replaceAll('_', ' '))} ${scalarText(fact)}`
+    )
+    .join(', ')
+}
+
+function listText(value: unknown): string {
+  return Array.isArray(value)
+    ? value.map(scalarText).join(', ')
+    : scalarText(value)
+}
+
+function scalarText(value: unknown): string {
+  return typeof value === 'string' || typeof value === 'number'
+    ? String(value)
+    : ''
+}

--- a/src/core/creatures/ATTRIBUTION.md
+++ b/src/core/creatures/ATTRIBUTION.md
@@ -1,0 +1,8 @@
+# SRD 5.1 attribution
+
+The generated creature catalog includes material from the System Reference
+Document 5.1 by Wizards of the Coast LLC, available under the Creative Commons
+Attribution 4.0 International license.
+
+The normalized source is the `wotc-srd` document published by Open5e. Its exact
+URL and source-content SHA-256 are recorded in `srd-5.1.generated.json`.

--- a/src/core/creatures/catalog.ts
+++ b/src/core/creatures/catalog.ts
@@ -1,0 +1,328 @@
+import Database from 'better-sqlite3'
+import { z } from 'zod'
+import catalogDocument from './srd-5.1.generated.json' with { type: 'json' }
+import {
+  creatureCatalogPageSchema,
+  creatureCatalogQuerySchema,
+  creatureFilterOptionsSchema,
+  creatureSchema,
+  type Creature,
+  type CreatureCatalogPage,
+  type CreatureCatalogQuery,
+  type CreatureFilterOptions
+} from '../../shared/contracts/encounter.js'
+import type { ResolvedEncounterSource } from '../worldplanner/encounter-source-store.js'
+
+type ReferenceOptions = Pick<
+  CreatureFilterOptions,
+  'encounterTables' | 'factions' | 'locations'
+>
+
+const documentSchema = z
+  .object({
+    manifest: z
+      .object({
+        catalogVersion: z.string(),
+        source: z.string(),
+        sourceHash: z.string(),
+        sourceDocument: z.string(),
+        license: z.string(),
+        attribution: z.string()
+      })
+      .strict(),
+    creatures: z.array(creatureSchema)
+  })
+  .strict()
+
+const catalog = documentSchema.parse(catalogDocument)
+export const creatures: readonly Creature[] = Object.freeze(catalog.creatures)
+const byId = new Map(creatures.map((creature) => [creature.id, creature]))
+
+export class CreatureCatalogService {
+  constructor(
+    private readonly installationPath: string,
+    private readonly sourceResolver?: (
+      query: CreatureCatalogQuery
+    ) => ResolvedEncounterSource,
+    private readonly referenceOptions?: () => ReferenceOptions
+  ) {}
+
+  search(input: CreatureCatalogQuery): CreatureCatalogPage {
+    const query = creatureCatalogQuerySchema.parse(input)
+    const source = this.sourceResolver?.(query)
+    const allowed =
+      source?.candidates === null || source === undefined
+        ? null
+        : new Set(
+            source.candidates
+              .filter(
+                (candidate) =>
+                  candidate.maximum === null || candidate.maximum > 0
+              )
+              .map((candidate) => candidate.creatureId)
+          )
+    const direction = query.direction === 'asc' ? 1 : -1
+    const matching = creatures
+      .filter(
+        (creature) =>
+          (allowed === null || allowed.has(creature.id)) &&
+          creatureMatchesQuery(creature, query)
+      )
+      .toSorted((left, right) => {
+        const primary =
+          query.sort === 'cr'
+            ? left.cr - right.cr
+            : query.sort === 'xp'
+              ? left.xp - right.xp
+              : left.name.localeCompare(right.name)
+        return (
+          primary * direction ||
+          left.name.localeCompare(right.name) ||
+          left.id.localeCompare(right.id)
+        )
+      })
+    const rows = matching.slice(query.offset, query.offset + query.limit)
+    return creatureCatalogPageSchema.parse({
+      status: rows.length === 0 ? 'empty' : 'ready',
+      rows,
+      total: matching.length,
+      offset: query.offset,
+      limit: query.limit,
+      message:
+        rows.length === 0
+          ? source?.catalogFallback
+            ? 'Keine Monster entsprechen den Filtern. Katalog-Fallback ist aktiv.'
+            : 'Keine Monster entsprechen den Quellen und Filtern.'
+          : source?.catalogFallback &&
+              (query.encounterTableIds.length > 0 ||
+                query.factionIds.length > 0 ||
+                query.locationId !== null)
+            ? 'Keine wirksame Encounter-Tabelle; der Monsterkatalog wird verwendet.'
+            : ''
+    })
+  }
+
+  filterOptions(): CreatureFilterOptions {
+    const db = this.open()
+    try {
+      const references = this.referenceOptions?.() ?? {
+        encounterTables: [],
+        factions: [],
+        locations: []
+      }
+      const strings = (sql: string) =>
+        (db.prepare(sql).all() as { value: string }[]).map((row) => row.value)
+      return creatureFilterOptionsSchema.parse({
+        challengeRatings: strings(
+          'SELECT DISTINCT challenge_rating_text AS value FROM creatures ORDER BY challenge_rating, value'
+        ),
+        sizes: strings(
+          'SELECT DISTINCT size AS value FROM creatures ORDER BY value'
+        ),
+        types: strings(
+          'SELECT DISTINCT creature_type AS value FROM creatures ORDER BY value'
+        ),
+        subtypes: strings(
+          'SELECT DISTINCT subtype AS value FROM creature_subtypes ORDER BY value'
+        ),
+        biomes: strings(
+          'SELECT DISTINCT biome AS value FROM creature_biomes ORDER BY value'
+        ),
+        alignments: strings(
+          'SELECT DISTINCT alignment AS value FROM creatures ORDER BY value'
+        ),
+        encounterTables: references.encounterTables,
+        factions: references.factions,
+        locations: references.locations
+      })
+    } finally {
+      db.close()
+    }
+  }
+
+  detail(id: string): Creature {
+    const db = this.open()
+    try {
+      const row = db
+        .prepare('SELECT detail_json AS detailJson FROM creatures WHERE id = ?')
+        .get(id) as { detailJson: string } | undefined
+      if (!row) throw new Error('not found')
+      return creatureSchema.parse(JSON.parse(row.detailJson))
+    } finally {
+      db.close()
+    }
+  }
+
+  private open(): Database.Database {
+    const db = new Database(this.installationPath)
+    initializeCreatureSchema(db)
+    return db
+  }
+}
+
+export function creatureMatchesQuery(
+  creature: Creature,
+  query: CreatureCatalogQuery
+): boolean {
+  const name = query.name.trim().toLocaleLowerCase()
+  return (
+    creature.name.toLocaleLowerCase().includes(name) &&
+    (query.crMin === undefined || creature.cr >= query.crMin) &&
+    (query.crMax === undefined || creature.cr <= query.crMax) &&
+    selectedIncludes(query.sizes, creature.size) &&
+    selectedIncludes(query.types, creature.type) &&
+    selectedIncludes(query.subtypes, creature.subtype) &&
+    selectedIncludes(query.alignments, creature.alignment) &&
+    (query.biomes.length === 0 ||
+      creature.biomes.some((biome) => query.biomes.includes(biome)))
+  )
+}
+
+function selectedIncludes(values: readonly string[], value: string): boolean {
+  return values.length === 0 || values.includes(value)
+}
+
+export function initializeCreatureSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS creature_catalog_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      catalog_version TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      attribution TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS creatures (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      size TEXT NOT NULL,
+      creature_type TEXT NOT NULL,
+      alignment TEXT NOT NULL,
+      challenge_rating REAL NOT NULL,
+      challenge_rating_text TEXT NOT NULL,
+      xp INTEGER NOT NULL,
+      hp INTEGER NOT NULL,
+      ac INTEGER NOT NULL,
+      detail_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS creature_biomes (
+      creature_id TEXT NOT NULL REFERENCES creatures(id) ON DELETE CASCADE,
+      biome TEXT NOT NULL,
+      PRIMARY KEY (creature_id, biome)
+    );
+    CREATE TABLE IF NOT EXISTS creature_subtypes (
+      creature_id TEXT NOT NULL REFERENCES creatures(id) ON DELETE CASCADE,
+      subtype TEXT NOT NULL,
+      PRIMARY KEY (creature_id, subtype)
+    );
+    CREATE TABLE IF NOT EXISTS creature_actions (
+      creature_id TEXT NOT NULL REFERENCES creatures(id) ON DELETE CASCADE,
+      action_kind TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      PRIMARY KEY (creature_id, action_kind, position)
+    );
+    CREATE INDEX IF NOT EXISTS idx_creatures_name ON creatures(name COLLATE NOCASE);
+    CREATE INDEX IF NOT EXISTS idx_creatures_cr ON creatures(challenge_rating);
+    CREATE INDEX IF NOT EXISTS idx_creatures_type ON creatures(creature_type);
+    CREATE INDEX IF NOT EXISTS idx_creature_biomes_biome ON creature_biomes(biome);
+    CREATE INDEX IF NOT EXISTS idx_creature_subtypes_subtype ON creature_subtypes(subtype);
+  `)
+  const metadata = db
+    .prepare(
+      'SELECT content_hash AS contentHash FROM creature_catalog_metadata WHERE singleton = 1'
+    )
+    .get() as { contentHash: string } | undefined
+  if (metadata?.contentHash === catalog.manifest.sourceHash) return
+  db.transaction(() => {
+    db.exec(`
+      DELETE FROM creature_actions;
+      DELETE FROM creature_biomes;
+      DELETE FROM creature_subtypes;
+      DELETE FROM creatures;
+      DELETE FROM creature_catalog_metadata;
+    `)
+    const insertCreature = db.prepare(`
+      INSERT INTO creatures (
+        id, name, size, creature_type, alignment, challenge_rating,
+        challenge_rating_text, xp, hp, ac, detail_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    const insertBiome = db.prepare(
+      'INSERT INTO creature_biomes (creature_id, biome) VALUES (?, ?)'
+    )
+    const insertSubtype = db.prepare(
+      'INSERT INTO creature_subtypes (creature_id, subtype) VALUES (?, ?)'
+    )
+    const insertAction = db.prepare(`
+      INSERT INTO creature_actions (
+        creature_id, action_kind, position, name, description
+      ) VALUES (?, ?, ?, ?, ?)
+    `)
+    for (const creature of creatures) {
+      insertCreature.run(
+        creature.id,
+        creature.name,
+        creature.size,
+        creature.type,
+        creature.alignment,
+        creature.cr,
+        creature.challengeRating,
+        creature.xp,
+        creature.hp,
+        creature.ac,
+        JSON.stringify(creature)
+      )
+      for (const biome of creature.biomes) insertBiome.run(creature.id, biome)
+      if (creature.subtype) insertSubtype.run(creature.id, creature.subtype)
+      const sets = [
+        ['trait', creature.traits],
+        ['action', creature.actions],
+        ['legendary', creature.legendaryActions]
+      ] as const
+      for (const [kind, actions] of sets)
+        actions.forEach((action, position) =>
+          insertAction.run(
+            creature.id,
+            kind,
+            position,
+            action.name,
+            action.description
+          )
+        )
+    }
+    db.prepare(
+      `
+      INSERT INTO creature_catalog_metadata (
+        singleton, catalog_version, content_hash, attribution
+      ) VALUES (1, ?, ?, ?)
+    `
+    ).run(
+      catalog.manifest.catalogVersion,
+      catalog.manifest.sourceHash,
+      catalog.manifest.attribution
+    )
+  })()
+}
+
+export function searchCreatures(
+  name = '',
+  crMin?: number,
+  crMax?: number,
+  type?: string,
+  limit = 30
+): readonly Creature[] {
+  const normalized = name.toLowerCase()
+  return creatures
+    .filter(
+      (creature) =>
+        creature.name.toLowerCase().includes(normalized) &&
+        (crMin === undefined || creature.cr >= crMin) &&
+        (crMax === undefined || creature.cr <= crMax) &&
+        (!type || creature.type.toLowerCase().includes(type.toLowerCase()))
+    )
+    .slice(0, limit)
+}
+
+export function creatureById(id: string): Creature | undefined {
+  return byId.get(id)
+}

--- a/src/core/creatures/srd-5.1.generated.json
+++ b/src/core/creatures/srd-5.1.generated.json
@@ -1,0 +1,19303 @@
+{
+  "manifest": {
+    "catalogVersion": "srd-5.1-open5e-wotc-srd-2026-08-01",
+    "source": "https://api.open5e.com/v1/monsters/?document__slug=wotc-srd&limit=500",
+    "sourceHash": "3f7de1a943acb66fe2ce130c2e8c8af0c7ce495394777622d224161289fec72f",
+    "sourceDocument": "Dungeons & Dragons System Reference Document 5.1",
+    "license": "CC-BY-4.0",
+    "attribution": "This work includes material from the System Reference Document 5.1 by Wizards of the Coast LLC, available under CC-BY-4.0."
+  },
+  "creatures": [
+    {
+      "id": "aboleth",
+      "name": "Aboleth",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Aberration",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Caverns", "Plane Of Water", "Sewer", "Underdark", "Water"],
+      "ac": 17,
+      "hp": 135,
+      "hitDice": "18d10+36",
+      "speed": "Walk 10, Swim 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 21,
+        "dex": 9,
+        "con": 15,
+        "int": 18,
+        "wis": 15,
+        "cha": 18
+      },
+      "senses": "darkvision 120 ft., passive Perception 20",
+      "languages": "Deep Speech, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "History 12, Perception 10",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The aboleth can breathe air and water."
+        },
+        {
+          "name": "Mucous Cloud",
+          "description": "While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within 5 ft. of it must make a DC 14 Constitution saving throw. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater."
+        },
+        {
+          "name": "Probing Telepathy",
+          "description": "If a creature communicates telepathically with the aboleth, the aboleth learns the creature's greatest desires if the aboleth can see the creature."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The aboleth makes three tentacle attacks."
+        },
+        {
+          "name": "Tentacle",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by heal or another disease-curing spell of 6th level or higher. When the creature is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes unless moisture is applied to the skin before 10 minutes have passed."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) bludgeoning damage."
+        },
+        {
+          "name": "Enslave (3/day)",
+          "description": "The aboleth targets one creature it can see within 30 ft. of it. The target must succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target. The charmed target is under the aboleth's control and can't take reactions, and the aboleth and the target can communicate telepathically with each other over any distance.\nWhenever the charmed target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The aboleth makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Swipe",
+          "description": "The aboleth makes one tail attack."
+        },
+        {
+          "name": "Psychic Drain (Costs 2 Actions)",
+          "description": "One creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth regains hit points equal to the damage the creature takes."
+        }
+      ],
+      "details": "The aboleth can breathe air and water."
+    },
+    {
+      "id": "acolyte",
+      "name": "Acolyte",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Desert", "Hills", "Settlement", "Temple", "Urban"],
+      "ac": 10,
+      "hp": 9,
+      "hitDice": "2d8",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 10,
+        "dex": 10,
+        "con": 10,
+        "int": 10,
+        "wis": 14,
+        "cha": 11
+      },
+      "senses": "passive Perception 12",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Medicine 4, Religion 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spellcasting",
+          "description": "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:\n\n* Cantrips (at will): light, sacred flame, thaumaturgy\n* 1st level (3 slots): bless, cure wounds, sanctuary"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Club",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Acolytes** are junior members of a clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities."
+    },
+    {
+      "id": "adult-black-dragon",
+      "name": "Adult Black Dragon",
+      "cr": 14,
+      "challengeRating": "14",
+      "xp": 11500,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Swamp"],
+      "ac": 19,
+      "hp": 195,
+      "hitDice": "17d12+85",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 23,
+        "dex": 14,
+        "con": 21,
+        "int": 14,
+        "wis": 13,
+        "cha": 17
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 11, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) acid damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "description": "The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "adult-blue-dragon",
+      "name": "Adult Blue Dragon",
+      "cr": 16,
+      "challengeRating": "16",
+      "xp": 15000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Evil",
+      "biomes": ["Coastal", "Desert"],
+      "ac": 19,
+      "hp": 225,
+      "hitDice": "18d12+108",
+      "speed": "Walk 40, Burrow 30, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 25,
+        "dex": 10,
+        "con": 23,
+        "int": 16,
+        "wis": 15,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 12, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "description": "The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "adult-brass-dragon",
+      "name": "Adult Brass Dragon",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Good",
+      "biomes": ["Desert"],
+      "ac": 18,
+      "hp": 172,
+      "hitDice": "15d12+75",
+      "speed": "Walk 40, Burrow 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 23,
+        "dex": 10,
+        "con": 21,
+        "int": 14,
+        "wis": 13,
+        "cha": 17
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "History 7, Perception 11, Persuasion 8, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "adult-bronze-dragon",
+      "name": "Adult Bronze Dragon",
+      "cr": 15,
+      "challengeRating": "15",
+      "xp": 13000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Good",
+      "biomes": ["Coastal", "Desert", "Water"],
+      "ac": 19,
+      "hp": 212,
+      "hitDice": "17d12+102",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 25,
+        "dex": 10,
+        "con": 23,
+        "int": 16,
+        "wis": 15,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 7, Perception 12, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "adult-copper-dragon",
+      "name": "Adult Copper Dragon",
+      "cr": 14,
+      "challengeRating": "14",
+      "xp": 11500,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Good",
+      "biomes": ["Hill", "Hills", "Mountains"],
+      "ac": 18,
+      "hp": 184,
+      "hitDice": "16d12+80",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 1,
+      "abilities": {
+        "str": 23,
+        "dex": 12,
+        "con": 21,
+        "int": 18,
+        "wis": 15,
+        "cha": 17
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 8, Perception 12, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "adult-gold-dragon",
+      "name": "Adult Gold Dragon",
+      "cr": 17,
+      "challengeRating": "17",
+      "xp": 18000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Forest", "Grassland", "Ruin", "Water"],
+      "ac": 19,
+      "hp": 256,
+      "hitDice": "19d12+133",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 27,
+        "dex": 14,
+        "con": 25,
+        "int": 16,
+        "wis": 15,
+        "cha": 24
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 24",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 8, Perception 14, Persuasion 13, Stealth 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 66 (12d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 21 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "adult-green-dragon",
+      "name": "Adult Green Dragon",
+      "cr": 15,
+      "challengeRating": "15",
+      "xp": 13000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Evil",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 19,
+      "hp": 207,
+      "hitDice": "18d12+90",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 23,
+        "dex": 12,
+        "con": 21,
+        "int": 18,
+        "wis": 15,
+        "cha": 17
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 8, Insight 7, Perception 12, Persuasion 8, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 7 (2d6) poison damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "description": "The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 56 (16d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "adult-red-dragon",
+      "name": "Adult Red Dragon",
+      "cr": 17,
+      "challengeRating": "17",
+      "xp": 18000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Hill", "Mountain", "Mountains"],
+      "ac": 19,
+      "hp": 256,
+      "hitDice": "19d12+133",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 27,
+        "dex": 10,
+        "con": 25,
+        "int": 16,
+        "wis": 13,
+        "cha": 21
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 23",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 13, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 7 (2d6) fire damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 63 (18d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "adult-silver-dragon",
+      "name": "Adult Silver Dragon",
+      "cr": 16,
+      "challengeRating": "16",
+      "xp": 15000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Good",
+      "biomes": ["Feywild", "Mountain", "Mountains", "Urban"],
+      "ac": 19,
+      "hp": 243,
+      "hitDice": "18d12+126",
+      "speed": "Walk 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 27,
+        "dex": 10,
+        "con": 25,
+        "int": 16,
+        "wis": 13,
+        "cha": 21
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Arcana 8, History 8, Perception 11, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 20 Constitution saving throw, taking 58 (13d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a DC 20 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "adult-white-dragon",
+      "name": "Adult White Dragon",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Arctic", "Tundra"],
+      "ac": 18,
+      "hp": 200,
+      "hitDice": "16d12+96",
+      "speed": "Walk 40, Burrow 30, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 22,
+        "dex": 10,
+        "con": 22,
+        "int": 8,
+        "wis": 12,
+        "cha": 12
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 11, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Ice Walk",
+          "description": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) cold damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "description": "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+    },
+    {
+      "id": "air-elemental",
+      "name": "Air Elemental",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": ["Laboratory", "Mountain", "Plane Of Air"],
+      "ac": 15,
+      "hp": 90,
+      "hitDice": "12d10+24",
+      "speed": "Hover true, Walk 0, Fly 90",
+      "initiative": 5,
+      "abilities": {
+        "str": 14,
+        "dex": 20,
+        "con": 14,
+        "int": 6,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Auran",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Air Form",
+          "description": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The elemental makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        },
+        {
+          "name": "Whirlwind (Recharge 4-6)",
+          "description": "Each creature in the elemental's space must make a DC 13 Strength saving throw. On a failure, a target takes 15 (3d8 + 2) bludgeoning damage and is flung up 20 feet away from the elemental in a random direction and knocked prone. If a thrown target strikes an object, such as a wall or floor, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 13 Dexterity saving throw or take the same damage and be knocked prone.\nIf the saving throw is successful, the target takes half the bludgeoning damage and isn't flung away or knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "ancient-black-dragon",
+      "name": "Ancient Black Dragon",
+      "cr": 21,
+      "challengeRating": "21",
+      "xp": 33000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Swamp"],
+      "ac": 22,
+      "hp": 367,
+      "hitDice": "21d20+147",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 27,
+        "dex": 14,
+        "con": 25,
+        "int": 16,
+        "wis": 15,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 16, Stealth 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "description": "The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 67 (15d8) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "ancient-blue-dragon",
+      "name": "Ancient Blue Dragon",
+      "cr": 23,
+      "challengeRating": "23",
+      "xp": 50000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Lawful Evil",
+      "biomes": ["Coastal", "Desert"],
+      "ac": 22,
+      "hp": 481,
+      "hitDice": "26d20+208",
+      "speed": "Walk 40, Burrow 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 29,
+        "dex": 10,
+        "con": 27,
+        "int": 18,
+        "wis": 17,
+        "cha": 21
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 17, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage plus 11 (2d10) lightning damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "description": "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "ancient-brass-dragon",
+      "name": "Ancient Brass Dragon",
+      "cr": 20,
+      "challengeRating": "20",
+      "xp": 25000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Good",
+      "biomes": ["Desert"],
+      "ac": 20,
+      "hp": 297,
+      "hitDice": "17d20+119",
+      "speed": "Walk 40, Burrow 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 27,
+        "dex": 10,
+        "con": 25,
+        "int": 16,
+        "wis": 15,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 24",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "History 9, Perception 14, Persuasion 10, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons:\n**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "ancient-bronze-dragon",
+      "name": "Ancient Bronze Dragon",
+      "cr": 22,
+      "challengeRating": "22",
+      "xp": 41000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Lawful Good",
+      "biomes": ["Coastal", "Desert", "Water"],
+      "ac": 22,
+      "hp": 444,
+      "hitDice": "24d20+192",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 29,
+        "dex": 10,
+        "con": 27,
+        "int": 18,
+        "wis": 17,
+        "cha": 21
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 10, Perception 17, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 23 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "ancient-copper-dragon",
+      "name": "Ancient Copper Dragon",
+      "cr": 21,
+      "challengeRating": "21",
+      "xp": 33000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Good",
+      "biomes": ["Hill", "Hills", "Mountains"],
+      "ac": 21,
+      "hp": 350,
+      "hitDice": "20d20+140",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 1,
+      "abilities": {
+        "str": 27,
+        "dex": 12,
+        "con": 25,
+        "int": 20,
+        "wis": 17,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 11, Perception 17, Stealth 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 63 (14d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 22 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "ancient-gold-dragon",
+      "name": "Ancient Gold Dragon",
+      "cr": 24,
+      "challengeRating": "24",
+      "xp": 62000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Forest", "Grassland", "Ruin", "Water"],
+      "ac": 22,
+      "hp": 546,
+      "hitDice": "28d20+252",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 30,
+        "dex": 14,
+        "con": 29,
+        "int": 18,
+        "wis": 17,
+        "cha": 28
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 10, Perception 17, Persuasion 16, Stealth 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 24 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 71 (13d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "ancient-green-dragon",
+      "name": "Ancient Green Dragon",
+      "cr": 22,
+      "challengeRating": "22",
+      "xp": 41000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Lawful Evil",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 21,
+      "hp": 385,
+      "hitDice": "22d20+154",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 27,
+        "dex": 12,
+        "con": 25,
+        "int": 20,
+        "wis": 17,
+        "cha": 19
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 11, Insight 10, Perception 17, Persuasion 11, Stealth 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 22 (4d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "description": "The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "ancient-red-dragon",
+      "name": "Ancient Red Dragon",
+      "cr": 24,
+      "challengeRating": "24",
+      "xp": 62000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Hill", "Mountain", "Mountains"],
+      "ac": 22,
+      "hp": 546,
+      "hitDice": "28d20+252",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 30,
+        "dex": 10,
+        "con": 29,
+        "int": 18,
+        "wis": 15,
+        "cha": 23
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 16, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage plus 14 (4d6) fire damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "ancient-silver-dragon",
+      "name": "Ancient Silver Dragon",
+      "cr": 23,
+      "challengeRating": "23",
+      "xp": 50000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Lawful Good",
+      "biomes": ["Feywild", "Mountain", "Mountains", "Urban"],
+      "ac": 22,
+      "hp": 487,
+      "hitDice": "25d20+225",
+      "speed": "Walk 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 30,
+        "dex": 10,
+        "con": 29,
+        "int": 18,
+        "wis": 15,
+        "cha": 23
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Arcana 11, History 11, Perception 16, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n\n**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.\n\n **Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "If the dragon fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "ancient-white-dragon",
+      "name": "Ancient White Dragon",
+      "cr": 20,
+      "challengeRating": "20",
+      "xp": 25000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Arctic", "Tundra"],
+      "ac": 20,
+      "hp": 333,
+      "hitDice": "18d20+144",
+      "speed": "Walk 40, Burrow 40, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 26,
+        "dex": 10,
+        "con": 26,
+        "int": 10,
+        "wis": 13,
+        "cha": 14
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 23",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 13, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Ice Walk",
+          "description": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the dragon fails a saving throw, it can choose to succeed instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) cold damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "description": "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (16d8) cold damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Detect",
+          "description": "The dragon makes a Wisdom (Perception) check."
+        },
+        {
+          "name": "Tail Attack",
+          "description": "The dragon makes a tail attack."
+        },
+        {
+          "name": "Wing Attack (Costs 2 Actions)",
+          "description": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        }
+      ],
+      "details": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+    },
+    {
+      "id": "androsphinx",
+      "name": "Androsphinx",
+      "cr": 17,
+      "challengeRating": "17",
+      "xp": 18000,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Neutral",
+      "biomes": ["Desert", "Ruins"],
+      "ac": 17,
+      "hp": 199,
+      "hitDice": "19d10+95",
+      "speed": "Walk 40, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 22,
+        "dex": 10,
+        "con": 20,
+        "int": 16,
+        "wis": 18,
+        "cha": 23
+      },
+      "senses": "truesight 120 ft., passive Perception 20",
+      "languages": "Common, Sphinx",
+      "savingThrows": "",
+      "skills": "Arcana 9, Perception 10, Religion 15",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "psychic; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "charmed, frightened",
+      "traits": [
+        {
+          "name": "Inscrutable",
+          "description": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The sphinx's weapon attacks are magical."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:\n\n* Cantrips (at will): sacred flame, spare the dying, thaumaturgy\n* 1st level (4 slots): command, detect evil and good, detect magic\n* 2nd level (3 slots): lesser restoration, zone of truth\n* 3rd level (3 slots): dispel magic, tongues\n* 4th level (3 slots): banishment, freedom of movement\n* 5th level (2 slots): flame strike, greater restoration\n* 6th level (1 slot): heroes' feast"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The sphinx makes two claw attacks."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 17 (2d10 + 6) slashing damage."
+        },
+        {
+          "name": "Roar (3/Day)",
+          "description": "The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.\n**First Roar.** Each creature that fails a DC 18 Wisdom saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.\n**Second Roar.** Each creature that fails a DC 18 Wisdom saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.\n**Third Roar.** Each creature makes a DC 18 Constitution saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn't knocked prone."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Claw Attack",
+          "description": "The sphinx makes one claw attack."
+        },
+        {
+          "name": "Teleport (Costs 2 Actions)",
+          "description": "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        },
+        {
+          "name": "Cast a Spell (Costs 3 Actions)",
+          "description": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        }
+      ],
+      "details": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+    },
+    {
+      "id": "animated-armor",
+      "name": "Animated Armor",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Laboratory", "Ruin", "Temple"],
+      "ac": 18,
+      "hp": 33,
+      "hitDice": "6d8+6",
+      "speed": "Walk 25",
+      "initiative": 0,
+      "abilities": {
+        "str": 14,
+        "dex": 11,
+        "con": 13,
+        "int": 1,
+        "wis": 3,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison, psychic",
+      "conditionImmunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Antimagic Susceptibility",
+          "description": "The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the armor remains motionless, it is indistinguishable from a normal suit of armor."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The armor makes two melee attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+    },
+    {
+      "id": "ankheg",
+      "name": "Ankheg",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Forest", "Grassland", "Hills", "Settlement"],
+      "ac": 14,
+      "hp": 39,
+      "hitDice": "6d10+6",
+      "speed": "Walk 30, Burrow 10",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 11,
+        "con": 13,
+        "int": 1,
+        "wis": 13,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage plus 3 (1d6) acid damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so."
+        },
+        {
+          "name": "Acid Spray (Recharge 6)",
+          "description": "The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled. Each creature in that line must make a DC 13 Dexterity saving throw, taking 10 (3d6) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage plus 3 (1d6) acid damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so."
+    },
+    {
+      "id": "ape",
+      "name": "Ape",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 12,
+      "hp": 19,
+      "hitDice": "3d8+6",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 16,
+        "dex": 14,
+        "con": 14,
+        "int": 6,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Athletics 5, Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The ape makes two fist attacks."
+        },
+        {
+          "name": "Fist",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ape makes two fist attacks."
+    },
+    {
+      "id": "archmage",
+      "name": "Archmage",
+      "cr": 12,
+      "challengeRating": "12",
+      "xp": 8400,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Forest", "Laboratory", "Settlement", "Urban"],
+      "ac": 12,
+      "hp": 99,
+      "hitDice": "18d8+18",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 14,
+        "con": 12,
+        "int": 20,
+        "wis": 15,
+        "cha": 16
+      },
+      "senses": "passive Perception 12",
+      "languages": "any six languages",
+      "savingThrows": "",
+      "skills": "Arcana 13, History 13",
+      "damageVulnerabilities": "",
+      "damageResistances": "damage from spells; non magical bludgeoning, piercing, and slashing (from stoneskin)",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The archmage has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:\n\n* Cantrips (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp\n* 1st level (4 slots): detect magic, identify, mage armor*, magic missile\n* 2nd level (3 slots): detect thoughts, mirror image, misty step\n* 3rd level (3 slots): counterspell,fly, lightning bolt\n* 4th level (3 slots): banishment, fire shield, stoneskin*\n* 5th level (3 slots): cone of cold, scrying, wall of force\n* 6th level (1 slot): globe of invulnerability\n* 7th level (1 slot): teleport\n* 8th level (1 slot): mind blank*\n* 9th level (1 slot): time stop\n* The archmage casts these spells on itself before combat."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Dagger",
+          "description": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Archmages** are powerful (and usually quite old) spellcasters dedicated to the study of the arcane arts. Benevolent ones counsel kings and queens, while evil ones rule as tyrants and pursue lichdom. Those who are neither good nor evil sequester themselves in remote towers to practice their magic without interruption.\nAn archmage typically has one or more apprentice mages, and an archmage's abode has numerous magical wards and guardians to discourage interlopers."
+    },
+    {
+      "id": "assassin",
+      "name": "Assassin",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Good Alignment",
+      "biomes": ["Desert", "Forest", "Settlement", "Sewer", "Urban"],
+      "ac": 15,
+      "hp": 78,
+      "hitDice": "12d8+24",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 11,
+        "dex": 16,
+        "con": 14,
+        "int": 13,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "passive Perception 13",
+      "languages": "Thieves' cant plus any two languages",
+      "savingThrows": "",
+      "skills": "Acrobatics 6, Deception 3, Perception 3, Stealth 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "poison",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Assassinate",
+          "description": "During its first turn, the assassin has advantage on attack rolls against any creature that hasn't taken a turn. Any hit the assassin scores against a surprised creature is a critical hit."
+        },
+        {
+          "name": "Evasion",
+          "description": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+        },
+        {
+          "name": "Sneak Attack (1/Turn)",
+          "description": "The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The assassin makes two shortsword attacks."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Light Crossbow",
+          "description": "Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Trained in the use of poison, **assassins** are remorseless killers who work for nobles, guildmasters, sovereigns, and anyone else who can afford them."
+    },
+    {
+      "id": "awakened-shrub",
+      "name": "Awakened Shrub",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle", "Laboratory", "Swamp"],
+      "ac": 9,
+      "hp": 10,
+      "hitDice": "3d6",
+      "speed": "Walk 20",
+      "initiative": -1,
+      "abilities": {
+        "str": 3,
+        "dex": 8,
+        "con": 11,
+        "int": 10,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "passive Perception 10",
+      "languages": "one language known by its creator",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "fire",
+      "damageResistances": "piercing",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the shrub remains motionless, it is indistinguishable from a normal shrub."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Rake",
+          "description": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "An **awakened shrub** is an ordinary shrub given sentience and mobility by the awaken spell or similar magic."
+    },
+    {
+      "id": "awakened-tree",
+      "name": "Awakened Tree",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle", "Swamp"],
+      "ac": 13,
+      "hp": 59,
+      "hitDice": "7d12+14",
+      "speed": "Walk 20",
+      "initiative": -2,
+      "abilities": {
+        "str": 19,
+        "dex": 6,
+        "con": 15,
+        "int": 10,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "passive Perception 10",
+      "languages": "one language known by its creator",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "fire",
+      "damageResistances": "bludgeoning, piercing",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the tree remains motionless, it is indistinguishable from a normal tree."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "An **awakened tree** is an ordinary tree given sentience and mobility by the awaken spell or similar magic."
+    },
+    {
+      "id": "axe-beak",
+      "name": "Axe Beak",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill", "Jungle", "Swamp"],
+      "ac": 11,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 50",
+      "initiative": 1,
+      "abilities": {
+        "str": 14,
+        "dex": 12,
+        "con": 12,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "An **axe beak** is a tall flightless bird with strong legs and a heavy, wedge-shaped beak. It has a nasty disposition and tends to attack any unfamiliar creature that wanders too close."
+    },
+    {
+      "id": "azer",
+      "name": "Azer",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Neutral",
+      "biomes": ["Caverns", "Plane Of Fire"],
+      "ac": 17,
+      "hp": 39,
+      "hitDice": "6d8+12",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 17,
+        "dex": 12,
+        "con": 15,
+        "int": 12,
+        "wis": 13,
+        "cha": 10
+      },
+      "senses": "passive Perception 11",
+      "languages": "Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Heated Body",
+          "description": "A creature that touches the azer or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage."
+        },
+        {
+          "name": "Heated Weapons",
+          "description": "When the azer hits with a metal melee weapon, it deals an extra 3 (1d6) fire damage (included in the attack)."
+        },
+        {
+          "name": "Illumination",
+          "description": "The azer sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Warhammer",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage, or 8 (1d10 + 3) bludgeoning damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A creature that touches the azer or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage."
+    },
+    {
+      "id": "baboon",
+      "name": "Baboon",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill", "Jungle"],
+      "ac": 12,
+      "hp": 3,
+      "hitDice": "1d6",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 8,
+        "dex": 14,
+        "con": 11,
+        "int": 4,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Pack Tactics",
+          "description": "The baboon has advantage on an attack roll against a creature if at least one of the baboon's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The baboon has advantage on an attack roll against a creature if at least one of the baboon's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+    },
+    {
+      "id": "badger",
+      "name": "Badger",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland"],
+      "ac": 10,
+      "hp": 3,
+      "hitDice": "1d4+1",
+      "speed": "Walk 20, Burrow 5",
+      "initiative": 0,
+      "abilities": {
+        "str": 4,
+        "dex": 11,
+        "con": 12,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "darkvision 30 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "balor",
+      "name": "Balor",
+      "cr": 19,
+      "challengeRating": "19",
+      "xp": 22000,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Huge",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 19,
+      "hp": 262,
+      "hitDice": "21d12+126",
+      "speed": "Walk 40, Fly 80",
+      "initiative": 2,
+      "abilities": {
+        "str": 26,
+        "dex": 15,
+        "con": 22,
+        "int": 20,
+        "wis": 16,
+        "cha": 22
+      },
+      "senses": "truesight 120 ft., passive Perception 13",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Death Throes",
+          "description": "When the balor dies, it explodes, and each creature within 30 feet of it must make a DC 20 Dexterity saving throw, taking 70 (20d6) fire damage on a failed save, or half as much damage on a successful one. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons."
+        },
+        {
+          "name": "Fire Aura",
+          "description": "At the start of each of the balor's turns, each creature within 5 feet of it takes 10 (3d6) fire damage, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The balor has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The balor's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The balor makes two attacks: one with its longsword and one with its whip."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) slashing damage plus 13 (3d8) lightning damage. If the balor scores a critical hit, it rolls damage dice three times, instead of twice."
+        },
+        {
+          "name": "Whip",
+          "description": "Melee Weapon Attack: +14 to hit, reach 30 ft., one target. Hit: 15 (2d6 + 8) slashing damage plus 10 (3d6) fire damage, and the target must succeed on a DC 20 Strength saving throw or be pulled up to 25 feet toward the balor."
+        },
+        {
+          "name": "Teleport",
+          "description": "The balor magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA balor has a 50 percent chance of summoning 1d8 vrocks, 1d6 hezrous, 1d4 glabrezus, 1d3 nalfeshnees, 1d2 mariliths, or one goristro.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the balor dies, it explodes, and each creature within 30 feet of it must make a DC 20 Dexterity saving throw, taking 70 (20d6) fire damage on a failed save, or half as much damage on a successful one. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons."
+    },
+    {
+      "id": "bandit",
+      "name": "Bandit",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Lawful Alignment",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Laboratory",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Tundra",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 11,
+        "dex": 12,
+        "con": 12,
+        "int": 10,
+        "wis": 10,
+        "cha": 10
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        },
+        {
+          "name": "Light Crossbow",
+          "description": "Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Bandits** rove in gangs and are sometimes led by thugs, veterans, or spellcasters. Not all bandits are evil. Oppression, drought, disease, or famine can often drive otherwise honest folk to a life of banditry. \n**Pirates** are bandits of the high seas. They might be freebooters interested only in treasure and murder, or they might be privateers sanctioned by the crown to attack and plunder an enemy nation's vessels."
+    },
+    {
+      "id": "bandit-captain",
+      "name": "Bandit Captain",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Lawful Alignment",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Laboratory",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Tundra",
+        "Urban"
+      ],
+      "ac": 15,
+      "hp": 65,
+      "hitDice": "10d8+20",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 15,
+        "dex": 16,
+        "con": 14,
+        "int": 14,
+        "wis": 11,
+        "cha": 14
+      },
+      "senses": "passive Perception 10",
+      "languages": "any two languages",
+      "savingThrows": "",
+      "skills": "Athletics 4, Deception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers."
+        },
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        },
+        {
+          "name": "Dagger",
+          "description": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "It takes a strong personality, ruthless cunning, and a silver tongue to keep a gang of bandits in line. The **bandit captain** has these qualities in spades. \nIn addition to managing a crew of selfish malcontents, the **pirate captain** is a variation of the bandit captain, with a ship to protect and command. To keep the crew in line, the captain must mete out rewards and punishment on a regular basis. \nMore than treasure, a bandit captain or pirate captain craves infamy. A prisoner who appeals to the captain's vanity or ego is more likely to be treated fairly than a prisoner who does not or claims not to know anything of the captain's colorful reputation."
+    },
+    {
+      "id": "barbed-devil",
+      "name": "Barbed Devil",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 15,
+      "hp": 110,
+      "hitDice": "13d8+52",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 16,
+        "dex": 17,
+        "con": 18,
+        "int": 12,
+        "wis": 14,
+        "cha": 14
+      },
+      "senses": "darkvision 120 ft., passive Perception 18",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "Deception 5, Insight 5, Perception 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Barbed Hide",
+          "description": "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it."
+        },
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        },
+        {
+          "name": "Hurl Flame",
+          "description": "Ranged Spell Attack: +5 to hit, range 150 ft., one target. Hit: 10 (3d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it."
+    },
+    {
+      "id": "basilisk",
+      "name": "Basilisk",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin"
+      ],
+      "ac": 12,
+      "hp": 52,
+      "hitDice": "8d8+16",
+      "speed": "Walk 20",
+      "initiative": -1,
+      "abilities": {
+        "str": 16,
+        "dex": 8,
+        "con": 15,
+        "int": 2,
+        "wis": 8,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Petrifying Gaze",
+          "description": "If a creature starts its turn within 30 ft. of the basilisk and the two of them can see each other, the basilisk can force the creature to make a DC 12 Constitution saving throw if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.\nA creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.\nIf the basilisk sees its reflection within 30 ft. of it in bright light, it mistakes itself for a rival and targets itself with its gaze."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage plus 7 (2d6) poison damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If a creature starts its turn within 30 ft. of the basilisk and the two of them can see each other, the basilisk can force the creature to make a DC 12 Constitution saving throw if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.\nA creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.\nIf the basilisk sees its reflection within 30 ft. of it in bright light, it mistakes itself for a rival and targets itself with its gaze."
+    },
+    {
+      "id": "bat",
+      "name": "Bat",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Forest"],
+      "ac": 12,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 5, Fly 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 2,
+        "dex": 15,
+        "con": 8,
+        "int": 2,
+        "wis": 12,
+        "cha": 4
+      },
+      "senses": "blindsight 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Echolocation",
+          "description": "The bat can't use its blindsight while deafened."
+        },
+        {
+          "name": "Keen Hearing",
+          "description": "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +0 to hit, reach 5 ft., one creature. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bat can't use its blindsight while deafened."
+    },
+    {
+      "id": "bearded-devil",
+      "name": "Bearded Devil",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 13,
+      "hp": 52,
+      "hitDice": "8d8+16",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 16,
+        "dex": 15,
+        "con": 15,
+        "int": 9,
+        "wis": 11,
+        "cha": 11
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Steadfast",
+          "description": "The devil can't be frightened while it can see an allied creature within 30 feet of it."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes two attacks: one with its beard and one with its glaive."
+        },
+        {
+          "name": "Beard",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Glaive",
+          "description": "Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 8 (1d10 + 3) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the devil's darkvision."
+    },
+    {
+      "id": "behir",
+      "name": "Behir",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Neutral Evil",
+      "biomes": ["Caverns", "Plane Of Earth", "Ruin", "Underdark"],
+      "ac": 17,
+      "hp": 168,
+      "hitDice": "16d12+64",
+      "speed": "Walk 50, Climb 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 23,
+        "dex": 16,
+        "con": 18,
+        "int": 7,
+        "wis": 14,
+        "cha": 12
+      },
+      "senses": "darkvision 90 ft., passive Perception 16",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 6, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The behir makes two attacks: one with its bite and one to constrict."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) piercing damage."
+        },
+        {
+          "name": "Constrict",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one Large or smaller creature. Hit: 17 (2d10 + 6) bludgeoning damage plus 17 (2d10 + 6) slashing damage. The target is grappled (escape DC 16) if the behir isn't already constricting a creature, and the target is restrained until this grapple ends."
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "description": "The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Swallow",
+          "description": "The behir makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects outside the behir, and it takes 21 (6d6) acid damage at the start of each of the behir's turns. A behir can have only one creature swallowed at a time.\nIf the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 ft. of the behir. If the behir dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 ft. of movement, exiting prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The behir makes two attacks: one with its bite and one to constrict."
+    },
+    {
+      "id": "berserker",
+      "name": "Berserker",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Chaotic Alignment",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Swamp",
+        "Tundra"
+      ],
+      "ac": 13,
+      "hp": 67,
+      "hitDice": "9d8+27",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 12,
+        "con": 17,
+        "int": 9,
+        "wis": 11,
+        "cha": 9
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Reckless",
+          "description": "At the start of its turn, the berserker can gain advantage on all melee weapon attack rolls during that turn, but attack rolls against it have advantage until the start of its next turn."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Hailing from uncivilized lands, unpredictable **berserkers** come together in war parties and seek conflict wherever they can find it."
+    },
+    {
+      "id": "black-bear",
+      "name": "Black Bear",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Mountains"],
+      "ac": 11,
+      "hp": 19,
+      "hitDice": "3d8+6",
+      "speed": "Walk 40, Climb 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 14,
+        "int": 2,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The bear makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "black-dragon-wyrmling",
+      "name": "Black Dragon Wyrmling",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Swamp"],
+      "ac": 17,
+      "hp": 33,
+      "hitDice": "6d8+6",
+      "speed": "Walk 30, Fly 60, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 13,
+        "int": 10,
+        "wis": 11,
+        "cha": 13
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) acid damage."
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "description": "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "black-pudding",
+      "name": "Black Pudding",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Ooze",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Ruin", "Sewer", "Underdark", "Water"],
+      "ac": 7,
+      "hp": 85,
+      "hitDice": "10d10+30",
+      "speed": "Walk 20, Climb 20",
+      "initiative": -3,
+      "abilities": {
+        "str": 16,
+        "dex": 5,
+        "con": 16,
+        "int": 1,
+        "wis": 6,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid, cold, lightning, slashing",
+      "conditionImmunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
+      "traits": [
+        {
+          "name": "Amorphous",
+          "description": "The pudding can move through a space as narrow as 1 inch wide without squeezing."
+        },
+        {
+          "name": "Corrosive Form",
+          "description": "A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes 4 (1d8) acid damage. Any nonmagical weapon made of metal or wood that hits the pudding corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage. The pudding can eat through 2-inch-thick, nonmagical wood or metal in 1 round."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The pudding can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage plus 18 (4d8) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The pudding can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "blink-dog",
+      "name": "Blink Dog",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": ["Feywild", "Forest", "Grassland", "Jungle"],
+      "ac": 13,
+      "hp": 22,
+      "hitDice": "4d8+4",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 12,
+        "dex": 17,
+        "con": 12,
+        "int": 10,
+        "wis": 13,
+        "cha": 11
+      },
+      "senses": "passive Perception 10",
+      "languages": "Blink Dog, understands Sylvan but can't speak it",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The dog has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage."
+        },
+        {
+          "name": "Teleport (Recharge 4-6)",
+          "description": "The dog magically teleports, along with any equipment it is wearing or carrying, up to 40 ft. to an unoccupied space it can see. Before or after teleporting, the dog can make one bite attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **blink dog** takes its name from its ability to blink in and out of existence, a talent it uses to aid its attacks and to avoid harm."
+    },
+    {
+      "id": "blood-hawk",
+      "name": "Blood Hawk",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Mountain"
+      ],
+      "ac": 12,
+      "hp": 7,
+      "hitDice": "2d6",
+      "speed": "Walk 10, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 6,
+        "dex": 14,
+        "con": 10,
+        "int": 3,
+        "wis": 14,
+        "cha": 5
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The hawk has advantage on an attack roll against a creature if at least one of the hawk's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Taking its name from its crimson feathers and aggressive nature, the **blood hawk** fearlessly attacks almost any animal, stabbing it with its daggerlike beak. Blood hawks flock together in large numbers, attacking as a pack to take down prey."
+    },
+    {
+      "id": "blue-dragon-wyrmling",
+      "name": "Blue Dragon Wyrmling",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Desert"],
+      "ac": 17,
+      "hp": 52,
+      "hitDice": "8d8+16",
+      "speed": "Walk 30, Burrow 15, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 10,
+        "con": 15,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage plus 3 (1d6) lightning damage."
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "description": "The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage plus 3 (1d6) lightning damage."
+    },
+    {
+      "id": "boar",
+      "name": "Boar",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill"],
+      "ac": 11,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 13,
+        "dex": 11,
+        "con": 12,
+        "int": 2,
+        "wis": 9,
+        "cha": 5
+      },
+      "senses": "passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 3 (1d6) slashing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Relentless (Recharges after a Short or Long Rest)",
+          "description": "If the boar takes 7 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tusk",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 3 (1d6) slashing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "bone-devil",
+      "name": "Bone Devil",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 19,
+      "hp": 142,
+      "hitDice": "15d10+60",
+      "speed": "Walk 40, Fly 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 18,
+        "dex": 16,
+        "con": 18,
+        "int": 13,
+        "wis": 14,
+        "cha": 16
+      },
+      "senses": "darkvision 120 ft., passive Perception 9",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "Deception 7, Insight 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes three attacks: two with its claws and one with its sting."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage."
+        },
+        {
+          "name": "Sting",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the devil's darkvision."
+    },
+    {
+      "id": "brass-dragon-wyrmling",
+      "name": "Brass Dragon Wyrmling",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Good",
+      "biomes": ["Desert"],
+      "ac": 16,
+      "hp": 16,
+      "hitDice": "3d8+3",
+      "speed": "Walk 30, Burrow 15, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 13,
+        "int": 10,
+        "wis": 11,
+        "cha": 13
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+    },
+    {
+      "id": "bronze-dragon-wyrmling",
+      "name": "Bronze Dragon Wyrmling",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": ["Water"],
+      "ac": 17,
+      "hp": 32,
+      "hitDice": "5d8+10",
+      "speed": "Walk 30, Fly 60, Swim 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 10,
+        "con": 15,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 16 (3d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 12 Strength saving throw. On a failed save, the creature is pushed 30 feet away from the dragon."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "brown-bear",
+      "name": "Brown Bear",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Arctic", "Feywild", "Forest", "Hill", "Mountains"],
+      "ac": 11,
+      "hp": 34,
+      "hitDice": "4d10+12",
+      "speed": "Walk 40, Climb 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 16,
+        "int": 2,
+        "wis": 13,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The bear makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "bugbear",
+      "name": "Bugbear",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Humanoid",
+      "subtype": "Goblinoid",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 16,
+      "hp": 27,
+      "hitDice": "5d8+5",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 13,
+        "int": 8,
+        "wis": 11,
+        "cha": 9
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Common, Goblin",
+      "savingThrows": "",
+      "skills": "Stealth 6, Survival 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Brute",
+          "description": "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
+        },
+        {
+          "name": "Surprise Attack",
+          "description": "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Morningstar",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage."
+        },
+        {
+          "name": "Javelin",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 9 (2d6 + 2) piercing damage in melee or 5 (1d6 + 2) piercing damage at range."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
+    },
+    {
+      "id": "bulette",
+      "name": "Bulette",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin",
+        "Settlement"
+      ],
+      "ac": 17,
+      "hp": 94,
+      "hitDice": "9d10+45",
+      "speed": "Walk 40, Burrow 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 11,
+        "con": 21,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 16",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Standing Leap",
+          "description": "The bulette's long jump is up to 30 ft. and its high jump is up to 15 ft., with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 30 (4d12 + 4) piercing damage."
+        },
+        {
+          "name": "Deadly Leap",
+          "description": "If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its ft. in a space that contains one or more other creatures. Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take 14 (3d6 + 4) bludgeoning damage plus 14 (3d6 + 4) slashing damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bulette's long jump is up to 30 ft. and its high jump is up to 15 ft., with or without a running start."
+    },
+    {
+      "id": "camel",
+      "name": "Camel",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Settlement"],
+      "ac": 9,
+      "hp": 15,
+      "hitDice": "2d10+4",
+      "speed": "Walk 50",
+      "initiative": -1,
+      "abilities": {
+        "str": 16,
+        "dex": 8,
+        "con": 14,
+        "int": 2,
+        "wis": 8,
+        "cha": 5
+      },
+      "senses": "passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+    },
+    {
+      "id": "cat",
+      "name": "Cat",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Settlement", "Urban"],
+      "ac": 12,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 40, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 3,
+        "dex": 15,
+        "con": 10,
+        "int": 3,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The cat has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The cat has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "centaur",
+      "name": "Centaur",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Good",
+      "biomes": ["Feywild", "Forest", "Grassland"],
+      "ac": 12,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Walk 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 14,
+        "con": 14,
+        "int": 9,
+        "wis": 13,
+        "cha": 11
+      },
+      "senses": "passive Perception 13",
+      "languages": "Elvish, Sylvan",
+      "savingThrows": "",
+      "skills": "Athletics 6, Perception 3, Survival 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra 10 (3d6) piercing damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow."
+        },
+        {
+          "name": "Pike",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        },
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra 10 (3d6) piercing damage."
+    },
+    {
+      "id": "chain-devil",
+      "name": "Chain Devil",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 16,
+      "hp": 85,
+      "hitDice": "10d8+40",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 18,
+        "int": 11,
+        "wis": 12,
+        "cha": 14
+      },
+      "senses": "darkvision 120 ft., passive Perception 8",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes two attacks with its chains."
+        },
+        {
+          "name": "Chain",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) slashing damage. The target is grappled (escape DC 14) if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained and takes 7 (2d6) piercing damage at the start of each of its turns."
+        },
+        {
+          "name": "Animate Chains (Recharges after a Short or Long Rest)",
+          "description": "Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.\nEach animated chain is an object with AC 20, 20 hit points, resistance to piercing damage, and immunity to psychic and thunder damage. When the devil uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the devil is incapacitated or dies."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the devil's darkvision."
+    },
+    {
+      "id": "chimera",
+      "name": "Chimera",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Sewer",
+        "Swamp",
+        "Tundra",
+        "Underdark",
+        "Water"
+      ],
+      "ac": 14,
+      "hp": 114,
+      "hitDice": "12d10+48",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 11,
+        "con": 19,
+        "int": 3,
+        "wis": 14,
+        "cha": 10
+      },
+      "senses": "darkvision 60 ft., passive Perception 18",
+      "languages": "understands Draconic but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+        },
+        {
+          "name": "Horns",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 31 (7d8) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."
+    },
+    {
+      "id": "chuul",
+      "name": "Chuul",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Aberration",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Caverns", "Plane Of Water", "Underdark", "Water"],
+      "ac": 16,
+      "hp": 93,
+      "hitDice": "11d10+33",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 16,
+        "int": 5,
+        "wis": 11,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "understands Deep Speech but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The chuul can breathe air and water."
+        },
+        {
+          "name": "Sense Magic",
+          "description": "The chuul senses magic within 120 feet of it at will. This trait otherwise works like the detect magic spell but isn't itself magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once."
+        },
+        {
+          "name": "Pincer",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage. The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn't have two other creatures grappled."
+        },
+        {
+          "name": "Tentacles",
+          "description": "One creature grappled by the chuul must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The chuul can breathe air and water."
+    },
+    {
+      "id": "clay-golem",
+      "name": "Clay Golem",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Any"],
+      "ac": 14,
+      "hp": 133,
+      "hitDice": "14d10+56",
+      "speed": "Walk 20",
+      "initiative": -1,
+      "abilities": {
+        "str": 20,
+        "dex": 9,
+        "con": 18,
+        "int": 3,
+        "wis": 8,
+        "cha": 1
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "understands the languages of its creator but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid, poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Acid Absorption",
+          "description": "Whenever the golem is subjected to acid damage, it takes no damage and instead regains a number of hit points equal to the acid damage dealt."
+        },
+        {
+          "name": "Berserk",
+          "description": "Whenever the golem starts its turn with 60 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points."
+        },
+        {
+          "name": "Immutable Form",
+          "description": "The golem is immune to any spell or effect that would alter its form."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The golem has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The golem's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The golem makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic."
+        },
+        {
+          "name": "Haste (Recharge 5-6)",
+          "description": "Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Whenever the golem is subjected to acid damage, it takes no damage and instead regains a number of hit points equal to the acid damage dealt."
+    },
+    {
+      "id": "cloaker",
+      "name": "Cloaker",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Aberration",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Neutral",
+      "biomes": ["Caverns", "Laboratory", "Sewer", "Underdark"],
+      "ac": 14,
+      "hp": 78,
+      "hitDice": "12d10+12",
+      "speed": "Walk 10, Fly 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 12,
+        "int": 13,
+        "wis": 12,
+        "cha": 14
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "Deep Speech, Undercommon",
+      "savingThrows": "",
+      "skills": "Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Damage Transfer",
+          "description": "While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down). and that creature takes the other half."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the cloaker remains motionless without its underside exposed, it is indistinguishable from a dark leather cloak."
+        },
+        {
+          "name": "Light Sensitivity",
+          "description": "While in bright light, the cloaker has disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The cloaker makes two attacks: one with its bite and one with its tail."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 10 (2d6 + 3) piercing damage, and if the target is Large or smaller, the cloaker attaches to it. If the cloaker has advantage against the target, the cloaker attaches to the target's head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 7 (1d8 + 3) slashing damage."
+        },
+        {
+          "name": "Moan",
+          "description": "Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must succeed on a DC 13 Wisdom saving throw or become frightened until the end of the cloaker's next turn. If a creature's saving throw is successful, the creature is immune to the cloaker's moan for the next 24 hours."
+        },
+        {
+          "name": "Phantasms (Recharges after a Short or Long Rest)",
+          "description": "The cloaker magically creates three illusory duplicates of itself if it isn't in bright light. The duplicates move with it and mimic its actions, shifting position so as to make it impossible to track which cloaker is the real one. If the cloaker is ever in an area of bright light, the duplicates disappear.\nWhenever any creature targets the cloaker with an attack or a harmful spell while a duplicate remains, that creature rolls randomly to determine whether it targets the cloaker or one of the duplicates. A creature is unaffected by this magical effect if it can't see or if it relies on senses other than sight.\nA duplicate has the cloaker's AC and uses its saving throws. If an attack hits a duplicate, or if a duplicate fails a saving throw against an effect that deals damage, the duplicate disappears."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down). and that creature takes the other half."
+    },
+    {
+      "id": "cloud-giant",
+      "name": "Cloud Giant",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Neutral Good (50%) Or Neutral Evil (50%)",
+      "biomes": ["Mountain", "Mountains", "Plane Of Air"],
+      "ac": 14,
+      "hp": 200,
+      "hitDice": "16d12+96",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 27,
+        "dex": 10,
+        "con": 22,
+        "int": 12,
+        "wis": 16,
+        "cha": 16
+      },
+      "senses": "passive Perception 17",
+      "languages": "Common, Giant",
+      "savingThrows": "",
+      "skills": "Insight 7, Perception 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The giant has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The giant's innate spellcasting ability is Charisma. It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, fog cloud, light\n3/day each: feather fall, fly, misty step, telekinesis\n1/day each: control weather, gaseous form"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two morningstar attacks."
+        },
+        {
+          "name": "Morningstar",
+          "description": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) piercing damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: 30 (4d10 + 8) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "cockatrice",
+      "name": "Cockatrice",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Desert",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Swamp"
+      ],
+      "ac": 11,
+      "hp": 27,
+      "hitDice": "6d6+6",
+      "speed": "Walk 20, Fly 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 6,
+        "dex": 12,
+        "con": 12,
+        "int": 2,
+        "wis": 13,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) piercing damage, and the target must succeed on a DC 11 Constitution saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) piercing damage, and the target must succeed on a DC 11 Constitution saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours."
+    },
+    {
+      "id": "commoner",
+      "name": "Commoner",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Settlement",
+        "Urban"
+      ],
+      "ac": 10,
+      "hp": 4,
+      "hitDice": "1d8",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 10,
+        "dex": 10,
+        "con": 10,
+        "int": 10,
+        "wis": 10,
+        "cha": 10
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Club",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Commoners** include peasants, serfs, slaves, servants, pilgrims, merchants, artisans, and hermits."
+    },
+    {
+      "id": "constrictor-snake",
+      "name": "Constrictor Snake",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle", "Swamp", "Underwater"],
+      "ac": 12,
+      "hp": 13,
+      "hitDice": "2d10+2",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 12,
+        "int": 1,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Constrict",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can't constrict another target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage."
+    },
+    {
+      "id": "copper-dragon-wyrmling",
+      "name": "Copper Dragon Wyrmling",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Good",
+      "biomes": ["Hills", "Mountains"],
+      "ac": 16,
+      "hp": 22,
+      "hitDice": "4d8+4",
+      "speed": "Walk 30, Climb 30, Fly 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 12,
+        "con": 13,
+        "int": 14,
+        "wis": 11,
+        "cha": 13
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 18 (4d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+    },
+    {
+      "id": "couatl",
+      "name": "Couatl",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": [
+        "Astral Plane",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Jungle",
+        "Urban"
+      ],
+      "ac": 19,
+      "hp": 97,
+      "hitDice": "13d8+39",
+      "speed": "Walk 30, Fly 90",
+      "initiative": 5,
+      "abilities": {
+        "str": 16,
+        "dex": 20,
+        "con": 17,
+        "int": 18,
+        "wis": 20,
+        "cha": 18
+      },
+      "senses": "truesight 120 ft., passive Perception 15",
+      "languages": "all, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "radiant",
+      "damageImmunities": "psychic; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The couatl's spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:\n\nAt will: detect evil and good, detect magic, detect thoughts\n3/day each: bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield\n1/day each: dream, greater restoration, scrying"
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The couatl's weapon attacks are magical."
+        },
+        {
+          "name": "Shielded Mind",
+          "description": "The couatl is immune to scrying and to any effect that would sense its emotions, read its thoughts, or detect its location."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one creature. Hit: 8 (1d6 + 5) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake."
+        },
+        {
+          "name": "Constrict",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one Medium or smaller creature. Hit: 10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).\nIn a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The couatl's spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:\n\nAt will: detect evil and good, detect magic, detect thoughts\n3/day each: bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield\n1/day each: dream, greater restoration, scrying"
+    },
+    {
+      "id": "crab",
+      "name": "Crab",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Coastal", "Desert", "Water"],
+      "ac": 11,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 20, Swim 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 2,
+        "dex": 11,
+        "con": 10,
+        "int": 1,
+        "wis": 8,
+        "cha": 2
+      },
+      "senses": "blindsight 30 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The crab can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The crab can breathe air and water."
+    },
+    {
+      "id": "crocodile",
+      "name": "Crocodile",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Swamp", "Urban", "Water"],
+      "ac": 12,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 20, Swim 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "The crocodile can hold its breath for 15 minutes."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The crocodile can hold its breath for 15 minutes."
+    },
+    {
+      "id": "cult-fanatic",
+      "name": "Cult Fanatic",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Good Alignment",
+      "biomes": [
+        "Desert",
+        "Forest",
+        "Hills",
+        "Jungle",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Temple",
+        "Urban"
+      ],
+      "ac": 13,
+      "hp": 22,
+      "hitDice": "6d8+6",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 11,
+        "dex": 14,
+        "con": 12,
+        "int": 10,
+        "wis": 13,
+        "cha": 14
+      },
+      "senses": "passive Perception 11",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Deception 4, Persuasion 4, Religion 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Dark Devotion",
+          "description": "The fanatic has advantage on saving throws against being charmed or frightened."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:\n\nCantrips (at will): light, sacred flame, thaumaturgy\n* 1st level (4 slots): command, inflict wounds, shield of faith\n* 2nd level (3 slots): hold person, spiritual weapon"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The fanatic makes two melee attacks."
+        },
+        {
+          "name": "Dagger",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 4 (1d4 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Fanatics** are often part of a cult's leadership, using their charisma and dogma to influence and prey on those of weak will. Most are interested in personal power above all else."
+    },
+    {
+      "id": "cultist",
+      "name": "Cultist",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Good Alignment",
+      "biomes": [
+        "Desert",
+        "Forest",
+        "Hills",
+        "Jungle",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Temple",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 9,
+      "hitDice": "2d8",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 11,
+        "dex": 12,
+        "con": 10,
+        "int": 10,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Deception 2, Religion 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Dark Devotion",
+          "description": "The cultist has advantage on saving throws against being charmed or frightened."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Cultists** swear allegiance to dark powers such as elemental princes, demon lords, or archdevils. Most conceal their loyalties to avoid being ostracized, imprisoned, or executed for their beliefs. Unlike evil acolytes, cultists often show signs of insanity in their beliefs and practices."
+    },
+    {
+      "id": "darkmantle",
+      "name": "Darkmantle",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Shadowfell", "Underdark"],
+      "ac": 11,
+      "hp": 22,
+      "hitDice": "5d6+5",
+      "speed": "Walk 10, Fly 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 12,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "blindsight 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Echolocation",
+          "description": "The darkmantle can't use its blindsight while deafened."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the darkmantle remains motionless, it is indistinguishable from a cave formation such as a stalactite or stalagmite."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Crush",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d6 + 3) bludgeoning damage, and the darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way.\nWhile attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. The darkmantle's speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.\nA creature can detach the darkmantle by making a successful DC 13 Strength check as an action. On its turn, the darkmantle can detach itself from the target by using 5 feet of movement."
+        },
+        {
+          "name": "Darkness Aura (1/day)",
+          "description": "A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. The darkness lasts as long as the darkmantle maintains concentration, up to 10 minutes (as if concentrating on a spell). Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The darkmantle can't use its blindsight while deafened."
+    },
+    {
+      "id": "death-dog",
+      "name": "Death Dog",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Abyss", "Desert", "Grassland", "Hell", "Shadowfell"],
+      "ac": 12,
+      "hp": 39,
+      "hitDice": "6d8+12",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 14,
+        "int": 3,
+        "wis": 13,
+        "cha": 6
+      },
+      "senses": "darkvision 120 ft., passive Perception 15",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 5, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Two-Headed",
+          "description": "The dog has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, or knocked unconscious."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dog makes two bite attacks."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **death dog** is an ugly two-headed hound that roams plains, and deserts. Hate burns in a death dog's heart, and a taste for humanoid flesh drives it to attack travelers and explorers. Death dog saliva carries a foul disease that causes a victim's flesh to slowly rot off the bone."
+    },
+    {
+      "id": "deep-gnome-svirfneblin",
+      "name": "Deep Gnome (Svirfneblin)",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Gnome",
+      "size": "Small",
+      "alignment": "Neutral Good",
+      "biomes": ["Caves", "Underdark"],
+      "ac": 15,
+      "hp": 16,
+      "hitDice": "3d6+6",
+      "speed": "Walk 20",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 14,
+        "int": 12,
+        "wis": 10,
+        "cha": 9
+      },
+      "senses": "darkvision 120 ft., passive Perception 12",
+      "languages": "Gnomish, Terran, Undercommon",
+      "savingThrows": "",
+      "skills": "Investigation 3, Perception 2, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Stone Camouflage",
+          "description": "The gnome has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        },
+        {
+          "name": "Gnome Cunning",
+          "description": "The gnome has advantage on Intelligence, Wisdom, and Charisma saving throws against magic."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The gnome's innate spellcasting ability is Intelligence (spell save DC 11). It can innately cast the following spells, requiring no material components:\nAt will: nondetection (self only)\n1/day each: blindness/deafness, blur, disguise self"
+        }
+      ],
+      "actions": [
+        {
+          "name": "War Pick",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        },
+        {
+          "name": "Poisoned Dart",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The gnome has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+    },
+    {
+      "id": "deer",
+      "name": "Deer",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Feywild", "Forest", "Grassland"],
+      "ac": 13,
+      "hp": 4,
+      "hitDice": "1d8",
+      "speed": "Walk 50",
+      "initiative": 3,
+      "abilities": {
+        "str": 11,
+        "dex": 16,
+        "con": 11,
+        "int": 2,
+        "wis": 14,
+        "cha": 5
+      },
+      "senses": "passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage."
+    },
+    {
+      "id": "deva",
+      "name": "Deva",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Temple"],
+      "ac": 17,
+      "hp": 136,
+      "hitDice": "16d8+64",
+      "speed": "Walk 30, Fly 90",
+      "initiative": 4,
+      "abilities": {
+        "str": 18,
+        "dex": 18,
+        "con": 18,
+        "int": 17,
+        "wis": 20,
+        "cha": 20
+      },
+      "senses": "darkvision 120 ft., passive Perception 19",
+      "languages": "all, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "Insight 9, Perception 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, exhaustion, frightened",
+      "traits": [
+        {
+          "name": "Angelic Weapons",
+          "description": "The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an extra 4d8 radiant damage (included in the attack)."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The deva's spellcasting ability is Charisma (spell save DC 17). The deva can innately cast the following spells, requiring only verbal components:\nAt will: detect evil and good\n1/day each: commune, raise dead"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The deva has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The deva makes two melee attacks."
+        },
+        {
+          "name": "Mace",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage plus 18 (4d8) radiant damage."
+        },
+        {
+          "name": "Healing Touch (3/Day)",
+          "description": "The deva touches another creature. The target magically regains 20 (4d8 + 2) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva's choice).\nIn a new form, the deva retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and special senses are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an extra 4d8 radiant damage (included in the attack)."
+    },
+    {
+      "id": "dire-wolf",
+      "name": "Dire Wolf",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountains",
+        "Tundra"
+      ],
+      "ac": 14,
+      "hp": 37,
+      "hitDice": "5d10+10",
+      "speed": "Walk 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 15,
+        "int": 3,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "djinni",
+      "name": "Djinni",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Good",
+      "biomes": ["Coastal", "Desert", "Plane Of Air"],
+      "ac": 17,
+      "hp": 161,
+      "hitDice": "14d10+84",
+      "speed": "Walk 30, Fly 90",
+      "initiative": 2,
+      "abilities": {
+        "str": 21,
+        "dex": 15,
+        "con": 22,
+        "int": 15,
+        "wis": 16,
+        "cha": 20
+      },
+      "senses": "darkvision 120 ft., passive Perception 13",
+      "languages": "Auran",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning, thunder",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Elemental Demise",
+          "description": "If the djinni dies, its body disintegrates into a warm breeze, leaving behind only equipment the djinni was wearing or carrying."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The djinni's innate spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\nAt will: detect evil and good, detect magic, thunderwave\n3/day each: create food and water (can create wine instead of water), tongues, wind walk\n1/day each: conjure elemental (air elemental only), creation, gaseous form, invisibility, major image, plane shift"
+        },
+        {
+          "name": "Variant: Genie Powers",
+          "description": "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.\n\n**Disguises.** Some genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.\n**Wishes.** The genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.\nTo be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The djinni makes three scimitar attacks."
+        },
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage plus 3 (1d6) lightning or thunder damage (djinni's choice)."
+        },
+        {
+          "name": "Create Whirlwind",
+          "description": "A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell). Any creature but the djinni that enters the whirlwind must succeed on a DC 18 Strength saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.\nA creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the djinni dies, its body disintegrates into a warm breeze, leaving behind only equipment the djinni was wearing or carrying."
+    },
+    {
+      "id": "doppelganger",
+      "name": "Doppelganger",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "Shapechanger",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Laboratory",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Shadowfell",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 14,
+      "hp": 52,
+      "hitDice": "8d8+16",
+      "speed": "Walk 30",
+      "initiative": 4,
+      "abilities": {
+        "str": 11,
+        "dex": 18,
+        "con": 14,
+        "int": 11,
+        "wis": 12,
+        "cha": 14
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "Common",
+      "savingThrows": "",
+      "skills": "Deception 6, Insight 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Ambusher",
+          "description": "The doppelganger has advantage on attack rolls against any creature it has surprised."
+        },
+        {
+          "name": "Surprise Attack",
+          "description": "If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The doppelganger makes two melee attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Read Thoughts",
+          "description": "The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "draft-horse",
+      "name": "Draft Horse",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Settlement", "Urban"],
+      "ac": 10,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 10,
+        "con": 12,
+        "int": 2,
+        "wis": 11,
+        "cha": 7
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) bludgeoning damage."
+    },
+    {
+      "id": "dragon-turtle",
+      "name": "Dragon Turtle",
+      "cr": 17,
+      "challengeRating": "17",
+      "xp": 18000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Neutral",
+      "biomes": ["Coastal", "Desert", "Plane Of Water", "Underwater", "Water"],
+      "ac": 20,
+      "hp": 341,
+      "hitDice": "22d20+110",
+      "speed": "Walk 20, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 25,
+        "dex": 10,
+        "con": 20,
+        "int": 10,
+        "wis": 12,
+        "cha": 12
+      },
+      "senses": "darkvision 120 ft., passive Perception 11",
+      "languages": "Aquan, Draconic",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "fire",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon turtle can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 16 (2d8 + 7) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone."
+        },
+        {
+          "name": "Steam Breath (Recharge 5-6)",
+          "description": "The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 52 (15d6) fire damage on a failed save, or half as much damage on a successful one. Being underwater doesn't grant resistance against this damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon turtle can breathe air and water."
+    },
+    {
+      "id": "dretch",
+      "name": "Dretch",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Small",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 11,
+      "hp": 18,
+      "hitDice": "4d6+4",
+      "speed": "Walk 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 11,
+        "dex": 11,
+        "con": 12,
+        "int": 5,
+        "wis": 8,
+        "cha": 3
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "Abyssal, telepathy 60 ft. (works only with creatures that understand Abyssal)",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dretch makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 5 (2d4) slashing damage."
+        },
+        {
+          "name": "Fetid Cloud (1/Day)",
+          "description": "A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it. Any creature that starts its turn in that area must succeed on a DC 11 Constitution saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dretch makes two attacks: one with its bite and one with its claws."
+    },
+    {
+      "id": "drider",
+      "name": "Drider",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Feywild", "Ruin", "Underdark"],
+      "ac": 19,
+      "hp": 123,
+      "hitDice": "13d10+52",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 16,
+        "dex": 16,
+        "con": 18,
+        "int": 13,
+        "wis": 14,
+        "cha": 12
+      },
+      "senses": "darkvision 120 ft., passive Perception 15",
+      "languages": "Elvish, Undercommon",
+      "savingThrows": "",
+      "skills": "Perception 5, Stealth 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Fey Ancestry",
+          "description": "The drider has advantage on saving throws against being charmed, and magic can't put the drider to sleep."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The drider's innate spellcasting ability is Wisdom (spell save DC 13). The drider can innately cast the following spells, requiring no material components:\nAt will: dancing lights\n1/day each: darkness, faerie fire"
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The drider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the drider has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The drider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 2 (1d4) piercing damage plus 9 (2d8) poison damage."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The drider has advantage on saving throws against being charmed, and magic can't put the drider to sleep."
+    },
+    {
+      "id": "drow",
+      "name": "Drow",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Humanoid",
+      "subtype": "Elf",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Underdark"],
+      "ac": 15,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 14,
+        "con": 10,
+        "int": 11,
+        "wis": 11,
+        "cha": 12
+      },
+      "senses": "darkvision 120 ft., passive Perception 12",
+      "languages": "Elvish, Undercommon",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Fey Ancestry",
+          "description": "The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The drow's spellcasting ability is Charisma (spell save DC 11). It can innately cast the following spells, requiring no material components:\nAt will: dancing lights\n1/day each: darkness, faerie fire"
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Hand Crossbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
+    },
+    {
+      "id": "druid",
+      "name": "Druid",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Swamp",
+        "Tundra",
+        "Underdark"
+      ],
+      "ac": 11,
+      "hp": 27,
+      "hitDice": "5d8+5",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 10,
+        "dex": 12,
+        "con": 13,
+        "int": 12,
+        "wis": 15,
+        "cha": 11
+      },
+      "senses": "passive Perception 14",
+      "languages": "Druidic plus any two languages",
+      "savingThrows": "",
+      "skills": "Medicine 4, Nature 3, Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spellcasting",
+          "description": "The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared:\n\n* Cantrips (at will): druidcraft, produce flame, shillelagh\n* 1st level (4 slots): entangle, longstrider, speak with animals, thunderwave\n* 2nd level (3 slots): animal messenger, barkskin"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Quarterstaff",
+          "description": "Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 6 (1d8 + 2) bludgeoning damage with shillelagh or if wielded with two hands."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Druids** dwell in forests and other secluded wilderness locations, where they protect the natural world from monsters and the encroachment of civilization. Some are **tribal shamans** who heal the sick, pray to animal spirits, and provide spiritual guidance."
+    },
+    {
+      "id": "dryad",
+      "name": "Dryad",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 11,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 10,
+        "dex": 12,
+        "con": 11,
+        "int": 14,
+        "wis": 15,
+        "cha": 18
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Elvish, Sylvan",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The dryad's innate spellcasting ability is Charisma (spell save DC 14). The dryad can innately cast the following spells, requiring no material components:\n\nAt will: druidcraft\n3/day each: entangle, goodberry\n1/day each: barkskin, pass without trace, shillelagh"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The dryad has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Speak with Beasts and Plants",
+          "description": "The dryad can communicate with beasts and plants as if they shared a language."
+        },
+        {
+          "name": "Tree Stride",
+          "description": "Once on her turn, the dryad can use 10 ft. of her movement to step magically into one living tree within her reach and emerge from a second living tree within 60 ft. of the first tree, appearing in an unoccupied space within 5 ft. of the second tree. Both trees must be large or bigger."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Club",
+          "description": "Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh."
+        },
+        {
+          "name": "Fey Charm",
+          "description": "The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must succeed on a DC 14 Wisdom saving throw or be magically charmed. The charmed creature regards the dryad as a trusted friend to be heeded and protected. Although the target isn't under the dryad's control, it takes the dryad's requests or actions in the most favorable way it can.\nEach time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.\nThe dryad can have no more than one humanoid and up to three beasts charmed at a time."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dryad's innate spellcasting ability is Charisma (spell save DC 14). The dryad can innately cast the following spells, requiring no material components:\n\nAt will: druidcraft\n3/day each: entangle, goodberry\n1/day each: barkskin, pass without trace, shillelagh"
+    },
+    {
+      "id": "duergar",
+      "name": "Duergar",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Humanoid",
+      "subtype": "Dwarf",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Underdark"],
+      "ac": 16,
+      "hp": 26,
+      "hitDice": "4d8+8",
+      "speed": "Walk 25",
+      "initiative": 0,
+      "abilities": {
+        "str": 14,
+        "dex": 11,
+        "con": 14,
+        "int": 11,
+        "wis": 10,
+        "cha": 9
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "Dwarvish, Undercommon",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "poison",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Duergar Resilience",
+          "description": "The duergar has advantage on saving throws against poison, spells, and illusions, as well as to resist being charmed or paralyzed."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the duergar has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Enlarge (Recharges after a Short or Long Rest)",
+          "description": "For 1 minute, the duergar magically increases in size, along with anything it is wearing or carrying. While enlarged, the duergar is Large, doubles its damage dice on Strength-based weapon attacks (included in the attacks), and makes Strength checks and Strength saving throws with advantage. If the duergar lacks the room to become Large, it attains the maximum size possible in the space available."
+        },
+        {
+          "name": "War Pick",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage, or 11 (2d8 + 2) piercing damage while enlarged."
+        },
+        {
+          "name": "Javelin",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 9 (2d6 + 2) piercing damage while enlarged."
+        },
+        {
+          "name": "Invisibility (Recharges after a Short or Long Rest)",
+          "description": "The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The duergar has advantage on saving throws against poison, spells, and illusions, as well as to resist being charmed or paralyzed."
+    },
+    {
+      "id": "dust-mephit",
+      "name": "Dust Mephit",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Neutral Evil",
+      "biomes": ["Desert", "Mountains", "Plane Of Air", "Plane Of Earth"],
+      "ac": 12,
+      "hp": 17,
+      "hitDice": "5d6",
+      "speed": "Walk 30, Fly 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 5,
+        "dex": 14,
+        "con": 10,
+        "int": 9,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "Auran, Terran",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 4",
+      "damageVulnerabilities": "fire",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Death Burst",
+          "description": "When the mephit dies, it explodes in a burst of dust. Each creature within 5 ft. of it must then succeed on a DC 10 Constitution saving throw or be blinded for 1 minute. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Innate Spellcasting (1/Day)",
+          "description": "The mephit can innately cast _sleep_, requiring no material components. Its innate spellcasting ability is Charisma."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) slashing damage."
+        },
+        {
+          "name": "Blinding Breath (Recharge 6)",
+          "description": "The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a DC 10 Dexterity saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Variant: Summon Mephits (1/Day)",
+          "description": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the mephit dies, it explodes in a burst of dust. Each creature within 5 ft. of it must then succeed on a DC 10 Constitution saving throw or be blinded for 1 minute. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success."
+    },
+    {
+      "id": "eagle",
+      "name": "Eagle",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains"
+      ],
+      "ac": 12,
+      "hp": 3,
+      "hitDice": "1d6",
+      "speed": "Walk 10, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 6,
+        "dex": 15,
+        "con": 10,
+        "int": 2,
+        "wis": 14,
+        "cha": 7
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "earth-elemental",
+      "name": "Earth Elemental",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": ["Laboratory", "Plane Of Earth", "Underdark"],
+      "ac": 17,
+      "hp": 126,
+      "hitDice": "12d10+60",
+      "speed": "Walk 30, Burrow 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 20,
+        "dex": 8,
+        "con": 20,
+        "int": 5,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 10",
+      "languages": "Terran",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "thunder",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
+      "traits": [
+        {
+          "name": "Earth Glide",
+          "description": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn't disturb the material it moves through."
+        },
+        {
+          "name": "Siege Monster",
+          "description": "The elemental deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The elemental makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn't disturb the material it moves through."
+    },
+    {
+      "id": "efreeti",
+      "name": "Efreeti",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Desert", "Mountains", "Plane Of Fire"],
+      "ac": 17,
+      "hp": 200,
+      "hitDice": "16d10+112",
+      "speed": "Walk 40, Fly 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 22,
+        "dex": 12,
+        "con": 24,
+        "int": 16,
+        "wis": 15,
+        "cha": 16
+      },
+      "senses": "darkvision 120 ft., passive Perception 12",
+      "languages": "Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Elemental Demise",
+          "description": "If the efreeti dies, its body disintegrates in a flash of fire and puff of smoke, leaving behind only equipment the djinni was wearing or carrying."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The efreeti's innate spell casting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic\n3/day each: enlarge/reduce, tongues\n1/day each: conjure elemental (fire elemental only), gaseous form, invisibility, major image, plane shift, wall of fire"
+        },
+        {
+          "name": "Variant: Genie Powers",
+          "description": "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.\n\n**Disguises.** Some genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.\n**Wishes.** The genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.\nTo be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The efreeti makes two scimitar attacks or uses its Hurl Flame twice."
+        },
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage plus 7 (2d6) fire damage."
+        },
+        {
+          "name": "Hurl Flame",
+          "description": "Ranged Spell Attack: +7 to hit, range 120 ft., one target. Hit: 17 (5d6) fire damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the efreeti dies, its body disintegrates in a flash of fire and puff of smoke, leaving behind only equipment the djinni was wearing or carrying."
+    },
+    {
+      "id": "elephant",
+      "name": "Elephant",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Forest", "Grassland", "Jungle"],
+      "ac": 12,
+      "hp": 76,
+      "hitDice": "8d12+24",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 22,
+        "dex": 9,
+        "con": 17,
+        "int": 3,
+        "wis": 11,
+        "cha": 6
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Trampling Charge",
+          "description": "If the elephant moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage."
+        },
+        {
+          "name": "Stomp",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the elephant moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action."
+    },
+    {
+      "id": "elk",
+      "name": "Elk",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill", "Tundra"],
+      "ac": 10,
+      "hp": 13,
+      "hitDice": "2d10+2",
+      "speed": "Walk 50",
+      "initiative": 0,
+      "abilities": {
+        "str": 16,
+        "dex": 10,
+        "con": 12,
+        "int": 2,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        },
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one prone creature. Hit: 8 (2d4 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "erinyes",
+      "name": "Erinyes",
+      "cr": 12,
+      "challengeRating": "12",
+      "xp": 8400,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 18,
+      "hp": 153,
+      "hitDice": "18d8+72",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 18,
+        "dex": 16,
+        "con": 18,
+        "int": 14,
+        "wis": 14,
+        "cha": 18
+      },
+      "senses": "truesight 120 ft., passive Perception 12",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Hellish Weapons",
+          "description": "The erinyes's weapon attacks are magical and deal an extra 13 (3d8) poison damage on a hit (included in the attacks)."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The erinyes has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The erinyes makes three attacks"
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands, plus 13 (3d8) poison damage."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 13 (3d8) poison damage, and the target must succeed on a DC 14 Constitution saving throw or be poisoned. The poison lasts until it is removed by the lesser restoration spell or similar magic."
+        },
+        {
+          "name": "Variant: Rope of Entanglement",
+          "description": "Some erinyes carry a rope of entanglement (detailed in the Dungeon Master's Guide). When such an erinyes uses its Multiattack, the erinyes can use the rope in place of two of the attacks."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The erinyes's weapon attacks are magical and deal an extra 13 (3d8) poison damage on a hit (included in the attacks)."
+    },
+    {
+      "id": "ettercap",
+      "name": "Ettercap",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Forest", "Jungle", "Swamp"],
+      "ac": 13,
+      "hp": 44,
+      "hitDice": "8d8+8",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 14,
+        "dex": 15,
+        "con": 13,
+        "int": 7,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4, Survival 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spider Climb",
+          "description": "The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "description": "While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The ettercap ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The ettercap makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage plus 4 (1d8) poison damage. The target must succeed on a DC 11 Constitution saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage."
+        },
+        {
+          "name": "Web (Recharge 5-6)",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/60 ft., one Large or smaller creature. Hit: The creature is restrained by webbing. As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, vulnerability to fire damage and immunity to bludgeoning, poison, and psychic damage."
+        },
+        {
+          "name": "Variant: Web Garrote",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one Medium or Small creature against which the ettercap has advantage on the attack roll. Hit: 4 (1d4 + 2) bludgeoning damage, and the target is grappled (escape DC 12). Until this grapple ends, the target can't breathe, and the ettercap has advantage on attack rolls against it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+    },
+    {
+      "id": "ettin",
+      "name": "Ettin",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Hill", "Hills", "Mountain", "Ruin", "Underdark"],
+      "ac": 12,
+      "hp": 85,
+      "hitDice": "10d10+30",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 21,
+        "dex": 8,
+        "con": 17,
+        "int": 6,
+        "wis": 10,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Giant, Orc",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Two Heads",
+          "description": "The ettin has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."
+        },
+        {
+          "name": "Wakeful",
+          "description": "When one of the ettin's heads is asleep, its other head is awake."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The ettin makes two attacks: one with its battleaxe and one with its morningstar."
+        },
+        {
+          "name": "Battleaxe",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage."
+        },
+        {
+          "name": "Morningstar",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ettin has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."
+    },
+    {
+      "id": "fire-elemental",
+      "name": "Fire Elemental",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": ["Laboratory", "Plane Of Fire"],
+      "ac": 13,
+      "hp": 102,
+      "hitDice": "12d10+36",
+      "speed": "Walk 50",
+      "initiative": 3,
+      "abilities": {
+        "str": 10,
+        "dex": 17,
+        "con": 16,
+        "int": 6,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Fire Form",
+          "description": "The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 (1d10) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 (1d10) fire damage at the start of each of its turns."
+        },
+        {
+          "name": "Illumination",
+          "description": "The elemental sheds bright light in a 30-foot radius and dim light in an additional 30 ft.."
+        },
+        {
+          "name": "Water Susceptibility",
+          "description": "For every 5 ft. the elemental moves in water, or for every gallon of water splashed on it, it takes 1 cold damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The elemental makes two touch attacks."
+        },
+        {
+          "name": "Touch",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 5 (1d10) fire damage at the start of each of its turns."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 (1d10) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 (1d10) fire damage at the start of each of its turns."
+    },
+    {
+      "id": "fire-giant",
+      "name": "Fire Giant",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Desert",
+        "Mountain",
+        "Mountains",
+        "Plane Of Fire",
+        "Settlement",
+        "Underdark"
+      ],
+      "ac": 18,
+      "hp": 162,
+      "hitDice": "13d12+78",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 25,
+        "dex": 9,
+        "con": 23,
+        "int": 10,
+        "wis": 14,
+        "cha": 13
+      },
+      "senses": "passive Perception 16",
+      "languages": "Giant",
+      "savingThrows": "",
+      "skills": "Athletics 11, Perception 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two greatsword attacks."
+        },
+        {
+          "name": "Greatsword",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 28 (6d6 + 7) slashing damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +11 to hit, range 60/240 ft., one target. Hit: 29 (4d10 + 7) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant makes two greatsword attacks."
+    },
+    {
+      "id": "flesh-golem",
+      "name": "Flesh Golem",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Any"],
+      "ac": 9,
+      "hp": 93,
+      "hitDice": "11d8+44",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 19,
+        "dex": 9,
+        "con": 18,
+        "int": 6,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "understands the languages of its creator but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning, poison; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Berserk",
+          "description": "Whenever the golem starts its turn with 40 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points.\nThe golem's creator, if within 60 feet of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a DC 15 Charisma (Persuasion) check. If the check succeeds, the golem ceases being berserk. If it takes damage while still at 40 hit points or fewer, the golem might go berserk again."
+        },
+        {
+          "name": "Aversion of Fire",
+          "description": "If the golem takes fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn."
+        },
+        {
+          "name": "Immutable Form",
+          "description": "The golem is immune to any spell or effect that would alter its form."
+        },
+        {
+          "name": "Lightning Absorption",
+          "description": "Whenever the golem is subjected to lightning damage, it takes no damage and instead regains a number of hit points equal to the lightning damage dealt."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The golem has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The golem's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The golem makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Whenever the golem starts its turn with 40 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points.\nThe golem's creator, if within 60 feet of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a DC 15 Charisma (Persuasion) check. If the check succeeds, the golem ceases being berserk. If it takes damage while still at 40 hit points or fewer, the golem might go berserk again."
+    },
+    {
+      "id": "flying-snake",
+      "name": "Flying Snake",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Jungle",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 14,
+      "hp": 5,
+      "hitDice": "2d4",
+      "speed": "Walk 30, Fly 60, Swim 30",
+      "initiative": 4,
+      "abilities": {
+        "str": 4,
+        "dex": 18,
+        "con": 11,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "blindsight 10 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Flyby",
+          "description": "The snake doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1 piercing damage plus 7 (3d4) poison damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **flying snake** is a brightly colored, winged serpent found in remote jungles. Tribespeople and cultists sometimes domesticate flying snakes to serve as messengers that deliver scrolls wrapped in their coils."
+    },
+    {
+      "id": "flying-sword",
+      "name": "Flying Sword",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Laboratory", "Ruin"],
+      "ac": 17,
+      "hp": 17,
+      "hitDice": "5d6",
+      "speed": "Hover true, Walk 0, Fly 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 12,
+        "dex": 15,
+        "con": 11,
+        "int": 1,
+        "wis": 5,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 7",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison, psychic",
+      "conditionImmunities": "blinded, charmed, deafened, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Antimagic Susceptibility",
+          "description": "The sword is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the sword remains motionless and isn't flying, it is indistinguishable from a normal sword."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The sword is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+    },
+    {
+      "id": "frog",
+      "name": "Frog",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Jungle", "Swamp"],
+      "ac": 11,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 20, Swim 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 1,
+        "dex": 13,
+        "con": 8,
+        "int": 1,
+        "wis": 8,
+        "cha": 3
+      },
+      "senses": "darkvision 30 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 1, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The frog can breathe air and water"
+        },
+        {
+          "name": "Standing Leap",
+          "description": "The frog's long jump is up to 10 ft. and its high jump is up to 5 ft., with or without a running start."
+        }
+      ],
+      "actions": [],
+      "legendaryActions": [],
+      "details": "A **frog** has no effective attacks. It feeds on small insects and typically dwells near water, in trees, or underground. The frog’s statistics can also be used to represent a **toad**."
+    },
+    {
+      "id": "frost-giant",
+      "name": "Frost Giant",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Neutral Evil",
+      "biomes": ["Arctic", "Mountain", "Mountains", "Shadowfell", "Tundra"],
+      "ac": 15,
+      "hp": 138,
+      "hitDice": "12d12+60",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 23,
+        "dex": 9,
+        "con": 21,
+        "int": 9,
+        "wis": 10,
+        "cha": 12
+      },
+      "senses": "passive Perception 13",
+      "languages": "Giant",
+      "savingThrows": "",
+      "skills": "Athletics 9, Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two greataxe attacks."
+        },
+        {
+          "name": "Greataxe",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 25 (3d12 + 6) slashing damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant makes two greataxe attacks."
+    },
+    {
+      "id": "gargoyle",
+      "name": "Gargoyle",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Hills",
+        "Laboratory",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin",
+        "Settlement",
+        "Temple",
+        "Tomb",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 15,
+      "hp": 52,
+      "hitDice": "7d8+21",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 11,
+        "con": 16,
+        "int": 6,
+        "wis": 11,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Terran",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, petrified, poisoned",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the gargoyle remains motion less, it is indistinguishable from an inanimate statue."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The gargoyle makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the gargoyle remains motion less, it is indistinguishable from an inanimate statue."
+    },
+    {
+      "id": "gelatinous-cube",
+      "name": "Gelatinous Cube",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Ooze",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Plane Of Water",
+        "Ruin",
+        "Sewer",
+        "Underdark",
+        "Water"
+      ],
+      "ac": 6,
+      "hp": 84,
+      "hitDice": "8d10+40",
+      "speed": "Walk 15",
+      "initiative": -4,
+      "abilities": {
+        "str": 14,
+        "dex": 3,
+        "con": 20,
+        "int": 1,
+        "wis": 6,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
+      "traits": [
+        {
+          "name": "Ooze Cube",
+          "description": "The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has disadvantage on the saving throw.\nCreatures inside the cube can be seen but have total cover.\nA creature within 5 feet of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful DC 12 Strength check, and the creature making the attempt takes 10 (3d6) acid damage.\nThe cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time."
+        },
+        {
+          "name": "Transparent",
+          "description": "Even when the cube is in plain sight, it takes a successful DC 15 Wisdom (Perception) check to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) acid damage."
+        },
+        {
+          "name": "Engulf",
+          "description": "The cube moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the cube enters a creature's space, the creature must make a DC 12 Dexterity saving throw.\nOn a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.\nOn a failed save, the cube enters the creature's space, and the creature takes 10 (3d6) acid damage and is engulfed. The engulfed creature can't breathe, is restrained, and takes 21 (6d6) acid damage at the start of each of the cube's turns. When the cube moves, the engulfed creature moves with it.\nAn engulfed creature can try to escape by taking an action to make a DC 12 Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the cube."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has disadvantage on the saving throw.\nCreatures inside the cube can be seen but have total cover.\nA creature within 5 feet of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful DC 12 Strength check, and the creature making the attempt takes 10 (3d6) acid damage.\nThe cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time."
+    },
+    {
+      "id": "ghast",
+      "name": "Ghast",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Abyss",
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Mountains",
+        "Ruin",
+        "Sewer",
+        "Shadowfell",
+        "Swamp",
+        "Temple",
+        "Tomb",
+        "Tundra",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 13,
+      "hp": 36,
+      "hitDice": "8d8",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 16,
+        "dex": 17,
+        "con": 10,
+        "int": 11,
+        "wis": 10,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Common",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "necrotic",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, exhaustion, poisoned",
+      "traits": [
+        {
+          "name": "Stench",
+          "description": "Any creature that starts its turn within 5 ft. of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours."
+        },
+        {
+          "name": "Turn Defiance",
+          "description": "The ghast and any ghouls within 30 ft. of it have advantage on saving throws against effects that turn undead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 12 (2d8 + 3) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Any creature that starts its turn within 5 ft. of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours."
+    },
+    {
+      "id": "ghost",
+      "name": "Ghost",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Desert",
+        "Ethereal Plane",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Swamp",
+        "Temple",
+        "Tomb",
+        "Tundra",
+        "Underdark",
+        "Urban",
+        "Water"
+      ],
+      "ac": 11,
+      "hp": 45,
+      "hitDice": "10d8",
+      "speed": "Hover true, Walk 0, Fly 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 7,
+        "dex": 13,
+        "con": 10,
+        "int": 10,
+        "wis": 12,
+        "cha": 17
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "any languages it knew in life",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "cold, necrotic, poison",
+      "conditionImmunities": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained",
+      "traits": [
+        {
+          "name": "Ethereal Sight",
+          "description": "The ghost can see 60 ft. into the Ethereal Plane when it is on the Material Plane, and vice versa."
+        },
+        {
+          "name": "Incorporeal Movement",
+          "description": "The ghost can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Withering Touch",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 17 (4d6 + 3) necrotic damage."
+        },
+        {
+          "name": "Etherealness",
+          "description": "The ghost enters the Ethereal Plane from the Material Plane, or vice versa. It is visible on the Material Plane while it is in the Border Ethereal, and vice versa, yet it can't affect or be affected by anything on the other plane."
+        },
+        {
+          "name": "Horrifying Visage",
+          "description": "Each non-undead creature within 60 ft. of the ghost that can see it must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 x 10 years. A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a greater restoration spell, but only within 24 hours of it occurring."
+        },
+        {
+          "name": "Possession (Recharge 6)",
+          "description": "One humanoid that the ghost can see within 5 ft. of it must succeed on a DC 13 Charisma saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.\nThe possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ghost can see 60 ft. into the Ethereal Plane when it is on the Material Plane, and vice versa."
+    },
+    {
+      "id": "ghoul",
+      "name": "Ghoul",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Abyss",
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Sewer",
+        "Shadowfell",
+        "Swamp",
+        "Temple",
+        "Tomb",
+        "Tundra",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 13,
+        "dex": 15,
+        "con": 10,
+        "int": 7,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Common",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, exhaustion, poisoned",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) piercing damage."
+    },
+    {
+      "id": "giant-ape",
+      "name": "Giant Ape",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 12,
+      "hp": 157,
+      "hitDice": "15d12+60",
+      "speed": "Walk 40, Climb 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 23,
+        "dex": 14,
+        "con": 18,
+        "int": 7,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Athletics 9, Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The ape makes two fist attacks."
+        },
+        {
+          "name": "Fist",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit: 30 (7d6 + 6) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ape makes two fist attacks."
+    },
+    {
+      "id": "giant-badger",
+      "name": "Giant Badger",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland"],
+      "ac": 10,
+      "hp": 13,
+      "hitDice": "2d8+4",
+      "speed": "Walk 30, Burrow 10",
+      "initiative": 0,
+      "abilities": {
+        "str": 13,
+        "dex": 10,
+        "con": 15,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "darkvision 30 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The badger makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "giant-bat",
+      "name": "Giant Bat",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Forest", "Underdark"],
+      "ac": 13,
+      "hp": 22,
+      "hitDice": "4d10",
+      "speed": "Walk 10, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 15,
+        "dex": 16,
+        "con": 11,
+        "int": 2,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "blindsight 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Echolocation",
+          "description": "The bat can't use its blindsight while deafened."
+        },
+        {
+          "name": "Keen Hearing",
+          "description": "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bat can't use its blindsight while deafened."
+    },
+    {
+      "id": "giant-boar",
+      "name": "Giant Boar",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Feywild", "Forest", "Grassland", "Hill", "Jungle"],
+      "ac": 12,
+      "hp": 42,
+      "hitDice": "5d10+15",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 10,
+        "con": 16,
+        "int": 2,
+        "wis": 7,
+        "cha": 5
+      },
+      "senses": "passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Relentless (Recharges after a Short or Long Rest)",
+          "description": "If the boar takes 10 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tusk",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "giant-centipede",
+      "name": "Giant Centipede",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Ruin", "Underdark", "Urban"],
+      "ac": 13,
+      "hp": 4,
+      "hitDice": "1d6+1",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 5,
+        "dex": 14,
+        "con": 12,
+        "int": 1,
+        "wis": 7,
+        "cha": 3
+      },
+      "senses": "blindsight 30 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or take 10 (3d6) poison damage. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or take 10 (3d6) poison damage. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+    },
+    {
+      "id": "giant-constrictor-snake",
+      "name": "Giant Constrictor Snake",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle", "Swamp", "Underdark", "Underwater"],
+      "ac": 12,
+      "hp": 60,
+      "hitDice": "8d12+8",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 19,
+        "dex": 14,
+        "con": 12,
+        "int": 1,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage."
+        },
+        {
+          "name": "Constrict",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 13 (2d8 + 4) bludgeoning damage, and the target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can't constrict another target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage."
+    },
+    {
+      "id": "giant-crab",
+      "name": "Giant Crab",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Coastal", "Desert", "Water"],
+      "ac": 15,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 13,
+        "dex": 15,
+        "con": 11,
+        "int": 1,
+        "wis": 9,
+        "cha": 3
+      },
+      "senses": "blindsight 30 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The crab can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage, and the target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The crab can breathe air and water."
+    },
+    {
+      "id": "giant-crocodile",
+      "name": "Giant Crocodile",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Swamp", "Water"],
+      "ac": 14,
+      "hp": 85,
+      "hitDice": "9d12+27",
+      "speed": "Walk 30, Swim 50",
+      "initiative": -1,
+      "abilities": {
+        "str": 21,
+        "dex": 9,
+        "con": 17,
+        "int": 2,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "The crocodile can hold its breath for 30 minutes."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The crocodile makes two attacks: one with its bite and one with its tail."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 21 (3d10 + 5) piercing damage, and the target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can't bite another target."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target not grappled by the crocodile. Hit: 14 (2d8 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The crocodile can hold its breath for 30 minutes."
+    },
+    {
+      "id": "giant-eagle",
+      "name": "Giant Eagle",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Good",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Feywild",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains"
+      ],
+      "ac": 13,
+      "hp": 26,
+      "hitDice": "4d10+4",
+      "speed": "Walk 10, Fly 80",
+      "initiative": 3,
+      "abilities": {
+        "str": 16,
+        "dex": 17,
+        "con": 13,
+        "int": 8,
+        "wis": 14,
+        "cha": 10
+      },
+      "senses": "passive Perception 14",
+      "languages": "Giant Eagle, understands Common and Auran but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The eagle makes two attacks: one with its beak and one with its talons."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **giant eagle** is a noble creature that speaks its own language and understands speech in the Common tongue. A mated pair of giant eagles typically has up to four eggs or young in their nest (treat the young as normal eagles)."
+    },
+    {
+      "id": "giant-elk",
+      "name": "Giant Elk",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill", "Mountain", "Tundra"],
+      "ac": 15,
+      "hp": 42,
+      "hitDice": "5d12+10",
+      "speed": "Walk 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 19,
+        "dex": 16,
+        "con": 14,
+        "int": 7,
+        "wis": 14,
+        "cha": 10
+      },
+      "senses": "passive Perception 14",
+      "languages": "Giant Elk, understands Common, Elvish, and Sylvan but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one prone creature. Hit: 22 (4d8 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The majestic **giant elk** is rare to the point that its appearance is often taken as a foreshadowing of an important event, such as the birth of a king. Legends tell of gods that take the form of giant elk when visiting the Material Plane. Many cultures therefore believe that to hunt these creatures is to invite divine wrath."
+    },
+    {
+      "id": "giant-fire-beetle",
+      "name": "Giant Fire Beetle",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Underdark"],
+      "ac": 13,
+      "hp": 4,
+      "hitDice": "1d6+1",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 8,
+        "dex": 10,
+        "con": 12,
+        "int": 1,
+        "wis": 7,
+        "cha": 3
+      },
+      "senses": "blindsight 30 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Illumination",
+          "description": "The beetle sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 2 (1d6 - 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **giant fire beetle** is a nocturnal creature that takes its name from a pair of glowing glands that give off light. Miners and adventurers prize these creatures, for a giant fire beetle's glands continue to shed light for 1d6 days after the beetle dies. Giant fire beetles are most commonly found underground and in dark forests."
+    },
+    {
+      "id": "giant-frog",
+      "name": "Giant Frog",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Jungle", "Swamp", "Water"],
+      "ac": 11,
+      "hp": 18,
+      "hitDice": "4d8",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 12,
+        "dex": 13,
+        "con": 11,
+        "int": 2,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "darkvision 30 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The frog can breathe air and water"
+        },
+        {
+          "name": "Standing Leap",
+          "description": "The frog's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage, and the target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can't bite another target."
+        },
+        {
+          "name": "Swallow",
+          "description": "The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 5 (2d4) acid damage at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The frog can breathe air and water"
+    },
+    {
+      "id": "giant-goat",
+      "name": "Giant Goat",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Grassland", "Hill", "Hills", "Mountain", "Mountains"],
+      "ac": 11,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 11,
+        "con": 12,
+        "int": 3,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 5 (2d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Sure-Footed",
+          "description": "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 5 (2d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "giant-hyena",
+      "name": "Giant Hyena",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Forest", "Grassland", "Hill", "Ruin", "Shadowfell"],
+      "ac": 12,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Walk 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 16,
+        "dex": 14,
+        "con": 14,
+        "int": 2,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Rampage",
+          "description": "When the hyena reduces a creature to 0 hit points with a melee attack on its turn, the hyena can take a bonus action to move up to half its speed and make a bite attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the hyena reduces a creature to 0 hit points with a melee attack on its turn, the hyena can take a bonus action to move up to half its speed and make a bite attack."
+    },
+    {
+      "id": "giant-lizard",
+      "name": "Giant Lizard",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Jungle",
+        "Ruin",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 12,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 12,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "darkvision 30 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Variant: Hold Breath",
+          "description": "The lizard can hold its breath for 15 minutes. (A lizard that has this trait also has a swimming speed of 30 feet.)"
+        },
+        {
+          "name": "Variant: Spider Climb",
+          "description": "The lizard can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **giant lizard** can be ridden or used as a draft animal. Lizardfolk also keep them as pets, and subterranean giant lizards are used as mounts and pack animals by drow, duergar, and others."
+    },
+    {
+      "id": "giant-octopus",
+      "name": "Giant Octopus",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Underwater", "Water"],
+      "ac": 11,
+      "hp": 52,
+      "hitDice": "8d10+8",
+      "speed": "Walk 10, Swim 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 17,
+        "dex": 13,
+        "con": 13,
+        "int": 4,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "While out of water, the octopus can hold its breath for 1 hour."
+        },
+        {
+          "name": "Underwater Camouflage",
+          "description": "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The octopus can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tentacles",
+          "description": "Melee Weapon Attack: +5 to hit, reach 15 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage. If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target."
+        },
+        {
+          "name": "Ink Cloud (Recharges after a Short or Long Rest)",
+          "description": "A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While out of water, the octopus can hold its breath for 1 hour."
+    },
+    {
+      "id": "giant-owl",
+      "name": "Giant Owl",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": ["Arctic", "Feywild", "Forest", "Hill"],
+      "ac": 12,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 5, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 13,
+        "dex": 15,
+        "con": 12,
+        "int": 8,
+        "wis": 13,
+        "cha": 10
+      },
+      "senses": "darkvision 120 ft., passive Perception 15",
+      "languages": "Giant Owl, understands Common, Elvish, and Sylvan but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 5, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Flyby",
+          "description": "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        },
+        {
+          "name": "Keen Hearing and Sight",
+          "description": "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 8 (2d6 + 1) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Giant owls** often befriend fey and other sylvan creatures and are guardians of their woodland realms."
+    },
+    {
+      "id": "giant-poisonous-snake",
+      "name": "Giant Poisonous Snake",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Sewer",
+        "Swamp",
+        "Tomb",
+        "Underdark",
+        "Urban",
+        "Water"
+      ],
+      "ac": 14,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 4,
+      "abilities": {
+        "str": 10,
+        "dex": 18,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 6 (1d4 + 4) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 6 (1d4 + 4) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+    },
+    {
+      "id": "giant-rat",
+      "name": "Giant Rat",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Forest",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 7,
+      "hitDice": "2d6",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 7,
+        "dex": 15,
+        "con": 11,
+        "int": 2,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The rat has advantage on an attack roll against a creature if at least one of the rat's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "giant-rat-diseased",
+      "name": "Giant Rat (Diseased)",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Forest", "Ruin", "Settlement", "Sewer", "Swamp"],
+      "ac": 12,
+      "hp": 7,
+      "hitDice": "2d6",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 7,
+        "dex": 15,
+        "con": 11,
+        "int": 2,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies."
+    },
+    {
+      "id": "giant-scorpion",
+      "name": "Giant Scorpion",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Jungle", "Shadowfell"],
+      "ac": 15,
+      "hp": 52,
+      "hitDice": "7d10+14",
+      "speed": "Walk 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 13,
+        "con": 15,
+        "int": 1,
+        "wis": 9,
+        "cha": 3
+      },
+      "senses": "blindsight 60 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target."
+        },
+        {
+          "name": "Multiattack",
+          "description": "The scorpion makes three attacks: two with its claws and one with its sting."
+        },
+        {
+          "name": "Sting",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 12 Constitution saving throw, taking 22 (4d10) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target."
+    },
+    {
+      "id": "giant-sea-horse",
+      "name": "Giant Sea Horse",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Underwater"],
+      "ac": 13,
+      "hp": 16,
+      "hitDice": "3d10",
+      "speed": "Walk 0, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 12,
+        "dex": 15,
+        "con": 11,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) bludgeoning damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The sea horse can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Like their smaller kin, **giant sea horses** are shy, colorful fish with elongated bodies and curled tails. Aquatic elves train them as mounts."
+    },
+    {
+      "id": "giant-shark",
+      "name": "Giant Shark",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Plane Of Water", "Underwater", "Water"],
+      "ac": 13,
+      "hp": 126,
+      "hitDice": "11d12+55",
+      "speed": "Swim 50",
+      "initiative": 0,
+      "abilities": {
+        "str": 23,
+        "dex": 11,
+        "con": 21,
+        "int": 1,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "blindsight 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Blood Frenzy",
+          "description": "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 22 (3d10 + 6) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **giant shark** is 30 feet long and normally found in deep oceans. Utterly fearless, it preys on anything that crosses its path, including whales and ships."
+    },
+    {
+      "id": "giant-spider",
+      "name": "Giant Spider",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Feywild",
+        "Forest",
+        "Jungle",
+        "Ruin",
+        "Shadowfell",
+        "Swamp",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 14,
+      "hp": 26,
+      "hitDice": "4d10+4",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 14,
+        "dex": 16,
+        "con": 12,
+        "int": 2,
+        "wis": 11,
+        "cha": 4
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spider Climb",
+          "description": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "description": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 9 (2d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        },
+        {
+          "name": "Web (Recharge 5-6)",
+          "description": "Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to fire damage; immunity to bludgeoning, poison, and psychic damage)."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "To snare its prey, a **giant spider** spins elaborate webs or shoots sticky strands of webbing from its abdomen. Giant spiders are most commonly found underground, making their lairs on ceilings or in dark, web-filled crevices. Such lairs are often festooned with web cocoons holding past victims."
+    },
+    {
+      "id": "giant-toad",
+      "name": "Giant Toad",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Jungle",
+        "Swamp",
+        "Underdark",
+        "Water"
+      ],
+      "ac": 11,
+      "hp": 39,
+      "hitDice": "6d10+6",
+      "speed": "Walk 20, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 13,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "darkvision 30 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The toad can breathe air and water"
+        },
+        {
+          "name": "Standing Leap",
+          "description": "The toad's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 5 (1d10) poison damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can't bite another target."
+        },
+        {
+          "name": "Swallow",
+          "description": "The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes 10 (3d6) acid damage at the start of each of the toad's turns. The toad can have only one target swallowed at a time.\nIf the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The toad can breathe air and water"
+    },
+    {
+      "id": "giant-vulture",
+      "name": "Giant Vulture",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Desert", "Grassland"],
+      "ac": 10,
+      "hp": 22,
+      "hitDice": "3d10+6",
+      "speed": "Walk 10, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 15,
+        "int": 6,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "understands Common but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight and Smell",
+          "description": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The vulture makes two attacks: one with its beak and one with its talons."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage."
+        },
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+    },
+    {
+      "id": "giant-wasp",
+      "name": "Giant Wasp",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hills", "Jungle", "Urban"],
+      "ac": 12,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 10, Fly 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 14,
+        "con": 10,
+        "int": 1,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Sting",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+    },
+    {
+      "id": "giant-weasel",
+      "name": "Giant Weasel",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Feywild", "Forest", "Grassland", "Hill"],
+      "ac": 13,
+      "hp": 9,
+      "hitDice": "2d8",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 11,
+        "dex": 16,
+        "con": 10,
+        "int": 4,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "giant-wolf-spider",
+      "name": "Giant Wolf Spider",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Ruin"
+      ],
+      "ac": 13,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 40, Climb 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 12,
+        "dex": 16,
+        "con": 13,
+        "int": 3,
+        "wis": 12,
+        "cha": 4
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spider Climb",
+          "description": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "description": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Smaller than a giant spider, a **giant wolf spider** hunts prey across open ground or hides in a burrow or crevice, or in a hidden cavity beneath debris."
+    },
+    {
+      "id": "gibbering-mouther",
+      "name": "Gibbering Mouther",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Aberration",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Astral Plane", "Caverns", "Laboratory", "Sewer", "Underdark"],
+      "ac": 9,
+      "hp": 67,
+      "hitDice": "9d8+27",
+      "speed": "Walk 10, Swim 10",
+      "initiative": -1,
+      "abilities": {
+        "str": 10,
+        "dex": 8,
+        "con": 16,
+        "int": 3,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "prone",
+      "traits": [
+        {
+          "name": "Aberrant Ground",
+          "description": "The ground in a 10-foot radius around the mouther is doughlike difficult terrain. Each creature that starts its turn in that area must succeed on a DC 10 Strength saving throw or have its speed reduced to 0 until the start of its next turn."
+        },
+        {
+          "name": "Gibbering",
+          "description": "The mouther babbles incoherently while it can see any creature and isn't incapacitated. Each creature that starts its turn within 20 feet of the mouther and can hear the gibbering must succeed on a DC 10 Wisdom saving throw. On a failure, the creature can't take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."
+        },
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 17 (5d6) piercing damage. If the target is Medium or smaller, it must succeed on a DC 10 Strength saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther."
+        },
+        {
+          "name": "Blinding Spittle (Recharge 5-6)",
+          "description": "The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must succeed on a DC 13 Dexterity saving throw or be blinded until the end of the mouther's next turn."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ground in a 10-foot radius around the mouther is doughlike difficult terrain. Each creature that starts its turn in that area must succeed on a DC 10 Strength saving throw or have its speed reduced to 0 until the start of its next turn."
+    },
+    {
+      "id": "glabrezu",
+      "name": "Glabrezu",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 17,
+      "hp": 157,
+      "hitDice": "15d10+75",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 20,
+        "dex": 15,
+        "con": 21,
+        "int": 19,
+        "wis": 17,
+        "cha": 16
+      },
+      "senses": "truesight 120 ft., passive Perception 13",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The glabrezu's spellcasting ability is Intelligence (spell save DC 16). The glabrezu can innately cast the following spells, requiring no material components:\nAt will: darkness, detect magic, dispel magic\n1/day each: confusion, fly, power word stun"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The glabrezu has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."
+        },
+        {
+          "name": "Pincer",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target."
+        },
+        {
+          "name": "Fist",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA glabrezu has a 30 percent chance of summoning 1d3 vrocks, 1d2 hezrous, or one glabrezu.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The glabrezu's spellcasting ability is Intelligence (spell save DC 16). The glabrezu can innately cast the following spells, requiring no material components:\nAt will: darkness, detect magic, dispel magic\n1/day each: confusion, fly, power word stun"
+    },
+    {
+      "id": "gladiator",
+      "name": "Gladiator",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Settlement", "Urban"],
+      "ac": 16,
+      "hp": 112,
+      "hitDice": "15d8+45",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 10,
+        "wis": 12,
+        "cha": 15
+      },
+      "senses": "passive Perception 11",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Athletics 10, Intimidation 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Brave",
+          "description": "The gladiator has advantage on saving throws against being frightened."
+        },
+        {
+          "name": "Brute",
+          "description": "A melee weapon deals one extra die of its damage when the gladiator hits with it (included in the attack)."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The gladiator makes three melee attacks or two ranged attacks."
+        },
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack."
+        },
+        {
+          "name": "Shield Bash",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 9 (2d4 + 4) bludgeoning damage. If the target is a Medium or smaller creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Gladiators** battle for the entertainment of raucous crowds. Some gladiators are brutal pit fighters who treat each match as a life-or-death struggle, while others are professional duelists who command huge fees but rarely fight to the death."
+    },
+    {
+      "id": "gnoll",
+      "name": "Gnoll",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Gnoll",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Abyss",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Settlement"
+      ],
+      "ac": 15,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 14,
+        "dex": 12,
+        "con": 11,
+        "int": 6,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Gnoll",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Rampage",
+          "description": "When the gnoll reduces a creature to 0 hit points with a melee attack on its turn, the gnoll can take a bonus action to move up to half its speed and make a bite attack."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage."
+        },
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the gnoll reduces a creature to 0 hit points with a melee attack on its turn, the gnoll can take a bonus action to move up to half its speed and make a bite attack."
+    },
+    {
+      "id": "goat",
+      "name": "Goat",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Settlement",
+        "Urban"
+      ],
+      "ac": 10,
+      "hp": 4,
+      "hitDice": "1d8",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 12,
+        "dex": 10,
+        "con": 11,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 2 (1d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 10 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Sure-Footed",
+          "description": "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 2 (1d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 10 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "goblin",
+      "name": "Goblin",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Humanoid",
+      "subtype": "Goblinoid",
+      "size": "Small",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Tundra",
+        "Underdark"
+      ],
+      "ac": 15,
+      "hp": 7,
+      "hitDice": "2d6",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 8,
+        "dex": 14,
+        "con": 10,
+        "int": 10,
+        "wis": 8,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "Common, Goblin",
+      "savingThrows": "",
+      "skills": "Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Nimble Escape",
+          "description": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Scimitar",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+        },
+        {
+          "name": "Shortbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+    },
+    {
+      "id": "gold-dragon-wyrmling",
+      "name": "Gold Dragon Wyrmling",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Grassland", "Ruin", "Water"],
+      "ac": 17,
+      "hp": 60,
+      "hitDice": "8d8+24",
+      "speed": "Walk 30, Fly 60, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 19,
+        "dex": 14,
+        "con": 17,
+        "int": 14,
+        "wis": 11,
+        "cha": 16
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 22 (4d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "gorgon",
+      "name": "Gorgon",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Plane Of Earth"
+      ],
+      "ac": 19,
+      "hp": 114,
+      "hitDice": "12d10+48",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 20,
+        "dex": 11,
+        "con": 18,
+        "int": 2,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "petrified",
+      "traits": [
+        {
+          "name": "Trampling Charge",
+          "description": "If the gorgon moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 16 Strength saving throw or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (2d12 + 5) piercing damage."
+        },
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage."
+        },
+        {
+          "name": "Petrifying Breath (Recharge 5-6)",
+          "description": "The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw. On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the greater restoration spell or other magic."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the gorgon moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 16 Strength saving throw or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action."
+    },
+    {
+      "id": "gray-ooze",
+      "name": "Gray Ooze",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Ooze",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin",
+        "Sewer",
+        "Underdark",
+        "Water"
+      ],
+      "ac": 8,
+      "hp": 22,
+      "hitDice": "3d8+9",
+      "speed": "Walk 10, Climb 10",
+      "initiative": -2,
+      "abilities": {
+        "str": 12,
+        "dex": 6,
+        "con": 16,
+        "int": 1,
+        "wis": 6,
+        "cha": 2
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid, cold, fire",
+      "damageImmunities": "",
+      "conditionImmunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
+      "traits": [
+        {
+          "name": "Amorphous",
+          "description": "The ooze can move through a space as narrow as 1 inch wide without squeezing."
+        },
+        {
+          "name": "Corrode Metal",
+          "description": "Any nonmagical weapon made of metal that hits the ooze corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage.\nThe ooze can eat through 2-inch-thick, nonmagical metal in 1 round."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the ooze remains motionless, it is indistinguishable from an oily pool or wet rock."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage plus 7 (2d6) acid damage, and if the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The ooze can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "green-dragon-wyrmling",
+      "name": "Green Dragon Wyrmling",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Forest", "Jungle"],
+      "ac": 17,
+      "hp": 38,
+      "hitDice": "7d8+7",
+      "speed": "Walk 30, Fly 60, Swim 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 12,
+        "con": 13,
+        "int": 14,
+        "wis": 11,
+        "cha": 13
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 3 (1d6) poison damage."
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "description": "The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 11 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "green-hag",
+      "name": "Green Hag",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Feywild",
+        "Forest",
+        "Hill",
+        "Jungle",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Swamp"
+      ],
+      "ac": 17,
+      "hp": 82,
+      "hitDice": "11d8+33",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 12,
+        "con": 16,
+        "int": 13,
+        "wis": 14,
+        "cha": 14
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Common, Draconic, Sylvan",
+      "savingThrows": "",
+      "skills": "Arcana 3, Deception 4, Perception 4, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The hag can breathe air and water."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The hag's innate spellcasting ability is Charisma (spell save DC 12). She can innately cast the following spells, requiring no material components:\n\nAt will: dancing lights, minor illusion, vicious mockery"
+        },
+        {
+          "name": "Mimicry",
+          "description": "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful DC 14 Wisdom (Insight) check."
+        },
+        {
+          "name": "Hag Coven",
+          "description": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        },
+        {
+          "name": "Shared Spellcasting (Coven Only)",
+          "description": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n* 1st level (4 slots): identify, ray of sickness\n* 2nd level (3 slots): hold person, locate object\n* 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n* 4th level (3 slots): phantasmal killer, polymorph\n* 5th level (2 slots): contact other plane, scrying\n* 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        },
+        {
+          "name": "Hag Eye (Coven Only)",
+          "description": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        },
+        {
+          "name": "Illusory Appearance",
+          "description": "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like another creature of her general size and humanoid shape. The illusion ends if the hag takes a bonus action to end it or if she dies.\nThe changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have smooth skin, but someone touching her would feel her rough flesh. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 20 Intelligence (Investigation) check to discern that the hag is disguised."
+        },
+        {
+          "name": "Invisible Passage",
+          "description": "The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hag can breathe air and water."
+    },
+    {
+      "id": "grick",
+      "name": "Grick",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": [
+        "Caverns",
+        "Forest",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin",
+        "Sewer",
+        "Tomb",
+        "Underdark"
+      ],
+      "ac": 14,
+      "hp": 27,
+      "hitDice": "6d8",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 14,
+        "dex": 14,
+        "con": 11,
+        "int": 3,
+        "wis": 14,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Stone Camouflage",
+          "description": "The grick has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."
+        },
+        {
+          "name": "Tentacles",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The grick has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+    },
+    {
+      "id": "griffon",
+      "name": "Griffon",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Plane Of Air"
+      ],
+      "ac": 12,
+      "hp": 59,
+      "hitDice": "7d10+21",
+      "speed": "Walk 30, Fly 80",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 2,
+        "wis": 13,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 15",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The griffon has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The griffon makes two attacks: one with its beak and one with its claws."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The griffon has advantage on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "grimlock",
+      "name": "Grimlock",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Humanoid",
+      "subtype": "Grimlock",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Plane Of Earth",
+        "Ruin",
+        "Sewer",
+        "Shadowfell",
+        "Tomb",
+        "Underdark"
+      ],
+      "ac": 11,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 12,
+        "con": 12,
+        "int": 9,
+        "wis": 8,
+        "cha": 6
+      },
+      "senses": "blindsight 30 ft. or 10 ft. while deafened (blind beyond this radius), passive Perception 13",
+      "languages": "Undercommon",
+      "savingThrows": "",
+      "skills": "Athletics 5, Perception 3, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "blinded",
+      "traits": [
+        {
+          "name": "Blind Senses",
+          "description": "The grimlock can't use its blindsight while deafened and unable to smell."
+        },
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The grimlock has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Stone Camouflage",
+          "description": "The grimlock has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Spiked Bone Club",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) bludgeoning damage plus 2 (1d4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The grimlock can't use its blindsight while deafened and unable to smell."
+    },
+    {
+      "id": "guard",
+      "name": "Guard",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Settlement",
+        "Urban"
+      ],
+      "ac": 16,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 13,
+        "dex": 12,
+        "con": 12,
+        "int": 10,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "passive Perception 12",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Guards** include members of a city watch, sentries in a citadel or fortified town, and the bodyguards of merchants and nobles."
+    },
+    {
+      "id": "guardian-naga",
+      "name": "Guardian Naga",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": [
+        "Astral Plane",
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Temple"
+      ],
+      "ac": 18,
+      "hp": 127,
+      "hitDice": "15d10+45",
+      "speed": "Walk 40",
+      "initiative": 4,
+      "abilities": {
+        "str": 19,
+        "dex": 18,
+        "con": 16,
+        "int": 16,
+        "wis": 19,
+        "cha": 18
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Celestial, Common",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, poisoned",
+      "traits": [
+        {
+          "name": "Rejuvenation",
+          "description": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:\n\n* Cantrips (at will): mending, sacred flame, thaumaturgy\n* 1st level (4 slots): command, cure wounds, shield of faith\n* 2nd level (3 slots): calm emotions, hold person\n* 3rd level (3 slots): bestow curse, clairvoyance\n* 4th level (3 slots): banishment, freedom of movement\n* 5th level (2 slots): flame strike, geas\n* 6th level (1 slot): true seeing"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one creature. Hit: 8 (1d8 + 4) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Spit Poison",
+          "description": "Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: The target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+    },
+    {
+      "id": "gynosphinx",
+      "name": "Gynosphinx",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Neutral",
+      "biomes": ["Desert", "Ruins"],
+      "ac": 17,
+      "hp": 136,
+      "hitDice": "16d10+48",
+      "speed": "Walk 40, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 18,
+        "wis": 18,
+        "cha": 18
+      },
+      "senses": "truesight 120 ft., passive Perception 18",
+      "languages": "Common, Sphinx",
+      "savingThrows": "",
+      "skills": "Arcana 12, History 12, Perception 8, Religion 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "psychic",
+      "conditionImmunities": "charmed, frightened",
+      "traits": [
+        {
+          "name": "Inscrutable",
+          "description": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The sphinx's weapon attacks are magical."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\n* Cantrips (at will): mage hand, minor illusion, prestidigitation\n* 1st level (4 slots): detect magic, identify, shield\n* 2nd level (3 slots): darkness, locate object, suggestion\n* 3rd level (3 slots): dispel magic, remove curse, tongues\n* 4th level (3 slots): banishment, greater invisibility\n* 5th level (1 slot): legend lore"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The sphinx makes two claw attacks."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Claw Attack",
+          "description": "The sphinx makes one claw attack."
+        },
+        {
+          "name": "Teleport (Costs 2 Actions)",
+          "description": "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        },
+        {
+          "name": "Cast a Spell (Costs 3 Actions)",
+          "description": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        }
+      ],
+      "details": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+    },
+    {
+      "id": "half-red-dragon-veteran",
+      "name": "Half-Red Dragon Veteran",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Desert",
+        "Hills",
+        "Mountains",
+        "Plane Of Fire",
+        "Ruin",
+        "Settlement"
+      ],
+      "ac": 18,
+      "hp": 65,
+      "hitDice": "10d8+20",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 13,
+        "con": 14,
+        "int": 10,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 12",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "fire",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Heavy Crossbow",
+          "description": "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The veteran exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+    },
+    {
+      "id": "harpy",
+      "name": "Harpy",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Swamp",
+        "Tundra"
+      ],
+      "ac": 11,
+      "hp": 38,
+      "hitDice": "7d8+7",
+      "speed": "Walk 20, Fly 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 12,
+        "dex": 13,
+        "con": 12,
+        "int": 7,
+        "wis": 10,
+        "cha": 13
+      },
+      "senses": "passive Perception 10",
+      "languages": "Common",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The harpy makes two attacks: one with its claws and one with its club."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage."
+        },
+        {
+          "name": "Club",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage."
+        },
+        {
+          "name": "Luring Song",
+          "description": "The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a DC 11 Wisdom saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.\nWhile charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 ft. away from the harpy, the must move on its turn toward the harpy by the most direct route. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, a target can repeat the saving throw. A creature can also repeat the saving throw at the end of each of its turns. If a creature's saving throw is successful, the effect ends on it.\nA target that successfully saves is immune to this harpy's song for the next 24 hours."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The harpy makes two attacks: one with its claws and one with its club."
+    },
+    {
+      "id": "hawk",
+      "name": "Hawk",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Mountains", "Settlement"],
+      "ac": 13,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 10, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 5,
+        "dex": 16,
+        "con": 8,
+        "int": 2,
+        "wis": 14,
+        "cha": 6
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "hell-hound",
+      "name": "Hell Hound",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Fiend",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Astral Plane",
+        "Desert",
+        "Hell",
+        "Laboratory",
+        "Mountain",
+        "Mountains",
+        "Plane Of Fire",
+        "Shadowfell",
+        "Underdark"
+      ],
+      "ac": 15,
+      "hp": 45,
+      "hitDice": "7d8+14",
+      "speed": "Walk 50",
+      "initiative": 1,
+      "abilities": {
+        "str": 17,
+        "dex": 12,
+        "con": 14,
+        "int": 6,
+        "wis": 13,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 15",
+      "languages": "understands Infernal but can't speak it",
+      "savingThrows": "",
+      "skills": "Perception 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The hound has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The hound has advantage on an attack roll against a creature if at least one of the hound's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) fire damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The hound exhales fire in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hound has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "hezrou",
+      "name": "Hezrou",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 16,
+      "hp": 136,
+      "hitDice": "13d10+65",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 19,
+        "dex": 17,
+        "con": 20,
+        "int": 5,
+        "wis": 12,
+        "cha": 13
+      },
+      "senses": "darkvision 120 ft., passive Perception 11",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The hezrou has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Stench",
+          "description": "Any creature that starts its turn within 10 feet of the hezrou must succeed on a DC 14 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou's stench for 24 hours."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The hezrou makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA hezrou has a 30 percent chance of summoning 2d6 dretches or one hezrou.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hezrou has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "hill-giant",
+      "name": "Hill Giant",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Feywild",
+        "Forest",
+        "Hill",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin"
+      ],
+      "ac": 13,
+      "hp": 105,
+      "hitDice": "10d12+40",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 21,
+        "dex": 8,
+        "con": 19,
+        "int": 5,
+        "wis": 9,
+        "cha": 6
+      },
+      "senses": "passive Perception 12",
+      "languages": "Giant",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two greatclub attacks."
+        },
+        {
+          "name": "Greatclub",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 18 (3d8 + 5) bludgeoning damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +8 to hit, range 60/240 ft., one target. Hit: 21 (3d10 + 5) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant makes two greatclub attacks."
+    },
+    {
+      "id": "hippogriff",
+      "name": "Hippogriff",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Plane Of Air"
+      ],
+      "ac": 11,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 40, Fly 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 17,
+        "dex": 13,
+        "con": 13,
+        "int": 2,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "passive Perception 15",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The hippogriff has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The hippogriff makes two attacks: one with its beak and one with its claws."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hippogriff has advantage on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "hobgoblin",
+      "name": "Hobgoblin",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Goblinoid",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountains",
+        "Underdark"
+      ],
+      "ac": 18,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 13,
+        "dex": 12,
+        "con": 12,
+        "int": 10,
+        "wis": 10,
+        "cha": 9
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Common, Goblin",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Martial Advantage",
+          "description": "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage, or 6 (1d10 + 1) slashing damage if used with two hands."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated."
+    },
+    {
+      "id": "homunculus",
+      "name": "Homunculus",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Neutral",
+      "biomes": ["Laboratory"],
+      "ac": 13,
+      "hp": 5,
+      "hitDice": "2d4",
+      "speed": "Walk 20, Fly 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 4,
+        "dex": 15,
+        "con": 11,
+        "int": 10,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "understands the languages of its creator but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, poisoned",
+      "traits": [
+        {
+          "name": "Telepathic Bond",
+          "description": "While the homunculus is on the same plane of existence as its master, it can magically convey what it senses to its master, and the two can communicate telepathically."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the homunculus is on the same plane of existence as its master, it can magically convey what it senses to its master, and the two can communicate telepathically."
+    },
+    {
+      "id": "horned-devil",
+      "name": "Horned Devil",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 18,
+      "hp": 178,
+      "hitDice": "17d10+85",
+      "speed": "Walk 20, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 22,
+        "dex": 17,
+        "con": 21,
+        "int": 12,
+        "wis": 16,
+        "cha": 17
+      },
+      "senses": "darkvision 120 ft., passive Perception 13",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."
+        },
+        {
+          "name": "Fork",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (2d8 + 6) piercing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 10 (1d8 + 6) piercing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 17 Constitution saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+        },
+        {
+          "name": "Hurl Flame",
+          "description": "Ranged Spell Attack: +7 to hit, range 150 ft., one target. Hit: 14 (4d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the devil's darkvision."
+    },
+    {
+      "id": "hunter-shark",
+      "name": "Hunter Shark",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Underwater", "Water"],
+      "ac": 12,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 13,
+        "con": 15,
+        "int": 1,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 30 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Blood Frenzy",
+          "description": "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Smaller than a giant shark but larger and fiercer than a reef shark, a **hunter shark** haunts deep waters. It usually hunts alone, but multiple hunter sharks might feed in the same area. A fully grown hunter shark is 15 to 20 feet long."
+    },
+    {
+      "id": "hydra",
+      "name": "Hydra",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Plane Of Water", "Swamp", "Water"],
+      "ac": 15,
+      "hp": 172,
+      "hitDice": "15d12+75",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 20,
+        "dex": 12,
+        "con": 20,
+        "int": 2,
+        "wis": 10,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 16",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "The hydra can hold its breath for 1 hour."
+        },
+        {
+          "name": "Multiple Heads",
+          "description": "The hydra has five heads. While it has more than one head, the hydra has advantage on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious.\nWhenever the hydra takes 25 or more damage in a single turn, one of its heads dies. If all its heads die, the hydra dies.\nAt the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken fire damage since its last turn. The hydra regains 10 hit points for each head regrown in this way."
+        },
+        {
+          "name": "Reactive Heads",
+          "description": "For each head the hydra has beyond one, it gets an extra reaction that can be used only for opportunity attacks."
+        },
+        {
+          "name": "Wakeful",
+          "description": "While the hydra sleeps, at least one of its heads is awake."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The hydra makes as many bite attacks as it has heads."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 10 (1d10 + 5) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hydra can hold its breath for 1 hour."
+    },
+    {
+      "id": "hyena",
+      "name": "Hyena",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Forest", "Grassland", "Hill", "Ruin", "Shadowfell"],
+      "ac": 11,
+      "hp": 5,
+      "hitDice": "1d8+1",
+      "speed": "Walk 50",
+      "initiative": 1,
+      "abilities": {
+        "str": 11,
+        "dex": 13,
+        "con": 12,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Pack Tactics",
+          "description": "The hyena has advantage on an attack roll against a creature if at least one of the hyena's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hyena has advantage on an attack roll against a creature if at least one of the hyena's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+    },
+    {
+      "id": "ice-devil",
+      "name": "Ice Devil",
+      "cr": 14,
+      "challengeRating": "14",
+      "xp": 11500,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 18,
+      "hp": 180,
+      "hitDice": "19d10+76",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 21,
+        "dex": 14,
+        "con": 18,
+        "int": 18,
+        "wis": 15,
+        "cha": 18
+      },
+      "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 12",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the devil's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The devil has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) piercing damage plus 10 (3d6) cold damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 10 (2d4 + 5) slashing damage plus 10 (3d6) cold damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage."
+        },
+        {
+          "name": "Wall of Ice",
+          "description": "The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.\nWhen the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a DC 17 Dexterity saving throw, taking 35 (10d6) cold damage on a failed save, or half as much damage on a successful one.\nThe wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to fire damage, and immunity to acid, cold, necrotic, poison, and psychic damage. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a DC 17 Constitution saving throw, taking 17 (5d6) cold damage on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the devil's darkvision."
+    },
+    {
+      "id": "ice-mephit",
+      "name": "Ice Mephit",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Arctic",
+        "Mountains",
+        "Plane Of Air",
+        "Plane Of Water",
+        "Tundra"
+      ],
+      "ac": 11,
+      "hp": 21,
+      "hitDice": "6d6",
+      "speed": "Walk 30, Fly 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 7,
+        "dex": 13,
+        "con": 10,
+        "int": 9,
+        "wis": 11,
+        "cha": 12
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "Aquan, Auran",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 3",
+      "damageVulnerabilities": "bludgeoning, fire",
+      "damageResistances": "",
+      "damageImmunities": "cold, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Death Burst",
+          "description": "When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a DC 10 Dexterity saving throw, taking 4 (1d8) slashing damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the mephit remains motionless, it is indistinguishable from an ordinary shard of ice."
+        },
+        {
+          "name": "Innate Spellcasting (1/Day)",
+          "description": "The mephit can innately cast _fog cloud_, requiring no material components. Its innate spellcasting ability is Charisma."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) cold damage."
+        },
+        {
+          "name": "Frost Breath (Recharge 6)",
+          "description": "The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 5 (2d4) cold damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Variant: Summon Mephits (1/Day)",
+          "description": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a DC 10 Dexterity saving throw, taking 4 (1d8) slashing damage on a failed save, or half as much damage on a successful one."
+    },
+    {
+      "id": "imp",
+      "name": "Imp",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Tiny",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 13,
+      "hp": 10,
+      "hitDice": "3d4+3",
+      "speed": "Walk 20, Fly 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 6,
+        "dex": 17,
+        "con": 13,
+        "int": 11,
+        "wis": 12,
+        "cha": 14
+      },
+      "senses": "darkvision 120 ft., passive Perception 11",
+      "languages": "Infernal, Common",
+      "savingThrows": "",
+      "skills": "Deception 4, Insight 3, Persuasion 4, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical/nonsilver weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The imp can use its action to polymorph into a beast form that resembles a rat (speed 20 ft.), a raven (20 ft., fly 60 ft.), or a spider (20 ft., climb 20 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the imp's darkvision."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The imp has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Variant: Familiar",
+          "description": "The imp can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the imp senses as long as they are within 1 mile of each other. While the imp is within 10 feet of its master, the master shares the imp's Magic Resistance trait. At any time and for any reason, the imp can end its service as a familiar, ending the telepathic bond."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Sting (Bite in Beast Form)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Invisibility",
+          "description": "The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The imp can use its action to polymorph into a beast form that resembles a rat (speed 20 ft.), a raven (20 ft., fly 60 ft.), or a spider (20 ft., climb 20 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "invisible-stalker",
+      "name": "Invisible Stalker",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": [
+        "Grassland",
+        "Laboratory",
+        "Plane Of Air",
+        "Settlement",
+        "Swamp",
+        "Temple",
+        "Urban"
+      ],
+      "ac": 14,
+      "hp": 104,
+      "hitDice": "16d8+32",
+      "speed": "Hover true, Walk 50, Fly 50",
+      "initiative": 4,
+      "abilities": {
+        "str": 16,
+        "dex": 19,
+        "con": 14,
+        "int": 10,
+        "wis": 15,
+        "cha": 11
+      },
+      "senses": "darkvision 60 ft., passive Perception 18",
+      "languages": "Auran, understands Common but doesn't speak it",
+      "savingThrows": "",
+      "skills": "Perception 8, Stealth 10",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Invisibility",
+          "description": "The stalker is invisible."
+        },
+        {
+          "name": "Faultless Tracker",
+          "description": "The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The stalker makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The stalker is invisible."
+    },
+    {
+      "id": "iron-golem",
+      "name": "Iron Golem",
+      "cr": 16,
+      "challengeRating": "16",
+      "xp": 15000,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Any"],
+      "ac": 20,
+      "hp": 210,
+      "hitDice": "20d10+100",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 24,
+        "dex": 9,
+        "con": 20,
+        "int": 3,
+        "wis": 11,
+        "cha": 1
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "understands the languages of its creator but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire, poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Fire Absorption",
+          "description": "Whenever the golem is subjected to fire damage, it takes no damage and instead regains a number of hit points equal to the fire damage dealt."
+        },
+        {
+          "name": "Immutable Form",
+          "description": "The golem is immune to any spell or effect that would alter its form."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The golem has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The golem's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The golem makes two melee attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage."
+        },
+        {
+          "name": "Sword",
+          "description": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 23 (3d10 + 7) slashing damage."
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "description": "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Whenever the golem is subjected to fire damage, it takes no damage and instead regains a number of hit points equal to the fire damage dealt."
+    },
+    {
+      "id": "jackal",
+      "name": "Jackal",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Grassland", "Ruin", "Shadowfell"],
+      "ac": 12,
+      "hp": 3,
+      "hitDice": "1d6",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 8,
+        "dex": 15,
+        "con": 11,
+        "int": 3,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The jackal has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The jackal has advantage on an attack roll against a creature if at least one of the jackal's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The jackal has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "killer-whale",
+      "name": "Killer Whale",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Underwater", "Water"],
+      "ac": 12,
+      "hp": 90,
+      "hitDice": "12d12+12",
+      "speed": "Swim 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 13,
+        "int": 3,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "blindsight 120 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Echolocation",
+          "description": "The whale can't use its blindsight while deafened."
+        },
+        {
+          "name": "Hold Breath",
+          "description": "The whale can hold its breath for 30 minutes"
+        },
+        {
+          "name": "Keen Hearing",
+          "description": "The whale has advantage on Wisdom (Perception) checks that rely on hearing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 21 (5d6 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The whale can't use its blindsight while deafened."
+    },
+    {
+      "id": "knight",
+      "name": "Knight",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Grassland",
+        "Hills",
+        "Mountains",
+        "Settlement",
+        "Temple",
+        "Urban"
+      ],
+      "ac": 18,
+      "hp": 52,
+      "hitDice": "8d8+16",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 16,
+        "dex": 11,
+        "con": 14,
+        "int": 11,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Brave",
+          "description": "The knight has advantage on saving throws against being frightened."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The knight makes two melee attacks."
+        },
+        {
+          "name": "Greatsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        },
+        {
+          "name": "Heavy Crossbow",
+          "description": "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage."
+        },
+        {
+          "name": "Leadership (Recharges after a Short or Long Rest)",
+          "description": "For 1 minute, the knight can utter a special command or warning whenever a nonhostile creature that it can see within 30 ft. of it makes an attack roll or a saving throw. The creature can add a d4 to its roll provided it can hear and understand the knight. A creature can benefit from only one Leadership die at a time. This effect ends if the knight is incapacitated."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Knights** are warriors who pledge service to rulers, religious orders, and noble causes. A knight's alignment determines the extent to which a pledge is honored. Whether undertaking a quest or patrolling a realm, a knight often travels with an entourage that includes squires and hirelings who are commoners."
+    },
+    {
+      "id": "kobold",
+      "name": "Kobold",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Kobold",
+      "size": "Small",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Plane Of Earth",
+        "Ruin",
+        "Settlement",
+        "Swamp",
+        "Tundra",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 5,
+      "hitDice": "2d6-2",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 7,
+        "dex": 15,
+        "con": 9,
+        "int": 8,
+        "wis": 7,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Dagger",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        },
+        {
+          "name": "Sling",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "kraken",
+      "name": "Kraken",
+      "cr": 23,
+      "challengeRating": "23",
+      "xp": 50000,
+      "type": "Monstrosity",
+      "subtype": "Titan",
+      "size": "Gargantuan",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Plane Of Water", "Underwater", "Water"],
+      "ac": 18,
+      "hp": 472,
+      "hitDice": "27d20+189",
+      "speed": "Walk 20, Swim 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 30,
+        "dex": 11,
+        "con": 25,
+        "int": 22,
+        "wis": 18,
+        "cha": 20
+      },
+      "senses": "truesight 120 ft., passive Perception 14",
+      "languages": "understands Abyssal, Celestial, Infernal, and Primordial but can't speak, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "frightened, paralyzed",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The kraken can breathe air and water."
+        },
+        {
+          "name": "Freedom of Movement",
+          "description": "The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. It can spend 5 feet of movement to escape from nonmagical restraints or being grappled."
+        },
+        {
+          "name": "Siege Monster",
+          "description": "The kraken deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 23 (3d8 + 10) piercing damage. If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the kraken, and it takes 42 (12d6) acid damage at the start of each of the kraken's turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the kraken. If the kraken dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
+        },
+        {
+          "name": "Tentacle",
+          "description": "Melee Weapon Attack: +7 to hit, reach 30 ft., one target. Hit: 20 (3d6 + 10) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target."
+        },
+        {
+          "name": "Fling",
+          "description": "One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. If a thrown target strikes a solid surface, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 18 Dexterity saving throw or take the same damage and be knocked prone."
+        },
+        {
+          "name": "Lightning Storm",
+          "description": "The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. A target must make a DC 23 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Tentacle Attack or Fling",
+          "description": "The kraken makes one tentacle attack or uses its Fling."
+        },
+        {
+          "name": "Lightning Storm (Costs 2 Actions)",
+          "description": "The kraken uses Lightning Storm."
+        },
+        {
+          "name": "Ink Cloud (Costs 3 Actions)",
+          "description": "While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a DC 23 Constitution saving throw, taking 16 (3d10) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
+        }
+      ],
+      "details": "The kraken can breathe air and water."
+    },
+    {
+      "id": "lamia",
+      "name": "Lamia",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss", "Desert", "Grassland", "Hills"],
+      "ac": 13,
+      "hp": 97,
+      "hitDice": "13d10+26",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 13,
+        "con": 15,
+        "int": 14,
+        "wis": 15,
+        "cha": 16
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "Abyssal, Common",
+      "savingThrows": "",
+      "skills": "Deception 7, Insight 4, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The lamia's innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components.\n\nAt will: disguise self (any humanoid form), major image\n3/day each: charm person, mirror image, scrying, suggestion\n1/day: geas"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage."
+        },
+        {
+          "name": "Dagger",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        },
+        {
+          "name": "Intoxicating Touch",
+          "description": "Melee Spell Attack: +5 to hit, reach 5 ft., one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The lamia's innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components.\n\nAt will: disguise self (any humanoid form), major image\n3/day each: charm person, mirror image, scrying, suggestion\n1/day: geas"
+    },
+    {
+      "id": "lemure",
+      "name": "Lemure",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 7,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 15",
+      "initiative": -3,
+      "abilities": {
+        "str": 10,
+        "dex": 5,
+        "con": 11,
+        "int": 1,
+        "wis": 11,
+        "cha": 3
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "understands infernal but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "charmed, frightened, poisoned",
+      "traits": [
+        {
+          "name": "Devil's Sight",
+          "description": "Magical darkness doesn't impede the lemure's darkvision."
+        },
+        {
+          "name": "Hellish Rejuvenation",
+          "description": "A lemure that dies in the Nine Hells comes back to life with all its hit points in 1d10 days unless it is killed by a good-aligned creature with a bless spell cast on that creature or its remains are sprinkled with holy water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Fist",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Magical darkness doesn't impede the lemure's darkvision."
+    },
+    {
+      "id": "lich",
+      "name": "Lich",
+      "cr": 21,
+      "challengeRating": "21",
+      "xp": 33000,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Any Evil Alignment",
+      "biomes": ["Laboratory", "Ruin", "Shadowfell", "Tomb"],
+      "ac": 17,
+      "hp": 135,
+      "hitDice": "18d8+54",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 11,
+        "dex": 16,
+        "con": 16,
+        "int": 20,
+        "wis": 14,
+        "cha": 16
+      },
+      "senses": "truesight 120 ft., passive Perception 19",
+      "languages": "Common plus up to five other languages",
+      "savingThrows": "",
+      "skills": "Arcana 19, History 12, Insight 9, Perception 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, lightning, necrotic",
+      "damageImmunities": "poison; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the lich fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Rejuvenation",
+          "description": "If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its hit points and becoming active again. The new body appears within 5 feet of the phylactery."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n\n* Cantrips (at will): mage hand, prestidigitation, ray of frost\n* 1st level (4 slots): detect magic, magic missile, shield, thunderwave\n* 2nd level (3 slots): detect thoughts, invisibility, acid arrow, mirror image\n* 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball\n* 4th level (3 slots): blight, dimension door\n* 5th level (3 slots): cloudkill, scrying\n* 6th level (1 slot): disintegrate, globe of invulnerability\n* 7th level (1 slot): finger of death, plane shift\n* 8th level (1 slot): dominate monster, power word stun\n* 9th level (1 slot): power word kill"
+        },
+        {
+          "name": "Turn Resistance",
+          "description": "The lich has advantage on saving throws against any effect that turns undead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Paralyzing Touch",
+          "description": "Melee Spell Attack: +12 to hit, reach 5 ft., one creature. Hit: 10 (3d6) cold damage. The target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Cantrip",
+          "description": "The lich casts a cantrip."
+        },
+        {
+          "name": "Paralyzing Touch (Costs 2 Actions)",
+          "description": "The lich uses its Paralyzing Touch."
+        },
+        {
+          "name": "Frightening Gaze (Costs 2 Actions)",
+          "description": "The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a DC 18 Wisdom saving throw against this magic or become frightened for 1 minute. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the lich's gaze for the next 24 hours."
+        },
+        {
+          "name": "Disrupt Life (Costs 3 Actions)",
+          "description": "Each non-undead creature within 20 feet of the lich must make a DC 18 Constitution saving throw against this magic, taking 21 (6d6) necrotic damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "details": "If the lich fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "lion",
+      "name": "Lion",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Forest", "Grassland", "Hill", "Mountain"],
+      "ac": 12,
+      "hp": 26,
+      "hitDice": "4d10+4",
+      "speed": "Walk 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 13,
+        "int": 3,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The lion has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The lion has advantage on an attack roll against a creature if at least one of the lion's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        },
+        {
+          "name": "Pounce",
+          "description": "If the lion moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the lion can make one bite attack against it as a bonus action."
+        },
+        {
+          "name": "Running Leap",
+          "description": "With a 10-foot running start, the lion can long jump up to 25 ft.."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The lion has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "lizard",
+      "name": "Lizard",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Grassland", "Jungle", "Ruin", "Swamp"],
+      "ac": 10,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 20, Climb 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 2,
+        "dex": 11,
+        "con": 10,
+        "int": 1,
+        "wis": 8,
+        "cha": 3
+      },
+      "senses": "darkvision 30 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+    },
+    {
+      "id": "lizardfolk",
+      "name": "Lizardfolk",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Lizardfolk",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Forest", "Jungle", "Swamp"],
+      "ac": 15,
+      "hp": 22,
+      "hitDice": "4d8+4",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 13,
+        "int": 7,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4, Survival 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "The lizardfolk can hold its breath for 15 minutes."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The lizardfolk makes two melee attacks, each one with a different weapon."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Heavy Club",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage."
+        },
+        {
+          "name": "Javelin",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Spiked Shield",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The lizardfolk can hold its breath for 15 minutes."
+    },
+    {
+      "id": "mage",
+      "name": "Mage",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Hills",
+        "Jungle",
+        "Laboratory",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 40,
+      "hitDice": "9d8",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 9,
+        "dex": 14,
+        "con": 11,
+        "int": 17,
+        "wis": 12,
+        "cha": 11
+      },
+      "senses": "passive Perception 11",
+      "languages": "any four languages",
+      "savingThrows": "",
+      "skills": "Arcana 6, History 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spellcasting",
+          "description": "The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:\n\n* Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n* 1st level (4 slots): detect magic, mage armor, magic missile, shield\n* 2nd level (3 slots): misty step, suggestion\n* 3rd level (3 slots): counterspell, fireball, fly\n* 4th level (3 slots): greater invisibility, ice storm\n* 5th level (1 slot): cone of cold"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Dagger",
+          "description": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Mages** spend their lives in the study and practice of magic. Good-aligned mages offer counsel to nobles and others in power, while evil mages dwell in isolated sites to perform unspeakable experiments without interference."
+    },
+    {
+      "id": "magma-mephit",
+      "name": "Magma Mephit",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Mountains",
+        "Plane Of Earth",
+        "Plane Of Fire",
+        "Underdark"
+      ],
+      "ac": 11,
+      "hp": 22,
+      "hitDice": "5d6+5",
+      "speed": "Walk 30, Fly 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 8,
+        "dex": 12,
+        "con": 12,
+        "int": 7,
+        "wis": 10,
+        "cha": 10
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Ignan, Terran",
+      "savingThrows": "",
+      "skills": "Stealth 3",
+      "damageVulnerabilities": "cold",
+      "damageResistances": "",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Death Burst",
+          "description": "When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the mephit remains motionless, it is indistinguishable from an ordinary mound of magma."
+        },
+        {
+          "name": "Innate Spellcasting (1/Day)",
+          "description": "The mephit can innately cast _heat metal_ (spell save DC 10), requiring no material components. Its innate spellcasting ability is Charisma."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 6)",
+          "description": "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Variant: Summon Mephits (1/Day)",
+          "description": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."
+    },
+    {
+      "id": "magmin",
+      "name": "Magmin",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Chaotic Neutral",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Laboratory",
+        "Mountains",
+        "Plane Of Fire"
+      ],
+      "ac": 14,
+      "hp": 9,
+      "hitDice": "2d6+2",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 7,
+        "dex": 15,
+        "con": 12,
+        "int": 8,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Death Burst",
+          "description": "When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited."
+        },
+        {
+          "name": "Ignited Illumination",
+          "description": "As a bonus action, the magmin can set itself ablaze or extinguish its flames. While ablaze, the magmin sheds bright light in a 10-foot radius and dim light for an additional 10 ft."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Touch",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d6) fire damage. If the target is a creature or a flammable object, it ignites. Until a target takes an action to douse the fire, the target takes 3 (1d6) fire damage at the end of each of its turns."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited."
+    },
+    {
+      "id": "mammoth",
+      "name": "Mammoth",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Arctic", "Tundra"],
+      "ac": 13,
+      "hp": 126,
+      "hitDice": "11d12+55",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 24,
+        "dex": 9,
+        "con": 21,
+        "int": 3,
+        "wis": 11,
+        "cha": 6
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Trampling Charge",
+          "description": "If the mammoth moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 18 Strength saving throw or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 25 (4d8 + 7) piercing damage."
+        },
+        {
+          "name": "Stomp",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one prone creature. Hit: 29 (4d10 + 7) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **mammoth** is an elephantine creature with thick fur and long tusks. Stockier and fiercer than normal elephants, mammoths inhabit a wide range of climes, from subarctic to subtropical."
+    },
+    {
+      "id": "manticore",
+      "name": "Manticore",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Tundra"
+      ],
+      "ac": 14,
+      "hp": 68,
+      "hitDice": "8d10+24",
+      "speed": "Walk 30, Fly 50",
+      "initiative": 3,
+      "abilities": {
+        "str": 17,
+        "dex": 16,
+        "con": 17,
+        "int": 7,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Tail Spike Regrowth",
+          "description": "The manticore has twenty-four tail spikes. Used spikes regrow when the manticore finishes a long rest."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        },
+        {
+          "name": "Tail Spike",
+          "description": "Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The manticore has twenty-four tail spikes. Used spikes regrow when the manticore finishes a long rest."
+    },
+    {
+      "id": "marilith",
+      "name": "Marilith",
+      "cr": 16,
+      "challengeRating": "16",
+      "xp": 15000,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 18,
+      "hp": 189,
+      "hitDice": "18d10+90",
+      "speed": "Walk 40",
+      "initiative": 5,
+      "abilities": {
+        "str": 18,
+        "dex": 20,
+        "con": 20,
+        "int": 18,
+        "wis": 16,
+        "cha": 20
+      },
+      "senses": "truesight 120 ft., passive Perception 13",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The marilith has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The marilith's weapon attacks are magical."
+        },
+        {
+          "name": "Reactive",
+          "description": "The marilith can take one reaction on every turn in combat."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The marilith can make seven attacks: six with its longswords and one with its tail."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one creature. Hit: 15 (2d10 + 4) bludgeoning damage. If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets."
+        },
+        {
+          "name": "Teleport",
+          "description": "The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA marilith has a 50 percent chance of summoning 1d6 vrocks, 1d4 hezrous, 1d3 glabrezus, 1d2 nalfeshnees, or one marilith.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The marilith has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "mastiff",
+      "name": "Mastiff",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Hill", "Settlement", "Urban"],
+      "ac": 12,
+      "hp": 5,
+      "hitDice": "1d8+1",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 13,
+        "dex": 14,
+        "con": 12,
+        "int": 3,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The mastiff has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Mastiffs** are impressive hounds prized by humanoids for their loyalty and keen senses. Mastiffs can be trained as guard dogs, hunting dogs, and war dogs. Halflings and other Small humanoids ride them as mounts."
+    },
+    {
+      "id": "medusa",
+      "name": "Medusa",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Jungle",
+        "Mountains",
+        "Plane Of Earth",
+        "Settlement",
+        "Tundra"
+      ],
+      "ac": 15,
+      "hp": 127,
+      "hitDice": "17d8+51",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 15,
+        "con": 16,
+        "int": 12,
+        "wis": 13,
+        "cha": 15
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Common",
+      "savingThrows": "",
+      "skills": "Deception 5, Insight 4, Perception 4, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Petrifying Gaze",
+          "description": "When a creature that can see the medusa's eyes starts its turn within 30 ft. of the medusa, the medusa can force it to make a DC 14 Constitution saving throw if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.\nUnless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.\nIf the medusa sees itself reflected on a polished surface within 30 ft. of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The medusa makes either three melee attacks - one with its snake hair and two with its shortsword - or two ranged attacks with its longbow."
+        },
+        {
+          "name": "Snake Hair",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage plus 14 (4d6) poison damage."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When a creature that can see the medusa's eyes starts its turn within 30 ft. of the medusa, the medusa can force it to make a DC 14 Constitution saving throw if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.\nUnless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.\nIf the medusa sees itself reflected on a polished surface within 30 ft. of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
+    },
+    {
+      "id": "merfolk",
+      "name": "Merfolk",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Merfolk",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Coastal", "Desert", "Underwater", "Water"],
+      "ac": 11,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 10, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 10,
+        "dex": 13,
+        "con": 12,
+        "int": 11,
+        "wis": 11,
+        "cha": 12
+      },
+      "senses": "passive Perception 12",
+      "languages": "Aquan, Common",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The merfolk can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 3 (1d6) piercing damage, or 4 (1d8) piercing damage if used with two hands to make a melee attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The merfolk can breathe air and water."
+    },
+    {
+      "id": "merrow",
+      "name": "Merrow",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Coastal", "Desert", "Swamp", "Underwater", "Water"],
+      "ac": 13,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Walk 10, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 10,
+        "con": 15,
+        "int": 8,
+        "wis": 10,
+        "cha": 9
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Abyssal, Aquan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The merrow can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The merrow makes two attacks: one with its bite and one with its claws or harpoon."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) slashing damage."
+        },
+        {
+          "name": "Harpoon",
+          "description": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The merrow can breathe air and water."
+    },
+    {
+      "id": "mimic",
+      "name": "Mimic",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Monstrosity",
+      "subtype": "Shapechanger",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Laboratory",
+        "Ruin",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 58,
+      "hitDice": "9d8+18",
+      "speed": "Walk 15",
+      "initiative": 1,
+      "abilities": {
+        "str": 17,
+        "dex": 12,
+        "con": 15,
+        "int": 5,
+        "wis": 13,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "prone",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The mimic can use its action to polymorph into an object or back into its true, amorphous form. Its statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Adhesive (Object Form Only)",
+          "description": "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it (escape DC 13). Ability checks made to escape this grapple have disadvantage."
+        },
+        {
+          "name": "False Appearance (Object Form Only)",
+          "description": "While the mimic remains motionless, it is indistinguishable from an ordinary object."
+        },
+        {
+          "name": "Grappler",
+          "description": "The mimic has advantage on attack rolls against any creature grappled by it."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage. If the mimic is in object form, the target is subjected to its Adhesive trait."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) acid damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The mimic can use its action to polymorph into an object or back into its true, amorphous form. Its statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "minotaur",
+      "name": "Minotaur",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss", "Caverns", "Plane Of Earth", "Underdark"],
+      "ac": 14,
+      "hp": 76,
+      "hitDice": "9d10+27",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 11,
+        "con": 16,
+        "int": 6,
+        "wis": 16,
+        "cha": 9
+      },
+      "senses": "darkvision 60 ft., passive Perception 17",
+      "languages": "Abyssal",
+      "savingThrows": "",
+      "skills": "Perception 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 ft. away and knocked prone."
+        },
+        {
+          "name": "Labyrinthine Recall",
+          "description": "The minotaur can perfectly recall any path it has traveled."
+        },
+        {
+          "name": "Reckless",
+          "description": "At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage."
+        },
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 ft. away and knocked prone."
+    },
+    {
+      "id": "minotaur-skeleton",
+      "name": "Minotaur Skeleton",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Underdark"],
+      "ac": 12,
+      "hp": 67,
+      "hitDice": "9d10+18",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 11,
+        "con": 15,
+        "int": 6,
+        "wis": 8,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "understands Abyssal but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "bludgeoning",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, poisoned",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage."
+        },
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."
+    },
+    {
+      "id": "mule",
+      "name": "Mule",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Grassland", "Hill", "Settlement", "Urban"],
+      "ac": 10,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 14,
+        "dex": 10,
+        "con": 13,
+        "int": 2,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Beast of Burden",
+          "description": "The mule is considered to be a Large animal for the purpose of determining its carrying capacity."
+        },
+        {
+          "name": "Sure-Footed",
+          "description": "The mule has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The mule is considered to be a Large animal for the purpose of determining its carrying capacity."
+    },
+    {
+      "id": "mummy",
+      "name": "Mummy",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Desert", "Ruin", "Shadowfell", "Temple", "Tomb"],
+      "ac": 11,
+      "hp": 58,
+      "hitDice": "9d8+18",
+      "speed": "Walk 20",
+      "initiative": -1,
+      "abilities": {
+        "str": 16,
+        "dex": 8,
+        "con": 15,
+        "int": 6,
+        "wis": 10,
+        "cha": 12
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "fire",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "necrotic, poison",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        },
+        {
+          "name": "Rotting Fist",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage plus 10 (3d6) necrotic damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic."
+        },
+        {
+          "name": "Dreadful Glare",
+          "description": "The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must succeed on a DC 11 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies (but not mummy lords) for the next 24 hours."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+    },
+    {
+      "id": "mummy-lord",
+      "name": "Mummy Lord",
+      "cr": 15,
+      "challengeRating": "15",
+      "xp": 13000,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Desert", "Ruin", "Shadowfell", "Temple", "Tomb"],
+      "ac": 17,
+      "hp": 97,
+      "hitDice": "13d8+39",
+      "speed": "Walk 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 10,
+        "con": 17,
+        "int": 11,
+        "wis": 18,
+        "cha": 16
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "History 5, Religion 5",
+      "damageVulnerabilities": "bludgeoning",
+      "damageResistances": "",
+      "damageImmunities": "necrotic, poison; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The mummy lord has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Rejuvenation",
+          "description": "A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its hit points and becoming active again. The new body appears within 5 feet of the mummy lord's heart."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:\n\n* Cantrips (at will): sacred flame, thaumaturgy\n* 1st level (4 slots): command, guiding bolt, shield of faith\n* 2nd level (3 slots): hold person, silence, spiritual weapon\n* 3rd level (3 slots): animate dead, dispel magic\n* 4th level (3 slots): divination, guardian of faith\n* 5th level (2 slots): contagion, insect plague\n* 6th level (1 slot): harm"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        },
+        {
+          "name": "Rotting Fist",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage plus 21 (6d6) necrotic damage. If the target is a creature, it must succeed on a DC 16 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic."
+        },
+        {
+          "name": "Dreadful Glare",
+          "description": "The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a DC 16 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Attack",
+          "description": "The mummy lord makes one attack with its rotting fist or uses its Dreadful Glare."
+        },
+        {
+          "name": "Blinding Dust",
+          "description": "Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a DC 16 Constitution saving throw or be blinded until the end of the creature's next turn."
+        },
+        {
+          "name": "Blasphemous Word (Costs 2 Actions)",
+          "description": "The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a DC 16 Constitution saving throw or be stunned until the end of the mummy lord's next turn."
+        },
+        {
+          "name": "Channel Negative Energy (Costs 2 Actions)",
+          "description": "The mummy lord magically unleashes negative energy. Creatures within 60 feet of the mummy lord, including ones behind barriers and around corners, can't regain hit points until the end of the mummy lord's next turn."
+        },
+        {
+          "name": "Whirlwind of Sand (Costs 2 Actions)",
+          "description": "The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can't be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession."
+        }
+      ],
+      "details": "The mummy lord has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "nalfeshnee",
+      "name": "Nalfeshnee",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 18,
+      "hp": 184,
+      "hitDice": "16d10+96",
+      "speed": "Walk 20, Fly 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 21,
+        "dex": 10,
+        "con": 22,
+        "int": 19,
+        "wis": 12,
+        "cha": 15
+      },
+      "senses": "truesight 120 ft., passive Perception 11",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The nalfeshnee has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The nalfeshnee uses Horror Nimbus if it can. It then makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 32 (5d10 + 5) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) slashing damage."
+        },
+        {
+          "name": "Horror Nimbus (Recharge 5-6)",
+          "description": "The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours."
+        },
+        {
+          "name": "Teleport",
+          "description": "The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA nalfeshnee has a 50 percent chance of summoning 1d4 vrocks, 1d3 hezrous, 1d2 glabrezus, or one nalfeshnee.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The nalfeshnee has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "night-hag",
+      "name": "Night Hag",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Fiend",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Feywild",
+        "Forest",
+        "Hell",
+        "Jungle",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Swamp"
+      ],
+      "ac": 17,
+      "hp": 112,
+      "hitDice": "15d8+45",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 16,
+        "wis": 14,
+        "cha": 16
+      },
+      "senses": "darkvision 120 ft., passive Perception 16",
+      "languages": "Abyssal, Common, Infernal, Primordial",
+      "savingThrows": "",
+      "skills": "Deception 7, Insight 6, Perception 6, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The hag's innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, magic missile\n2/day each: plane shift (self only), ray of enfeeblement, sleep"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The hag has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Night Hag Items",
+          "description": "A night hag carries two very rare magic items that she must craft for herself If either object is lost, the night hag will go to great lengths to retrieve it, as creating a new tool takes time and effort.\nHeartstone: This lustrous black gem allows a night hag to become ethereal while it is in her possession. The touch of a heartstone also cures any disease. Crafting a heartstone takes 30 days.\nSoul Bag: When an evil humanoid dies as a result of a night hag's Nightmare Haunting, the hag catches the soul in this black sack made of stitched flesh. A soul bag can hold only one evil soul at a time, and only the night hag who crafted the bag can catch a soul with it. Crafting a soul bag takes 7 days and a humanoid sacrifice (whose flesh is used to make the bag)."
+        },
+        {
+          "name": "Hag Coven",
+          "description": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        },
+        {
+          "name": "Shared Spellcasting (Coven Only)",
+          "description": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n* 1st level (4 slots): identify, ray of sickness\n* 2nd level (3 slots): hold person, locate object\n* 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n* 4th level (3 slots): phantasmal killer, polymorph\n* 5th level (2 slots): contact other plane, scrying\n* 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        },
+        {
+          "name": "Hag Eye (Coven Only)",
+          "description": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws (Hag Form Only)",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The hag magically polymorphs into a Small or Medium female humanoid, or back into her true form. Her statistics are the same in each form. Any equipment she is wearing or carrying isn't transformed. She reverts to her true form if she dies."
+        },
+        {
+          "name": "Etherealness",
+          "description": "The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a heartstone in her possession."
+        },
+        {
+          "name": "Nightmare Haunting (1/Day)",
+          "description": "While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hag's innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, magic missile\n2/day each: plane shift (self only), ray of enfeeblement, sleep"
+    },
+    {
+      "id": "nightmare",
+      "name": "Nightmare",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Fiend",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Abyss", "Hell", "Shadowfell"],
+      "ac": 13,
+      "hp": 68,
+      "hitDice": "8d10+24",
+      "speed": "Walk 60, Fly 90",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 10,
+        "wis": 13,
+        "cha": 15
+      },
+      "senses": "passive Perception 11",
+      "languages": "understands Abyssal, Common, and Infernal but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Confer Fire Resistance",
+          "description": "The nightmare can grant resistance to fire damage to anyone riding it."
+        },
+        {
+          "name": "Illumination",
+          "description": "The nightmare sheds bright light in a 10-foot radius and dim light for an additional 10 feet."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage plus 7 (2d6) fire damage."
+        },
+        {
+          "name": "Ethereal Stride",
+          "description": "The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The nightmare can grant resistance to fire damage to anyone riding it."
+    },
+    {
+      "id": "noble",
+      "name": "Noble",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Grassland", "Hills", "Settlement", "Urban"],
+      "ac": 15,
+      "hp": 9,
+      "hitDice": "2d8",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 11,
+        "dex": 12,
+        "con": 11,
+        "int": 12,
+        "wis": 14,
+        "cha": 16
+      },
+      "senses": "passive Perception 12",
+      "languages": "any two languages",
+      "savingThrows": "",
+      "skills": "Deception 5, Insight 4, Persuasion 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Rapier",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Nobles** wield great authority and influence as members of the upper class, possessing wealth and connections that can make them as powerful as monarchs and generals. A noble often travels in the company of guards, as well as servants who are commoners.\nThe noble's statistics can also be used to represent **courtiers** who aren't of noble birth."
+    },
+    {
+      "id": "ochre-jelly",
+      "name": "Ochre Jelly",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Ooze",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Ruin", "Sewer", "Underdark", "Water"],
+      "ac": 8,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Walk 10, Climb 10",
+      "initiative": -2,
+      "abilities": {
+        "str": 15,
+        "dex": 6,
+        "con": 14,
+        "int": 2,
+        "wis": 6,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid",
+      "damageImmunities": "lightning, slashing",
+      "conditionImmunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
+      "traits": [
+        {
+          "name": "Amorphous",
+          "description": "The jelly can move through a space as narrow as 1 inch wide without squeezing."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The jelly can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Pseudopod",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) bludgeoning damage plus 3 (1d6) acid damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The jelly can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "octopus",
+      "name": "Octopus",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Unaligned",
+      "biomes": ["Water"],
+      "ac": 12,
+      "hp": 3,
+      "hitDice": "1d6",
+      "speed": "Walk 5, Swim 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 4,
+        "dex": 15,
+        "con": 11,
+        "int": 3,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 30 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "While out of water, the octopus can hold its breath for 30 minutes."
+        },
+        {
+          "name": "Underwater Camouflage",
+          "description": "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The octopus can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Tentacles",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage, and the target is grappled (escape DC 10). Until this grapple ends, the octopus can't use its tentacles on another target."
+        },
+        {
+          "name": "Ink Cloud (Recharges after a Short or Long Rest)",
+          "description": "A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While out of water, the octopus can hold its breath for 30 minutes."
+    },
+    {
+      "id": "ogre",
+      "name": "Ogre",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Ruin",
+        "Swamp",
+        "Tundra",
+        "Underdark"
+      ],
+      "ac": 11,
+      "hp": 59,
+      "hitDice": "7d10+21",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 19,
+        "dex": 8,
+        "con": 16,
+        "int": 5,
+        "wis": 7,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "Common, Giant",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Greatclub",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Javelin",
+          "description": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+    },
+    {
+      "id": "ogre-zombie",
+      "name": "Ogre Zombie",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Ruin", "Shadowfell", "Temple", "Tomb"],
+      "ac": 8,
+      "hp": 85,
+      "hitDice": "9d10+36",
+      "speed": "Walk 30",
+      "initiative": -2,
+      "abilities": {
+        "str": 19,
+        "dex": 6,
+        "con": 18,
+        "int": 3,
+        "wis": 6,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "understands Common and Giant but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Undead Fortitude",
+          "description": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Morningstar",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+    },
+    {
+      "id": "oni",
+      "name": "Oni",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Forest", "Urban"],
+      "ac": 16,
+      "hp": 110,
+      "hitDice": "13d10+39",
+      "speed": "Walk 30, Fly 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 11,
+        "con": 16,
+        "int": 14,
+        "wis": 12,
+        "cha": 15
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Common, Giant",
+      "savingThrows": "",
+      "skills": "Arcana 5, Deception 8, Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Innate Spellcasting",
+          "description": "The oni's innate spellcasting ability is Charisma (spell save DC 13). The oni can innately cast the following spells, requiring no material components:\n\nAt will: darkness, invisibility\n1/day each: charm person, cone of cold, gaseous form, sleep"
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The oni's weapon attacks are magical."
+        },
+        {
+          "name": "Regeneration",
+          "description": "The oni regains 10 hit points at the start of its turn if it has at least 1 hit point."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The oni makes two attacks, either with its claws or its glaive."
+        },
+        {
+          "name": "Claw (Oni Form Only)",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage."
+        },
+        {
+          "name": "Glaive",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) slashing damage, or 9 (1d10 + 4) slashing damage in Small or Medium form."
+        },
+        {
+          "name": "Change Shape",
+          "description": "The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The oni's innate spellcasting ability is Charisma (spell save DC 13). The oni can innately cast the following spells, requiring no material components:\n\nAt will: darkness, invisibility\n1/day each: charm person, cone of cold, gaseous form, sleep"
+    },
+    {
+      "id": "orc",
+      "name": "Orc",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Orc",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Arctic",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Mountain",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 13,
+      "hp": 15,
+      "hitDice": "2d8+6",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 12,
+        "con": 16,
+        "int": 7,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Common, Orc",
+      "savingThrows": "",
+      "skills": "Intimidation 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Aggressive",
+          "description": "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Greataxe",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+        },
+        {
+          "name": "Javelin",
+          "description": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+    },
+    {
+      "id": "otyugh",
+      "name": "Otyugh",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Aberration",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": [
+        "Caverns",
+        "Laboratory",
+        "Ruin",
+        "Sewer",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 14,
+      "hp": 114,
+      "hitDice": "12d10+48",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 16,
+        "dex": 11,
+        "con": 19,
+        "int": 6,
+        "wis": 13,
+        "cha": 6
+      },
+      "senses": "darkvision 120 ft., passive Perception 11",
+      "languages": "Otyugh",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Limited Telepathy",
+          "description": "The otyugh can magically transmit simple messages and images to any creature within 120 ft. of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The otyugh makes three attacks: one with its bite and two with its tentacles."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d8 + 3) piercing damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured."
+        },
+        {
+          "name": "Tentacle",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target."
+        },
+        {
+          "name": "Tentacle Slam",
+          "description": "The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a DC 14 Constitution saving throw or take 10 (2d6 + 3) bludgeoning damage and be stunned until the end of the otyugh's next turn. On a successful save, the target takes half the bludgeoning damage and isn't stunned."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The otyugh can magically transmit simple messages and images to any creature within 120 ft. of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond."
+    },
+    {
+      "id": "owl",
+      "name": "Owl",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Arctic", "Forest"],
+      "ac": 11,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 5, Fly 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 8,
+        "int": 2,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "darkvision 120 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Flyby",
+          "description": "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        },
+        {
+          "name": "Keen Hearing and Sight",
+          "description": "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+    },
+    {
+      "id": "owlbear",
+      "name": "Owlbear",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Feywild", "Forest", "Hills", "Jungle", "Mountains"],
+      "ac": 13,
+      "hp": 59,
+      "hitDice": "7d10+21",
+      "speed": "Walk 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 20,
+        "dex": 12,
+        "con": 17,
+        "int": 3,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight and Smell",
+          "description": "The owlbear has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The owlbear makes two attacks: one with its beak and one with its claws."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 10 (1d10 + 5) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The owlbear has advantage on Wisdom (Perception) checks that rely on sight or smell."
+    },
+    {
+      "id": "panther",
+      "name": "Panther",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill", "Jungle"],
+      "ac": 12,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 50, Climb 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 14,
+        "dex": 15,
+        "con": 10,
+        "int": 3,
+        "wis": 14,
+        "cha": 7
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The panther has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Pounce",
+          "description": "If the panther moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the panther can make one bite attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The panther has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "pegasus",
+      "name": "Pegasus",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Good",
+      "biomes": [
+        "Astral Plane",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountains"
+      ],
+      "ac": 12,
+      "hp": 59,
+      "hitDice": "7d10+21",
+      "speed": "Walk 60, Fly 90",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 10,
+        "wis": 15,
+        "cha": 13
+      },
+      "senses": "passive Perception 16",
+      "languages": "understands Celestial, Common, Elvish, and Sylvan but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+    },
+    {
+      "id": "phase-spider",
+      "name": "Phase Spider",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Astral Plane",
+        "Caverns",
+        "Ethereal Plane",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Mountains",
+        "Ruin",
+        "Shadowfell",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 13,
+      "hp": 32,
+      "hitDice": "5d10+5",
+      "speed": "Walk 30, Climb 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 15,
+        "con": 12,
+        "int": 6,
+        "wis": 10,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Ethereal Jaunt",
+          "description": "As a bonus action, the spider can magically shift from the Material Plane to the Ethereal Plane, or vice versa."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 18 (4d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **phase spider** possesses the magical ability to phase in and out of the Ethereal Plane. It seems to appear out of nowhere and quickly vanishes after attacking. Its movement on the Ethereal Plane before coming back to the Material Plane makes it seem like it can teleport."
+    },
+    {
+      "id": "pit-fiend",
+      "name": "Pit Fiend",
+      "cr": 20,
+      "challengeRating": "20",
+      "xp": 25000,
+      "type": "Fiend",
+      "subtype": "Devil",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Hell"],
+      "ac": 19,
+      "hp": 300,
+      "hitDice": "24d10+168",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 26,
+        "dex": 14,
+        "con": 24,
+        "int": 22,
+        "wis": 18,
+        "cha": 24
+      },
+      "senses": "truesight 120 ft., passive Perception 14",
+      "languages": "Infernal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Fear Aura",
+          "description": "Any creature hostile to the pit fiend that starts its turn within 20 feet of the pit fiend must make a DC 21 Wisdom saving throw, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The pit fiend has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The pit fiend's weapon attacks are magical."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The pit fiend's spellcasting ability is Charisma (spell save DC 21). The pit fiend can innately cast the following spells, requiring no material components:\nAt will: detect magic, fireball\n3/day each: hold monster, wall of fire"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) piercing damage. The target must succeed on a DC 21 Constitution saving throw or become poisoned. While poisoned in this way, the target can't regain hit points, and it takes 21 (6d6) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 17 (2d8 + 8) slashing damage."
+        },
+        {
+          "name": "Mace",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 24 (3d10 + 8) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Any creature hostile to the pit fiend that starts its turn within 20 feet of the pit fiend must make a DC 21 Wisdom saving throw, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours."
+    },
+    {
+      "id": "planetar",
+      "name": "Planetar",
+      "cr": 16,
+      "challengeRating": "16",
+      "xp": 15000,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Temple"],
+      "ac": 19,
+      "hp": 200,
+      "hitDice": "16d10+112",
+      "speed": "Walk 40, Fly 120",
+      "initiative": 5,
+      "abilities": {
+        "str": 24,
+        "dex": 20,
+        "con": 24,
+        "int": 19,
+        "wis": 22,
+        "cha": 25
+      },
+      "senses": "truesight 120 ft., passive Perception 21",
+      "languages": "all, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "Perception 11",
+      "damageVulnerabilities": "",
+      "damageResistances": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, exhaustion, frightened",
+      "traits": [
+        {
+          "name": "Angelic Weapons",
+          "description": "The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an extra 5d8 radiant damage (included in the attack)."
+        },
+        {
+          "name": "Divine Awareness",
+          "description": "The planetar knows if it hears a lie."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The planetar's spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:\nAt will: detect evil and good, invisibility (self only)\n3/day each: blade barrier, dispel evil and good, flame strike, raise dead\n1/day each: commune, control weather, insect plague"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The planetar has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The planetar makes two melee attacks."
+        },
+        {
+          "name": "Greatsword",
+          "description": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 21 (4d6 + 7) slashing damage plus 22 (5d8) radiant damage."
+        },
+        {
+          "name": "Healing Touch (4/Day)",
+          "description": "The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an extra 5d8 radiant damage (included in the attack)."
+    },
+    {
+      "id": "plesiosaurus",
+      "name": "Plesiosaurus",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Coastal", "Desert", "Plane Of Water", "Underwater", "Water"],
+      "ac": 13,
+      "hp": 68,
+      "hitDice": "8d10+24",
+      "speed": "Walk 20, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 15,
+        "con": 16,
+        "int": 2,
+        "wis": 12,
+        "cha": 5
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Hold Breath",
+          "description": "The plesiosaurus can hold its breath for 1 hour."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The plesiosaurus can hold its breath for 1 hour."
+    },
+    {
+      "id": "poisonous-snake",
+      "name": "Poisonous Snake",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Sewer",
+        "Swamp",
+        "Tomb",
+        "Water"
+      ],
+      "ac": 13,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 2,
+        "dex": 16,
+        "con": 11,
+        "int": 1,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a DC 10 Constitution saving throw, taking 5 (2d4) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a DC 10 Constitution saving throw, taking 5 (2d4) poison damage on a failed save, or half as much damage on a successful one."
+    },
+    {
+      "id": "polar-bear",
+      "name": "Polar Bear",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Arctic", "Tundra", "Underdark"],
+      "ac": 12,
+      "hp": 42,
+      "hitDice": "5d10+15",
+      "speed": "Walk 40, Swim 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 20,
+        "dex": 10,
+        "con": 16,
+        "int": 2,
+        "wis": 13,
+        "cha": 7
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The bear makes two attacks: one with its bite and one with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (1d8 + 5) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "pony",
+      "name": "Pony",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Mountains", "Settlement", "Urban"],
+      "ac": 10,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 10,
+        "con": 13,
+        "int": 2,
+        "wis": 11,
+        "cha": 7
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage."
+    },
+    {
+      "id": "priest",
+      "name": "Priest",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Desert", "Hills", "Settlement", "Temple", "Urban"],
+      "ac": 13,
+      "hp": 27,
+      "hitDice": "5d8+5",
+      "speed": "Walk 25",
+      "initiative": 0,
+      "abilities": {
+        "str": 10,
+        "dex": 10,
+        "con": 12,
+        "int": 13,
+        "wis": 16,
+        "cha": 13
+      },
+      "senses": "passive Perception 13",
+      "languages": "any two languages",
+      "savingThrows": "",
+      "skills": "Medicine 7, Persuasion 3, Religion 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Divine Eminence",
+          "description": "As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra 10 (3d6) radiant damage to a target on a hit. This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:\n\n* Cantrips (at will): light, sacred flame, thaumaturgy\n* 1st level (4 slots): cure wounds, guiding bolt, sanctuary\n* 2nd level (3 slots): lesser restoration, spiritual weapon\n* 3rd level (2 slots): dispel magic, spirit guardians"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Mace",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Priests** bring the teachings of their gods to the common folk. They are the spiritual leaders of temples and shrines and often hold positions of influence in their communities. Evil priests might work openly under a tyrant, or they might be the leaders of religious sects hidden in the shadows of good society, overseeing depraved rites. \nA priest typically has one or more acolytes to help with religious ceremonies and other sacred duties."
+    },
+    {
+      "id": "pseudodragon",
+      "name": "Pseudodragon",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Neutral Good",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Hill",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 13,
+      "hp": 7,
+      "hitDice": "2d4+2",
+      "speed": "Walk 15, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 6,
+        "dex": 15,
+        "con": 13,
+        "int": 10,
+        "wis": 12,
+        "cha": 10
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 13",
+      "languages": "understands Common and Draconic but can't speak",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Senses",
+          "description": "The pseudodragon has advantage on Wisdom (Perception) checks that rely on sight, hearing, or smell."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The pseudodragon has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Limited Telepathy",
+          "description": "The pseudodragon can magically communicate simple ideas, emotions, and images telepathically with any creature within 100 ft. of it that can understand a language."
+        },
+        {
+          "name": "Variant: Familiar",
+          "description": "The pseudodragon can serve another creature as a familiar, forming a magic, telepathic bond with that willing companion. While the two are bonded, the companion can sense what the pseudodragon senses as long as they are within 1 mile of each other. While the pseudodragon is within 10 feet of its companion, the companion shares the pseudodragon's Magic Resistance trait. At any time and for any reason, the pseudodragon can end its service as a familiar, ending the telepathic bond."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        },
+        {
+          "name": "Sting",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The pseudodragon has advantage on Wisdom (Perception) checks that rely on sight, hearing, or smell."
+    },
+    {
+      "id": "purple-worm",
+      "name": "Purple Worm",
+      "cr": 15,
+      "challengeRating": "15",
+      "xp": 13000,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Mountains", "Underdark"],
+      "ac": 18,
+      "hp": 247,
+      "hitDice": "15d20+90",
+      "speed": "Walk 50, Burrow 30",
+      "initiative": -2,
+      "abilities": {
+        "str": 28,
+        "dex": 7,
+        "con": 22,
+        "int": 1,
+        "wis": 8,
+        "cha": 4
+      },
+      "senses": "blindsight 30 ft., tremorsense 60 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Tunneler",
+          "description": "The worm can burrow through solid rock at half its burrow speed and leaves a 10-foot-diameter tunnel in its wake."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The worm makes two attacks: one with its bite and one with its stinger."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 22 (3d8 + 9) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 19 Dexterity saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes 21 (6d6) acid damage at the start of each of the worm's turns.\nIf the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the worm. If the worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone."
+        },
+        {
+          "name": "Tail Stinger",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 19 (3d6 + 9) piercing damage, and the target must make a DC 19 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The worm can burrow through solid rock at half its burrow speed and leaves a 10-foot-diameter tunnel in its wake."
+    },
+    {
+      "id": "quasit",
+      "name": "Quasit",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Tiny",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 13,
+      "hp": 7,
+      "hitDice": "3d4",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 5,
+        "dex": 17,
+        "con": 10,
+        "int": 7,
+        "wis": 10,
+        "cha": 10
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "Abyssal, Common",
+      "savingThrows": "",
+      "skills": "Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The quasit has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Variant: Familiar",
+          "description": "The quasit can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the quasit senses as long as they are within 1 mile of each other. While the quasit is within 10 feet of its master, the master shares the quasit's Magic Resistance trait. At any time and for any reason, the quasit can end its service as a familiar, ending the telepathic bond."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw (Bite in Beast Form)",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        },
+        {
+          "name": "Scare (1/day)",
+          "description": "One creature of the quasit's choice within 20 ft. of it must succeed on a DC 10 Wisdom saving throw or be frightened for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success."
+        },
+        {
+          "name": "Invisibility",
+          "description": "The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "quipper",
+      "name": "Quipper",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Sewer", "Underwater", "Water"],
+      "ac": 13,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Swim 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 2,
+        "dex": 16,
+        "con": 9,
+        "int": 1,
+        "wis": 7,
+        "cha": 2
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Blood Frenzy",
+          "description": "The quipper has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The quipper can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **quipper** is a carnivorous fish with sharp teeth. Quippers can adapt to any aquatic environment, including cold subterranean lakes. They frequently gather in swarms; the statistics for a swarm of quippers appear later in this appendix."
+    },
+    {
+      "id": "rakshasa",
+      "name": "Rakshasa",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Fiend",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Abyss",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hell",
+        "Hills",
+        "Jungle",
+        "Settlement",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 16,
+      "hp": 110,
+      "hitDice": "13d8+52",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 14,
+        "dex": 17,
+        "con": 18,
+        "int": 13,
+        "wis": 16,
+        "cha": 20
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "Common, Infernal",
+      "savingThrows": "",
+      "skills": "Deception 10, Insight 8",
+      "damageVulnerabilities": "piercing from magic weapons wielded by good creatures",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Limited Magic Immunity",
+          "description": "The rakshasa can't be affected or detected by spells of 6th level or lower unless it wishes to be. It has advantage on saving throws against all other spells and magical effects."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The rakshasa's innate spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The rakshasa can innately cast the following spells, requiring no material components:\n\nAt will: detect thoughts, disguise self, mage hand, minor illusion\n3/day each: charm person, detect magic, invisibility, major image, suggestion\n1/day each: dominate person, fly, plane shift, true seeing"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The rakshasa makes two claw attacks"
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The rakshasa can't be affected or detected by spells of 6th level or lower unless it wishes to be. It has advantage on saving throws against all other spells and magical effects."
+    },
+    {
+      "id": "rat",
+      "name": "Rat",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Forest",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 10,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 2,
+        "dex": 11,
+        "con": 9,
+        "int": 2,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "darkvision 30 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "raven",
+      "name": "Raven",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Hill", "Swamp", "Urban"],
+      "ac": 12,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 10, Fly 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 2,
+        "dex": 14,
+        "con": 8,
+        "int": 2,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Mimicry",
+          "description": "The raven can mimic simple sounds it has heard, such as a person whispering, a baby crying, or an animal chittering. A creature that hears the sounds can tell they are imitations with a successful DC 10 Wisdom (Insight) check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The raven can mimic simple sounds it has heard, such as a person whispering, a baby crying, or an animal chittering. A creature that hears the sounds can tell they are imitations with a successful DC 10 Wisdom (Insight) check."
+    },
+    {
+      "id": "red-dragon-wyrmling",
+      "name": "Red Dragon Wyrmling",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Mountains"],
+      "ac": 17,
+      "hp": 75,
+      "hitDice": "10d8+30",
+      "speed": "Walk 30, Climb 30, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 17,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage plus 3 (1d6) fire damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage plus 3 (1d6) fire damage."
+    },
+    {
+      "id": "reef-shark",
+      "name": "Reef Shark",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Underwater", "Water"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "4d8+1",
+      "speed": "Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 14,
+        "dex": 13,
+        "con": 13,
+        "int": 1,
+        "wis": 10,
+        "cha": 4
+      },
+      "senses": "blindsight 30 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Pack Tactics",
+          "description": "The shark has advantage on an attack roll against a creature if at least one of the shark's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The shark can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Smaller than giant sharks and hunter sharks, **reef sharks** inhabit shallow waters and coral reefs, gathering in small packs to hunt. A full-grown specimen measures 6 to 10 feet long."
+    },
+    {
+      "id": "remorhaz",
+      "name": "Remorhaz",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Arctic", "Mountains", "Tundra"],
+      "ac": 17,
+      "hp": 195,
+      "hitDice": "17d12+85",
+      "speed": "Walk 30, Burrow 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 24,
+        "dex": 13,
+        "con": 21,
+        "int": 4,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold, fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Heated Body",
+          "description": "A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 40 (6d10 + 7) piercing damage plus 10 (3d6) fire damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can't bite another target."
+        },
+        {
+          "name": "Swallow",
+          "description": "The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes 21 (6d6) acid damage at the start of each of the remorhaz's turns.\nIf the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet oft he remorhaz. If the remorhaz dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."
+    },
+    {
+      "id": "rhinoceros",
+      "name": "Rhinoceros",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Grassland"],
+      "ac": 11,
+      "hp": 45,
+      "hitDice": "6d10+12",
+      "speed": "Walk 40",
+      "initiative": -1,
+      "abilities": {
+        "str": 21,
+        "dex": 8,
+        "con": 15,
+        "int": 2,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "riding-horse",
+      "name": "Riding Horse",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Grassland", "Settlement", "Urban"],
+      "ac": 10,
+      "hp": 13,
+      "hitDice": "2d10+2",
+      "speed": "Walk 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 16,
+        "dex": 10,
+        "con": 12,
+        "int": 2,
+        "wis": 11,
+        "cha": 7
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage."
+    },
+    {
+      "id": "roc",
+      "name": "Roc",
+      "cr": 11,
+      "challengeRating": "11",
+      "xp": 7200,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Gargantuan",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Water"
+      ],
+      "ac": 15,
+      "hp": 248,
+      "hitDice": "16d20+80",
+      "speed": "Walk 20, Fly 120",
+      "initiative": 0,
+      "abilities": {
+        "str": 28,
+        "dex": 10,
+        "con": 20,
+        "int": 3,
+        "wis": 10,
+        "cha": 9
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight",
+          "description": "The roc has advantage on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The roc makes two attacks: one with its beak and one with its talons."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 27 (4d8 + 9) piercing damage."
+        },
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 23 (4d6 + 9) slashing damage, and the target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can't use its talons on another target."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The roc has advantage on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "roper",
+      "name": "Roper",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Caverns", "Underdark"],
+      "ac": 20,
+      "hp": 93,
+      "hitDice": "11d10+33",
+      "speed": "Walk 10, Climb 10",
+      "initiative": -1,
+      "abilities": {
+        "str": 18,
+        "dex": 8,
+        "con": 17,
+        "int": 7,
+        "wis": 16,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 16",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 6, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the roper remains motionless, it is indistinguishable from a normal cave formation, such as a stalagmite."
+        },
+        {
+          "name": "Grasping Tendrils",
+          "description": "The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; 10 hit points; immunity to poison and psychic damage). Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a DC 15 Strength check against it."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The roper can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 22 (4d8 + 4) piercing damage."
+        },
+        {
+          "name": "Tendril",
+          "description": "Melee Weapon Attack: +7 to hit, reach 50 ft., one creature. Hit: The target is grappled (escape DC 15). Until the grapple ends, the target is restrained and has disadvantage on Strength checks and Strength saving throws, and the roper can't use the same tendril on another target."
+        },
+        {
+          "name": "Reel",
+          "description": "The roper pulls each creature grappled by it up to 25 ft. straight toward it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the roper remains motionless, it is indistinguishable from a normal cave formation, such as a stalagmite."
+    },
+    {
+      "id": "rug-of-smothering",
+      "name": "Rug of Smothering",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Laboratory", "Ruin"],
+      "ac": 12,
+      "hp": 33,
+      "hitDice": "6d10",
+      "speed": "Walk 10",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 14,
+        "con": 10,
+        "int": 1,
+        "wis": 3,
+        "cha": 1
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison, psychic",
+      "conditionImmunities": "blinded, charmed, deafened, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Antimagic Susceptibility",
+          "description": "The rug is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        },
+        {
+          "name": "Damage Transfer",
+          "description": "While it is grappling a creature, the rug takes only half the damage dealt to it, and the creature grappled by the rug takes the other half."
+        },
+        {
+          "name": "False Appearance",
+          "description": "While the rug remains motionless, it is indistinguishable from a normal rug."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Smother",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one Medium or smaller creature. Hit: The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes 10 (2d6 + 3) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The rug is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+    },
+    {
+      "id": "rust-monster",
+      "name": "Rust Monster",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Underdark"],
+      "ac": 14,
+      "hp": 27,
+      "hitDice": "5d8+5",
+      "speed": "Walk 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 13,
+        "dex": 12,
+        "con": 13,
+        "int": 2,
+        "wis": 13,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Iron Scent",
+          "description": "The rust monster can pinpoint, by scent, the location of ferrous metal within 30 feet of it."
+        },
+        {
+          "name": "Rust Metal",
+          "description": "Any nonmagical weapon made of metal that hits the rust monster corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Non magical ammunition made of metal that hits the rust monster is destroyed after dealing damage."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        },
+        {
+          "name": "Antennae",
+          "description": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The rust monster can pinpoint, by scent, the location of ferrous metal within 30 feet of it."
+    },
+    {
+      "id": "saber-toothed-tiger",
+      "name": "Saber-Toothed Tiger",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Arctic",
+        "Forest",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Tundra"
+      ],
+      "ac": 12,
+      "hp": 52,
+      "hitDice": "7d10+14",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 14,
+        "con": 15,
+        "int": 3,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Pounce",
+          "description": "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (1d10 + 5) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "sahuagin",
+      "name": "Sahuagin",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Sahuagin",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Coastal", "Desert", "Underwater", "Water"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "4d8+4",
+      "speed": "Walk 30, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 13,
+        "dex": 11,
+        "con": 12,
+        "int": 12,
+        "wis": 13,
+        "cha": 9
+      },
+      "senses": "darkvision 120 ft., passive Perception 15",
+      "languages": "Sahuagin",
+      "savingThrows": "",
+      "skills": "Perception 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Blood Frenzy",
+          "description": "The sahuagin has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        },
+        {
+          "name": "Limited Amphibiousness",
+          "description": "The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating."
+        },
+        {
+          "name": "Shark Telepathy",
+          "description": "The sahuagin can magically command any shark within 120 feet of it, using a limited telepathy."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) slashing damage."
+        },
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The sahuagin has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+    },
+    {
+      "id": "salamander",
+      "name": "Salamander",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Caverns", "Plane Of Fire", "Underdark"],
+      "ac": 15,
+      "hp": 90,
+      "hitDice": "12d10+24",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 14,
+        "con": 15,
+        "int": 11,
+        "wis": 10,
+        "cha": 12
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "cold",
+      "damageResistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Heated Body",
+          "description": "A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes 7 (2d6) fire damage."
+        },
+        {
+          "name": "Heated Weapons",
+          "description": "Any metal melee weapon the salamander wields deals an extra 3 (1d6) fire damage on a hit (included in the attack)."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The salamander makes two attacks: one with its spear and one with its tail."
+        },
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage plus 7 (2d6) fire damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes 7 (2d6) fire damage."
+    },
+    {
+      "id": "satyr",
+      "name": "Satyr",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Neutral",
+      "biomes": ["Feywild", "Forest", "Hills", "Jungle"],
+      "ac": 14,
+      "hp": 31,
+      "hitDice": "7d8",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 12,
+        "dex": 16,
+        "con": 11,
+        "int": 12,
+        "wis": 10,
+        "cha": 14
+      },
+      "senses": "passive Perception 12",
+      "languages": "Common, Elvish, Sylvan",
+      "savingThrows": "",
+      "skills": "Perception 2, Performance 6, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The satyr has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Ram",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) bludgeoning damage."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Shortbow",
+          "description": "Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Variant: Panpipes",
+          "description": "Gentle Lullaby. The creature falls asleep and is unconscious for 1 minute. The effect ends if the creature takes damage or if someone takes an action to shake the creature awake."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The satyr has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "scorpion",
+      "name": "Scorpion",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Grassland"],
+      "ac": 11,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 10",
+      "initiative": 0,
+      "abilities": {
+        "str": 2,
+        "dex": 11,
+        "con": 8,
+        "int": 1,
+        "wis": 8,
+        "cha": 2
+      },
+      "senses": "blindsight 10 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Sting",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must make a DC 9 Constitution saving throw, taking 4 (1d8) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must make a DC 9 Constitution saving throw, taking 4 (1d8) poison damage on a failed save, or half as much damage on a successful one."
+    },
+    {
+      "id": "scout",
+      "name": "Scout",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Swamp",
+        "Tundra",
+        "Underdark"
+      ],
+      "ac": 13,
+      "hp": 16,
+      "hitDice": "3d8+3",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 11,
+        "dex": 14,
+        "con": 12,
+        "int": 11,
+        "wis": 13,
+        "cha": 11
+      },
+      "senses": "passive Perception 15",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Nature 4, Perception 5, Stealth 6, Survival 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Sight",
+          "description": "The scout has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The scout makes two melee attacks or two ranged attacks."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Scouts** are skilled hunters and trackers who offer their services for a fee. Most hunt wild game, but a few work as bounty hunters, serve as guides, or provide military reconnaissance."
+    },
+    {
+      "id": "sea-hag",
+      "name": "Sea Hag",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Feywild",
+        "Plane Of Water",
+        "Underwater",
+        "Water"
+      ],
+      "ac": 14,
+      "hp": 52,
+      "hitDice": "7d8+21",
+      "speed": "Walk 30, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 13,
+        "con": 16,
+        "int": 12,
+        "wis": 12,
+        "cha": 13
+      },
+      "senses": "darkvision 60 ft., passive Perception 11",
+      "languages": "Aquan, Common, Giant",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The hag can breathe air and water."
+        },
+        {
+          "name": "Horrific Appearance",
+          "description": "Any humanoid that starts its turn within 30 feet of the hag and can see the hag's true form must make a DC 11 Wisdom saving throw. On a failed save, the creature is frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the hag is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Horrific Appearance for the next 24 hours.\nUnless the target is surprised or the revelation of the hag's true form is sudden, the target can avert its eyes and avoid making the initial saving throw. Until the start of its next turn, a creature that averts its eyes has disadvantage on attack rolls against the hag."
+        },
+        {
+          "name": "Hag Coven",
+          "description": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        },
+        {
+          "name": "Shared Spellcasting (Coven Only)",
+          "description": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n* 1st level (4 slots): identify, ray of sickness\n* 2nd level (3 slots): hold person, locate object\n* 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n* 4th level (3 slots): phantasmal killer, polymorph\n* 5th level (2 slots): contact other plane, scrying\n* 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        },
+        {
+          "name": "Hag Eye (Coven Only)",
+          "description": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        },
+        {
+          "name": "Death Glare",
+          "description": "The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must succeed on a DC 11 Wisdom saving throw against this magic or drop to 0 hit points."
+        },
+        {
+          "name": "Illusory Appearance",
+          "description": "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.\nThe changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The hag can breathe air and water."
+    },
+    {
+      "id": "sea-horse",
+      "name": "Sea Horse",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Lake", "Ocean", "Plane Of Water", "Water"],
+      "ac": 11,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Swim 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 1,
+        "dex": 12,
+        "con": 8,
+        "int": 1,
+        "wis": 10,
+        "cha": 2
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Water Breathing",
+          "description": "The sea horse can breathe only underwater."
+        }
+      ],
+      "actions": [],
+      "legendaryActions": [],
+      "details": "The sea horse can breathe only underwater."
+    },
+    {
+      "id": "shadow",
+      "name": "Shadow",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Caverns", "Ruin", "Shadowfell", "Tomb", "Underdark", "Urban"],
+      "ac": 12,
+      "hp": 16,
+      "hitDice": "3d8+3",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 6,
+        "dex": 14,
+        "con": 13,
+        "int": 6,
+        "wis": 10,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 4",
+      "damageVulnerabilities": "radiant",
+      "damageResistances": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "necrotic, poison",
+      "conditionImmunities": "exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained",
+      "traits": [
+        {
+          "name": "Amorphous",
+          "description": "The shadow can move through a space as narrow as 1 inch wide without squeezing."
+        },
+        {
+          "name": "Shadow Stealth",
+          "description": "While in dim light or darkness, the shadow can take the Hide action as a bonus action."
+        },
+        {
+          "name": "Sunlight Weakness",
+          "description": "While in sunlight, the shadow has disadvantage on attack rolls, ability checks, and saving throws."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Strength Drain",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) necrotic damage, and the target's Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.\nIf a non-evil humanoid dies from this attack, a new shadow rises from the corpse 1d4 hours later."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The shadow can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "shambling-mound",
+      "name": "Shambling Mound",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Feywild", "Forest", "Jungle", "Swamp"],
+      "ac": 15,
+      "hp": 136,
+      "hitDice": "16d10+48",
+      "speed": "Walk 20, Swim 20",
+      "initiative": -1,
+      "abilities": {
+        "str": 18,
+        "dex": 8,
+        "con": 16,
+        "int": 5,
+        "wis": 10,
+        "cha": 5
+      },
+      "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "blinded, deafened, exhaustion",
+      "traits": [
+        {
+          "name": "Lightning Absorption",
+          "description": "Whenever the shambling mound is subjected to lightning damage, it takes no damage and regains a number of hit points equal to the lightning damage dealt."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Engulf",
+          "description": "The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a DC 14 Constitution saving throw at the start of each of the mound's turns or take 13 (2d8 + 4) bludgeoning damage. If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Whenever the shambling mound is subjected to lightning damage, it takes no damage and regains a number of hit points equal to the lightning damage dealt."
+    },
+    {
+      "id": "shield-guardian",
+      "name": "Shield Guardian",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Laboratory", "Ruin", "Temple", "Tomb", "Urban"],
+      "ac": 17,
+      "hp": 142,
+      "hitDice": "15d10+60",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 18,
+        "dex": 8,
+        "con": 18,
+        "int": 7,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 10",
+      "languages": "understands commands given in any language but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
+      "traits": [
+        {
+          "name": "Bound",
+          "description": "The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian."
+        },
+        {
+          "name": "Regeneration",
+          "description": "The shield guardian regains 10 hit points at the start of its turn if it has at least 1 hit. point."
+        },
+        {
+          "name": "Spell Storing",
+          "description": "A spellcaster who wears the shield guardian's amulet can cause the guardian to store one spell of 4th level or lower. To do so, the wearer must cast the spell on the guardian. The spell has no effect but is stored within the guardian. When commanded to do so by the wearer or when a situation arises that was predefined by the spellcaster, the guardian casts the stored spell with any parameters set by the original caster, requiring no components. When the spell is cast or a new spell is stored, any previously stored spell is lost."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The guardian makes two fist attacks."
+        },
+        {
+          "name": "Fist",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian."
+    },
+    {
+      "id": "shrieker",
+      "name": "Shrieker",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Forest", "Swamp", "Underdark"],
+      "ac": 5,
+      "hp": 13,
+      "hitDice": "3d8",
+      "speed": "Walk 0",
+      "initiative": -5,
+      "abilities": {
+        "str": 1,
+        "dex": 1,
+        "con": 10,
+        "int": 1,
+        "wis": 3,
+        "cha": 1
+      },
+      "senses": "blindsight 30 ft. (blind beyond this radius), passive Perception 6",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "blinded, deafened, frightened",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Shriek",
+          "description": "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward"
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."
+    },
+    {
+      "id": "silver-dragon-wyrmling",
+      "name": "Silver Dragon Wyrmling",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Good",
+      "biomes": ["Feywild", "Mountains"],
+      "ac": 17,
+      "hp": 45,
+      "hitDice": "6d8+18",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 17,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 13 Constitution saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+    },
+    {
+      "id": "skeleton",
+      "name": "Skeleton",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": ["Ruin", "Shadowfell", "Temple", "Tomb", "Urban"],
+      "ac": 13,
+      "hp": 13,
+      "hitDice": "2d8+4",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 14,
+        "con": 15,
+        "int": 6,
+        "wis": 8,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "understands the languages it knew in life but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "bludgeoning",
+      "damageResistances": "poison",
+      "damageImmunities": "",
+      "conditionImmunities": "exhaustion, poisoned",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Shortbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+    },
+    {
+      "id": "solar",
+      "name": "Solar",
+      "cr": 21,
+      "challengeRating": "21",
+      "xp": 33000,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Astral Plane", "Temple"],
+      "ac": 21,
+      "hp": 243,
+      "hitDice": "18d10+144",
+      "speed": "Walk 50, Fly 150",
+      "initiative": 6,
+      "abilities": {
+        "str": 26,
+        "dex": 22,
+        "con": 26,
+        "int": 25,
+        "wis": 25,
+        "cha": 30
+      },
+      "senses": "truesight 120 ft., passive Perception 24",
+      "languages": "all, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "Perception 14",
+      "damageVulnerabilities": "",
+      "damageResistances": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "necrotic, poison",
+      "conditionImmunities": "charmed, exhaustion, frightened, poisoned",
+      "traits": [
+        {
+          "name": "Angelic Weapons",
+          "description": "The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an extra 6d8 radiant damage (included in the attack)."
+        },
+        {
+          "name": "Divine Awareness",
+          "description": "The solar knows if it hears a lie."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The solar's spell casting ability is Charisma (spell save DC 25). It can innately cast the following spells, requiring no material components:\nAt will: detect evil and good, invisibility (self only)\n3/day each: blade barrier, dispel evil and good, resurrection\n1/day each: commune, control weather"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The solar has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The solar makes two greatsword attacks."
+        },
+        {
+          "name": "Greatsword",
+          "description": "Melee Weapon Attack: +15 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) slashing damage plus 27 (6d8) radiant damage."
+        },
+        {
+          "name": "Slaying Longbow",
+          "description": "Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 15 (2d8 + 6) piercing damage plus 27 (6d8) radiant damage. If the target is a creature that has 190 hit points or fewer, it must succeed on a DC 15 Constitution saving throw or die."
+        },
+        {
+          "name": "Flying Sword",
+          "description": "The solar releases its greatsword to hover magically in an unoccupied space within 5 ft. of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to 50 ft. and either make one attack against a target or return to the solar's hands. If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies."
+        },
+        {
+          "name": "Healing Touch (4/Day)",
+          "description": "The solar touches another creature. The target magically regains 40 (8d8 + 4) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Teleport",
+          "description": "The solar magically teleports, along with any equipment it is wearing or carrying, up to 120 ft. to an unoccupied space it can see."
+        },
+        {
+          "name": "Searing Burst (Costs 2 Actions)",
+          "description": "The solar emits magical, divine energy. Each creature of its choice in a 10 -foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Blinding Gaze (Costs 3 Actions)",
+          "description": "The solar targets one creature it can see within 30 ft. of it. If the target can see it, the target must succeed on a DC 15 Constitution saving throw or be blinded until magic such as the lesser restoration spell removes the blindness."
+        }
+      ],
+      "details": "The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an extra 6d8 radiant damage (included in the attack)."
+    },
+    {
+      "id": "specter",
+      "name": "Specter",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Ruin", "Shadowfell", "Tomb", "Underdark", "Urban"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Hover true, Walk 0, Fly 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 1,
+        "dex": 14,
+        "con": 11,
+        "int": 10,
+        "wis": 10,
+        "cha": 11
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "understands all languages it knew in life but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "necrotic, poison",
+      "conditionImmunities": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Incorporeal Movement",
+          "description": "The specter can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the specter has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Life Drain",
+          "description": "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) necrotic damage. The target must succeed on a DC 10 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The specter can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+    },
+    {
+      "id": "spider",
+      "name": "Spider",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Jungle", "Ruin"],
+      "ac": 12,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 20, Climb 20",
+      "initiative": 2,
+      "abilities": {
+        "str": 2,
+        "dex": 14,
+        "con": 8,
+        "int": 1,
+        "wis": 10,
+        "cha": 2
+      },
+      "senses": "darkvision 30 ft., passive Perception 12",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Spider Climb",
+          "description": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "description": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The spider ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 9 Constitution saving throw or take 2 (1d4) poison damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+    },
+    {
+      "id": "spirit-naga",
+      "name": "Spirit Naga",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Astral Plane",
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Temple",
+        "Underdark"
+      ],
+      "ac": 15,
+      "hp": 75,
+      "hitDice": "10d10+20",
+      "speed": "Walk 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 18,
+        "dex": 17,
+        "con": 14,
+        "int": 16,
+        "wis": 15,
+        "cha": 16
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "Abyssal, Common",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, poisoned",
+      "traits": [
+        {
+          "name": "Rejuvenation",
+          "description": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        },
+        {
+          "name": "Spellcasting",
+          "description": "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:\n\n* Cantrips (at will): mage hand, minor illusion, ray of frost\n* 1st level (4 slots): charm person, detect magic, sleep\n* 2nd level (3 slots): detect thoughts, hold person\n* 3rd level (3 slots): lightning bolt, water breathing\n* 4th level (3 slots): blight, dimension door\n* 5th level (2 slots): dominate person"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 7 (1d6 + 4) piercing damage, and the target must make a DC 13 Constitution saving throw, taking 31 (7d8) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+    },
+    {
+      "id": "sprite",
+      "name": "Sprite",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Fey",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Neutral Good",
+      "biomes": ["Feywild", "Forest", "Swamp"],
+      "ac": 15,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 10, Fly 40",
+      "initiative": 4,
+      "abilities": {
+        "str": 3,
+        "dex": 18,
+        "con": 10,
+        "int": 14,
+        "wis": 13,
+        "cha": 11
+      },
+      "senses": "passive Perception 13",
+      "languages": "Common, Elvish, Sylvan",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 8",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        },
+        {
+          "name": "Shortbow",
+          "description": "Ranged Weapon Attack: +6 to hit, range 40/160 ft., one target. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or become poisoned for 1 minute. If its saving throw result is 5 or lower, the poisoned target falls unconscious for the same duration, or until it takes damage or another creature takes an action to shake it awake."
+        },
+        {
+          "name": "Heart Sight",
+          "description": "The sprite touches a creature and magically knows the creature's current emotional state. If the target fails a DC 10 Charisma saving throw, the sprite also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw."
+        },
+        {
+          "name": "Invisibility",
+          "description": "The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+    },
+    {
+      "id": "spy",
+      "name": "Spy",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": ["Ruin", "Settlement", "Sewer", "Urban"],
+      "ac": 12,
+      "hp": 27,
+      "hitDice": "6d8",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 15,
+        "con": 10,
+        "int": 12,
+        "wis": 14,
+        "cha": 16
+      },
+      "senses": "passive Perception 16",
+      "languages": "any two languages",
+      "savingThrows": "",
+      "skills": "Deception 5, Insight 4, Investigation 5, Perception 6, Persuasion 5, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Cunning Action",
+          "description": "On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+        },
+        {
+          "name": "Sneak Attack (1/Turn)",
+          "description": "The spy deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the spy that isn't incapacitated and the spy doesn't have disadvantage on the attack roll."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The spy makes two melee attacks."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Hand Crossbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Rulers, nobles, merchants, guildmasters, and other wealthy individuals use **spies** to gain the upper hand in a world of cutthroat politics. A spy is trained to secretly gather information. Loyal spies would rather die than divulge information that could compromise them or their employers."
+    },
+    {
+      "id": "steam-mephit",
+      "name": "Steam Mephit",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Small",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Caverns",
+        "Jungle",
+        "Plane Of Fire",
+        "Plane Of Water",
+        "Settlement",
+        "Underwater",
+        "Water"
+      ],
+      "ac": 10,
+      "hp": 21,
+      "hitDice": "6d6",
+      "speed": "Walk 30, Fly 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 5,
+        "dex": 11,
+        "con": 10,
+        "int": 11,
+        "wis": 10,
+        "cha": 12
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Aquan, Ignan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire, poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Death Burst",
+          "description": "When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must succeed on a DC 10 Dexterity saving throw or take 4 (1d8) fire damage."
+        },
+        {
+          "name": "Innate Spellcasting (1/Day)",
+          "description": "The mephit can innately cast _blur_, requiring no material components. Its innate spellcasting ability is Charisma."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 2 (1d4) slashing damage plus 2 (1d4) fire damage."
+        },
+        {
+          "name": "Steam Breath (Recharge 6)",
+          "description": "The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 4 (1d8) fire damage on a failed save, or half as much damage on a successful one."
+        },
+        {
+          "name": "Variant: Summon Mephits (1/Day)",
+          "description": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must succeed on a DC 10 Dexterity saving throw or take 4 (1d8) fire damage."
+    },
+    {
+      "id": "stirge",
+      "name": "Stirge",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Swamp",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 14,
+      "hp": 2,
+      "hitDice": "1d4",
+      "speed": "Walk 10, Fly 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 4,
+        "dex": 16,
+        "con": 11,
+        "int": 2,
+        "wis": 8,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Blood Drain",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 5 (1d4 + 3) piercing damage, and the stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.\nThe stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies. A creature, including the target, can use its action to detach the stirge."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 5 (1d4 + 3) piercing damage, and the stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.\nThe stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies. A creature, including the target, can use its action to detach the stirge."
+    },
+    {
+      "id": "stone-giant",
+      "name": "Stone Giant",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Neutral",
+      "biomes": [
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Plane Of Earth",
+        "Underdark"
+      ],
+      "ac": 17,
+      "hp": 126,
+      "hitDice": "11d12+55",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 23,
+        "dex": 15,
+        "con": 20,
+        "int": 10,
+        "wis": 12,
+        "cha": 9
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Giant",
+      "savingThrows": "",
+      "skills": "Athletics 12, Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Stone Camouflage",
+          "description": "The giant has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two greatclub attacks."
+        },
+        {
+          "name": "Greatclub",
+          "description": "Melee Weapon Attack: +9 to hit, reach 15 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage. If the target is a creature, it must succeed on a DC 17 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+    },
+    {
+      "id": "stone-golem",
+      "name": "Stone Golem",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Construct",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Any"],
+      "ac": 17,
+      "hp": 178,
+      "hitDice": "17d10+85",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 22,
+        "dex": 9,
+        "con": 20,
+        "int": 3,
+        "wis": 11,
+        "cha": 1
+      },
+      "senses": "darkvision 120 ft., passive Perception 10",
+      "languages": "understands the languages of its creator but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
+      "conditionImmunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
+      "traits": [
+        {
+          "name": "Immutable Form",
+          "description": "The golem is immune to any spell or effect that would alter its form."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The golem has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The golem's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The golem makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Slow (Recharge 5-6)",
+          "description": "The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a DC 17 Wisdom saving throw against this magic. On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The golem is immune to any spell or effect that would alter its form."
+    },
+    {
+      "id": "storm-giant",
+      "name": "Storm Giant",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Good",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Mountains",
+        "Plane Of Air",
+        "Plane Of Water",
+        "Water"
+      ],
+      "ac": 16,
+      "hp": 230,
+      "hitDice": "20d12+100",
+      "speed": "Walk 50, Swim 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 29,
+        "dex": 14,
+        "con": 20,
+        "int": 16,
+        "wis": 18,
+        "cha": 18
+      },
+      "senses": "passive Perception 19",
+      "languages": "Common, Giant",
+      "savingThrows": "",
+      "skills": "Arcana 8, Athletics 14, History 8, Perception 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold",
+      "damageImmunities": "lightning, thunder",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The giant can breathe air and water."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The giant's innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, feather fall, levitate, light\n3/day each: control weather, water breathing"
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The giant makes two greatsword attacks."
+        },
+        {
+          "name": "Greatsword",
+          "description": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 30 (6d6 + 9) slashing damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +14 to hit, range 60/240 ft., one target. Hit: 35 (4d12 + 9) bludgeoning damage."
+        },
+        {
+          "name": "Lightning Strike (Recharge 5-6)",
+          "description": "The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC 17 Dexterity saving throw, taking 54 (12d8) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The giant can breathe air and water."
+    },
+    {
+      "id": "succubusincubus",
+      "name": "Succubus/Incubus",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Fiend",
+      "subtype": "Shapechanger",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Any", "Hell"],
+      "ac": 15,
+      "hp": 66,
+      "hitDice": "12d8+12",
+      "speed": "Walk 30, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 8,
+        "dex": 17,
+        "con": 13,
+        "int": 15,
+        "wis": 12,
+        "cha": 20
+      },
+      "senses": "darkvision 60 ft., passive Perception 15",
+      "languages": "Abyssal, Common, Infernal, telepathy 60 ft.",
+      "savingThrows": "",
+      "skills": "Deception 9, Insight 5, Perception 5, Persuasion 9, Stealth 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning, poison; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Telepathic Bond",
+          "description": "The fiend ignores the range restriction on its telepathy when communicating with a creature it has charmed. The two don't even need to be on the same plane of existence."
+        },
+        {
+          "name": "Shapechanger",
+          "description": "The fiend can use its action to polymorph into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Claw (Fiend Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        },
+        {
+          "name": "Charm",
+          "description": "One humanoid the fiend can see within 30 feet of it must succeed on a DC 15 Wisdom saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands. If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.\nThe fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends."
+        },
+        {
+          "name": "Draining Kiss",
+          "description": "The fiend kisses a creature charmed by it or a willing creature. The target must make a DC 15 Constitution saving throw against this magic, taking 32 (5d10 + 5) psychic damage on a failed save, or half as much damage on a successful one. The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        },
+        {
+          "name": "Etherealness",
+          "description": "The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The fiend ignores the range restriction on its telepathy when communicating with a creature it has charmed. The two don't even need to be on the same plane of existence."
+    },
+    {
+      "id": "swarm-of-bats",
+      "name": "Swarm of Bats",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Hill",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Shadowfell",
+        "Tomb",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 0, Fly 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 5,
+        "dex": 15,
+        "con": 10,
+        "int": 2,
+        "wis": 12,
+        "cha": 4
+      },
+      "senses": "blindsight 60 ft., passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Echolocation",
+          "description": "The swarm can't use its blindsight while deafened."
+        },
+        {
+          "name": "Keen Hearing",
+          "description": "The swarm has advantage on Wisdom (Perception) checks that rely on hearing."
+        },
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +4 to hit, reach 0 ft., one creature in the swarm's space. Hit: 5 (2d4) piercing damage, or 2 (1d4) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can't use its blindsight while deafened."
+    },
+    {
+      "id": "swarm-of-beetles",
+      "name": "Swarm of Beetles",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Caves", "Desert", "Underdark"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 20, Burrow 5, Climb 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 10,
+        "int": 1,
+        "wis": 7,
+        "cha": 1
+      },
+      "senses": "blindsight 10 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-centipedes",
+      "name": "Swarm of Centipedes",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Any", "Caves", "Forest", "Ruins", "Underdark"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 20, Climb 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 10,
+        "int": 1,
+        "wis": 7,
+        "cha": 1
+      },
+      "senses": "blindsight 10 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.\nA creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-insects",
+      "name": "Swarm of Insects",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Jungle",
+        "Swamp",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 20, Climb 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 10,
+        "int": 1,
+        "wis": 7,
+        "cha": 1
+      },
+      "senses": "blindsight 10 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-poisonous-snakes",
+      "name": "Swarm of Poisonous Snakes",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hills",
+        "Jungle",
+        "Mountains",
+        "Ruin",
+        "Sewer",
+        "Swamp",
+        "Tomb",
+        "Water"
+      ],
+      "ac": 14,
+      "hp": 36,
+      "hitDice": "8d8",
+      "speed": "Walk 30, Swim 30",
+      "initiative": 4,
+      "abilities": {
+        "str": 8,
+        "dex": 18,
+        "con": 11,
+        "int": 1,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "blindsight 10 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +6 to hit, reach 0 ft., one creature in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer. The target must make a DC 10 Constitution saving throw, taking 14 (4d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-quippers",
+      "name": "Swarm of Quippers",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Sewer", "Underwater", "Water"],
+      "ac": 13,
+      "hp": 28,
+      "hitDice": "8d8-8",
+      "speed": "Walk 0, Swim 40",
+      "initiative": 3,
+      "abilities": {
+        "str": 13,
+        "dex": 16,
+        "con": 9,
+        "int": 1,
+        "wis": 7,
+        "cha": 2
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Blood Frenzy",
+          "description": "The swarm has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        },
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny quipper. The swarm can't regain hit points or gain temporary hit points."
+        },
+        {
+          "name": "Water Breathing",
+          "description": "The swarm can breathe only underwater."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +5 to hit, reach 0 ft., one creature in the swarm's space. Hit: 14 (4d6) piercing damage, or 7 (2d6) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+    },
+    {
+      "id": "swarm-of-rats",
+      "name": "Swarm of Rats",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": [
+        "Caverns",
+        "Forest",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Swamp",
+        "Urban"
+      ],
+      "ac": 10,
+      "hp": 24,
+      "hitDice": "7d8-7",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 9,
+        "dex": 11,
+        "con": 9,
+        "int": 2,
+        "wis": 10,
+        "cha": 3
+      },
+      "senses": "darkvision 30 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The swarm has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +2 to hit, reach 0 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "swarm-of-ravens",
+      "name": "Swarm of Ravens",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Hill", "Swamp", "Urban"],
+      "ac": 12,
+      "hp": 24,
+      "hitDice": "7d8-7",
+      "speed": "Walk 10, Fly 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 6,
+        "dex": 14,
+        "con": 8,
+        "int": 3,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 15",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beaks",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-spiders",
+      "name": "Swarm of Spiders",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Any", "Caves", "Forest", "Ruins", "Underdark"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 20, Climb 20",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 10,
+        "int": 1,
+        "wis": 7,
+        "cha": 1
+      },
+      "senses": "blindsight 10 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The swarm can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Web Sense",
+          "description": "While in contact with a web, the swarm knows the exact location of any other creature in contact with the same web."
+        },
+        {
+          "name": "Web Walker",
+          "description": "The swarm ignores movement restrictions caused by webbing."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "swarm-of-wasps",
+      "name": "Swarm of Wasps",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "Swarm",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Any", "Forest"],
+      "ac": 12,
+      "hp": 22,
+      "hitDice": "5d8",
+      "speed": "Walk 5, Fly 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 3,
+        "dex": 13,
+        "con": 10,
+        "int": 1,
+        "wis": 7,
+        "cha": 1
+      },
+      "senses": "blindsight 10 ft., passive Perception 8",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "bludgeoning, piercing, slashing",
+      "damageImmunities": "",
+      "conditionImmunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
+      "traits": [
+        {
+          "name": "Swarm",
+          "description": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bites",
+          "description": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+    },
+    {
+      "id": "tarrasque",
+      "name": "Tarrasque",
+      "cr": 30,
+      "challengeRating": "30",
+      "xp": 155000,
+      "type": "Monstrosity",
+      "subtype": "Titan",
+      "size": "Gargantuan",
+      "alignment": "Unaligned",
+      "biomes": ["Hills", "Settlement", "Urban"],
+      "ac": 25,
+      "hp": 676,
+      "hitDice": "33d20+330",
+      "speed": "Walk 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 30,
+        "dex": 11,
+        "con": 30,
+        "int": 3,
+        "wis": 11,
+        "cha": 11
+      },
+      "senses": "blindsight 120 ft., passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire, poison; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "conditionImmunities": "charmed, frightened, paralyzed, poisoned",
+      "traits": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the tarrasque fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The tarrasque has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Reflective Carapace",
+          "description": "Any time the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target."
+        },
+        {
+          "name": "Siege Monster",
+          "description": "The tarrasque deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tail. It can use its Swallow instead of its bite."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 36 (4d12 + 10) piercing damage. If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can't bite another target."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +19 to hit, reach 15 ft., one target. Hit: 28 (4d8 + 10) slashing damage."
+        },
+        {
+          "name": "Horns",
+          "description": "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 32 (4d10 + 10) piercing damage."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +19 to hit, reach 20 ft., one target. Hit: 24 (4d6 + 10) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Frightful Presence",
+          "description": "Each creature of the tarrasque's choice within 120 feet of it and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the tarrasque's Frightful Presence for the next 24 hours."
+        },
+        {
+          "name": "Swallow",
+          "description": "The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite's damage, the target is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) acid damage at the start of each of the tarrasque's turns.\nIf the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the tarrasque. If the tarrasque dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 30 feet of movement, exiting prone."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Attack",
+          "description": "The tarrasque makes one claw attack or tail attack."
+        },
+        {
+          "name": "Move",
+          "description": "The tarrasque moves up to half its speed."
+        },
+        {
+          "name": "Chomp (Costs 2 Actions)",
+          "description": "The tarrasque makes one bite attack or uses its Swallow."
+        }
+      ],
+      "details": "If the tarrasque fails a saving throw, it can choose to succeed instead."
+    },
+    {
+      "id": "thug",
+      "name": "Thug",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Non-Good Alignment",
+      "biomes": ["Settlement", "Urban"],
+      "ac": 11,
+      "hp": 32,
+      "hitDice": "5d8+10",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 15,
+        "dex": 11,
+        "con": 14,
+        "int": 10,
+        "wis": 10,
+        "cha": 11
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Intimidation 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Pack Tactics",
+          "description": "The thug has advantage on an attack roll against a creature if at least one of the thug's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The thug makes two melee attacks."
+        },
+        {
+          "name": "Mace",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) bludgeoning damage."
+        },
+        {
+          "name": "Heavy Crossbow",
+          "description": "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Thugs** are ruthless enforcers skilled at intimidation and violence. They work for money and have few scruples."
+    },
+    {
+      "id": "tiger",
+      "name": "Tiger",
+      "cr": 1,
+      "challengeRating": "1",
+      "xp": 200,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Jungle"],
+      "ac": 12,
+      "hp": 37,
+      "hitDice": "5d10+10",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 14,
+        "int": 3,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Pounce",
+          "description": "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "treant",
+      "name": "Treant",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Chaotic Good",
+      "biomes": ["Forest", "Jungle", "Swamp"],
+      "ac": 16,
+      "hp": 138,
+      "hitDice": "12d12+60",
+      "speed": "Walk 30",
+      "initiative": -1,
+      "abilities": {
+        "str": 23,
+        "dex": 8,
+        "con": 21,
+        "int": 12,
+        "wis": 16,
+        "cha": 12
+      },
+      "senses": "passive Perception 13",
+      "languages": "Common, Druidic, Elvish, Sylvan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "fire",
+      "damageResistances": "bludgeoning, piercing",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the treant remains motionless, it is indistinguishable from a normal tree."
+        },
+        {
+          "name": "Siege Monster",
+          "description": "The treant deals double damage to objects and structures."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The treant makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 16 (3d6 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Rock",
+          "description": "Ranged Weapon Attack: +10 to hit, range 60/180 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage."
+        },
+        {
+          "name": "Animate Trees (1/Day)",
+          "description": "The treant magically animates one or two trees it can see within 60 feet of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can't speak, and they have only the Slam action option. An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the treant remains motionless, it is indistinguishable from a normal tree."
+    },
+    {
+      "id": "tribal-warrior",
+      "name": "Tribal Warrior",
+      "cr": 0.125,
+      "challengeRating": "1/8",
+      "xp": 25,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Jungle",
+        "Mountain",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 12,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 13,
+        "dex": 11,
+        "con": 12,
+        "int": 8,
+        "wis": 11,
+        "cha": 8
+      },
+      "senses": "passive Perception 10",
+      "languages": "any one language",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Pack Tactics",
+          "description": "The warrior has advantage on an attack roll against a creature if at least one of the warrior's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Spear",
+          "description": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Tribal warriors** live beyond civilization, most often subsisting on fishing and hunting. Each tribe acts in accordance with the wishes of its chief, who is the greatest or oldest warrior of the tribe or a tribe member blessed by the gods."
+    },
+    {
+      "id": "triceratops",
+      "name": "Triceratops",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Grassland", "Jungle", "Mountains", "Swamp"],
+      "ac": 13,
+      "hp": 95,
+      "hitDice": "10d12+30",
+      "speed": "Walk 50",
+      "initiative": -1,
+      "abilities": {
+        "str": 22,
+        "dex": 9,
+        "con": 17,
+        "int": 2,
+        "wis": 11,
+        "cha": 5
+      },
+      "senses": "passive Perception 10",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Trampling Charge",
+          "description": "If the triceratops moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Gore",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 24 (4d8 + 6) piercing damage."
+        },
+        {
+          "name": "Stomp",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the triceratops moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action."
+    },
+    {
+      "id": "troll",
+      "name": "Troll",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Giant",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": [
+        "Arctic",
+        "Caverns",
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Mountain",
+        "Mountains",
+        "Ruin",
+        "Swamp",
+        "Underdark"
+      ],
+      "ac": 15,
+      "hp": 84,
+      "hitDice": "8d10+40",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 13,
+        "con": 20,
+        "int": 7,
+        "wis": 9,
+        "cha": 7
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "Giant",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "description": "The troll has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Regeneration",
+          "description": "The troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with 0 hit points and doesn't regenerate."
+        },
+        {
+          "name": "Variant: Loathsome Limbs",
+          "description": "Whenever the troll takes at least 15 slashing damage at one time, roll a d20 to determine what else happens to it:\n\n**1-10:** Nothing else happens.\n**11-14:** One leg is severed from the troll if it has any legs left.\n**15- 18:** One arm is severed from the troll if it has any arms left.\n**19-20:** The troll is decapitated, but the troll dies only if it can't regenerate. If it dies, so does the severed head.\n\nIf the troll finishes a short or long rest without reattaching a severed limb or head, the part regrows. At that point, the severed part dies. Until then, a severed part acts on the troll's initiative and has its own action and movement. A severed part has AC 13, 10 hit points, and the troll's Regeneration trait.\nA **severed leg** is unable to attack and has a speed of 5 feet.\nA **severed arm** has a speed of 5 feet and can make one claw attack on its turn, with disadvantage on the attack roll unless the troll can see the arm and its target. Each time the troll loses an arm, it loses a claw attack.\nIf its head is severed, the troll loses its bite attack and its body is blinded unless the head can see it. The **severed head** has a speed of 0 feet and the troll's Keen Smell trait. It can make a bite attack but only against a target in its space.\nThe troll's speed is halved if it's missing a leg. If it loses both legs, it falls prone. If it has both arms, it can crawl. With only one arm, it can still crawl, but its speed is halved. With no arms or legs, its speed is 0, and it can't benefit from bonuses to speed."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The troll makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The troll has advantage on Wisdom (Perception) checks that rely on smell."
+    },
+    {
+      "id": "tyrannosaurus-rex",
+      "name": "Tyrannosaurus Rex",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Huge",
+      "alignment": "Unaligned",
+      "biomes": ["Grassland", "Jungle", "Mountains", "Swamp"],
+      "ac": 13,
+      "hp": 136,
+      "hitDice": "13d12+52",
+      "speed": "Walk 50",
+      "initiative": 0,
+      "abilities": {
+        "str": 25,
+        "dex": 10,
+        "con": 19,
+        "int": 2,
+        "wis": 12,
+        "cha": 9
+      },
+      "senses": "passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 33 (4d12 + 7) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target."
+        },
+        {
+          "name": "Tail",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
+    },
+    {
+      "id": "unicorn",
+      "name": "Unicorn",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Celestial",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Feywild", "Forest", "Jungle"],
+      "ac": 12,
+      "hp": 67,
+      "hitDice": "9d10+18",
+      "speed": "Walk 50",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 14,
+        "con": 15,
+        "int": 11,
+        "wis": 17,
+        "cha": 16
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "Celestial, Elvish, Sylvan, telepathy 60 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "charmed, paralyzed, poisoned",
+      "traits": [
+        {
+          "name": "Charge",
+          "description": "If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Innate Spellcasting",
+          "description": "The unicorn's innate spellcasting ability is Charisma (spell save DC 14). The unicorn can innately cast the following spells, requiring no components:\n\nAt will: detect evil and good, druidcraft, pass without trace\n1/day each: calm emotions, dispel evil and good, entangle"
+        },
+        {
+          "name": "Magic Resistance",
+          "description": "The unicorn has advantage on saving throws against spells and other magical effects."
+        },
+        {
+          "name": "Magic Weapons",
+          "description": "The unicorn's weapon attacks are magical."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The unicorn makes two attacks: one with its hooves and one with its horn."
+        },
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Horn",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        },
+        {
+          "name": "Healing Touch (3/Day)",
+          "description": "The unicorn touches another creature with its horn. The target magically regains 11 (2d8 + 2) hit points. In addition, the touch removes all diseases and neutralizes all poisons afflicting the target."
+        },
+        {
+          "name": "Teleport (1/Day)",
+          "description": "The unicorn magically teleports itself and up to three willing creatures it can see within 5 ft. of it, along with any equipment they are wearing or carrying, to a location the unicorn is familiar with, up to 1 mile away."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Hooves",
+          "description": "The unicorn makes one attack with its hooves."
+        },
+        {
+          "name": "Shimmering Shield (Costs 2 Actions)",
+          "description": "The unicorn creates a shimmering, magical field around itself or another creature it can see within 60 ft. of it. The target gains a +2 bonus to AC until the end of the unicorn's next turn."
+        },
+        {
+          "name": "Heal Self (Costs 3 Actions)",
+          "description": "The unicorn magically regains 11 (2d8 + 2) hit points."
+        }
+      ],
+      "details": "If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+    },
+    {
+      "id": "vampire",
+      "name": "Vampire",
+      "cr": 13,
+      "challengeRating": "13",
+      "xp": 10000,
+      "type": "Undead",
+      "subtype": "Shapechanger",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Forest",
+        "Hills",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Tomb",
+        "Urban"
+      ],
+      "ac": 16,
+      "hp": 144,
+      "hitDice": "17d8+68",
+      "speed": "Walk 30",
+      "initiative": 4,
+      "abilities": {
+        "str": 18,
+        "dex": 18,
+        "con": 18,
+        "int": 17,
+        "wis": 15,
+        "cha": 18
+      },
+      "senses": "darkvision 120 ft., passive Perception 17",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "Perception 7, Stealth 9",
+      "damageVulnerabilities": "",
+      "damageResistances": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.\nWhile in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.\nWhile in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+        },
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "description": "If the vampire fails a saving throw, it can choose to succeed instead."
+        },
+        {
+          "name": "Misty Escape",
+          "description": "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.\nWhile it has 0 hit points in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least 1 hit point. After spending 1 hour in its resting place with 0 hit points, it regains 1 hit point."
+        },
+        {
+          "name": "Regeneration",
+          "description": "The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Vampire Weaknesses",
+          "description": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage if it ends its turn in running water.\nStake to the Heart. If a piercing weapon made of wood is driven into the vampire's heart while the vampire is incapacitated in its resting place, the vampire is paralyzed until the stake is removed.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Vampire Form Only)",
+          "description": "The vampire makes two attacks, only one of which can be a bite attack."
+        },
+        {
+          "name": "Unarmed Strike (Vampire Form Only)",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 8 (1d8 + 4) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18)."
+        },
+        {
+          "name": "Bite (Bat or Vampire Form Only)",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control."
+        },
+        {
+          "name": "Charm",
+          "description": "The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a DC 17 Wisdom saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bite attack.\nEach time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect."
+        },
+        {
+          "name": "Children of the Night (1/Day)",
+          "description": "The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
+        }
+      ],
+      "legendaryActions": [
+        {
+          "name": "Move",
+          "description": "The vampire moves up to its speed without provoking opportunity attacks."
+        },
+        {
+          "name": "Unarmed Strike",
+          "description": "The vampire makes one unarmed strike."
+        },
+        {
+          "name": "Bite (Costs 2 Actions)",
+          "description": "The vampire makes one bite attack."
+        }
+      ],
+      "details": "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.\nWhile in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.\nWhile in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+    },
+    {
+      "id": "vampire-spawn",
+      "name": "Vampire Spawn",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Forest",
+        "Hills",
+        "Mountains",
+        "Ruin",
+        "Settlement",
+        "Shadowfell",
+        "Tomb",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 15,
+      "hp": 82,
+      "hitDice": "11d8+33",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 16,
+        "dex": 16,
+        "con": 16,
+        "int": 11,
+        "wis": 10,
+        "cha": 12
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Regeneration",
+          "description": "The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        },
+        {
+          "name": "Spider Climb",
+          "description": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        },
+        {
+          "name": "Vampire Weaknesses",
+          "description": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage when it ends its turn in running water.\nStake to the Heart. The vampire is destroyed if a piercing weapon made of wood is driven into its heart while it is incapacitated in its resting place.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The vampire makes two attacks, only one of which can be a bite attack."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 6 (1d6 + 3) piercing damage plus 7 (2d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 8 (2d4 + 3) slashing damage. Instead of dealing damage, the vampire can grapple the target (escape DC 13)."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+    },
+    {
+      "id": "veteran",
+      "name": "Veteran",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Humanoid",
+      "subtype": "Any Race",
+      "size": "Medium",
+      "alignment": "Any Alignment",
+      "biomes": [
+        "Arctic",
+        "Coastal",
+        "Desert",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Mountain",
+        "Mountains",
+        "Settlement",
+        "Underdark",
+        "Urban"
+      ],
+      "ac": 17,
+      "hp": 58,
+      "hitDice": "9d8+18",
+      "speed": "Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 13,
+        "con": 14,
+        "int": 10,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "passive Perception 12",
+      "languages": "any one language (usually Common)",
+      "savingThrows": "",
+      "skills": "Athletics 5, Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        },
+        {
+          "name": "Shortsword",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        },
+        {
+          "name": "Heavy Crossbow",
+          "description": "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "**Veterans** are professional fighters that take up arms for pay or to protect something they believe in or value. Their ranks include soldiers retired from long service and warriors who never served anyone but themselves."
+    },
+    {
+      "id": "violet-fungus",
+      "name": "Violet Fungus",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Plant",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Caverns", "Forest", "Swamp", "Underdark"],
+      "ac": 5,
+      "hp": 18,
+      "hitDice": "4d8",
+      "speed": "Walk 5",
+      "initiative": -5,
+      "abilities": {
+        "str": 3,
+        "dex": 1,
+        "con": 10,
+        "int": 1,
+        "wis": 3,
+        "cha": 1
+      },
+      "senses": "blindsight 30 ft. (blind beyond this radius), passive Perception 6",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "blinded, deafened, frightened",
+      "traits": [
+        {
+          "name": "False Appearance",
+          "description": "While the violet fungus remains motionless, it is indistinguishable from an ordinary fungus."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The fungus makes 1d4 Rotting Touch attacks."
+        },
+        {
+          "name": "Rotting Touch",
+          "description": "Melee Weapon Attack: +2 to hit, reach 10 ft., one creature. Hit: 4 (1d8) necrotic damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While the violet fungus remains motionless, it is indistinguishable from an ordinary fungus."
+    },
+    {
+      "id": "vrock",
+      "name": "Vrock",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Fiend",
+      "subtype": "Demon",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Abyss"],
+      "ac": 15,
+      "hp": 104,
+      "hitDice": "11d10+44",
+      "speed": "Walk 40, Fly 60",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 18,
+        "int": 8,
+        "wis": 13,
+        "cha": 8
+      },
+      "senses": "darkvision 120 ft., passive Perception 11",
+      "languages": "Abyssal, telepathy 120 ft.",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Magic Resistance",
+          "description": "The vrock has advantage on saving throws against spells and other magical effects."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The vrock makes two attacks: one with its beak and one with its talons."
+        },
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        },
+        {
+          "name": "Talons",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage."
+        },
+        {
+          "name": "Spores (Recharge 6)",
+          "description": "A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a DC 14 Constitution saving throw or become poisoned. While poisoned in this way, a target takes 5 (1d10) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it."
+        },
+        {
+          "name": "Stunning Screech (1/Day)",
+          "description": "The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a DC 14 Constitution saving throw or be stunned until the end of the vrock's next turn."
+        },
+        {
+          "name": "Variant: Summon Demon (1/Day)",
+          "description": "The demon chooses what to summon and attempts a magical summoning.\nA vrock has a 30 percent chance of summoning 2d4 dretches or one vrock.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The vrock has advantage on saving throws against spells and other magical effects."
+    },
+    {
+      "id": "vulture",
+      "name": "Vulture",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Desert", "Grassland", "Hill"],
+      "ac": 10,
+      "hp": 5,
+      "hitDice": "1d8+1",
+      "speed": "Walk 10, Fly 50",
+      "initiative": 0,
+      "abilities": {
+        "str": 7,
+        "dex": 10,
+        "con": 13,
+        "int": 2,
+        "wis": 12,
+        "cha": 4
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Sight and Smell",
+          "description": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Beak",
+          "description": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+    },
+    {
+      "id": "warhorse",
+      "name": "Warhorse",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Settlement", "Urban"],
+      "ac": 11,
+      "hp": 19,
+      "hitDice": "3d10+3",
+      "speed": "Walk 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 12,
+        "con": 13,
+        "int": 2,
+        "wis": 12,
+        "cha": 7
+      },
+      "senses": "passive Perception 11",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Trampling Charge",
+          "description": "If the horse moves at least 20 ft. straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If the horse moves at least 20 ft. straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action."
+    },
+    {
+      "id": "warhorse-skeleton",
+      "name": "Warhorse Skeleton",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Any", "Ruins"],
+      "ac": 13,
+      "hp": 22,
+      "hitDice": "3d10+6",
+      "speed": "Walk 60",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 12,
+        "con": 15,
+        "int": 2,
+        "wis": 8,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 9",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "bludgeoning",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, poisoned",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Hooves",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+    },
+    {
+      "id": "water-elemental",
+      "name": "Water Elemental",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral",
+      "biomes": [
+        "Coastal",
+        "Desert",
+        "Laboratory",
+        "Plane Of Water",
+        "Swamp",
+        "Underwater",
+        "Water"
+      ],
+      "ac": 14,
+      "hp": 114,
+      "hitDice": "12d10+48",
+      "speed": "Walk 30, Swim 90",
+      "initiative": 2,
+      "abilities": {
+        "str": 18,
+        "dex": 14,
+        "con": 18,
+        "int": 5,
+        "wis": 10,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 10",
+      "languages": "Aquan",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "poison",
+      "conditionImmunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Water Form",
+          "description": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        },
+        {
+          "name": "Freeze",
+          "description": "If the elemental takes cold damage, it partially freezes; its speed is reduced by 20 ft. until the end of its next turn."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The elemental makes two slam attacks."
+        },
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        },
+        {
+          "name": "Whelm (Recharge 4-6)",
+          "description": "Each creature in the elemental's space must make a DC 15 Strength saving throw. On a failure, a target takes 13 (2d8 + 4) bludgeoning damage. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. If the saving throw is successful, the target is pushed out of the elemental's space.\nThe elemental can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the elemental's turns, each target grappled by it takes 13 (2d8 + 4) bludgeoning damage. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a DC 14 Strength and succeeding."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+    },
+    {
+      "id": "weasel",
+      "name": "Weasel",
+      "cr": 0,
+      "challengeRating": "0",
+      "xp": 10,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Unaligned",
+      "biomes": ["Forest"],
+      "ac": 13,
+      "hp": 1,
+      "hitDice": "1d4-1",
+      "speed": "Walk 30",
+      "initiative": 3,
+      "abilities": {
+        "str": 3,
+        "dex": 16,
+        "con": 8,
+        "int": 2,
+        "wis": 12,
+        "cha": 3
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 1 piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "werebear",
+      "name": "Werebear",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Neutral Good",
+      "biomes": [
+        "Arctic",
+        "Feywild",
+        "Forest",
+        "Hill",
+        "Hills",
+        "Mountains",
+        "Settlement",
+        "Shadowfell",
+        "Tundra"
+      ],
+      "ac": 10,
+      "hp": 135,
+      "hitDice": "18d8+54",
+      "speed": "Notes 40 ft., climb 30 ft. in bear or hybrid form, Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 17,
+        "int": 11,
+        "wis": 12,
+        "cha": 12
+      },
+      "senses": "passive Perception 17",
+      "languages": "Common (can't speak in bear form)",
+      "savingThrows": "",
+      "skills": "Perception 7",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The werebear can use its action to polymorph into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. Its statistics, other than its size and AC, are the same in each form. Any equipment it. is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Keen Smell",
+          "description": "The werebear has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid."
+        },
+        {
+          "name": "Bite (Bear or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage. If the target is a humanoid, it must succeed on a DC 14 Constitution saving throw or be cursed with were bear lycanthropy."
+        },
+        {
+          "name": "Claw (Bear or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        },
+        {
+          "name": "Greataxe (Humanoid or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The werebear can use its action to polymorph into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. Its statistics, other than its size and AC, are the same in each form. Any equipment it. is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "wereboar",
+      "name": "Wereboar",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": [
+        "Feywild",
+        "Forest",
+        "Grassland",
+        "Hill",
+        "Hills",
+        "Jungle",
+        "Settlement",
+        "Shadowfell"
+      ],
+      "ac": 10,
+      "hp": 78,
+      "hitDice": "12d8+24",
+      "speed": "Notes 40 ft. in boar form, Walk 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 10,
+        "con": 15,
+        "int": 10,
+        "wis": 11,
+        "cha": 8
+      },
+      "senses": "passive Perception 12",
+      "languages": "Common (can't speak in boar form)",
+      "savingThrows": "",
+      "skills": "Perception 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The wereboar can use its action to polymorph into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Charge (Boar or Hybrid Form Only)",
+          "description": "If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Relentless (Recharges after a Short or Long Rest)",
+          "description": "If the wereboar takes 14 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Humanoid or Hybrid Form Only)",
+          "description": "The wereboar makes two attacks, only one of which can be with its tusks."
+        },
+        {
+          "name": "Maul (Humanoid or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage."
+        },
+        {
+          "name": "Tusks (Boar or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with wereboar lycanthropy."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wereboar can use its action to polymorph into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "wererat",
+      "name": "Wererat",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Lawful Evil",
+      "biomes": [
+        "Caverns",
+        "Feywild",
+        "Forest",
+        "Ruin",
+        "Settlement",
+        "Sewer",
+        "Shadowfell",
+        "Urban"
+      ],
+      "ac": 12,
+      "hp": 33,
+      "hitDice": "6d8+6",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 10,
+        "dex": 15,
+        "con": 12,
+        "int": 11,
+        "wis": 10,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft. (rat form only), passive Perception 12",
+      "languages": "Common (can't speak in rat form)",
+      "savingThrows": "",
+      "skills": "Perception 2, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The wererat can use its action to polymorph into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Keen Smell",
+          "description": "The wererat has advantage on Wisdom (Perception) checks that rely on smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Humanoid or Hybrid Form Only)",
+          "description": "The wererat makes two attacks, only one of which can be a bite."
+        },
+        {
+          "name": "Bite (Rat or Hybrid Form Only).",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 11 Constitution saving throw or be cursed with wererat lycanthropy."
+        },
+        {
+          "name": "Shortsword (Humanoid or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        },
+        {
+          "name": "Hand Crossbow (Humanoid or Hybrid Form Only)",
+          "description": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wererat can use its action to polymorph into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "weretiger",
+      "name": "Weretiger",
+      "cr": 4,
+      "challengeRating": "4",
+      "xp": 1100,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Forest", "Grassland", "Jungle"],
+      "ac": 12,
+      "hp": 120,
+      "hitDice": "16d8+48",
+      "speed": "Notes 40 ft. in tiger form, Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 17,
+        "dex": 15,
+        "con": 16,
+        "int": 10,
+        "wis": 13,
+        "cha": 11
+      },
+      "senses": "darkvision 60 ft., passive Perception 15",
+      "languages": "Common (can't speak in tiger form)",
+      "savingThrows": "",
+      "skills": "Perception 5, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The weretiger can use its action to polymorph into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The weretiger has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pounce (Tiger or Hybrid Form Only)",
+          "description": "If the weretiger moves at least 15 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Humanoid or Hybrid Form Only)",
+          "description": "In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks."
+        },
+        {
+          "name": "Bite (Tiger or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage. If the target is a humanoid, it must succeed on a DC 13 Constitution saving throw or be cursed with weretiger lycanthropy."
+        },
+        {
+          "name": "Claw (Tiger or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage."
+        },
+        {
+          "name": "Scimitar (Humanoid or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        },
+        {
+          "name": "Longbow (Humanoid or Hybrid Form Only)",
+          "description": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The weretiger can use its action to polymorph into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "werewolf",
+      "name": "Werewolf",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Humanoid",
+      "subtype": "Human",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Forest", "Hill"],
+      "ac": 11,
+      "hp": 58,
+      "hitDice": "9d8+18",
+      "speed": "Notes 40 ft. in wolf form, Walk 30",
+      "initiative": 1,
+      "abilities": {
+        "str": 15,
+        "dex": 13,
+        "con": 14,
+        "int": 10,
+        "wis": 11,
+        "cha": 10
+      },
+      "senses": "passive Perception 14",
+      "languages": "Common (can't speak in wolf form)",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "The werewolf can use its action to polymorph into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        },
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The werewolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack (Humanoid or Hybrid Form Only)",
+          "description": "The werewolf makes two attacks: two with its spear (humanoid form) or one with its bite and one with its claws (hybrid form)."
+        },
+        {
+          "name": "Bite (Wolf or Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with werewolf lycanthropy."
+        },
+        {
+          "name": "Claws (Hybrid Form Only)",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (2d4 + 2) slashing damage."
+        },
+        {
+          "name": "Spear (Humanoid Form Only)",
+          "description": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The werewolf can use its action to polymorph into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+    },
+    {
+      "id": "white-dragon-wyrmling",
+      "name": "White Dragon Wyrmling",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Ice", "Mountains", "Tundra"],
+      "ac": 16,
+      "hp": 32,
+      "hitDice": "5d8+10",
+      "speed": "Walk 30, Burrow 15, Fly 60, Swim 30",
+      "initiative": 0,
+      "abilities": {
+        "str": 14,
+        "dex": 10,
+        "con": 14,
+        "int": 5,
+        "wis": 10,
+        "cha": 11
+      },
+      "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+      "languages": "Draconic",
+      "savingThrows": "",
+      "skills": "Perception 4, Stealth 2",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) cold damage."
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "description": "The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 22 (5d8) cold damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) cold damage."
+    },
+    {
+      "id": "wight",
+      "name": "Wight",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Swamp", "Underdark", "Urban"],
+      "ac": 14,
+      "hp": 45,
+      "hitDice": "6d8+18",
+      "speed": "Walk 30",
+      "initiative": 2,
+      "abilities": {
+        "str": 15,
+        "dex": 14,
+        "con": 16,
+        "int": 10,
+        "wis": 13,
+        "cha": 15
+      },
+      "senses": "darkvision 60 ft., passive Perception 13",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the wight has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack."
+        },
+        {
+          "name": "Life Drain",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) necrotic damage. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.\nA humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time."
+        },
+        {
+          "name": "Longsword",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage, or 7 (1d10 + 2) slashing damage if used with two hands."
+        },
+        {
+          "name": "Longbow",
+          "description": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "While in sunlight, the wight has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+    },
+    {
+      "id": "will-o-wisp",
+      "name": "Will-o'-Wisp",
+      "cr": 2,
+      "challengeRating": "2",
+      "xp": 450,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Tiny",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Forest", "Swamp", "Urban"],
+      "ac": 19,
+      "hp": 22,
+      "hitDice": "9d4",
+      "speed": "Hover true, Walk 0, Fly 50",
+      "initiative": 9,
+      "abilities": {
+        "str": 1,
+        "dex": 28,
+        "con": 10,
+        "int": 13,
+        "wis": 14,
+        "cha": 11
+      },
+      "senses": "darkvision 120 ft., passive Perception 12",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid, cold, fire, necrotic, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
+      "damageImmunities": "lightning, poison",
+      "conditionImmunities": "exhaustion, grappled, paralyzed, poisoned, prone, restrained, unconscious",
+      "traits": [
+        {
+          "name": "Consume Life",
+          "description": "As a bonus action, the will-o'-wisp can target one creature it can see within 5 ft. of it that has 0 hit points and is still alive. The target must succeed on a DC 10 Constitution saving throw against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6) hit points."
+        },
+        {
+          "name": "Ephemeral",
+          "description": "The will-o'-wisp can't wear or carry anything."
+        },
+        {
+          "name": "Incorporeal Movement",
+          "description": "The will-o'-wisp can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        },
+        {
+          "name": "Variable Illumination",
+          "description": "The will-o'-wisp sheds bright light in a 5- to 20-foot radius and dim light for an additional number of ft. equal to the chosen radius. The will-o'-wisp can alter the radius as a bonus action."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Shock",
+          "description": "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d8) lightning damage."
+        },
+        {
+          "name": "Invisibility",
+          "description": "The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "As a bonus action, the will-o'-wisp can target one creature it can see within 5 ft. of it that has 0 hit points and is still alive. The target must succeed on a DC 10 Constitution saving throw against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6) hit points."
+    },
+    {
+      "id": "winter-wolf",
+      "name": "Winter Wolf",
+      "cr": 3,
+      "challengeRating": "3",
+      "xp": 700,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Arctic"],
+      "ac": 13,
+      "hp": 75,
+      "hitDice": "10d10+20",
+      "speed": "Walk 50",
+      "initiative": 1,
+      "abilities": {
+        "str": 18,
+        "dex": 13,
+        "con": 14,
+        "int": 7,
+        "wis": 12,
+        "cha": 8
+      },
+      "senses": "passive Perception 15",
+      "languages": "Common, Giant, Winter Wolf",
+      "savingThrows": "",
+      "skills": "Perception 5, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        },
+        {
+          "name": "Snow Camouflage",
+          "description": "The wolf has advantage on Dexterity (Stealth) checks made to hide in snowy terrain."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "description": "The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The arctic-dwelling **winter wolf** is as large as a dire wolf but has snow-white fur and pale blue eyes. Frost giants use these evil creatures as guards and hunting companions, putting the wolves'deadly breath weapon to use against their foes. Winter wolves communicate with one another using growls and barks, but they speak Common and Giant well enough to follow simple conversations."
+    },
+    {
+      "id": "wolf",
+      "name": "Wolf",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Beast",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Unaligned",
+      "biomes": ["Forest", "Grassland", "Hill"],
+      "ac": 13,
+      "hp": 11,
+      "hitDice": "2d8+2",
+      "speed": "Walk 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 12,
+        "dex": 15,
+        "con": 12,
+        "int": 3,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "passive Perception 13",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 3, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        },
+        {
+          "name": "Pack Tactics",
+          "description": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+    },
+    {
+      "id": "worg",
+      "name": "Worg",
+      "cr": 0.5,
+      "challengeRating": "1/2",
+      "xp": 100,
+      "type": "Monstrosity",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Neutral Evil",
+      "biomes": ["Forest", "Grassland", "Hill"],
+      "ac": 13,
+      "hp": 26,
+      "hitDice": "4d10+4",
+      "speed": "Walk 50",
+      "initiative": 1,
+      "abilities": {
+        "str": 16,
+        "dex": 13,
+        "con": 13,
+        "int": 7,
+        "wis": 11,
+        "cha": 8
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "Goblin, Worg",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Keen Hearing and Smell",
+          "description": "The worg has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "A **worg** is an evil predator that delights in hunting and devouring creatures weaker than itself. Cunning and malevolent, worgs roam across the remote wilderness or are raised by goblins and hobgoblins. Those creatures use worgs as mounts, but a worg will turn on its rider if it feels mistreated or malnourished. Worgs speak in their own language and Goblin, and a few learn to speak Common as well."
+    },
+    {
+      "id": "wraith",
+      "name": "Wraith",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Underdark"],
+      "ac": 13,
+      "hp": 67,
+      "hitDice": "9d8+27",
+      "speed": "Hover true, Walk 0, Fly 60",
+      "initiative": 3,
+      "abilities": {
+        "str": 6,
+        "dex": 16,
+        "con": 16,
+        "int": 12,
+        "wis": 14,
+        "cha": 15
+      },
+      "senses": "darkvision 60 ft., passive Perception 12",
+      "languages": "the languages it knew in life",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
+      "damageImmunities": "necrotic, poison",
+      "conditionImmunities": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained",
+      "traits": [
+        {
+          "name": "Incorporeal Movement",
+          "description": "The wraith can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        },
+        {
+          "name": "Sunlight Sensitivity",
+          "description": "While in sunlight, the wraith has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Life Drain",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 21 (4d8 + 3) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        },
+        {
+          "name": "Create Specter",
+          "description": "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wraith can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+    },
+    {
+      "id": "wyvern",
+      "name": "Wyvern",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Unaligned",
+      "biomes": ["Hill", "Mountain"],
+      "ac": 13,
+      "hp": 110,
+      "hitDice": "13d10+39",
+      "speed": "Walk 20, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 16,
+        "int": 5,
+        "wis": 12,
+        "cha": 6
+      },
+      "senses": "darkvision 60 ft., passive Perception 14",
+      "languages": "",
+      "savingThrows": "",
+      "skills": "Perception 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage."
+        },
+        {
+          "name": "Claws",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        },
+        {
+          "name": "Stinger",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage. The target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."
+    },
+    {
+      "id": "xorn",
+      "name": "Xorn",
+      "cr": 5,
+      "challengeRating": "5",
+      "xp": 1800,
+      "type": "Elemental",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral",
+      "biomes": ["Underdark"],
+      "ac": 19,
+      "hp": 73,
+      "hitDice": "7d8+42",
+      "speed": "Walk 20, Burrow 20",
+      "initiative": 0,
+      "abilities": {
+        "str": 17,
+        "dex": 10,
+        "con": 22,
+        "int": 11,
+        "wis": 10,
+        "cha": 11
+      },
+      "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 16",
+      "languages": "Terran",
+      "savingThrows": "",
+      "skills": "Perception 6, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "piercing and slashing from nonmagical attacks not made with adamantine weapons",
+      "damageImmunities": "",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Earth Glide",
+          "description": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn't disturb the material it moves through."
+        },
+        {
+          "name": "Stone Camouflage",
+          "description": "The xorn has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        },
+        {
+          "name": "Treasure Sense",
+          "description": "The xorn can pinpoint, by scent, the location of precious metals and stones, such as coins and gems, within 60 ft. of it."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The xorn makes three claw attacks and one bite attack."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (3d6 + 3) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn't disturb the material it moves through."
+    },
+    {
+      "id": "young-black-dragon",
+      "name": "Young Black Dragon",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Swamp"],
+      "ac": 18,
+      "hp": 127,
+      "hitDice": "15d10+45",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 19,
+        "dex": 14,
+        "con": 17,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 6, Stealth 5",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) acid damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Acid Breath (Recharge 5-6)",
+          "description": "The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 49 (11d8) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "young-blue-dragon",
+      "name": "Young Blue Dragon",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Coastal", "Desert"],
+      "ac": 18,
+      "hp": 152,
+      "hitDice": "16d10+64",
+      "speed": "Walk 40, Burrow 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 21,
+        "dex": 10,
+        "con": 19,
+        "int": 14,
+        "wis": 13,
+        "cha": 17
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 19",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 9, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage plus 5 (1d10) lightning damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        },
+        {
+          "name": "Lightning Breath (Recharge 5-6)",
+          "description": "The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon makes three attacks: one with its bite and two with its claws."
+    },
+    {
+      "id": "young-brass-dragon",
+      "name": "Young Brass Dragon",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Good",
+      "biomes": ["Any", "Desert", "Volcano"],
+      "ac": 17,
+      "hp": 110,
+      "hitDice": "13d10+39",
+      "speed": "Walk 40, Burrow 20, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 19,
+        "dex": 10,
+        "con": 17,
+        "int": 12,
+        "wis": 11,
+        "cha": 15
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 6, Persuasion 5, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon makes three attacks: one with its bite and two with its claws."
+    },
+    {
+      "id": "young-bronze-dragon",
+      "name": "Young Bronze Dragon",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Coastal", "Desert"],
+      "ac": 18,
+      "hp": 142,
+      "hitDice": "15d10+60",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 21,
+        "dex": 10,
+        "con": 19,
+        "int": 14,
+        "wis": 13,
+        "cha": 17
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 4, Perception 7, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "lightning",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 15 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 15 Strength saving throw. On a failed save, the creature is pushed 40 feet away from the dragon."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "young-copper-dragon",
+      "name": "Young Copper Dragon",
+      "cr": 7,
+      "challengeRating": "7",
+      "xp": 2900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Good",
+      "biomes": ["Hill"],
+      "ac": 17,
+      "hp": 119,
+      "hitDice": "14d10+42",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 1,
+      "abilities": {
+        "str": 19,
+        "dex": 12,
+        "con": 17,
+        "int": 16,
+        "wis": 13,
+        "cha": 15
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 5, Perception 7, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "acid",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 40 (9d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon makes three attacks: one with its bite and two with its claws."
+    },
+    {
+      "id": "young-gold-dragon",
+      "name": "Young Gold Dragon",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Forest", "Grassland"],
+      "ac": 18,
+      "hp": 178,
+      "hitDice": "17d10+85",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 2,
+      "abilities": {
+        "str": 23,
+        "dex": 14,
+        "con": 21,
+        "int": 16,
+        "wis": 13,
+        "cha": 20
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 19",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Insight 5, Perception 9, Persuasion 9, Stealth 6",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 55 (10d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "young-green-dragon",
+      "name": "Young Green Dragon",
+      "cr": 8,
+      "challengeRating": "8",
+      "xp": 3900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Evil",
+      "biomes": ["Forest"],
+      "ac": 18,
+      "hp": 136,
+      "hitDice": "16d10+48",
+      "speed": "Walk 40, Fly 80, Swim 40",
+      "initiative": 1,
+      "abilities": {
+        "str": 19,
+        "dex": 12,
+        "con": 17,
+        "int": 16,
+        "wis": 13,
+        "cha": 15
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Deception 5, Perception 7, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "poison",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "The dragon can breathe air and water."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 7 (2d6) poison damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Poison Breath (Recharge 5-6)",
+          "description": "The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can breathe air and water."
+    },
+    {
+      "id": "young-red-dragon",
+      "name": "Young Red Dragon",
+      "cr": 10,
+      "challengeRating": "10",
+      "xp": 5900,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Hill", "Mountain"],
+      "ac": 18,
+      "hp": 178,
+      "hitDice": "17d10+85",
+      "speed": "Walk 40, Climb 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 23,
+        "dex": 10,
+        "con": 21,
+        "int": 14,
+        "wis": 11,
+        "cha": 19
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 18",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 8, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "fire",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 3 (1d6) fire damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Fire Breath (Recharge 5-6)",
+          "description": "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon makes three attacks: one with its bite and two with its claws."
+    },
+    {
+      "id": "young-silver-dragon",
+      "name": "Young Silver Dragon",
+      "cr": 9,
+      "challengeRating": "9",
+      "xp": 5000,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Lawful Good",
+      "biomes": ["Mountain", "Urban"],
+      "ac": 18,
+      "hp": 168,
+      "hitDice": "16d10+80",
+      "speed": "Walk 40, Fly 80",
+      "initiative": 0,
+      "abilities": {
+        "str": 23,
+        "dex": 10,
+        "con": 21,
+        "int": 14,
+        "wis": 11,
+        "cha": 19
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 18",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Arcana 6, History 6, Perception 8, Stealth 4",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        },
+        {
+          "name": "Breath Weapons (Recharge 5-6)",
+          "description": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 17 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon makes three attacks: one with its bite and two with its claws."
+    },
+    {
+      "id": "young-white-dragon",
+      "name": "Young White Dragon",
+      "cr": 6,
+      "challengeRating": "6",
+      "xp": 2300,
+      "type": "Dragon",
+      "subtype": "",
+      "size": "Large",
+      "alignment": "Chaotic Evil",
+      "biomes": ["Arctic"],
+      "ac": 17,
+      "hp": 133,
+      "hitDice": "14d10+56",
+      "speed": "Walk 40, Burrow 20, Fly 80, Swim 40",
+      "initiative": 0,
+      "abilities": {
+        "str": 18,
+        "dex": 10,
+        "con": 18,
+        "int": 6,
+        "wis": 11,
+        "cha": 12
+      },
+      "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+      "languages": "Common, Draconic",
+      "savingThrows": "",
+      "skills": "Perception 6, Stealth 3",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "cold",
+      "conditionImmunities": "",
+      "traits": [
+        {
+          "name": "Ice Walk",
+          "description": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "description": "The dragon makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "description": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) cold damage."
+        },
+        {
+          "name": "Claw",
+          "description": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Cold Breath (Recharge 5-6)",
+          "description": "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw, taking 45 (10d8) cold damage on a failed save, or half as much damage on a successful one."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
+    },
+    {
+      "id": "zombie",
+      "name": "Zombie",
+      "cr": 0.25,
+      "challengeRating": "1/4",
+      "xp": 50,
+      "type": "Undead",
+      "subtype": "",
+      "size": "Medium",
+      "alignment": "Neutral Evil",
+      "biomes": ["Jungle", "Urban"],
+      "ac": 8,
+      "hp": 22,
+      "hitDice": "3d8+9",
+      "speed": "Walk 20",
+      "initiative": -2,
+      "abilities": {
+        "str": 13,
+        "dex": 6,
+        "con": 16,
+        "int": 3,
+        "wis": 6,
+        "cha": 5
+      },
+      "senses": "darkvision 60 ft., passive Perception 8",
+      "languages": "understands the languages it knew in life but can't speak",
+      "savingThrows": "",
+      "skills": "",
+      "damageVulnerabilities": "",
+      "damageResistances": "",
+      "damageImmunities": "",
+      "conditionImmunities": "poisoned",
+      "traits": [
+        {
+          "name": "Undead Fortitude",
+          "description": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Slam",
+          "description": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+        }
+      ],
+      "legendaryActions": [],
+      "details": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+    }
+  ]
+}

--- a/src/core/encounter/live-combat.ts
+++ b/src/core/encounter/live-combat.ts
@@ -1,0 +1,1338 @@
+import Database from 'better-sqlite3'
+import { z } from 'zod'
+import {
+  combatSnapshotSchema,
+  liveSessionSnapshotSchema,
+  type CombatSnapshot,
+  type LiveSessionSnapshot,
+  type PartyMember
+} from '../../shared/contracts/live-session.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+import type { PartyCharacterDraft } from '../../shared/contracts/party.js'
+import type { CreatureCatalogQuery } from '../../shared/contracts/encounter.js'
+import type { EncounterTuning } from '../../shared/contracts/encounter-tuning.js'
+import type {
+  EncounterSelectionEvaluation,
+  GroupGenerationMode,
+  SceneGroupDraftEntry,
+  SceneGroupDraftEvaluation,
+  SceneGroupDraftGeneration
+} from '../../shared/contracts/scene.js'
+import { creatureById } from '../creatures/catalog.js'
+import {
+  calculateAdventuringDay,
+  initializePartySchema,
+  PartyStore
+} from '../party/party-store.js'
+import { initializeSceneSchema, SceneStore } from '../scene/scene-store.js'
+import {
+  evaluateSceneGroupDraft,
+  evaluateSceneGroups,
+  generateSceneGroupDraft
+} from '../scene/group-generator.js'
+import {
+  initializeWorldLocationSchema,
+  WorldLocationStore
+} from '../worldplanner/location-store.js'
+import {
+  initializeEncounterSourceSchema,
+  resolveEncounterSource
+} from '../worldplanner/encounter-source-store.js'
+
+const sourceSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('party'),
+      rowId: z.string(),
+      partyId: z.uuid(),
+      name: z.string(),
+      initiative: z.number().int()
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('monster'),
+      rowId: z.string(),
+      creatureId: z.string(),
+      name: z.string(),
+      quantity: z.number().int().positive(),
+      initiative: z.number().int()
+    })
+    .strict()
+])
+
+const combatantSchema = z
+  .object({
+    id: z.string(),
+    cardId: z.string(),
+    name: z.string(),
+    playerCharacter: z.boolean(),
+    currentHp: z.number().int().nonnegative(),
+    maxHp: z.number().int().nonnegative(),
+    armorClass: z.number().int().nonnegative(),
+    initiative: z.number().int(),
+    xp: z.number().int().nonnegative(),
+    detail: z.string(),
+    order: z.number().int().nonnegative()
+  })
+  .strict()
+
+const resolutionStateSchema = z
+  .object({
+    selectedEnemyIds: z.array(z.string()),
+    thresholdFraction: z.number().min(0).max(1),
+    xpFraction: z.number().min(0).max(1),
+    xpAwarded: z.boolean()
+  })
+  .strict()
+
+const combatMementoSchema = z
+  .object({
+    id: z.uuid(),
+    revision: z.number().int().nonnegative(),
+    phase: z.enum(['initiative', 'combat', 'resolution']),
+    selectedGroupIds: z.array(z.uuid()),
+    sources: z.array(sourceSchema),
+    combatants: z.array(combatantSchema),
+    turnOrder: z.array(z.string()),
+    activeIndex: z.number().int().nonnegative(),
+    round: z.number().int().positive(),
+    resolution: resolutionStateSchema.nullable()
+  })
+  .strict()
+
+type CombatMemento = z.infer<typeof combatMementoSchema>
+type Combatant = z.infer<typeof combatantSchema>
+
+export function initializeCombatSchema(db: Database.Database): void {
+  const runtimeColumns = db
+    .prepare("PRAGMA table_info('encounter_combat_runtime')")
+    .all() as { name: string }[]
+  if (
+    runtimeColumns.length > 0 &&
+    !runtimeColumns.some((column) => column.name === 'scene_id')
+  ) {
+    db.exec(`
+      DROP TABLE IF EXISTS encounter_combat_resolution_enemies;
+      DROP TABLE IF EXISTS encounter_combat_resolution;
+      DROP TABLE IF EXISTS encounter_combat_turn_order;
+      DROP TABLE IF EXISTS encounter_combatants;
+      DROP TABLE IF EXISTS encounter_combat_sources;
+      DROP TABLE IF EXISTS encounter_combat_selected_groups;
+      DROP TABLE IF EXISTS encounter_combat_runtime;
+      DROP TABLE IF EXISTS live_combat_runtime;
+    `)
+  }
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS encounter_combat_runtime (
+      scene_id TEXT PRIMARY KEY NOT NULL,
+      id TEXT NOT NULL,
+      revision INTEGER NOT NULL,
+      phase TEXT NOT NULL,
+      active_index INTEGER NOT NULL,
+      round INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combat_selected_groups (
+      scene_id TEXT NOT NULL,
+      group_id TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      PRIMARY KEY(scene_id, group_id)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combat_sources (
+      scene_id TEXT NOT NULL,
+      row_id TEXT NOT NULL,
+      source_kind TEXT NOT NULL,
+      party_id TEXT,
+      creature_id TEXT,
+      name TEXT NOT NULL,
+      quantity INTEGER,
+      initiative INTEGER NOT NULL,
+      position INTEGER NOT NULL,
+      PRIMARY KEY(scene_id, row_id)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combatants (
+      scene_id TEXT NOT NULL,
+      id TEXT NOT NULL,
+      card_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      player_character INTEGER NOT NULL,
+      current_hp INTEGER NOT NULL,
+      max_hp INTEGER NOT NULL,
+      armor_class INTEGER NOT NULL,
+      initiative INTEGER NOT NULL,
+      xp INTEGER NOT NULL,
+      detail TEXT NOT NULL,
+      combat_order INTEGER NOT NULL,
+      PRIMARY KEY(scene_id, id)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combat_turn_order (
+      scene_id TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      card_id TEXT NOT NULL,
+      PRIMARY KEY(scene_id, position)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combat_resolution (
+      scene_id TEXT PRIMARY KEY NOT NULL,
+      threshold_fraction REAL NOT NULL,
+      xp_fraction REAL NOT NULL,
+      xp_awarded INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS encounter_combat_resolution_enemies (
+      scene_id TEXT NOT NULL,
+      enemy_id TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      PRIMARY KEY(scene_id, enemy_id)
+    );
+  `)
+}
+
+export class LivePlayService {
+  constructor(private readonly campaignPath: () => string) {}
+
+  readParty() {
+    return this.withStores(({ party }) => party.read())
+  }
+
+  setMembership(id: string, active: boolean, expectedRevision: number) {
+    return this.withStores(({ party, scene, combat }) => {
+      const snapshot = party.setMembership(id, active, expectedRevision)
+      if (!active) scene.unassignPartyMember(id)
+      combat.reconcileParty(scene.assignedParty(snapshot.members))
+      return snapshot
+    })
+  }
+
+  createPartyCharacter(
+    character: PartyCharacterDraft,
+    expectedRevision: number
+  ) {
+    return this.withStores(({ party }) =>
+      party.create(character, expectedRevision)
+    )
+  }
+
+  updatePartyCharacter(
+    id: string,
+    character: PartyCharacterDraft,
+    expectedRevision: number
+  ) {
+    return this.withStores(({ party, scene, combat }) => {
+      const snapshot = party.update(id, character, expectedRevision)
+      combat.reconcileParty(scene.assignedParty(snapshot.members))
+      return snapshot
+    })
+  }
+
+  deletePartyCharacter(id: string, expectedRevision: number) {
+    return this.withStores(({ party, scene, combat }) => {
+      const snapshot = party.delete(id, expectedRevision)
+      scene.unassignPartyMember(id)
+      combat.reconcileParty(scene.assignedParty(snapshot.members))
+      return snapshot
+    })
+  }
+
+  adjustPartyXp(id: string, delta: number, expectedRevision: number) {
+    return this.withStores(({ party }) =>
+      party.adjustXp(id, delta, expectedRevision)
+    )
+  }
+
+  restParty(type: 'short' | 'long', expectedRevision: number) {
+    return this.withStores(({ party }) => party.rest(type, expectedRevision))
+  }
+
+  calculateAdventuringDay(
+    rows: readonly { level: number; count: number }[],
+    totalXp?: number
+  ) {
+    return calculateAdventuringDay(rows, totalXp)
+  }
+
+  readSession(): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) =>
+      this.snapshotFrom(party, scene, combat)
+    )
+  }
+
+  focusScene(sceneId: string, expectedRevision: number): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combatFor }) => {
+      scene.focus(sceneId, expectedRevision)
+      return this.snapshotFrom(party, scene, combatFor(sceneId))
+    })
+  }
+
+  setSceneLocation(
+    sceneId: string,
+    locationId: string | null,
+    expectedRevision: number
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat, locations }) => {
+      if (
+        locationId !== null &&
+        !locations
+          .read()
+          .locations.some((location) => location.id === locationId)
+      )
+        throw new Error('not found')
+      scene.setLocation(sceneId, locationId, expectedRevision)
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  saveSceneGroup(
+    sceneId: string,
+    groupId: string | null,
+    name: string,
+    entries: readonly { creatureId: string; quantity: number }[],
+    expectedRevision: number
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      scene.saveGroup(sceneId, groupId, name, entries, expectedRevision)
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  deleteSceneGroup(
+    sceneId: string,
+    groupId: string,
+    expectedRevision: number
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      scene.deleteGroup(sceneId, groupId, expectedRevision)
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  assignScenePartyMember(
+    sceneId: string,
+    partyMemberId: string,
+    assigned: boolean,
+    expectedRevision: number
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      scene.assignPartyMember(
+        sceneId,
+        partyMemberId,
+        assigned,
+        expectedRevision
+      )
+      combat.reconcileParty(scene.assignedParty(party.read().members, sceneId))
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  generateGroupDraft(
+    sceneId: string,
+    entries: readonly SceneGroupDraftEntry[],
+    mode: GroupGenerationMode,
+    filters: CreatureCatalogQuery,
+    tuning: EncounterTuning,
+    seed: number,
+    expectedRevision: number
+  ): SceneGroupDraftGeneration {
+    return this.withStores(({ party, scene }) => {
+      if (scene.revision() !== expectedRevision) throw new Error('stale')
+      const partySnapshot = party.read()
+      const focused = scene.focused(partySnapshot.members)
+      if (focused.id !== sceneId) throw new Error('not found')
+      const resolvedFilters = { ...filters, locationId: focused.locationId }
+      return generateSceneGroupDraft(
+        focused,
+        scene.assignedParty(partySnapshot.members, sceneId),
+        entries,
+        mode,
+        resolvedFilters,
+        tuning,
+        seed,
+        expectedRevision,
+        resolveEncounterSource(scene.database(), resolvedFilters)
+      )
+    })
+  }
+
+  evaluateGroupDraft(
+    sceneId: string,
+    entries: readonly SceneGroupDraftEntry[],
+    expectedRevision: number
+  ): SceneGroupDraftEvaluation {
+    return this.withStores(({ party, scene }) => {
+      if (scene.revision() !== expectedRevision) throw new Error('stale')
+      const partySnapshot = party.read()
+      const focused = scene.focused(partySnapshot.members)
+      if (focused.id !== sceneId) throw new Error('not found')
+      return evaluateSceneGroupDraft(
+        sceneId,
+        scene.assignedParty(partySnapshot.members, sceneId),
+        entries
+      )
+    })
+  }
+
+  evaluateEncounter(
+    sceneId: string,
+    groupIds: readonly string[],
+    expectedRevision: number
+  ): EncounterSelectionEvaluation {
+    return this.withStores(({ party, scene }) => {
+      if (scene.revision() !== expectedRevision) throw new Error('stale')
+      const partySnapshot = party.read()
+      const focused = scene.focused(partySnapshot.members)
+      if (focused.id !== sceneId) throw new Error('not found')
+      return evaluateSceneGroups(
+        focused,
+        scene.assignedParty(partySnapshot.members, sceneId),
+        groupIds
+      )
+    })
+  }
+
+  prepareCombat(
+    sceneId: string,
+    expectedSceneRevision: number,
+    groupIds: readonly string[]
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      if (scene.revision() !== expectedSceneRevision) throw new Error('stale')
+      const partySnapshot = party.read()
+      const focused = scene.focused(partySnapshot.members)
+      if (focused.id !== sceneId) throw new Error('not found')
+      const assigned = scene.assignedParty(partySnapshot.members, sceneId)
+      const evaluation = evaluateSceneGroups(focused, assigned, groupIds)
+      if (!evaluation.canStart) throw new Error('validation')
+      combat.prepare(assigned, focused.groups, groupIds)
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  rollInitiative(expectedRevision: number): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) => combat.roll())
+  }
+
+  confirmInitiative(
+    expectedRevision: number,
+    values: readonly { id: string; initiative: number }[]
+  ): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) =>
+      combat.confirmInitiative(values)
+    )
+  }
+
+  advanceTurn(expectedRevision: number): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) => combat.advance())
+  }
+
+  adjustInitiative(
+    expectedRevision: number,
+    id: string,
+    initiative: number
+  ): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) =>
+      combat.adjustInitiative(id, initiative)
+    )
+  }
+
+  changeHp(
+    expectedRevision: number,
+    cardId: string,
+    amount: number,
+    healing: boolean
+  ): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) =>
+      combat.changeHp(cardId, amount, healing)
+    )
+  }
+
+  endCombat(expectedRevision: number): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) => combat.end())
+  }
+
+  updateResolution(
+    expectedRevision: number,
+    selectedEnemyIds: readonly string[],
+    thresholdFraction: number,
+    xpFraction: number
+  ): LiveSessionSnapshot {
+    return this.mutateCombat(expectedRevision, (combat) =>
+      combat.updateResolution(selectedEnemyIds, thresholdFraction, xpFraction)
+    )
+  }
+
+  awardXp(expectedRevision: number): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      combat.assertRevision(expectedRevision)
+      const assigned = scene.assignedParty(party.read().members)
+      const award = combat.xpAward(assigned)
+      party.awardCombatXp(
+        award.combatId,
+        award.xpEach,
+        assigned.map((member) => member.id)
+      )
+      combat.markXpAwarded()
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  completeCombat(expectedRevision: number): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      combat.assertRevision(expectedRevision)
+      combat.clear()
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  private mutateCombat(
+    expectedRevision: number,
+    mutation: (combat: CombatStore) => void
+  ): LiveSessionSnapshot {
+    return this.withStores(({ party, scene, combat }) => {
+      combat.assertRevision(expectedRevision)
+      mutation(combat)
+      return this.snapshotFrom(party, scene, combat)
+    })
+  }
+
+  private snapshotFrom(
+    party: PartyStore,
+    scene: SceneStore,
+    combat: CombatStore
+  ): LiveSessionSnapshot {
+    const partySnapshot = party.read()
+    const sceneSnapshot = scene.snapshot(partySnapshot.members)
+    return liveSessionSnapshotSchema.parse({
+      revision: sceneSnapshot.revision,
+      party: partySnapshot,
+      scene: sceneSnapshot,
+      travel: {
+        kind: 'none',
+        label: 'Kein aktiver Reisekontext',
+        hint: 'Dungeon oder Hex stellen derzeit keinen Live-Kontext bereit.'
+      },
+      combat: combat.snapshot(scene.assignedParty(partySnapshot.members))
+    })
+  }
+
+  private withStores<T>(
+    work: (stores: {
+      party: PartyStore
+      scene: SceneStore
+      combat: CombatStore
+      combatFor: (sceneId: string) => CombatStore
+      locations: WorldLocationStore
+    }) => T
+  ): T {
+    const db = new Database(this.campaignPath())
+    db.pragma('foreign_keys = ON')
+    try {
+      initializePartySchema(db)
+      initializeSceneSchema(db)
+      initializeCombatSchema(db)
+      initializeWorldLocationSchema(db)
+      initializeEncounterSourceSchema(db)
+      const locations = new WorldLocationStore(db)
+      const scene = new SceneStore(db, () => locations.read().locations)
+      const combatFor = (sceneId: string) => new CombatStore(db, sceneId)
+      return work({
+        party: new PartyStore(db),
+        scene,
+        combat: combatFor(scene.focusedSceneId()),
+        combatFor,
+        locations
+      })
+    } finally {
+      db.close()
+    }
+  }
+}
+
+class CombatStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly sceneId: string
+  ) {}
+
+  prepare(
+    members: readonly PartyMember[],
+    groups: readonly {
+      id: string
+      name: string
+      entries: readonly {
+        id: string
+        creatureId: string
+        quantity: number
+        available: boolean
+      }[]
+    }[],
+    groupIds: readonly string[]
+  ): void {
+    const party = members.filter((member) => member.active)
+    if (party.length === 0) throw new Error('validation')
+    const selected = Array.from(new Set(groupIds))
+    const chosenGroups = selected.map((id) =>
+      groups.find((group) => group.id === id)
+    )
+    if (chosenGroups.some((group) => group === undefined))
+      throw new Error('not found')
+    const sources: CombatMemento['sources'] = party.map((member, index) => ({
+      kind: 'party',
+      rowId: `party:${member.id}`,
+      partyId: member.id,
+      name: member.name,
+      initiative: 10 + index
+    }))
+    for (const group of chosenGroups) {
+      for (const entry of group?.entries ?? []) {
+        const creature = creatureById(entry.creatureId)
+        if (!entry.available || !creature) throw new Error('not found')
+        sources.push({
+          kind: 'monster',
+          rowId: `monster:${entry.id}`,
+          creatureId: creature.id,
+          name: creature.name,
+          quantity: entry.quantity,
+          initiative: 12 + Math.max(-3, Math.min(6, creature.initiative))
+        })
+      }
+    }
+    if (!sources.some((source) => source.kind === 'monster'))
+      throw new Error('validation')
+    this.save({
+      id: uuidv7(),
+      revision: 0,
+      phase: 'initiative',
+      selectedGroupIds: selected,
+      sources,
+      combatants: [],
+      turnOrder: [],
+      activeIndex: 0,
+      round: 1,
+      resolution: null
+    })
+  }
+
+  prepareRoster(
+    members: readonly PartyMember[],
+    roster: readonly {
+      creatureId: string
+      name: string
+      quantity: number
+      available: boolean
+    }[]
+  ): void {
+    const party = members.filter((member) => member.active)
+    if (party.length === 0 || roster.length === 0) throw new Error('validation')
+    const sources: CombatMemento['sources'] = party.map((member, index) => ({
+      kind: 'party',
+      rowId: `party:${member.id}`,
+      partyId: member.id,
+      name: member.name,
+      initiative: 10 + index
+    }))
+    roster.forEach((entry) => {
+      const creature = creatureById(entry.creatureId)
+      if (!entry.available || !creature) throw new Error('not found')
+      sources.push({
+        kind: 'monster',
+        rowId: `monster:builder:${entry.creatureId}`,
+        creatureId: entry.creatureId,
+        name: entry.name,
+        quantity: entry.quantity,
+        initiative: 12 + Math.max(-3, Math.min(6, creature.initiative))
+      })
+    })
+    this.save({
+      id: uuidv7(),
+      revision: 0,
+      phase: 'initiative',
+      selectedGroupIds: [],
+      sources,
+      combatants: [],
+      turnOrder: [],
+      activeIndex: 0,
+      round: 1,
+      resolution: null
+    })
+  }
+
+  addReinforcement(creatureId: string, quantity: number): void {
+    const state = this.requireCombat()
+    const creature = creatureById(creatureId)
+    if (!creature) throw new Error('not found')
+    const activeCard = state.turnOrder[state.activeIndex]
+    const initiative = creature.initiative
+    const sourceId = `monster:reinforcement:${uuidv7()}`
+    state.sources.push({
+      kind: 'monster',
+      rowId: sourceId,
+      creatureId,
+      name: creature.name,
+      quantity,
+      initiative
+    })
+    let ordinal = 1
+    for (const size of mobSizes(quantity)) {
+      const cardId = `monster-card:${uuidv7()}`
+      for (let member = 0; member < size; member += 1) {
+        state.combatants.push({
+          id: `monster-member:${uuidv7()}`,
+          cardId,
+          name:
+            quantity === 1 ? creature.name : `${creature.name} #${ordinal++}`,
+          playerCharacter: false,
+          currentHp: creature.hp,
+          maxHp: creature.hp,
+          armorClass: creature.ac,
+          initiative,
+          xp: creature.xp,
+          detail: `CR ${creature.challengeRating} · ${creature.type}`,
+          order: state.combatants.length
+        })
+      }
+    }
+    state.turnOrder = sortedCardIds(state.combatants)
+    state.activeIndex = Math.max(0, state.turnOrder.indexOf(activeCard ?? ''))
+    this.bump(state)
+  }
+
+  roll(): void {
+    const state = this.require()
+    if (state.phase !== 'initiative') throw new Error('validation')
+    const values = [13, 15, 17, 19, 11]
+    state.sources = state.sources.map((source, index) => ({
+      ...source,
+      initiative: values[index % values.length] ?? 13
+    }))
+    this.bump(state)
+  }
+
+  confirmInitiative(
+    values: readonly { id: string; initiative: number }[]
+  ): void {
+    const state = this.require()
+    if (state.phase !== 'initiative') throw new Error('validation')
+    const input = new Map(values.map((value) => [value.id, value.initiative]))
+    state.sources = state.sources.map((source) => ({
+      ...source,
+      initiative: input.get(source.rowId) ?? source.initiative
+    }))
+    const combatants: Combatant[] = []
+    let order = 0
+    for (const source of state.sources) {
+      if (source.kind === 'party') {
+        combatants.push({
+          id: source.partyId,
+          cardId: `party-card:${source.partyId}`,
+          name: source.name,
+          playerCharacter: true,
+          currentHp: 0,
+          maxHp: 0,
+          armorClass: 0,
+          initiative: source.initiative,
+          xp: 0,
+          detail: 'Aktives Party-Mitglied',
+          order: order++
+        })
+        continue
+      }
+      const creature = creatureById(source.creatureId)
+      if (!creature) throw new Error('not found')
+      let ordinal = 1
+      for (const size of mobSizes(source.quantity)) {
+        const cardId = `monster-card:${uuidv7()}`
+        for (let member = 0; member < size; member += 1) {
+          const name =
+            source.quantity === 1
+              ? creature.name
+              : `${creature.name} #${ordinal++}`
+          combatants.push({
+            id: `monster-member:${uuidv7()}`,
+            cardId,
+            name,
+            playerCharacter: false,
+            currentHp: creature.hp,
+            maxHp: creature.hp,
+            armorClass: creature.ac,
+            initiative: source.initiative,
+            xp: creature.xp,
+            detail: `CR ${creature.cr} · ${creature.type}`,
+            order: order++
+          })
+        }
+      }
+    }
+    state.combatants = combatants
+    state.turnOrder = sortedCardIds(combatants)
+    state.activeIndex = 0
+    state.round = 1
+    state.phase = 'combat'
+    this.bump(state)
+  }
+
+  advance(): void {
+    const state = this.requireCombat()
+    if (state.turnOrder.length === 0) return
+    for (let attempt = 0; attempt < state.turnOrder.length; attempt += 1) {
+      const next = (state.activeIndex + 1) % state.turnOrder.length
+      if (next === 0) state.round += 1
+      state.activeIndex = next
+      if (cardAlive(state.combatants, state.turnOrder[next] ?? '')) break
+    }
+    this.bump(state)
+  }
+
+  adjustInitiative(id: string, initiative: number): void {
+    const state = this.requireCombat()
+    const activeCard = state.turnOrder[state.activeIndex]
+    let changed = false
+    state.combatants = state.combatants.map((combatant) => {
+      if (combatant.cardId !== id) return combatant
+      changed = true
+      return { ...combatant, initiative }
+    })
+    if (!changed) throw new Error('not found')
+    state.turnOrder = sortedCardIds(state.combatants)
+    state.activeIndex = Math.max(0, state.turnOrder.indexOf(activeCard ?? ''))
+    this.bump(state)
+  }
+
+  changeHp(cardId: string, amount: number, healing: boolean): void {
+    const state = this.requireCombat()
+    const members = state.combatants
+      .filter(
+        (combatant) =>
+          combatant.cardId === cardId &&
+          !combatant.playerCharacter &&
+          combatant.currentHp > 0
+      )
+      .sort((a, b) => a.currentHp - b.currentHp || a.name.localeCompare(b.name))
+    if (members.length === 0) throw new Error('not found')
+    let remaining = amount
+    const nextHp = new Map<string, number>()
+    if (healing) {
+      const target = members[0]
+      if (target)
+        nextHp.set(target.id, Math.min(target.maxHp, target.currentHp + amount))
+    } else {
+      for (const target of members) {
+        if (remaining <= 0) break
+        const applied = Math.min(remaining, target.currentHp)
+        nextHp.set(target.id, target.currentHp - applied)
+        remaining -= applied
+      }
+    }
+    state.combatants = state.combatants.map((combatant) => ({
+      ...combatant,
+      currentHp: nextHp.get(combatant.id) ?? combatant.currentHp
+    }))
+    this.bump(state)
+  }
+
+  end(): void {
+    const state = this.requireCombat()
+    state.phase = 'resolution'
+    state.resolution = {
+      selectedEnemyIds: state.combatants
+        .filter(
+          (combatant) => !combatant.playerCharacter && combatant.currentHp === 0
+        )
+        .map((combatant) => combatant.id),
+      thresholdFraction: 1,
+      xpFraction: 1,
+      xpAwarded: false
+    }
+    this.bump(state)
+  }
+
+  updateResolution(
+    selectedEnemyIds: readonly string[],
+    thresholdFraction: number,
+    xpFraction: number
+  ): void {
+    const state = this.require()
+    if (state.phase !== 'resolution' || !state.resolution)
+      throw new Error('validation')
+    const enemyIds = new Set(
+      state.combatants
+        .filter((combatant) => !combatant.playerCharacter)
+        .map((combatant) => combatant.id)
+    )
+    if (selectedEnemyIds.some((id) => !enemyIds.has(id)))
+      throw new Error('not found')
+    state.resolution = {
+      ...state.resolution,
+      selectedEnemyIds: Array.from(new Set(selectedEnemyIds)),
+      thresholdFraction,
+      xpFraction
+    }
+    this.bump(state)
+  }
+
+  xpAward(members: readonly PartyMember[]): {
+    combatId: string
+    xpEach: number
+  } {
+    const state = this.require()
+    if (
+      state.phase !== 'resolution' ||
+      !state.resolution ||
+      state.resolution.xpAwarded
+    )
+      throw new Error('validation')
+    const partySize = members.filter((member) => member.active).length
+    if (partySize === 0) throw new Error('validation')
+    const selected = new Set(state.resolution.selectedEnemyIds)
+    const eligible = state.combatants
+      .filter((combatant) => selected.has(combatant.id))
+      .reduce((total, combatant) => total + combatant.xp, 0)
+    return {
+      combatId: state.id,
+      xpEach: Math.floor((eligible * state.resolution.xpFraction) / partySize)
+    }
+  }
+
+  markXpAwarded(): void {
+    const state = this.require()
+    if (!state.resolution) throw new Error('validation')
+    state.resolution = { ...state.resolution, xpAwarded: true }
+    this.bump(state)
+  }
+
+  reconcileParty(members: readonly PartyMember[]): void {
+    const state = this.load()
+    if (!state || state.phase === 'resolution') return
+    const active = members.filter((member) => member.active)
+    if (state.phase === 'initiative') {
+      const monsters = state.sources.filter(
+        (source) => source.kind === 'monster'
+      )
+      const nextSources: CombatMemento['sources'] = [
+        ...active.map((member, index) => ({
+          kind: 'party' as const,
+          rowId: `party:${member.id}`,
+          partyId: member.id,
+          name: member.name,
+          initiative: 10 + index
+        })),
+        ...monsters
+      ]
+      if (JSON.stringify(nextSources) === JSON.stringify(state.sources)) return
+      state.sources = nextSources
+      this.bump(state)
+      return
+    }
+    const activeIds = new Set(active.map((member) => member.id))
+    const activeCard = state.turnOrder[state.activeIndex]
+    const before = JSON.stringify(state.combatants)
+    state.combatants = state.combatants.filter(
+      (combatant) => !combatant.playerCharacter || activeIds.has(combatant.id)
+    )
+    active.forEach((member, index) => {
+      if (state.combatants.some((combatant) => combatant.id === member.id))
+        return
+      state.combatants.push({
+        id: member.id,
+        cardId: `party-card:${member.id}`,
+        name: member.name,
+        playerCharacter: true,
+        currentHp: 0,
+        maxHp: 0,
+        armorClass: 0,
+        initiative: 10 + index,
+        xp: 0,
+        detail: 'Aktives Party-Mitglied',
+        order: state.combatants.length
+      })
+    })
+    if (JSON.stringify(state.combatants) === before) return
+    state.turnOrder = sortedCardIds(state.combatants)
+    state.activeIndex = Math.max(0, state.turnOrder.indexOf(activeCard ?? ''))
+    this.bump(state)
+  }
+
+  snapshot(members: readonly PartyMember[]): CombatSnapshot | null {
+    const state = this.load()
+    if (!state) return null
+    const activeCard = state.turnOrder[state.activeIndex]
+    const cards = projectedCards(state.combatants, activeCard)
+    const activePartySize = Math.max(
+      1,
+      members.filter((member) => member.active).length
+    )
+    const selected = new Set(state.resolution?.selectedEnemyIds ?? [])
+    const eligibleXp = state.combatants
+      .filter((combatant) => selected.has(combatant.id))
+      .reduce((total, combatant) => total + combatant.xp, 0)
+    const awardedXp = Math.floor(
+      eligibleXp * (state.resolution?.xpFraction ?? 1)
+    )
+    return combatSnapshotSchema.parse({
+      id: state.id,
+      revision: state.revision,
+      phase: state.phase,
+      selectedGroupIds: state.selectedGroupIds,
+      initiativeRows: state.sources.map((source) => ({
+        id: source.rowId,
+        label:
+          source.kind === 'monster' && source.quantity > 1
+            ? `${source.name} × ${source.quantity}`
+            : source.name,
+        kind: source.kind,
+        initiative: source.initiative
+      })),
+      cards,
+      round: state.round,
+      allEnemiesDefeated:
+        state.combatants.some((combatant) => !combatant.playerCharacter) &&
+        state.combatants
+          .filter((combatant) => !combatant.playerCharacter)
+          .every((combatant) => combatant.currentHp === 0),
+      resolution: state.resolution
+        ? {
+            enemies: state.combatants
+              .filter((combatant) => !combatant.playerCharacter)
+              .map((combatant) => ({
+                id: combatant.id,
+                name: combatant.name,
+                alive: combatant.currentHp > 0,
+                xp: combatant.xp,
+                selected: selected.has(combatant.id)
+              })),
+            thresholdFraction: state.resolution.thresholdFraction,
+            xpFraction: state.resolution.xpFraction,
+            eligibleXp,
+            awardedXp,
+            perPlayerXp: Math.floor(awardedXp / activePartySize),
+            partySize: activePartySize,
+            xpAwarded: state.resolution.xpAwarded,
+            lootSummary:
+              'Kein Loot · Loot-Persistenz ist in diesem Generator-Pass nicht angebunden.'
+          }
+        : null
+    })
+  }
+
+  assertRevision(expectedRevision: number): void {
+    if (this.require().revision !== expectedRevision) throw new Error('stale')
+  }
+
+  clear(): void {
+    clearCombatTables(this.db, this.sceneId)
+  }
+
+  private requireCombat(): CombatMemento {
+    const state = this.require()
+    if (state.phase !== 'combat') throw new Error('validation')
+    return state
+  }
+
+  private require(): CombatMemento {
+    const state = this.load()
+    if (!state) throw new Error('not found')
+    return state
+  }
+
+  private load(): CombatMemento | null {
+    const root = this.db
+      .prepare(
+        `
+        SELECT id, revision, phase, active_index AS activeIndex, round
+        FROM encounter_combat_runtime WHERE scene_id = ?
+      `
+      )
+      .get(this.sceneId) as
+      | {
+          id: string
+          revision: number
+          phase: CombatMemento['phase']
+          activeIndex: number
+          round: number
+        }
+      | undefined
+    if (!root) return null
+    const selectedGroupIds = (
+      this.db
+        .prepare(
+          'SELECT group_id AS id FROM encounter_combat_selected_groups WHERE scene_id = ? ORDER BY position'
+        )
+        .all(this.sceneId) as { id: string }[]
+    ).map((row) => row.id)
+    const sources = (
+      this.db
+        .prepare(
+          `
+          SELECT row_id AS rowId, source_kind AS kind, party_id AS partyId,
+            creature_id AS creatureId, name, quantity, initiative
+          FROM encounter_combat_sources WHERE scene_id = ? ORDER BY position
+        `
+        )
+        .all(this.sceneId) as {
+        rowId: string
+        kind: 'party' | 'monster'
+        partyId: string | null
+        creatureId: string | null
+        name: string
+        quantity: number | null
+        initiative: number
+      }[]
+    ).map((row) =>
+      row.kind === 'party'
+        ? {
+            kind: 'party' as const,
+            rowId: row.rowId,
+            partyId: row.partyId,
+            name: row.name,
+            initiative: row.initiative
+          }
+        : {
+            kind: 'monster' as const,
+            rowId: row.rowId,
+            creatureId: row.creatureId,
+            name: row.name,
+            quantity: row.quantity,
+            initiative: row.initiative
+          }
+    )
+    const combatants = this.db
+      .prepare(
+        `
+        SELECT id, card_id AS cardId, name,
+          player_character AS playerCharacter, current_hp AS currentHp,
+          max_hp AS maxHp, armor_class AS armorClass, initiative, xp, detail,
+          combat_order AS "order"
+        FROM encounter_combatants WHERE scene_id = ? ORDER BY combat_order
+      `
+      )
+      .all(this.sceneId)
+      .map((row) => ({
+        ...(row as Combatant),
+        playerCharacter:
+          Number((row as { playerCharacter: number }).playerCharacter) === 1
+      }))
+    const turnOrder = (
+      this.db
+        .prepare(
+          'SELECT card_id AS cardId FROM encounter_combat_turn_order WHERE scene_id = ? ORDER BY position'
+        )
+        .all(this.sceneId) as { cardId: string }[]
+    ).map((row) => row.cardId)
+    const resolutionRow = this.db
+      .prepare(
+        `
+        SELECT threshold_fraction AS thresholdFraction,
+          xp_fraction AS xpFraction, xp_awarded AS xpAwarded
+        FROM encounter_combat_resolution WHERE scene_id = ?
+      `
+      )
+      .get(this.sceneId) as
+      | { thresholdFraction: number; xpFraction: number; xpAwarded: number }
+      | undefined
+    const selectedEnemyIds = (
+      this.db
+        .prepare(
+          'SELECT enemy_id AS id FROM encounter_combat_resolution_enemies WHERE scene_id = ? ORDER BY position'
+        )
+        .all(this.sceneId) as { id: string }[]
+    ).map((row) => row.id)
+    return combatMementoSchema.parse({
+      ...root,
+      selectedGroupIds,
+      sources,
+      combatants,
+      turnOrder,
+      resolution: resolutionRow
+        ? {
+            selectedEnemyIds,
+            thresholdFraction: resolutionRow.thresholdFraction,
+            xpFraction: resolutionRow.xpFraction,
+            xpAwarded: resolutionRow.xpAwarded === 1
+          }
+        : null
+    })
+  }
+
+  private bump(state: CombatMemento): void {
+    state.revision += 1
+    this.save(state)
+  }
+
+  private save(state: CombatMemento): void {
+    persistCombat(this.db, this.sceneId, combatMementoSchema.parse(state))
+  }
+}
+
+function clearCombatTables(db: Database.Database, sceneId: string): void {
+  const tables = [
+    'encounter_combat_resolution_enemies',
+    'encounter_combat_resolution',
+    'encounter_combat_turn_order',
+    'encounter_combatants',
+    'encounter_combat_sources',
+    'encounter_combat_selected_groups',
+    'encounter_combat_runtime'
+  ] as const
+  for (const table of tables)
+    db.prepare(`DELETE FROM ${table} WHERE scene_id = ?`).run(sceneId)
+}
+
+function persistCombat(
+  db: Database.Database,
+  sceneId: string,
+  state: CombatMemento
+): void {
+  db.transaction(() => {
+    clearCombatTables(db, sceneId)
+    db.prepare(
+      `
+      INSERT INTO encounter_combat_runtime (
+        scene_id, id, revision, phase, active_index, round
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `
+    ).run(
+      sceneId,
+      state.id,
+      state.revision,
+      state.phase,
+      state.activeIndex,
+      state.round
+    )
+    const group = db.prepare(
+      'INSERT INTO encounter_combat_selected_groups (scene_id, group_id, position) VALUES (?, ?, ?)'
+    )
+    state.selectedGroupIds.forEach((id, position) =>
+      group.run(sceneId, id, position)
+    )
+    const source = db.prepare(`
+      INSERT INTO encounter_combat_sources (
+        scene_id, row_id, source_kind, party_id, creature_id, name, quantity,
+        initiative, position
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    state.sources.forEach((entry, position) =>
+      source.run(
+        sceneId,
+        entry.rowId,
+        entry.kind,
+        entry.kind === 'party' ? entry.partyId : null,
+        entry.kind === 'monster' ? entry.creatureId : null,
+        entry.name,
+        entry.kind === 'monster' ? entry.quantity : null,
+        entry.initiative,
+        position
+      )
+    )
+    const combatant = db.prepare(`
+      INSERT INTO encounter_combatants (
+        scene_id, id, card_id, name, player_character, current_hp, max_hp, armor_class,
+        initiative, xp, detail, combat_order
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    state.combatants.forEach((entry) =>
+      combatant.run(
+        sceneId,
+        entry.id,
+        entry.cardId,
+        entry.name,
+        entry.playerCharacter ? 1 : 0,
+        entry.currentHp,
+        entry.maxHp,
+        entry.armorClass,
+        entry.initiative,
+        entry.xp,
+        entry.detail,
+        entry.order
+      )
+    )
+    const turn = db.prepare(
+      'INSERT INTO encounter_combat_turn_order (scene_id, position, card_id) VALUES (?, ?, ?)'
+    )
+    state.turnOrder.forEach((id, position) => turn.run(sceneId, position, id))
+    if (state.resolution) {
+      db.prepare(
+        `
+        INSERT INTO encounter_combat_resolution (
+          scene_id, threshold_fraction, xp_fraction, xp_awarded
+        ) VALUES (?, ?, ?, ?)
+      `
+      ).run(
+        sceneId,
+        state.resolution.thresholdFraction,
+        state.resolution.xpFraction,
+        state.resolution.xpAwarded ? 1 : 0
+      )
+      const selected = db.prepare(
+        'INSERT INTO encounter_combat_resolution_enemies (scene_id, enemy_id, position) VALUES (?, ?, ?)'
+      )
+      state.resolution.selectedEnemyIds.forEach((id, position) =>
+        selected.run(sceneId, id, position)
+      )
+    }
+  })()
+}
+
+function mobSizes(quantity: number): readonly number[] {
+  if (quantity <= 3) return Array.from({ length: quantity }, () => 1)
+  const groups = Math.ceil(quantity / 10)
+  const base = Math.floor(quantity / groups)
+  const remainder = quantity % groups
+  return Array.from(
+    { length: groups },
+    (_, index) => base + (index < remainder ? 1 : 0)
+  )
+}
+
+function sortedCardIds(combatants: readonly Combatant[]): string[] {
+  const cards = new Map<string, Combatant>()
+  for (const combatant of combatants)
+    if (!cards.has(combatant.cardId)) cards.set(combatant.cardId, combatant)
+  return Array.from(cards.values())
+    .sort((a, b) => b.initiative - a.initiative || a.order - b.order)
+    .map((combatant) => combatant.cardId)
+}
+
+function cardAlive(combatants: readonly Combatant[], cardId: string): boolean {
+  return combatants.some(
+    (combatant) =>
+      combatant.cardId === cardId &&
+      (combatant.playerCharacter || combatant.currentHp > 0)
+  )
+}
+
+function projectedCards(
+  combatants: readonly Combatant[],
+  activeCard: string | undefined
+) {
+  const grouped = new Map<string, Combatant[]>()
+  for (const combatant of combatants) {
+    const values = grouped.get(combatant.cardId) ?? []
+    values.push(combatant)
+    grouped.set(combatant.cardId, values)
+  }
+  return Array.from(grouped.entries())
+    .map(([id, values]) => {
+      const first = values[0]
+      if (!first) throw new Error('invalid combat card')
+      const alive = values.filter(
+        (value) => value.playerCharacter || value.currentHp > 0
+      )
+      return {
+        id,
+        memberIds: values.map((value) => value.id),
+        name: values.length > 1 ? first.name.replace(/ #\d+$/, '') : first.name,
+        playerCharacter: first.playerCharacter,
+        active: id === activeCard,
+        alive: alive.length > 0,
+        currentHp: values.reduce((total, value) => total + value.currentHp, 0),
+        maxHp: values.reduce((total, value) => total + value.maxHp, 0),
+        armorClass: first.armorClass,
+        initiative: first.initiative,
+        count: values.length,
+        detail: first.detail
+      }
+    })
+    .sort(
+      (a, b) =>
+        b.initiative - a.initiative ||
+        Number(b.playerCharacter) - Number(a.playerCharacter) ||
+        a.name.localeCompare(b.name)
+    )
+}

--- a/src/core/encounter/math.ts
+++ b/src/core/encounter/math.ts
@@ -1,0 +1,79 @@
+import type { PartyMember } from '../../shared/contracts/live-session.js'
+export const thresholds = [
+  [25, 50, 75, 100],
+  [50, 100, 150, 200],
+  [75, 150, 225, 400],
+  [125, 250, 375, 500],
+  [250, 500, 750, 1100],
+  [300, 600, 900, 1400],
+  [350, 750, 1100, 1700],
+  [450, 900, 1400, 2100],
+  [550, 1100, 1600, 2400],
+  [600, 1200, 1900, 2800],
+  [800, 1600, 2400, 3600],
+  [1000, 2000, 3000, 4500],
+  [1100, 2200, 3400, 5100],
+  [1250, 2500, 3800, 5700],
+  [1400, 2800, 4300, 6400],
+  [1600, 3200, 4800, 7200],
+  [2000, 3900, 5900, 8800],
+  [2100, 4200, 6300, 9500],
+  [2400, 4900, 7300, 10900],
+  [2800, 5700, 8500, 12700]
+] as const
+export function partyThresholds(
+  party: readonly PartyMember[]
+): readonly number[] {
+  return party
+    .filter(
+      (p): p is PartyMember & { level: number } => p.active && p.level !== null
+    )
+    .reduce(
+      (sum, p) => sum.map((v, i) => v + thresholds[p.level - 1]![i]!),
+      [0, 0, 0, 0]
+    )
+}
+export function multiplier(count: number, partySize: number): number {
+  let m =
+    count === 1
+      ? 1
+      : count === 2
+        ? 1.5
+        : count <= 6
+          ? 2
+          : count <= 10
+            ? 2.5
+            : count <= 14
+              ? 3
+              : 4
+  if (partySize < 3)
+    m =
+      count === 1
+        ? 1.5
+        : count === 2
+          ? 2
+          : count <= 6
+            ? 2.5
+            : count <= 10
+              ? 3
+              : count <= 14
+                ? 4
+                : 5
+  if (partySize > 5 && m > 1)
+    m = [1, 1, 1.5, 2, 2.5, 3][[1, 1.5, 2, 2.5, 3, 4].indexOf(m)] ?? m
+  return m
+}
+export function difficulty(
+  adjusted: number,
+  values: readonly number[]
+): string {
+  return adjusted >= values[3]!
+    ? 'Deadly'
+    : adjusted >= values[2]!
+      ? 'Hard'
+      : adjusted >= values[1]!
+        ? 'Medium'
+        : adjusted >= values[0]!
+          ? 'Easy'
+          : 'Trivial'
+}

--- a/src/core/party/party-store.ts
+++ b/src/core/party/party-store.ts
@@ -1,0 +1,417 @@
+import Database from 'better-sqlite3'
+import {
+  partySnapshotSchema,
+  type AdventuringDaySummary,
+  type AdventuringDayCalculation,
+  type PartyCharacter,
+  type PartyCharacterDraft,
+  type PartySnapshot
+} from '../../shared/contracts/party.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+
+const seededCharacters = ['Alrik', 'Brynn', 'Cora', 'Dain'] as const
+
+export const levelXp = [
+  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000, 85000, 100000,
+  120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
+] as const
+
+export const dailyXp = [
+  300, 600, 1200, 1700, 3500, 4000, 5000, 6000, 7500, 9000, 10500, 11500, 13500,
+  15000, 18000, 20000, 25000, 27000, 30000, 40000
+] as const
+
+export function initializePartySchema(db: Database.Database): void {
+  const columns = db
+    .prepare("PRAGMA table_info('player_characters')")
+    .all() as readonly { name: string }[]
+  if (
+    columns.length > 0 &&
+    !columns.some((column) => column.name === 'player_name')
+  ) {
+    db.transaction(() => {
+      db.exec('ALTER TABLE player_characters RENAME TO player_characters_old')
+      createPartyTables(db)
+      db.exec(`
+        INSERT INTO player_characters (
+          id, name, level, active, xp, position,
+          player_name, passive_perception, armor_class,
+          xp_since_short_rest, xp_since_long_rest
+        )
+        SELECT id, name, level, active, xp, position, NULL, NULL, NULL, 0, 0
+        FROM player_characters_old;
+        DROP TABLE player_characters_old;
+      `)
+    })()
+  } else createPartyTables(db)
+
+  const metadata = db
+    .prepare('SELECT 1 FROM party_roster_metadata WHERE singleton = 1')
+    .get()
+  if (metadata !== undefined) return
+  db.transaction(() => {
+    db.prepare(
+      'INSERT INTO party_roster_metadata (singleton, revision) VALUES (1, 0)'
+    ).run()
+    const insert = db.prepare(`
+      INSERT INTO player_characters (
+        id, name, player_name, level, passive_perception, armor_class,
+        active, xp, xp_since_short_rest, xp_since_long_rest, position
+      ) VALUES (?, ?, NULL, 3, NULL, NULL, 0, 900, 0, 0, ?)
+    `)
+    seededCharacters.forEach((name, position) =>
+      insert.run(uuidv7(), name, position)
+    )
+  })()
+}
+
+function createPartyTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS party_roster_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS player_characters (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      player_name TEXT,
+      level INTEGER CHECK(level BETWEEN 1 AND 20),
+      passive_perception INTEGER CHECK(passive_perception BETWEEN 0 AND 99),
+      armor_class INTEGER CHECK(armor_class BETWEEN 0 AND 99),
+      active INTEGER NOT NULL CHECK(active IN (0, 1)),
+      xp INTEGER NOT NULL CHECK(xp >= 0),
+      xp_since_short_rest INTEGER NOT NULL CHECK(xp_since_short_rest >= 0),
+      xp_since_long_rest INTEGER NOT NULL CHECK(xp_since_long_rest >= 0),
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS party_xp_awards (
+      combat_id TEXT PRIMARY KEY NOT NULL,
+      xp_each INTEGER NOT NULL CHECK(xp_each >= 0)
+    );
+  `)
+}
+
+export class PartyStore {
+  constructor(private readonly db: Database.Database) {}
+
+  read(): PartySnapshot {
+    const metadata = this.db
+      .prepare('SELECT revision FROM party_roster_metadata WHERE singleton = 1')
+      .get() as { revision: number }
+    const members = this.db
+      .prepare(
+        `
+        SELECT id, name, player_name, level, passive_perception, armor_class,
+               active, xp, xp_since_short_rest, xp_since_long_rest
+        FROM player_characters ORDER BY position, id
+      `
+      )
+      .all()
+      .map(rowPartyMember)
+    return partySnapshotSchema.parse({
+      revision: metadata.revision,
+      members,
+      adventuringDay: adventuringDay(members)
+    })
+  }
+
+  create(draft: PartyCharacterDraft, expectedRevision: number): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      const position = (
+        this.db
+          .prepare(
+            'SELECT COALESCE(MAX(position), -1) + 1 AS value FROM player_characters'
+          )
+          .get() as { value: number }
+      ).value
+      const xp = draft.level === null ? 0 : levelXp[draft.level - 1]!
+      this.db
+        .prepare(
+          `
+          INSERT INTO player_characters (
+            id, name, player_name, level, passive_perception, armor_class,
+            active, xp, xp_since_short_rest, xp_since_long_rest, position
+          ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, 0, 0, ?)
+        `
+        )
+        .run(
+          uuidv7(),
+          draft.name.trim(),
+          nullable(draft.playerName),
+          draft.level,
+          draft.passivePerception,
+          draft.armorClass,
+          xp,
+          position
+        )
+    })
+    return this.read()
+  }
+
+  update(
+    id: string,
+    draft: PartyCharacterDraft,
+    expectedRevision: number
+  ): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      const current = this.db
+        .prepare('SELECT xp FROM player_characters WHERE id = ?')
+        .get(id) as { xp: number } | undefined
+      if (!current) throw new Error('not found')
+      const xp =
+        draft.level === null
+          ? current.xp
+          : Math.max(current.xp, levelXp[draft.level - 1]!)
+      this.db
+        .prepare(
+          `
+          UPDATE player_characters
+          SET name = ?, player_name = ?, level = ?, passive_perception = ?,
+              armor_class = ?, xp = ?
+          WHERE id = ?
+        `
+        )
+        .run(
+          draft.name.trim(),
+          nullable(draft.playerName),
+          draft.level,
+          draft.passivePerception,
+          draft.armorClass,
+          xp,
+          id
+        )
+    })
+    return this.read()
+  }
+
+  delete(id: string, expectedRevision: number): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      if (
+        this.db.prepare('DELETE FROM player_characters WHERE id = ?').run(id)
+          .changes === 0
+      )
+        throw new Error('not found')
+    })
+    return this.read()
+  }
+
+  setMembership(
+    id: string,
+    active: boolean,
+    expectedRevision: number
+  ): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      const changed = this.db
+        .prepare('UPDATE player_characters SET active = ? WHERE id = ?')
+        .run(active ? 1 : 0, id).changes
+      if (changed === 0) throw new Error('not found')
+    })
+    return this.read()
+  }
+
+  adjustXp(id: string, delta: number, expectedRevision: number): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      const member = this.db
+        .prepare(
+          `
+          SELECT level, xp, xp_since_short_rest AS shortXp,
+                 xp_since_long_rest AS longXp
+          FROM player_characters WHERE id = ?
+        `
+        )
+        .get(id) as
+        | { level: number | null; xp: number; shortXp: number; longXp: number }
+        | undefined
+      if (!member) throw new Error('not found')
+      const floor = member.level === null ? 0 : levelXp[member.level - 1]!
+      const nextXp = Math.max(floor, member.xp + delta)
+      const applied = nextXp - member.xp
+      this.db
+        .prepare(
+          `
+          UPDATE player_characters
+          SET xp = ?,
+              xp_since_short_rest = ?,
+              xp_since_long_rest = ?
+          WHERE id = ?
+        `
+        )
+        .run(
+          nextXp,
+          Math.max(0, member.shortXp + applied),
+          Math.max(0, member.longXp + applied),
+          id
+        )
+    })
+    return this.read()
+  }
+
+  rest(type: 'short' | 'long', expectedRevision: number): PartySnapshot {
+    this.mutate(expectedRevision, () => {
+      if (type === 'short')
+        this.db
+          .prepare(
+            'UPDATE player_characters SET xp_since_short_rest = 0 WHERE active = 1'
+          )
+          .run()
+      else
+        this.db
+          .prepare(
+            `
+            UPDATE player_characters
+            SET xp_since_short_rest = 0, xp_since_long_rest = 0
+            WHERE active = 1
+          `
+          )
+          .run()
+    })
+    return this.read()
+  }
+
+  awardCombatXp(
+    combatId: string,
+    xpEach: number,
+    memberIds?: readonly string[]
+  ): PartySnapshot {
+    this.db.transaction(() => {
+      const inserted = this.db
+        .prepare(
+          'INSERT OR IGNORE INTO party_xp_awards (combat_id, xp_each) VALUES (?, ?)'
+        )
+        .run(combatId, xpEach).changes
+      if (inserted === 0) return
+      const selected = memberIds ? Array.from(new Set(memberIds)) : null
+      if (selected && selected.length === 0) throw new Error('validation')
+      const selection = selected
+        ? ` AND id IN (${selected.map(() => '?').join(', ')})`
+        : ''
+      this.db
+        .prepare(
+          `
+          UPDATE player_characters
+          SET xp = xp + ?, xp_since_short_rest = xp_since_short_rest + ?,
+              xp_since_long_rest = xp_since_long_rest + ?
+          WHERE active = 1${selection}
+        `
+        )
+        .run(xpEach, xpEach, xpEach, ...(selected ?? []))
+      this.bumpRevision()
+    })()
+    return this.read()
+  }
+
+  private mutate(expectedRevision: number, mutation: () => void): void {
+    this.db.transaction(() => {
+      const current = (
+        this.db
+          .prepare(
+            'SELECT revision FROM party_roster_metadata WHERE singleton = 1'
+          )
+          .get() as { revision: number }
+      ).revision
+      if (current !== expectedRevision) throw new Error('stale')
+      mutation()
+      this.bumpRevision()
+    })()
+  }
+
+  private bumpRevision(): void {
+    this.db
+      .prepare(
+        'UPDATE party_roster_metadata SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
+  }
+}
+
+function nullable(value: string | null): string | null {
+  const normalized = value?.trim() ?? ''
+  return normalized === '' ? null : normalized
+}
+
+function rowPartyMember(row: unknown): PartyCharacter {
+  const value = row as Record<string, unknown>
+  const level = value['level'] === null ? null : Number(value['level'])
+  return {
+    id: String(value['id']),
+    name: String(value['name']),
+    playerName:
+      typeof value['player_name'] === 'string' ? value['player_name'] : null,
+    level,
+    passivePerception:
+      value['passive_perception'] === null
+        ? null
+        : Number(value['passive_perception']),
+    armorClass:
+      value['armor_class'] === null ? null : Number(value['armor_class']),
+    active: Number(value['active']) === 1,
+    xp: Number(value['xp']),
+    currentLevelFloor: level === null ? 0 : levelXp[level - 1]!,
+    nextLevelXp: level === null || level === 20 ? null : levelXp[level]!,
+    xpSinceShortRest: Number(value['xp_since_short_rest']),
+    xpSinceLongRest: Number(value['xp_since_long_rest'])
+  }
+}
+
+export function adventuringDay(
+  members: readonly PartyCharacter[]
+): AdventuringDaySummary {
+  const active = members.filter((member) => member.active)
+  const withLevel = active.filter(
+    (member): member is PartyCharacter & { level: number } =>
+      member.level !== null
+  )
+  const available = active.length > 0 && withLevel.length === active.length
+  return {
+    available,
+    partySize: active.length,
+    dailyBudget: available
+      ? withLevel.reduce((sum, member) => sum + dailyXp[member.level - 1]!, 0)
+      : 0,
+    shortRestXp: active.reduce(
+      (sum, member) => sum + member.xpSinceShortRest,
+      0
+    ),
+    longRestXp: active.reduce((sum, member) => sum + member.xpSinceLongRest, 0)
+  }
+}
+
+export function calculateAdventuringDay(
+  rows: readonly { level: number; count: number }[],
+  totalXp = 0
+): AdventuringDayCalculation {
+  const budget = rows.reduce(
+    (sum, row) => sum + dailyXp[row.level - 1]! * row.count,
+    0
+  )
+  if (budget === 0)
+    return {
+      dailyBudget: 0,
+      totalXp,
+      completedDays: 0,
+      dayProgress: 0,
+      shortRests: 0,
+      longRests: 0,
+      timeline: []
+    }
+  const completedDays = Math.floor(totalXp / budget)
+  const remainder = totalXp % budget
+  const partialRests = Math.min(2, Math.floor(remainder / (budget / 3)))
+  const timeline = Array.from(
+    { length: completedDays },
+    (_, index) => `Tag ${index + 1}: ${budget.toLocaleString()} XP · Long Rest`
+  )
+  if (remainder > 0)
+    timeline.push(
+      `Tag ${completedDays + 1}: ${remainder.toLocaleString()} / ${budget.toLocaleString()} XP`
+    )
+  return {
+    dailyBudget: budget,
+    totalXp,
+    completedDays,
+    dayProgress: remainder / budget,
+    shortRests: completedDays * 2 + partialRests,
+    longRests: completedDays,
+    timeline
+  }
+}

--- a/src/core/persistence/sqlite/campaign-store.ts
+++ b/src/core/persistence/sqlite/campaign-store.ts
@@ -5,8 +5,12 @@ import type {
   Campaign,
   CampaignSnapshot
 } from '../../../shared/contracts/campaign.js'
-import { uuidv7 } from '../../../shared/ids/uuidv7.js'
 import { freezeCampaignSnapshot } from '../../../shared/contracts/campaign.js'
+import { uuidv7 } from '../../../shared/ids/uuidv7.js'
+import { initializePartySchema } from '../../party/party-store.js'
+import { initializeSceneSchema } from '../../scene/scene-store.js'
+import { initializeCombatSchema } from '../../encounter/live-combat.js'
+import { initializeWorldLocationSchema } from '../../worldplanner/location-store.js'
 
 export type CampaignCreatePhase =
   | 'before-registry-entry'
@@ -95,6 +99,12 @@ export class CampaignStore {
     this.installation.close()
   }
 
+  activeCampaignPath(): string {
+    const id = this.list().activeCampaignId
+    if (!id) throw new Error('Campaign not found')
+    return this.campaignPath(id)
+  }
+
   private addCreationStatusToPreCutoverStore(): void {
     const columns = this.installation
       .prepare('PRAGMA table_info(campaigns)')
@@ -114,6 +124,10 @@ export class CampaignStore {
     campaign.exec(
       'CREATE TABLE IF NOT EXISTS campaign_runtime (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL)'
     )
+    initializePartySchema(campaign)
+    initializeSceneSchema(campaign)
+    initializeCombatSchema(campaign)
+    initializeWorldLocationSchema(campaign)
     campaign.close()
   }
 

--- a/src/core/scene/group-generator.ts
+++ b/src/core/scene/group-generator.ts
@@ -1,0 +1,469 @@
+import type {
+  Creature,
+  CreatureCatalogQuery
+} from '../../shared/contracts/encounter.js'
+import type { EncounterTuning } from '../../shared/contracts/encounter-tuning.js'
+import type { PartyMember } from '../../shared/contracts/live-session.js'
+import {
+  encounterSelectionEvaluationSchema,
+  sceneGroupDraftEvaluationSchema,
+  sceneGroupDraftGenerationSchema,
+  type EncounterSelectionEvaluation,
+  type GroupGenerationMode,
+  type RunningScene,
+  type SceneGroup,
+  type SceneGroupDraftEntry,
+  type SceneGroupDraftEvaluation,
+  type SceneGroupDraftGeneration
+} from '../../shared/contracts/scene.js'
+import {
+  creatureById,
+  creatureMatchesQuery,
+  creatures
+} from '../creatures/catalog.js'
+import { difficulty, multiplier, partyThresholds } from '../encounter/math.js'
+import type { ResolvedEncounterSource } from '../worldplanner/encounter-source-store.js'
+
+type DraftEntry = { creatureId: string; quantity: number }
+
+type GeneratedOption = {
+  entries: DraftEntry[]
+  adjustedXp: number
+  exact: boolean
+  score: number
+  weight: number
+}
+
+export function evaluateSceneGroups(
+  scene: RunningScene,
+  assignedParty: readonly PartyMember[],
+  groupIds: readonly string[]
+): EncounterSelectionEvaluation {
+  const selectedIds = Array.from(new Set(groupIds))
+  const selected = selectedIds.map((id) =>
+    scene.groups.find((group) => group.id === id)
+  )
+  if (selected.some((group) => group === undefined))
+    throw new Error('not found')
+  const groups = selected as SceneGroup[]
+  const evaluation = evaluateSceneGroupDraft(
+    scene.id,
+    assignedParty,
+    groups.flatMap((group) => group.entries)
+  )
+  return encounterSelectionEvaluationSchema.parse({
+    ...evaluation,
+    selectedGroupIds: selectedIds,
+    canStart: evaluation.canStart && groups.length > 0,
+    message:
+      groups.length === 0
+        ? 'Mindestens eine Scene-Gruppe auswählen.'
+        : evaluation.message === 'Gruppe ist kampfbereit.'
+          ? 'Auswahl ist kampfbereit.'
+          : evaluation.message
+  })
+}
+
+export function evaluateSceneGroupDraft(
+  sceneId: string,
+  assignedParty: readonly PartyMember[],
+  input: readonly SceneGroupDraftEntry[]
+): SceneGroupDraftEvaluation {
+  const entries = normalizeEntries(input)
+  const creatureCount = entries.reduce((sum, entry) => sum + entry.quantity, 0)
+  const baseXp = entries.reduce(
+    (sum, entry) =>
+      sum + (creatureById(entry.creatureId)?.xp ?? 0) * entry.quantity,
+    0
+  )
+  const thresholds = partyThresholds(assignedParty)
+  const adjustedXp = Math.round(
+    baseXp * multiplier(creatureCount, Math.max(1, assignedParty.length))
+  )
+  const completeLevels = assignedParty.every((member) => member.level !== null)
+  const available = entries.every((entry) => creatureById(entry.creatureId))
+  const canStart =
+    assignedParty.length > 0 && completeLevels && creatureCount > 0 && available
+  return sceneGroupDraftEvaluationSchema.parse({
+    sceneId,
+    partySize: assignedParty.length,
+    creatureCount,
+    partyThresholds: thresholds,
+    baseXp,
+    adjustedXp,
+    difficultyLabel: completeLevels
+      ? difficulty(adjustedXp, thresholds)
+      : 'Party-Level fehlen',
+    canStart,
+    message:
+      assignedParty.length === 0
+        ? 'Der Scene sind keine aktiven PCs zugewiesen.'
+        : !completeLevels
+          ? 'Für das Balancing brauchen alle zugewiesenen PCs ein Level.'
+          : creatureCount === 0
+            ? 'Mindestens ein Monster hinzufügen.'
+            : !available
+              ? 'Die Gruppe enthält nicht verfügbare Monster.'
+              : 'Gruppe ist kampfbereit.'
+  })
+}
+
+export function generateSceneGroupDraft(
+  scene: RunningScene,
+  assignedParty: readonly PartyMember[],
+  input: readonly SceneGroupDraftEntry[],
+  mode: GroupGenerationMode,
+  filters: CreatureCatalogQuery,
+  tuning: EncounterTuning,
+  seed: number,
+  sceneRevision: number,
+  source: ResolvedEncounterSource = {
+    candidates: null,
+    effectiveEncounterTableIds: [],
+    effectiveFactionIds: [],
+    locationId: filters.locationId,
+    catalogFallback: true
+  }
+): SceneGroupDraftGeneration {
+  if (
+    assignedParty.length === 0 ||
+    assignedParty.some((member) => member.level === null)
+  )
+    throw new Error('validation')
+
+  const base = mode === 'fill' ? normalizeEntries(input) : []
+  const thresholds = partyThresholds(assignedParty)
+  const resolvedDifficulty =
+    tuning.difficulty === 'auto' ? 'medium' : tuning.difficulty
+  const band = { easy: 0, medium: 1, hard: 2, deadly: 3 }[resolvedDifficulty]
+  const lower = thresholds[band] ?? 0
+  const upper =
+    band < 3
+      ? (thresholds[band + 1] ?? Math.round(lower * 1.35))
+      : Math.round(lower * 1.35)
+  const target = Math.round((lower + upper) / 2)
+  const baseEvaluation = evaluateSceneGroupDraft(scene.id, assignedParty, base)
+
+  if (mode === 'fill' && baseEvaluation.adjustedXp >= lower) {
+    const exact = baseEvaluation.adjustedXp < upper
+    return generationResult(
+      scene,
+      assignedParty,
+      base,
+      sceneRevision,
+      resolvedDifficulty,
+      exact ? 'exact' : 'fallback',
+      exact
+        ? 'Die Gruppe liegt bereits im gewünschten Schwierigkeitsband.'
+        : 'Die Gruppe erreicht oder überschreitet das gewünschte Schwierigkeitsband und wurde nicht verändert.',
+      source
+    )
+  }
+
+  const sourceByCreature = new Map(
+    source.candidates?.map((candidate) => [candidate.creatureId, candidate]) ??
+      []
+  )
+  const pool = creatures.filter(
+    (creature) =>
+      (source.candidates === null || sourceByCreature.has(creature.id)) &&
+      creatureMatchesQuery(creature, filters)
+  )
+  const maxCount = preferredMaximum(tuning.amount)
+  const options = generateOptions(
+    base,
+    pool,
+    lower,
+    upper,
+    target,
+    assignedParty.length,
+    maxCount,
+    tuning,
+    sourceByCreature
+  )
+  const option =
+    options.length > 0 ? weightedOption(options.slice(0, 5), seed) : undefined
+  const entries = option?.entries ?? base
+
+  return generationResult(
+    scene,
+    assignedParty,
+    entries,
+    sceneRevision,
+    resolvedDifficulty,
+    !option ? 'none' : option.exact ? 'exact' : 'fallback',
+    !option
+      ? pool.length === 0
+        ? 'Keine Monster entsprechen den gewählten Filtern.'
+        : 'Mit den gewählten Mengenregeln konnte die Gruppe nicht ergänzt werden.'
+      : option.exact
+        ? 'Das gewünschte Schwierigkeitsband wurde getroffen.'
+        : 'Beste verfügbare Annäherung.',
+    source
+  )
+}
+
+function generationResult(
+  scene: RunningScene,
+  assignedParty: readonly PartyMember[],
+  entries: readonly DraftEntry[],
+  sceneRevision: number,
+  resolvedDifficulty: string,
+  quality: 'exact' | 'fallback' | 'none',
+  message: string,
+  source: ResolvedEncounterSource
+): SceneGroupDraftGeneration {
+  return sceneGroupDraftGenerationSchema.parse({
+    sceneId: scene.id,
+    sceneRevision,
+    name: `${title(resolvedDifficulty)}-Gruppe`,
+    entries: entries.map((entry) => {
+      const creature = creatureById(entry.creatureId)
+      return {
+        ...entry,
+        displayName:
+          creature?.name ?? existingDisplayName(scene, entry.creatureId),
+        cr: creature?.cr ?? 0,
+        xp: creature?.xp ?? 0,
+        available: creature !== undefined
+      }
+    }),
+    evaluation: evaluateSceneGroupDraft(scene.id, assignedParty, entries),
+    context: {
+      sceneTitle: scene.title,
+      locationId: scene.locationId,
+      locationName: scene.locationName,
+      existingGroupCount: scene.groups.length,
+      effectiveEncounterTableIds: source.effectiveEncounterTableIds,
+      effectiveFactionIds: source.effectiveFactionIds,
+      catalogFallback: source.catalogFallback
+    },
+    quality,
+    message: source.catalogFallback
+      ? `Keine wirksame Encounter-Tabelle; Katalog-Fallback. ${message}`
+      : message
+  })
+}
+
+function existingDisplayName(scene: RunningScene, creatureId: string): string {
+  for (const group of scene.groups) {
+    const entry = group.entries.find(
+      (candidate) => candidate.creatureId === creatureId
+    )
+    if (entry) return entry.displayName
+  }
+  return `Nicht verfügbares Monster (${creatureId})`
+}
+
+function preferredMaximum(amount: EncounterTuning['amount']): number {
+  return amount === 'few' ? 3 : amount === 'many' ? 10 : 6
+}
+
+function generateOptions(
+  base: readonly DraftEntry[],
+  pool: readonly Creature[],
+  lower: number,
+  upper: number,
+  target: number,
+  partySize: number,
+  maxCount: number,
+  tuning: EncounterTuning,
+  sourceByCreature: ReadonlyMap<
+    string,
+    { weight: number; maximum: number | null }
+  >
+): GeneratedOption[] {
+  const baseCount = count(base)
+  const remaining = maxCount - baseCount
+  if (remaining <= 0 || pool.length === 0) return []
+
+  const additions: DraftEntry[][] = []
+  for (const creature of pool) {
+    const maximum = sourceByCreature.get(creature.id)?.maximum ?? null
+    const already =
+      base.find((entry) => entry.creatureId === creature.id)?.quantity ?? 0
+    const available =
+      maximum === null ? remaining : Math.max(0, maximum - already)
+    for (
+      let quantity = 1;
+      quantity <= Math.min(remaining, available);
+      quantity += 1
+    )
+      additions.push([{ creatureId: creature.id, quantity }])
+  }
+
+  const rankedPool = [...pool]
+    .sort((a, b) => Math.abs(target - a.xp) - Math.abs(target - b.xp))
+    .slice(0, 24)
+  if (remaining >= 2) {
+    for (let left = 0; left < rankedPool.length; left += 1) {
+      for (let right = left + 1; right < rankedPool.length; right += 1) {
+        if (!canAdd(rankedPool[left]!.id, base, sourceByCreature)) continue
+        if (!canAdd(rankedPool[right]!.id, base, sourceByCreature)) continue
+        additions.push([
+          { creatureId: rankedPool[left]!.id, quantity: 1 },
+          { creatureId: rankedPool[right]!.id, quantity: 1 }
+        ])
+      }
+    }
+  }
+
+  if (remaining >= 3) {
+    const diversePool = rankedPool.slice(0, 12)
+    for (let first = 0; first < diversePool.length; first += 1) {
+      for (let second = first + 1; second < diversePool.length; second += 1) {
+        for (let third = second + 1; third < diversePool.length; third += 1) {
+          if (!canAdd(diversePool[first]!.id, base, sourceByCreature)) continue
+          if (!canAdd(diversePool[second]!.id, base, sourceByCreature)) continue
+          if (!canAdd(diversePool[third]!.id, base, sourceByCreature)) continue
+          additions.push([
+            { creatureId: diversePool[first]!.id, quantity: 1 },
+            { creatureId: diversePool[second]!.id, quantity: 1 },
+            { creatureId: diversePool[third]!.id, quantity: 1 }
+          ])
+        }
+      }
+    }
+  }
+
+  const unique = new Map<string, GeneratedOption>()
+  for (const addition of additions) {
+    const entries = mergeEntries(base, addition)
+    const baseXp = entries.reduce(
+      (sum, entry) =>
+        sum + (creatureById(entry.creatureId)?.xp ?? 0) * entry.quantity,
+      0
+    )
+    const adjustedXp = Math.round(
+      baseXp * multiplier(count(entries), partySize)
+    )
+    const exact = adjustedXp >= lower && adjustedXp < upper
+    const score =
+      bandDistance(adjustedXp, lower, upper) * 1000 +
+      Math.abs(target - adjustedXp) +
+      tuningPenalty(entries, target, tuning)
+    const weight = addition.reduce(
+      (sum, entry) =>
+        sum +
+        (sourceByCreature.get(entry.creatureId)?.weight ?? 1) * entry.quantity,
+      0
+    )
+    const key = entries
+      .map((entry) => `${entry.creatureId}:${entry.quantity}`)
+      .join('|')
+    const current = unique.get(key)
+    if (!current || score < current.score)
+      unique.set(key, { entries, adjustedXp, exact, score, weight })
+  }
+
+  return [...unique.values()].sort(
+    (a, b) =>
+      Number(b.exact) - Number(a.exact) ||
+      a.score - b.score ||
+      b.weight - a.weight ||
+      a.adjustedXp - b.adjustedXp ||
+      rosterKey(a.entries).localeCompare(rosterKey(b.entries))
+  )
+}
+
+function canAdd(
+  creatureId: string,
+  base: readonly DraftEntry[],
+  source: ReadonlyMap<string, { maximum: number | null }>
+): boolean {
+  const maximum = source.get(creatureId)?.maximum ?? null
+  const current =
+    base.find((entry) => entry.creatureId === creatureId)?.quantity ?? 0
+  return maximum === null || current < maximum
+}
+
+function weightedOption(
+  options: readonly GeneratedOption[],
+  seed: number
+): GeneratedOption | undefined {
+  const total = options.reduce(
+    (sum, option) => sum + Math.max(1, option.weight),
+    0
+  )
+  if (total === 0) return undefined
+  let cursor = seed % total
+  for (const option of options) {
+    cursor -= Math.max(1, option.weight)
+    if (cursor < 0) return option
+  }
+  return options.at(-1)
+}
+
+function tuningPenalty(
+  entries: readonly DraftEntry[],
+  target: number,
+  tuning: EncounterTuning
+): number {
+  const distinct = entries.length
+  const desiredCount =
+    tuning.amount === 'few' ? 2 : tuning.amount === 'many' ? 8 : 4
+  const amountPenalty = Math.abs(count(entries) - desiredCount) * target * 0.02
+  const diversityPenalty =
+    tuning.diversity === 'low'
+      ? Math.max(0, distinct - 1) * target * 0.08
+      : tuning.diversity === 'high'
+        ? Math.max(0, 3 - distinct) * target * 0.08
+        : 0
+  const xp = entries.map((entry) => creatureById(entry.creatureId)?.xp ?? 0)
+  const maximum = Math.max(1, ...xp)
+  const spread = (Math.max(...xp) - Math.min(...xp)) / maximum
+  const balancePenalty =
+    tuning.balance === 'even'
+      ? spread * target * 0.08
+      : tuning.balance === 'varied'
+        ? (1 - spread) * target * 0.08
+        : 0
+  return amountPenalty + diversityPenalty + balancePenalty
+}
+
+function bandDistance(
+  adjustedXp: number,
+  lower: number,
+  upper: number
+): number {
+  return adjustedXp < lower
+    ? lower - adjustedXp
+    : adjustedXp >= upper
+      ? adjustedXp - upper + 1
+      : 0
+}
+
+function normalizeEntries(
+  input: readonly SceneGroupDraftEntry[]
+): DraftEntry[] {
+  return mergeEntries([], input)
+}
+
+function mergeEntries(
+  base: readonly DraftEntry[],
+  additions: readonly DraftEntry[]
+): DraftEntry[] {
+  const quantities = new Map<string, number>()
+  for (const entry of [...base, ...additions])
+    quantities.set(
+      entry.creatureId,
+      Math.min(999, (quantities.get(entry.creatureId) ?? 0) + entry.quantity)
+    )
+  return [...quantities.entries()]
+    .map(([creatureId, quantity]) => ({ creatureId, quantity }))
+    .sort((a, b) => a.creatureId.localeCompare(b.creatureId))
+}
+
+function count(entries: readonly DraftEntry[]): number {
+  return entries.reduce((sum, entry) => sum + entry.quantity, 0)
+}
+
+function rosterKey(entries: readonly DraftEntry[]): string {
+  return entries
+    .map((entry) => `${entry.creatureId}:${entry.quantity}`)
+    .join('|')
+}
+
+function title(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}

--- a/src/core/scene/scene-store.ts
+++ b/src/core/scene/scene-store.ts
@@ -1,0 +1,386 @@
+import Database from 'better-sqlite3'
+import {
+  sceneSnapshotSchema,
+  type RunningScene,
+  type SceneGroup,
+  type SceneSnapshot
+} from '../../shared/contracts/scene.js'
+import type { PartyMember } from '../../shared/contracts/live-session.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+import { creatureById } from '../creatures/catalog.js'
+import type { WorldLocation } from '../../shared/contracts/world-location.js'
+
+export function initializeSceneSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS scene_workspace (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0),
+      default_scene_id TEXT NOT NULL,
+      focused_scene_id TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS scene_running_scene (
+      id TEXT PRIMARY KEY NOT NULL,
+      title TEXT NOT NULL,
+      location_id TEXT,
+      location_name TEXT NOT NULL DEFAULT '',
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS scene_party_member (
+      scene_id TEXT NOT NULL REFERENCES scene_running_scene(id) ON DELETE CASCADE,
+      party_member_id TEXT NOT NULL UNIQUE,
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY(scene_id, party_member_id)
+    );
+    CREATE TABLE IF NOT EXISTS scene_group (
+      id TEXT PRIMARY KEY NOT NULL,
+      scene_id TEXT NOT NULL REFERENCES scene_running_scene(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS scene_group_entry (
+      id TEXT PRIMARY KEY NOT NULL,
+      group_id TEXT NOT NULL REFERENCES scene_group(id) ON DELETE CASCADE,
+      creature_id TEXT NOT NULL,
+      quantity INTEGER NOT NULL CHECK(quantity > 0),
+      position INTEGER NOT NULL CHECK(position >= 0),
+      UNIQUE(group_id, creature_id)
+    );
+  `)
+  const exists = db
+    .prepare('SELECT 1 FROM scene_workspace WHERE singleton = 1')
+    .get()
+  if (exists !== undefined) return
+  const sceneId = uuidv7()
+  db.transaction(() => {
+    db.prepare(
+      'INSERT INTO scene_workspace (singleton, revision, default_scene_id, focused_scene_id) VALUES (1, 0, ?, ?)'
+    ).run(sceneId, sceneId)
+    db.prepare(
+      "INSERT INTO scene_running_scene (id, title, location_id, location_name, position) VALUES (?, 'Standardszene', NULL, '', 0)"
+    ).run(sceneId)
+    const active = db
+      .prepare(
+        'SELECT id FROM player_characters WHERE active = 1 ORDER BY position, id'
+      )
+      .all() as { id: string }[]
+    const insert = db.prepare(
+      'INSERT INTO scene_party_member (scene_id, party_member_id, position) VALUES (?, ?, ?)'
+    )
+    active.forEach((member, position) =>
+      insert.run(sceneId, member.id, position)
+    )
+  })()
+}
+
+export class SceneStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly locationProvider: () => readonly WorldLocation[] = () => []
+  ) {}
+
+  database(): Database.Database {
+    return this.db
+  }
+
+  revision(): number {
+    return this.root().revision
+  }
+
+  focusedSceneId(): string {
+    return this.root().focusedSceneId
+  }
+
+  snapshot(party: readonly PartyMember[]): SceneSnapshot {
+    const root = this.root()
+    const locations = this.locationProvider()
+    const rows = this.db
+      .prepare(
+        'SELECT id, title, location_id AS locationId, position FROM scene_running_scene ORDER BY position, id'
+      )
+      .all() as Array<{
+      id: string
+      title: string
+      locationId: string | null
+      position: number
+    }>
+    const scenes = rows.map((row) => this.resolveScene(row, root, locations))
+    const assigned = new Set(scenes.flatMap((scene) => scene.partyMemberIds))
+    return sceneSnapshotSchema.parse({
+      revision: root.revision,
+      defaultSceneId: root.defaultSceneId,
+      focusedSceneId: root.focusedSceneId,
+      scenes,
+      locationChoices: locations
+        .map((location) => ({
+          id: location.id,
+          displayName: location.displayName
+        }))
+        .sort((a, b) => a.displayName.localeCompare(b.displayName)),
+      unassignedPartyMemberIds: party
+        .filter((member) => member.active && !assigned.has(member.id))
+        .map((member) => member.id)
+    })
+  }
+
+  focused(party: readonly PartyMember[]): RunningScene {
+    const snapshot = this.snapshot(party)
+    const scene = snapshot.scenes.find(
+      (candidate) => candidate.id === snapshot.focusedSceneId
+    )
+    if (!scene) throw new Error('not found')
+    return scene
+  }
+
+  focus(sceneId: string, expectedRevision: number): void {
+    this.mutate(expectedRevision, () => {
+      this.requireScene(sceneId)
+      this.db
+        .prepare(
+          'UPDATE scene_workspace SET focused_scene_id = ? WHERE singleton = 1'
+        )
+        .run(sceneId)
+    })
+  }
+
+  setLocation(
+    sceneId: string,
+    locationId: string | null,
+    expectedRevision: number
+  ): void {
+    this.mutate(expectedRevision, () => {
+      this.requireScene(sceneId)
+      this.db
+        .prepare(
+          "UPDATE scene_running_scene SET location_id = ?, location_name = '' WHERE id = ?"
+        )
+        .run(locationId, sceneId)
+    })
+  }
+
+  assignedParty(
+    party: readonly PartyMember[],
+    sceneId = this.focusedSceneId()
+  ): PartyMember[] {
+    const ids = new Set(
+      (
+        this.db
+          .prepare(
+            'SELECT party_member_id AS id FROM scene_party_member WHERE scene_id = ? ORDER BY position'
+          )
+          .all(sceneId) as { id: string }[]
+      ).map((row) => row.id)
+    )
+    return party.filter((member) => member.active && ids.has(member.id))
+  }
+
+  assignPartyMember(
+    sceneId: string,
+    partyMemberId: string,
+    assigned: boolean,
+    expectedRevision: number
+  ): void {
+    this.mutate(expectedRevision, () => {
+      this.requireScene(sceneId)
+      if (assigned) {
+        const member = this.db
+          .prepare('SELECT active FROM player_characters WHERE id = ?')
+          .get(partyMemberId) as { active: number } | undefined
+        if (!member || member.active !== 1) throw new Error('not found')
+        this.db
+          .prepare('DELETE FROM scene_party_member WHERE party_member_id = ?')
+          .run(partyMemberId)
+        this.db
+          .prepare(
+            'INSERT INTO scene_party_member (scene_id, party_member_id, position) VALUES (?, ?, COALESCE((SELECT MAX(position) + 1 FROM scene_party_member WHERE scene_id = ?), 0))'
+          )
+          .run(sceneId, partyMemberId, sceneId)
+      } else {
+        this.db
+          .prepare(
+            'DELETE FROM scene_party_member WHERE scene_id = ? AND party_member_id = ?'
+          )
+          .run(sceneId, partyMemberId)
+      }
+    })
+  }
+
+  unassignPartyMember(partyMemberId: string): void {
+    const changed = this.db
+      .prepare('DELETE FROM scene_party_member WHERE party_member_id = ?')
+      .run(partyMemberId).changes
+    if (changed > 0) this.bump()
+  }
+
+  saveGroup(
+    sceneId: string,
+    groupId: string | null,
+    name: string,
+    entries: readonly { creatureId: string; quantity: number }[],
+    expectedRevision: number
+  ): void {
+    this.mutate(expectedRevision, () => {
+      this.requireScene(sceneId)
+      const normalized = normalizeEntries(entries)
+      if (normalized.size === 0) throw new Error('validation')
+      for (const creatureId of normalized.keys())
+        if (!creatureById(creatureId)) throw new Error('not found')
+      const id = groupId ?? uuidv7()
+      if (groupId) {
+        const group = this.db
+          .prepare('SELECT scene_id AS sceneId FROM scene_group WHERE id = ?')
+          .get(groupId) as { sceneId: string } | undefined
+        if (!group || group.sceneId !== sceneId) throw new Error('not found')
+        this.db
+          .prepare('UPDATE scene_group SET name = ? WHERE id = ?')
+          .run(name, id)
+        this.db
+          .prepare('DELETE FROM scene_group_entry WHERE group_id = ?')
+          .run(id)
+      } else {
+        this.db
+          .prepare(
+            'INSERT INTO scene_group (id, scene_id, name, position) VALUES (?, ?, ?, COALESCE((SELECT MAX(position) + 1 FROM scene_group WHERE scene_id = ?), 0))'
+          )
+          .run(id, sceneId, name, sceneId)
+      }
+      const insert = this.db.prepare(
+        'INSERT INTO scene_group_entry (id, group_id, creature_id, quantity, position) VALUES (?, ?, ?, ?, ?)'
+      )
+      Array.from(normalized).forEach(([creatureId, quantity], position) =>
+        insert.run(uuidv7(), id, creatureId, quantity, position)
+      )
+    })
+  }
+
+  deleteGroup(
+    sceneId: string,
+    groupId: string,
+    expectedRevision: number
+  ): void {
+    this.mutate(expectedRevision, () => {
+      const result = this.db
+        .prepare('DELETE FROM scene_group WHERE id = ? AND scene_id = ?')
+        .run(groupId, sceneId)
+      if (result.changes === 0) throw new Error('not found')
+    })
+  }
+
+  groups(sceneId: string): readonly SceneGroup[] {
+    this.requireScene(sceneId)
+    const rows = this.db
+      .prepare(
+        'SELECT id, name, position FROM scene_group WHERE scene_id = ? ORDER BY position, id'
+      )
+      .all(sceneId) as Array<{ id: string; name: string; position: number }>
+    return rows.map((row) => ({ ...row, entries: this.groupEntries(row.id) }))
+  }
+
+  private resolveScene(
+    row: {
+      id: string
+      title: string
+      locationId: string | null
+      position: number
+    },
+    root: SceneRoot,
+    locations: readonly WorldLocation[]
+  ): RunningScene {
+    const partyMemberIds = (
+      this.db
+        .prepare(
+          'SELECT party_member_id AS id FROM scene_party_member WHERE scene_id = ? ORDER BY position, party_member_id'
+        )
+        .all(row.id) as { id: string }[]
+    ).map((member) => member.id)
+    const location = locations.find(
+      (candidate) => candidate.id === row.locationId
+    )
+    return {
+      id: row.id,
+      title: row.title,
+      defaultScene: row.id === root.defaultSceneId,
+      focused: row.id === root.focusedSceneId,
+      locationId: row.locationId,
+      locationName: row.locationId
+        ? (location?.displayName ?? 'Nicht verfügbarer Ort')
+        : '',
+      partyMemberIds,
+      groups: [...this.groups(row.id)]
+    }
+  }
+
+  private groupEntries(groupId: string): SceneGroup['entries'] {
+    return (
+      this.db
+        .prepare(
+          'SELECT id, creature_id AS creatureId, quantity, position FROM scene_group_entry WHERE group_id = ? ORDER BY position, id'
+        )
+        .all(groupId) as Array<{
+        id: string
+        creatureId: string
+        quantity: number
+        position: number
+      }>
+    ).map((entry) => {
+      const creature = creatureById(entry.creatureId)
+      return {
+        ...entry,
+        displayName: creature?.name ?? 'Nicht verfügbare Kreatur',
+        available: creature !== undefined
+      }
+    })
+  }
+
+  private requireScene(id: string): void {
+    if (
+      this.db
+        .prepare('SELECT 1 FROM scene_running_scene WHERE id = ?')
+        .get(id) === undefined
+    )
+      throw new Error('not found')
+  }
+
+  private root(): SceneRoot {
+    return this.db
+      .prepare(
+        'SELECT revision, default_scene_id AS defaultSceneId, focused_scene_id AS focusedSceneId FROM scene_workspace WHERE singleton = 1'
+      )
+      .get() as SceneRoot
+  }
+
+  private mutate(expectedRevision: number, operation: () => void): void {
+    this.db.transaction(() => {
+      if (this.revision() !== expectedRevision) throw new Error('stale')
+      operation()
+      this.bump()
+    })()
+  }
+
+  private bump(): void {
+    this.db
+      .prepare(
+        'UPDATE scene_workspace SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
+  }
+}
+
+interface SceneRoot {
+  revision: number
+  defaultSceneId: string
+  focusedSceneId: string
+}
+
+function normalizeEntries(
+  entries: readonly { creatureId: string; quantity: number }[]
+): Map<string, number> {
+  const normalized = new Map<string, number>()
+  for (const entry of entries) {
+    if (entry.quantity <= 0) continue
+    normalized.set(
+      entry.creatureId,
+      (normalized.get(entry.creatureId) ?? 0) + entry.quantity
+    )
+  }
+  return normalized
+}

--- a/src/core/worldplanner/encounter-source-store.ts
+++ b/src/core/worldplanner/encounter-source-store.ts
@@ -1,0 +1,718 @@
+import Database from 'better-sqlite3'
+import {
+  encounterTableDraftSchema,
+  encounterTableSnapshotSchema,
+  worldFactionDraftSchema,
+  worldFactionSnapshotSchema,
+  type EncounterTableDraft,
+  type EncounterTableSnapshot,
+  type WorldFactionDraft,
+  type WorldFactionSnapshot
+} from '../../shared/contracts/encounter-source.js'
+import type { CreatureCatalogQuery } from '../../shared/contracts/encounter.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+import { creatureById } from '../creatures/catalog.js'
+import {
+  initializeWorldLocationSchema,
+  WorldLocationStore
+} from './location-store.js'
+
+export type ResolvedSourceCandidate = Readonly<{
+  creatureId: string
+  weight: number
+  maximum: number | null
+}>
+
+export type ResolvedEncounterSource = Readonly<{
+  candidates: readonly ResolvedSourceCandidate[] | null
+  effectiveEncounterTableIds: readonly string[]
+  effectiveFactionIds: readonly string[]
+  locationId: string | null
+  catalogFallback: boolean
+}>
+
+export function initializeEncounterSourceSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS encounter_table_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_table (
+      id TEXT PRIMARY KEY NOT NULL,
+      display_name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_table_entry (
+      encounter_table_id TEXT NOT NULL,
+      creature_id TEXT NOT NULL,
+      weight INTEGER NOT NULL CHECK(weight BETWEEN 1 AND 10),
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY (encounter_table_id, creature_id)
+    );
+    CREATE TABLE IF NOT EXISTS encounter_table_loot_link (
+      encounter_table_id TEXT PRIMARY KEY NOT NULL,
+      loot_table_id TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_encounter_table_name
+      ON encounter_table(display_name COLLATE NOCASE, id);
+
+    CREATE TABLE IF NOT EXISTS worldplanner_faction_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS worldplanner_faction (
+      id TEXT PRIMARY KEY NOT NULL,
+      display_name TEXT NOT NULL,
+      notes TEXT NOT NULL,
+      disposition INTEGER NOT NULL CHECK(disposition BETWEEN -50 AND 50),
+      primary_encounter_table_id TEXT,
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS worldplanner_faction_inventory (
+      faction_id TEXT NOT NULL,
+      creature_id TEXT NOT NULL,
+      maximum INTEGER NOT NULL CHECK(maximum >= 0),
+      PRIMARY KEY (faction_id, creature_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worldplanner_faction_name
+      ON worldplanner_faction(display_name COLLATE NOCASE, id);
+
+    CREATE TABLE IF NOT EXISTS worldplanner_location_faction (
+      location_id TEXT NOT NULL,
+      faction_id TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY (location_id, faction_id)
+    );
+    CREATE TABLE IF NOT EXISTS worldplanner_location_encounter_table (
+      location_id TEXT NOT NULL,
+      encounter_table_id TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY (location_id, encounter_table_id)
+    );
+  `)
+  db.prepare(
+    'INSERT OR IGNORE INTO encounter_table_metadata (singleton, revision) VALUES (1, 0)'
+  ).run()
+  db.prepare(
+    'INSERT OR IGNORE INTO worldplanner_faction_metadata (singleton, revision) VALUES (1, 0)'
+  ).run()
+}
+
+export class EncounterTableStore {
+  constructor(private readonly db: Database.Database) {}
+
+  read(): EncounterTableSnapshot {
+    const revision = this.revision()
+    const rows = this.db
+      .prepare(
+        'SELECT id, display_name AS displayName, description, position FROM encounter_table ORDER BY position, id'
+      )
+      .all() as {
+      id: string
+      displayName: string
+      description: string
+      position: number
+    }[]
+    return encounterTableSnapshotSchema.parse({
+      revision,
+      tables: rows.map((row) => ({
+        ...row,
+        entries: this.db
+          .prepare(
+            'SELECT creature_id AS creatureId, weight, position FROM encounter_table_entry WHERE encounter_table_id = ? ORDER BY position, creature_id'
+          )
+          .all(row.id)
+      }))
+    })
+  }
+
+  create(draft: EncounterTableDraft, expectedRevision: number) {
+    const parsed = encounterTableDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      this.assertCreatures(parsed.entries.map((entry) => entry.creatureId))
+      const id = uuidv7()
+      const position = this.nextPosition('encounter_table')
+      this.db
+        .prepare(
+          'INSERT INTO encounter_table (id, display_name, description, position) VALUES (?, ?, ?, ?)'
+        )
+        .run(id, parsed.displayName, parsed.description, position)
+      this.replaceEntries(id, parsed.entries)
+    })
+    return this.read()
+  }
+
+  update(id: string, draft: EncounterTableDraft, expectedRevision: number) {
+    const parsed = encounterTableDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      this.assertCreatures(parsed.entries.map((entry) => entry.creatureId))
+      const changed = this.db
+        .prepare(
+          'UPDATE encounter_table SET display_name = ?, description = ? WHERE id = ?'
+        )
+        .run(parsed.displayName, parsed.description, id).changes
+      if (changed === 0) throw new Error('not found')
+      this.replaceEntries(id, parsed.entries)
+    })
+    return this.read()
+  }
+
+  delete(id: string, expectedRevision: number) {
+    this.mutate(expectedRevision, () => {
+      if (
+        this.db.prepare('DELETE FROM encounter_table WHERE id = ?').run(id)
+          .changes === 0
+      )
+        throw new Error('not found')
+      this.db
+        .prepare(
+          'DELETE FROM encounter_table_entry WHERE encounter_table_id = ?'
+        )
+        .run(id)
+      this.db
+        .prepare(
+          'DELETE FROM encounter_table_loot_link WHERE encounter_table_id = ?'
+        )
+        .run(id)
+    })
+    return this.read()
+  }
+
+  private replaceEntries(
+    id: string,
+    entries: readonly { creatureId: string; weight: number }[]
+  ) {
+    this.db
+      .prepare('DELETE FROM encounter_table_entry WHERE encounter_table_id = ?')
+      .run(id)
+    const insert = this.db.prepare(
+      'INSERT INTO encounter_table_entry (encounter_table_id, creature_id, weight, position) VALUES (?, ?, ?, ?)'
+    )
+    entries.forEach((entry, position) =>
+      insert.run(id, entry.creatureId, entry.weight, position)
+    )
+  }
+
+  private assertCreatures(ids: readonly string[]) {
+    if (ids.some((id) => !creatureById(id))) throw new Error('not found')
+  }
+
+  private revision(): number {
+    return (
+      this.db
+        .prepare(
+          'SELECT revision FROM encounter_table_metadata WHERE singleton = 1'
+        )
+        .get() as { revision: number }
+    ).revision
+  }
+
+  private nextPosition(table: string): number {
+    return (
+      this.db
+        .prepare(
+          `SELECT COALESCE(MAX(position), -1) + 1 AS value FROM ${table}`
+        )
+        .get() as { value: number }
+    ).value
+  }
+
+  private mutate(expectedRevision: number, operation: () => void) {
+    const mutation = () => {
+      if (this.revision() !== expectedRevision) throw new Error('stale')
+      operation()
+      this.db
+        .prepare(
+          'UPDATE encounter_table_metadata SET revision = revision + 1 WHERE singleton = 1'
+        )
+        .run()
+    }
+    if (this.db.inTransaction) mutation()
+    else this.db.transaction(mutation)()
+  }
+}
+
+export class WorldFactionStore {
+  constructor(private readonly db: Database.Database) {}
+
+  read(): WorldFactionSnapshot {
+    const revision = this.revision()
+    const rows = this.db
+      .prepare(
+        `SELECT id, display_name AS displayName, notes, disposition,
+          primary_encounter_table_id AS primaryEncounterTableId, position
+         FROM worldplanner_faction ORDER BY position, id`
+      )
+      .all() as {
+      id: string
+      displayName: string
+      notes: string
+      disposition: number
+      primaryEncounterTableId: string | null
+      position: number
+    }[]
+    return worldFactionSnapshotSchema.parse({
+      revision,
+      factions: rows.map((row) => ({
+        ...row,
+        inventory: this.db
+          .prepare(
+            `SELECT i.creature_id AS creatureId, i.maximum
+             FROM worldplanner_faction_inventory i
+             JOIN worldplanner_faction f ON f.id = i.faction_id
+             JOIN encounter_table_entry e
+               ON e.encounter_table_id = f.primary_encounter_table_id
+              AND e.creature_id = i.creature_id
+             WHERE i.faction_id = ? ORDER BY i.creature_id`
+          )
+          .all(row.id)
+      }))
+    })
+  }
+
+  create(draft: WorldFactionDraft, expectedRevision: number) {
+    const parsed = worldFactionDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      this.assertReferences(parsed)
+      const id = uuidv7()
+      const position = (
+        this.db
+          .prepare(
+            'SELECT COALESCE(MAX(position), -1) + 1 AS value FROM worldplanner_faction'
+          )
+          .get() as { value: number }
+      ).value
+      this.db
+        .prepare(
+          `INSERT INTO worldplanner_faction
+           (id, display_name, notes, disposition, primary_encounter_table_id, position)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          id,
+          parsed.displayName,
+          parsed.notes,
+          parsed.disposition,
+          parsed.primaryEncounterTableId,
+          position
+        )
+      this.replaceInventory(id, parsed.inventory)
+    })
+    return this.read()
+  }
+
+  update(id: string, draft: WorldFactionDraft, expectedRevision: number) {
+    const parsed = worldFactionDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      this.assertReferences(parsed)
+      const changed = this.db
+        .prepare(
+          `UPDATE worldplanner_faction SET display_name = ?, notes = ?, disposition = ?,
+           primary_encounter_table_id = ? WHERE id = ?`
+        )
+        .run(
+          parsed.displayName,
+          parsed.notes,
+          parsed.disposition,
+          parsed.primaryEncounterTableId,
+          id
+        ).changes
+      if (changed === 0) throw new Error('not found')
+      this.replaceInventory(id, parsed.inventory)
+    })
+    return this.read()
+  }
+
+  delete(id: string, expectedRevision: number) {
+    this.mutate(expectedRevision, () => {
+      if (
+        this.db.prepare('DELETE FROM worldplanner_faction WHERE id = ?').run(id)
+          .changes === 0
+      )
+        throw new Error('not found')
+      this.db
+        .prepare(
+          'DELETE FROM worldplanner_faction_inventory WHERE faction_id = ?'
+        )
+        .run(id)
+    })
+    return this.read()
+  }
+
+  clearPrimaryEncounterTable(encounterTableId: string): void {
+    const factionIds = (
+      this.db
+        .prepare(
+          'SELECT id FROM worldplanner_faction WHERE primary_encounter_table_id = ?'
+        )
+        .all(encounterTableId) as { id: string }[]
+    ).map((row) => row.id)
+    const changes = this.db
+      .prepare(
+        'UPDATE worldplanner_faction SET primary_encounter_table_id = NULL WHERE primary_encounter_table_id = ?'
+      )
+      .run(encounterTableId).changes
+    if (changes > 0) {
+      const removeInventory = this.db.prepare(
+        'DELETE FROM worldplanner_faction_inventory WHERE faction_id = ?'
+      )
+      factionIds.forEach((id) => removeInventory.run(id))
+      this.bumpRevision()
+    }
+  }
+
+  pruneInventoryForTable(
+    encounterTableId: string,
+    allowedCreatureIds: readonly string[]
+  ): void {
+    const values: unknown[] = [encounterTableId]
+    const outsideTable =
+      allowedCreatureIds.length === 0
+        ? ''
+        : `AND creature_id NOT IN (${allowedCreatureIds.map(() => '?').join(', ')})`
+    values.push(...allowedCreatureIds)
+    const changes = this.db
+      .prepare(
+        `DELETE FROM worldplanner_faction_inventory
+         WHERE faction_id IN (
+           SELECT id FROM worldplanner_faction
+           WHERE primary_encounter_table_id = ?
+         ) ${outsideTable}`
+      )
+      .run(...values).changes
+    if (changes > 0) this.bumpRevision()
+  }
+
+  private assertReferences(draft: WorldFactionDraft) {
+    if (!draft.primaryEncounterTableId) {
+      if (draft.inventory.length > 0) throw new Error('validation')
+      return
+    }
+    if (
+      !this.db
+        .prepare('SELECT 1 FROM encounter_table WHERE id = ?')
+        .get(draft.primaryEncounterTableId)
+    )
+      throw new Error('not found')
+    if (draft.inventory.some((entry) => !creatureById(entry.creatureId)))
+      throw new Error('not found')
+    const belongs = this.db.prepare(
+      'SELECT 1 FROM encounter_table_entry WHERE encounter_table_id = ? AND creature_id = ?'
+    )
+    if (
+      draft.inventory.some(
+        (entry) => !belongs.get(draft.primaryEncounterTableId, entry.creatureId)
+      )
+    )
+      throw new Error('validation')
+  }
+
+  private replaceInventory(
+    id: string,
+    inventory: readonly { creatureId: string; maximum: number }[]
+  ) {
+    this.db
+      .prepare(
+        'DELETE FROM worldplanner_faction_inventory WHERE faction_id = ?'
+      )
+      .run(id)
+    const insert = this.db.prepare(
+      'INSERT INTO worldplanner_faction_inventory (faction_id, creature_id, maximum) VALUES (?, ?, ?)'
+    )
+    inventory.forEach((entry) =>
+      insert.run(id, entry.creatureId, entry.maximum)
+    )
+  }
+
+  private revision(): number {
+    return (
+      this.db
+        .prepare(
+          'SELECT revision FROM worldplanner_faction_metadata WHERE singleton = 1'
+        )
+        .get() as { revision: number }
+    ).revision
+  }
+
+  private mutate(expectedRevision: number, operation: () => void) {
+    const mutation = () => {
+      if (this.revision() !== expectedRevision) throw new Error('stale')
+      operation()
+      this.bumpRevision()
+    }
+    if (this.db.inTransaction) mutation()
+    else this.db.transaction(mutation)()
+  }
+
+  private bumpRevision(): void {
+    this.db
+      .prepare(
+        'UPDATE worldplanner_faction_metadata SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
+  }
+}
+
+export class EncounterSourceService {
+  constructor(private readonly campaignPath: () => string) {}
+
+  readTables() {
+    return this.withStores(({ tables }) => tables.read())
+  }
+  createTable(draft: EncounterTableDraft, revision: number) {
+    return this.withStores(({ tables }) => tables.create(draft, revision))
+  }
+  updateTable(id: string, draft: EncounterTableDraft, revision: number) {
+    return this.withStores(({ db, tables, factions }) => {
+      db.transaction(() => {
+        tables.update(id, draft, revision)
+        factions.pruneInventoryForTable(
+          id,
+          draft.entries.map((entry) => entry.creatureId)
+        )
+      })()
+      return tables.read()
+    })
+  }
+  deleteTable(id: string, revision: number) {
+    return this.withStores(({ db, tables, factions, locations }) => {
+      db.transaction(() => {
+        tables.delete(id, revision)
+        factions.clearPrimaryEncounterTable(id)
+        locations.unlinkEncounterTable(id)
+      })()
+      return tables.read()
+    })
+  }
+  readFactions() {
+    return this.withStores(({ factions }) => factions.read())
+  }
+  createFaction(draft: WorldFactionDraft, revision: number) {
+    return this.withStores(({ factions }) => factions.create(draft, revision))
+  }
+  updateFaction(id: string, draft: WorldFactionDraft, revision: number) {
+    return this.withStores(({ factions }) =>
+      factions.update(id, draft, revision)
+    )
+  }
+  deleteFaction(id: string, revision: number) {
+    return this.withStores(({ db, factions, locations }) => {
+      db.transaction(() => {
+        factions.delete(id, revision)
+        locations.unlinkFaction(id)
+      })()
+      return factions.read()
+    })
+  }
+  resolve(query: CreatureCatalogQuery) {
+    const db = new Database(this.campaignPath())
+    try {
+      initializeEncounterSourceSchema(db)
+      return resolveEncounterSource(db, query)
+    } finally {
+      db.close()
+    }
+  }
+
+  private withStores<T>(
+    work: (stores: {
+      db: Database.Database
+      tables: EncounterTableStore
+      factions: WorldFactionStore
+      locations: WorldLocationStore
+    }) => T
+  ): T {
+    const db = new Database(this.campaignPath())
+    try {
+      initializeEncounterSourceSchema(db)
+      initializeWorldLocationSchema(db)
+      return work({
+        db,
+        tables: new EncounterTableStore(db),
+        factions: new WorldFactionStore(db),
+        locations: new WorldLocationStore(db)
+      })
+    } finally {
+      db.close()
+    }
+  }
+}
+
+type Dimension = Map<string, { weight: number; maximum: number | null }>
+
+export function resolveEncounterSource(
+  db: Database.Database,
+  query: CreatureCatalogQuery
+): ResolvedEncounterSource {
+  initializeEncounterSourceSchema(db)
+  const dimensions: Dimension[] = []
+  const effectiveTables = new Set<string>()
+  const effectiveFactions = new Set<string>()
+
+  let tableCount = effectiveTables.size
+  const direct = tableDimension(db, query.encounterTableIds, effectiveTables)
+  if (effectiveTables.size > tableCount) dimensions.push(direct)
+
+  tableCount = effectiveTables.size
+  const factions = factionDimension(
+    db,
+    query.factionIds,
+    effectiveFactions,
+    effectiveTables
+  )
+  if (effectiveTables.size > tableCount) dimensions.push(factions)
+
+  if (query.locationId) {
+    tableCount = effectiveTables.size
+    const locationTableIds = ids(
+      db,
+      'SELECT encounter_table_id AS id FROM worldplanner_location_encounter_table WHERE location_id = ? ORDER BY position',
+      query.locationId
+    )
+    const locationFactionIds = ids(
+      db,
+      'SELECT faction_id AS id FROM worldplanner_location_faction WHERE location_id = ? ORDER BY position',
+      query.locationId
+    )
+    const tablePart = tableDimension(db, locationTableIds, effectiveTables)
+    const factionPart = factionDimension(
+      db,
+      locationFactionIds,
+      effectiveFactions,
+      effectiveTables
+    )
+    const location = unionDimensions(tablePart, factionPart)
+    if (effectiveTables.size > tableCount) dimensions.push(location)
+  }
+
+  if (effectiveTables.size === 0)
+    return {
+      candidates: null,
+      effectiveEncounterTableIds: [],
+      effectiveFactionIds: [...effectiveFactions],
+      locationId: query.locationId,
+      catalogFallback: true
+    }
+
+  const candidates = intersectDimensions(dimensions)
+  return {
+    candidates: [...candidates.entries()].map(([creatureId, value]) => ({
+      creatureId,
+      ...value
+    })),
+    effectiveEncounterTableIds: [...effectiveTables],
+    effectiveFactionIds: [...effectiveFactions],
+    locationId: query.locationId,
+    catalogFallback: false
+  }
+}
+
+function tableDimension(
+  db: Database.Database,
+  tableIds: readonly string[],
+  effective: Set<string>
+): Dimension {
+  const result: Dimension = new Map()
+  const table = db.prepare('SELECT 1 FROM encounter_table WHERE id = ?')
+  const entries = db.prepare(
+    'SELECT creature_id AS creatureId, weight FROM encounter_table_entry WHERE encounter_table_id = ?'
+  )
+  for (const tableId of new Set(tableIds)) {
+    if (!table.get(tableId)) continue
+    effective.add(tableId)
+    for (const row of entries.all(tableId) as {
+      creatureId: string
+      weight: number
+    }[]) {
+      const current = result.get(row.creatureId)
+      result.set(row.creatureId, {
+        weight: (current?.weight ?? 0) + row.weight,
+        maximum: null
+      })
+    }
+  }
+  return result
+}
+
+function factionDimension(
+  db: Database.Database,
+  factionIds: readonly string[],
+  effectiveFactions: Set<string>,
+  effectiveTables: Set<string>
+): Dimension {
+  const result: Dimension = new Map()
+  const faction = db.prepare(
+    'SELECT primary_encounter_table_id AS tableId FROM worldplanner_faction WHERE id = ?'
+  )
+  const entries = db.prepare(
+    'SELECT creature_id AS creatureId, weight FROM encounter_table_entry WHERE encounter_table_id = ?'
+  )
+  const maximum = db.prepare(
+    'SELECT maximum FROM worldplanner_faction_inventory WHERE faction_id = ? AND creature_id = ?'
+  )
+  for (const factionId of new Set(factionIds)) {
+    const row = faction.get(factionId) as { tableId: string | null } | undefined
+    if (!row) continue
+    effectiveFactions.add(factionId)
+    if (!row.tableId) continue
+    effectiveTables.add(row.tableId)
+    for (const entry of entries.all(row.tableId) as {
+      creatureId: string
+      weight: number
+    }[]) {
+      const inventory = maximum.get(factionId, entry.creatureId) as
+        { maximum: number } | undefined
+      const current = result.get(entry.creatureId)
+      result.set(entry.creatureId, {
+        weight: (current?.weight ?? 0) + entry.weight,
+        maximum:
+          current?.maximum === null || inventory === undefined
+            ? null
+            : (current?.maximum ?? 0) + inventory.maximum
+      })
+    }
+  }
+  return result
+}
+
+function unionDimensions(...dimensions: Dimension[]): Dimension {
+  const result: Dimension = new Map()
+  for (const dimension of dimensions)
+    for (const [id, value] of dimension) {
+      const current = result.get(id)
+      result.set(id, {
+        weight: (current?.weight ?? 0) + value.weight,
+        maximum:
+          current?.maximum === null || value.maximum === null
+            ? null
+            : (current?.maximum ?? 0) + value.maximum
+      })
+    }
+  return result
+}
+
+function intersectDimensions(dimensions: readonly Dimension[]): Dimension {
+  if (dimensions.length === 0) return new Map()
+  const result = new Map(dimensions[0])
+  for (const dimension of dimensions.slice(1))
+    for (const [id, current] of result) {
+      const other = dimension.get(id)
+      if (!other) result.delete(id)
+      else
+        result.set(id, {
+          weight: Math.min(current.weight, other.weight),
+          maximum:
+            current.maximum === null
+              ? other.maximum
+              : other.maximum === null
+                ? current.maximum
+                : Math.min(current.maximum, other.maximum)
+        })
+    }
+  return result
+}
+
+function ids(db: Database.Database, sql: string, value: string): string[] {
+  return (db.prepare(sql).all(value) as { id: string }[]).map((row) => row.id)
+}

--- a/src/core/worldplanner/location-store.ts
+++ b/src/core/worldplanner/location-store.ts
@@ -1,0 +1,267 @@
+import Database from 'better-sqlite3'
+import {
+  worldLocationDraftSchema,
+  worldLocationSnapshotSchema,
+  type WorldLocationDraft,
+  type WorldLocationSnapshot
+} from '../../shared/contracts/world-location.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+
+export function initializeWorldLocationSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS worldplanner_location_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS worldplanner_location (
+      id TEXT PRIMARY KEY NOT NULL,
+      display_name TEXT NOT NULL,
+      notes TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE INDEX IF NOT EXISTS idx_worldplanner_location_name
+      ON worldplanner_location(display_name COLLATE NOCASE, id);
+    CREATE TABLE IF NOT EXISTS worldplanner_location_faction (
+      location_id TEXT NOT NULL,
+      faction_id TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY (location_id, faction_id)
+    );
+    CREATE TABLE IF NOT EXISTS worldplanner_location_encounter_table (
+      location_id TEXT NOT NULL,
+      encounter_table_id TEXT NOT NULL,
+      position INTEGER NOT NULL CHECK(position >= 0),
+      PRIMARY KEY (location_id, encounter_table_id)
+    );
+  `)
+  db.prepare(
+    'INSERT OR IGNORE INTO worldplanner_location_metadata (singleton, revision) VALUES (1, 0)'
+  ).run()
+}
+
+export class WorldLocationStore {
+  constructor(private readonly db: Database.Database) {}
+
+  read(): WorldLocationSnapshot {
+    const metadata = this.db
+      .prepare(
+        'SELECT revision FROM worldplanner_location_metadata WHERE singleton = 1'
+      )
+      .get() as { revision: number }
+    const locations = this.db
+      .prepare(
+        `
+        SELECT id, display_name AS displayName, notes, position
+        FROM worldplanner_location ORDER BY position, id
+      `
+      )
+      .all()
+      .map((location) => ({
+        ...(location as object),
+        factionIds: this.references(
+          'worldplanner_location_faction',
+          'faction_id',
+          (location as { id: string }).id
+        ),
+        encounterTableIds: this.references(
+          'worldplanner_location_encounter_table',
+          'encounter_table_id',
+          (location as { id: string }).id
+        )
+      }))
+    return worldLocationSnapshotSchema.parse({
+      revision: metadata.revision,
+      locations
+    })
+  }
+
+  create(
+    draft: WorldLocationDraft,
+    expectedRevision: number
+  ): WorldLocationSnapshot {
+    const parsed = worldLocationDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      const position = (
+        this.db
+          .prepare(
+            'SELECT COALESCE(MAX(position), -1) + 1 AS value FROM worldplanner_location'
+          )
+          .get() as { value: number }
+      ).value
+      const id = uuidv7()
+      this.db
+        .prepare(
+          'INSERT INTO worldplanner_location (id, display_name, notes, position) VALUES (?, ?, ?, ?)'
+        )
+        .run(id, parsed.displayName, parsed.notes, position)
+      this.replaceReferences(id, parsed.factionIds, parsed.encounterTableIds)
+    })
+    return this.read()
+  }
+
+  update(
+    id: string,
+    draft: WorldLocationDraft,
+    expectedRevision: number
+  ): WorldLocationSnapshot {
+    const parsed = worldLocationDraftSchema.parse(draft)
+    this.mutate(expectedRevision, () => {
+      const changed = this.db
+        .prepare(
+          'UPDATE worldplanner_location SET display_name = ?, notes = ? WHERE id = ?'
+        )
+        .run(parsed.displayName, parsed.notes, id).changes
+      if (changed === 0) throw new Error('not found')
+      this.replaceReferences(id, parsed.factionIds, parsed.encounterTableIds)
+    })
+    return this.read()
+  }
+
+  delete(id: string, expectedRevision: number): WorldLocationSnapshot {
+    this.mutate(expectedRevision, () => {
+      if (
+        this.db
+          .prepare('DELETE FROM worldplanner_location WHERE id = ?')
+          .run(id).changes === 0
+      )
+        throw new Error('not found')
+      this.db
+        .prepare(
+          'DELETE FROM worldplanner_location_faction WHERE location_id = ?'
+        )
+        .run(id)
+      this.db
+        .prepare(
+          'DELETE FROM worldplanner_location_encounter_table WHERE location_id = ?'
+        )
+        .run(id)
+    })
+    return this.read()
+  }
+
+  unlinkFaction(factionId: string): void {
+    const changes = this.db
+      .prepare('DELETE FROM worldplanner_location_faction WHERE faction_id = ?')
+      .run(factionId).changes
+    if (changes > 0) this.bumpRevision()
+  }
+
+  unlinkEncounterTable(encounterTableId: string): void {
+    const changes = this.db
+      .prepare(
+        'DELETE FROM worldplanner_location_encounter_table WHERE encounter_table_id = ?'
+      )
+      .run(encounterTableId).changes
+    if (changes > 0) this.bumpRevision()
+  }
+
+  private references(
+    table: string,
+    column: string,
+    locationId: string
+  ): string[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT ${column} AS id FROM ${table} WHERE location_id = ? ORDER BY position, ${column}`
+        )
+        .all(locationId) as { id: string }[]
+    ).map((row) => row.id)
+  }
+
+  private replaceReferences(
+    locationId: string,
+    factionIds: readonly string[],
+    encounterTableIds: readonly string[]
+  ): void {
+    this.assertReferences('worldplanner_faction', factionIds)
+    this.assertReferences('encounter_table', encounterTableIds)
+    this.db
+      .prepare(
+        'DELETE FROM worldplanner_location_faction WHERE location_id = ?'
+      )
+      .run(locationId)
+    this.db
+      .prepare(
+        'DELETE FROM worldplanner_location_encounter_table WHERE location_id = ?'
+      )
+      .run(locationId)
+    const faction = this.db.prepare(
+      'INSERT INTO worldplanner_location_faction (location_id, faction_id, position) VALUES (?, ?, ?)'
+    )
+    const table = this.db.prepare(
+      'INSERT INTO worldplanner_location_encounter_table (location_id, encounter_table_id, position) VALUES (?, ?, ?)'
+    )
+    Array.from(new Set(factionIds)).forEach((id, position) =>
+      faction.run(locationId, id, position)
+    )
+    Array.from(new Set(encounterTableIds)).forEach((id, position) =>
+      table.run(locationId, id, position)
+    )
+  }
+
+  private assertReferences(table: string, ids: readonly string[]): void {
+    if (ids.length === 0) return
+    const exists = this.db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(table)
+    if (!exists) throw new Error('not found')
+    const statement = this.db.prepare(`SELECT 1 FROM ${table} WHERE id = ?`)
+    if (ids.some((id) => !statement.get(id))) throw new Error('not found')
+  }
+
+  private mutate(expectedRevision: number, operation: () => void): void {
+    const mutation = () => {
+      const current = (
+        this.db
+          .prepare(
+            'SELECT revision FROM worldplanner_location_metadata WHERE singleton = 1'
+          )
+          .get() as { revision: number }
+      ).revision
+      if (current !== expectedRevision) throw new Error('stale')
+      operation()
+      this.bumpRevision()
+    }
+    if (this.db.inTransaction) mutation()
+    else this.db.transaction(mutation)()
+  }
+
+  private bumpRevision(): void {
+    this.db
+      .prepare(
+        'UPDATE worldplanner_location_metadata SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
+  }
+}
+
+export class WorldLocationService {
+  constructor(private readonly campaignPath: () => string) {}
+
+  read(): WorldLocationSnapshot {
+    return this.withStore((store) => store.read())
+  }
+
+  create(draft: WorldLocationDraft, expectedRevision: number) {
+    return this.withStore((store) => store.create(draft, expectedRevision))
+  }
+
+  update(id: string, draft: WorldLocationDraft, expectedRevision: number) {
+    return this.withStore((store) => store.update(id, draft, expectedRevision))
+  }
+
+  delete(id: string, expectedRevision: number) {
+    return this.withStore((store) => store.delete(id, expectedRevision))
+  }
+
+  private withStore<T>(work: (store: WorldLocationStore) => T): T {
+    const db = new Database(this.campaignPath())
+    try {
+      initializeWorldLocationSchema(db)
+      return work(new WorldLocationStore(db))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/src/main/application-lifecycle/application.ts
+++ b/src/main/application-lifecycle/application.ts
@@ -16,6 +16,10 @@ import {
   type CampaignSnapshot
 } from '../../shared/contracts/campaign.js'
 import { CapabilityError } from '../../shared/errors/capability-error.js'
+import {
+  runtimeGpuObservationSchema,
+  type RuntimeGpuObservation
+} from '../../shared/qualification/runtime-observation.js'
 
 let core: CoreProcessClient | undefined
 
@@ -55,11 +59,81 @@ export async function startApplication(): Promise<void> {
       .getAppMetrics()
       .reduce((total, metric) => total + metric.memory.workingSetSize * 1024, 0)
   })
+  ipcMain.handle('runtime:gpu-observation', async (event) => {
+    authorize(event, false)
+    await app.getGPUInfo('complete')
+    return runtimeGpuObservationSchema.parse(await gpuObservation())
+  })
   createMainWindow()
   if (!isE2eRuntime()) createSecondaryWindow()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
   })
+}
+
+async function gpuObservation(): Promise<RuntimeGpuObservation> {
+  const [featureStatus, info] = await Promise.all([
+    Promise.resolve(app.getGPUFeatureStatus()),
+    app.getGPUInfo('complete')
+  ])
+  const devices = gpuDevices(info)
+  return {
+    operatingSystem: process.platform,
+    architecture: process.arch,
+    electronVersion: process.versions.electron,
+    featureStatus: Object.fromEntries(
+      Object.entries(featureStatus).map(([key, value]) => [key, String(value)])
+    ),
+    activeGpuDevices: devices.filter((device) => device.active),
+    softwareRendering: usesSoftwareRendering(featureStatus, devices)
+  }
+}
+
+function gpuDevices(info: unknown): RuntimeGpuObservation['activeGpuDevices'] {
+  const records = objectValue(info)['gpuDevice']
+  if (!Array.isArray(records)) return []
+  return records.flatMap((record) => {
+    const device = objectValue(record)
+    return [
+      {
+        active: device['active'] === true,
+        deviceId: stringValue(device['deviceId']),
+        vendorId: stringValue(device['vendorId']),
+        deviceName: stringValue(device['deviceString']),
+        vendorName: stringValue(device['vendorString']),
+        driverVendor: stringValue(device['driverVendor']),
+        driverVersion: stringValue(device['driverVersion'])
+      }
+    ]
+  })
+}
+
+function usesSoftwareRendering(
+  status: Electron.GPUFeatureStatus,
+  devices: RuntimeGpuObservation['activeGpuDevices']
+): boolean {
+  const webgl = String(status.webgl ?? '').toLowerCase()
+  const names = devices
+    .flatMap((device) => [
+      device.deviceName,
+      device.vendorName,
+      device.driverVendor
+    ])
+    .join(' ')
+    .toLowerCase()
+  return (
+    webgl.includes('software') || /swiftshader|llvmpipe|software/.test(names)
+  )
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : ''
 }
 
 export function stopApplication(): void {

--- a/src/main/application-lifecycle/application.ts
+++ b/src/main/application-lifecycle/application.ts
@@ -1,14 +1,11 @@
 import { app, BrowserWindow, ipcMain, type IpcMainInvokeEvent } from 'electron'
 import { join } from 'node:path'
+import { readFile, rename, writeFile } from 'node:fs/promises'
 import { CoreProcessClient } from '../core-process/core-process-client.js'
 import { createMainWindow } from '../windows/main-window.js'
-import {
-  createSecondaryWindow,
-  isReadOnlyWindow
-} from '../windows/secondary-window.js'
+import { isReadOnlyWindow } from '../windows/secondary-window.js'
 import { configureSecurity } from '../security/security.js'
 import { outputPath } from './runtime-paths.js'
-import { isE2eRuntime } from './e2e-runtime.js'
 import {
   activateCampaignInputSchema,
   campaignCapabilityResponseSchema,
@@ -20,8 +17,83 @@ import {
   runtimeGpuObservationSchema,
   type RuntimeGpuObservation
 } from '../../shared/qualification/runtime-observation.js'
+import {
+  creatureCatalogPageSchema,
+  creatureCatalogQuerySchema,
+  creatureFilterOptionsSchema,
+  creatureSchema
+} from '../../shared/contracts/encounter.js'
+import {
+  adjustInitiativeInputSchema,
+  changeHpInputSchema,
+  combatRevisionInputSchema,
+  confirmInitiativeInputSchema,
+  liveSessionSnapshotSchema,
+  prepareCombatInputSchema,
+  updateResolutionInputSchema
+} from '../../shared/contracts/live-session.js'
+import {
+  adjustPartyXpInputSchema,
+  adventuringDayCalculationSchema,
+  adventuringDayInputSchema,
+  createPartyCharacterInputSchema,
+  deletePartyCharacterInputSchema,
+  partySnapshotSchema,
+  restPartyInputSchema,
+  setMembershipInputSchema,
+  updatePartyCharacterInputSchema
+} from '../../shared/contracts/party.js'
+import { z } from 'zod'
+import {
+  assignScenePartyInputSchema,
+  deleteSceneGroupInputSchema,
+  encounterSelectionEvaluationSchema,
+  evaluateEncounterSelectionInputSchema,
+  evaluateSceneGroupDraftInputSchema,
+  focusSceneInputSchema,
+  saveSceneGroupInputSchema,
+  setSceneLocationInputSchema,
+  sceneGroupDraftEvaluationSchema,
+  sceneGroupDraftGenerationRequestSchema,
+  sceneGroupDraftGenerationSchema
+} from '../../shared/contracts/scene.js'
+import {
+  defaultSessionLayoutPreference,
+  sessionLayoutPreferenceSchema
+} from '../../shared/contracts/session-layout.js'
+import {
+  createWorldLocationInputSchema,
+  deleteWorldLocationInputSchema,
+  updateWorldLocationInputSchema,
+  worldLocationSnapshotSchema
+} from '../../shared/contracts/world-location.js'
+import {
+  createEncounterTableInputSchema,
+  createWorldFactionInputSchema,
+  deleteEncounterTableInputSchema,
+  deleteWorldFactionInputSchema,
+  encounterTableSnapshotSchema,
+  updateEncounterTableInputSchema,
+  updateWorldFactionInputSchema,
+  worldFactionSnapshotSchema
+} from '../../shared/contracts/encounter-source.js'
 
 let core: CoreProcessClient | undefined
+
+const legacySessionLayoutPreferenceSchema = z
+  .object({
+    mode: z.enum(['rows', 'columns']),
+    rows: z.unknown(),
+    columns: z
+      .object({
+        leftFraction: z.number(),
+        leftTopFraction: z.number(),
+        rightTopFraction: z.number()
+      })
+      .strict(),
+    upperRightTab: z.enum(['details', 'map'])
+  })
+  .strict()
 
 export async function startApplication(): Promise<void> {
   await app.whenReady()
@@ -36,6 +108,39 @@ export async function startApplication(): Promise<void> {
       authorize(event, false)
       return requireCore().list()
     })
+  )
+  const sessionLayoutPath = join(app.getPath('userData'), 'session-layout.json')
+  ipcMain.handle('session-layout:read', (event) =>
+    invokeGeneric(async () => {
+      authorize(event, false)
+      try {
+        const raw: unknown = JSON.parse(
+          await readFile(sessionLayoutPath, 'utf8')
+        )
+        const current = sessionLayoutPreferenceSchema.safeParse(raw)
+        if (current.success) return current.data
+        const legacy = legacySessionLayoutPreferenceSchema.parse(raw)
+        return sessionLayoutPreferenceSchema.parse({
+          leftFraction: legacy.columns.leftFraction,
+          rightTopFraction: legacy.columns.rightTopFraction,
+          upperRightTab: legacy.upperRightTab
+        })
+      } catch {
+        return defaultSessionLayoutPreference
+      }
+    }, sessionLayoutPreferenceSchema)
+  )
+  ipcMain.handle('session-layout:save', (event, raw) =>
+    invokeGeneric(async () => {
+      authorize(event, true)
+      const preference = sessionLayoutPreferenceSchema.safeParse(raw)
+      if (!preference.success)
+        throw new CapabilityError('validation_failed', false)
+      const temporary = `${sessionLayoutPath}.tmp`
+      await writeFile(temporary, JSON.stringify(preference.data), 'utf8')
+      await rename(temporary, sessionLayoutPath)
+      return preference.data
+    }, sessionLayoutPreferenceSchema)
   )
   ipcMain.handle('campaign:create', (event, raw) =>
     invokeCapability(() => {
@@ -53,6 +158,463 @@ export async function startApplication(): Promise<void> {
       return requireCore().activate(input.data.id)
     })
   )
+  const capability = <T>(
+    channel: string,
+    schema: z.ZodType<T>,
+    write: boolean,
+    parse: z.ZodType<unknown>,
+    operation: (input: unknown) => Promise<T>
+  ) =>
+    ipcMain.handle(channel, (event, raw) =>
+      invokeGeneric(() => {
+        authorize(event, write)
+        const value = parse.safeParse(raw)
+        if (!value.success)
+          throw new CapabilityError('validation_failed', false)
+        return operation(value.data)
+      }, schema)
+    )
+  capability('party:read', partySnapshotSchema, false, z.undefined(), () =>
+    requireCore().partyRead()
+  )
+  capability(
+    'party:setMembership',
+    partySnapshotSchema,
+    true,
+    setMembershipInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof setMembershipInputSchema>
+      return requireCore().partySetMembership(
+        i.id,
+        i.active,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'party:create',
+    partySnapshotSchema,
+    true,
+    createPartyCharacterInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof createPartyCharacterInputSchema>
+      return requireCore().partyCreate(i.character, i.expectedRevision)
+    }
+  )
+  capability(
+    'party:update',
+    partySnapshotSchema,
+    true,
+    updatePartyCharacterInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof updatePartyCharacterInputSchema>
+      return requireCore().partyUpdate(i.id, i.character, i.expectedRevision)
+    }
+  )
+  capability(
+    'party:delete',
+    partySnapshotSchema,
+    true,
+    deletePartyCharacterInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof deletePartyCharacterInputSchema>
+      return requireCore().partyDelete(i.id, i.expectedRevision)
+    }
+  )
+  capability(
+    'party:adjustXp',
+    partySnapshotSchema,
+    true,
+    adjustPartyXpInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof adjustPartyXpInputSchema>
+      return requireCore().partyAdjustXp(i.id, i.delta, i.expectedRevision)
+    }
+  )
+  capability(
+    'party:rest',
+    partySnapshotSchema,
+    true,
+    restPartyInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof restPartyInputSchema>
+      return requireCore().partyRest(i.type, i.expectedRevision)
+    }
+  )
+  capability(
+    'party:calculateAdventuringDay',
+    adventuringDayCalculationSchema,
+    false,
+    adventuringDayInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof adventuringDayInputSchema>
+      return requireCore().partyCalculateAdventuringDay(i.rows, i.totalXp)
+    }
+  )
+  capability(
+    'creatures:search',
+    creatureCatalogPageSchema,
+    false,
+    creatureCatalogQuerySchema,
+    (v) =>
+      requireCore().creaturesSearch(
+        v as z.infer<typeof creatureCatalogQuerySchema>
+      )
+  )
+  capability(
+    'creatures:filterOptions',
+    creatureFilterOptionsSchema,
+    false,
+    z.undefined(),
+    () => requireCore().creaturesFilterOptions()
+  )
+  capability(
+    'creatures:detail',
+    creatureSchema,
+    false,
+    z.object({ id: z.string() }).strict(),
+    (v) => requireCore().creaturesDetail((v as { id: string }).id)
+  )
+  capability(
+    'locations:read',
+    worldLocationSnapshotSchema,
+    false,
+    z.undefined(),
+    () => requireCore().locationsRead()
+  )
+  capability(
+    'locations:create',
+    worldLocationSnapshotSchema,
+    true,
+    createWorldLocationInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof createWorldLocationInputSchema>
+      return requireCore().locationsCreate(i.location, i.expectedRevision)
+    }
+  )
+  capability(
+    'locations:update',
+    worldLocationSnapshotSchema,
+    true,
+    updateWorldLocationInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof updateWorldLocationInputSchema>
+      return requireCore().locationsUpdate(i.id, i.location, i.expectedRevision)
+    }
+  )
+  capability(
+    'locations:delete',
+    worldLocationSnapshotSchema,
+    true,
+    deleteWorldLocationInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof deleteWorldLocationInputSchema>
+      return requireCore().locationsDelete(i.id, i.expectedRevision)
+    }
+  )
+  capability(
+    'encounter-tables:read',
+    encounterTableSnapshotSchema,
+    false,
+    z.undefined(),
+    () => requireCore().encounterTablesRead()
+  )
+  capability(
+    'encounter-tables:create',
+    encounterTableSnapshotSchema,
+    true,
+    createEncounterTableInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof createEncounterTableInputSchema>
+      return requireCore().encounterTablesCreate(i.table, i.expectedRevision)
+    }
+  )
+  capability(
+    'encounter-tables:update',
+    encounterTableSnapshotSchema,
+    true,
+    updateEncounterTableInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof updateEncounterTableInputSchema>
+      return requireCore().encounterTablesUpdate(
+        i.id,
+        i.table,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'encounter-tables:delete',
+    encounterTableSnapshotSchema,
+    true,
+    deleteEncounterTableInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof deleteEncounterTableInputSchema>
+      return requireCore().encounterTablesDelete(i.id, i.expectedRevision)
+    }
+  )
+  capability(
+    'factions:read',
+    worldFactionSnapshotSchema,
+    false,
+    z.undefined(),
+    () => requireCore().factionsRead()
+  )
+  capability(
+    'factions:create',
+    worldFactionSnapshotSchema,
+    true,
+    createWorldFactionInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof createWorldFactionInputSchema>
+      return requireCore().factionsCreate(i.faction, i.expectedRevision)
+    }
+  )
+  capability(
+    'factions:update',
+    worldFactionSnapshotSchema,
+    true,
+    updateWorldFactionInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof updateWorldFactionInputSchema>
+      return requireCore().factionsUpdate(i.id, i.faction, i.expectedRevision)
+    }
+  )
+  capability(
+    'factions:delete',
+    worldFactionSnapshotSchema,
+    true,
+    deleteWorldFactionInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof deleteWorldFactionInputSchema>
+      return requireCore().factionsDelete(i.id, i.expectedRevision)
+    }
+  )
+  capability(
+    'session:read',
+    liveSessionSnapshotSchema,
+    false,
+    z.undefined(),
+    () => requireCore().sessionRead()
+  )
+  capability(
+    'scene:focus',
+    liveSessionSnapshotSchema,
+    true,
+    focusSceneInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof focusSceneInputSchema>
+      return requireCore().sceneFocus(i.sceneId, i.expectedRevision)
+    }
+  )
+  capability(
+    'scene:setLocation',
+    liveSessionSnapshotSchema,
+    true,
+    setSceneLocationInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof setSceneLocationInputSchema>
+      return requireCore().sceneSetLocation(
+        i.sceneId,
+        i.locationId,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'scene:saveGroup',
+    liveSessionSnapshotSchema,
+    true,
+    saveSceneGroupInputSchema,
+    (v) =>
+      requireCore().sceneSaveGroup(
+        v as z.infer<typeof saveSceneGroupInputSchema>
+      )
+  )
+  capability(
+    'scene:deleteGroup',
+    liveSessionSnapshotSchema,
+    true,
+    deleteSceneGroupInputSchema,
+    (v) =>
+      requireCore().sceneDeleteGroup(
+        v as z.infer<typeof deleteSceneGroupInputSchema>
+      )
+  )
+  capability(
+    'scene:assignPartyMember',
+    liveSessionSnapshotSchema,
+    true,
+    assignScenePartyInputSchema,
+    (v) =>
+      requireCore().sceneAssignPartyMember(
+        v as z.infer<typeof assignScenePartyInputSchema>
+      )
+  )
+  capability(
+    'scene:evaluateGroupDraft',
+    sceneGroupDraftEvaluationSchema,
+    false,
+    evaluateSceneGroupDraftInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof evaluateSceneGroupDraftInputSchema>
+      return requireCore().sceneEvaluateGroupDraft(
+        i.sceneId,
+        i.entries,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'scene:generateGroupDraft',
+    sceneGroupDraftGenerationSchema,
+    false,
+    sceneGroupDraftGenerationRequestSchema,
+    (v) => {
+      const i = v as z.infer<typeof sceneGroupDraftGenerationRequestSchema>
+      return requireCore().sceneGenerateGroupDraft(
+        i.sceneId,
+        i.entries,
+        i.mode,
+        i.filters,
+        i.tuning,
+        i.seed,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'encounter:evaluate',
+    encounterSelectionEvaluationSchema,
+    false,
+    evaluateEncounterSelectionInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof evaluateEncounterSelectionInputSchema>
+      return requireCore().encounterEvaluate(
+        i.sceneId,
+        i.groupIds,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'combat:prepare',
+    liveSessionSnapshotSchema,
+    true,
+    prepareCombatInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof prepareCombatInputSchema>
+      return requireCore().combatPrepare(
+        i.sceneId,
+        i.groupIds,
+        i.expectedSceneRevision
+      )
+    }
+  )
+  capability(
+    'combat:rollInitiative',
+    liveSessionSnapshotSchema,
+    true,
+    combatRevisionInputSchema,
+    (v) =>
+      requireCore().combatRollInitiative(
+        (v as z.infer<typeof combatRevisionInputSchema>).expectedRevision
+      )
+  )
+  capability(
+    'combat:confirmInitiative',
+    liveSessionSnapshotSchema,
+    true,
+    confirmInitiativeInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof confirmInitiativeInputSchema>
+      return requireCore().combatConfirmInitiative(i.values, i.expectedRevision)
+    }
+  )
+  capability(
+    'combat:advanceTurn',
+    liveSessionSnapshotSchema,
+    true,
+    combatRevisionInputSchema,
+    (v) =>
+      requireCore().combatAdvanceTurn(
+        (v as z.infer<typeof combatRevisionInputSchema>).expectedRevision
+      )
+  )
+  capability(
+    'combat:adjustInitiative',
+    liveSessionSnapshotSchema,
+    true,
+    adjustInitiativeInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof adjustInitiativeInputSchema>
+      return requireCore().combatAdjustInitiative(
+        i.id,
+        i.initiative,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'combat:changeHp',
+    liveSessionSnapshotSchema,
+    true,
+    changeHpInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof changeHpInputSchema>
+      return requireCore().combatChangeHp(
+        i.cardId,
+        i.amount,
+        i.healing,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'combat:end',
+    liveSessionSnapshotSchema,
+    true,
+    combatRevisionInputSchema,
+    (v) =>
+      requireCore().combatEnd(
+        (v as z.infer<typeof combatRevisionInputSchema>).expectedRevision
+      )
+  )
+  capability(
+    'combat:updateResolution',
+    liveSessionSnapshotSchema,
+    true,
+    updateResolutionInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof updateResolutionInputSchema>
+      return requireCore().combatUpdateResolution(
+        i.selectedEnemyIds,
+        i.thresholdFraction,
+        i.xpFraction,
+        i.expectedRevision
+      )
+    }
+  )
+  capability(
+    'combat:awardXp',
+    liveSessionSnapshotSchema,
+    true,
+    combatRevisionInputSchema,
+    (v) =>
+      requireCore().combatAwardXp(
+        (v as z.infer<typeof combatRevisionInputSchema>).expectedRevision
+      )
+  )
+  capability(
+    'combat:complete',
+    liveSessionSnapshotSchema,
+    true,
+    combatRevisionInputSchema,
+    (v) =>
+      requireCore().combatComplete(
+        (v as z.infer<typeof combatRevisionInputSchema>).expectedRevision
+      )
+  )
   ipcMain.handle('runtime:memory', (event) => {
     authorize(event, false)
     return app
@@ -65,7 +627,6 @@ export async function startApplication(): Promise<void> {
     return runtimeGpuObservationSchema.parse(await gpuObservation())
   })
   createMainWindow()
-  if (!isE2eRuntime()) createSecondaryWindow()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
   })
@@ -169,5 +730,16 @@ async function invokeCapability(
         ? { code: error.code, retryable: error.retryable }
         : { code: 'internal' as const, retryable: false }
     return campaignCapabilityResponseSchema.parse({ ok: false, error: failure })
+  }
+}
+async function invokeGeneric<T>(
+  operation: () => Promise<T>,
+  schema: z.ZodType<T>
+): Promise<unknown> {
+  try {
+    return { ok: true, payload: schema.parse(await operation()) }
+  } catch (error) {
+    const code = error instanceof CapabilityError ? error.code : 'internal'
+    return { ok: false, error: { code, retryable: false } }
   }
 }

--- a/src/main/application-lifecycle/runtime-paths.ts
+++ b/src/main/application-lifecycle/runtime-paths.ts
@@ -1,10 +1,13 @@
 import { app } from 'electron'
+import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
 export function outputPath(...segments: string[]): string {
   const appPath = app.getAppPath()
   const outputRoot = appPath.endsWith('.asar')
     ? join(appPath, 'out')
-    : dirname(appPath)
+    : existsSync(join(appPath, 'out'))
+      ? join(appPath, 'out')
+      : dirname(appPath)
   return join(outputRoot, ...segments)
 }

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -1,191 +1,518 @@
 import { randomUUID } from 'node:crypto'
 import { utilityProcess, type UtilityProcess } from 'electron'
+import { z } from 'zod'
 import {
   coreReadySchema,
-  coreResponseSchema,
-  freezeCampaignSnapshot,
-  type CampaignSnapshot,
-  type CoreRequest
+  type CampaignSnapshot
 } from '../../shared/contracts/campaign.js'
+import {
+  coreRequestSchema,
+  coreResultSchema
+} from '../../shared/contracts/core-protocol.js'
+import {
+  creatureCatalogPageSchema,
+  creatureCatalogQuerySchema,
+  creatureFilterOptionsSchema,
+  creatureSchema,
+  type CreatureCatalogPage,
+  type CreatureCatalogQuery,
+  type CreatureFilterOptions
+} from '../../shared/contracts/encounter.js'
+import {
+  liveSessionSnapshotSchema,
+  partySnapshotSchema,
+  type LiveSessionSnapshot,
+  type PartySnapshot
+} from '../../shared/contracts/live-session.js'
+import {
+  adventuringDayCalculationSchema,
+  type AdventuringDayCalculation,
+  type PartyCharacterDraft
+} from '../../shared/contracts/party.js'
+import type { EncounterTuning } from '../../shared/contracts/encounter-tuning.js'
+import {
+  encounterSelectionEvaluationSchema,
+  sceneGroupDraftEvaluationSchema,
+  sceneGroupDraftGenerationSchema,
+  type EncounterSelectionEvaluation,
+  type GroupGenerationMode,
+  type SceneGroupDraftEntry,
+  type SceneGroupDraftEvaluation,
+  type SceneGroupDraftGeneration
+} from '../../shared/contracts/scene.js'
 import { CapabilityError } from '../../shared/errors/capability-error.js'
+import {
+  worldLocationSnapshotSchema,
+  type WorldLocationDraft,
+  type WorldLocationSnapshot
+} from '../../shared/contracts/world-location.js'
+import {
+  encounterTableSnapshotSchema,
+  worldFactionSnapshotSchema,
+  type EncounterTableDraft,
+  type EncounterTableSnapshot,
+  type WorldFactionDraft,
+  type WorldFactionSnapshot
+} from '../../shared/contracts/encounter-source.js'
 
 export class CoreProcessClient {
   readonly #process: UtilityProcess
   readonly #ready: Promise<void>
-  #resolveReady: (() => void) | undefined
-  #rejectReady: ((error: Error) => void) | undefined
+  #resolve?: () => void
+  #reject?: (error: Error) => void
   #closed = false
   readonly #pending = new Map<
     string,
     {
-      resolve: (value: CampaignSnapshot) => void
+      resolve: (value: unknown) => void
       reject: (error: Error) => void
+      schema: z.ZodType<unknown>
     }
   >()
-  readonly #timedOutRequestIds = new Set<string>()
 
-  public constructor(dataRoot: string, utilityPath: string) {
-    this.#process = utilityProcess.fork(utilityPath, [dataRoot], {
-      stdio: 'ignore'
+  constructor(dataRoot: string, path: string) {
+    this.#process = utilityProcess.fork(path, [dataRoot], { stdio: 'ignore' })
+    this.#ready = new Promise((resolve, reject) => {
+      this.#resolve = resolve
+      this.#reject = reject
     })
-    this.#ready = new Promise<void>((resolve, reject) => {
-      this.#resolveReady = resolve
-      this.#rejectReady = reject
+    this.#process.on('message', (value) => this.handle(value))
+    this.#process.on('exit', () =>
+      this.fail(new CapabilityError('core_unavailable', false))
+    )
+  }
+
+  waitUntilReady() {
+    return this.#ready
+  }
+  list() {
+    return this.request({ kind: 'campaign.list' }, campaignSchema)
+  }
+  create(name: string) {
+    return this.request(
+      { kind: 'campaign.create', input: { name } },
+      campaignSchema
+    )
+  }
+  activate(id: string) {
+    return this.request(
+      { kind: 'campaign.activate', input: { id } },
+      campaignSchema
+    )
+  }
+  partyRead(): Promise<PartySnapshot> {
+    return this.request({ kind: 'party.read' }, partySnapshotSchema)
+  }
+  partySetMembership(id: string, active: boolean, expectedRevision: number) {
+    return this.request(
+      { kind: 'party.setMembership', input: { id, active, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyCreate(character: PartyCharacterDraft, expectedRevision: number) {
+    return this.request(
+      { kind: 'party.create', input: { character, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyUpdate(
+    id: string,
+    character: PartyCharacterDraft,
+    expectedRevision: number
+  ) {
+    return this.request(
+      { kind: 'party.update', input: { id, character, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyDelete(id: string, expectedRevision: number) {
+    return this.request(
+      { kind: 'party.delete', input: { id, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyAdjustXp(id: string, delta: number, expectedRevision: number) {
+    return this.request(
+      { kind: 'party.adjustXp', input: { id, delta, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyRest(type: 'short' | 'long', expectedRevision: number) {
+    return this.request(
+      { kind: 'party.rest', input: { type, expectedRevision } },
+      partySnapshotSchema
+    )
+  }
+  partyCalculateAdventuringDay(
+    rows: readonly { level: number; count: number }[],
+    totalXp?: number
+  ): Promise<AdventuringDayCalculation> {
+    return this.request(
+      {
+        kind: 'party.calculateAdventuringDay',
+        input: { rows, ...(totalXp === undefined ? {} : { totalXp }) }
+      },
+      adventuringDayCalculationSchema
+    )
+  }
+  creaturesSearch(query: CreatureCatalogQuery): Promise<CreatureCatalogPage> {
+    return this.request(
+      {
+        kind: 'creatures.search',
+        input: creatureCatalogQuerySchema.parse(query)
+      },
+      creatureCatalogPageSchema
+    )
+  }
+  creaturesFilterOptions(): Promise<CreatureFilterOptions> {
+    return this.request(
+      { kind: 'creatures.filterOptions' },
+      creatureFilterOptionsSchema
+    )
+  }
+  creaturesDetail(id: string) {
+    return this.request(
+      { kind: 'creatures.detail', input: { id } },
+      creatureSchema
+    )
+  }
+  locationsRead(): Promise<WorldLocationSnapshot> {
+    return this.request({ kind: 'locations.read' }, worldLocationSnapshotSchema)
+  }
+  locationsCreate(
+    location: WorldLocationDraft,
+    expectedRevision: number
+  ): Promise<WorldLocationSnapshot> {
+    return this.request(
+      { kind: 'locations.create', input: { location, expectedRevision } },
+      worldLocationSnapshotSchema
+    )
+  }
+  locationsUpdate(
+    id: string,
+    location: WorldLocationDraft,
+    expectedRevision: number
+  ): Promise<WorldLocationSnapshot> {
+    return this.request(
+      { kind: 'locations.update', input: { id, location, expectedRevision } },
+      worldLocationSnapshotSchema
+    )
+  }
+  locationsDelete(
+    id: string,
+    expectedRevision: number
+  ): Promise<WorldLocationSnapshot> {
+    return this.request(
+      { kind: 'locations.delete', input: { id, expectedRevision } },
+      worldLocationSnapshotSchema
+    )
+  }
+  encounterTablesRead(): Promise<EncounterTableSnapshot> {
+    return this.request(
+      { kind: 'encounterTables.read' },
+      encounterTableSnapshotSchema
+    )
+  }
+  encounterTablesCreate(
+    table: EncounterTableDraft,
+    expectedRevision: number
+  ): Promise<EncounterTableSnapshot> {
+    return this.request(
+      { kind: 'encounterTables.create', input: { table, expectedRevision } },
+      encounterTableSnapshotSchema
+    )
+  }
+  encounterTablesUpdate(
+    id: string,
+    table: EncounterTableDraft,
+    expectedRevision: number
+  ): Promise<EncounterTableSnapshot> {
+    return this.request(
+      {
+        kind: 'encounterTables.update',
+        input: { id, table, expectedRevision }
+      },
+      encounterTableSnapshotSchema
+    )
+  }
+  encounterTablesDelete(
+    id: string,
+    expectedRevision: number
+  ): Promise<EncounterTableSnapshot> {
+    return this.request(
+      { kind: 'encounterTables.delete', input: { id, expectedRevision } },
+      encounterTableSnapshotSchema
+    )
+  }
+  factionsRead(): Promise<WorldFactionSnapshot> {
+    return this.request({ kind: 'factions.read' }, worldFactionSnapshotSchema)
+  }
+  factionsCreate(
+    faction: WorldFactionDraft,
+    expectedRevision: number
+  ): Promise<WorldFactionSnapshot> {
+    return this.request(
+      { kind: 'factions.create', input: { faction, expectedRevision } },
+      worldFactionSnapshotSchema
+    )
+  }
+  factionsUpdate(
+    id: string,
+    faction: WorldFactionDraft,
+    expectedRevision: number
+  ): Promise<WorldFactionSnapshot> {
+    return this.request(
+      { kind: 'factions.update', input: { id, faction, expectedRevision } },
+      worldFactionSnapshotSchema
+    )
+  }
+  factionsDelete(
+    id: string,
+    expectedRevision: number
+  ): Promise<WorldFactionSnapshot> {
+    return this.request(
+      { kind: 'factions.delete', input: { id, expectedRevision } },
+      worldFactionSnapshotSchema
+    )
+  }
+  sessionRead(): Promise<LiveSessionSnapshot> {
+    return this.request({ kind: 'session.read' }, liveSessionSnapshotSchema)
+  }
+  sceneFocus(sceneId: string, expectedRevision: number) {
+    return this.request(
+      { kind: 'scene.focus', input: { sceneId, expectedRevision } },
+      liveSessionSnapshotSchema
+    )
+  }
+  sceneSetLocation(
+    sceneId: string,
+    locationId: string | null,
+    expectedRevision: number
+  ) {
+    return this.request(
+      {
+        kind: 'scene.setLocation',
+        input: { sceneId, locationId, expectedRevision }
+      },
+      liveSessionSnapshotSchema
+    )
+  }
+  sceneSaveGroup(input: {
+    sceneId: string
+    groupId: string | null
+    name: string
+    entries: readonly { creatureId: string; quantity: number }[]
+    expectedRevision: number
+  }) {
+    return this.request(
+      { kind: 'scene.saveGroup', input },
+      liveSessionSnapshotSchema
+    )
+  }
+  sceneDeleteGroup(input: {
+    sceneId: string
+    groupId: string
+    expectedRevision: number
+  }) {
+    return this.request(
+      { kind: 'scene.deleteGroup', input },
+      liveSessionSnapshotSchema
+    )
+  }
+  sceneAssignPartyMember(input: {
+    sceneId: string
+    partyMemberId: string
+    assigned: boolean
+    expectedRevision: number
+  }) {
+    return this.request(
+      { kind: 'scene.assignPartyMember', input },
+      liveSessionSnapshotSchema
+    )
+  }
+  sceneEvaluateGroupDraft(
+    sceneId: string,
+    entries: readonly SceneGroupDraftEntry[],
+    expectedRevision: number
+  ): Promise<SceneGroupDraftEvaluation> {
+    return this.request(
+      {
+        kind: 'scene.evaluateGroupDraft',
+        input: { sceneId, entries, expectedRevision }
+      },
+      sceneGroupDraftEvaluationSchema
+    )
+  }
+  sceneGenerateGroupDraft(
+    sceneId: string,
+    entries: readonly SceneGroupDraftEntry[],
+    mode: GroupGenerationMode,
+    filters: CreatureCatalogQuery,
+    tuning: EncounterTuning,
+    seed: number,
+    expectedRevision: number
+  ): Promise<SceneGroupDraftGeneration> {
+    return this.request(
+      {
+        kind: 'scene.generateGroupDraft',
+        input: {
+          sceneId,
+          entries,
+          mode,
+          filters,
+          tuning,
+          seed,
+          expectedRevision
+        }
+      },
+      sceneGroupDraftGenerationSchema
+    )
+  }
+  encounterEvaluate(
+    sceneId: string,
+    groupIds: readonly string[],
+    expectedRevision: number
+  ): Promise<EncounterSelectionEvaluation> {
+    return this.request(
+      {
+        kind: 'encounter.evaluate',
+        input: { sceneId, groupIds, expectedRevision }
+      },
+      encounterSelectionEvaluationSchema
+    )
+  }
+  combatPrepare(
+    sceneId: string,
+    groupIds: readonly string[],
+    expectedSceneRevision: number
+  ) {
+    return this.live('combat.prepare', {
+      sceneId,
+      groupIds,
+      expectedSceneRevision
     })
-    this.#process.on('message', (raw) => this.handleMessage(raw))
-    this.#process.on('exit', () => {
-      const error = new CapabilityError('core_unavailable', false)
-      if (!this.#closed) console.error(error.message)
-      this.fail(error)
+  }
+  combatRollInitiative(expectedRevision: number) {
+    return this.live('combat.rollInitiative', { expectedRevision })
+  }
+  combatConfirmInitiative(
+    values: readonly { id: string; initiative: number }[],
+    expectedRevision: number
+  ) {
+    return this.live('combat.confirmInitiative', { values, expectedRevision })
+  }
+  combatAdvanceTurn(expectedRevision: number) {
+    return this.live('combat.advanceTurn', { expectedRevision })
+  }
+  combatAdjustInitiative(
+    id: string,
+    initiative: number,
+    expectedRevision: number
+  ) {
+    return this.live('combat.adjustInitiative', {
+      id,
+      initiative,
+      expectedRevision
     })
   }
-
-  public async waitUntilReady(): Promise<void> {
-    await this.withTimeout(this.#ready)
+  combatChangeHp(
+    cardId: string,
+    amount: number,
+    healing: boolean,
+    expectedRevision: number
+  ) {
+    return this.live('combat.changeHp', {
+      cardId,
+      amount,
+      healing,
+      expectedRevision
+    })
   }
-
-  public list(): Promise<CampaignSnapshot> {
-    return this.request({ kind: 'campaign.list' })
+  combatEnd(expectedRevision: number) {
+    return this.live('combat.end', { expectedRevision })
   }
-
-  public create(name: string): Promise<CampaignSnapshot> {
-    return this.request({ kind: 'campaign.create', input: { name } })
+  combatUpdateResolution(
+    selectedEnemyIds: readonly string[],
+    thresholdFraction: number,
+    xpFraction: number,
+    expectedRevision: number
+  ) {
+    return this.live('combat.updateResolution', {
+      selectedEnemyIds,
+      thresholdFraction,
+      xpFraction,
+      expectedRevision
+    })
   }
-
-  public activate(id: string): Promise<CampaignSnapshot> {
-    return this.request({ kind: 'campaign.activate', input: { id } })
+  combatAwardXp(expectedRevision: number) {
+    return this.live('combat.awardXp', { expectedRevision })
   }
-
-  public close(): void {
-    if (this.#closed) return
+  combatComplete(expectedRevision: number) {
+    return this.live('combat.complete', { expectedRevision })
+  }
+  close() {
     this.#closed = true
-    this.rejectAll(new CapabilityError('core_unavailable', false))
-    this.#process.postMessage({
-      kind: 'core.shutdown',
+    this.#process.kill()
+  }
+
+  private live(kind: string, input: Record<string, unknown>) {
+    return this.request({ kind, input }, liveSessionSnapshotSchema)
+  }
+
+  private request<T>(raw: unknown, schema: z.ZodType<T>): Promise<T> {
+    const request = coreRequestSchema.parse({
+      ...(raw as object),
       requestId: randomUUID()
     })
-    setTimeout(() => {
-      this.#process.kill()
-    }, 1_000).unref()
-  }
-
-  private request(request: CoreRequestWithoutId): Promise<CampaignSnapshot> {
-    const requestId = randomUUID()
     return new Promise((resolve, reject) => {
       if (this.#closed) {
         reject(new CapabilityError('core_unavailable', false))
         return
       }
-      const timeout = setTimeout(() => {
-        if (!this.#pending.delete(requestId)) return
-        this.#timedOutRequestIds.add(requestId)
-        setTimeout(
-          () => this.#timedOutRequestIds.delete(requestId),
-          10_000
-        ).unref()
-        reject(timeoutFor(request.kind))
-      }, 10_000)
-      this.#pending.set(requestId, {
-        resolve: (snapshot) => {
-          clearTimeout(timeout)
-          resolve(snapshot)
-        },
-        reject: (error) => {
-          clearTimeout(timeout)
-          reject(error)
-        }
+      this.#pending.set(request.requestId, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        schema
       })
-      this.#process.postMessage({ ...request, requestId })
+      this.#process.postMessage(request)
     })
   }
 
-  private handleMessage(raw: unknown): void {
+  private handle(raw: unknown) {
     if (coreReadySchema.safeParse(raw).success) {
-      this.#resolveReady?.()
-      this.#resolveReady = undefined
-      this.#rejectReady = undefined
+      this.#resolve?.()
       return
     }
-    const response = coreResponseSchema.safeParse(raw)
-    if (!response.success) {
-      this.protocolViolation()
-      return
-    }
-    const pending = this.#pending.get(response.data.requestId)
-    if (pending === undefined) {
-      if (this.#timedOutRequestIds.delete(response.data.requestId)) return
-      this.protocolViolation()
-      return
-    }
-    this.#pending.delete(response.data.requestId)
-    if (!response.data.ok) {
-      pending.reject(
-        new CapabilityError(
-          response.data.error.code,
-          response.data.error.retryable
-        )
+    const result = coreResultSchema.safeParse(raw)
+    if (!result.success) return this.protocol()
+    const pending = this.#pending.get(result.data.requestId)
+    if (!pending) return this.protocol()
+    this.#pending.delete(result.data.requestId)
+    if (!result.data.ok)
+      return pending.reject(
+        new CapabilityError(result.data.error.code, result.data.error.retryable)
       )
-      return
-    }
-    pending.resolve(freezeCampaignSnapshot(response.data.snapshot))
+    const value = pending.schema.safeParse(result.data.payload)
+    if (!value.success) return this.protocol()
+    pending.resolve(value.data)
   }
 
-  private rejectAll(error: Error): void {
+  private protocol() {
+    this.fail(new CapabilityError('protocol_violation', false))
+    this.#process.kill()
+  }
+  private fail(error: Error) {
+    if (this.#closed) return
+    this.#closed = true
+    this.#reject?.(error)
     for (const pending of this.#pending.values()) pending.reject(error)
     this.#pending.clear()
   }
-
-  private fail(error: Error): void {
-    this.#closed = true
-    this.#rejectReady?.(error)
-    this.#resolveReady = undefined
-    this.#rejectReady = undefined
-    this.rejectAll(error)
-  }
-
-  private protocolViolation(): void {
-    if (this.#closed) return
-    this.#closed = true
-    const error = new CapabilityError('protocol_violation', false)
-    this.#rejectReady?.(error)
-    this.#resolveReady = undefined
-    this.#rejectReady = undefined
-    this.rejectAll(error)
-    this.#process.kill()
-  }
-
-  private withTimeout<T>(operation: Promise<T>): Promise<T> {
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new CapabilityError('timeout', true)),
-        10_000
-      )
-      operation.then(
-        (value) => {
-          clearTimeout(timeout)
-          resolve(value)
-        },
-        (error: unknown) => {
-          clearTimeout(timeout)
-          reject(
-            error instanceof CapabilityError
-              ? error
-              : new CapabilityError('internal', false)
-          )
-        }
-      )
-    })
-  }
 }
 
-function timeoutFor(kind: CoreRequestWithoutId['kind']): CapabilityError {
-  return kind === 'campaign.create'
-    ? new CapabilityError('outcome_unknown', false)
-    : new CapabilityError('timeout', true)
-}
-
-type CoreRequestWithoutId =
-  | Omit<Extract<CoreRequest, { kind: 'core.shutdown' }>, 'requestId'>
-  | Omit<Extract<CoreRequest, { kind: 'campaign.list' }>, 'requestId'>
-  | Omit<Extract<CoreRequest, { kind: 'campaign.create' }>, 'requestId'>
-  | Omit<Extract<CoreRequest, { kind: 'campaign.activate' }>, 'requestId'>
+const campaignSchema = z.object({
+  activeCampaignId: z.uuid().nullable(),
+  campaigns: z.array(
+    z.object({ id: z.uuid(), name: z.string(), createdAt: z.string() })
+  )
+}) as z.ZodType<CampaignSnapshot>

--- a/src/main/core-process/utility.ts
+++ b/src/main/core-process/utility.ts
@@ -1,85 +1,312 @@
 import {
   capabilityFailureSchema,
   coreReadySchema,
-  coreRequestSchema,
-  type CapabilityErrorCode,
-  type CampaignSnapshot
+  type CapabilityErrorCode
 } from '../../shared/contracts/campaign.js'
+import { coreRequestSchema } from '../../shared/contracts/core-protocol.js'
 import { CampaignStore } from '../../core/persistence/sqlite/campaign-store.js'
+import { CreatureCatalogService } from '../../core/creatures/catalog.js'
+import { LivePlayService } from '../../core/encounter/live-combat.js'
 import { z } from 'zod'
-
-const suppliedDataRoot = process.argv[2]
-
-if (suppliedDataRoot === undefined || process.parentPort === undefined) {
+import { join } from 'node:path'
+import { WorldLocationService } from '../../core/worldplanner/location-store.js'
+import { EncounterSourceService } from '../../core/worldplanner/encounter-source-store.js'
+const root = process.argv[2]
+if (!root || !process.parentPort)
   throw new Error('Utility process requires a data root and parent port')
-}
-const dataRoot: string = suppliedDataRoot
-
-const campaigns = new CampaignStore(dataRoot)
-
+const campaigns = new CampaignStore(root)
+const play = new LivePlayService(() => campaigns.activeCampaignPath())
+const locations = new WorldLocationService(() => campaigns.activeCampaignPath())
+const sources = new EncounterSourceService(() => campaigns.activeCampaignPath())
+const creatures = new CreatureCatalogService(
+  join(root, 'installation.sqlite'),
+  (query) => sources.resolve(query),
+  () => ({
+    encounterTables: sources
+      .readTables()
+      .tables.map((table) => ({ id: table.id, label: table.displayName })),
+    factions: sources.readFactions().factions.map((faction) => ({
+      id: faction.id,
+      label: faction.displayName
+    })),
+    locations: locations.read().locations.map((location) => ({
+      id: location.id,
+      label: location.displayName
+    }))
+  })
+)
 process.parentPort.postMessage(coreReadySchema.parse({ kind: 'core.ready' }))
-
 process.parentPort.on('message', (event) => {
-  const raw: unknown = event.data
-  const parsed = coreRequestSchema.safeParse(raw)
+  const parsed = coreRequestSchema.safeParse(event.data)
   if (!parsed.success) {
-    const envelope = requestEnvelopeSchema.safeParse(raw)
-    if (envelope.success)
-      respondFailure(
-        envelope.data.requestId,
-        envelope.data.kind.startsWith('campaign.')
-          ? 'validation_failed'
-          : 'protocol_violation',
-        false
-      )
+    const envelope = z
+      .object({ requestId: z.uuid(), kind: z.string() })
+      .safeParse(event.data)
+    if (envelope.success) failure(envelope.data.requestId, 'validation_failed')
     return
   }
-
+  const r = parsed.data
   try {
-    if (parsed.data.kind === 'core.shutdown') {
-      respond(parsed.data.requestId, campaigns.list())
+    if (r.kind === 'core.shutdown') {
+      respond(r.requestId, campaigns.list())
       campaigns.close()
       process.exit(0)
-      return
-    }
-    if (parsed.data.kind === 'campaign.create') {
-      const snapshot = campaigns.create(parsed.data.input.name)
-      respond(parsed.data.requestId, snapshot)
-      return
-    }
-    if (parsed.data.kind === 'campaign.activate') {
-      const snapshot = campaigns.activate(parsed.data.input.id)
-      respond(parsed.data.requestId, snapshot)
-      return
-    }
-    respond(parsed.data.requestId, campaigns.list())
-  } catch (error) {
-    respondFailure(parsed.data.requestId, toCapabilityCode(error), false)
+    } else if (r.kind === 'campaign.list')
+      respond(r.requestId, campaigns.list())
+    else if (r.kind === 'campaign.create')
+      respond(r.requestId, campaigns.create(r.input.name))
+    else if (r.kind === 'campaign.activate')
+      respond(r.requestId, campaigns.activate(r.input.id))
+    else if (r.kind === 'party.read') respond(r.requestId, play.readParty())
+    else if (r.kind === 'party.setMembership')
+      respond(
+        r.requestId,
+        play.setMembership(r.input.id, r.input.active, r.input.expectedRevision)
+      )
+    else if (r.kind === 'party.create')
+      respond(
+        r.requestId,
+        play.createPartyCharacter(r.input.character, r.input.expectedRevision)
+      )
+    else if (r.kind === 'party.update')
+      respond(
+        r.requestId,
+        play.updatePartyCharacter(
+          r.input.id,
+          r.input.character,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'party.delete')
+      respond(
+        r.requestId,
+        play.deletePartyCharacter(r.input.id, r.input.expectedRevision)
+      )
+    else if (r.kind === 'party.adjustXp')
+      respond(
+        r.requestId,
+        play.adjustPartyXp(r.input.id, r.input.delta, r.input.expectedRevision)
+      )
+    else if (r.kind === 'party.rest')
+      respond(
+        r.requestId,
+        play.restParty(r.input.type, r.input.expectedRevision)
+      )
+    else if (r.kind === 'party.calculateAdventuringDay')
+      respond(
+        r.requestId,
+        play.calculateAdventuringDay(r.input.rows, r.input.totalXp)
+      )
+    else if (r.kind === 'creatures.search')
+      respond(r.requestId, creatures.search(r.input))
+    else if (r.kind === 'creatures.filterOptions')
+      respond(r.requestId, creatures.filterOptions())
+    else if (r.kind === 'creatures.detail') {
+      respond(r.requestId, creatures.detail(r.input.id))
+    } else if (r.kind === 'locations.read')
+      respond(r.requestId, locations.read())
+    else if (r.kind === 'locations.create')
+      respond(
+        r.requestId,
+        locations.create(r.input.location, r.input.expectedRevision)
+      )
+    else if (r.kind === 'locations.update')
+      respond(
+        r.requestId,
+        locations.update(r.input.id, r.input.location, r.input.expectedRevision)
+      )
+    else if (r.kind === 'locations.delete')
+      respond(
+        r.requestId,
+        locations.delete(r.input.id, r.input.expectedRevision)
+      )
+    else if (r.kind === 'encounterTables.read')
+      respond(r.requestId, sources.readTables())
+    else if (r.kind === 'encounterTables.create')
+      respond(
+        r.requestId,
+        sources.createTable(r.input.table, r.input.expectedRevision)
+      )
+    else if (r.kind === 'encounterTables.update')
+      respond(
+        r.requestId,
+        sources.updateTable(r.input.id, r.input.table, r.input.expectedRevision)
+      )
+    else if (r.kind === 'encounterTables.delete')
+      respond(
+        r.requestId,
+        sources.deleteTable(r.input.id, r.input.expectedRevision)
+      )
+    else if (r.kind === 'factions.read')
+      respond(r.requestId, sources.readFactions())
+    else if (r.kind === 'factions.create')
+      respond(
+        r.requestId,
+        sources.createFaction(r.input.faction, r.input.expectedRevision)
+      )
+    else if (r.kind === 'factions.update')
+      respond(
+        r.requestId,
+        sources.updateFaction(
+          r.input.id,
+          r.input.faction,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'factions.delete')
+      respond(
+        r.requestId,
+        sources.deleteFaction(r.input.id, r.input.expectedRevision)
+      )
+    else if (r.kind === 'session.read') respond(r.requestId, play.readSession())
+    else if (r.kind === 'scene.focus')
+      respond(
+        r.requestId,
+        play.focusScene(r.input.sceneId, r.input.expectedRevision)
+      )
+    else if (r.kind === 'scene.setLocation')
+      respond(
+        r.requestId,
+        play.setSceneLocation(
+          r.input.sceneId,
+          r.input.locationId,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'scene.saveGroup')
+      respond(
+        r.requestId,
+        play.saveSceneGroup(
+          r.input.sceneId,
+          r.input.groupId,
+          r.input.name,
+          r.input.entries,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'scene.deleteGroup')
+      respond(
+        r.requestId,
+        play.deleteSceneGroup(
+          r.input.sceneId,
+          r.input.groupId,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'scene.assignPartyMember')
+      respond(
+        r.requestId,
+        play.assignScenePartyMember(
+          r.input.sceneId,
+          r.input.partyMemberId,
+          r.input.assigned,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'scene.evaluateGroupDraft')
+      respond(
+        r.requestId,
+        play.evaluateGroupDraft(
+          r.input.sceneId,
+          r.input.entries,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'scene.generateGroupDraft')
+      respond(
+        r.requestId,
+        play.generateGroupDraft(
+          r.input.sceneId,
+          r.input.entries,
+          r.input.mode,
+          r.input.filters,
+          r.input.tuning,
+          r.input.seed,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'encounter.evaluate')
+      respond(
+        r.requestId,
+        play.evaluateEncounter(
+          r.input.sceneId,
+          r.input.groupIds,
+          r.input.expectedRevision
+        )
+      )
+    else if (r.kind === 'combat.prepare')
+      respond(
+        r.requestId,
+        play.prepareCombat(
+          r.input.sceneId,
+          r.input.expectedSceneRevision,
+          r.input.groupIds
+        )
+      )
+    else if (r.kind === 'combat.rollInitiative')
+      respond(r.requestId, play.rollInitiative(r.input.expectedRevision))
+    else if (r.kind === 'combat.confirmInitiative')
+      respond(
+        r.requestId,
+        play.confirmInitiative(r.input.expectedRevision, r.input.values)
+      )
+    else if (r.kind === 'combat.advanceTurn')
+      respond(r.requestId, play.advanceTurn(r.input.expectedRevision))
+    else if (r.kind === 'combat.adjustInitiative')
+      respond(
+        r.requestId,
+        play.adjustInitiative(
+          r.input.expectedRevision,
+          r.input.id,
+          r.input.initiative
+        )
+      )
+    else if (r.kind === 'combat.changeHp')
+      respond(
+        r.requestId,
+        play.changeHp(
+          r.input.expectedRevision,
+          r.input.cardId,
+          r.input.amount,
+          r.input.healing
+        )
+      )
+    else if (r.kind === 'combat.end')
+      respond(r.requestId, play.endCombat(r.input.expectedRevision))
+    else if (r.kind === 'combat.updateResolution')
+      respond(
+        r.requestId,
+        play.updateResolution(
+          r.input.expectedRevision,
+          r.input.selectedEnemyIds,
+          r.input.thresholdFraction,
+          r.input.xpFraction
+        )
+      )
+    else if (r.kind === 'combat.awardXp')
+      respond(r.requestId, play.awardXp(r.input.expectedRevision))
+    else if (r.kind === 'combat.complete')
+      respond(r.requestId, play.completeCombat(r.input.expectedRevision))
+  } catch (e) {
+    failure(
+      r.requestId,
+      e instanceof Error && e.message === 'not found'
+        ? 'not_found'
+        : e instanceof Error && e.message === 'stale'
+          ? 'stale'
+          : e instanceof Error && e.message === 'validation'
+            ? 'validation_failed'
+            : 'internal'
+    )
   }
 })
-
-function respond(requestId: string, snapshot: CampaignSnapshot): void {
-  process.parentPort?.postMessage({ requestId, ok: true, snapshot })
+function respond(requestId: string, payload: unknown) {
+  process.parentPort?.postMessage({ requestId, ok: true, payload })
 }
-
-const requestEnvelopeSchema = capabilityFailureSchema
-  .pick({})
-  .extend({ requestId: z.uuid(), kind: z.string() })
-
-function respondFailure(
-  requestId: string,
-  code: CapabilityErrorCode,
-  retryable: boolean
-): void {
+function failure(requestId: string, code: CapabilityErrorCode) {
   process.parentPort?.postMessage({
     requestId,
     ok: false,
-    error: capabilityFailureSchema.parse({ code, retryable })
+    error: capabilityFailureSchema.parse({ code, retryable: false })
   })
-}
-
-function toCapabilityCode(error: unknown): CapabilityErrorCode {
-  return error instanceof Error && error.message === 'Campaign not found'
-    ? 'not_found'
-    : 'internal'
 }

--- a/src/preload/capability-bridge/index.ts
+++ b/src/preload/capability-bridge/index.ts
@@ -1,83 +1,529 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import { z } from 'zod'
 import {
-  createCampaignInputSchema,
   activateCampaignInputSchema,
   campaignCapabilityResponseSchema,
+  createCampaignInputSchema,
   freezeCampaignSnapshot
 } from '../../shared/contracts/campaign.js'
+import {
+  creatureCatalogPageSchema,
+  creatureCatalogQuerySchema,
+  creatureFilterOptionsSchema,
+  creatureSchema
+} from '../../shared/contracts/encounter.js'
+import {
+  adjustInitiativeInputSchema,
+  changeHpInputSchema,
+  combatRevisionInputSchema,
+  confirmInitiativeInputSchema,
+  liveSessionSnapshotSchema,
+  prepareCombatInputSchema,
+  updateResolutionInputSchema
+} from '../../shared/contracts/live-session.js'
+import {
+  adjustPartyXpInputSchema,
+  adventuringDayCalculationSchema,
+  adventuringDayInputSchema,
+  createPartyCharacterInputSchema,
+  deletePartyCharacterInputSchema,
+  partySnapshotSchema,
+  restPartyInputSchema,
+  setMembershipInputSchema,
+  updatePartyCharacterInputSchema
+} from '../../shared/contracts/party.js'
 import { CapabilityError } from '../../shared/errors/capability-error.js'
 import { runtimeGpuObservationSchema } from '../../shared/qualification/runtime-observation.js'
-import type {
-  CampaignCapability,
-  CampaignReadCapability,
-  SaltMarcherApi
-} from '../../shared/contracts/capability-api.js'
+import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import {
+  assignScenePartyInputSchema,
+  deleteSceneGroupInputSchema,
+  encounterSelectionEvaluationSchema,
+  evaluateEncounterSelectionInputSchema,
+  evaluateSceneGroupDraftInputSchema,
+  focusSceneInputSchema,
+  saveSceneGroupInputSchema,
+  setSceneLocationInputSchema,
+  sceneGroupDraftEvaluationSchema,
+  sceneGroupDraftGenerationRequestSchema,
+  sceneGroupDraftGenerationSchema
+} from '../../shared/contracts/scene.js'
+import { sessionLayoutPreferenceSchema } from '../../shared/contracts/session-layout.js'
+import {
+  createWorldLocationInputSchema,
+  deleteWorldLocationInputSchema,
+  updateWorldLocationInputSchema,
+  worldLocationSnapshotSchema
+} from '../../shared/contracts/world-location.js'
+import {
+  createEncounterTableInputSchema,
+  createWorldFactionInputSchema,
+  deleteEncounterTableInputSchema,
+  deleteWorldFactionInputSchema,
+  encounterTableSnapshotSchema,
+  updateEncounterTableInputSchema,
+  updateWorldFactionInputSchema,
+  worldFactionSnapshotSchema
+} from '../../shared/contracts/encounter-source.js'
 
-const readCampaigns: CampaignReadCapability = {
-  async list() {
-    return invokeCampaign('campaign:list')
+async function invoke<T>(
+  channel: string,
+  input: unknown,
+  schema: { safeParse(value: unknown): { success: boolean; data?: T } }
+): Promise<T> {
+  try {
+    const raw: unknown = await ipcRenderer.invoke(channel, input)
+    const result = z
+      .discriminatedUnion('ok', [
+        z.object({ ok: z.literal(true), payload: z.unknown() }).passthrough(),
+        z
+          .object({
+            ok: z.literal(false),
+            error: z
+              .object({
+                code: z.enum([
+                  'validation_failed',
+                  'stale',
+                  'not_found',
+                  'read_only',
+                  'timeout',
+                  'outcome_unknown',
+                  'core_unavailable',
+                  'protocol_violation',
+                  'internal'
+                ]),
+                retryable: z.boolean()
+              })
+              .strict()
+          })
+          .passthrough()
+      ])
+      .parse(raw)
+    if (!result.ok)
+      throw new CapabilityError(result.error.code, result.error.retryable)
+    const value = schema.safeParse(result.payload)
+    if (!value.success) throw new CapabilityError('protocol_violation', false)
+    return value.data!
+  } catch (error) {
+    if (error instanceof CapabilityError) throw error
+    throw new CapabilityError('core_unavailable', true)
   }
 }
-const campaigns: CampaignCapability = {
-  ...readCampaigns,
-  async create(name) {
-    const input = createCampaignInputSchema.safeParse({ name })
-    if (!input.success) throw new CapabilityError('validation_failed', false)
-    return invokeCampaign('campaign:create', input.data)
-  },
-  async activate(id) {
-    const input = activateCampaignInputSchema.safeParse({ id })
-    if (!input.success) throw new CapabilityError('validation_failed', false)
-    return invokeCampaign('campaign:activate', input.data)
-  }
-}
+
+const live = async (channel: string, input: unknown) =>
+  freezeDeep(await invoke(channel, input, liveSessionSnapshotSchema))
+
 const api: SaltMarcherApi = {
-  campaigns: process.argv.includes('--salt-marcher-read-only')
-    ? readCampaigns
-    : campaigns,
+  campaigns: {
+    async list() {
+      const result = campaignCapabilityResponseSchema.parse(
+        await ipcRenderer.invoke('campaign:list')
+      )
+      if (!result.ok)
+        throw new CapabilityError(result.error.code, result.error.retryable)
+      return freezeCampaignSnapshot(result.snapshot)
+    },
+    async create(name) {
+      const input = createCampaignInputSchema.parse({ name })
+      const result = campaignCapabilityResponseSchema.parse(
+        await ipcRenderer.invoke('campaign:create', input)
+      )
+      if (!result.ok)
+        throw new CapabilityError(result.error.code, result.error.retryable)
+      return freezeCampaignSnapshot(result.snapshot)
+    },
+    async activate(id) {
+      const input = activateCampaignInputSchema.parse({ id })
+      const result = campaignCapabilityResponseSchema.parse(
+        await ipcRenderer.invoke('campaign:activate', input)
+      )
+      if (!result.ok)
+        throw new CapabilityError(result.error.code, result.error.retryable)
+      return freezeCampaignSnapshot(result.snapshot)
+    }
+  },
+  party: {
+    read: async () =>
+      freezeDeep(await invoke('party:read', undefined, partySnapshotSchema)),
+    setMembership: async (id, active, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:setMembership',
+          setMembershipInputSchema.parse({ id, active, expectedRevision }),
+          partySnapshotSchema
+        )
+      ),
+    create: async (character, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:create',
+          createPartyCharacterInputSchema.parse({
+            character,
+            expectedRevision
+          }),
+          partySnapshotSchema
+        )
+      ),
+    update: async (id, character, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:update',
+          updatePartyCharacterInputSchema.parse({
+            id,
+            character,
+            expectedRevision
+          }),
+          partySnapshotSchema
+        )
+      ),
+    delete: async (id, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:delete',
+          deletePartyCharacterInputSchema.parse({ id, expectedRevision }),
+          partySnapshotSchema
+        )
+      ),
+    adjustXp: async (id, delta, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:adjustXp',
+          adjustPartyXpInputSchema.parse({ id, delta, expectedRevision }),
+          partySnapshotSchema
+        )
+      ),
+    rest: async (type, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'party:rest',
+          restPartyInputSchema.parse({ type, expectedRevision }),
+          partySnapshotSchema
+        )
+      ),
+    calculateAdventuringDay: (rows, totalXp) =>
+      invoke(
+        'party:calculateAdventuringDay',
+        adventuringDayInputSchema.parse({
+          rows,
+          ...(totalXp === undefined ? {} : { totalXp })
+        }),
+        adventuringDayCalculationSchema
+      )
+  },
+  creatures: {
+    search: (query) =>
+      invoke(
+        'creatures:search',
+        creatureCatalogQuerySchema.parse(query),
+        creatureCatalogPageSchema
+      ),
+    filterOptions: () =>
+      invoke('creatures:filterOptions', undefined, creatureFilterOptionsSchema),
+    detail: (id) => invoke('creatures:detail', { id }, creatureSchema)
+  },
+  locations: {
+    read: async () =>
+      freezeDeep(
+        await invoke('locations:read', undefined, worldLocationSnapshotSchema)
+      ),
+    create: async (location, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'locations:create',
+          createWorldLocationInputSchema.parse({ location, expectedRevision }),
+          worldLocationSnapshotSchema
+        )
+      ),
+    update: async (id, location, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'locations:update',
+          updateWorldLocationInputSchema.parse({
+            id,
+            location,
+            expectedRevision
+          }),
+          worldLocationSnapshotSchema
+        )
+      ),
+    delete: async (id, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'locations:delete',
+          deleteWorldLocationInputSchema.parse({ id, expectedRevision }),
+          worldLocationSnapshotSchema
+        )
+      )
+  },
+  encounterTables: {
+    read: async () =>
+      freezeDeep(
+        await invoke(
+          'encounter-tables:read',
+          undefined,
+          encounterTableSnapshotSchema
+        )
+      ),
+    create: async (table, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'encounter-tables:create',
+          createEncounterTableInputSchema.parse({ table, expectedRevision }),
+          encounterTableSnapshotSchema
+        )
+      ),
+    update: async (id, table, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'encounter-tables:update',
+          updateEncounterTableInputSchema.parse({
+            id,
+            table,
+            expectedRevision
+          }),
+          encounterTableSnapshotSchema
+        )
+      ),
+    delete: async (id, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'encounter-tables:delete',
+          deleteEncounterTableInputSchema.parse({ id, expectedRevision }),
+          encounterTableSnapshotSchema
+        )
+      )
+  },
+  factions: {
+    read: async () =>
+      freezeDeep(
+        await invoke('factions:read', undefined, worldFactionSnapshotSchema)
+      ),
+    create: async (faction, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'factions:create',
+          createWorldFactionInputSchema.parse({ faction, expectedRevision }),
+          worldFactionSnapshotSchema
+        )
+      ),
+    update: async (id, faction, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'factions:update',
+          updateWorldFactionInputSchema.parse({
+            id,
+            faction,
+            expectedRevision
+          }),
+          worldFactionSnapshotSchema
+        )
+      ),
+    delete: async (id, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'factions:delete',
+          deleteWorldFactionInputSchema.parse({ id, expectedRevision }),
+          worldFactionSnapshotSchema
+        )
+      )
+  },
+  session: {
+    read: () => live('session:read', undefined),
+    readLayout: async () =>
+      freezeDeep(
+        await invoke(
+          'session-layout:read',
+          undefined,
+          sessionLayoutPreferenceSchema
+        )
+      ),
+    saveLayout: async (preference) =>
+      freezeDeep(
+        await invoke(
+          'session-layout:save',
+          sessionLayoutPreferenceSchema.parse(preference),
+          sessionLayoutPreferenceSchema
+        )
+      )
+  },
+  scene: {
+    focus: (sceneId, expectedRevision) =>
+      live(
+        'scene:focus',
+        focusSceneInputSchema.parse({ sceneId, expectedRevision })
+      ),
+    setLocation: (sceneId, locationId, expectedRevision) =>
+      live(
+        'scene:setLocation',
+        setSceneLocationInputSchema.parse({
+          sceneId,
+          locationId,
+          expectedRevision
+        })
+      ),
+    saveGroup: (sceneId, groupId, name, entries, expectedRevision) =>
+      live(
+        'scene:saveGroup',
+        saveSceneGroupInputSchema.parse({
+          sceneId,
+          groupId,
+          name,
+          entries,
+          expectedRevision
+        })
+      ),
+    deleteGroup: (sceneId, groupId, expectedRevision) =>
+      live(
+        'scene:deleteGroup',
+        deleteSceneGroupInputSchema.parse({
+          sceneId,
+          groupId,
+          expectedRevision
+        })
+      ),
+    assignPartyMember: (sceneId, partyMemberId, assigned, expectedRevision) =>
+      live(
+        'scene:assignPartyMember',
+        assignScenePartyInputSchema.parse({
+          sceneId,
+          partyMemberId,
+          assigned,
+          expectedRevision
+        })
+      ),
+    evaluateGroupDraft: async (sceneId, entries, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'scene:evaluateGroupDraft',
+          evaluateSceneGroupDraftInputSchema.parse({
+            sceneId,
+            entries,
+            expectedRevision
+          }),
+          sceneGroupDraftEvaluationSchema
+        )
+      ),
+    generateGroupDraft: async (
+      sceneId,
+      entries,
+      mode,
+      filters,
+      tuning,
+      seed,
+      expectedRevision
+    ) =>
+      freezeDeep(
+        await invoke(
+          'scene:generateGroupDraft',
+          sceneGroupDraftGenerationRequestSchema.parse({
+            sceneId,
+            entries,
+            mode,
+            filters,
+            tuning,
+            seed,
+            expectedRevision
+          }),
+          sceneGroupDraftGenerationSchema
+        )
+      )
+  },
+  encounter: {
+    evaluate: (sceneId, groupIds, expectedRevision) =>
+      invoke(
+        'encounter:evaluate',
+        evaluateEncounterSelectionInputSchema.parse({
+          sceneId,
+          groupIds,
+          expectedRevision
+        }),
+        encounterSelectionEvaluationSchema
+      )
+  },
+  combat: {
+    prepare: (sceneId, groupIds, expectedSceneRevision) =>
+      live(
+        'combat:prepare',
+        prepareCombatInputSchema.parse({
+          sceneId,
+          groupIds,
+          expectedSceneRevision
+        })
+      ),
+    rollInitiative: (expectedRevision) =>
+      live(
+        'combat:rollInitiative',
+        combatRevisionInputSchema.parse({ expectedRevision })
+      ),
+    confirmInitiative: (values, expectedRevision) =>
+      live(
+        'combat:confirmInitiative',
+        confirmInitiativeInputSchema.parse({ values, expectedRevision })
+      ),
+    advanceTurn: (expectedRevision) =>
+      live(
+        'combat:advanceTurn',
+        combatRevisionInputSchema.parse({ expectedRevision })
+      ),
+    adjustInitiative: (id, initiative, expectedRevision) =>
+      live(
+        'combat:adjustInitiative',
+        adjustInitiativeInputSchema.parse({ id, initiative, expectedRevision })
+      ),
+    changeHp: (cardId, amount, healing, expectedRevision) =>
+      live(
+        'combat:changeHp',
+        changeHpInputSchema.parse({ cardId, amount, healing, expectedRevision })
+      ),
+    end: (expectedRevision) =>
+      live('combat:end', combatRevisionInputSchema.parse({ expectedRevision })),
+    updateResolution: (
+      selectedEnemyIds,
+      thresholdFraction,
+      xpFraction,
+      expectedRevision
+    ) =>
+      live(
+        'combat:updateResolution',
+        updateResolutionInputSchema.parse({
+          selectedEnemyIds,
+          thresholdFraction,
+          xpFraction,
+          expectedRevision
+        })
+      ),
+    awardXp: (expectedRevision) =>
+      live(
+        'combat:awardXp',
+        combatRevisionInputSchema.parse({ expectedRevision })
+      ),
+    complete: (expectedRevision) =>
+      live(
+        'combat:complete',
+        combatRevisionInputSchema.parse({ expectedRevision })
+      )
+  },
   runtime: Object.freeze({
     readOnly: process.argv.includes('--salt-marcher-read-only'),
     e2e: process.argv.includes('--salt-marcher-e2e'),
     async processMemoryBytes() {
       const value: unknown = await ipcRenderer.invoke('runtime:memory')
-      if (
-        typeof value !== 'number' ||
-        !Number.isSafeInteger(value) ||
-        value < 0
-      )
-        throw new Error('Invalid runtime memory response')
-      return value
+      return z.number().nonnegative().parse(value)
     },
     async gpuObservation() {
-      const response = runtimeGpuObservationSchema.safeParse(
+      return runtimeGpuObservationSchema.parse(
         await ipcRenderer.invoke('runtime:gpu-observation')
       )
-      if (!response.success) throw new Error('Invalid runtime GPU response')
-      return response.data
     }
   })
 }
 
 contextBridge.exposeInMainWorld('saltMarcher', Object.freeze(api))
 
-async function invokeCampaign(
-  channel: 'campaign:list' | 'campaign:create' | 'campaign:activate',
-  input?: unknown
-) {
-  try {
-    const response = campaignCapabilityResponseSchema.safeParse(
-      await ipcRenderer.invoke(channel, input)
-    )
-    if (!response.success)
-      throw new CapabilityError('protocol_violation', false)
-    if (!response.data.ok)
-      throw new CapabilityError(
-        response.data.error.code,
-        response.data.error.retryable
-      )
-    return freezeCampaignSnapshot(response.data.snapshot)
-  } catch (error) {
-    if (error instanceof CapabilityError) throw error
-    throw new CapabilityError('core_unavailable', true)
+function freezeDeep<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) freezeDeep(child)
+    Object.freeze(value)
   }
+  return value
 }

--- a/src/preload/capability-bridge/index.ts
+++ b/src/preload/capability-bridge/index.ts
@@ -6,6 +6,7 @@ import {
   freezeCampaignSnapshot
 } from '../../shared/contracts/campaign.js'
 import { CapabilityError } from '../../shared/errors/capability-error.js'
+import { runtimeGpuObservationSchema } from '../../shared/qualification/runtime-observation.js'
 import type {
   CampaignCapability,
   CampaignReadCapability,
@@ -46,6 +47,13 @@ const api: SaltMarcherApi = {
       )
         throw new Error('Invalid runtime memory response')
       return value
+    },
+    async gpuObservation() {
+      const response = runtimeGpuObservationSchema.safeParse(
+        await ipcRenderer.invoke('runtime:gpu-observation')
+      )
+      if (!response.success) throw new Error('Invalid runtime GPU response')
+      return response.data
     }
   })
 }

--- a/src/renderer/shell/app.css
+++ b/src/renderer/shell/app.css
@@ -1,85 +1,1579 @@
 :root {
   color-scheme: dark;
-  font-family: system-ui, sans-serif;
-  background: #15201e;
-  color: #f7f2e8;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #101716;
+  color: #f5f2e9;
 }
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
+  min-width: 320px;
 }
-.app-shell {
-  max-width: 760px;
-  margin: 0 auto;
-  padding: clamp(1.5rem, 4vw, 4rem);
-}
-.eyebrow {
-  color: #a8d7c7;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.inline-form {
-  display: flex;
-  gap: 0.75rem;
-  margin-top: 0.35rem;
-}
+
+button,
 input,
-button {
+select {
   font: inherit;
-  padding: 0.65rem 0.8rem;
-  border-radius: 0.35rem;
 }
-input {
-  flex: 1;
-  border: 1px solid #92b5a9;
-  background: #0c1513;
-  color: inherit;
-}
+
 button {
-  border: 1px solid #a8d7c7;
-  background: #245f4d;
+  border: 1px solid #4e7066;
+  border-radius: 0.35rem;
+  background: #1d4b3f;
   color: inherit;
   cursor: pointer;
+  padding: 0.55rem 0.7rem;
 }
-button[aria-pressed='true'] {
-  background: #a8d7c7;
-  color: #10211b;
+
+button:hover {
+  background: #286451;
 }
-ul {
-  list-style: none;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
-li button {
-  width: 100%;
-  text-align: left;
-}
+
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+select:focus-visible {
   outline: 3px solid #f1cc7d;
   outline-offset: 3px;
 }
-.qualification-grid {
+
+input {
+  border: 1px solid #637f76;
+  border-radius: 0.35rem;
+  background: #101b18;
+  color: inherit;
+  padding: 0.58rem 0.7rem;
+}
+
+.app-shell {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 100vh;
 }
-.qualification-canvas {
-  width: 100%;
-  min-height: 300px;
-  border: 1px solid #92b5a9;
-  display: block;
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  min-height: 4.25rem;
+  border-bottom: 1px solid #3a554d;
+  background: #172420;
 }
-.qualification-canvas canvas {
-  max-width: 100%;
-  height: auto;
+
+.menu-button {
+  align-self: stretch;
+  width: 4.25rem;
+  border: 0;
+  border-right: 1px solid #3a554d;
+  border-radius: 0;
+  background: transparent;
+  font-size: 1.35rem;
 }
-.sr-only {
+
+.menu-button:hover {
+  background: #21352e;
+}
+
+.shell-quick-actions {
+  display: flex;
+  align-self: stretch;
+}
+
+.party-dropdown {
+  position: relative;
+  align-self: stretch;
+}
+
+.party-trigger {
+  height: 100%;
+  border: 0;
+  border-right: 1px solid #3a554d;
+  border-radius: 0;
+  background: transparent;
+}
+
+.party-panel {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
+  z-index: 20;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  display: grid;
+  width: min(24rem, calc(100vw - 1rem));
+  max-height: min(40rem, calc(100vh - 5rem));
+  gap: 0.65rem;
+  overflow: auto;
+  border: 1px solid #55776d;
+  border-radius: 0.45rem;
+  background: #17251f;
+  box-shadow: 0 0.8rem 2.4rem #0009;
+  padding: 0.85rem;
+}
+
+.party-panel header,
+.group-dialog header,
+.groups-heading,
+.scenario-content footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.party-panel h2,
+.party-panel h3,
+.groups-heading h2,
+.scenario-content h2,
+.group-dialog h2 {
+  margin: 0;
+}
+
+.party-panel h2,
+.party-panel h3 {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+}
+
+.party-list,
+.monster-picker,
+.initiative-list,
+.combat-cards,
+.result-enemies {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.party-list li,
+.monster-picker li,
+.initiative-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  border: 1px solid #38544b;
+  border-radius: 0.3rem;
+  background: #101b18;
+  padding: 0.5rem;
+}
+
+.party-list span,
+.monster-picker span {
+  display: grid;
+  min-width: 0;
+}
+
+.party-list small,
+.monster-picker small,
+.combat-card small {
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  color: #aebdb7;
+  text-overflow: ellipsis;
+}
+
+.shell-quick-actions button {
+  border: 0;
+  border-right: 1px solid #3a554d;
+  border-radius: 0;
+  background: transparent;
+  color: #d6e0db;
+  font-size: 0.8rem;
+}
+
+.shell-quick-actions button:hover {
+  background: #21352e;
+}
+
+.workspace-heading {
+  padding-left: 1.15rem;
+}
+
+.workspace-heading h1,
+.workspace-heading p,
+.panel-heading h2,
+.workspace-panel h2,
+.workspace-panel h3 {
+  margin: 0;
+}
+
+.workspace-heading h1 {
+  font-size: 1.05rem;
+  font-weight: 650;
+}
+
+.eyebrow,
+.section-kicker {
+  color: #b7d9ca;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin: 0 0 0.1rem;
+}
+
+.top-bar-status {
+  margin: 0 1.25rem 0 auto;
+  color: #aebdb7;
+  font-size: 0.85rem;
+}
+
+.shell-body {
+  display: grid;
+  grid-template-columns: 4.25rem minmax(0, 1fr);
+  min-height: 0;
+}
+
+.icon-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.55rem;
+  border-right: 1px solid #3a554d;
+  background: #14201d;
+}
+
+.icon-button {
+  display: grid;
+  width: 3.1rem;
+  height: 3.1rem;
+  place-items: center;
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+  color: #c6d8d1;
+  font-size: 1.25rem;
+}
+
+.icon-button:hover,
+.icon-button[aria-pressed='true'] {
+  border-color: #628a7d;
+  background: #285245;
+  color: #fffdf6;
+}
+
+.work-area {
+  overflow: auto;
+  padding: clamp(1.25rem, 3vw, 3rem);
+}
+
+.session-work-area {
+  display: flex;
+  overflow: hidden;
+  padding: 0;
+}
+
+.workspace-panel {
+  width: min(100%, 72rem);
+  border: 1px solid #3e5c53;
+  border-radius: 0.6rem;
+  background: #192722;
+  padding: clamp(1rem, 2.5vw, 1.75rem);
+}
+
+.workspace-panel h2 {
+  font-size: 1.35rem;
+}
+
+.campaign-panel {
+  display: grid;
+  gap: 1.25rem;
+  max-width: 42rem;
+}
+
+.campaign-panel > div > p:not(.section-kicker) {
+  color: #b5c3bd;
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.65rem;
+}
+
+.inline-form input:not(.level-input) {
+  min-width: 0;
+  flex: 1;
+}
+
+.level-input {
+  width: 5.5rem;
+}
+
+.campaigns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.6rem;
+}
+
+.campaigns button {
+  text-align: left;
+}
+
+.item-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 1rem 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.75rem;
+  border: 1px solid #38544b;
+  border-radius: 0.35rem;
+  background: #14211d;
+}
+
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.row-actions button {
+  padding: 0.32rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.encounter {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+}
+
+.encounter label {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  color: #c9d6d0;
+  font-size: 0.88rem;
+}
+
+.encounter-summary {
+  padding-left: clamp(0rem, 3vw, 2.5rem);
+  border-left: 1px solid #3a554d;
+}
+
+.difficulty {
+  margin-top: 1.25rem;
+  padding: 0.9rem 1rem;
+  border-left: 3px solid #f1cc7d;
+  background: #202e29;
+}
+
+.difficulty p,
+.attribution {
+  color: #b5c3bd;
+  font-size: 0.85rem;
+}
+
+.error-message {
+  width: min(100%, 72rem);
+  margin: 0 0 1rem;
+  border: 1px solid #b56d5d;
+  border-radius: 0.35rem;
+  background: #3b2420;
+  color: #ffe3db;
+  padding: 0.75rem;
+}
+
+.session-mockup {
+  flex: 1;
+  min-width: 0;
+  background: #101b18;
+}
+
+.session-layout {
+  height: 100%;
+  min-height: 35rem;
+}
+
+.session-workspace {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.session-column {
+  flex-direction: column;
+}
+
+.session-column {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+}
+
+.session-column[style],
+.session-pane[style] {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.session-pane {
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.session-pane > * {
+  box-sizing: border-box;
+  height: 100%;
+}
+
+.session-control-pane {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.session-divider {
+  position: relative;
+  z-index: 3;
+  flex: 0 0 0.55rem;
+  background: #29443b;
+  outline: none;
+  touch-action: none;
+}
+
+.session-divider:hover,
+.session-divider:focus-visible {
+  background: #5c8a78;
+}
+
+.session-divider-vertical {
+  cursor: col-resize;
+}
+
+.session-divider-horizontal {
+  cursor: row-resize;
+}
+
+.session-control-panel,
+.session-detail-panel,
+.scenario-panel,
+.session-groups {
+  min-height: 0;
+  padding: 0.8rem;
+}
+
+.groups-heading {
+  margin-bottom: 0.8rem;
+}
+
+.session-groups .group-card + .group-card {
+  margin-top: 0.7rem;
+}
+
+.session-control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  overflow: auto;
+  background: #14241f;
+}
+
+.session-control-panel .panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.session-control-panel h2,
+.session-groups h2 {
+  margin: 0;
+}
+
+.session-control-panel label {
+  display: grid;
+  gap: 0.25rem;
+  color: #b9cac3;
+  font-size: 0.75rem;
+}
+
+.panel-hint {
+  margin: 0;
+  color: #93aaa1;
+  font-size: 0.72rem;
+}
+
+.session-groups {
+  overflow: auto;
+  background: #0f1a17;
+}
+
+.session-detail-panel {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 0.55rem;
+  overflow: hidden;
+  background: #101b18;
+}
+
+.session-panel-tabs,
+.detail-history {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.session-panel-tabs button[aria-selected='true'] {
+  border-color: #8fb7a7;
+  background: #29483d;
+}
+
+.detail-history span {
+  min-width: 0;
+  margin-left: 0.35rem;
+  overflow: hidden;
+  color: #c7d5cf;
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-scroll {
+  min-height: 0;
+  overflow: auto;
+}
+
+.detail-empty,
+.session-map-empty {
+  display: grid;
+  height: 100%;
+  align-content: center;
+  justify-items: center;
+  border: 1px dashed #47675d;
+  color: #aabbb4;
+  padding: 1rem;
+  text-align: center;
+}
+
+.session-map-empty {
+  grid-row: 2 / 4;
+}
+
+.group-card {
+  display: grid;
+  gap: 0.7rem;
+  max-width: 22rem;
+  border: 1px solid #31594d;
+  border-radius: 0.25rem;
+  background: #14241f;
+  padding: 0.75rem;
+}
+
+.group-card-title,
+.group-members {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.group-card-title > span {
+  margin-left: auto;
+  color: #aebdb7;
+  font-size: 0.72rem;
+}
+
+.group-card-title button {
+  margin-left: auto;
+  padding: 0.28rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.group-members {
+  flex-wrap: wrap;
+}
+
+.group-members span,
+.group-members button {
+  border: 1px solid #47675d;
+  border-radius: 0.25rem;
+  background: #172720;
+  padding: 0.45rem;
+  font-size: 0.74rem;
+}
+
+.group-members span:first-child {
+  flex-basis: 100%;
+}
+
+.group-card p {
+  margin: 0;
+  color: #b7c6bf;
+  font-size: 0.78rem;
+}
+
+.scenario-panel {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.7rem;
+  min-width: 0;
+  padding: 0.55rem;
+  background: #101b18;
+}
+
+.scenario-panel button {
+  padding: 0.45rem 0.3rem;
+  background: #20352d;
+  font-size: 0.72rem;
+}
+
+.scenario-panel > select {
+  width: 100%;
+}
+
+.scenario-empty {
+  display: grid;
+  place-items: center;
+  border: 1px dashed #47675d;
+  color: #aabbb4;
+  font-size: 0.77rem;
+  text-align: center;
+}
+
+.scenario-content {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.65rem;
+  overflow: auto;
+  border: 1px solid #47675d;
+  padding: 0.65rem;
+}
+
+.scenario-content > button,
+.scenario-content footer button {
+  font-size: 0.78rem;
+}
+
+.scenario-choice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid #38544b;
+  border-radius: 0.3rem;
+  padding: 0.55rem;
+}
+
+.scenario-choice.locked {
+  border-color: #b89955;
+}
+
+.initiative-list input,
+.card-controls input,
+.monster-picker input[type='number'] {
+  width: 4.5rem;
+}
+
+.combat-card {
+  display: grid;
+  gap: 0.35rem;
+  border: 1px solid #38544b;
+  border-radius: 0.35rem;
+  background: #14211d;
+  padding: 0.6rem;
+}
+
+.combat-card.active {
+  border-color: #f1cc7d;
+  box-shadow: inset 3px 0 #f1cc7d;
+}
+
+.combat-card.dead {
+  opacity: 0.6;
+}
+
+.card-controls,
+.confirm-row {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.primary-action,
+.accent {
+  border-color: #f1cc7d;
+  background: #6b5527;
+}
+
+.resolution-panel > label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.25rem;
+}
+
+.resolution-panel input[type='range'] {
+  grid-column: 1 / 3;
+  width: 100%;
+}
+
+.result-enemies label {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.loot-summary,
+.empty-state {
+  color: #aebdb7;
+  font-size: 0.8rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  z-index: 30;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #000a;
+  padding: 1rem;
+}
+
+.group-dialog {
+  width: min(40rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  border: 1px solid #55776d;
+  border-radius: 0.55rem;
+  background: #17251f;
+  box-shadow: 0 1rem 3rem #000b;
+  padding: 1rem;
+}
+
+.group-dialog form,
+.group-dialog label {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.group-dialog form {
+  gap: 0.85rem;
+}
+
+.group-dialog footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+}
+
+.monster-picker {
+  max-height: 20rem;
+  overflow: auto;
+}
+
+.monster-picker label {
+  grid-template-columns: auto 4.5rem;
+  align-items: center;
+}
+
+.inline-error,
+.unavailable {
+  color: #ffb3a2;
+}
+
+select {
+  min-height: 2.15rem;
+  border: 1px solid #637f76;
+  border-radius: 0.35rem;
+  background: #101b18;
+  color: inherit;
+  padding: 0.35rem 0.5rem;
+}
+
+progress {
+  width: 100%;
+  accent-color: #d4ad5d;
+}
+
+.muted {
+  color: #9eb0a9;
+}
+
+.day-panel {
+  width: min(21rem, calc(100vw - 1rem));
+}
+
+.day-summary {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid #47675d;
+  background: #101b18;
+  padding: 0.75rem;
+}
+
+.day-summary strong {
+  font-size: 1.25rem;
+}
+
+.day-rows,
+.day-timeline {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.day-rows li {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  align-items: end;
+  gap: 0.35rem;
+}
+
+.day-rows label {
+  display: grid;
+  gap: 0.2rem;
+  color: #aebdb7;
+  font-size: 0.7rem;
+}
+
+.day-rows input {
+  min-width: 0;
+  width: 100%;
+}
+
+.day-timeline {
+  border-left: 2px solid #d4ad5d;
+  padding-left: 0.65rem;
+  color: #b7c6bf;
+  font-size: 0.75rem;
+}
+
+.party-character-card {
+  display: grid !important;
+  align-items: stretch !important;
+}
+
+.party-card-main,
+.party-editor {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.party-card-actions,
+.party-rest-actions,
+.editor-numbers,
+.save-row,
+.tuning-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.party-card-actions span {
+  flex: 1;
+  color: #aebdb7;
+  font-size: 0.75rem;
+}
+
+.party-card-actions button,
+.party-rest-actions button,
+.xp-popover button {
+  padding: 0.3rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.xp-popover {
+  display: flex;
+  gap: 0.3rem;
+  border-top: 1px solid #38544b;
+  padding-top: 0.45rem;
+}
+
+.xp-popover input {
+  min-width: 0;
+  width: 5rem;
+}
+
+.party-editor {
+  position: sticky;
+  z-index: 2;
+  bottom: 0;
+  border: 1px solid #6f8d82;
+  border-radius: 0.4rem;
+  background: #20342c;
+  box-shadow: 0 -0.7rem 1.5rem #0008;
+  padding: 0.75rem;
+}
+
+.party-editor footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.editor-numbers input {
+  min-width: 5rem;
+  flex: 1;
+}
+
+.danger {
+  border-color: #a95e51;
+  background: #63342e;
+}
+
+.catalog-workspace {
+  display: grid;
+  grid-template-columns: minmax(28rem, 1fr);
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.catalog-browser {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  background: #0f1a17;
+}
+
+.locations-catalog-browser {
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+}
+
+.catalog-section-selector,
+.catalog-footer,
+.encounter-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.catalog-section-selector {
+  border-bottom: 1px solid #29443b;
+  padding: 0.55rem 0.75rem;
+}
+
+.catalog-section-selector button[aria-pressed='true'] {
+  border-color: #8fb7a7;
+  background: #29483d;
+}
+
+.catalog-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.4rem;
+  border-bottom: 1px solid #29443b;
+  padding: 0.55rem;
+}
+
+.catalog-filters > input {
+  min-width: 13rem;
+}
+
+.catalog-filters input,
+.catalog-filters select,
+.catalog-filters button {
+  min-height: 1.75rem;
+  padding: 0.28rem 0.45rem;
+  font-size: 0.75rem;
+}
+
+.multi-filter {
+  position: relative;
+  display: grid;
+}
+
+.multi-filter > span {
+  position: absolute;
+  z-index: 1;
+  top: 0.35rem;
+  left: 0.5rem;
+  pointer-events: none;
+  font-size: 0.72rem;
+}
+
+.multi-filter select {
+  width: 8rem;
+  height: 1.85rem;
+  padding-top: 1.55rem;
+}
+
+.multi-filter select:focus,
+.multi-filter select:active {
+  height: 9rem;
+  padding-top: 1.8rem;
+}
+
+.filter-chips {
+  display: flex;
+  min-height: 2.25rem;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.35rem 0.55rem;
+}
+
+.filter-chip {
+  border-radius: 999px;
+  background: #29483e;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.72rem;
+}
+
+.catalog-table-wrap {
+  min-height: 0;
+  overflow: auto;
+}
+
+.catalog-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.catalog-table th,
+.catalog-table td {
+  border-bottom: 1px solid #29443b;
+  padding: 0.42rem 0.5rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.catalog-table thead {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  background: #172820;
+}
+
+.sort-header,
+.link-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #f5f2e9;
+  font-weight: 650;
+}
+
+.link-button:hover,
+.sort-header:hover {
+  background: transparent;
+  color: #f1cc7d;
+  text-decoration: underline;
+}
+
+.catalog-footer {
+  border-top: 1px solid #29443b;
+  padding: 0.45rem 0.6rem;
+  color: #aebdb7;
+  font-size: 0.75rem;
+}
+
+.catalog-footer > div {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.difficulty-summary,
+.generator-status {
+  display: grid;
+  gap: 0.25rem;
+  border-left: 3px solid #d4ad5d;
+  background: #1b2c26;
+  padding: 0.6rem;
+}
+
+.difficulty-summary small {
+  color: #9eb0a9;
+}
+
+.encounter-roster {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.encounter-roster li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  border: 1px solid #38544b;
+  background: #14211d;
+  padding: 0.45rem;
+}
+
+.encounter-roster li > span {
+  display: grid;
+}
+
+.encounter-roster small {
+  color: #aebdb7;
+}
+
+.save-row input {
+  min-width: 0;
+  flex: 1;
+}
+
+.scenario-scroll {
+  min-height: 0;
+  overflow: auto;
+}
+
+.scenario-scroll > * + * {
+  margin-top: 0.6rem;
+}
+
+.wide-dialog {
+  width: min(64rem, 100%);
+}
+
+.group-builder-dialog {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  width: min(90rem, 100%);
+  height: min(52rem, calc(100vh - 2rem));
+  overflow: hidden;
+  padding: 0;
+}
+
+.group-builder-dialog > header,
+.group-builder-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.group-builder-dialog > header {
+  border-bottom: 1px solid #38544b;
+}
+
+.group-builder-dialog > header h2,
+.group-builder-dialog > header p {
+  margin: 0;
+}
+
+.group-builder-layout {
+  display: grid;
+  grid-template-columns: minmax(28rem, 1.25fr) minmax(24rem, 0.9fr);
+  min-width: 0;
+  min-height: 0;
+}
+
+.group-catalog-pane,
+.group-draft-pane {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+}
+
+.group-catalog-pane {
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  border-right: 1px solid #38544b;
+  background: #101b18;
+}
+
+.group-catalog-pane .catalog-filters {
+  border-bottom: 1px solid #29443b;
+}
+
+.group-catalog-table-wrap {
+  min-height: 0;
+  overflow: auto;
+}
+
+.group-catalog-table th:last-child,
+.group-catalog-table td:last-child {
+  width: 3rem;
+  text-align: right;
+}
+
+.group-draft-pane {
+  align-content: start;
+  gap: 0.7rem;
+  overflow: auto;
+  padding: 0.85rem;
+}
+
+.group-selection-row,
+.group-generator-actions,
+.group-builder-footer > div,
+.roster-quantity {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.group-selection-row label {
+  min-width: 0;
+  flex: 1;
+}
+
+.group-selection-row select {
+  width: 100%;
+}
+
+.group-draft-roster {
+  display: grid;
+  gap: 0.4rem;
+  max-height: 16rem;
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.group-draft-roster li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid #38544b;
+  border-radius: 0.35rem;
+  background: #14211d;
+  padding: 0.5rem;
+}
+
+.group-draft-roster li > span {
+  display: grid;
+  min-width: 0;
+}
+
+.group-draft-roster small {
+  color: #aebdb7;
+}
+
+.roster-quantity strong {
+  min-width: 2rem;
+  text-align: center;
+}
+
+.group-generator-actions button {
+  flex: 1;
+}
+
+.group-draft-confirm {
+  flex-wrap: wrap;
+  border: 1px solid #a95e51;
+  border-radius: 0.35rem;
+  padding: 0.55rem;
+}
+
+.group-draft-confirm span {
+  flex: 1 0 100%;
+}
+
+.group-builder-footer {
+  border-top: 1px solid #38544b;
+}
+
+.tuning-controls label {
+  display: grid;
+  gap: 0.2rem;
+  color: #aebdb7;
+  font-size: 0.7rem;
+}
+
+.difficulty-meter {
+  height: 0.55rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    #55895f 0 25%,
+    #c19b48 25% 50%,
+    #bd713f 50% 75%,
+    #a9473c 75% 100%
+  );
+}
+
+.difficulty-meter span {
+  display: block;
+  height: 100%;
+  border-right: 3px solid #f5f2e9;
+  background: #0002;
+}
+
+.generator-dialog {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.generator-dialog > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.generator-suggestion {
+  border: 1px solid #47675d;
+  border-radius: 0.35rem;
+  background: #101b18;
+  padding: 0.75rem;
+}
+
+.generator-suggestion h3,
+.generator-suggestion ul {
+  margin-block: 0 0.65rem;
+}
+
+.scene-party-member {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.compact-filters {
+  max-height: 13rem;
+  overflow: auto;
+}
+
+.creature-inspector {
+  position: fixed;
+  z-index: 40;
+  top: 4.6rem;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  width: min(29rem, calc(100vw - 1.2rem));
+  overflow: auto;
+  border: 1px solid #6f8d82;
+  border-radius: 0.45rem;
+  background: #f4ead1;
+  box-shadow: 0 1rem 3rem #000b;
+  color: #281d16;
+  padding: 1rem;
+}
+
+.location-inspector {
+  position: fixed;
+  z-index: 40;
+  top: 4.6rem;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  display: flex;
+  width: min(29rem, calc(100vw - 1.2rem));
+  flex-direction: column;
+  gap: 1rem;
+  overflow: auto;
+  border: 1px solid #6f8d82;
+  border-radius: 0.45rem;
+  background: #f4ead1;
+  box-shadow: 0 1rem 3rem #000b;
+  color: #281d16;
+  padding: 1rem;
+}
+
+.location-inspector header,
+.location-editor header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.location-inspector h2,
+.location-editor h2 {
+  margin: 0.35rem 0;
+  color: #7a251d;
+  font-family: Georgia, serif;
+}
+
+.location-notes {
+  flex: 1;
+  white-space: pre-wrap;
+}
+
+.location-inspector footer {
+  justify-content: flex-end;
+}
+
+.location-editor {
+  display: grid;
+  width: min(38rem, 100%);
+  max-height: calc(100vh - 2rem);
+  gap: 0.85rem;
+  overflow: auto;
+  border: 1px solid #6f8d82;
+  border-radius: 0.55rem;
+  background: #17251f;
+  box-shadow: 0 1rem 3rem #000b;
+  padding: 1rem;
+}
+
+.location-editor label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.location-editor textarea {
+  min-height: 12rem;
+  resize: vertical;
+}
+
+.location-editor footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+}
+
+.source-entry-list {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.source-entry-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: end;
+  gap: 0.5rem;
+  border: 1px solid #38544b;
+  border-radius: 0.3rem;
+  padding: 0.45rem;
+}
+
+.source-entry-list input[type='number'] {
+  width: 5rem;
+}
+
+.faction-editor {
+  width: min(48rem, calc(100vw - 2rem));
+}
+
+.faction-editor h3 {
+  margin: 0.25rem 0;
+}
+
+.faction-table-selection {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.45rem;
+}
+
+.creature-inspector header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.creature-inspector.embedded {
+  position: static;
+  width: auto;
+  min-height: 100%;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.creature-inspector h2,
+.creature-inspector h3,
+.creature-inspector p {
+  margin: 0.35rem 0;
+}
+
+.creature-inspector h2,
+.creature-inspector h3 {
+  color: #7a251d;
+  font-family: Georgia, serif;
+}
+
+.stat-meta {
+  font-style: italic;
+}
+
+.ability-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  border-block: 2px solid #9b4a37;
+  margin: 0.65rem 0;
+  padding: 0.5rem 0;
+}
+
+.ability-grid > div {
+  display: grid;
+  gap: 0.15rem;
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .top-bar-status {
+    display: none;
+  }
+
+  .work-area {
+    padding: 1rem;
+  }
+
+  .encounter {
+    grid-template-columns: 1fr;
+  }
+
+  .encounter-summary {
+    padding: 1.25rem 0 0;
+    border-top: 1px solid #3a554d;
+    border-left: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .session-work-area {
+    overflow: auto;
+  }
+
+  .session-layout {
+    min-width: 48rem;
+  }
+
+  .catalog-workspace {
+    grid-template-columns: 1fr;
+    min-width: 50rem;
+  }
+
+  .group-builder-dialog {
+    overflow: auto;
+  }
+
+  .group-builder-layout {
+    grid-template-columns: minmax(42rem, 1fr);
+  }
+
+  .group-catalog-pane {
+    min-height: 28rem;
+    border-right: 0;
+    border-bottom: 1px solid #38544b;
+  }
+}
+
+@media (max-width: 480px) {
+  .inline-form,
+  .item-list li {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .row-actions {
+    justify-content: flex-start;
+  }
 }

--- a/src/renderer/shell/app.tsx
+++ b/src/renderer/shell/app.tsx
@@ -28,8 +28,13 @@ import {
 import {
   RendererResourceCycleTracker,
   type QualificationRenderer,
+  type RendererCycleResult,
   type RendererResourceCounts
 } from '../renderer-resource-cycle.js'
+import {
+  runtimeObservationSchema,
+  type ContextRecoveryObservation
+} from '../../shared/qualification/runtime-observation.js'
 
 declare global {
   interface Window {
@@ -51,6 +56,25 @@ export function App(): ReactElement {
   const [qualificationSamples, setQualificationSamples] = useState<
     Readonly<Partial<Record<QualificationPopulation, readonly number[]>>>
   >({})
+  const [configuration, setConfiguration] = useState<
+    'normal' | 'scale200Percent'
+  >('normal')
+  const [contextLoss, setContextLoss] = useState<
+    Partial<Record<QualificationRenderer, ContextRecoveryObservation>>
+  >({})
+  const [webgl, setWebgl] = useState<
+    Partial<
+      Record<
+        QualificationRenderer,
+        { readonly version: string; readonly renderer: string }
+      >
+    >
+  >({})
+  const [resourceObservation, setResourceObservation] = useState<{
+    readonly result: RendererCycleResult
+    readonly processMemoryBytesBefore: readonly number[]
+    readonly processMemoryBytesAfterSettling: readonly number[]
+  } | null>(null)
   const rendererResources = useRef<
     Partial<Record<QualificationRenderer, RendererResourceCounts>>
   >({})
@@ -88,6 +112,42 @@ export function App(): ReactElement {
   const completePixiPopulation = useCallback((samples: readonly number[]) => {
     setQualificationSamples((current) => ({ ...current, pixiPan: samples }))
   }, [])
+  const updateContextLoss = useCallback(
+    (
+      renderer: QualificationRenderer,
+      observation: ContextRecoveryObservation
+    ) => {
+      setContextLoss((current) => ({ ...current, [renderer]: observation }))
+    },
+    []
+  )
+  const updateWebgl = useCallback(
+    (
+      renderer: QualificationRenderer,
+      observation: { readonly version: string; readonly renderer: string }
+    ) => setWebgl((current) => ({ ...current, [renderer]: observation })),
+    []
+  )
+  const updatePixiContextLoss = useCallback(
+    (observation: ContextRecoveryObservation) =>
+      updateContextLoss('pixi', observation),
+    [updateContextLoss]
+  )
+  const updateBabylonContextLoss = useCallback(
+    (observation: ContextRecoveryObservation) =>
+      updateContextLoss('babylon', observation),
+    [updateContextLoss]
+  )
+  const updatePixiWebgl = useCallback(
+    (observation: { readonly version: string; readonly renderer: string }) =>
+      updateWebgl('pixi', observation),
+    [updateWebgl]
+  )
+  const updateBabylonWebgl = useCallback(
+    (observation: { readonly version: string; readonly renderer: string }) =>
+      updateWebgl('babylon', observation),
+    [updateWebgl]
+  )
   const completeBabylonPopulation = useCallback(
     (
       population: 'babylonCamera' | 'babylonHoverPick' | 'babylonVoxelPreview',
@@ -116,6 +176,11 @@ export function App(): ReactElement {
         observedResources(rendererResources.current)
       )
       const processMemoryBytesAfterSettling = await settledWorkingSetSamples()
+      setResourceObservation({
+        result,
+        processMemoryBytesBefore,
+        processMemoryBytesAfterSettling
+      })
       setResourceCycleStatus(
         result.settled && result.rendererCycles >= 20
           ? `Completed ${result.rendererCycles} renderer cycles with stable canvas, mesh, and listener counts. Settled process working sets: ${processMemoryBytesBefore.join(', ')} → ${processMemoryBytesAfterSettling.join(', ')} bytes.`
@@ -227,6 +292,8 @@ export function App(): ReactElement {
                 onResourcesCreated={resourcesCreated}
                 onResourcesDisposed={resourcesDisposed}
                 onPopulationComplete={completePixiPopulation}
+                onContextRecoveryChange={updatePixiContextLoss}
+                onWebglReady={updatePixiWebgl}
               />
             </div>
             <div key={`babylon-${qualificationGeneration}`}>
@@ -236,6 +303,8 @@ export function App(): ReactElement {
                 onResourcesCreated={resourcesCreated}
                 onResourcesDisposed={resourcesDisposed}
                 onPopulationComplete={completeBabylonPopulation}
+                onContextRecoveryChange={updateBabylonContextLoss}
+                onWebglReady={updateBabylonWebgl}
               />
             </div>
           </div>
@@ -253,6 +322,38 @@ export function App(): ReactElement {
             }
           >
             Download all complete raw timing populations
+          </button>
+          <label htmlFor="qualification-configuration">
+            Measurement configuration
+          </label>
+          <select
+            id="qualification-configuration"
+            value={configuration}
+            onChange={(event) =>
+              setConfiguration(
+                event.target.value as 'normal' | 'scale200Percent'
+              )
+            }
+          >
+            <option value="normal">Normal display</option>
+            <option value="scale200Percent">200% display scaling</option>
+          </select>
+          <button
+            type="button"
+            disabled={
+              !qualificationSamplesComplete || !hasWebglObservations(webgl)
+            }
+            onClick={() =>
+              void downloadRuntimeObservation(
+                configuration,
+                qualificationSamples,
+                contextLoss,
+                webgl,
+                resourceObservation
+              )
+            }
+          >
+            Download complete runtime observation
           </button>
           {resourceCycleStatus !== null ? (
             <p aria-live="polite">{resourceCycleStatus}</p>
@@ -303,6 +404,101 @@ function downloadCompleteQualificationSamples(
     'm1-render-qualification-raw.json',
     populations
   )
+}
+
+function hasWebglObservations(
+  observations: Partial<
+    Record<
+      QualificationRenderer,
+      { readonly version: string; readonly renderer: string }
+    >
+  >
+): observations is Record<
+  QualificationRenderer,
+  { readonly version: string; readonly renderer: string }
+> {
+  return observations.pixi !== undefined && observations.babylon !== undefined
+}
+
+async function downloadRuntimeObservation(
+  configuration: 'normal' | 'scale200Percent',
+  populations: Readonly<
+    Partial<Record<QualificationPopulation, readonly number[]>>
+  >,
+  contextLoss: Partial<
+    Record<QualificationRenderer, ContextRecoveryObservation>
+  >,
+  webgl: Partial<
+    Record<
+      QualificationRenderer,
+      { readonly version: string; readonly renderer: string }
+    >
+  >,
+  resources: {
+    readonly result: RendererCycleResult
+    readonly processMemoryBytesBefore: readonly number[]
+    readonly processMemoryBytesAfterSettling: readonly number[]
+  } | null
+): Promise<void> {
+  if (
+    !hasCompleteQualificationPopulations(populations) ||
+    !hasWebglObservations(webgl)
+  )
+    return
+  const artifact = runtimeObservationSchema.parse({
+    captureKind: 'm1-runtime-observation',
+    formatVersion: 'm1-runtime-observation-v1',
+    recordedAt: new Date().toISOString(),
+    configuration,
+    environment: {
+      userAgent: navigator.userAgent,
+      displayWidth: window.screen.width,
+      displayHeight: window.screen.height,
+      devicePixelRatio: window.devicePixelRatio,
+      gpu: await window.saltMarcher.runtime.gpuObservation(),
+      webgl: { pixi: webgl.pixi, babylon: webgl.babylon }
+    },
+    populations,
+    contextLoss: {
+      pixi: contextLoss.pixi ?? emptyRecoveryObservation(),
+      babylon: contextLoss.babylon ?? emptyRecoveryObservation()
+    },
+    resources:
+      resources === null
+        ? null
+        : {
+            rendererCycles: resources.result.rendererCycles,
+            rendererBuilds: resources.result.rendererBuilds,
+            rendererDisposals: resources.result.rendererDisposals,
+            before: resources.result.before,
+            after: resources.result.after,
+            settled: resources.result.settled,
+            processMemoryBytesBefore: resources.processMemoryBytesBefore,
+            processMemoryBytesAfterSettling:
+              resources.processMemoryBytesAfterSettling
+          }
+  })
+  const anchor = document.createElement('a')
+  const objectUrl = URL.createObjectURL(
+    new Blob([JSON.stringify(artifact, null, 2)], {
+      type: 'application/json'
+    })
+  )
+  anchor.href = objectUrl
+  anchor.download = `m1-runtime-observation-${configuration}.json`
+  anchor.click()
+  URL.revokeObjectURL(objectUrl)
+}
+
+function emptyRecoveryObservation(): ContextRecoveryObservation {
+  return {
+    requestedCycles: 0,
+    observedLossCycles: 0,
+    restoredCycles: 0,
+    rerenderedCycles: 0,
+    nextInteractionSucceededCycles: 0,
+    completedCycles: 0
+  }
 }
 
 async function waitForRendererBuilds(

--- a/src/renderer/shell/app.tsx
+++ b/src/renderer/shell/app.tsx
@@ -1,599 +1,4330 @@
 import {
-  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
   type FormEvent,
-  type ReactElement
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode
 } from 'react'
+import type { CampaignSnapshot } from '../../shared/contracts/campaign.js'
+import type {
+  Creature,
+  CreatureCatalogPage,
+  CreatureCatalogQuery,
+  CreatureFilterOptions
+} from '../../shared/contracts/encounter.js'
+import type { EncounterTuning } from '../../shared/contracts/encounter-tuning.js'
+import type {
+  EncounterSelectionEvaluation,
+  SceneGroup,
+  SceneGroupDraftEvaluation
+} from '../../shared/contracts/scene.js'
+import type {
+  CombatSnapshot,
+  LiveSessionSnapshot,
+  PartySnapshot
+} from '../../shared/contracts/live-session.js'
+import type {
+  AdventuringDayCalculation,
+  PartyCharacter,
+  PartyCharacterDraft
+} from '../../shared/contracts/party.js'
 import {
-  capabilityErrorCodeSchema,
-  type CampaignSnapshot,
-  type CapabilityErrorCode
-} from '../../shared/contracts/campaign.js'
-import { CapabilityError } from '../../shared/errors/capability-error.js'
-import { PixiQualificationView } from '../spatial-2d/pixi-qualification-view.js'
-import {
-  downloadRawQualificationSamples,
-  hasCompleteQualificationPopulations,
-  type QualificationPopulation
-} from '../spatial-3d/render-qualification-metrics.js'
-import { BabylonQualificationView } from '../spatial-3d/babylon-qualification-view.js'
-import { qualificationViewport } from '../spatial-2d/sparse-pixi-qualification.js'
-import {
-  SpatialQualificationModel,
-  type SpatialQualificationState
-} from '../spatial-qualification-model.js'
-import {
-  RendererResourceCycleTracker,
-  type QualificationRenderer,
-  type RendererCycleResult,
-  type RendererResourceCounts
-} from '../renderer-resource-cycle.js'
-import {
-  runtimeObservationSchema,
-  type ContextRecoveryObservation
-} from '../../shared/qualification/runtime-observation.js'
+  defaultSessionLayoutPreference,
+  type SessionLayoutPreference
+} from '../../shared/contracts/session-layout.js'
+import type {
+  WorldLocation,
+  WorldLocationDraft,
+  WorldLocationSnapshot
+} from '../../shared/contracts/world-location.js'
+import type {
+  EncounterTable,
+  EncounterTableDraft,
+  EncounterTableSnapshot,
+  WorldFaction,
+  WorldFactionDraft,
+  WorldFactionSnapshot
+} from '../../shared/contracts/encounter-source.js'
 
 declare global {
   interface Window {
     saltMarcher: import('../../shared/contracts/capability-api.js').SaltMarcherApi
   }
 }
-const emptySnapshot: CampaignSnapshot = {
+
+const emptyCampaigns: CampaignSnapshot = {
   activeCampaignId: null,
   campaigns: []
 }
-export function App(): ReactElement {
-  const [snapshot, setSnapshot] = useState<CampaignSnapshot>(emptySnapshot)
-  const [name, setName] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [qualificationGeneration, setQualificationGeneration] = useState(0)
-  const [resourceCycleStatus, setResourceCycleStatus] = useState<string | null>(
-    null
-  )
-  const [qualificationSamples, setQualificationSamples] = useState<
-    Readonly<Partial<Record<QualificationPopulation, readonly number[]>>>
+
+const emptyQuery: CreatureCatalogQuery = {
+  name: '',
+  sizes: [],
+  types: [],
+  subtypes: [],
+  biomes: [],
+  alignments: [],
+  encounterTableIds: [],
+  factionIds: [],
+  locationId: null,
+  sort: 'name',
+  direction: 'asc',
+  offset: 0,
+  limit: 50
+}
+
+const emptyCreatureOptions: CreatureFilterOptions = {
+  challengeRatings: [],
+  sizes: [],
+  types: [],
+  subtypes: [],
+  biomes: [],
+  alignments: [],
+  encounterTables: [],
+  factions: [],
+  locations: []
+}
+
+export function App() {
+  const [campaigns, setCampaigns] = useState(emptyCampaigns)
+  const [session, setSession] = useState<LiveSessionSnapshot | null>(null)
+  const [campaignName, setCampaignName] = useState('')
+  const [workspace, setWorkspace] = useState<'session' | 'catalog'>('session')
+  const [partyOpen, setPartyOpen] = useState(false)
+  const [dayOpen, setDayOpen] = useState(false)
+  const [groupDialogOpen, setGroupDialogOpen] = useState(false)
+  const [scenarios, setScenarios] = useState<
+    Record<string, '' | 'encounter' | 'travel'>
   >({})
-  const [configuration, setConfiguration] = useState<
-    'normal' | 'scale200Percent'
-  >('normal')
-  const [contextLoss, setContextLoss] = useState<
-    Partial<Record<QualificationRenderer, ContextRecoveryObservation>>
-  >({})
-  const [webgl, setWebgl] = useState<
-    Partial<
-      Record<
-        QualificationRenderer,
-        { readonly version: string; readonly renderer: string }
-      >
-    >
-  >({})
-  const [resourceObservation, setResourceObservation] = useState<{
-    readonly result: RendererCycleResult
-    readonly processMemoryBytesBefore: readonly number[]
-    readonly processMemoryBytesAfterSettling: readonly number[]
-  } | null>(null)
-  const rendererResources = useRef<
-    Partial<Record<QualificationRenderer, RendererResourceCounts>>
-  >({})
-  const resourceCycles = useRef(new RendererResourceCycleTracker())
-  const spatialModel = useMemo(
-    () => new SpatialQualificationModel(qualificationViewport()),
-    []
+  const [sessionLayout, setSessionLayout] = useState(
+    defaultSessionLayoutPreference
   )
-  const [spatialState, setSpatialState] = useState<SpatialQualificationState>(
-    spatialModel.state
-  )
-  const readOnly = window.saltMarcher.runtime.readOnly
-  const e2e = window.saltMarcher.runtime.e2e
-  useEffect(() => {
-    void window.saltMarcher.campaigns
-      .list()
-      .then(setSnapshot)
-      .catch((cause: unknown) => setError(readError(cause)))
-  }, [])
-  useEffect(() => spatialModel.subscribe(setSpatialState), [spatialModel])
-  const resourcesCreated = useCallback(
-    (renderer: QualificationRenderer, counts: RendererResourceCounts) => {
-      rendererResources.current[renderer] = counts
-      resourceCycles.current.rendererBuilt()
-    },
-    []
-  )
-  const resourcesDisposed = useCallback(
-    (renderer: QualificationRenderer, _counts: RendererResourceCounts) => {
-      delete rendererResources.current[renderer]
-      resourceCycles.current.rendererDisposed(_counts)
-    },
-    []
-  )
-  const completePixiPopulation = useCallback((samples: readonly number[]) => {
-    setQualificationSamples((current) => ({ ...current, pixiPan: samples }))
-  }, [])
-  const updateContextLoss = useCallback(
-    (
-      renderer: QualificationRenderer,
-      observation: ContextRecoveryObservation
-    ) => {
-      setContextLoss((current) => ({ ...current, [renderer]: observation }))
-    },
-    []
-  )
-  const updateWebgl = useCallback(
-    (
-      renderer: QualificationRenderer,
-      observation: { readonly version: string; readonly renderer: string }
-    ) => setWebgl((current) => ({ ...current, [renderer]: observation })),
-    []
-  )
-  const updatePixiContextLoss = useCallback(
-    (observation: ContextRecoveryObservation) =>
-      updateContextLoss('pixi', observation),
-    [updateContextLoss]
-  )
-  const updateBabylonContextLoss = useCallback(
-    (observation: ContextRecoveryObservation) =>
-      updateContextLoss('babylon', observation),
-    [updateContextLoss]
-  )
-  const updatePixiWebgl = useCallback(
-    (observation: { readonly version: string; readonly renderer: string }) =>
-      updateWebgl('pixi', observation),
-    [updateWebgl]
-  )
-  const updateBabylonWebgl = useCallback(
-    (observation: { readonly version: string; readonly renderer: string }) =>
-      updateWebgl('babylon', observation),
-    [updateWebgl]
-  )
-  const completeBabylonPopulation = useCallback(
-    (
-      population: 'babylonCamera' | 'babylonHoverPick' | 'babylonVoxelPreview',
-      samples: readonly number[]
-    ) => {
-      setQualificationSamples((current) => ({
-        ...current,
-        [population]: samples
-      }))
-    },
-    []
-  )
-  const qualificationSamplesComplete =
-    hasCompleteQualificationPopulations(qualificationSamples)
-  const runRendererResourceCycles = async (): Promise<void> => {
-    try {
-      resourceCycles.current.begin(observedResources(rendererResources.current))
-      setResourceCycleStatus('Running 20 renderer build/dispose cycles…')
-      const processMemoryBytesBefore = await settledWorkingSetSamples()
-      for (let cycle = 1; cycle <= 20; cycle += 1) {
-        setQualificationGeneration((current) => current + 1)
-        await waitForRendererBuilds(resourceCycles.current, cycle * 2)
-      }
-      await settleRenderer()
-      const result = resourceCycles.current.finish(
-        observedResources(rendererResources.current)
-      )
-      const processMemoryBytesAfterSettling = await settledWorkingSetSamples()
-      setResourceObservation({
-        result,
-        processMemoryBytesBefore,
-        processMemoryBytesAfterSettling
-      })
-      setResourceCycleStatus(
-        result.settled && result.rendererCycles >= 20
-          ? `Completed ${result.rendererCycles} renderer cycles with stable canvas, mesh, and listener counts. Settled process working sets: ${processMemoryBytesBefore.join(', ')} → ${processMemoryBytesAfterSettling.join(', ')} bytes.`
-          : `Resource cycle check did not settle (${result.rendererCycles} completed cycles). Record this as a failed resource observation.`
-      )
-    } catch {
-      setResourceCycleStatus(
-        'Resource cycle check could not rebuild both renderers. Record this as a failed resource observation.'
-      )
-    }
+  const layoutLoaded = useRef(false)
+  const [inspected, setInspected] = useState<Creature | null>(null)
+  const [error, setError] = useState('')
+  const active = campaigns.activeCampaignId !== null
+
+  const load = async () => {
+    const [nextCampaigns, nextLayout] = await Promise.all([
+      window.saltMarcher.campaigns.list(),
+      window.saltMarcher.session.readLayout()
+    ])
+    layoutLoaded.current = true
+    setSessionLayout(nextLayout)
+    setCampaigns(nextCampaigns)
+    setSession(
+      nextCampaigns.activeCampaignId
+        ? await window.saltMarcher.session.read()
+        : null
+    )
   }
-  async function createCampaign(
-    event: FormEvent<HTMLFormElement>
-  ): Promise<void> {
+
+  useEffect(() => {
+    void Promise.resolve().then(load).catch(showError(setError))
+  }, [])
+
+  useEffect(() => {
+    if (!layoutLoaded.current) return
+    const timer = window.setTimeout(() => {
+      void window.saltMarcher.session.saveLayout(sessionLayout).catch(() => {})
+    }, 250)
+    return () => window.clearTimeout(timer)
+  }, [sessionLayout])
+
+  useEffect(() => {
+    const keydown = (event: KeyboardEvent) => {
+      if (event.altKey && event.key.toLowerCase() === 'p' && active) {
+        event.preventDefault()
+        setPartyOpen((current) => !current)
+      }
+    }
+    window.addEventListener('keydown', keydown)
+    return () => window.removeEventListener('keydown', keydown)
+  }, [active])
+
+  async function createCampaign(event: FormEvent) {
     event.preventDefault()
     try {
-      if (!hasCampaignWriteCapability(window.saltMarcher.campaigns)) return
-      setSnapshot(await window.saltMarcher.campaigns.create(name))
-      setName('')
-      setError(null)
+      const capability = window.saltMarcher
+        .campaigns as import('../../shared/contracts/capability-api.js').CampaignCapability
+      setCampaigns(await capability.create(campaignName))
+      setCampaignName('')
+      setSession(await window.saltMarcher.session.read())
+      setWorkspace('session')
     } catch (cause) {
-      if (errorCode(cause) === 'outcome_unknown')
-        void window.saltMarcher.campaigns
-          .list()
-          .then(setSnapshot)
-          .catch(setError)
-      setError(readError(cause))
+      setError(errorText(cause))
     }
   }
-  async function activateCampaign(id: string): Promise<void> {
+
+  async function switchCampaign(id: string) {
     try {
-      if (!hasCampaignWriteCapability(window.saltMarcher.campaigns)) return
-      setSnapshot(await window.saltMarcher.campaigns.activate(id))
-      setError(null)
+      const capability = window.saltMarcher
+        .campaigns as import('../../shared/contracts/capability-api.js').CampaignCapability
+      setCampaigns(await capability.activate(id))
+      setSession(await window.saltMarcher.session.read())
+      setWorkspace('session')
+      setScenarios({})
     } catch (cause) {
-      setError(readError(cause))
+      setError(errorText(cause))
     }
   }
+
+  const heading = active
+    ? workspace === 'catalog'
+      ? 'Katalog'
+      : 'Session'
+    : 'Campaigns'
+
   return (
     <main className="app-shell">
-      <header>
-        <p className="eyebrow">SaltMarcher · Electron foundation</p>
-        <h1>{readOnly ? 'Campaign display' : 'Campaigns'}</h1>
-        <p>
-          {readOnly
-            ? 'This secondary window cannot write campaign data.'
-            : 'Create, switch, and resume campaigns locally.'}
+      <header className="top-bar">
+        <button className="menu-button" aria-label="Menü" title="Menü">
+          <span aria-hidden="true">☰</span>
+        </button>
+        {active && session && (
+          <>
+            <nav className="shell-quick-actions" aria-label="Session controls">
+              <button>Zeit</button>
+              <button>Wetter</button>
+              <button>Musik</button>
+            </nav>
+            <AdventuringDayDropdown
+              party={session.party}
+              open={dayOpen}
+              setOpen={setDayOpen}
+            />
+            <PartyDropdown
+              party={session.party}
+              open={partyOpen}
+              setOpen={setPartyOpen}
+              changed={(party) => {
+                setSession({ ...session, party })
+                void window.saltMarcher.session.read().then(setSession)
+              }}
+              onError={setError}
+            />
+          </>
+        )}
+        <div className="workspace-heading">
+          <p className="eyebrow">SaltMarcher</p>
+          <h1>{heading}</h1>
+        </div>
+        <p className="top-bar-status">
+          {active ? 'Live-Session' : 'Kampagne auswählen oder erstellen'}
         </p>
       </header>
-      {error !== null ? <p role="alert">{error}</p> : null}
-      {!readOnly ? (
-        <form onSubmit={(event) => void createCampaign(event)}>
-          <label htmlFor="campaign-name">Campaign name</label>
-          <div className="inline-form">
-            <input
-              id="campaign-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              maxLength={100}
-              required
+      <div className="shell-body">
+        <nav className="icon-bar" aria-label="Workspace">
+          <button
+            className="icon-button"
+            aria-label="Campaigns"
+            title="Campaigns"
+            aria-pressed={!active}
+            onClick={() => {
+              setCampaigns({ ...campaigns, activeCampaignId: null })
+              setSession(null)
+            }}
+          >
+            <span aria-hidden="true">⌂</span>
+          </button>
+          {active && (
+            <>
+              <button
+                className="icon-button"
+                aria-label="Session"
+                title="Session"
+                aria-pressed={workspace === 'session'}
+                onClick={() => setWorkspace('session')}
+              >
+                <span aria-hidden="true">▤</span>
+              </button>
+              <button
+                className="icon-button"
+                aria-label="Katalog"
+                title="Katalog"
+                aria-pressed={workspace === 'catalog'}
+                onClick={() => setWorkspace('catalog')}
+              >
+                <span aria-hidden="true">⚔</span>
+              </button>
+            </>
+          )}
+        </nav>
+        <div className={`work-area${active ? ' session-work-area' : ''}`}>
+          {error && (
+            <p className="error-message" role="alert">
+              {error}{' '}
+              <button className="compact" onClick={() => setError('')}>
+                Schließen
+              </button>
+            </p>
+          )}
+          {!active && (
+            <CampaignChooser
+              campaigns={campaigns}
+              name={campaignName}
+              setName={setCampaignName}
+              createCampaign={createCampaign}
+              switchCampaign={switchCampaign}
             />
-            <button type="submit">Create campaign</button>
-          </div>
-        </form>
-      ) : null}
-      <section aria-labelledby="campaign-list-heading">
-        <h2 id="campaign-list-heading">Available campaigns</h2>
-        {snapshot.campaigns.length === 0 ? (
-          <p>No campaign exists yet.</p>
-        ) : (
-          <ul>
-            {snapshot.campaigns.map((campaign) => {
-              const active = campaign.id === snapshot.activeCampaignId
-              return (
-                <li key={campaign.id}>
-                  {readOnly ? (
-                    <span aria-current={active ? 'true' : undefined}>
-                      {campaign.name}
-                      {active ? ' (active)' : ''}
-                    </span>
-                  ) : (
-                    <button
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() => void activateCampaign(campaign.id)}
-                    >
-                      {campaign.name}
-                      {active ? ' (active)' : ''}
-                    </button>
-                  )}
-                </li>
-              )
-            })}
-          </ul>
-        )}
-      </section>
-      {!readOnly && !e2e ? (
-        <section aria-labelledby="rendering-qualification-heading">
-          <h2 id="rendering-qualification-heading">Rendering qualification</h2>
-          <p>
-            PixiJS renders 100,000 sparse cells (8,192 facts); Babylon.js
-            renders pickable dungeon chunks with a local preview path.
-          </p>
-          <div className="qualification-grid">
-            <div key={`pixi-${qualificationGeneration}`}>
-              <h3>2D sparse map</h3>
-              <PixiQualificationView
-                model={spatialModel}
-                onResourcesCreated={resourcesCreated}
-                onResourcesDisposed={resourcesDisposed}
-                onPopulationComplete={completePixiPopulation}
-                onContextRecoveryChange={updatePixiContextLoss}
-                onWebglReady={updatePixiWebgl}
-              />
-            </div>
-            <div key={`babylon-${qualificationGeneration}`}>
-              <h3>3D dungeon</h3>
-              <BabylonQualificationView
-                model={spatialModel}
-                onResourcesCreated={resourcesCreated}
-                onResourcesDisposed={resourcesDisposed}
-                onPopulationComplete={completeBabylonPopulation}
-                onContextRecoveryChange={updateBabylonContextLoss}
-                onWebglReady={updateBabylonWebgl}
-              />
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => void runRendererResourceCycles()}
-          >
-            Run 20 renderer build/dispose cycles
-          </button>
-          <button
-            type="button"
-            disabled={!qualificationSamplesComplete}
-            onClick={() =>
-              downloadCompleteQualificationSamples(qualificationSamples)
-            }
-          >
-            Download all complete raw timing populations
-          </button>
-          <label htmlFor="qualification-configuration">
-            Measurement configuration
-          </label>
-          <select
-            id="qualification-configuration"
-            value={configuration}
-            onChange={(event) =>
-              setConfiguration(
-                event.target.value as 'normal' | 'scale200Percent'
-              )
-            }
-          >
-            <option value="normal">Normal display</option>
-            <option value="scale200Percent">200% display scaling</option>
-          </select>
-          <button
-            type="button"
-            disabled={
-              !qualificationSamplesComplete || !hasWebglObservations(webgl)
-            }
-            onClick={() =>
-              void downloadRuntimeObservation(
-                configuration,
-                qualificationSamples,
-                contextLoss,
-                webgl,
-                resourceObservation
-              )
-            }
-          >
-            Download complete runtime observation
-          </button>
-          {resourceCycleStatus !== null ? (
-            <p aria-live="polite">{resourceCycleStatus}</p>
-          ) : null}
-          <SpatialTextAlternative model={spatialModel} state={spatialState} />
-        </section>
-      ) : null}
+          )}
+          {active && session && workspace === 'session' && (
+            <SessionWorkspace
+              snapshot={session}
+              setSnapshot={setSession}
+              groupDialogOpen={groupDialogOpen}
+              setGroupDialogOpen={setGroupDialogOpen}
+              scenario={
+                session.combat
+                  ? 'encounter'
+                  : (scenarios[session.scene.focusedSceneId] ?? '')
+              }
+              setScenario={(scenario) =>
+                setScenarios((current) => ({
+                  ...current,
+                  [session.scene.focusedSceneId]: scenario
+                }))
+              }
+              layout={sessionLayout}
+              setLayout={setSessionLayout}
+              onError={setError}
+            />
+          )}
+          {active && session && workspace === 'catalog' && (
+            <CatalogWorkspace
+              snapshot={session}
+              setSnapshot={setSession}
+              close={() => setWorkspace('session')}
+              inspect={setInspected}
+              onError={setError}
+            />
+          )}
+        </div>
+      </div>
+      {inspected && (
+        <CreatureInspector
+          creature={inspected}
+          close={() => setInspected(null)}
+        />
+      )}
     </main>
   )
 }
 
-function observedResources(
-  records: Partial<Record<QualificationRenderer, RendererResourceCounts>>
-): RendererResourceCounts {
-  return {
-    canvases: document.querySelectorAll('.qualification-grid canvas').length,
-    meshes: Object.values(records).reduce(
-      (total, counts) => total + (counts?.meshes ?? 0),
-      0
-    ),
-    listeners: Object.values(records).reduce(
-      (total, counts) => total + (counts?.listeners ?? 0),
-      0
-    )
-  }
-}
-
-function settleRenderer(): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, 100))
-}
-
-async function settledWorkingSetSamples(): Promise<readonly number[]> {
-  const samples: number[] = []
-  for (let sample = 0; sample < 3; sample += 1) {
-    await settleRenderer()
-    samples.push(await window.saltMarcher.runtime.processMemoryBytes())
-  }
-  return samples
-}
-
-function downloadCompleteQualificationSamples(
-  populations: Readonly<
-    Partial<Record<QualificationPopulation, readonly number[]>>
-  >
-): void {
-  if (!hasCompleteQualificationPopulations(populations)) return
-  downloadRawQualificationSamples(
-    'm1-render-qualification-raw.json',
-    populations
-  )
-}
-
-function hasWebglObservations(
-  observations: Partial<
-    Record<
-      QualificationRenderer,
-      { readonly version: string; readonly renderer: string }
-    >
-  >
-): observations is Record<
-  QualificationRenderer,
-  { readonly version: string; readonly renderer: string }
-> {
-  return observations.pixi !== undefined && observations.babylon !== undefined
-}
-
-async function downloadRuntimeObservation(
-  configuration: 'normal' | 'scale200Percent',
-  populations: Readonly<
-    Partial<Record<QualificationPopulation, readonly number[]>>
-  >,
-  contextLoss: Partial<
-    Record<QualificationRenderer, ContextRecoveryObservation>
-  >,
-  webgl: Partial<
-    Record<
-      QualificationRenderer,
-      { readonly version: string; readonly renderer: string }
-    >
-  >,
-  resources: {
-    readonly result: RendererCycleResult
-    readonly processMemoryBytesBefore: readonly number[]
-    readonly processMemoryBytesAfterSettling: readonly number[]
-  } | null
-): Promise<void> {
-  if (
-    !hasCompleteQualificationPopulations(populations) ||
-    !hasWebglObservations(webgl)
-  )
-    return
-  const artifact = runtimeObservationSchema.parse({
-    captureKind: 'm1-runtime-observation',
-    formatVersion: 'm1-runtime-observation-v1',
-    recordedAt: new Date().toISOString(),
-    configuration,
-    environment: {
-      userAgent: navigator.userAgent,
-      displayWidth: window.screen.width,
-      displayHeight: window.screen.height,
-      devicePixelRatio: window.devicePixelRatio,
-      gpu: await window.saltMarcher.runtime.gpuObservation(),
-      webgl: { pixi: webgl.pixi, babylon: webgl.babylon }
-    },
-    populations,
-    contextLoss: {
-      pixi: contextLoss.pixi ?? emptyRecoveryObservation(),
-      babylon: contextLoss.babylon ?? emptyRecoveryObservation()
-    },
-    resources:
-      resources === null
-        ? null
-        : {
-            rendererCycles: resources.result.rendererCycles,
-            rendererBuilds: resources.result.rendererBuilds,
-            rendererDisposals: resources.result.rendererDisposals,
-            before: resources.result.before,
-            after: resources.result.after,
-            settled: resources.result.settled,
-            processMemoryBytesBefore: resources.processMemoryBytesBefore,
-            processMemoryBytesAfterSettling:
-              resources.processMemoryBytesAfterSettling
-          }
-  })
-  const anchor = document.createElement('a')
-  const objectUrl = URL.createObjectURL(
-    new Blob([JSON.stringify(artifact, null, 2)], {
-      type: 'application/json'
-    })
-  )
-  anchor.href = objectUrl
-  anchor.download = `m1-runtime-observation-${configuration}.json`
-  anchor.click()
-  URL.revokeObjectURL(objectUrl)
-}
-
-function emptyRecoveryObservation(): ContextRecoveryObservation {
-  return {
-    requestedCycles: 0,
-    observedLossCycles: 0,
-    restoredCycles: 0,
-    rerenderedCycles: 0,
-    nextInteractionSucceededCycles: 0,
-    completedCycles: 0
-  }
-}
-
-async function waitForRendererBuilds(
-  tracker: RendererResourceCycleTracker,
-  expectedBuilds: number
-): Promise<void> {
-  const deadline = performance.now() + 10_000
-  while (tracker.rendererBuilds < expectedBuilds) {
-    if (performance.now() > deadline)
-      throw new Error(
-        `Renderer cycle timed out before both views rebuilt (${tracker.rendererBuilds}/${expectedBuilds}).`
-      )
-    await new Promise((resolve) => globalThis.setTimeout(resolve, 25))
-  }
-}
-
-function SpatialTextAlternative({
-  model,
-  state
-}: {
-  readonly model: SpatialQualificationModel
-  readonly state: SpatialQualificationState
-}): ReactElement {
+function CampaignChooser(props: {
+  campaigns: CampaignSnapshot
+  name: string
+  setName: (value: string) => void
+  createCampaign: (event: FormEvent) => Promise<void>
+  switchCampaign: (id: string) => Promise<void>
+}) {
   return (
-    <section aria-labelledby="spatial-text-alternative-heading">
-      <h3 id="spatial-text-alternative-heading">
-        Text alternative for the spatial qualification
-      </h3>
-      <p>
-        This keyboard-operable alternative exposes the same fixture scale and
-        spatial selection information without requiring WebGL.
-      </p>
-      <p>
-        2D position:{' '}
-        <output>{`${state.viewport.x}, ${state.viewport.y}`}</output>. The
-        fixture contains 100,000 sparse cells and 8,192 initially visible facts.
-      </p>
-      <div className="inline-form" aria-label="Move the 2D text alternative">
-        <button type="button" onClick={() => model.pan(-24, 0)}>
-          Move west
-        </button>
-        <button type="button" onClick={() => model.pan(24, 0)}>
-          Move east
-        </button>
+    <section className="workspace-panel campaign-panel">
+      <div>
+        <p className="section-kicker">Campaign library</p>
+        <h2>Choose a campaign</h2>
+        <p>Start a new campaign or continue an existing one.</p>
       </div>
-      <p>
-        3D selection:{' '}
-        <output>{state.selectedChunk ?? 'no chunk selected'}</output>. The
-        dungeon fixture includes a remeshable 32 × 32 × 16 voxel chunk and 25
-        pickable surrounding chunks.
-      </p>
-      <div className="inline-form" aria-label="Select a dungeon chunk">
-        <button type="button" onClick={() => model.select('chunk--2--2')}>
-          Select northwest chunk
-        </button>
-        <button type="button" onClick={() => model.select('chunk-2-2')}>
-          Select southeast chunk
-        </button>
+      <form
+        onSubmit={(event) => void props.createCampaign(event)}
+        className="inline-form"
+      >
+        <input
+          id="campaign-name"
+          aria-label="Campaign name"
+          placeholder="Campaign name"
+          required
+          value={props.name}
+          onChange={(event) => props.setName(event.target.value)}
+        />
+        <button>Create campaign</button>
+      </form>
+      <div className="campaigns">
+        {props.campaigns.campaigns.map((campaign) => (
+          <button
+            key={campaign.id}
+            onClick={() => void props.switchCampaign(campaign.id)}
+          >
+            {campaign.name}
+          </button>
+        ))}
       </div>
-      <p aria-live="polite" className="sr-only">
-        Text alternative updated: {state.viewport.x}, {state.viewport.y};{' '}
-        {state.selectedChunk ?? 'no chunk selected'}.
-      </p>
     </section>
   )
 }
-function readError(cause: unknown): string {
-  const messages: Record<CapabilityErrorCode, string> = {
-    validation_failed: 'Die Eingabe ist nicht gültig.',
-    not_found: 'Diese Campaign ist nicht mehr verfügbar.',
-    read_only: 'Dieses Fenster darf Campaigns nicht ändern.',
-    outcome_unknown:
-      'Es ist unklar, ob die Campaign erstellt wurde. Die Liste wird neu geladen.',
-    core_unavailable: 'Der lokale Programmkern ist nicht erreichbar.',
-    protocol_violation:
-      'Die interne Verbindung wurde aus Sicherheitsgründen beendet.',
-    timeout: 'Die Anfrage hat zu lange gedauert. Sie kann wiederholt werden.',
-    internal: 'Die angeforderte Operation konnte nicht abgeschlossen werden.'
+
+function AdventuringDayDropdown(props: {
+  party: PartySnapshot
+  open: boolean
+  setOpen: (open: boolean) => void
+}) {
+  const day = props.party.adventuringDay
+  const [rows, setRows] = useState(() => partyRows(props.party))
+  const [custom, setCustom] = useState(false)
+  const [mode, setMode] = useState<'budget' | 'progress'>('budget')
+  const [totalXp, setTotalXp] = useState(0)
+  const [calculation, setCalculation] =
+    useState<AdventuringDayCalculation | null>(null)
+  useEffect(() => {
+    if (!props.open) return
+    void window.saltMarcher.party
+      .calculateAdventuringDay(rows, mode === 'progress' ? totalXp : 0)
+      .then(setCalculation)
+  }, [props.open, rows, totalXp, mode])
+  return (
+    <div className="party-dropdown day-dropdown">
+      <button
+        className="party-trigger"
+        aria-expanded={props.open}
+        onClick={() => {
+          if (!props.open && !custom) setRows(partyRows(props.party))
+          props.setOpen(!props.open)
+        }}
+      >
+        {!day.available
+          ? 'Kein Rastbudget'
+          : `SR ${day.shortRestXp} · LR ${day.longRestXp}`}
+      </button>
+      {props.open && (
+        <section className="party-panel day-panel" aria-label="Adventuring Day">
+          <header>
+            <h2>ADVENTURING DAY</h2>
+            <button onClick={() => props.setOpen(false)}>×</button>
+          </header>
+          {!day.available ? (
+            <p className="empty-state">
+              Für das Rastbudget brauchen alle aktiven SC ein Level.
+            </p>
+          ) : (
+            <>
+              <div className="party-rest-actions">
+                <button
+                  onClick={() => {
+                    setRows(partyRows(props.party))
+                    setCustom(false)
+                  }}
+                >
+                  Aktive Party
+                </button>
+                <button
+                  onClick={() => {
+                    setRows([...rows, { level: 1, count: 1 }])
+                    setCustom(true)
+                  }}
+                >
+                  Zeile
+                </button>
+                <button
+                  onClick={() => {
+                    setRows([])
+                    setCustom(true)
+                  }}
+                >
+                  Leeren
+                </button>
+              </div>
+              <div className="party-rest-actions">
+                <button
+                  className={mode === 'budget' ? 'accent' : ''}
+                  onClick={() => setMode('budget')}
+                >
+                  Budget
+                </button>
+                <button
+                  className={mode === 'progress' ? 'accent' : ''}
+                  onClick={() => setMode('progress')}
+                >
+                  XP → Tage
+                </button>
+              </div>
+              <ul className="day-rows">
+                {rows.map((row, index) => (
+                  <li key={`${index}-${row.level}`}>
+                    <label>
+                      Level
+                      <input
+                        type="number"
+                        min="1"
+                        max="20"
+                        value={row.level}
+                        onChange={(event) => {
+                          const next = [...rows]
+                          next[index] = {
+                            ...row,
+                            level: Number(event.target.value)
+                          }
+                          setRows(next)
+                          setCustom(true)
+                        }}
+                      />
+                    </label>
+                    <label>
+                      Anzahl
+                      <input
+                        type="number"
+                        min="1"
+                        max="99"
+                        value={row.count}
+                        onChange={(event) => {
+                          const next = [...rows]
+                          next[index] = {
+                            ...row,
+                            count: Number(event.target.value)
+                          }
+                          setRows(next)
+                          setCustom(true)
+                        }}
+                      />
+                    </label>
+                    <button
+                      onClick={() => {
+                        setRows(
+                          rows.filter((_, position) => position !== index)
+                        )
+                        setCustom(true)
+                      }}
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {mode === 'progress' && (
+                <input
+                  aria-label="Gesamt-XP"
+                  type="number"
+                  min="0"
+                  placeholder="Gesamt-XP"
+                  value={totalXp}
+                  onChange={(event) =>
+                    setTotalXp(Math.max(0, Number(event.target.value)))
+                  }
+                />
+              )}
+              <div className="day-summary">
+                <strong>
+                  {calculation?.dailyBudget.toLocaleString() ?? 0} XP
+                </strong>
+                <span>
+                  {custom
+                    ? 'Eigene Party'
+                    : `Aktive Party · ${day.partySize} SC`}
+                </span>
+                {mode === 'progress' && calculation && (
+                  <span>
+                    {calculation.completedDays} volle Tage ·{' '}
+                    {Math.round(calculation.dayProgress * 100)}% aktueller Tag ·{' '}
+                    {calculation.shortRests} SR · {calculation.longRests} LR
+                  </span>
+                )}
+              </div>
+              {mode === 'progress' && calculation && (
+                <>
+                  <progress max="1" value={calculation.dayProgress} />
+                  <div className="day-timeline">
+                    {calculation.timeline.map((entry) => (
+                      <span key={entry}>{entry}</span>
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}
+
+function PartyDropdown(props: {
+  party: PartySnapshot
+  open: boolean
+  setOpen: (open: boolean) => void
+  changed: (party: PartySnapshot) => void
+  onError: (message: string) => void
+}) {
+  const [search, setSearch] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [editor, setEditor] = useState<PartyCharacter | 'new' | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [xpMember, setXpMember] = useState<string | null>(null)
+  const [xpDelta, setXpDelta] = useState(100)
+  const active = props.party.members.filter((member) => member.active)
+  const leveled = active.filter(
+    (member): member is PartyCharacter & { level: number } =>
+      member.level !== null
+  )
+  const average = leveled.length
+    ? Math.round(
+        leveled.reduce((total, member) => total + member.level, 0) /
+          leveled.length
+      )
+    : null
+  const filtered = props.party.members.filter((member) =>
+    `${member.name} ${member.playerName ?? ''} ${member.id}`
+      .toLowerCase()
+      .includes(search.toLowerCase())
+  )
+
+  async function run(operation: () => Promise<PartySnapshot>) {
+    setBusy(true)
+    try {
+      props.changed(await operation())
+    } catch (cause) {
+      props.onError(errorText(cause))
+    } finally {
+      setBusy(false)
+    }
   }
-  const code = errorCode(cause)
-  return code === undefined
-    ? 'The requested operation could not be completed.'
-    : messages[code]
+
+  return (
+    <div className="party-dropdown">
+      <button
+        className="party-trigger"
+        aria-expanded={props.open}
+        aria-controls="party-panel"
+        title="Party-Panel öffnen (Alt+P)"
+        onClick={() => props.setOpen(!props.open)}
+      >
+        {active.length === 0
+          ? 'Keine Party'
+          : `${active.length} SC · Ø Lv ${average ?? '—'}`}
+      </button>
+      {props.open && (
+        <section id="party-panel" className="party-panel" aria-label="Party">
+          <header>
+            <h2>PARTY</h2>
+            <button
+              aria-label="Party-Panel schließen"
+              onClick={() => props.setOpen(false)}
+            >
+              ×
+            </button>
+          </header>
+          {active.length === 0 ? (
+            <p className="empty-state">Keine aktiven Party-Mitglieder.</p>
+          ) : (
+            <ul className="party-list active-party-list">
+              {active.map((member) => (
+                <li key={member.id} className="party-character-card">
+                  <div className="party-card-main">
+                    <strong>{member.name}</strong>
+                    <small>
+                      {member.playerName ?? 'Kein Spieler'} · Lv{' '}
+                      {member.level ?? '—'}
+                    </small>
+                    <progress
+                      max={member.nextLevelXp ?? Math.max(1, member.xp)}
+                      value={member.xp}
+                    />
+                    <small>
+                      {member.xp.toLocaleString()} XP
+                      {member.nextLevelXp
+                        ? ` / ${member.nextLevelXp.toLocaleString()}`
+                        : ''}
+                    </small>
+                  </div>
+                  <div className="party-card-actions">
+                    <span>
+                      PP {member.passivePerception ?? '—'} · AC{' '}
+                      {member.armorClass ?? '—'}
+                    </span>
+                    <button
+                      onClick={() => {
+                        setXpMember(member.id)
+                        setXpDelta(100)
+                      }}
+                    >
+                      XP
+                    </button>
+                    <button onClick={() => setEditor(member)}>
+                      Bearbeiten
+                    </button>
+                    <button
+                      disabled={busy}
+                      onClick={() =>
+                        void run(() =>
+                          window.saltMarcher.party.setMembership(
+                            member.id,
+                            false,
+                            props.party.revision
+                          )
+                        )
+                      }
+                    >
+                      Entfernen
+                    </button>
+                  </div>
+                  {xpMember === member.id && (
+                    <div className="xp-popover">
+                      <input
+                        aria-label="XP Betrag"
+                        type="number"
+                        min="1"
+                        value={xpDelta}
+                        onChange={(event) =>
+                          setXpDelta(Math.max(1, Number(event.target.value)))
+                        }
+                      />
+                      <button
+                        onClick={() =>
+                          void run(() =>
+                            window.saltMarcher.party.adjustXp(
+                              member.id,
+                              -xpDelta,
+                              props.party.revision
+                            )
+                          )
+                        }
+                      >
+                        −XP
+                      </button>
+                      <button
+                        onClick={() =>
+                          void run(() =>
+                            window.saltMarcher.party.adjustXp(
+                              member.id,
+                              xpDelta,
+                              props.party.revision
+                            )
+                          )
+                        }
+                      >
+                        +XP
+                      </button>
+                      <button onClick={() => setXpMember(null)}>×</button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="party-rest-actions">
+            <button
+              disabled={busy || active.length === 0}
+              onClick={() =>
+                void run(() =>
+                  window.saltMarcher.party.rest('short', props.party.revision)
+                )
+              }
+            >
+              Short Rest
+            </button>
+            <button
+              disabled={busy || active.length === 0}
+              onClick={() =>
+                void run(() =>
+                  window.saltMarcher.party.rest('long', props.party.revision)
+                )
+              }
+            >
+              Long Rest
+            </button>
+          </div>
+          <h3>CHARAKTER-ROSTER</h3>
+          <input
+            aria-label="Charakter-Roster durchsuchen"
+            placeholder="Name, Spieler oder Roster-ID"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <ul className="party-list roster-list">
+            {filtered.map((member) => (
+              <li key={member.id}>
+                <span>
+                  <strong>{member.name}</strong>
+                  <small>
+                    {member.playerName ?? 'Kein Spieler'} · #
+                    {member.id.slice(0, 8)} · Lv {member.level ?? '—'}
+                  </small>
+                </span>
+                <div className="row-actions">
+                  <button onClick={() => setEditor(member)}>Bearbeiten</button>
+                  <button
+                    disabled={busy}
+                    onClick={() =>
+                      void run(() =>
+                        window.saltMarcher.party.setMembership(
+                          member.id,
+                          !member.active,
+                          props.party.revision
+                        )
+                      )
+                    }
+                  >
+                    {member.active ? 'Aus Party' : 'Zur Party'}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <button onClick={() => setEditor('new')}>
+            Neuer Roster-Charakter
+          </button>
+          {editor && (
+            <PartyEditor
+              member={editor === 'new' ? null : editor}
+              busy={busy}
+              deleteConfirm={deleteConfirm}
+              setDeleteConfirm={setDeleteConfirm}
+              close={() => {
+                setEditor(null)
+                setDeleteConfirm(false)
+              }}
+              save={(draft) =>
+                void run(async () => {
+                  const snapshot =
+                    editor === 'new'
+                      ? await window.saltMarcher.party.create(
+                          draft,
+                          props.party.revision
+                        )
+                      : await window.saltMarcher.party.update(
+                          editor.id,
+                          draft,
+                          props.party.revision
+                        )
+                  setEditor(null)
+                  return snapshot
+                })
+              }
+              {...(editor === 'new'
+                ? {}
+                : {
+                    remove: () =>
+                      void run(async () => {
+                        const snapshot = await window.saltMarcher.party.delete(
+                          editor.id,
+                          props.party.revision
+                        )
+                        setEditor(null)
+                        setDeleteConfirm(false)
+                        return snapshot
+                      })
+                  })}
+            />
+          )}
+        </section>
+      )}
+    </div>
+  )
 }
 
-function errorCode(cause: unknown): CapabilityErrorCode | undefined {
-  if (!(cause instanceof CapabilityError)) return undefined
-  const parsed = capabilityErrorCodeSchema.safeParse(cause.code)
-  return parsed.success ? parsed.data : undefined
+function PartyEditor(props: {
+  member: PartyCharacter | null
+  busy: boolean
+  deleteConfirm: boolean
+  setDeleteConfirm: (value: boolean) => void
+  close: () => void
+  save: (draft: PartyCharacterDraft) => void
+  remove?: () => void
+}) {
+  const [name, setName] = useState(props.member?.name ?? '')
+  const [player, setPlayer] = useState(props.member?.playerName ?? '')
+  const [level, setLevel] = useState(props.member?.level?.toString() ?? '')
+  const [perception, setPerception] = useState(
+    props.member?.passivePerception?.toString() ?? ''
+  )
+  const [armor, setArmor] = useState(props.member?.armorClass?.toString() ?? '')
+  const optional = (value: string) =>
+    value.trim() === '' ? null : Number(value)
+  return (
+    <form
+      className="party-editor"
+      onSubmit={(event) => {
+        event.preventDefault()
+        props.save({
+          name,
+          playerName: player.trim() || null,
+          level: optional(level),
+          passivePerception: optional(perception),
+          armorClass: optional(armor)
+        })
+      }}
+    >
+      <h3>
+        {props.member
+          ? `CHARAKTER #${props.member.id.slice(0, 8)} BEARBEITEN`
+          : 'CHARAKTER ERSTELLEN'}
+      </h3>
+      <input
+        autoFocus
+        required
+        placeholder="Charaktername"
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+      />
+      <input
+        placeholder="Spielername"
+        value={player}
+        onChange={(event) => setPlayer(event.target.value)}
+      />
+      <div className="editor-numbers">
+        <input
+          aria-label="Level"
+          type="number"
+          min="1"
+          max="20"
+          placeholder="Level"
+          value={level}
+          onChange={(event) => setLevel(event.target.value)}
+        />
+        <input
+          aria-label="Passive Perception"
+          type="number"
+          min="0"
+          max="99"
+          placeholder="Passive Perception"
+          value={perception}
+          onChange={(event) => setPerception(event.target.value)}
+        />
+        <input
+          aria-label="Armor Class"
+          type="number"
+          min="0"
+          max="99"
+          placeholder="AC"
+          value={armor}
+          onChange={(event) => setArmor(event.target.value)}
+        />
+      </div>
+      {props.member && !props.deleteConfirm && (
+        <button
+          type="button"
+          className="danger"
+          onClick={() => props.setDeleteConfirm(true)}
+        >
+          Löschen
+        </button>
+      )}
+      {props.deleteConfirm && (
+        <div className="confirm-row">
+          <span>{props.member?.name} wirklich löschen?</span>
+          <button type="button" onClick={() => props.setDeleteConfirm(false)}>
+            Abbrechen
+          </button>
+          <button type="button" className="danger" onClick={props.remove}>
+            Wirklich löschen
+          </button>
+        </div>
+      )}
+      <footer>
+        <button type="button" onClick={props.close}>
+          Abbrechen
+        </button>
+        <button disabled={props.busy || !name.trim()}>
+          {props.member ? 'Speichern' : 'Erstellen'}
+        </button>
+      </footer>
+    </form>
+  )
 }
 
-function hasCampaignWriteCapability(
-  campaigns:
-    | import('../../shared/contracts/capability-api.js').CampaignReadCapability
-    | import('../../shared/contracts/capability-api.js').CampaignCapability
-): campaigns is import('../../shared/contracts/capability-api.js').CampaignCapability {
-  return 'create' in campaigns && 'activate' in campaigns
+function SessionWorkspace(props: {
+  snapshot: LiveSessionSnapshot
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+  groupDialogOpen: boolean
+  setGroupDialogOpen: (open: boolean) => void
+  scenario: '' | 'encounter' | 'travel'
+  setScenario: (scenario: '' | 'encounter' | 'travel') => void
+  layout: SessionLayoutPreference
+  setLayout: (layout: SessionLayoutPreference) => void
+  onError: (message: string) => void
+}) {
+  const [editingGroup, setEditingGroup] = useState<SceneGroup | null>(null)
+  const [detailHistories, setDetailHistories] = useState<
+    Record<string, { entries: Creature[]; index: number }>
+  >({})
+  const focused = props.snapshot.scene.scenes.find(
+    (scene) => scene.id === props.snapshot.scene.focusedSceneId
+  )!
+
+  const history = detailHistories[focused.id] ?? { entries: [], index: -1 }
+  const detail = history.entries[history.index] ?? null
+  const openDetail = (creature: Creature) =>
+    setDetailHistories((current) => {
+      const previous = current[focused.id] ?? { entries: [], index: -1 }
+      if (previous.entries[previous.index]?.id === creature.id) return current
+      const entries = [
+        ...previous.entries.slice(0, previous.index + 1),
+        creature
+      ]
+      return {
+        ...current,
+        [focused.id]: { entries, index: entries.length - 1 }
+      }
+    })
+  const moveHistory = (offset: number) =>
+    setDetailHistories((current) => {
+      const previous = current[focused.id] ?? { entries: [], index: -1 }
+      return {
+        ...current,
+        [focused.id]: {
+          ...previous,
+          index: Math.max(
+            -1,
+            Math.min(previous.entries.length - 1, previous.index + offset)
+          )
+        }
+      }
+    })
+
+  const control = (
+    <section className="session-control-panel" aria-label="Session Steuerung">
+      <div className="panel-heading">
+        <div>
+          <p className="section-kicker">Session</p>
+          <h2>Steuerung</h2>
+        </div>
+        <button
+          onClick={() => {
+            setEditingGroup(null)
+            props.setGroupDialogOpen(true)
+          }}
+        >
+          Gruppen managen
+        </button>
+      </div>
+      <label>
+        Aktive Szene
+        <select
+          aria-label="Aktive Szene"
+          value={focused.id}
+          disabled={props.snapshot.scene.scenes.length < 2}
+          onChange={(event) =>
+            void scenarioAction(props, () =>
+              window.saltMarcher.scene.focus(
+                event.target.value,
+                props.snapshot.scene.revision
+              )
+            )
+          }
+        >
+          {props.snapshot.scene.scenes.map((scene) => (
+            <option key={scene.id} value={scene.id}>
+              {scene.title}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Ort
+        <select
+          aria-label="Scene-Ort"
+          value={focused.locationId ?? ''}
+          onChange={(event) =>
+            void scenarioAction(props, () =>
+              window.saltMarcher.scene.setLocation(
+                focused.id,
+                event.target.value || null,
+                props.snapshot.scene.revision
+              )
+            )
+          }
+        >
+          <option value="">Kein Ort</option>
+          {focused.locationId &&
+            !props.snapshot.scene.locationChoices.some(
+              (location) => location.id === focused.locationId
+            ) && (
+              <option value={focused.locationId}>Nicht verfügbarer Ort</option>
+            )}
+          {props.snapshot.scene.locationChoices.map((location) => (
+            <option key={location.id} value={location.id}>
+              {location.displayName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="panel-hint">
+        {props.snapshot.scene.scenes.length > 1
+          ? 'Szenen führen Gruppen, Details und Combat unabhängig.'
+          : 'Weitere simultane Szenen erscheinen automatisch in der Auswahl.'}
+      </p>
+    </section>
+  )
+
+  const groups = (
+    <section className="session-groups" aria-label="Gruppen">
+      <div className="groups-heading">
+        <h2>Gruppen</h2>
+      </div>
+      <PartyGroup
+        snapshot={props.snapshot}
+        sceneId={focused.id}
+        setSnapshot={props.setSnapshot}
+        onError={props.onError}
+      />
+      {focused.groups.map((group) => (
+        <article className="group-card" key={group.id}>
+          <div className="group-card-title">
+            <strong>{group.name}</strong>
+            <div className="row-actions">
+              <button
+                onClick={() => {
+                  setEditingGroup(group)
+                  props.setGroupDialogOpen(true)
+                }}
+              >
+                Bearbeiten
+              </button>
+              <button
+                className="danger"
+                onClick={() =>
+                  void scenarioAction(props, () =>
+                    window.saltMarcher.scene.deleteGroup(
+                      focused.id,
+                      group.id,
+                      props.snapshot.scene.revision
+                    )
+                  )
+                }
+              >
+                Löschen
+              </button>
+            </div>
+          </div>
+          <div className="group-members">
+            {group.entries.map((entry) => (
+              <button
+                key={entry.id}
+                className={entry.available ? '' : 'unavailable'}
+                disabled={!entry.available}
+                onClick={() =>
+                  void window.saltMarcher.creatures
+                    .detail(entry.creatureId)
+                    .then(openDetail)
+                    .catch(showError(props.onError))
+                }
+              >
+                {entry.displayName} × {entry.quantity}
+              </button>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  )
+
+  const details = (
+    <section className="session-detail-panel" aria-label="Detailansicht">
+      <div className="session-panel-tabs" role="tablist">
+        <button
+          role="tab"
+          aria-selected={props.layout.upperRightTab === 'details'}
+          onClick={() =>
+            props.setLayout({ ...props.layout, upperRightTab: 'details' })
+          }
+        >
+          Details
+        </button>
+        <button
+          role="tab"
+          aria-selected={props.layout.upperRightTab === 'map'}
+          onClick={() =>
+            props.setLayout({ ...props.layout, upperRightTab: 'map' })
+          }
+        >
+          Karte
+        </button>
+      </div>
+      {props.layout.upperRightTab === 'map' ? (
+        <div className="session-map-empty">
+          <strong>Reiseplanung</strong>
+          <p>
+            Sobald ein Hex- oder Dungeon-Provider verfügbar ist, können hier
+            Orte gewählt und Routen geplant werden.
+          </p>
+        </div>
+      ) : (
+        <>
+          <nav className="detail-history" aria-label="Detail Verlauf">
+            <button
+              aria-label="Zurück"
+              disabled={history.index <= 0}
+              onClick={() => moveHistory(-1)}
+            >
+              ←
+            </button>
+            <button
+              aria-label="Vor"
+              disabled={history.index >= history.entries.length - 1}
+              onClick={() => moveHistory(1)}
+            >
+              →
+            </button>
+            <button
+              aria-label="Detail schließen"
+              disabled={!detail}
+              onClick={() =>
+                setDetailHistories((current) => ({
+                  ...current,
+                  [focused.id]: { entries: [], index: -1 }
+                }))
+              }
+            >
+              ×
+            </button>
+            <span>
+              {detail?.name ?? (focused.locationName || focused.title)}
+            </span>
+          </nav>
+          <div className="detail-scroll">
+            {detail ? (
+              <CreatureInspector creature={detail} embedded />
+            ) : (
+              <div className="detail-empty">
+                <p className="section-kicker">{focused.title}</p>
+                <h2>{focused.locationName || 'Keine Detailauswahl'}</h2>
+                <p>
+                  Wähle ein Monster aus einer Gruppe oder später einen Ort bzw.
+                  ein anderes beschriebenes Szenenobjekt aus.
+                </p>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  )
+
+  const scenarioPanel = (
+    <aside className="scenario-panel" aria-label="Szenario Panel">
+      <select
+        aria-label="Szenario Auswahl"
+        value={props.scenario}
+        onChange={(event) =>
+          props.setScenario(event.target.value as '' | 'encounter' | 'travel')
+        }
+      >
+        <option value="">Szenario auswählen …</option>
+        <option value="encounter">Encounter</option>
+        <option value="travel">Reise</option>
+      </select>
+      {!props.scenario ? (
+        <div className="scenario-empty">Szenario Panel</div>
+      ) : props.scenario === 'travel' ? (
+        <TravelScenario snapshot={props.snapshot} />
+      ) : (
+        <SessionEncounterPanel
+          {...props}
+          inspect={openDetail}
+          close={() => props.setScenario('')}
+        />
+      )}
+    </aside>
+  )
+
+  return (
+    <section className="session-mockup" aria-label="Session workspace">
+      <div className="session-layout">
+        <SessionPanelLayout
+          preference={props.layout}
+          changed={props.setLayout}
+          control={control}
+          groups={groups}
+          details={details}
+          scenario={scenarioPanel}
+        />
+      </div>
+      {props.groupDialogOpen && (
+        <GroupDialog
+          snapshot={props.snapshot}
+          group={editingGroup}
+          close={() => props.setGroupDialogOpen(false)}
+          saved={(snapshot) => {
+            props.setSnapshot(snapshot)
+            props.setGroupDialogOpen(false)
+          }}
+          inspect={openDetail}
+          onError={props.onError}
+        />
+      )}
+    </section>
+  )
+}
+
+function SessionPanelLayout(props: {
+  preference: SessionLayoutPreference
+  changed: (preference: SessionLayoutPreference) => void
+  control: ReactNode
+  groups: ReactNode
+  details: ReactNode
+  scenario: ReactNode
+}) {
+  const p = props.preference
+  return (
+    <div className="session-workspace">
+      <div
+        className="session-column session-left-column"
+        style={{ flexBasis: `${p.leftFraction * 100}%` }}
+      >
+        <div className="session-control-pane">{props.control}</div>
+        <div className="session-pane">{props.groups}</div>
+      </div>
+      <SessionDivider
+        axis="vertical"
+        value={p.leftFraction}
+        changed={(leftFraction) => props.changed({ ...p, leftFraction })}
+        label="Gekoppelte Grenze zwischen linker und rechter Spalte"
+      />
+      <div className="session-column">
+        <div
+          className="session-pane"
+          style={{ flexBasis: `${p.rightTopFraction * 100}%` }}
+        >
+          {props.details}
+        </div>
+        <SessionDivider
+          axis="horizontal"
+          value={p.rightTopFraction}
+          changed={(rightTopFraction) =>
+            props.changed({ ...p, rightTopFraction })
+          }
+          label="Grenze zwischen Details und Szenario"
+        />
+        <div className="session-pane">{props.scenario}</div>
+      </div>
+    </div>
+  )
+}
+
+function SessionDivider(props: {
+  axis: 'horizontal' | 'vertical'
+  value: number
+  changed: (value: number) => void
+  label: string
+}) {
+  const resize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('button')) return
+    event.preventDefault()
+    const parent = event.currentTarget.parentElement
+    if (!parent) return
+    const bounds = parent.getBoundingClientRect()
+    const update = (clientX: number, clientY: number) => {
+      const raw =
+        props.axis === 'vertical'
+          ? (clientX - bounds.left) / bounds.width
+          : (clientY - bounds.top) / bounds.height
+      props.changed(Math.max(0.18, Math.min(0.82, raw)))
+    }
+    update(event.clientX, event.clientY)
+    const move = (next: PointerEvent) => update(next.clientX, next.clientY)
+    const stop = () => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', stop)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', stop, { once: true })
+  }
+  const keyboard = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const direction =
+      props.axis === 'vertical'
+        ? event.key === 'ArrowLeft'
+          ? -1
+          : event.key === 'ArrowRight'
+            ? 1
+            : 0
+        : event.key === 'ArrowUp'
+          ? -1
+          : event.key === 'ArrowDown'
+            ? 1
+            : 0
+    if (!direction) return
+    event.preventDefault()
+    props.changed(
+      Math.max(0.18, Math.min(0.82, props.value + direction * 0.02))
+    )
+  }
+  return (
+    <div
+      className={`session-divider session-divider-${props.axis}`}
+      role="separator"
+      aria-label={props.label}
+      aria-orientation={props.axis}
+      aria-valuemin={18}
+      aria-valuemax={82}
+      aria-valuenow={Math.round(props.value * 100)}
+      tabIndex={0}
+      onPointerDown={resize}
+      onKeyDown={keyboard}
+    />
+  )
+}
+
+function PartyGroup(props: {
+  snapshot: LiveSessionSnapshot
+  sceneId: string
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+  onError: (message: string) => void
+}) {
+  const active = props.snapshot.party.members.filter((member) => member.active)
+  const scene = props.snapshot.scene.scenes.find(
+    (entry) => entry.id === props.sceneId
+  )!
+  return (
+    <article className="group-card party-group">
+      <div className="group-card-title">
+        <strong>Party</strong>
+        <span>{scene.partyMemberIds.length} in dieser Scene</span>
+      </div>
+      <div className="group-members">
+        {active.length === 0 ? (
+          <span>Keine aktiven Mitglieder</span>
+        ) : (
+          active.map((member) => (
+            <span key={member.id} className="scene-party-member">
+              {member.name} · Lv {member.level ?? '—'}{' '}
+              <button
+                onClick={() =>
+                  void scenarioAction(props, () =>
+                    window.saltMarcher.scene.assignPartyMember(
+                      props.sceneId,
+                      member.id,
+                      !scene.partyMemberIds.includes(member.id),
+                      props.snapshot.scene.revision
+                    )
+                  )
+                }
+              >
+                {scene.partyMemberIds.includes(member.id)
+                  ? 'Entfernen'
+                  : 'Zur Scene'}
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+    </article>
+  )
+}
+
+function CreatureCollectionCatalogPane(props: {
+  query: CreatureCatalogQuery
+  options: CreatureFilterOptions
+  page: CreatureCatalogPage | null
+  changed: (query: CreatureCatalogQuery) => void
+  add: (creature: Creature) => void
+  inspect: (creature: Creature) => void
+}) {
+  return (
+    <section className="group-catalog-pane" aria-label="Monsterkatalog">
+      <CreatureFilters
+        query={props.query}
+        options={props.options}
+        changed={props.changed}
+        compact
+      />
+      <div className="filter-chips">
+        <FilterChips query={props.query} changed={props.changed} />
+      </div>
+      <div className="group-catalog-table-wrap">
+        <table className="catalog-table group-catalog-table">
+          <thead>
+            <tr>
+              <th>Monster</th>
+              <th>CR</th>
+              <th>Typ</th>
+              <th>XP</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {props.page?.rows.map((creature) => (
+              <tr key={creature.id}>
+                <td>
+                  <button
+                    type="button"
+                    className="link-button"
+                    onClick={() => props.inspect(creature)}
+                  >
+                    {creature.name}
+                  </button>
+                </td>
+                <td>{creature.challengeRating}</td>
+                <td>{creature.type}</td>
+                <td>{creature.xp.toLocaleString()}</td>
+                <td>
+                  <button
+                    type="button"
+                    aria-label={`${creature.name} hinzufügen`}
+                    onClick={() => props.add(creature)}
+                  >
+                    +
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {props.page?.status === 'empty' && (
+          <p className="empty-state">{props.page.message}</p>
+        )}
+      </div>
+      <footer className="catalog-footer">
+        <span>
+          {props.page?.message || `${props.page?.total ?? 0} Monster`}
+        </span>
+        <div>
+          <button
+            type="button"
+            disabled={!props.page || props.query.offset === 0}
+            onClick={() =>
+              props.changed({
+                ...props.query,
+                offset: Math.max(0, props.query.offset - props.query.limit)
+              })
+            }
+          >
+            Zurück
+          </button>
+          <span>{Math.floor(props.query.offset / props.query.limit) + 1}</span>
+          <button
+            type="button"
+            disabled={
+              !props.page ||
+              props.query.offset + props.query.limit >= props.page.total
+            }
+            onClick={() =>
+              props.changed({
+                ...props.query,
+                offset: props.query.offset + props.query.limit
+              })
+            }
+          >
+            Weiter
+          </button>
+        </div>
+      </footer>
+    </section>
+  )
+}
+
+function CreatureCollectionSelection(props: {
+  label: string
+  value: string | null
+  emptyLabel: string
+  newLabel: string
+  choices: readonly { id: string; label: string }[]
+  changed: (value: string | null) => void
+}) {
+  return (
+    <div className="group-selection-row">
+      <label>
+        {props.label}
+        <select
+          aria-label={`${props.label} auswählen`}
+          value={props.value ?? ''}
+          onChange={(event) => props.changed(event.target.value || null)}
+        >
+          <option value="">{props.emptyLabel}</option>
+          <option value="new">{props.newLabel}</option>
+          {props.choices.map((choice) => (
+            <option key={choice.id} value={choice.id}>
+              {choice.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button type="button" onClick={() => props.changed('new')}>
+        {props.newLabel}
+      </button>
+    </div>
+  )
+}
+
+function GroupDialog(props: {
+  snapshot: LiveSessionSnapshot
+  group: SceneGroup | null
+  close: () => void
+  saved: (snapshot: LiveSessionSnapshot) => void
+  inspect: (creature: Creature) => void
+  onError: (message: string) => void
+}) {
+  const focused = props.snapshot.scene.scenes.find(
+    (scene) => scene.id === props.snapshot.scene.focusedSceneId
+  )!
+  const initialQuantities = Object.fromEntries(
+    props.group?.entries.map((entry) => [entry.creatureId, entry.quantity]) ??
+      []
+  )
+  const initialFacts = Object.fromEntries(
+    props.group?.entries.map((entry) => [
+      entry.creatureId,
+      {
+        displayName: entry.displayName,
+        cr: 0,
+        xp: 0,
+        available: entry.available
+      }
+    ]) ?? []
+  )
+  const [selection, setSelection] = useState<string | null>(
+    props.group?.id ?? null
+  )
+  const [name, setName] = useState(props.group?.name ?? '')
+  const [query, setQuery] = useState<CreatureCatalogQuery>({
+    ...emptyQuery,
+    limit: 30
+  })
+  const [page, setPage] = useState<CreatureCatalogPage | null>(null)
+  const [options, setOptions] = useState(emptyCreatureOptions)
+  const [quantities, setQuantities] =
+    useState<Record<string, number>>(initialQuantities)
+  const [facts, setFacts] =
+    useState<Record<string, DraftCreatureFact>>(initialFacts)
+  const [tuning, setTuning] = useState<EncounterTuning>({
+    difficulty: 'auto',
+    amount: 'auto',
+    balance: 'auto',
+    diversity: 'auto'
+  })
+  const [evaluation, setEvaluation] =
+    useState<SceneGroupDraftEvaluation | null>(null)
+  const [baseline, setBaseline] = useState(() =>
+    groupDraftSignature(props.group?.name ?? '', initialQuantities)
+  )
+  const [pending, setPending] = useState<GroupDraftAction | null>(null)
+  const [seed, setSeed] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState('')
+  const evaluationRequest = useRef(0)
+  const factsRequest = useRef(0)
+  const entries = useMemo(() => groupDraftEntries(quantities), [quantities])
+  const active = selection !== null
+  const dirty = active && groupDraftSignature(name, quantities) !== baseline
+  const assigned = props.snapshot.party.members.filter((member) =>
+    focused.partyMemberIds.includes(member.id)
+  )
+  const canGenerate =
+    active &&
+    assigned.length > 0 &&
+    assigned.every((member) => member.level !== null)
+  const sourceQuery = useMemo(
+    () => ({ ...query, locationId: focused.locationId }),
+    [focused.locationId, query]
+  )
+
+  useCreatureSearch(sourceQuery, setPage, props.onError)
+  useEffect(() => {
+    void window.saltMarcher.creatures
+      .filterOptions()
+      .then(setOptions)
+      .catch(showError(props.onError))
+  }, [props.onError])
+
+  useEffect(() => {
+    if (!active) return
+    const token = ++evaluationRequest.current
+    const timer = window.setTimeout(() => {
+      void window.saltMarcher.scene
+        .evaluateGroupDraft(focused.id, entries, props.snapshot.scene.revision)
+        .then((next) => {
+          if (evaluationRequest.current === token) setEvaluation(next)
+        })
+        .catch((cause) => {
+          if (evaluationRequest.current === token) setMessage(errorText(cause))
+        })
+    }, 120)
+    return () => window.clearTimeout(timer)
+  }, [active, entries, focused.id, props.snapshot.scene.revision])
+
+  useEffect(() => {
+    if (!selection || selection === 'new') return
+    const group = focused.groups.find((candidate) => candidate.id === selection)
+    if (!group) return
+    const token = ++factsRequest.current
+    void Promise.all(
+      group.entries.map((entry) =>
+        window.saltMarcher.creatures.detail(entry.creatureId).catch(() => null)
+      )
+    ).then((creatures) => {
+      if (factsRequest.current !== token) return
+      setFacts((current) => {
+        const next = { ...current }
+        for (const creature of creatures)
+          if (creature) next[creature.id] = creatureFact(creature)
+        return next
+      })
+    })
+  }, [focused.groups, selection])
+
+  function load(nextSelection: string | null) {
+    const group =
+      nextSelection && nextSelection !== 'new'
+        ? focused.groups.find((candidate) => candidate.id === nextSelection)
+        : undefined
+    const nextName = group?.name ?? ''
+    const nextQuantities = Object.fromEntries(
+      group?.entries.map((entry) => [entry.creatureId, entry.quantity]) ?? []
+    )
+    const nextFacts = Object.fromEntries(
+      group?.entries.map((entry) => [
+        entry.creatureId,
+        {
+          displayName: entry.displayName,
+          cr: 0,
+          xp: 0,
+          available: entry.available
+        }
+      ]) ?? []
+    )
+    setSelection(nextSelection)
+    setName(nextName)
+    setQuantities(nextQuantities)
+    setFacts(nextFacts)
+    setBaseline(groupDraftSignature(nextName, nextQuantities))
+    setEvaluation(null)
+    setMessage('')
+    setSeed(0)
+  }
+
+  function perform(action: GroupDraftAction) {
+    setPending(null)
+    if (action.kind === 'close') props.close()
+    else load(action.selection)
+  }
+
+  function request(action: GroupDraftAction) {
+    if (dirty) setPending(action)
+    else perform(action)
+  }
+
+  function addCreature(creature: Creature) {
+    if (!active) {
+      setSelection('new')
+      setName('')
+      setQuantities({ [creature.id]: 1 })
+      setBaseline(groupDraftSignature('', {}))
+    } else {
+      setQuantities((current) => ({
+        ...current,
+        [creature.id]: Math.min(999, (current[creature.id] ?? 0) + 1)
+      }))
+    }
+    setFacts((current) => ({
+      ...current,
+      [creature.id]: creatureFact(creature)
+    }))
+  }
+
+  function changeQuantity(creatureId: string, delta: number) {
+    setQuantities((current) => {
+      const quantity = Math.max(
+        0,
+        Math.min(999, (current[creatureId] ?? 0) + delta)
+      )
+      const next = { ...current }
+      if (quantity === 0) delete next[creatureId]
+      else next[creatureId] = quantity
+      return next
+    })
+  }
+
+  async function inspect(creature: Creature) {
+    try {
+      props.inspect(await window.saltMarcher.creatures.detail(creature.id))
+    } catch (cause) {
+      setMessage(errorText(cause))
+    }
+  }
+
+  async function generate(mode: 'fill' | 'replace') {
+    if (!canGenerate) return
+    const nextSeed = seed + 1
+    setBusy(true)
+    try {
+      const result = await window.saltMarcher.scene.generateGroupDraft(
+        focused.id,
+        entries,
+        mode,
+        sourceQuery,
+        tuning,
+        nextSeed,
+        props.snapshot.scene.revision
+      )
+      setQuantities(
+        Object.fromEntries(
+          result.entries.map((entry) => [entry.creatureId, entry.quantity])
+        )
+      )
+      setFacts((current) => ({
+        ...current,
+        ...Object.fromEntries(
+          result.entries.map((entry) => [
+            entry.creatureId,
+            {
+              displayName: entry.displayName,
+              cr: entry.cr,
+              xp: entry.xp,
+              available: entry.available
+            }
+          ])
+        )
+      }))
+      setEvaluation(result.evaluation)
+      setSeed(nextSeed)
+      setMessage(result.message)
+    } catch (cause) {
+      setMessage(errorText(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function save() {
+    if (!active || !name.trim() || entries.length === 0) {
+      setMessage('Gruppenname und mindestens ein Monster sind erforderlich.')
+      return
+    }
+    if (!entries.some((entry) => facts[entry.creatureId]?.available === true)) {
+      setMessage('Mindestens ein verfügbares Monster ist erforderlich.')
+      return
+    }
+    setBusy(true)
+    try {
+      props.saved(
+        await window.saltMarcher.scene.saveGroup(
+          focused.id,
+          selection === 'new' ? null : selection,
+          name.trim(),
+          entries,
+          props.snapshot.scene.revision
+        )
+      )
+    } catch (cause) {
+      setMessage(errorText(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <section
+        className="group-dialog group-builder-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="group-builder-title"
+      >
+        <header>
+          <div>
+            <p className="section-kicker">{focused.title}</p>
+            <h2 id="group-builder-title">Gruppen managen</h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Dialog schließen"
+            onClick={() => request({ kind: 'close' })}
+          >
+            ×
+          </button>
+        </header>
+        <div className="group-builder-layout">
+          <CreatureCollectionCatalogPane
+            query={query}
+            options={{ ...options, locations: [] }}
+            page={page}
+            changed={setQuery}
+            add={addCreature}
+            inspect={(creature) => void inspect(creature)}
+          />
+          <section className="group-draft-pane" aria-label="Aktuelle Gruppe">
+            <CreatureCollectionSelection
+              label="Gruppe"
+              value={selection}
+              emptyLabel="Gruppe auswählen …"
+              newLabel="Neue Gruppe"
+              choices={focused.groups.map((group) => ({
+                id: group.id,
+                label: group.name
+              }))}
+              changed={(nextSelection) =>
+                request({ kind: 'select', selection: nextSelection })
+              }
+            />
+            {!active ? (
+              <p className="empty-state">
+                Wähle eine Gruppe aus oder lege eine neue Gruppe an.
+              </p>
+            ) : (
+              <>
+                <input
+                  autoFocus
+                  aria-label="Gruppenname"
+                  placeholder="Gruppenname"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                />
+                <ul className="group-draft-roster">
+                  {entries.map((entry) => {
+                    const fact = facts[entry.creatureId]
+                    return (
+                      <li
+                        key={entry.creatureId}
+                        className={
+                          fact?.available === false ? 'unavailable' : ''
+                        }
+                      >
+                        <div className="roster-quantity">
+                          <button
+                            aria-label={`Anzahl ${fact?.displayName ?? entry.creatureId} verringern`}
+                            onClick={() => changeQuantity(entry.creatureId, -1)}
+                          >
+                            −
+                          </button>
+                          <strong>{entry.quantity}</strong>
+                          <button
+                            aria-label={`Anzahl ${fact?.displayName ?? entry.creatureId} erhöhen`}
+                            onClick={() => changeQuantity(entry.creatureId, 1)}
+                          >
+                            +
+                          </button>
+                        </div>
+                        <span>
+                          <strong>
+                            {fact?.displayName ?? entry.creatureId}
+                          </strong>
+                          <small>
+                            CR {fact?.cr ?? '—'} ·{' '}
+                            {(fact?.xp ?? 0).toLocaleString()} XP
+                          </small>
+                        </span>
+                        <button
+                          aria-label={`${fact?.displayName ?? entry.creatureId} entfernen`}
+                          onClick={() =>
+                            changeQuantity(entry.creatureId, -entry.quantity)
+                          }
+                        >
+                          ×
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
+                {entries.length === 0 && (
+                  <p className="empty-state">
+                    Monster links mit <strong>+</strong> hinzufügen oder eine
+                    Gruppe generieren.
+                  </p>
+                )}
+                <TuningControls tuning={tuning} changed={setTuning} />
+                <div className="group-generator-actions">
+                  <button
+                    disabled={busy || !canGenerate}
+                    onClick={() => void generate('fill')}
+                  >
+                    Auffüllen
+                  </button>
+                  <button
+                    disabled={busy || !canGenerate}
+                    onClick={() => void generate('replace')}
+                  >
+                    Neu generieren
+                  </button>
+                </div>
+                {!canGenerate && (
+                  <small className="muted">
+                    Zum Generieren braucht die Scene eine zugewiesene Party mit
+                    vollständigen Leveln.
+                  </small>
+                )}
+                {evaluation && (
+                  <DifficultySummary evaluation={evaluation} meter />
+                )}
+              </>
+            )}
+            {pending && (
+              <div className="confirm-row group-draft-confirm" role="alert">
+                <span>Ungespeicherte Änderungen verwerfen?</span>
+                <button onClick={() => setPending(null)}>Abbrechen</button>
+                <button className="danger" onClick={() => perform(pending)}>
+                  Änderungen verwerfen
+                </button>
+              </div>
+            )}
+            {message && (
+              <p className="generator-status" role="status">
+                {message}
+              </p>
+            )}
+          </section>
+        </div>
+        <footer className="group-builder-footer">
+          <span className="muted">
+            {focused.locationName || 'Kein Ort gesetzt'} · {assigned.length}{' '}
+            zugewiesene PCs
+          </span>
+          <div>
+            <button type="button" onClick={() => request({ kind: 'close' })}>
+              Abbrechen
+            </button>
+            <button
+              disabled={busy || !active || !name.trim() || entries.length === 0}
+              onClick={() => void save()}
+            >
+              {selection === 'new' ? 'Gruppe erstellen' : 'Speichern'}
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
+type DraftCreatureFact = {
+  displayName: string
+  cr: number
+  xp: number
+  available: boolean
+}
+
+type GroupDraftAction =
+  { kind: 'close' } | { kind: 'select'; selection: string | null }
+
+function creatureFact(creature: Creature): DraftCreatureFact {
+  return {
+    displayName: creature.name,
+    cr: creature.cr,
+    xp: creature.xp,
+    available: true
+  }
+}
+
+function groupDraftEntries(quantities: Record<string, number>) {
+  return Object.entries(quantities)
+    .filter(([, quantity]) => quantity > 0)
+    .map(([creatureId, quantity]) => ({ creatureId, quantity }))
+    .sort((a, b) => a.creatureId.localeCompare(b.creatureId))
+}
+
+function groupDraftSignature(
+  name: string,
+  quantities: Record<string, number>
+): string {
+  return JSON.stringify({ name, entries: groupDraftEntries(quantities) })
+}
+
+function TravelScenario({ snapshot }: { snapshot: LiveSessionSnapshot }) {
+  return (
+    <section className="scenario-content travel-context">
+      <p className="section-kicker">Reise</p>
+      <h2>{snapshot.travel.label}</h2>
+      <p>{snapshot.travel.hint}</p>
+      <small>Dieser globale Zustand ist schreibgeschützt.</small>
+    </section>
+  )
+}
+
+function CatalogWorkspace(
+  props: ScenarioProps & { inspect: (creature: Creature) => void }
+) {
+  const [section, setSection] = useState<
+    'monsters' | 'locations' | 'factions' | 'encounterTables'
+  >('monsters')
+  const [query, setQuery] = useState<CreatureCatalogQuery>(emptyQuery)
+  const [page, setPage] = useState<CreatureCatalogPage | null>(null)
+  const [options, setOptions] = useState(emptyCreatureOptions)
+  const [loading, setLoading] = useState(false)
+  const [locations, setLocations] = useState<WorldLocationSnapshot>({
+    revision: 0,
+    locations: []
+  })
+  const [locationLoading, setLocationLoading] = useState(false)
+  const [locationSearchInput, setLocationSearchInput] = useState('')
+  const [locationSearch, setLocationSearch] = useState('')
+  const [locationDirection, setLocationDirection] = useState<'asc' | 'desc'>(
+    'asc'
+  )
+  const [selectedLocation, setSelectedLocation] =
+    useState<WorldLocation | null>(null)
+  const [editingLocation, setEditingLocation] = useState<
+    WorldLocation | null | undefined
+  >(undefined)
+  const [deleteLocationConfirm, setDeleteLocationConfirm] = useState(false)
+  const [locationTables, setLocationTables] = useState<EncounterTable[]>([])
+  const [locationFactions, setLocationFactions] = useState<WorldFaction[]>([])
+  const request = useRef(0)
+  const onError = props.onError
+  useEffect(() => {
+    if (section !== 'monsters') return
+    void window.saltMarcher.creatures
+      .filterOptions()
+      .then(setOptions)
+      .catch(showError(onError))
+  }, [onError, section])
+  useEffect(() => {
+    if (section !== 'monsters') return
+    const token = ++request.current
+    const timer = window.setTimeout(async () => {
+      setLoading(true)
+      try {
+        const result = await window.saltMarcher.creatures.search(query)
+        if (request.current !== token) return
+        setPage(result)
+      } catch (cause) {
+        if (request.current === token) onError(errorText(cause))
+      } finally {
+        if (request.current === token) setLoading(false)
+      }
+    }, 200)
+    return () => window.clearTimeout(timer)
+  }, [query, onError, section])
+  useEffect(() => {
+    if (section !== 'locations') return
+    void Promise.resolve().then(async () => {
+      setLocationLoading(true)
+      try {
+        const [next, tableSnapshot, factionSnapshot] = await Promise.all([
+          window.saltMarcher.locations.read(),
+          window.saltMarcher.encounterTables.read(),
+          window.saltMarcher.factions.read()
+        ])
+        setLocations(next)
+        setLocationTables([...tableSnapshot.tables])
+        setLocationFactions([...factionSnapshot.factions])
+        setSelectedLocation((current) =>
+          current
+            ? (next.locations.find((location) => location.id === current.id) ??
+              null)
+            : null
+        )
+      } catch (cause) {
+        onError(errorText(cause))
+      } finally {
+        setLocationLoading(false)
+      }
+    })
+  }, [onError, section])
+  useEffect(() => {
+    if (section !== 'locations') return
+    const timer = window.setTimeout(
+      () => setLocationSearch(locationSearchInput),
+      200
+    )
+    return () => window.clearTimeout(timer)
+  }, [locationSearchInput, section])
+  const open = async (creature: Creature) => {
+    try {
+      props.inspect(await window.saltMarcher.creatures.detail(creature.id))
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const visibleLocations = useMemo(() => {
+    const needle = locationSearch.trim().toLocaleLowerCase()
+    return locations.locations
+      .filter(
+        (location) =>
+          !needle ||
+          location.displayName.toLocaleLowerCase().includes(needle) ||
+          location.notes.toLocaleLowerCase().includes(needle)
+      )
+      .toSorted((a, b) => {
+        const order = a.displayName.localeCompare(b.displayName)
+        return locationDirection === 'asc' ? order : -order
+      })
+  }, [locationDirection, locationSearch, locations.locations])
+
+  const saveLocation = async (draft: WorldLocationDraft) => {
+    try {
+      const previousIds = new Set(
+        locations.locations.map((location) => location.id)
+      )
+      const next = editingLocation
+        ? await window.saltMarcher.locations.update(
+            editingLocation.id,
+            draft,
+            locations.revision
+          )
+        : await window.saltMarcher.locations.create(draft, locations.revision)
+      const selectedId =
+        editingLocation?.id ??
+        next.locations.find((location) => !previousIds.has(location.id))?.id
+      setLocations(next)
+      setSelectedLocation(
+        next.locations.find((location) => location.id === selectedId) ?? null
+      )
+      setEditingLocation(undefined)
+      props.setSnapshot(await window.saltMarcher.session.read())
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  const deleteLocation = async () => {
+    if (!selectedLocation) return
+    try {
+      const next = await window.saltMarcher.locations.delete(
+        selectedLocation.id,
+        locations.revision
+      )
+      setLocations(next)
+      setSelectedLocation(null)
+      setDeleteLocationConfirm(false)
+      props.setSnapshot(await window.saltMarcher.session.read())
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  return (
+    <section className="catalog-workspace">
+      <div
+        className={`catalog-browser${section !== 'monsters' ? ' locations-catalog-browser' : ''}`}
+      >
+        <header className="catalog-section-selector">
+          <button
+            aria-pressed={section === 'monsters'}
+            onClick={() => setSection('monsters')}
+          >
+            Monster
+          </button>
+          <button
+            aria-pressed={section === 'locations'}
+            onClick={() => setSection('locations')}
+          >
+            Orte
+          </button>
+          <button
+            aria-pressed={section === 'factions'}
+            onClick={() => setSection('factions')}
+          >
+            Fraktionen
+          </button>
+          <button
+            aria-pressed={section === 'encounterTables'}
+            onClick={() => setSection('encounterTables')}
+          >
+            Encounter-Tabellen
+          </button>
+        </header>
+        {section === 'monsters' ? (
+          <>
+            <CreatureFilters
+              query={query}
+              options={options}
+              changed={setQuery}
+            />
+            <div className="filter-chips">
+              <FilterChips query={query} changed={setQuery} />
+            </div>
+            <div className="catalog-table-wrap">
+              <table className="catalog-table">
+                <thead>
+                  <tr>
+                    <SortHeader
+                      label="Name"
+                      field="name"
+                      query={query}
+                      changed={setQuery}
+                    />
+                    <SortHeader
+                      label="CR"
+                      field="cr"
+                      query={query}
+                      changed={setQuery}
+                    />
+                    <th>Typ</th>
+                    <th>Größe</th>
+                    <SortHeader
+                      label="XP"
+                      field="xp"
+                      query={query}
+                      changed={setQuery}
+                    />
+                  </tr>
+                </thead>
+                <tbody>
+                  {page?.rows.map((creature) => (
+                    <tr key={creature.id} className="catalog-row">
+                      <td>
+                        <button
+                          className="link-button"
+                          onClick={() => void open(creature)}
+                        >
+                          {creature.name}
+                        </button>
+                      </td>
+                      <td>{creature.challengeRating}</td>
+                      <td>
+                        {creature.type}
+                        {creature.subtype ? ` (${creature.subtype})` : ''}
+                      </td>
+                      <td>{creature.size}</td>
+                      <td>{creature.xp.toLocaleString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <footer className="catalog-footer">
+              <span>
+                {loading
+                  ? 'Monster werden aktualisiert …'
+                  : page?.message || `${page?.total ?? 0} Monster`}
+              </span>
+              <div>
+                <button
+                  disabled={!page || query.offset === 0}
+                  onClick={() =>
+                    setQuery({
+                      ...query,
+                      offset: Math.max(0, query.offset - query.limit)
+                    })
+                  }
+                >
+                  Zurück
+                </button>
+                <span>{Math.floor(query.offset / query.limit) + 1}</span>
+                <button
+                  disabled={!page || query.offset + query.limit >= page.total}
+                  onClick={() =>
+                    setQuery({ ...query, offset: query.offset + query.limit })
+                  }
+                >
+                  Weiter
+                </button>
+              </div>
+            </footer>
+          </>
+        ) : section === 'locations' ? (
+          <>
+            <form
+              className="catalog-filters"
+              onSubmit={(event) => {
+                event.preventDefault()
+                setLocationSearch(locationSearchInput)
+              }}
+            >
+              <input
+                aria-label="Orte suchen"
+                placeholder="Orte suchen …"
+                value={locationSearchInput}
+                onChange={(event) => setLocationSearchInput(event.target.value)}
+              />
+              <button type="button" onClick={() => setEditingLocation(null)}>
+                Erstellen
+              </button>
+            </form>
+            <div className="catalog-table-wrap">
+              <table className="catalog-table">
+                <thead>
+                  <tr>
+                    <th>
+                      <button
+                        className="sort-header"
+                        onClick={() =>
+                          setLocationDirection((current) =>
+                            current === 'asc' ? 'desc' : 'asc'
+                          )
+                        }
+                      >
+                        Name {locationDirection === 'asc' ? '↑' : '↓'}
+                      </button>
+                    </th>
+                    <th>Notizen</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleLocations.map((location) => (
+                    <tr key={location.id} className="catalog-row">
+                      <td>
+                        <button
+                          className="link-button"
+                          onClick={() => {
+                            setSelectedLocation(location)
+                            setDeleteLocationConfirm(false)
+                          }}
+                        >
+                          {location.displayName}
+                        </button>
+                      </td>
+                      <td>{location.notes || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <footer className="catalog-footer">
+              <span>
+                {locationLoading
+                  ? 'Orte werden aktualisiert …'
+                  : visibleLocations.length === 0
+                    ? 'Keine Orte gefunden.'
+                    : `${visibleLocations.length} von ${locations.locations.length} Orten`}
+              </span>
+            </footer>
+          </>
+        ) : section === 'factions' ? (
+          <FactionCatalog onError={props.onError} inspect={props.inspect} />
+        ) : (
+          <EncounterTableCatalog
+            onError={props.onError}
+            inspect={props.inspect}
+          />
+        )}
+      </div>
+      {selectedLocation && (
+        <LocationInspector
+          location={selectedLocation}
+          close={() => {
+            setSelectedLocation(null)
+            setDeleteLocationConfirm(false)
+          }}
+          edit={() => {
+            setEditingLocation(selectedLocation)
+            setSelectedLocation(null)
+          }}
+          deleteConfirm={deleteLocationConfirm}
+          setDeleteConfirm={setDeleteLocationConfirm}
+          remove={() => void deleteLocation()}
+        />
+      )}
+      {editingLocation !== undefined && (
+        <LocationDialog
+          location={editingLocation}
+          factions={locationFactions}
+          tables={locationTables}
+          close={() => setEditingLocation(undefined)}
+          save={(draft) => void saveLocation(draft)}
+        />
+      )}
+    </section>
+  )
+}
+
+function LocationInspector(props: {
+  location: WorldLocation
+  close: () => void
+  edit: () => void
+  deleteConfirm: boolean
+  setDeleteConfirm: (value: boolean) => void
+  remove: () => void
+}) {
+  return (
+    <aside className="location-inspector" aria-label="Ort Details">
+      <header>
+        <div>
+          <p className="section-kicker">Ort</p>
+          <h2>{props.location.displayName}</h2>
+        </div>
+        <button aria-label="Ort Details schließen" onClick={props.close}>
+          ×
+        </button>
+      </header>
+      <p className="location-notes">
+        {props.location.notes || 'Keine Beschreibung hinterlegt.'}
+      </p>
+      <p>
+        {props.location.factionIds.length} Fraktionen ·{' '}
+        {props.location.encounterTableIds.length} direkte Encounter-Tabellen
+      </p>
+      <footer className="row-actions">
+        <button onClick={props.edit}>Bearbeiten</button>
+        {!props.deleteConfirm ? (
+          <button
+            className="danger"
+            onClick={() => props.setDeleteConfirm(true)}
+          >
+            Löschen
+          </button>
+        ) : (
+          <>
+            <span>Ort wirklich löschen?</span>
+            <button onClick={() => props.setDeleteConfirm(false)}>
+              Abbrechen
+            </button>
+            <button className="danger" onClick={props.remove}>
+              Wirklich löschen
+            </button>
+          </>
+        )}
+      </footer>
+    </aside>
+  )
+}
+
+function LocationDialog(props: {
+  location: WorldLocation | null
+  factions: readonly WorldFaction[]
+  tables: readonly EncounterTable[]
+  close: () => void
+  save: (draft: WorldLocationDraft) => void
+}) {
+  const [displayName, setDisplayName] = useState(
+    props.location?.displayName ?? ''
+  )
+  const [notes, setNotes] = useState(props.location?.notes ?? '')
+  const [factionIds, setFactionIds] = useState<string[]>([
+    ...(props.location?.factionIds ?? [])
+  ])
+  const [encounterTableIds, setEncounterTableIds] = useState<string[]>([
+    ...(props.location?.encounterTableIds ?? [])
+  ])
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <form
+        className="location-editor"
+        role="dialog"
+        aria-modal="true"
+        aria-label={props.location ? 'Ort bearbeiten' : 'Ort erstellen'}
+        onSubmit={(event) => {
+          event.preventDefault()
+          props.save({ displayName, notes, factionIds, encounterTableIds })
+        }}
+      >
+        <header>
+          <div>
+            <p className="section-kicker">World Planner</p>
+            <h2>{props.location ? 'Ort bearbeiten' : 'Ort erstellen'}</h2>
+          </div>
+        </header>
+        <label>
+          Name
+          <input
+            aria-label="Ortsname"
+            required
+            maxLength={100}
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+        </label>
+        <ReferenceMultiSelect
+          label="Verknüpfte Fraktionen"
+          options={props.factions.map((faction) => ({
+            id: faction.id,
+            label: faction.displayName
+          }))}
+          selected={factionIds}
+          changed={setFactionIds}
+        />
+        <ReferenceMultiSelect
+          label="Direkte Encounter-Tabellen"
+          options={props.tables.map((table) => ({
+            id: table.id,
+            label: table.displayName
+          }))}
+          selected={encounterTableIds}
+          changed={setEncounterTableIds}
+        />
+        <label>
+          Notizen
+          <textarea
+            aria-label="Ortsnotizen"
+            maxLength={20_000}
+            rows={10}
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+          />
+        </label>
+        <footer>
+          <button type="button" onClick={props.close}>
+            Abbrechen
+          </button>
+          <button disabled={!displayName.trim()}>
+            {props.location ? 'Speichern' : 'Erstellen'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}
+
+function EncounterTableCatalog(props: {
+  onError: (message: string) => void
+  inspect: (creature: Creature) => void
+}) {
+  const [snapshot, setSnapshot] = useState<EncounterTableSnapshot>({
+    revision: 0,
+    tables: []
+  })
+  const [search, setSearch] = useState('')
+  const [editing, setEditing] = useState<EncounterTable | null | undefined>(
+    undefined
+  )
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  useEffect(() => {
+    void window.saltMarcher.encounterTables
+      .read()
+      .then(setSnapshot)
+      .catch(showError(props.onError))
+  }, [props.onError])
+
+  const visible = snapshot.tables.filter((table) =>
+    `${table.displayName} ${table.description}`
+      .toLocaleLowerCase()
+      .includes(search.trim().toLocaleLowerCase())
+  )
+
+  async function save(
+    table: EncounterTable | null,
+    draft: EncounterTableDraft
+  ) {
+    try {
+      const next = table
+        ? await window.saltMarcher.encounterTables.update(
+            table.id,
+            draft,
+            snapshot.revision
+          )
+        : await window.saltMarcher.encounterTables.create(
+            draft,
+            snapshot.revision
+          )
+      setSnapshot(next)
+      setEditing(undefined)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  async function remove(id: string) {
+    try {
+      setSnapshot(
+        await window.saltMarcher.encounterTables.delete(id, snapshot.revision)
+      )
+      setDeleteId(null)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  return (
+    <>
+      <div className="catalog-filters">
+        <input
+          aria-label="Encounter-Tabellen suchen"
+          placeholder="Encounter-Tabellen suchen …"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <button onClick={() => setEditing(null)}>Erstellen</button>
+      </div>
+      <div className="catalog-table-wrap">
+        <table className="catalog-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Einträge</th>
+              <th>Beschreibung</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((table) => (
+              <tr key={table.id}>
+                <td>
+                  <button
+                    className="link-button"
+                    onClick={() => setEditing(table)}
+                  >
+                    {table.displayName}
+                  </button>
+                </td>
+                <td>{table.entries.length}</td>
+                <td>{table.description || '—'}</td>
+                <td className="row-actions">
+                  {deleteId === table.id ? (
+                    <>
+                      <button onClick={() => setDeleteId(null)}>
+                        Abbrechen
+                      </button>
+                      <button
+                        className="danger"
+                        onClick={() => void remove(table.id)}
+                      >
+                        Bestätigen
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="danger"
+                      onClick={() => setDeleteId(table.id)}
+                    >
+                      Löschen
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <footer className="catalog-footer">
+        <span>{visible.length} Encounter-Tabellen</span>
+      </footer>
+      {editing !== undefined && (
+        <EncounterTableDialog
+          key={editing?.id ?? 'new'}
+          table={editing}
+          tables={snapshot.tables}
+          close={() => setEditing(undefined)}
+          select={setEditing}
+          save={(table, draft) => void save(table, draft)}
+          onError={props.onError}
+          inspect={props.inspect}
+        />
+      )}
+    </>
+  )
+}
+
+function EncounterTableDialog(props: {
+  table: EncounterTable | null
+  tables: readonly EncounterTable[]
+  close: () => void
+  select: (table: EncounterTable | null) => void
+  save: (table: EncounterTable | null, draft: EncounterTableDraft) => void
+  onError: (message: string) => void
+  inspect: (creature: Creature) => void
+}) {
+  const [displayName, setDisplayName] = useState(props.table?.displayName ?? '')
+  const [description, setDescription] = useState(props.table?.description ?? '')
+  const [query, setQuery] = useState<CreatureCatalogQuery>({
+    ...emptyQuery,
+    limit: 30
+  })
+  const [page, setPage] = useState<CreatureCatalogPage | null>(null)
+  const [options, setOptions] = useState(emptyCreatureOptions)
+  const [weights, setWeights] = useState<Record<string, number>>(
+    Object.fromEntries(
+      props.table?.entries.map((entry) => [entry.creatureId, entry.weight]) ??
+        []
+    )
+  )
+  const [names, setNames] = useState<Record<string, string>>({})
+  const [pending, setPending] = useState<
+    { kind: 'close' } | { kind: 'select'; id: string } | null
+  >(null)
+  useCreatureSearch(query, setPage, props.onError)
+
+  useEffect(() => {
+    void window.saltMarcher.creatures
+      .filterOptions()
+      .then(setOptions)
+      .catch(showError(props.onError))
+  }, [props.onError])
+
+  useEffect(() => {
+    void Promise.all(
+      Object.keys(weights).map((id) =>
+        window.saltMarcher.creatures.detail(id).catch(() => null)
+      )
+    ).then((rows) =>
+      setNames(
+        Object.fromEntries(
+          rows
+            .filter((row): row is Creature => row !== null)
+            .map((row) => [row.id, row.name])
+        )
+      )
+    )
+  }, [weights])
+
+  const entries = Object.entries(weights).toSorted((left, right) =>
+    (names[left[0]] ?? left[0]).localeCompare(names[right[0]] ?? right[0])
+  )
+  const signature = JSON.stringify({
+    displayName,
+    description,
+    entries: Object.entries(weights).toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  })
+  const initialSignature = JSON.stringify({
+    displayName: props.table?.displayName ?? '',
+    description: props.table?.description ?? '',
+    entries: (props.table?.entries ?? [])
+      .map((entry) => [entry.creatureId, entry.weight])
+      .toSorted((left, right) =>
+        String(left[0]).localeCompare(String(right[0]))
+      )
+  })
+  const dirty = signature !== initialSignature
+
+  function requestClose() {
+    if (dirty) setPending({ kind: 'close' })
+    else props.close()
+  }
+
+  function requestSelection(id: string | null) {
+    if (!id) return
+    if (dirty) setPending({ kind: 'select', id })
+    else select(id)
+  }
+
+  function select(id: string) {
+    props.select(
+      id === 'new'
+        ? null
+        : (props.tables.find((table) => table.id === id) ?? null)
+    )
+  }
+
+  function discardPending() {
+    if (!pending) return
+    const action = pending
+    setPending(null)
+    if (action.kind === 'close') props.close()
+    else select(action.id)
+  }
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <section
+        className="group-dialog group-builder-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="encounter-table-manager-title"
+      >
+        <header>
+          <div>
+            <p className="section-kicker">Katalog</p>
+            <h2 id="encounter-table-manager-title">
+              Encounter-Tabellen managen
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Dialog schließen"
+            onClick={requestClose}
+          >
+            ×
+          </button>
+        </header>
+        <div className="group-builder-layout">
+          <CreatureCollectionCatalogPane
+            query={query}
+            options={options}
+            page={page}
+            changed={setQuery}
+            inspect={props.inspect}
+            add={(creature) => {
+              setWeights((current) => ({
+                ...current,
+                [creature.id]: current[creature.id] ?? 1
+              }))
+              setNames((current) => ({
+                ...current,
+                [creature.id]: creature.name
+              }))
+            }}
+          />
+          <section
+            className="group-draft-pane"
+            aria-label="Aktuelle Encounter-Tabelle"
+          >
+            <CreatureCollectionSelection
+              label="Encounter-Tabelle"
+              value={props.table?.id ?? 'new'}
+              emptyLabel="Tabelle auswählen …"
+              newLabel="Neue Tabelle"
+              choices={props.tables.map((table) => ({
+                id: table.id,
+                label: table.displayName
+              }))}
+              changed={requestSelection}
+            />
+            <label>
+              Name
+              <input
+                required
+                aria-label="Tabellenname"
+                maxLength={100}
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+              />
+            </label>
+            <label>
+              Beschreibung
+              <textarea
+                aria-label="Tabellenbeschreibung"
+                rows={4}
+                maxLength={20_000}
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </label>
+            <h3>Gewichtete Einträge</h3>
+            <ul className="group-draft-roster">
+              {entries.map(([id, weight]) => (
+                <li key={id}>
+                  <div className="roster-quantity">
+                    <button
+                      type="button"
+                      aria-label={`Gewicht ${names[id] ?? id} verringern`}
+                      disabled={weight <= 1}
+                      onClick={() =>
+                        setWeights({ ...weights, [id]: weight - 1 })
+                      }
+                    >
+                      −
+                    </button>
+                    <strong>{weight}</strong>
+                    <button
+                      type="button"
+                      aria-label={`Gewicht ${names[id] ?? id} erhöhen`}
+                      disabled={weight >= 10}
+                      onClick={() =>
+                        setWeights({ ...weights, [id]: weight + 1 })
+                      }
+                    >
+                      +
+                    </button>
+                  </div>
+                  <span>
+                    <strong>{names[id] ?? `Nicht verfügbar (${id})`}</strong>
+                    <small>Gewicht {weight} von 10</small>
+                  </span>
+                  <button
+                    type="button"
+                    aria-label={`${names[id] ?? id} entfernen`}
+                    onClick={() => {
+                      const next = { ...weights }
+                      delete next[id]
+                      setWeights(next)
+                    }}
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+            {entries.length === 0 && (
+              <p className="empty-state">
+                Monster links mit <strong>+</strong> hinzufügen.
+              </p>
+            )}
+            {pending && (
+              <div className="confirm-row group-draft-confirm" role="alert">
+                <span>Ungespeicherte Änderungen verwerfen?</span>
+                <button type="button" onClick={() => setPending(null)}>
+                  Abbrechen
+                </button>
+                <button
+                  type="button"
+                  className="danger"
+                  onClick={discardPending}
+                >
+                  Änderungen verwerfen
+                </button>
+              </div>
+            )}
+          </section>
+        </div>
+        <footer className="group-builder-footer">
+          <span className="muted">
+            Gewichte bestimmen die relative Auswahlwahrscheinlichkeit.
+          </span>
+          <div>
+            <button type="button" onClick={requestClose}>
+              Abbrechen
+            </button>
+            <button
+              type="button"
+              disabled={!displayName.trim()}
+              onClick={() =>
+                props.save(props.table, {
+                  displayName,
+                  description,
+                  entries: Object.entries(weights).map(
+                    ([creatureId, weight]) => ({ creatureId, weight })
+                  )
+                })
+              }
+            >
+              {props.table ? 'Speichern' : 'Erstellen'}
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
+function FactionCatalog(props: {
+  onError: (message: string) => void
+  inspect: (creature: Creature) => void
+}) {
+  const [snapshot, setSnapshot] = useState<WorldFactionSnapshot>({
+    revision: 0,
+    factions: []
+  })
+  const [tableSnapshot, setTableSnapshot] = useState<EncounterTableSnapshot>({
+    revision: 0,
+    tables: []
+  })
+  const [search, setSearch] = useState('')
+  const [editing, setEditing] = useState<WorldFaction | null | undefined>(
+    undefined
+  )
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+  useEffect(() => {
+    void Promise.all([
+      window.saltMarcher.factions.read(),
+      window.saltMarcher.encounterTables.read()
+    ])
+      .then(([factions, tableSnapshot]) => {
+        setSnapshot(factions)
+        setTableSnapshot(tableSnapshot)
+      })
+      .catch(showError(props.onError))
+  }, [props.onError])
+
+  const visible = snapshot.factions.filter((faction) =>
+    `${faction.displayName} ${faction.notes}`
+      .toLocaleLowerCase()
+      .includes(search.trim().toLocaleLowerCase())
+  )
+  async function save(draft: WorldFactionDraft) {
+    try {
+      setSnapshot(
+        editing
+          ? await window.saltMarcher.factions.update(
+              editing.id,
+              draft,
+              snapshot.revision
+            )
+          : await window.saltMarcher.factions.create(draft, snapshot.revision)
+      )
+      setEditing(undefined)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  async function remove(id: string) {
+    try {
+      setSnapshot(
+        await window.saltMarcher.factions.delete(id, snapshot.revision)
+      )
+      setDeleteId(null)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  return (
+    <>
+      <div className="catalog-filters">
+        <input
+          aria-label="Fraktionen suchen"
+          placeholder="Fraktionen suchen …"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <button onClick={() => setEditing(null)}>Erstellen</button>
+      </div>
+      <div className="catalog-table-wrap">
+        <table className="catalog-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Gesinnung</th>
+              <th>Primärtabelle</th>
+              <th>Bestand</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((faction) => (
+              <tr key={faction.id}>
+                <td>
+                  <button
+                    className="link-button"
+                    onClick={() => setEditing(faction)}
+                  >
+                    {faction.displayName}
+                  </button>
+                </td>
+                <td>{faction.disposition}</td>
+                <td>
+                  {tableSnapshot.tables.find(
+                    (table) => table.id === faction.primaryEncounterTableId
+                  )?.displayName ?? 'Keine'}
+                </td>
+                <td>{faction.inventory.length} Grenzen</td>
+                <td className="row-actions">
+                  {deleteId === faction.id ? (
+                    <>
+                      <button onClick={() => setDeleteId(null)}>
+                        Abbrechen
+                      </button>
+                      <button
+                        className="danger"
+                        onClick={() => void remove(faction.id)}
+                      >
+                        Bestätigen
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="danger"
+                      onClick={() => setDeleteId(faction.id)}
+                    >
+                      Löschen
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <footer className="catalog-footer">
+        <span>{visible.length} Fraktionen</span>
+      </footer>
+      {editing !== undefined && (
+        <FactionDialog
+          faction={editing}
+          tableSnapshot={tableSnapshot}
+          tablesChanged={setTableSnapshot}
+          factionsChanged={setSnapshot}
+          close={() => setEditing(undefined)}
+          save={(draft) => void save(draft)}
+          onError={props.onError}
+          inspect={props.inspect}
+        />
+      )}
+    </>
+  )
+}
+
+function FactionDialog(props: {
+  faction: WorldFaction | null
+  tableSnapshot: EncounterTableSnapshot
+  tablesChanged: (snapshot: EncounterTableSnapshot) => void
+  factionsChanged: (snapshot: WorldFactionSnapshot) => void
+  close: () => void
+  save: (draft: WorldFactionDraft) => void
+  onError: (message: string) => void
+  inspect: (creature: Creature) => void
+}) {
+  const [displayName, setDisplayName] = useState(
+    props.faction?.displayName ?? ''
+  )
+  const [notes, setNotes] = useState(props.faction?.notes ?? '')
+  const [disposition, setDisposition] = useState(
+    props.faction?.disposition ?? 0
+  )
+  const [primaryEncounterTableId, setPrimaryEncounterTableId] = useState<
+    string | null
+  >(props.faction?.primaryEncounterTableId ?? null)
+  const [inventory, setInventory] = useState<Record<string, number>>(
+    Object.fromEntries(
+      props.faction?.inventory.map((entry) => [
+        entry.creatureId,
+        entry.maximum
+      ]) ?? []
+    )
+  )
+  const [names, setNames] = useState<Record<string, string>>({})
+  const [tableManager, setTableManager] = useState<
+    EncounterTable | null | undefined
+  >(undefined)
+  const selectedTable = props.tableSnapshot.tables.find(
+    (table) => table.id === primaryEncounterTableId
+  )
+  const selectedCreatureIds = useMemo(
+    () => selectedTable?.entries.map((entry) => entry.creatureId) ?? [],
+    [selectedTable]
+  )
+  useEffect(() => {
+    void Promise.all(
+      selectedCreatureIds.map((id) =>
+        window.saltMarcher.creatures.detail(id).catch(() => null)
+      )
+    ).then((rows) =>
+      setNames(
+        Object.fromEntries(
+          rows
+            .filter((row): row is Creature => row !== null)
+            .map((row) => [row.id, row.name])
+        )
+      )
+    )
+  }, [selectedCreatureIds])
+
+  function selectPrimaryTable(id: string | null) {
+    const allowed = new Set(
+      props.tableSnapshot.tables
+        .find((table) => table.id === id)
+        ?.entries.map((entry) => entry.creatureId) ?? []
+    )
+    setPrimaryEncounterTableId(id)
+    setInventory((current) =>
+      Object.fromEntries(
+        Object.entries(current).filter(([creatureId]) =>
+          allowed.has(creatureId)
+        )
+      )
+    )
+  }
+
+  async function saveTable(
+    table: EncounterTable | null,
+    draft: EncounterTableDraft
+  ) {
+    try {
+      const previousIds = new Set(
+        props.tableSnapshot.tables.map((candidate) => candidate.id)
+      )
+      const next = table
+        ? await window.saltMarcher.encounterTables.update(
+            table.id,
+            draft,
+            props.tableSnapshot.revision
+          )
+        : await window.saltMarcher.encounterTables.create(
+            draft,
+            props.tableSnapshot.revision
+          )
+      const selectedId =
+        table?.id ??
+        next.tables.find((candidate) => !previousIds.has(candidate.id))?.id ??
+        null
+      props.tablesChanged(next)
+      props.factionsChanged(await window.saltMarcher.factions.read())
+      selectPrimaryTableFromSnapshot(selectedId, next)
+      setTableManager(undefined)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  function selectPrimaryTableFromSnapshot(
+    id: string | null,
+    snapshot: EncounterTableSnapshot
+  ) {
+    const allowed = new Set(
+      snapshot.tables
+        .find((table) => table.id === id)
+        ?.entries.map((entry) => entry.creatureId) ?? []
+    )
+    setPrimaryEncounterTableId(id)
+    setInventory((current) =>
+      Object.fromEntries(
+        Object.entries(current).filter(([creatureId]) =>
+          allowed.has(creatureId)
+        )
+      )
+    )
+  }
+  return (
+    <>
+      <div className="modal-backdrop" role="presentation">
+        <form
+          className="location-editor faction-editor"
+          role="dialog"
+          aria-modal="true"
+          aria-label={
+            props.faction ? 'Fraktion bearbeiten' : 'Fraktion erstellen'
+          }
+          onSubmit={(event) => {
+            event.preventDefault()
+            props.save({
+              displayName,
+              notes,
+              disposition,
+              primaryEncounterTableId,
+              inventory: Object.entries(inventory).map(
+                ([creatureId, maximum]) => ({ creatureId, maximum })
+              )
+            })
+          }}
+        >
+          <header>
+            <div>
+              <p className="section-kicker">World Planner</p>
+              <h2>
+                {props.faction ? 'Fraktion bearbeiten' : 'Fraktion erstellen'}
+              </h2>
+            </div>
+            <button
+              type="button"
+              aria-label="Dialog schließen"
+              onClick={props.close}
+            >
+              ×
+            </button>
+          </header>
+          <label>
+            Name
+            <input
+              required
+              aria-label="Fraktionsname"
+              maxLength={100}
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+            />
+          </label>
+          <label>
+            Notizen
+            <textarea
+              aria-label="Fraktionsnotizen"
+              rows={4}
+              maxLength={20_000}
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+            />
+          </label>
+          <label>
+            Gesinnung ({disposition})
+            <input
+              aria-label="Fraktionsgesinnung"
+              type="range"
+              min={-50}
+              max={50}
+              value={disposition}
+              onChange={(event) => setDisposition(Number(event.target.value))}
+            />
+          </label>
+          <label>
+            Primäre Encounter-Tabelle
+            <span className="faction-table-selection">
+              <select
+                aria-label="Primäre Encounter-Tabelle"
+                value={primaryEncounterTableId ?? ''}
+                onChange={(event) =>
+                  selectPrimaryTable(event.target.value || null)
+                }
+              >
+                <option value="">Keine primäre Tabelle</option>
+                {props.tableSnapshot.tables.map((table) => (
+                  <option key={table.id} value={table.id}>
+                    {table.displayName}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={() => setTableManager(null)}>
+                Neue Encounter-Tabelle
+              </button>
+            </span>
+          </label>
+          <h3>Endlicher Bestand</h3>
+          <p className="muted">
+            Der Bestand basiert auf der Primärtabelle. Ein leeres Maximum
+            bedeutet unbegrenzt.
+          </p>
+          <ul className="source-entry-list">
+            {selectedTable?.entries.map((entry) => (
+              <li key={entry.creatureId}>
+                <span>
+                  {names[entry.creatureId] ??
+                    `Nicht verfügbar (${entry.creatureId})`}
+                </span>
+                <label>
+                  Maximum
+                  <input
+                    aria-label={`Maximum ${names[entry.creatureId] ?? entry.creatureId}`}
+                    type="number"
+                    min={0}
+                    placeholder="Unbegrenzt"
+                    value={inventory[entry.creatureId] ?? ''}
+                    onChange={(event) => {
+                      const next = { ...inventory }
+                      if (!event.target.value) delete next[entry.creatureId]
+                      else
+                        next[entry.creatureId] = Math.max(
+                          0,
+                          Number(event.target.value)
+                        )
+                      setInventory(next)
+                    }}
+                  />
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = { ...inventory }
+                    delete next[entry.creatureId]
+                    setInventory(next)
+                  }}
+                >
+                  Unbegrenzt
+                </button>
+              </li>
+            ))}
+          </ul>
+          {!selectedTable && (
+            <p className="empty-state">
+              Wähle eine Encounter-Tabelle, um den Bestand festzulegen.
+            </p>
+          )}
+          <footer>
+            <button type="button" onClick={props.close}>
+              Abbrechen
+            </button>
+            <button disabled={!displayName.trim()}>
+              {props.faction ? 'Speichern' : 'Erstellen'}
+            </button>
+          </footer>
+        </form>
+      </div>
+      {tableManager !== undefined && (
+        <EncounterTableDialog
+          key={tableManager?.id ?? 'new-faction-table'}
+          table={tableManager}
+          tables={props.tableSnapshot.tables}
+          close={() => setTableManager(undefined)}
+          select={setTableManager}
+          save={(table, draft) => void saveTable(table, draft)}
+          onError={props.onError}
+          inspect={props.inspect}
+        />
+      )}
+    </>
+  )
+}
+
+function CreatureFilters(props: {
+  query: CreatureCatalogQuery
+  options: CreatureFilterOptions
+  changed: (query: CreatureCatalogQuery) => void
+  compact?: boolean
+}) {
+  const q = props.query
+  const update = (values: Partial<CreatureCatalogQuery>) =>
+    props.changed({ ...q, ...values, offset: 0 })
+  return (
+    <div
+      className={`catalog-filters${props.compact ? ' compact-filters' : ''}`}
+    >
+      <input
+        aria-label="Monster suchen"
+        placeholder="Monster suchen …"
+        value={q.name}
+        onChange={(event) => update({ name: event.target.value })}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') update({ name: event.currentTarget.value })
+        }}
+      />
+      <select
+        aria-label="CR minimum"
+        value={q.crMin ?? ''}
+        onChange={(event) =>
+          update({
+            crMin: event.target.value ? Number(event.target.value) : undefined
+          })
+        }
+      >
+        <option value="">CR min</option>
+        {props.options.challengeRatings.map((value) => (
+          <option key={value} value={crNumber(value)}>
+            {value}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="CR maximum"
+        value={q.crMax ?? ''}
+        onChange={(event) =>
+          update({
+            crMax: event.target.value ? Number(event.target.value) : undefined
+          })
+        }
+      >
+        <option value="">CR max</option>
+        {props.options.challengeRatings.map((value) => (
+          <option key={value} value={crNumber(value)}>
+            {value}
+          </option>
+        ))}
+      </select>
+      <MultiSelect
+        label="Größe"
+        options={props.options.sizes}
+        selected={q.sizes}
+        changed={(sizes) => update({ sizes })}
+      />
+      <MultiSelect
+        label="Typ"
+        options={props.options.types}
+        selected={q.types}
+        changed={(types) => update({ types })}
+      />
+      <MultiSelect
+        label="Unterart"
+        options={props.options.subtypes}
+        selected={q.subtypes}
+        changed={(subtypes) => update({ subtypes })}
+      />
+      <MultiSelect
+        label="Umgebung"
+        options={props.options.biomes}
+        selected={q.biomes}
+        changed={(biomes) => update({ biomes })}
+      />
+      <MultiSelect
+        label="Gesinnung"
+        options={props.options.alignments}
+        selected={q.alignments}
+        changed={(alignments) => update({ alignments })}
+      />
+      {props.options.encounterTables.length > 0 && (
+        <ReferenceMultiSelect
+          label="Tabelle"
+          options={props.options.encounterTables}
+          selected={q.encounterTableIds}
+          changed={(encounterTableIds) => update({ encounterTableIds })}
+        />
+      )}
+      {props.options.factions.length > 0 && (
+        <ReferenceMultiSelect
+          label="Fraktionen"
+          options={props.options.factions}
+          selected={q.factionIds}
+          changed={(factionIds) => update({ factionIds })}
+        />
+      )}
+      {props.options.locations.length > 0 && (
+        <select
+          aria-label="Ort"
+          value={q.locationId ?? ''}
+          onChange={(event) =>
+            update({ locationId: event.target.value || null })
+          }
+        >
+          <option value="">Ort</option>
+          {props.options.locations.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      )}
+      <button onClick={() => props.changed({ ...emptyQuery, limit: q.limit })}>
+        Filter zurücksetzen
+      </button>
+    </div>
+  )
+}
+
+function MultiSelect(props: {
+  label: string
+  options: readonly string[]
+  selected: readonly string[]
+  changed: (values: string[]) => void
+}) {
+  return (
+    <label className="multi-filter">
+      <span>
+        {props.label}
+        {props.selected.length ? ` (${props.selected.length})` : ''}
+      </span>
+      <select
+        multiple
+        aria-label={props.label}
+        value={[...props.selected]}
+        onChange={(event) =>
+          props.changed(
+            Array.from(
+              event.currentTarget.selectedOptions,
+              (option) => option.value
+            )
+          )
+        }
+      >
+        {props.options.map((option) => (
+          <option key={option}>{option}</option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function ReferenceMultiSelect(props: {
+  label: string
+  options: readonly { id: string; label: string }[]
+  selected: readonly string[]
+  changed: (values: string[]) => void
+}) {
+  return (
+    <label className="multi-filter">
+      <span>
+        {props.label}
+        {props.selected.length ? ` (${props.selected.length})` : ''}
+      </span>
+      <select
+        multiple
+        aria-label={props.label}
+        value={[...props.selected]}
+        onChange={(event) =>
+          props.changed(
+            Array.from(
+              event.currentTarget.selectedOptions,
+              (option) => option.value
+            )
+          )
+        }
+      >
+        {props.options.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function FilterChips(props: {
+  query: CreatureCatalogQuery
+  changed: (query: CreatureCatalogQuery) => void
+}) {
+  const chips: { label: string; clear: () => void }[] = []
+  const q = props.query
+  if (q.name)
+    chips.push({
+      label: `Suche: ${q.name}`,
+      clear: () => props.changed({ ...q, name: '', offset: 0 })
+    })
+  if (q.crMin !== undefined || q.crMax !== undefined)
+    chips.push({
+      label: `CR ${q.crMin ?? '0'}–${q.crMax ?? '∞'}`,
+      clear: () => {
+        const { crMin, crMax, ...rest } = q
+        void crMin
+        void crMax
+        props.changed({ ...rest, offset: 0 })
+      }
+    })
+  const groups = [
+    ['sizes', q.sizes],
+    ['types', q.types],
+    ['subtypes', q.subtypes],
+    ['biomes', q.biomes],
+    ['alignments', q.alignments],
+    ['encounterTableIds', q.encounterTableIds],
+    ['factionIds', q.factionIds]
+  ] as const
+  for (const [field, values] of groups)
+    for (const value of values)
+      chips.push({
+        label: value,
+        clear: () =>
+          props.changed({
+            ...q,
+            [field]: values.filter((entry) => entry !== value),
+            offset: 0
+          })
+      })
+  if (q.locationId)
+    chips.push({
+      label: `Ort: ${q.locationId}`,
+      clear: () => props.changed({ ...q, locationId: null, offset: 0 })
+    })
+  return (
+    <>
+      {chips.map((chip, index) => (
+        <button
+          key={`${chip.label}-${index}`}
+          className="filter-chip"
+          onClick={chip.clear}
+        >
+          {chip.label} ×
+        </button>
+      ))}
+    </>
+  )
+}
+
+function SortHeader(props: {
+  label: string
+  field: 'name' | 'cr' | 'xp'
+  query: CreatureCatalogQuery
+  changed: (query: CreatureCatalogQuery) => void
+}) {
+  const active = props.query.sort === props.field
+  return (
+    <th>
+      <button
+        className="sort-header"
+        onClick={() =>
+          props.changed({
+            ...props.query,
+            sort: props.field,
+            direction:
+              active && props.query.direction === 'asc' ? 'desc' : 'asc',
+            offset: 0
+          })
+        }
+      >
+        {props.label}{' '}
+        {active ? (props.query.direction === 'asc' ? '▲' : '▼') : ''}
+      </button>
+    </th>
+  )
+}
+
+function SessionEncounterPanel(
+  props: ScenarioProps & { inspect: (creature: Creature) => void }
+) {
+  const [selected, setSelected] = useState<string[]>([])
+  const [evaluation, setEvaluation] =
+    useState<EncounterSelectionEvaluation | null>(null)
+  const onError = props.onError
+  const focused = props.snapshot.scene.scenes.find(
+    (scene) => scene.id === props.snapshot.scene.focusedSceneId
+  )!
+  const assignedParty = props.snapshot.party.members.filter(
+    (member) => member.active && focused.partyMemberIds.includes(member.id)
+  )
+  useEffect(() => {
+    let current = true
+    void window.saltMarcher.encounter
+      .evaluate(focused.id, selected, props.snapshot.scene.revision)
+      .then((value) => {
+        if (current) setEvaluation(value)
+      })
+      .catch((cause) => {
+        if (current) onError(errorText(cause))
+      })
+    return () => {
+      current = false
+    }
+  }, [focused.id, props.snapshot.scene.revision, selected, onError])
+  if (props.snapshot.combat) return <CombatScenario {...props} />
+  async function direct() {
+    await scenarioAction(props, () =>
+      window.saltMarcher.combat.prepare(
+        focused.id,
+        selected,
+        props.snapshot.scene.revision
+      )
+    )
+  }
+  return (
+    <div className="scenario-scroll">
+      <section className="scenario-content combat-setup">
+        <p className="section-kicker">Encounter</p>
+        <h2>Gruppen aus {focused.title}</h2>
+        <label className="scenario-choice locked">
+          <input type="checkbox" checked readOnly /> Scene-Party (
+          {assignedParty.length})
+        </label>
+        {focused.groups.map((group) => (
+          <label className="scenario-choice" key={group.id}>
+            <input
+              type="checkbox"
+              checked={selected.includes(group.id)}
+              onChange={(event) =>
+                setSelected(
+                  event.target.checked
+                    ? [...selected, group.id]
+                    : selected.filter((id) => id !== group.id)
+                )
+              }
+            />
+            {group.name}
+          </label>
+        ))}
+        {focused.groups.length === 0 && (
+          <p className="empty-state">
+            Lege zuerst eine Gruppe in dieser Scene an.
+          </p>
+        )}
+        {evaluation && <DifficultySummary evaluation={evaluation} />}
+        <footer>
+          <button onClick={props.close}>Schließen</button>
+          <button
+            disabled={!evaluation?.canStart}
+            onClick={() => void direct()}
+          >
+            Initiative vorbereiten
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
+function DifficultySummary(props: {
+  evaluation: Pick<
+    EncounterSelectionEvaluation,
+    | 'difficultyLabel'
+    | 'adjustedXp'
+    | 'baseXp'
+    | 'partyThresholds'
+    | 'creatureCount'
+    | 'message'
+  >
+  meter?: boolean
+}) {
+  const evaluation = props.evaluation
+  const meterMaximum = Math.max(1, evaluation.partyThresholds[3] * 1.5)
+  const meterPosition = Math.min(
+    100,
+    Math.round((evaluation.adjustedXp / meterMaximum) * 100)
+  )
+  return (
+    <div className="difficulty-summary" aria-live="polite">
+      <strong>{evaluation.difficultyLabel}</strong>
+      <span>
+        {evaluation.adjustedXp.toLocaleString()} adjusted XP ·{' '}
+        {evaluation.baseXp.toLocaleString()} base XP ·{' '}
+        {evaluation.creatureCount} Monster
+      </span>
+      <small>
+        Easy {evaluation.partyThresholds[0]} · Medium{' '}
+        {evaluation.partyThresholds[1]} · Hard {evaluation.partyThresholds[2]} ·
+        Deadly {evaluation.partyThresholds[3]}
+      </small>
+      {props.meter && (
+        <div className="difficulty-meter" aria-hidden="true">
+          <span style={{ width: `${meterPosition}%` }} />
+        </div>
+      )}
+      <small>{evaluation.message}</small>
+    </div>
+  )
+}
+
+function TuningControls(props: {
+  tuning: EncounterTuning
+  changed: (tuning: EncounterTuning) => void
+}) {
+  const select = <K extends keyof EncounterTuning>(
+    field: K,
+    values: readonly EncounterTuning[K][]
+  ) => (
+    <select
+      aria-label={field}
+      value={props.tuning[field]}
+      onChange={(event) =>
+        props.changed({
+          ...props.tuning,
+          [field]: event.target.value as EncounterTuning[K]
+        })
+      }
+    >
+      {values.map((value) => (
+        <option key={value} value={value}>
+          {tuningLabel(value)}
+        </option>
+      ))}
+    </select>
+  )
+  return (
+    <div className="tuning-controls">
+      <label>
+        Schwierigkeit
+        {select('difficulty', ['auto', 'easy', 'medium', 'hard', 'deadly'])}
+      </label>
+      <label>
+        Menge
+        {select('amount', ['auto', 'few', 'standard', 'many'])}
+      </label>
+      <label>
+        Balance
+        {select('balance', ['auto', 'even', 'varied'])}
+      </label>
+      <label>
+        Vielfalt
+        {select('diversity', ['auto', 'low', 'high'])}
+      </label>
+    </div>
+  )
+}
+
+function tuningLabel(value: string): string {
+  return (
+    {
+      auto: 'Auto',
+      easy: 'Leicht',
+      medium: 'Mittel',
+      hard: 'Schwer',
+      deadly: 'Tödlich',
+      few: 'Wenige',
+      standard: 'Standard',
+      many: 'Viele',
+      even: 'Ausgeglichen',
+      varied: 'Variiert',
+      low: 'Niedrig',
+      high: 'Hoch'
+    }[value] ?? value
+  )
+}
+
+function CombatScenario(props: ScenarioProps) {
+  if (!props.snapshot.combat)
+    return <p className="scenario-empty">Kein aktiver Encounter.</p>
+  if (props.snapshot.combat.phase === 'initiative')
+    return <InitiativePanel {...props} combat={props.snapshot.combat} />
+  if (props.snapshot.combat.phase === 'combat')
+    return <CombatPanel {...props} combat={props.snapshot.combat} />
+  return <ResolutionPanel {...props} combat={props.snapshot.combat} />
+}
+
+function InitiativePanel(props: ScenarioProps & { combat: CombatSnapshot }) {
+  const [values, setValues] = useState<Record<string, number>>(() =>
+    Object.fromEntries(
+      props.combat.initiativeRows.map((row) => [row.id, row.initiative])
+    )
+  )
+  return (
+    <section className="scenario-content">
+      <h2>Initiative</h2>
+      <ul className="initiative-list">
+        {props.combat.initiativeRows.map((row) => (
+          <li key={row.id}>
+            <span>{row.label}</span>
+            <input
+              aria-label={`Initiative ${row.label}`}
+              type="number"
+              min="-10"
+              max="40"
+              value={values[row.id] ?? row.initiative}
+              onChange={(event) =>
+                setValues({ ...values, [row.id]: Number(event.target.value) })
+              }
+            />
+          </li>
+        ))}
+      </ul>
+      <footer>
+        <button
+          onClick={() =>
+            void scenarioAction(props, () =>
+              window.saltMarcher.combat.rollInitiative(props.combat.revision)
+            )
+          }
+        >
+          Alle würfeln
+        </button>
+        <button
+          onClick={() =>
+            void scenarioAction(props, () =>
+              window.saltMarcher.combat.confirmInitiative(
+                props.combat.initiativeRows.map((row) => ({
+                  id: row.id,
+                  initiative: values[row.id] ?? row.initiative
+                })),
+                props.combat.revision
+              )
+            )
+          }
+        >
+          Kampf starten
+        </button>
+      </footer>
+    </section>
+  )
+}
+
+function CombatPanel(props: ScenarioProps & { combat: CombatSnapshot }) {
+  const [confirmEnd, setConfirmEnd] = useState(false)
+  return (
+    <section className="scenario-content">
+      <h2>Runde {props.combat.round}</h2>
+      <ul className="combat-cards">
+        {props.combat.cards.map((card) => (
+          <CombatCardView
+            key={card.id}
+            card={card}
+            combat={props.combat}
+            action={(operation) => scenarioAction(props, operation)}
+          />
+        ))}
+      </ul>
+      <button
+        className="primary-action"
+        onClick={() =>
+          void scenarioAction(props, () =>
+            window.saltMarcher.combat.advanceTurn(props.combat.revision)
+          )
+        }
+      >
+        ▶ Weiter
+      </button>
+      {!confirmEnd ? (
+        <button
+          className={props.combat.allEnemiesDefeated ? 'accent' : ''}
+          onClick={() => setConfirmEnd(true)}
+        >
+          Kampf beenden
+        </button>
+      ) : (
+        <div className="confirm-row">
+          <button onClick={() => setConfirmEnd(false)}>Abbruch</button>
+          <button
+            onClick={() =>
+              void scenarioAction(props, () =>
+                window.saltMarcher.combat.end(props.combat.revision)
+              )
+            }
+          >
+            Bestätigen
+          </button>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function CombatCardView(props: {
+  card: CombatSnapshot['cards'][number]
+  combat: CombatSnapshot
+  action: (operation: () => Promise<LiveSessionSnapshot>) => Promise<void>
+}) {
+  const [amount, setAmount] = useState(1)
+  const [initiative, setInitiative] = useState(props.card.initiative)
+  const card = props.card
+  return (
+    <li
+      className={`combat-card${card.active ? ' active' : ''}${!card.alive ? ' dead' : ''}`}
+    >
+      <header>
+        <strong>
+          {card.active ? '▶ ' : ''}
+          {card.alive ? card.name : `† ${card.name}`}
+          {card.count > 1 ? ` × ${card.count}` : ''}
+        </strong>
+      </header>
+      {!card.playerCharacter && (
+        <>
+          <span>
+            HP {card.currentHp}/{card.maxHp} · AC {card.armorClass}
+          </span>
+          <progress max={card.maxHp} value={card.currentHp} />
+          <div className="card-controls">
+            <input
+              aria-label={`HP Änderung ${card.name}`}
+              type="number"
+              min="1"
+              value={amount}
+              onChange={(event) =>
+                setAmount(Math.max(1, Number(event.target.value)))
+              }
+            />
+            <button
+              disabled={!card.alive}
+              onClick={() =>
+                void props.action(() =>
+                  window.saltMarcher.combat.changeHp(
+                    card.id,
+                    amount,
+                    false,
+                    props.combat.revision
+                  )
+                )
+              }
+            >
+              − HP
+            </button>
+            <button
+              disabled={!card.alive}
+              onClick={() =>
+                void props.action(() =>
+                  window.saltMarcher.combat.changeHp(
+                    card.id,
+                    amount,
+                    true,
+                    props.combat.revision
+                  )
+                )
+              }
+            >
+              + HP
+            </button>
+          </div>
+        </>
+      )}
+      <div className="card-controls">
+        <input
+          aria-label={`Initiative ändern ${card.name}`}
+          type="number"
+          min="-10"
+          max="40"
+          value={initiative}
+          onChange={(event) => setInitiative(Number(event.target.value))}
+        />
+        <button
+          onClick={() =>
+            void props.action(() =>
+              window.saltMarcher.combat.adjustInitiative(
+                card.id,
+                initiative,
+                props.combat.revision
+              )
+            )
+          }
+        >
+          Init
+        </button>
+      </div>
+      <small>{card.detail}</small>
+    </li>
+  )
+}
+
+function ResolutionPanel(props: ScenarioProps & { combat: CombatSnapshot }) {
+  const resolution = props.combat.resolution
+  const [selected, setSelected] = useState(() =>
+    (resolution?.enemies ?? [])
+      .filter((enemy) => enemy.selected)
+      .map((enemy) => enemy.id)
+  )
+  const [threshold, setThreshold] = useState(resolution?.thresholdFraction ?? 1)
+  const [fraction, setFraction] = useState(resolution?.xpFraction ?? 1)
+  if (!resolution) return null
+  const saveResolution = () =>
+    window.saltMarcher.combat.updateResolution(
+      selected,
+      threshold,
+      fraction,
+      props.combat.revision
+    )
+  async function award() {
+    try {
+      const updated = await saveResolution()
+      if (!updated.combat) throw new Error('Combat nicht verfügbar')
+      props.setSnapshot(
+        await window.saltMarcher.combat.awardXp(updated.combat.revision)
+      )
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  async function complete() {
+    try {
+      const updated = await saveResolution()
+      if (!updated.combat) throw new Error('Combat nicht verfügbar')
+      props.setSnapshot(
+        await window.saltMarcher.combat.complete(updated.combat.revision)
+      )
+      props.close()
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const eligible = resolution.enemies
+    .filter((enemy) => selected.includes(enemy.id))
+    .reduce((total, enemy) => total + enemy.xp, 0)
+  const awarded = Math.floor(eligible * fraction)
+  const perPlayer = Math.floor(awarded / Math.max(1, resolution.partySize))
+  return (
+    <section className="scenario-content resolution-panel">
+      <h2>Kampfergebnis</h2>
+      <p>
+        {selected.length} Gegner besiegt · {eligible} XP
+      </p>
+      <p>
+        <strong>{perPlayer} XP pro Spieler</strong> ({awarded} gesamt)
+      </p>
+      <label>
+        Besiegungsschwelle <span>{Math.round(threshold * 100)}%</span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={threshold}
+          onChange={(event) => setThreshold(Number(event.target.value))}
+        />
+      </label>
+      <label>
+        XP-Anteil <span>{Math.round(fraction * 100)}%</span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={fraction}
+          onChange={(event) => setFraction(Number(event.target.value))}
+        />
+      </label>
+      <ul className="result-enemies">
+        {resolution.enemies.map((enemy) => (
+          <li key={enemy.id}>
+            <label>
+              <input
+                type="checkbox"
+                checked={selected.includes(enemy.id)}
+                onChange={(event) =>
+                  setSelected(
+                    event.target.checked
+                      ? [...selected, enemy.id]
+                      : selected.filter((id) => id !== enemy.id)
+                  )
+                }
+              />
+              {enemy.name} ({enemy.alive ? 'Lebt' : 'Tot'}) · {enemy.xp} XP
+            </label>
+          </li>
+        ))}
+      </ul>
+      <p className="loot-summary">{resolution.lootSummary}</p>
+      <footer>
+        <button
+          disabled={resolution.xpAwarded || perPlayer <= 0}
+          onClick={() => void award()}
+        >
+          {resolution.xpAwarded ? 'XP verteilt' : 'XP verteilen'}
+        </button>
+        <button onClick={() => void complete()}>Zum Planer</button>
+      </footer>
+    </section>
+  )
+}
+
+function CreatureInspector(props: {
+  creature: Creature
+  close?: () => void
+  embedded?: boolean
+}) {
+  const c = props.creature
+  const ability = (label: string, value: number) => (
+    <div>
+      <strong>{label}</strong>
+      <span>
+        {value} ({Math.floor((value - 10) / 2) >= 0 ? '+' : ''}
+        {Math.floor((value - 10) / 2)})
+      </span>
+    </div>
+  )
+  return (
+    <aside
+      className={`creature-inspector${props.embedded ? ' embedded' : ''}`}
+      aria-label="Monster Details"
+    >
+      <header>
+        <div>
+          <p className="section-kicker">Statblock</p>
+          <h2>{c.name}</h2>
+        </div>
+        {props.close && <button onClick={props.close}>×</button>}
+      </header>
+      <p className="stat-meta">
+        {c.size} {c.type}
+        {c.subtype ? ` (${c.subtype})` : ''}, {c.alignment}
+      </p>
+      <hr />
+      <p>
+        <strong>Armor Class</strong> {c.ac}
+      </p>
+      <p>
+        <strong>Hit Points</strong> {c.hp} ({c.hitDice})
+      </p>
+      <p>
+        <strong>Speed</strong> {c.speed}
+      </p>
+      <div className="ability-grid">
+        {ability('STR', c.abilities.str)}
+        {ability('DEX', c.abilities.dex)}
+        {ability('CON', c.abilities.con)}
+        {ability('INT', c.abilities.int)}
+        {ability('WIS', c.abilities.wis)}
+        {ability('CHA', c.abilities.cha)}
+      </div>
+      <p>
+        <strong>Saving Throws</strong> {c.savingThrows || '—'}
+      </p>
+      <p>
+        <strong>Skills</strong> {c.skills || '—'}
+      </p>
+      <p>
+        <strong>Senses</strong> {c.senses || '—'}
+      </p>
+      <p>
+        <strong>Languages</strong> {c.languages || '—'}
+      </p>
+      <p>
+        <strong>Challenge</strong> {c.challengeRating} ({c.xp.toLocaleString()}{' '}
+        XP)
+      </p>
+      {c.traits.length > 0 && (
+        <>
+          <h3>Traits</h3>
+          {c.traits.map((trait) => (
+            <p key={trait.name}>
+              <strong>{trait.name}.</strong> {trait.description}
+            </p>
+          ))}
+        </>
+      )}
+      <h3>Actions</h3>
+      {c.actions.map((action) => (
+        <p key={action.name}>
+          <strong>{action.name}.</strong> {action.description}
+        </p>
+      ))}
+      {c.legendaryActions.length > 0 && (
+        <>
+          <h3>Legendary Actions</h3>
+          {c.legendaryActions.map((action) => (
+            <p key={action.name}>
+              <strong>{action.name}.</strong> {action.description}
+            </p>
+          ))}
+        </>
+      )}
+    </aside>
+  )
+}
+
+function useCreatureSearch(
+  query: CreatureCatalogQuery,
+  setPage: (page: CreatureCatalogPage) => void,
+  onError: (message: string) => void
+) {
+  const request = useRef(0)
+  useEffect(() => {
+    const token = ++request.current
+    const timer = window.setTimeout(() => {
+      void window.saltMarcher.creatures
+        .search(query)
+        .then((page) => {
+          if (request.current === token) setPage(page)
+        })
+        .catch((cause) => {
+          if (request.current === token) onError(errorText(cause))
+        })
+    }, 200)
+    return () => window.clearTimeout(timer)
+  }, [query, setPage, onError])
+}
+
+function crNumber(value: string): number {
+  const [left, right] = value.split('/')
+  return right ? Number(left) / Number(right) : Number(value)
+}
+
+function partyRows(party: PartySnapshot): { level: number; count: number }[] {
+  const counts = new Map<number, number>()
+  party.members
+    .filter(
+      (member): member is PartyCharacter & { level: number } =>
+        member.active && member.level !== null
+    )
+    .forEach((member) =>
+      counts.set(member.level, (counts.get(member.level) ?? 0) + 1)
+    )
+  return [...counts].map(([level, count]) => ({ level, count }))
+}
+
+type ScenarioProps = {
+  snapshot: LiveSessionSnapshot
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+  close: () => void
+  onError: (message: string) => void
+}
+
+async function scenarioAction(
+  props: Pick<ScenarioProps, 'snapshot' | 'setSnapshot' | 'onError'>,
+  operation: () => Promise<LiveSessionSnapshot>
+) {
+  try {
+    props.setSnapshot(await operation())
+  } catch (cause) {
+    props.onError(errorText(cause))
+  }
+}
+function errorText(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+function showError(setError: (message: string) => void) {
+  return (cause: unknown) => setError(errorText(cause))
 }

--- a/src/renderer/spatial-2d/pixi-qualification-view.tsx
+++ b/src/renderer/spatial-2d/pixi-qualification-view.tsx
@@ -15,8 +15,10 @@ import {
 import {
   ContextRecoveryTracker,
   exerciseWebglContextLoss,
-  webgl2Description
+  webgl2Description,
+  webgl2Renderer
 } from '../spatial-3d/webgl-context.js'
+import type { ContextRecoveryObservation } from '../../shared/qualification/runtime-observation.js'
 import { type SpatialQualificationModel } from '../spatial-qualification-model.js'
 import {
   ListenerRegistrationTracker,
@@ -31,7 +33,9 @@ export function PixiQualificationView({
   model,
   onResourcesCreated,
   onResourcesDisposed,
-  onPopulationComplete
+  onPopulationComplete,
+  onContextRecoveryChange,
+  onWebglReady
 }: {
   readonly model: SpatialQualificationModel
   readonly onResourcesCreated?: (
@@ -43,6 +47,13 @@ export function PixiQualificationView({
     counts: RendererResourceCounts
   ) => void
   readonly onPopulationComplete?: (samples: readonly number[]) => void
+  readonly onContextRecoveryChange?: (
+    observation: ContextRecoveryObservation
+  ) => void
+  readonly onWebglReady?: (observation: {
+    readonly version: string
+    readonly renderer: string
+  }) => void
 }): ReactElement {
   const host = useRef<HTMLDivElement>(null)
   const downloadSamples = useRef<(() => void) | null>(null)
@@ -79,6 +90,10 @@ export function PixiQualificationView({
           application.destroy(true, { children: true })
           return
         }
+        onWebglReady?.({
+          version: backend,
+          renderer: webgl2Renderer(application.canvas) ?? 'unavailable'
+        })
         const layer = new Container()
         layer.scale.set(0.4)
         const graphic = new Graphics()
@@ -98,9 +113,11 @@ export function PixiQualificationView({
         const postrenderListener = {
           postrender: () => {
             recovery.current.observedRerender()
+            onContextRecoveryChange?.(recovery.current.observation)
             const timing = frameTracker.afterRender()
             if (timing === undefined) return
             recovery.current.observedNextInteraction()
+            onContextRecoveryChange?.(recovery.current.observation)
             if (recovery.current.completedCycles > 0)
               setStatus(
                 `2D context recovery cycle ${recovery.current.completedCycles} completed after a successful pan.`
@@ -166,10 +183,12 @@ export function PixiQualificationView({
         const contextLost = (event: Event): void => {
           event.preventDefault()
           recovery.current.observedLoss()
+          onContextRecoveryChange?.(recovery.current.observation)
           setStatus('2D graphics context lost; waiting for restoration.')
         }
         const contextRestored = (): void => {
           recovery.current.observedRestoration()
+          onContextRecoveryChange?.(recovery.current.observation)
           setStatus(
             '2D graphics context restored; pan once to complete this cycle.'
           )
@@ -205,7 +224,14 @@ export function PixiQualificationView({
           listeners: listeners.count
         })
     }
-  }, [model, onPopulationComplete, onResourcesCreated, onResourcesDisposed])
+  }, [
+    model,
+    onContextRecoveryChange,
+    onPopulationComplete,
+    onResourcesCreated,
+    onResourcesDisposed,
+    onWebglReady
+  ])
   return (
     <>
       <div
@@ -221,9 +247,10 @@ export function PixiQualificationView({
         onClick={() => {
           if (
             contextCanvas === null ||
-            !exerciseWebglContextLoss(contextCanvas, () =>
+            !exerciseWebglContextLoss(contextCanvas, () => {
               recovery.current.requested()
-            )
+              onContextRecoveryChange?.(recovery.current.observation)
+            })
           )
             setStatus(
               'This browser does not expose the WebGL context-loss test extension.'

--- a/src/renderer/spatial-3d/babylon-qualification-view.tsx
+++ b/src/renderer/spatial-3d/babylon-qualification-view.tsx
@@ -25,8 +25,10 @@ import {
 import {
   ContextRecoveryTracker,
   exerciseWebglContextLoss,
-  webgl2Description
+  webgl2Description,
+  webgl2Renderer
 } from './webgl-context.js'
+import type { ContextRecoveryObservation } from '../../shared/qualification/runtime-observation.js'
 import { type SpatialQualificationModel } from '../spatial-qualification-model.js'
 import {
   ListenerRegistrationTracker,
@@ -39,7 +41,9 @@ export function BabylonQualificationView({
   model,
   onResourcesCreated,
   onResourcesDisposed,
-  onPopulationComplete
+  onPopulationComplete,
+  onContextRecoveryChange,
+  onWebglReady
 }: {
   readonly model: SpatialQualificationModel
   readonly onResourcesCreated?: (
@@ -54,6 +58,13 @@ export function BabylonQualificationView({
     population: 'babylonCamera' | 'babylonHoverPick' | 'babylonVoxelPreview',
     samples: readonly number[]
   ) => void
+  readonly onContextRecoveryChange?: (
+    observation: ContextRecoveryObservation
+  ) => void
+  readonly onWebglReady?: (observation: {
+    readonly version: string
+    readonly renderer: string
+  }) => void
 }): ReactElement {
   const canvas = useRef<HTMLCanvasElement>(null)
   const downloadSamples = useRef<(() => void) | null>(null)
@@ -63,7 +74,10 @@ export function BabylonQualificationView({
     const element = canvas.current
     if (
       element === null ||
-      !exerciseWebglContextLoss(element, () => recovery.current.requested())
+      !exerciseWebglContextLoss(element, () => {
+        recovery.current.requested()
+        onContextRecoveryChange?.(recovery.current.observation)
+      })
     )
       setStatus(
         'This browser does not expose the WebGL context-loss test extension.'
@@ -87,6 +101,10 @@ export function BabylonQualificationView({
         )
         return
       }
+      onWebglReady?.({
+        version: webgl2Description(element) ?? 'unavailable',
+        renderer: webgl2Renderer(element) ?? 'unavailable'
+      })
       const scene = new Scene(engine)
       scene.clearColor = new Color4(0.047, 0.082, 0.075, 1)
       const camera = new ArcRotateCamera(
@@ -185,6 +203,7 @@ export function BabylonQualificationView({
       )
       const afterRenderObserver = scene.onAfterRenderObservable.add(() => {
         recovery.current.observedRerender()
+        onContextRecoveryChange?.(recovery.current.observation)
         collect(
           cameraTracker,
           cameraSampler,
@@ -222,6 +241,7 @@ export function BabylonQualificationView({
       const noteRecoveredInteraction = (): void => {
         const completedBefore = recovery.current.completedCycles
         recovery.current.observedNextInteraction()
+        onContextRecoveryChange?.(recovery.current.observation)
         if (recovery.current.completedCycles > completedBefore)
           setStatus(
             `3D context recovery cycle ${recovery.current.completedCycles} completed after a successful interaction.`
@@ -306,6 +326,7 @@ export function BabylonQualificationView({
       listeners.listen(element, 'pointermove', beginHoverMeasurement, true)
       const contextLostObserver = engine.onContextLostObservable.add(() => {
         recovery.current.observedLoss()
+        onContextRecoveryChange?.(recovery.current.observation)
         setStatus('3D graphics context lost; waiting for restoration.')
       })
       listeners.track(() =>
@@ -314,6 +335,7 @@ export function BabylonQualificationView({
       const contextRestoredObserver = engine.onContextRestoredObservable.add(
         () => {
           recovery.current.observedRestoration()
+          onContextRecoveryChange?.(recovery.current.observation)
           setStatus(
             '3D graphics context restored; move the camera, hover, or rebuild a preview to complete this cycle.'
           )
@@ -349,7 +371,14 @@ export function BabylonQualificationView({
       )
       return
     }
-  }, [model, onPopulationComplete, onResourcesCreated, onResourcesDisposed])
+  }, [
+    model,
+    onContextRecoveryChange,
+    onPopulationComplete,
+    onResourcesCreated,
+    onResourcesDisposed,
+    onWebglReady
+  ])
   return (
     <>
       <canvas

--- a/src/renderer/spatial-3d/webgl-context.ts
+++ b/src/renderer/spatial-3d/webgl-context.ts
@@ -24,6 +24,11 @@ export class ContextRecoveryTracker {
     nextInteractionSucceeded: false
   }
   #completedCycles = 0
+  #requestedCycles = 0
+  #observedLossCycles = 0
+  #restoredCycles = 0
+  #rerenderedCycles = 0
+  #nextInteractionSucceededCycles = 0
 
   public get record(): ContextRecoveryRecord {
     return this.#record
@@ -31,6 +36,17 @@ export class ContextRecoveryTracker {
 
   public get completedCycles(): number {
     return this.#completedCycles
+  }
+
+  public get observation(): ContextRecoveryObservation {
+    return {
+      requestedCycles: this.#requestedCycles,
+      observedLossCycles: this.#observedLossCycles,
+      restoredCycles: this.#restoredCycles,
+      rerenderedCycles: this.#rerenderedCycles,
+      nextInteractionSucceededCycles: this.#nextInteractionSucceededCycles,
+      completedCycles: this.#completedCycles
+    }
   }
 
   public requested(): void {
@@ -43,27 +59,35 @@ export class ContextRecoveryTracker {
         nextInteractionSucceeded: false
       }
     this.#record = { ...this.#record, lossRequested: true }
+    this.#requestedCycles += 1
   }
 
   public observedLoss(): void {
-    if (this.#record.lossRequested)
+    if (this.#record.lossRequested && !this.#record.lossObserved) {
       this.#record = { ...this.#record, lossObserved: true }
+      this.#observedLossCycles += 1
+    }
   }
 
   public observedRestoration(): void {
-    if (this.#record.lossObserved)
+    if (this.#record.lossObserved && !this.#record.restorationObserved) {
       this.#record = { ...this.#record, restorationObserved: true }
+      this.#restoredCycles += 1
+    }
   }
 
   public observedRerender(): void {
-    if (this.#record.restorationObserved)
+    if (this.#record.restorationObserved && !this.#record.rerendered) {
       this.#record = { ...this.#record, rerendered: true }
+      this.#rerenderedCycles += 1
+    }
   }
 
   public observedNextInteraction(): void {
     if (this.#record.rerendered && !this.#record.nextInteractionSucceeded) {
       this.#record = { ...this.#record, nextInteractionSucceeded: true }
       this.#completedCycles += 1
+      this.#nextInteractionSucceededCycles += 1
     }
   }
 }
@@ -91,3 +115,12 @@ export function webgl2Description(
   if (context === null) return undefined
   return context.getParameter(context.VERSION) as string
 }
+
+export function webgl2Renderer(canvas: HTMLCanvasElement): string | undefined {
+  const context = canvas.getContext('webgl2')
+  if (context === null) return undefined
+  const debug = context.getExtension('WEBGL_debug_renderer_info')
+  if (debug === null) return 'unavailable (WEBGL_debug_renderer_info disabled)'
+  return context.getParameter(debug.UNMASKED_RENDERER_WEBGL) as string
+}
+import type { ContextRecoveryObservation } from '../../shared/qualification/runtime-observation.js'

--- a/src/shared/contracts/campaign.ts
+++ b/src/shared/contracts/campaign.ts
@@ -35,6 +35,7 @@ export function freezeCampaignSnapshot(
 
 export const capabilityErrorCodeSchema = z.enum([
   'validation_failed',
+  'stale',
   'not_found',
   'read_only',
   'timeout',

--- a/src/shared/contracts/capability-api.ts
+++ b/src/shared/contracts/capability-api.ts
@@ -1,4 +1,5 @@
 import type { CampaignSnapshot } from './campaign.js'
+import type { RuntimeGpuObservation } from '../qualification/runtime-observation.js'
 
 export interface CampaignReadCapability {
   list(): Promise<CampaignSnapshot>
@@ -15,5 +16,6 @@ export interface SaltMarcherApi {
     readOnly: boolean
     e2e: boolean
     processMemoryBytes(): Promise<number>
+    gpuObservation(): Promise<RuntimeGpuObservation>
   }>
 }

--- a/src/shared/contracts/capability-api.ts
+++ b/src/shared/contracts/capability-api.ts
@@ -1,5 +1,32 @@
 import type { CampaignSnapshot } from './campaign.js'
 import type { RuntimeGpuObservation } from '../qualification/runtime-observation.js'
+import type {
+  Creature,
+  CreatureCatalogPage,
+  CreatureCatalogQuery,
+  CreatureFilterOptions
+} from './encounter.js'
+import type { LiveSessionSnapshot, PartySnapshot } from './live-session.js'
+import type { AdventuringDayCalculation, PartyCharacterDraft } from './party.js'
+import type { EncounterTuning } from './encounter-tuning.js'
+import type {
+  EncounterSelectionEvaluation,
+  GroupGenerationMode,
+  SceneGroupDraftEntry,
+  SceneGroupDraftEvaluation,
+  SceneGroupDraftGeneration
+} from './scene.js'
+import type { SessionLayoutPreference } from './session-layout.js'
+import type {
+  WorldLocationDraft,
+  WorldLocationSnapshot
+} from './world-location.js'
+import type {
+  EncounterTableDraft,
+  EncounterTableSnapshot,
+  WorldFactionDraft,
+  WorldFactionSnapshot
+} from './encounter-source.js'
 
 export interface CampaignReadCapability {
   list(): Promise<CampaignSnapshot>
@@ -18,4 +45,172 @@ export interface SaltMarcherApi {
     processMemoryBytes(): Promise<number>
     gpuObservation(): Promise<RuntimeGpuObservation>
   }>
+  party: {
+    read(): Promise<PartySnapshot>
+    create(
+      character: PartyCharacterDraft,
+      expectedRevision: number
+    ): Promise<PartySnapshot>
+    update(
+      id: string,
+      character: PartyCharacterDraft,
+      expectedRevision: number
+    ): Promise<PartySnapshot>
+    delete(id: string, expectedRevision: number): Promise<PartySnapshot>
+    setMembership(
+      id: string,
+      active: boolean,
+      expectedRevision: number
+    ): Promise<PartySnapshot>
+    adjustXp(
+      id: string,
+      delta: number,
+      expectedRevision: number
+    ): Promise<PartySnapshot>
+    rest(
+      type: 'short' | 'long',
+      expectedRevision: number
+    ): Promise<PartySnapshot>
+    calculateAdventuringDay(
+      rows: readonly { level: number; count: number }[],
+      totalXp?: number
+    ): Promise<AdventuringDayCalculation>
+  }
+  creatures: {
+    search(query: CreatureCatalogQuery): Promise<CreatureCatalogPage>
+    filterOptions(): Promise<CreatureFilterOptions>
+    detail(id: string): Promise<Creature>
+  }
+  locations: {
+    read(): Promise<WorldLocationSnapshot>
+    create(
+      location: WorldLocationDraft,
+      expectedRevision: number
+    ): Promise<WorldLocationSnapshot>
+    update(
+      id: string,
+      location: WorldLocationDraft,
+      expectedRevision: number
+    ): Promise<WorldLocationSnapshot>
+    delete(id: string, expectedRevision: number): Promise<WorldLocationSnapshot>
+  }
+  encounterTables: {
+    read(): Promise<EncounterTableSnapshot>
+    create(
+      table: EncounterTableDraft,
+      expectedRevision: number
+    ): Promise<EncounterTableSnapshot>
+    update(
+      id: string,
+      table: EncounterTableDraft,
+      expectedRevision: number
+    ): Promise<EncounterTableSnapshot>
+    delete(
+      id: string,
+      expectedRevision: number
+    ): Promise<EncounterTableSnapshot>
+  }
+  factions: {
+    read(): Promise<WorldFactionSnapshot>
+    create(
+      faction: WorldFactionDraft,
+      expectedRevision: number
+    ): Promise<WorldFactionSnapshot>
+    update(
+      id: string,
+      faction: WorldFactionDraft,
+      expectedRevision: number
+    ): Promise<WorldFactionSnapshot>
+    delete(id: string, expectedRevision: number): Promise<WorldFactionSnapshot>
+  }
+  session: {
+    read(): Promise<LiveSessionSnapshot>
+    readLayout(): Promise<SessionLayoutPreference>
+    saveLayout(
+      preference: SessionLayoutPreference
+    ): Promise<SessionLayoutPreference>
+  }
+  scene: {
+    focus(
+      sceneId: string,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    setLocation(
+      sceneId: string,
+      locationId: string | null,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    saveGroup(
+      sceneId: string,
+      groupId: string | null,
+      name: string,
+      entries: readonly { creatureId: string; quantity: number }[],
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    deleteGroup(
+      sceneId: string,
+      groupId: string,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    assignPartyMember(
+      sceneId: string,
+      partyMemberId: string,
+      assigned: boolean,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    evaluateGroupDraft(
+      sceneId: string,
+      entries: readonly SceneGroupDraftEntry[],
+      expectedRevision: number
+    ): Promise<SceneGroupDraftEvaluation>
+    generateGroupDraft(
+      sceneId: string,
+      entries: readonly SceneGroupDraftEntry[],
+      mode: GroupGenerationMode,
+      filters: CreatureCatalogQuery,
+      tuning: EncounterTuning,
+      seed: number,
+      expectedRevision: number
+    ): Promise<SceneGroupDraftGeneration>
+  }
+  encounter: {
+    evaluate(
+      sceneId: string,
+      groupIds: readonly string[],
+      expectedRevision: number
+    ): Promise<EncounterSelectionEvaluation>
+  }
+  combat: {
+    prepare(
+      sceneId: string,
+      groupIds: readonly string[],
+      expectedSceneRevision: number
+    ): Promise<LiveSessionSnapshot>
+    rollInitiative(expectedRevision: number): Promise<LiveSessionSnapshot>
+    confirmInitiative(
+      values: readonly { id: string; initiative: number }[],
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    advanceTurn(expectedRevision: number): Promise<LiveSessionSnapshot>
+    adjustInitiative(
+      id: string,
+      initiative: number,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    changeHp(
+      cardId: string,
+      amount: number,
+      healing: boolean,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    end(expectedRevision: number): Promise<LiveSessionSnapshot>
+    updateResolution(
+      selectedEnemyIds: readonly string[],
+      thresholdFraction: number,
+      xpFraction: number,
+      expectedRevision: number
+    ): Promise<LiveSessionSnapshot>
+    awardXp(expectedRevision: number): Promise<LiveSessionSnapshot>
+    complete(expectedRevision: number): Promise<LiveSessionSnapshot>
+  }
 }

--- a/src/shared/contracts/core-protocol.ts
+++ b/src/shared/contracts/core-protocol.ts
@@ -1,0 +1,353 @@
+import { z } from 'zod'
+import {
+  adjustInitiativeInputSchema,
+  changeHpInputSchema,
+  combatRevisionInputSchema,
+  confirmInitiativeInputSchema,
+  prepareCombatInputSchema,
+  updateResolutionInputSchema
+} from './live-session.js'
+import {
+  adjustPartyXpInputSchema,
+  adventuringDayInputSchema,
+  createPartyCharacterInputSchema,
+  deletePartyCharacterInputSchema,
+  restPartyInputSchema,
+  setMembershipInputSchema,
+  updatePartyCharacterInputSchema
+} from './party.js'
+import { creatureCatalogQuerySchema } from './encounter.js'
+import {
+  assignScenePartyInputSchema,
+  deleteSceneGroupInputSchema,
+  evaluateEncounterSelectionInputSchema,
+  evaluateSceneGroupDraftInputSchema,
+  focusSceneInputSchema,
+  saveSceneGroupInputSchema,
+  sceneGroupDraftGenerationRequestSchema,
+  setSceneLocationInputSchema
+} from './scene.js'
+import {
+  createWorldLocationInputSchema,
+  deleteWorldLocationInputSchema,
+  updateWorldLocationInputSchema
+} from './world-location.js'
+import {
+  createEncounterTableInputSchema,
+  createWorldFactionInputSchema,
+  deleteEncounterTableInputSchema,
+  deleteWorldFactionInputSchema,
+  updateEncounterTableInputSchema,
+  updateWorldFactionInputSchema
+} from './encounter-source.js'
+
+const id = z.uuid()
+const simple = <const K extends string>(kind: K) =>
+  z.object({ requestId: id, kind: z.literal(kind) }).strict()
+
+export const coreRequestSchema = z.discriminatedUnion('kind', [
+  simple('campaign.list'),
+  simple('core.shutdown'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('campaign.create'),
+      input: z.object({ name: z.string().trim().min(1).max(100) }).strict()
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('campaign.activate'),
+      input: z.object({ id }).strict()
+    })
+    .strict(),
+  simple('party.read'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.setMembership'),
+      input: setMembershipInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.create'),
+      input: createPartyCharacterInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.update'),
+      input: updatePartyCharacterInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.delete'),
+      input: deletePartyCharacterInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.adjustXp'),
+      input: adjustPartyXpInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.rest'),
+      input: restPartyInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('party.calculateAdventuringDay'),
+      input: adventuringDayInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('creatures.search'),
+      input: creatureCatalogQuerySchema
+    })
+    .strict(),
+  simple('creatures.filterOptions'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('creatures.detail'),
+      input: z.object({ id: z.string().min(1) }).strict()
+    })
+    .strict(),
+  simple('locations.read'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('locations.create'),
+      input: createWorldLocationInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('locations.update'),
+      input: updateWorldLocationInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('locations.delete'),
+      input: deleteWorldLocationInputSchema
+    })
+    .strict(),
+  simple('encounterTables.read'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('encounterTables.create'),
+      input: createEncounterTableInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('encounterTables.update'),
+      input: updateEncounterTableInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('encounterTables.delete'),
+      input: deleteEncounterTableInputSchema
+    })
+    .strict(),
+  simple('factions.read'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('factions.create'),
+      input: createWorldFactionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('factions.update'),
+      input: updateWorldFactionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('factions.delete'),
+      input: deleteWorldFactionInputSchema
+    })
+    .strict(),
+  simple('session.read'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.focus'),
+      input: focusSceneInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.setLocation'),
+      input: setSceneLocationInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.saveGroup'),
+      input: saveSceneGroupInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.deleteGroup'),
+      input: deleteSceneGroupInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.assignPartyMember'),
+      input: assignScenePartyInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.evaluateGroupDraft'),
+      input: evaluateSceneGroupDraftInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('scene.generateGroupDraft'),
+      input: sceneGroupDraftGenerationRequestSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('encounter.evaluate'),
+      input: evaluateEncounterSelectionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.prepare'),
+      input: prepareCombatInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.rollInitiative'),
+      input: combatRevisionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.confirmInitiative'),
+      input: confirmInitiativeInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.advanceTurn'),
+      input: combatRevisionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.adjustInitiative'),
+      input: adjustInitiativeInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.changeHp'),
+      input: changeHpInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.end'),
+      input: combatRevisionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.updateResolution'),
+      input: updateResolutionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.awardXp'),
+      input: combatRevisionInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('combat.complete'),
+      input: combatRevisionInputSchema
+    })
+    .strict()
+])
+
+export const coreResultSchema = z.discriminatedUnion('ok', [
+  z
+    .object({ requestId: id, ok: z.literal(true), payload: z.unknown() })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      ok: z.literal(false),
+      error: z
+        .object({
+          code: z.enum([
+            'validation_failed',
+            'stale',
+            'not_found',
+            'read_only',
+            'timeout',
+            'outcome_unknown',
+            'core_unavailable',
+            'protocol_violation',
+            'internal'
+          ]),
+          retryable: z.boolean()
+        })
+        .strict()
+    })
+    .strict()
+])
+
+export type CoreRequest = z.infer<typeof coreRequestSchema>

--- a/src/shared/contracts/encounter-source.ts
+++ b/src/shared/contracts/encounter-source.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod'
+
+export const encounterTableEntrySchema = z
+  .object({
+    creatureId: z.string().min(1),
+    weight: z.number().int().min(1).max(10),
+    position: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const encounterTableSchema = z
+  .object({
+    id: z.uuid(),
+    displayName: z.string().min(1).max(100),
+    description: z.string().max(20_000),
+    position: z.number().int().nonnegative(),
+    entries: z.array(encounterTableEntrySchema)
+  })
+  .strict()
+
+export const encounterTableDraftSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(100),
+    description: z.string().trim().max(20_000),
+    entries: z
+      .array(
+        z
+          .object({
+            creatureId: z.string().min(1),
+            weight: z.number().int().min(1).max(10)
+          })
+          .strict()
+      )
+      .refine(
+        (entries) =>
+          new Set(entries.map((entry) => entry.creatureId)).size ===
+          entries.length,
+        { message: 'Encounter table entries must be unique' }
+      )
+  })
+  .strict()
+
+export const encounterTableSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    tables: z.array(encounterTableSchema)
+  })
+  .strict()
+
+export const factionInventoryEntrySchema = z
+  .object({
+    creatureId: z.string().min(1),
+    maximum: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const worldFactionSchema = z
+  .object({
+    id: z.uuid(),
+    displayName: z.string().min(1).max(100),
+    notes: z.string().max(20_000),
+    disposition: z.number().int().min(-50).max(50),
+    primaryEncounterTableId: z.uuid().nullable(),
+    position: z.number().int().nonnegative(),
+    inventory: z.array(factionInventoryEntrySchema)
+  })
+  .strict()
+
+export const worldFactionDraftSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(100),
+    notes: z.string().trim().max(20_000),
+    disposition: z.number().int().min(-50).max(50),
+    primaryEncounterTableId: z.uuid().nullable(),
+    inventory: z
+      .array(factionInventoryEntrySchema)
+      .refine(
+        (entries) =>
+          new Set(entries.map((entry) => entry.creatureId)).size ===
+          entries.length,
+        { message: 'Faction inventory entries must be unique' }
+      )
+  })
+  .strict()
+
+export const worldFactionSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    factions: z.array(worldFactionSchema)
+  })
+  .strict()
+
+const mutationBaseSchema = z
+  .object({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const createEncounterTableInputSchema = mutationBaseSchema
+  .extend({ table: encounterTableDraftSchema })
+  .strict()
+export const updateEncounterTableInputSchema = createEncounterTableInputSchema
+  .extend({ id: z.uuid() })
+  .strict()
+export const deleteEncounterTableInputSchema = mutationBaseSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export const createWorldFactionInputSchema = mutationBaseSchema
+  .extend({ faction: worldFactionDraftSchema })
+  .strict()
+export const updateWorldFactionInputSchema = createWorldFactionInputSchema
+  .extend({ id: z.uuid() })
+  .strict()
+export const deleteWorldFactionInputSchema = mutationBaseSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export type EncounterTable = Readonly<z.infer<typeof encounterTableSchema>>
+export type EncounterTableDraft = Readonly<
+  z.infer<typeof encounterTableDraftSchema>
+>
+export type EncounterTableSnapshot = Readonly<
+  z.infer<typeof encounterTableSnapshotSchema>
+>
+export type WorldFaction = Readonly<z.infer<typeof worldFactionSchema>>
+export type WorldFactionDraft = Readonly<
+  z.infer<typeof worldFactionDraftSchema>
+>
+export type WorldFactionSnapshot = Readonly<
+  z.infer<typeof worldFactionSnapshotSchema>
+>

--- a/src/shared/contracts/encounter-tuning.ts
+++ b/src/shared/contracts/encounter-tuning.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const encounterDifficultySchema = z.enum([
+  'auto',
+  'easy',
+  'medium',
+  'hard',
+  'deadly'
+])
+
+export const encounterTuningSchema = z
+  .object({
+    difficulty: encounterDifficultySchema,
+    amount: z.enum(['auto', 'few', 'standard', 'many']),
+    balance: z.enum(['auto', 'even', 'varied']),
+    diversity: z.enum(['auto', 'low', 'high'])
+  })
+  .strict()
+
+export type EncounterTuning = Readonly<z.infer<typeof encounterTuningSchema>>

--- a/src/shared/contracts/encounter.ts
+++ b/src/shared/contracts/encounter.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+
+const textList = z.array(z.string())
+
+export const creatureActionSchema = z
+  .object({ name: z.string(), description: z.string() })
+  .strict()
+
+export const creatureSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string(),
+    cr: z.number().nonnegative(),
+    challengeRating: z.string(),
+    xp: z.number().int().nonnegative(),
+    type: z.string(),
+    subtype: z.string(),
+    size: z.string(),
+    alignment: z.string(),
+    biomes: textList,
+    ac: z.number().int(),
+    hp: z.number().int(),
+    hitDice: z.string(),
+    speed: z.string(),
+    initiative: z.number().int(),
+    abilities: z
+      .object({
+        str: z.number().int(),
+        dex: z.number().int(),
+        con: z.number().int(),
+        int: z.number().int(),
+        wis: z.number().int(),
+        cha: z.number().int()
+      })
+      .strict(),
+    senses: z.string(),
+    languages: z.string(),
+    savingThrows: z.string(),
+    skills: z.string(),
+    damageVulnerabilities: z.string(),
+    damageResistances: z.string(),
+    damageImmunities: z.string(),
+    conditionImmunities: z.string(),
+    traits: z.array(creatureActionSchema),
+    actions: z.array(creatureActionSchema),
+    legendaryActions: z.array(creatureActionSchema),
+    details: z.string()
+  })
+  .strict()
+
+export const creatureCatalogQuerySchema = z
+  .object({
+    name: z.string().max(100).default(''),
+    crMin: z.number().nonnegative().optional(),
+    crMax: z.number().nonnegative().optional(),
+    sizes: textList.default([]),
+    types: textList.default([]),
+    subtypes: textList.default([]),
+    biomes: textList.default([]),
+    alignments: textList.default([]),
+    encounterTableIds: textList.default([]),
+    factionIds: textList.default([]),
+    locationId: z.string().nullable().default(null),
+    sort: z.enum(['name', 'cr', 'xp']).default('name'),
+    direction: z.enum(['asc', 'desc']).default('asc'),
+    offset: z.number().int().nonnegative().default(0),
+    limit: z.number().int().min(1).max(100).default(50)
+  })
+  .strict()
+  .refine(
+    (query) =>
+      query.crMin === undefined ||
+      query.crMax === undefined ||
+      query.crMin <= query.crMax,
+    { message: 'CR minimum must not exceed maximum' }
+  )
+
+export const creatureFilterOptionsSchema = z
+  .object({
+    challengeRatings: textList,
+    sizes: textList,
+    types: textList,
+    subtypes: textList,
+    biomes: textList,
+    alignments: textList,
+    encounterTables: z.array(
+      z.object({ id: z.string(), label: z.string() }).strict()
+    ),
+    factions: z.array(z.object({ id: z.string(), label: z.string() }).strict()),
+    locations: z.array(z.object({ id: z.string(), label: z.string() }).strict())
+  })
+  .strict()
+
+export const creatureCatalogPageSchema = z
+  .object({
+    status: z.enum(['ready', 'empty', 'invalid', 'unavailable', 'failed']),
+    rows: z.array(creatureSchema),
+    total: z.number().int().nonnegative(),
+    offset: z.number().int().nonnegative(),
+    limit: z.number().int().positive(),
+    message: z.string()
+  })
+  .strict()
+
+export type Creature = Readonly<z.infer<typeof creatureSchema>>
+export type CreatureCatalogQuery = Readonly<
+  z.infer<typeof creatureCatalogQuerySchema>
+>
+export type CreatureCatalogPage = Readonly<
+  z.infer<typeof creatureCatalogPageSchema>
+>
+export type CreatureFilterOptions = Readonly<
+  z.infer<typeof creatureFilterOptionsSchema>
+>

--- a/src/shared/contracts/live-session.ts
+++ b/src/shared/contracts/live-session.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod'
+import { partyCharacterSchema, partySnapshotSchema } from './party.js'
+import { sceneSnapshotSchema } from './scene.js'
+
+export { partyCharacterSchema as partyMemberSchema, partySnapshotSchema }
+
+export const initiativeRowSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    kind: z.enum(['party', 'monster']),
+    initiative: z.number().int().min(-10).max(40)
+  })
+  .strict()
+
+export const combatCardSchema = z
+  .object({
+    id: z.string().min(1),
+    memberIds: z.array(z.string().min(1)).min(1),
+    name: z.string().min(1),
+    playerCharacter: z.boolean(),
+    active: z.boolean(),
+    alive: z.boolean(),
+    currentHp: z.number().int().nonnegative(),
+    maxHp: z.number().int().nonnegative(),
+    armorClass: z.number().int().nonnegative(),
+    initiative: z.number().int().min(-10).max(40),
+    count: z.number().int().positive(),
+    detail: z.string()
+  })
+  .strict()
+
+export const resultEnemySchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    alive: z.boolean(),
+    xp: z.number().int().nonnegative(),
+    selected: z.boolean()
+  })
+  .strict()
+
+export const resolutionSchema = z
+  .object({
+    enemies: z.array(resultEnemySchema),
+    thresholdFraction: z.number().min(0).max(1),
+    xpFraction: z.number().min(0).max(1),
+    eligibleXp: z.number().int().nonnegative(),
+    awardedXp: z.number().int().nonnegative(),
+    perPlayerXp: z.number().int().nonnegative(),
+    partySize: z.number().int().positive(),
+    xpAwarded: z.boolean(),
+    lootSummary: z.string()
+  })
+  .strict()
+
+export const combatSnapshotSchema = z
+  .object({
+    id: z.uuid(),
+    revision: z.number().int().nonnegative(),
+    phase: z.enum(['initiative', 'combat', 'resolution']),
+    selectedGroupIds: z.array(z.uuid()),
+    initiativeRows: z.array(initiativeRowSchema),
+    cards: z.array(combatCardSchema),
+    round: z.number().int().positive(),
+    allEnemiesDefeated: z.boolean(),
+    resolution: resolutionSchema.nullable()
+  })
+  .strict()
+
+export const liveSessionSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    party: partySnapshotSchema,
+    scene: sceneSnapshotSchema,
+    travel: z
+      .object({
+        kind: z.literal('none'),
+        label: z.string(),
+        hint: z.string()
+      })
+      .strict(),
+    combat: combatSnapshotSchema.nullable()
+  })
+  .strict()
+
+export const prepareCombatInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    expectedSceneRevision: z.number().int().nonnegative(),
+    groupIds: z.array(z.uuid()).min(1)
+  })
+  .strict()
+
+export const confirmInitiativeInputSchema = z
+  .object({
+    expectedRevision: z.number().int().nonnegative(),
+    values: z.array(
+      z
+        .object({
+          id: z.string().min(1),
+          initiative: z.number().int().min(-10).max(40)
+        })
+        .strict()
+    )
+  })
+  .strict()
+
+export const combatRevisionInputSchema = z
+  .object({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const adjustInitiativeInputSchema = combatRevisionInputSchema
+  .extend({
+    id: z.string().min(1),
+    initiative: z.number().int().min(-10).max(40)
+  })
+  .strict()
+
+export const changeHpInputSchema = combatRevisionInputSchema
+  .extend({
+    cardId: z.string().min(1),
+    amount: z.number().int().positive(),
+    healing: z.boolean()
+  })
+  .strict()
+
+export const updateResolutionInputSchema = combatRevisionInputSchema
+  .extend({
+    selectedEnemyIds: z.array(z.string().min(1)),
+    thresholdFraction: z.number().min(0).max(1),
+    xpFraction: z.number().min(0).max(1)
+  })
+  .strict()
+
+export type PartyMember = Readonly<z.infer<typeof partyCharacterSchema>>
+export type PartySnapshot = Readonly<z.infer<typeof partySnapshotSchema>>
+export type CombatSnapshot = Readonly<z.infer<typeof combatSnapshotSchema>>
+export type LiveSessionSnapshot = Readonly<
+  z.infer<typeof liveSessionSnapshotSchema>
+>

--- a/src/shared/contracts/party.ts
+++ b/src/shared/contracts/party.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+
+export const partyCharacterSchema = z
+  .object({
+    id: z.uuid(),
+    name: z.string().min(1).max(100),
+    playerName: z.string().max(100).nullable(),
+    level: z.number().int().min(1).max(20).nullable(),
+    passivePerception: z.number().int().min(0).max(99).nullable(),
+    armorClass: z.number().int().min(0).max(99).nullable(),
+    active: z.boolean(),
+    xp: z.number().int().nonnegative(),
+    currentLevelFloor: z.number().int().nonnegative(),
+    nextLevelXp: z.number().int().nonnegative().nullable(),
+    xpSinceShortRest: z.number().int().nonnegative(),
+    xpSinceLongRest: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const adventuringDaySummarySchema = z
+  .object({
+    available: z.boolean(),
+    partySize: z.number().int().nonnegative(),
+    dailyBudget: z.number().int().nonnegative(),
+    shortRestXp: z.number().int().nonnegative(),
+    longRestXp: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const partySnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    members: z.array(partyCharacterSchema),
+    adventuringDay: adventuringDaySummarySchema
+  })
+  .strict()
+
+export const partyCharacterDraftSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100),
+    playerName: z.string().trim().max(100).nullable(),
+    level: z.number().int().min(1).max(20).nullable(),
+    passivePerception: z.number().int().min(0).max(99).nullable(),
+    armorClass: z.number().int().min(0).max(99).nullable()
+  })
+  .strict()
+
+export const partyMutationBaseSchema = z
+  .object({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const createPartyCharacterInputSchema = partyMutationBaseSchema
+  .extend({ character: partyCharacterDraftSchema })
+  .strict()
+
+export const updatePartyCharacterInputSchema = createPartyCharacterInputSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export const deletePartyCharacterInputSchema = partyMutationBaseSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export const setMembershipInputSchema = deletePartyCharacterInputSchema
+  .extend({ active: z.boolean() })
+  .strict()
+
+export const adjustPartyXpInputSchema = deletePartyCharacterInputSchema
+  .extend({ delta: z.number().int().min(-1_000_000).max(1_000_000) })
+  .strict()
+
+export const restPartyInputSchema = partyMutationBaseSchema
+  .extend({ type: z.enum(['short', 'long']) })
+  .strict()
+
+export const adventuringDayInputSchema = z
+  .object({
+    rows: z
+      .array(
+        z
+          .object({
+            level: z.number().int().min(1).max(20),
+            count: z.number().int().min(1).max(99)
+          })
+          .strict()
+      )
+      .max(20),
+    totalXp: z.number().int().nonnegative().optional()
+  })
+  .strict()
+
+export const adventuringDayCalculationSchema = z
+  .object({
+    dailyBudget: z.number().int().nonnegative(),
+    totalXp: z.number().int().nonnegative(),
+    completedDays: z.number().int().nonnegative(),
+    dayProgress: z.number().min(0).max(1),
+    shortRests: z.number().int().nonnegative(),
+    longRests: z.number().int().nonnegative(),
+    timeline: z.array(z.string())
+  })
+  .strict()
+
+export type PartyCharacter = Readonly<z.infer<typeof partyCharacterSchema>>
+export type PartySnapshot = Readonly<z.infer<typeof partySnapshotSchema>>
+export type PartyCharacterDraft = Readonly<
+  z.infer<typeof partyCharacterDraftSchema>
+>
+export type AdventuringDaySummary = Readonly<
+  z.infer<typeof adventuringDaySummarySchema>
+>
+export type AdventuringDayCalculation = Readonly<
+  z.infer<typeof adventuringDayCalculationSchema>
+>

--- a/src/shared/contracts/scene.ts
+++ b/src/shared/contracts/scene.ts
@@ -1,0 +1,211 @@
+import { z } from 'zod'
+import { creatureCatalogQuerySchema } from './encounter.js'
+import { encounterTuningSchema } from './encounter-tuning.js'
+
+export const sceneGroupEntrySchema = z
+  .object({
+    id: z.uuid(),
+    creatureId: z.string().min(1),
+    displayName: z.string().min(1),
+    quantity: z.number().int().positive(),
+    position: z.number().int().nonnegative(),
+    available: z.boolean()
+  })
+  .strict()
+
+export const sceneGroupSchema = z
+  .object({
+    id: z.uuid(),
+    name: z.string().min(1).max(100),
+    position: z.number().int().nonnegative(),
+    entries: z.array(sceneGroupEntrySchema).min(1)
+  })
+  .strict()
+
+export const runningSceneSchema = z
+  .object({
+    id: z.uuid(),
+    title: z.string().min(1).max(100),
+    defaultScene: z.boolean(),
+    focused: z.boolean(),
+    locationId: z.string().nullable(),
+    locationName: z.string(),
+    partyMemberIds: z.array(z.uuid()),
+    groups: z.array(sceneGroupSchema)
+  })
+  .strict()
+
+export const sceneLocationChoiceSchema = z
+  .object({
+    id: z.uuid(),
+    displayName: z.string().min(1).max(100)
+  })
+  .strict()
+
+export const sceneSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    defaultSceneId: z.uuid(),
+    focusedSceneId: z.uuid(),
+    scenes: z.array(runningSceneSchema).min(1),
+    locationChoices: z.array(sceneLocationChoiceSchema),
+    unassignedPartyMemberIds: z.array(z.uuid())
+  })
+  .strict()
+
+export const sceneGroupDraftEntrySchema = z
+  .object({
+    creatureId: z.string().min(1),
+    quantity: z.number().int().positive().max(999)
+  })
+  .strict()
+
+const groupEntriesInputSchema = z.array(sceneGroupDraftEntrySchema).min(1)
+
+export const saveSceneGroupInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    groupId: z.uuid().nullable(),
+    name: z.string().trim().min(1).max(100),
+    entries: groupEntriesInputSchema,
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const deleteSceneGroupInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    groupId: z.uuid(),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const assignScenePartyInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    partyMemberId: z.uuid(),
+    assigned: z.boolean(),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const focusSceneInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const setSceneLocationInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    locationId: z.uuid().nullable(),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const groupGenerationModeSchema = z.enum(['fill', 'replace'])
+
+export const sceneGroupDraftGenerationRequestSchema = z
+  .object({
+    sceneId: z.uuid(),
+    expectedRevision: z.number().int().nonnegative(),
+    entries: z.array(sceneGroupDraftEntrySchema),
+    mode: groupGenerationModeSchema,
+    filters: creatureCatalogQuerySchema,
+    tuning: encounterTuningSchema,
+    seed: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const evaluateSceneGroupDraftInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    entries: z.array(sceneGroupDraftEntrySchema),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const sceneGroupDraftEvaluationSchema = z
+  .object({
+    sceneId: z.uuid(),
+    partySize: z.number().int().nonnegative(),
+    creatureCount: z.number().int().nonnegative(),
+    partyThresholds: z.tuple([
+      z.number().int().nonnegative(),
+      z.number().int().nonnegative(),
+      z.number().int().nonnegative(),
+      z.number().int().nonnegative()
+    ]),
+    baseXp: z.number().int().nonnegative(),
+    adjustedXp: z.number().int().nonnegative(),
+    difficultyLabel: z.string(),
+    canStart: z.boolean(),
+    message: z.string()
+  })
+  .strict()
+
+export const encounterSelectionEvaluationSchema =
+  sceneGroupDraftEvaluationSchema
+    .extend({ selectedGroupIds: z.array(z.uuid()) })
+    .strict()
+
+export const evaluateEncounterSelectionInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    groupIds: z.array(z.uuid()),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const sceneGroupDraftGenerationSchema = z
+  .object({
+    sceneId: z.uuid(),
+    sceneRevision: z.number().int().nonnegative(),
+    name: z.string().min(1).max(100),
+    entries: z.array(
+      z
+        .object({
+          creatureId: z.string().min(1),
+          displayName: z.string().min(1),
+          quantity: z.number().int().positive(),
+          cr: z.number().nonnegative(),
+          xp: z.number().int().nonnegative(),
+          available: z.boolean()
+        })
+        .strict()
+    ),
+    evaluation: sceneGroupDraftEvaluationSchema,
+    context: z
+      .object({
+        sceneTitle: z.string(),
+        locationId: z.string().nullable(),
+        locationName: z.string(),
+        existingGroupCount: z.number().int().nonnegative(),
+        effectiveEncounterTableIds: z.array(z.string()),
+        effectiveFactionIds: z.array(z.string()),
+        catalogFallback: z.boolean()
+      })
+      .strict(),
+    quality: z.enum(['exact', 'fallback', 'none']),
+    message: z.string()
+  })
+  .strict()
+
+export type SceneGroup = Readonly<z.infer<typeof sceneGroupSchema>>
+export type RunningScene = Readonly<z.infer<typeof runningSceneSchema>>
+export type SceneSnapshot = Readonly<z.infer<typeof sceneSnapshotSchema>>
+export type SceneGroupDraftGeneration = Readonly<
+  z.infer<typeof sceneGroupDraftGenerationSchema>
+>
+export type SceneGroupSuggestion = SceneGroupDraftGeneration
+export type SceneGroupDraftEvaluation = Readonly<
+  z.infer<typeof sceneGroupDraftEvaluationSchema>
+>
+export type SceneGroupDraftEntry = Readonly<
+  z.infer<typeof sceneGroupDraftEntrySchema>
+>
+export type GroupGenerationMode = z.infer<typeof groupGenerationModeSchema>
+export type EncounterSelectionEvaluation = Readonly<
+  z.infer<typeof encounterSelectionEvaluationSchema>
+>

--- a/src/shared/contracts/session-layout.ts
+++ b/src/shared/contracts/session-layout.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+const fraction = z.number().min(0.18).max(0.82)
+
+export const sessionLayoutPreferenceSchema = z
+  .object({
+    leftFraction: fraction,
+    rightTopFraction: fraction,
+    upperRightTab: z.enum(['details', 'map'])
+  })
+  .strict()
+
+export type SessionLayoutPreference = Readonly<
+  z.infer<typeof sessionLayoutPreferenceSchema>
+>
+
+export const defaultSessionLayoutPreference: SessionLayoutPreference =
+  sessionLayoutPreferenceSchema.parse({
+    leftFraction: 0.62,
+    rightTopFraction: 0.45,
+    upperRightTab: 'details'
+  })

--- a/src/shared/contracts/world-location.ts
+++ b/src/shared/contracts/world-location.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+export const worldLocationSchema = z
+  .object({
+    id: z.uuid(),
+    displayName: z.string().min(1).max(100),
+    notes: z.string().max(20_000),
+    position: z.number().int().nonnegative(),
+    factionIds: z.array(z.uuid()),
+    encounterTableIds: z.array(z.uuid())
+  })
+  .strict()
+
+export const worldLocationSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    locations: z.array(worldLocationSchema)
+  })
+  .strict()
+
+export const worldLocationDraftSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(100),
+    notes: z.string().trim().max(20_000),
+    factionIds: z.array(z.uuid()).default([]),
+    encounterTableIds: z.array(z.uuid()).default([])
+  })
+  .strict()
+
+const locationMutationBaseSchema = z
+  .object({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const createWorldLocationInputSchema = locationMutationBaseSchema
+  .extend({ location: worldLocationDraftSchema })
+  .strict()
+
+export const updateWorldLocationInputSchema = createWorldLocationInputSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export const deleteWorldLocationInputSchema = locationMutationBaseSchema
+  .extend({ id: z.uuid() })
+  .strict()
+
+export type WorldLocation = Readonly<z.infer<typeof worldLocationSchema>>
+export type WorldLocationDraft = Readonly<
+  z.input<typeof worldLocationDraftSchema>
+>
+export type WorldLocationSnapshot = Readonly<
+  z.infer<typeof worldLocationSnapshotSchema>
+>

--- a/src/shared/qualification/runtime-observation.ts
+++ b/src/shared/qualification/runtime-observation.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod'
+
+const sampleSchema = z.number().finite().nonnegative()
+const samplesSchema = z.array(sampleSchema).length(100)
+
+export const runtimeObservationConfigurationSchema = z.enum([
+  'normal',
+  'scale200Percent'
+])
+
+export const contextRecoveryObservationSchema = z
+  .object({
+    requestedCycles: z.number().int().nonnegative(),
+    observedLossCycles: z.number().int().nonnegative(),
+    restoredCycles: z.number().int().nonnegative(),
+    rerenderedCycles: z.number().int().nonnegative(),
+    nextInteractionSucceededCycles: z.number().int().nonnegative(),
+    completedCycles: z.number().int().nonnegative()
+  })
+  .strict()
+
+export type ContextRecoveryObservation = z.infer<
+  typeof contextRecoveryObservationSchema
+>
+
+export const runtimeGpuObservationSchema = z
+  .object({
+    operatingSystem: z.string().min(1),
+    architecture: z.string().min(1),
+    electronVersion: z.string().min(1),
+    featureStatus: z.record(z.string(), z.string()),
+    activeGpuDevices: z.array(
+      z
+        .object({
+          active: z.boolean(),
+          deviceId: z.string(),
+          vendorId: z.string(),
+          deviceName: z.string(),
+          vendorName: z.string(),
+          driverVendor: z.string(),
+          driverVersion: z.string()
+        })
+        .strict()
+    ),
+    softwareRendering: z.boolean()
+  })
+  .strict()
+
+export type RuntimeGpuObservation = z.infer<typeof runtimeGpuObservationSchema>
+
+const webglCanvasObservationSchema = z
+  .object({
+    version: z.string().min(1),
+    renderer: z.string().min(1)
+  })
+  .strict()
+
+const resourceCountsSchema = z
+  .object({
+    canvases: z.number().int().nonnegative(),
+    meshes: z.number().int().nonnegative(),
+    listeners: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const runtimeObservationSchema = z
+  .object({
+    captureKind: z.literal('m1-runtime-observation'),
+    formatVersion: z.literal('m1-runtime-observation-v1'),
+    recordedAt: z.iso.datetime(),
+    configuration: runtimeObservationConfigurationSchema,
+    environment: z
+      .object({
+        userAgent: z.string().min(1),
+        displayWidth: z.number().positive(),
+        displayHeight: z.number().positive(),
+        devicePixelRatio: z.number().positive(),
+        gpu: runtimeGpuObservationSchema,
+        webgl: z
+          .object({
+            pixi: webglCanvasObservationSchema,
+            babylon: webglCanvasObservationSchema
+          })
+          .strict()
+      })
+      .strict(),
+    populations: z
+      .object({
+        pixiPan: samplesSchema,
+        babylonCamera: samplesSchema,
+        babylonHoverPick: samplesSchema,
+        babylonVoxelPreview: samplesSchema
+      })
+      .strict(),
+    contextLoss: z
+      .object({
+        pixi: contextRecoveryObservationSchema,
+        babylon: contextRecoveryObservationSchema
+      })
+      .strict(),
+    resources: z
+      .object({
+        rendererCycles: z.number().int().nonnegative(),
+        rendererBuilds: z.number().int().nonnegative(),
+        rendererDisposals: z.number().int().nonnegative(),
+        before: resourceCountsSchema,
+        after: resourceCountsSchema,
+        settled: z.boolean(),
+        processMemoryBytesBefore: z.array(z.number().int().nonnegative()),
+        processMemoryBytesAfterSettling: z.array(z.number().int().nonnegative())
+      })
+      .strict()
+      .nullable()
+  })
+  .strict()
+
+export type RuntimeObservation = z.infer<typeof runtimeObservationSchema>

--- a/tests/e2e/campaign-restart.e2e.ts
+++ b/tests/e2e/campaign-restart.e2e.ts
@@ -4,15 +4,31 @@ import type { Browser as WdioBrowser } from 'webdriverio'
 describe('campaign restart', () => {
   it('resumes Campaign A after an Electron process restart and accepts a mutation', async () => {
     const client = browser as unknown as WdioBrowser
+    await expect(await client.$('h1=Session')).toBeExisting()
+    await expect(
+      await client.$(
+        '[aria-label="Gekoppelte Grenze zwischen linker und rechter Spalte"]'
+      )
+    ).toHaveAttribute('aria-valuenow', '60')
+    await expect(
+      await client.$('[aria-label="Grenze zwischen Details und Szenario"]')
+    ).toHaveAttribute('aria-valuenow', '47')
+    await expect(
+      await client.$('select[aria-label="Scene-Ort"] option:checked')
+    ).toHaveText('Salzmarschhafen')
+    await (await client.$('button[aria-label="Katalog"]')).click()
+    await (await client.$('button=Orte')).click()
+    await expect(await client.$('button=Salzmarschhafen')).toBeExisting()
+    await (await client.$('button[aria-label="Campaigns"]')).click()
     const field = await client.$('#campaign-name')
     await client.waitUntil(() => field.isExisting(), {
       timeout: 5_000,
       timeoutMsg: 'Campaign input was not rendered after restart.'
     })
-    await expect(await client.$('button=Campaign A (active)')).toBeExisting()
+    await expect(await client.$('button=Campaign A')).toBeExisting()
 
     await field.setValue('Campaign C')
     await (await client.$('button=Create campaign')).click()
-    await expect(await client.$('button=Campaign C (active)')).toBeExisting()
+    await expect(await client.$('h1=Session')).toBeExisting()
   })
 })

--- a/tests/e2e/campaign-walking.e2e.ts
+++ b/tests/e2e/campaign-walking.e2e.ts
@@ -13,15 +13,215 @@ describe('campaign walking skeleton', () => {
     expect(accessibility.violations).toHaveLength(0)
     await field.setValue('Campaign A')
     await (await client.$('button=Create campaign')).click()
-    await expect(await client.$('button=Campaign A (active)')).toBeExisting()
+    await expect(await client.$('h1=Session')).toBeExisting()
+    await expect(
+      await client.$('section[aria-label="Session Steuerung"]')
+    ).toBeExisting()
+    await expect(
+      await client.$('section[aria-label="Detailansicht"]')
+    ).toBeExisting()
+    await expect(await client.$('section[aria-label="Gruppen"]')).toBeExisting()
+    await expect(
+      await client.$('aside[aria-label="Szenario Panel"]')
+    ).toBeExisting()
+    await (await client.$('button=Karte')).click()
+    await expect(await client.$('strong=Reiseplanung')).toBeExisting()
+    await (await client.$('button=Details')).click()
+    await expect(await client.$$('[role="separator"]')).toBeElementsArrayOfSize(
+      2
+    )
+    const columnDivider = await client.$(
+      '[aria-label="Gekoppelte Grenze zwischen linker und rechter Spalte"]'
+    )
+    await pressDividerKey(
+      client,
+      'Gekoppelte Grenze zwischen linker und rechter Spalte',
+      'ArrowLeft'
+    )
+    await expect(columnDivider).toHaveAttribute('aria-valuenow', '60')
+    const rightDivider = await client.$(
+      '[aria-label="Grenze zwischen Details und Szenario"]'
+    )
+    await pressDividerKey(
+      client,
+      'Grenze zwischen Details und Szenario',
+      'ArrowDown'
+    )
+    await expect(rightDivider).toHaveAttribute('aria-valuenow', '47')
+    await client.pause(400)
 
-    await field.setValue('Campaign B')
+    await (await client.$('button[aria-label="Campaigns"]')).click()
+    const nextField = await client.$('#campaign-name')
+    await nextField.setValue('Campaign B')
     await (await client.$('button=Create campaign')).click()
-    await expect(await client.$('button=Campaign B (active)')).toBeExisting()
+    await expect(await client.$('h1=Session')).toBeExisting()
 
+    await (await client.$('button[aria-label="Campaigns"]')).click()
     await (await client.$('button=Campaign A')).click()
-    await expect(await client.$('button=Campaign A (active)')).toBeExisting()
-    await expect(await client.$('button=Campaign B')).toBeExisting()
+    await expect(await client.$('h1=Session')).toBeExisting()
+  })
+
+  it('builds a scene party, browses monsters and starts a scene group combat', async () => {
+    const client = browser as unknown as WdioBrowser
+    await createLocation(client, 'Saltmarsh', 'A busy harbour town.')
+    await (await client.$('button=Bearbeiten')).click()
+    const editLocation = await client.$('form[aria-label="Ort bearbeiten"]')
+    await (
+      await editLocation.$('input[aria-label="Ortsname"]')
+    ).setValue('Salzmarschhafen')
+    await (
+      await editLocation.$('textarea[aria-label="Ortsnotizen"]')
+    ).setValue('Nebel, Lagerhäuser und eine geschäftige Anlegestelle.')
+    await (await editLocation.$('button=Speichern')).click()
+    await expect(await client.$('h2=Salzmarschhafen')).toBeExisting()
+    await (await client.$('button[aria-label="Ort Details schließen"]')).click()
+    await (await client.$('button[aria-label="Session"]')).click()
+    const sceneLocation = await client.$('select[aria-label="Scene-Ort"]')
+    await sceneLocation.selectByVisibleText('Salzmarschhafen')
+    await waitForSceneLocation(client, 'Salzmarschhafen')
+
+    await createLocation(client, 'Verfallener Turm', 'Soll gelöscht werden.')
+    await (await client.$('button[aria-label="Ort Details schließen"]')).click()
+    await (await client.$('button[aria-label="Session"]')).click()
+    await (
+      await client.$('select[aria-label="Scene-Ort"]')
+    ).selectByVisibleText('Verfallener Turm')
+    await (await client.$('button[aria-label="Katalog"]')).click()
+    await (await client.$('button=Orte')).click()
+    await (await client.$('button=Verfallener Turm')).click()
+    await (await client.$('button=Löschen')).click()
+    await (await client.$('button=Wirklich löschen')).click()
+    await (await client.$('button[aria-label="Session"]')).click()
+    await waitForSceneLocation(client, 'Nicht verfügbarer Ort')
+    await (
+      await client.$('select[aria-label="Scene-Ort"]')
+    ).selectByVisibleText('Salzmarschhafen')
+
+    await (await client.$('button[aria-label="Katalog"]')).click()
+    await (await client.$('button=Fraktionen')).click()
+    await (await client.$('button=Erstellen')).click()
+    const factionDialog = await client.$(
+      'form[aria-label="Fraktion erstellen"]'
+    )
+    await (
+      await factionDialog.$('input[aria-label="Fraktionsname"]')
+    ).setValue('Hafenwache')
+    await (await factionDialog.$('button=Neue Encounter-Tabelle')).click()
+    const tableDialog = await client.$(
+      'section[aria-labelledby="encounter-table-manager-title"]'
+    )
+    await (
+      await tableDialog.$('input[aria-label="Tabellenname"]')
+    ).setValue('Wachpatrouille')
+    await (
+      await tableDialog.$('input[aria-label="Monster suchen"]')
+    ).setValue('wolf')
+    const addTableWolf = await tableDialog.$(
+      'button[aria-label="Wolf hinzufügen"]'
+    )
+    await client.waitUntil(() => addTableWolf.isExisting(), {
+      timeout: 5_000,
+      timeoutMsg: 'Shared table manager did not render the filtered Wolf.'
+    })
+    await addTableWolf.click()
+    await (await tableDialog.$('button=Erstellen')).click()
+    await expect(
+      await factionDialog.$('input[aria-label="Fraktionsname"]')
+    ).toHaveValue('Hafenwache')
+    await expect(
+      await factionDialog.$(
+        'select[aria-label="Primäre Encounter-Tabelle"] option:checked'
+      )
+    ).toHaveText('Wachpatrouille')
+    await (
+      await factionDialog.$('input[aria-label="Maximum Wolf"]')
+    ).setValue('2')
+    await (await factionDialog.$('button=Erstellen')).click()
+    await expect(await client.$('button=Hafenwache')).toBeExisting()
+    await (await client.$('button=Encounter-Tabellen')).click()
+    await (await client.$('button=Wachpatrouille')).click()
+    const reopenedTable = await client.$(
+      'section[aria-labelledby="encounter-table-manager-title"]'
+    )
+    await expect(
+      await reopenedTable.$(
+        'select[aria-label="Encounter-Tabelle auswählen"] option:checked'
+      )
+    ).toHaveText('Wachpatrouille')
+    await (
+      await reopenedTable.$('button[aria-label="Dialog schließen"]')
+    ).click()
+    await (await client.$('button[aria-label="Session"]')).click()
+
+    await (await client.$('button=Keine Party')).click()
+    for (let active = 1; active <= 2; active += 1) {
+      const addButtons = await client.$$('button=Zur Party')
+      await addButtons[0]?.click()
+      await client.waitUntil(
+        async () => (await client.$$('button=Aus Party').length) === active,
+        {
+          timeout: 5_000,
+          timeoutMsg: `Party membership ${active} was not published.`
+        }
+      )
+    }
+    await (await client.$('button[aria-label="Party-Panel schließen"]')).click()
+
+    for (let assigned = 1; assigned <= 2; assigned += 1) {
+      const sceneButtons = await client.$$('button=Zur Scene')
+      await sceneButtons[0]?.click()
+      await client.pause(300)
+      const assignmentError = await client.$('.error-message')
+      if (await assignmentError.isExisting())
+        throw new Error(await assignmentError.getText())
+      await client.waitUntil(
+        async () => (await client.$$('button=Entfernen').length) === assigned,
+        {
+          timeout: 5_000,
+          timeoutMsg: `Scene assignment ${assigned} was not published.`
+        }
+      )
+    }
+
+    await (await client.$('button[aria-label="Katalog"]')).click()
+    const monsterSearch = await client.$('input[aria-label="Monster suchen"]')
+    await monsterSearch.setValue('wolf')
+    const wolf = await client.$('button=Wolf')
+    await client.waitUntil(() => wolf.isExisting(), {
+      timeout: 5_000,
+      timeoutMsg: 'Filtered Wolf catalog row was not rendered.'
+    })
+    await expect(await client.$('button=+ Encounter')).not.toBeExisting()
+
+    await (await client.$('button[aria-label="Session"]')).click()
+    await (await client.$('button=Gruppen managen')).click()
+    await (await client.$('button=Neue Gruppe')).click()
+    await (
+      await client.$('input[aria-label="Gruppenname"]')
+    ).setValue('Wolf Pack')
+    const dialogSearch = await client.$('input[aria-label="Monster suchen"]')
+    await dialogSearch.setValue('wolf')
+    const addWolf = await client.$('button[aria-label="Wolf hinzufügen"]')
+    await client.waitUntil(() => addWolf.isExisting(), {
+      timeout: 5_000,
+      timeoutMsg: 'Wolf add action was not rendered.'
+    })
+    for (let count = 0; count < 4; count += 1) await addWolf.click()
+    await (await client.$('button=Gruppe erstellen')).click()
+    await expect(await client.$('strong=Wolf Pack')).toBeExisting()
+
+    await (
+      await client.$('select[aria-label="Szenario Auswahl"]')
+    ).selectByAttribute('value', 'encounter')
+    const groupChoice = await client.$('label*=Wolf Pack')
+    await (await groupChoice.$('input')).click()
+    const prepare = await client.$('button=Initiative vorbereiten')
+    await client.waitUntil(() => prepare.isEnabled(), {
+      timeout: 5_000,
+      timeoutMsg: 'Encounter selection evaluation did not become ready.'
+    })
+    await prepare.click()
+    await expect(await client.$('h2=Initiative')).toBeExisting()
   })
 })
 
@@ -33,4 +233,55 @@ async function waitForCampaignInput(
     timeout: 5_000,
     timeoutMsg: 'Campaign input was not rendered.'
   })
+}
+
+async function createLocation(
+  client: WdioBrowser,
+  name: string,
+  notes: string
+): Promise<void> {
+  await (await client.$('button[aria-label="Katalog"]')).click()
+  await (await client.$('button=Orte')).click()
+  await (await client.$('button=Erstellen')).click()
+  const dialog = await client.$('form[aria-label="Ort erstellen"]')
+  await (await dialog.$('input[aria-label="Ortsname"]')).setValue(name)
+  await (await dialog.$('textarea[aria-label="Ortsnotizen"]')).setValue(notes)
+  await (await dialog.$('button=Erstellen')).click()
+  await expect(await client.$(`h2=${name}`)).toBeExisting()
+}
+
+async function waitForSceneLocation(
+  client: WdioBrowser,
+  expected: string
+): Promise<void> {
+  await client.waitUntil(
+    async () =>
+      (await (
+        await client.$('select[aria-label="Scene-Ort"] option:checked')
+      ).getText()) === expected,
+    {
+      timeout: 5_000,
+      timeoutMsg: `Scene location did not become ${expected}.`
+    }
+  )
+}
+
+async function pressDividerKey(
+  client: WdioBrowser,
+  label: string,
+  key: string
+): Promise<void> {
+  await client.execute(
+    (ariaLabel, keyboardKey) => {
+      const divider = document.querySelector<HTMLElement>(
+        `[aria-label="${ariaLabel}"]`
+      )
+      divider?.focus()
+      divider?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: keyboardKey, bubbles: true })
+      )
+    },
+    label,
+    key
+  )
 }

--- a/tests/integration/encounter-sources.test.ts
+++ b/tests/integration/encounter-sources.test.ts
@@ -1,0 +1,287 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CreatureCatalogService,
+  creatures
+} from '../../src/core/creatures/catalog.js'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { EncounterSourceService } from '../../src/core/worldplanner/encounter-source-store.js'
+import { WorldLocationService } from '../../src/core/worldplanner/location-store.js'
+import { creatureCatalogQuerySchema } from '../../src/shared/contracts/encounter.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-sources-'))
+  roots.push(root)
+  const campaigns = new CampaignStore(root)
+  campaigns.create('Sources')
+  const path = () => campaigns.activeCampaignPath()
+  const sources = new EncounterSourceService(path)
+  const locations = new WorldLocationService(path)
+  const catalog = new CreatureCatalogService(
+    join(root, 'installation.sqlite'),
+    (query) => sources.resolve(query),
+    () => ({
+      encounterTables: sources
+        .readTables()
+        .tables.map((table) => ({ id: table.id, label: table.displayName })),
+      factions: sources.readFactions().factions.map((faction) => ({
+        id: faction.id,
+        label: faction.displayName
+      })),
+      locations: locations.read().locations.map((location) => ({
+        id: location.id,
+        label: location.displayName
+      }))
+    })
+  )
+  return {
+    campaigns,
+    sources,
+    locations,
+    catalog,
+    play: new LivePlayService(path)
+  }
+}
+
+const query = (values: Record<string, unknown> = {}) =>
+  creatureCatalogQuerySchema.parse({ limit: 100, ...values })
+
+describe('encounter tables and factions', () => {
+  it('persists CRUD data, resolves dimensions and exposes source choices', () => {
+    const { campaigns, sources, locations, catalog } = harness()
+    const [first, second] = creatures
+    expect(first).toBeDefined()
+    expect(second).toBeDefined()
+
+    let tables = sources.createTable(
+      {
+        displayName: 'Coast Patrol',
+        description: 'Weighted coastal opposition',
+        entries: [
+          { creatureId: first!.id, weight: 2 },
+          { creatureId: second!.id, weight: 8 }
+        ]
+      },
+      0
+    )
+    tables = sources.createTable(
+      {
+        displayName: 'Elite',
+        description: '',
+        entries: [{ creatureId: second!.id, weight: 4 }]
+      },
+      tables.revision
+    )
+    const patrolId = tables.tables[0]!.id
+    const eliteId = tables.tables[1]!.id
+    let factions = sources.createFaction(
+      {
+        displayName: 'Sea Princes',
+        notes: 'Hostile smugglers',
+        disposition: -35,
+        primaryEncounterTableId: eliteId,
+        inventory: [{ creatureId: second!.id, maximum: 2 }]
+      },
+      0
+    )
+    const factionId = factions.factions[0]!.id
+    let world = locations.create(
+      {
+        displayName: 'Hidden Cove',
+        notes: '',
+        factionIds: [factionId],
+        encounterTableIds: []
+      },
+      0
+    )
+
+    const resolved = sources.resolve(
+      query({ encounterTableIds: [patrolId], factionIds: [factionId] })
+    )
+    expect(resolved.catalogFallback).toBe(false)
+    expect(resolved.candidates).toEqual([
+      expect.objectContaining({ creatureId: second!.id, maximum: 2 })
+    ])
+    const options = catalog.filterOptions()
+    expect(options.encounterTables).toContainEqual({
+      id: patrolId,
+      label: 'Coast Patrol'
+    })
+    expect(options.factions).toEqual([{ id: factionId, label: 'Sea Princes' }])
+    expect(options.locations).toEqual([
+      { id: world.locations[0]!.id, label: 'Hidden Cove' }
+    ])
+
+    const filtered = catalog.search(query({ factionIds: [factionId] }))
+    expect(filtered.rows.map((creature) => creature.id)).toEqual([second!.id])
+
+    tables = sources.updateTable(
+      eliteId,
+      {
+        displayName: 'Elite',
+        description: 'Changed membership',
+        entries: [{ creatureId: first!.id, weight: 4 }]
+      },
+      tables.revision
+    )
+    factions = sources.readFactions()
+    expect(factions.factions[0]).toMatchObject({
+      primaryEncounterTableId: eliteId,
+      inventory: []
+    })
+
+    tables = sources.deleteTable(eliteId, tables.revision)
+    factions = sources.readFactions()
+    world = locations.read()
+    expect(factions.factions[0]).toMatchObject({
+      primaryEncounterTableId: null,
+      inventory: []
+    })
+    expect(world.locations[0]!.factionIds).toEqual([factionId])
+    expect(tables.tables).toHaveLength(1)
+    campaigns.close()
+  })
+
+  it('accepts faction limits only for creatures in the primary table', () => {
+    const { campaigns, sources } = harness()
+    const [first, second] = creatures
+    const tables = sources.createTable(
+      {
+        displayName: 'Narrow source',
+        description: '',
+        entries: [{ creatureId: first!.id, weight: 1 }]
+      },
+      0
+    )
+    const tableId = tables.tables[0]!.id
+    expect(() =>
+      sources.createFaction(
+        {
+          displayName: 'Invalid stock',
+          notes: '',
+          disposition: 0,
+          primaryEncounterTableId: tableId,
+          inventory: [{ creatureId: second!.id, maximum: 2 }]
+        },
+        0
+      )
+    ).toThrow('validation')
+    expect(() =>
+      sources.createFaction(
+        {
+          displayName: 'Missing source',
+          notes: '',
+          disposition: 0,
+          primaryEncounterTableId: null,
+          inventory: [{ creatureId: first!.id, maximum: 2 }]
+        },
+        0
+      )
+    ).toThrow('validation')
+    campaigns.close()
+  })
+
+  it('falls back only without effective tables and treats an empty table as no solution', () => {
+    const { campaigns, sources, catalog } = harness()
+    expect(sources.resolve(query({ locationId: null })).catalogFallback).toBe(
+      true
+    )
+    const tables = sources.createTable(
+      { displayName: 'Empty', description: '', entries: [] },
+      0
+    )
+    const emptyId = tables.tables[0]!.id
+    const resolved = sources.resolve(query({ encounterTableIds: [emptyId] }))
+    expect(resolved.catalogFallback).toBe(false)
+    expect(resolved.candidates).toEqual([])
+    expect(
+      catalog.search(query({ encounterTableIds: [emptyId] }))
+    ).toMatchObject({
+      status: 'empty',
+      total: 0
+    })
+    campaigns.close()
+  })
+
+  it('uses the focused location faction and inventory cap in generation', () => {
+    const { campaigns, sources, locations, play } = harness()
+    const creature = creatures.find((entry) => entry.xp > 0)!
+    const tables = sources.createTable(
+      {
+        displayName: 'Limited Guard',
+        description: '',
+        entries: [{ creatureId: creature.id, weight: 10 }]
+      },
+      0
+    )
+    const factions = sources.createFaction(
+      {
+        displayName: 'Watch',
+        notes: '',
+        disposition: 10,
+        primaryEncounterTableId: tables.tables[0]!.id,
+        inventory: [{ creatureId: creature.id, maximum: 1 }]
+      },
+      0
+    )
+    const world = locations.create(
+      {
+        displayName: 'Gate',
+        notes: '',
+        factionIds: [factions.factions[0]!.id],
+        encounterTableIds: []
+      },
+      0
+    )
+    let party = play.readParty()
+    for (const member of party.members)
+      party = play.setMembership(member.id, true, party.revision)
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    for (const member of party.members)
+      session = play.assignScenePartyMember(
+        sceneId,
+        member.id,
+        true,
+        session.scene.revision
+      )
+    session = play.setSceneLocation(
+      sceneId,
+      world.locations[0]!.id,
+      session.scene.revision
+    )
+    const generation = play.generateGroupDraft(
+      sceneId,
+      [],
+      'replace',
+      query(),
+      {
+        difficulty: 'medium',
+        amount: 'many',
+        balance: 'auto',
+        diversity: 'auto'
+      },
+      7,
+      session.scene.revision
+    )
+    expect(generation.entries).toEqual([
+      expect.objectContaining({ creatureId: creature.id, quantity: 1 })
+    ])
+    expect(generation.context).toMatchObject({
+      locationId: world.locations[0]!.id,
+      effectiveFactionIds: [factions.factions[0]!.id],
+      catalogFallback: false
+    })
+    campaigns.close()
+  })
+})

--- a/tests/integration/live-play.test.ts
+++ b/tests/integration/live-play.test.ts
@@ -1,0 +1,206 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import Database from 'better-sqlite3'
+import { uuidv7 } from '../../src/shared/ids/uuidv7.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-live-play-'))
+  roots.push(root)
+  const campaigns = new CampaignStore(root)
+  campaigns.create('Test Campaign')
+  const play = new LivePlayService(() => campaigns.activeCampaignPath())
+  return { campaigns, play }
+}
+
+describe('live party, scene groups and combat', () => {
+  it('seeds four inactive roster characters exactly once', () => {
+    const { campaigns, play } = harness()
+    const first = play.readParty()
+    campaigns.close()
+
+    const reopened = new CampaignStore(roots[0] ?? '')
+    const second = new LivePlayService(() =>
+      reopened.activeCampaignPath()
+    ).readParty()
+    reopened.close()
+
+    expect(first.members.map((member) => member.name)).toEqual([
+      'Alrik',
+      'Brynn',
+      'Cora',
+      'Dain'
+    ])
+    expect(first.members.every((member) => !member.active)).toBe(true)
+    expect(second).toEqual(first)
+  })
+
+  it('runs party and a monster group through resolution and awards XP once', () => {
+    const { campaigns, play } = harness()
+    let party = play.readParty()
+    for (const member of party.members.slice(0, 2))
+      party = play.setMembership(member.id, true, party.revision)
+
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    for (const member of party.members.filter((entry) => entry.active))
+      session = play.assignScenePartyMember(
+        sceneId,
+        member.id,
+        true,
+        session.scene.revision
+      )
+    session = play.saveSceneGroup(
+      sceneId,
+      null,
+      'Goblin Patrol',
+      [{ creatureId: 'goblin', quantity: 4 }],
+      session.scene.revision
+    )
+    const groupId = session.scene.scenes[0]?.groups[0]?.id
+    expect(groupId).toBeDefined()
+
+    session = play.prepareCombat(sceneId, session.scene.revision, [
+      groupId ?? ''
+    ])
+    expect(session.combat?.phase).toBe('initiative')
+    const initiatives =
+      session.combat?.initiativeRows.map((row) => ({
+        id: row.id,
+        initiative: row.initiative
+      })) ?? []
+    session = play.confirmInitiative(
+      session.combat?.revision ?? -1,
+      initiatives
+    )
+    const monsterCard = session.combat?.cards.find(
+      (card) => !card.playerCharacter
+    )
+    expect(monsterCard?.count).toBe(4)
+
+    session = play.changeHp(
+      session.combat?.revision ?? -1,
+      monsterCard?.id ?? '',
+      28,
+      false
+    )
+    expect(session.combat?.allEnemiesDefeated).toBe(true)
+    session = play.endCombat(session.combat?.revision ?? -1)
+    const enemyIds =
+      session.combat?.resolution?.enemies.map((enemy) => enemy.id) ?? []
+    session = play.updateResolution(
+      session.combat?.revision ?? -1,
+      enemyIds,
+      1,
+      1
+    )
+    session = play.awardXp(session.combat?.revision ?? -1)
+
+    expect(session.combat?.resolution?.xpAwarded).toBe(true)
+    expect(session.combat?.resolution?.perPlayerXp).toBe(100)
+    expect(
+      session.party.members
+        .filter((member) => member.active)
+        .map((member) => member.xp)
+    ).toEqual([1000, 1000])
+    expect(() => play.awardXp(session.combat?.revision ?? -1)).toThrow(
+      'validation'
+    )
+    campaigns.close()
+  })
+
+  it('resumes the exact running combat after reopening the campaign', () => {
+    const { campaigns, play } = harness()
+    const party = play.readParty()
+    play.setMembership(party.members[0]?.id ?? '', true, party.revision)
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    session = play.assignScenePartyMember(
+      sceneId,
+      party.members[0]?.id ?? '',
+      true,
+      session.scene.revision
+    )
+    session = play.saveSceneGroup(
+      sceneId,
+      null,
+      'Wolves',
+      [{ creatureId: 'wolf', quantity: 2 }],
+      session.scene.revision
+    )
+    session = play.prepareCombat(sceneId, session.scene.revision, [
+      session.scene.scenes[0]?.groups[0]?.id ?? ''
+    ])
+    session = play.confirmInitiative(
+      session.combat?.revision ?? -1,
+      session.combat?.initiativeRows.map((row) => ({
+        id: row.id,
+        initiative: row.initiative
+      })) ?? []
+    )
+    session = play.advanceTurn(session.combat?.revision ?? -1)
+    const expected = session.combat
+    campaigns.close()
+
+    const reopened = new CampaignStore(roots[0] ?? '')
+    const resumed = new LivePlayService(() =>
+      reopened.activeCampaignPath()
+    ).readSession()
+    reopened.close()
+
+    expect(resumed.combat).toEqual(expected)
+  })
+
+  it('keeps combat bound to its scene while focus changes', () => {
+    const { campaigns, play } = harness()
+    const party = play.readParty()
+    const memberId = party.members[0]?.id ?? ''
+    play.setMembership(memberId, true, party.revision)
+    let session = play.readSession()
+    const firstSceneId = session.scene.focusedSceneId
+    session = play.assignScenePartyMember(
+      firstSceneId,
+      memberId,
+      true,
+      session.scene.revision
+    )
+    session = play.saveSceneGroup(
+      firstSceneId,
+      null,
+      'Wölfe',
+      [{ creatureId: 'wolf', quantity: 2 }],
+      session.scene.revision
+    )
+    session = play.prepareCombat(firstSceneId, session.scene.revision, [
+      session.scene.scenes[0]?.groups[0]?.id ?? ''
+    ])
+    const firstCombat = session.combat
+
+    const secondSceneId = uuidv7()
+    const db = new Database(campaigns.activeCampaignPath())
+    db.prepare(
+      "INSERT INTO scene_running_scene (id, title, location_id, location_name, position) VALUES (?, 'Nebenszene', NULL, '', 1)"
+    ).run(secondSceneId)
+    db.prepare(
+      'UPDATE scene_workspace SET revision = revision + 1 WHERE singleton = 1'
+    ).run()
+    db.close()
+
+    session = play.readSession()
+    session = play.focusScene(secondSceneId, session.scene.revision)
+    expect(session.combat).toBeNull()
+    session = play.focusScene(firstSceneId, session.scene.revision)
+    expect(session.combat).toEqual(firstCombat)
+    campaigns.close()
+  })
+})

--- a/tests/integration/party-catalog-encounter.test.ts
+++ b/tests/integration/party-catalog-encounter.test.ts
@@ -1,0 +1,239 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CreatureCatalogService } from '../../src/core/creatures/catalog.js'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { creatureCatalogQuerySchema } from '../../src/shared/contracts/encounter.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-parity-'))
+  roots.push(root)
+  const campaigns = new CampaignStore(root)
+  campaigns.create('Parity Campaign')
+  const play = new LivePlayService(() => campaigns.activeCampaignPath())
+  const catalog = new CreatureCatalogService(join(root, 'installation.sqlite'))
+  return { campaigns, play, catalog }
+}
+
+describe('party and catalog parity slice', () => {
+  it('preserves absent character facts and caps XP correction at the level floor', () => {
+    const { campaigns, play } = harness()
+    let party = play.readParty()
+    party = play.createPartyCharacter(
+      {
+        name: 'Namesake',
+        playerName: null,
+        level: null,
+        passivePerception: null,
+        armorClass: null
+      },
+      party.revision
+    )
+    const created = party.members.at(-1)
+    expect(created).toMatchObject({
+      name: 'Namesake',
+      active: false,
+      playerName: null,
+      level: null,
+      passivePerception: null,
+      armorClass: null
+    })
+
+    party = play.updatePartyCharacter(
+      created?.id ?? '',
+      {
+        name: 'Namesake',
+        playerName: 'Mara',
+        level: 5,
+        passivePerception: 14,
+        armorClass: 17
+      },
+      party.revision
+    )
+    party = play.adjustPartyXp(created?.id ?? '', -1_000_000, party.revision)
+    expect(party.members.at(-1)).toMatchObject({
+      level: 5,
+      xp: 6500,
+      currentLevelFloor: 6500
+    })
+    campaigns.close()
+  })
+
+  it('calculates adventuring-day budget and progress without mutating the roster', () => {
+    const { campaigns, play } = harness()
+    const before = play.readParty()
+    const result = play.calculateAdventuringDay([{ level: 3, count: 4 }], 6000)
+    expect(result.dailyBudget).toBe(4800)
+    expect(result.completedDays).toBe(1)
+    expect(result.dayProgress).toBe(0.25)
+    expect(play.readParty()).toEqual(before)
+    campaigns.close()
+  })
+
+  it('queries the bundled SRD catalog with filters, paging and rich details', () => {
+    const { campaigns, catalog } = harness()
+    const options = catalog.filterOptions()
+    const wolves = catalog.search(
+      creatureCatalogQuerySchema.parse({
+        name: 'wolf',
+        types: ['Beast'],
+        biomes: options.biomes.includes('Forest') ? ['Forest'] : [],
+        sort: 'cr',
+        direction: 'asc',
+        limit: 50
+      })
+    )
+    expect(options.types).toContain('Beast')
+    expect(options.biomes.length).toBeGreaterThan(0)
+    expect(wolves.total).toBeGreaterThan(0)
+    expect(wolves.rows.every((creature) => creature.type === 'Beast')).toBe(
+      true
+    )
+    const detail = catalog.detail(wolves.rows[0]?.id ?? '')
+    expect(detail.actions.length).toBeGreaterThan(0)
+    expect(detail.abilities.dex).toBeGreaterThan(0)
+    campaigns.close()
+  })
+
+  it('generates a transient scene group, evaluates it and starts combat', () => {
+    const { campaigns, play } = harness()
+    let party = play.readParty()
+    for (const member of party.members)
+      party = play.setMembership(member.id, true, party.revision)
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    for (const member of party.members)
+      session = play.assignScenePartyMember(
+        sceneId,
+        member.id,
+        true,
+        session.scene.revision
+      )
+    const suggestion = play.generateGroupDraft(
+      sceneId,
+      [],
+      'replace',
+      creatureCatalogQuerySchema.parse({
+        types: ['Beast'],
+        crMax: 2,
+        limit: 50
+      }),
+      {
+        difficulty: 'medium',
+        amount: 'standard',
+        balance: 'auto',
+        diversity: 'auto'
+      },
+      0,
+      session.scene.revision
+    )
+    expect(suggestion.entries.length).toBeGreaterThan(0)
+    expect(play.readSession().scene.scenes[0]?.groups).toHaveLength(0)
+    session = play.saveSceneGroup(
+      sceneId,
+      null,
+      'Forest trouble',
+      suggestion.entries,
+      session.scene.revision
+    )
+    const groupId = session.scene.scenes[0]?.groups[0]?.id ?? ''
+    const evaluation = play.evaluateEncounter(
+      sceneId,
+      [groupId],
+      session.scene.revision
+    )
+    expect(evaluation.canStart).toBe(true)
+    session = play.prepareCombat(sceneId, session.scene.revision, [groupId])
+    expect(session.combat?.phase).toBe('initiative')
+    const expected = session.combat
+    campaigns.close()
+
+    const reopened = new CampaignStore(roots[0] ?? '')
+    const resumed = new LivePlayService(() =>
+      reopened.activeCampaignPath()
+    ).readSession()
+    expect(resumed.combat).toEqual(expected)
+    expect(resumed.scene.scenes[0]?.groups[0]?.name).toBe('Forest trouble')
+    reopened.close()
+  })
+
+  it('evaluates manual drafts, fills a base roster and replaces it on request', () => {
+    const { campaigns, play, catalog } = harness()
+    let party = play.readParty()
+    for (const member of party.members)
+      party = play.setMembership(member.id, true, party.revision)
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    for (const member of party.members)
+      session = play.assignScenePartyMember(
+        sceneId,
+        member.id,
+        true,
+        session.scene.revision
+      )
+    const base = [{ creatureId: 'wolf', quantity: 1 }] as const
+    const before = play.evaluateGroupDraft(
+      sceneId,
+      base,
+      session.scene.revision
+    )
+    expect(before.creatureCount).toBe(1)
+    expect(before.baseXp).toBeGreaterThan(0)
+
+    const filled = play.generateGroupDraft(
+      sceneId,
+      base,
+      'fill',
+      creatureCatalogQuerySchema.parse({ types: ['Beast'], limit: 50 }),
+      {
+        difficulty: 'hard',
+        amount: 'many',
+        balance: 'even',
+        diversity: 'high'
+      },
+      0,
+      session.scene.revision
+    )
+    expect(
+      filled.entries.find((entry) => entry.creatureId === 'wolf')?.quantity
+    ).toBeGreaterThanOrEqual(1)
+    expect(filled.evaluation.adjustedXp).toBeGreaterThanOrEqual(
+      before.adjustedXp
+    )
+
+    const replaced = play.generateGroupDraft(
+      sceneId,
+      [{ creatureId: 'goblin', quantity: 3 }],
+      'replace',
+      creatureCatalogQuerySchema.parse({ types: ['Beast'], limit: 50 }),
+      {
+        difficulty: 'medium',
+        amount: 'standard',
+        balance: 'varied',
+        diversity: 'low'
+      },
+      0,
+      session.scene.revision
+    )
+    expect(replaced.entries.length).toBeGreaterThan(0)
+    expect(
+      replaced.entries.some((entry) => entry.creatureId === 'goblin')
+    ).toBe(false)
+    expect(
+      replaced.entries.every(
+        (entry) => catalog.detail(entry.creatureId).type === 'Beast'
+      )
+    ).toBe(true)
+    expect(play.readSession().scene.scenes[0]?.groups).toHaveLength(0)
+    campaigns.close()
+  })
+})

--- a/tests/integration/world-location.test.ts
+++ b/tests/integration/world-location.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { WorldLocationService } from '../../src/core/worldplanner/location-store.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-locations-'))
+  roots.push(root)
+  const campaigns = new CampaignStore(root)
+  campaigns.create('Locations')
+  const path = () => campaigns.activeCampaignPath()
+  return {
+    campaigns,
+    play: new LivePlayService(path),
+    locations: new WorldLocationService(path)
+  }
+}
+
+describe('world locations', () => {
+  it('creates, updates, deletes and revision-checks independent namesakes', () => {
+    const { campaigns, locations } = harness()
+    let snapshot = locations.read()
+    snapshot = locations.create(
+      { displayName: 'Saltmarsh', notes: 'Harbour town' },
+      snapshot.revision
+    )
+    const first = snapshot.locations[0]
+    snapshot = locations.create(
+      { displayName: 'Saltmarsh', notes: 'Independent namesake' },
+      snapshot.revision
+    )
+    expect(snapshot.locations).toHaveLength(2)
+    expect(
+      new Set(snapshot.locations.map((location) => location.id)).size
+    ).toBe(2)
+    expect(() =>
+      locations.update(first?.id ?? '', { displayName: 'Stale', notes: '' }, 0)
+    ).toThrow('stale')
+    snapshot = locations.update(
+      first?.id ?? '',
+      { displayName: 'New Saltmarsh', notes: 'Updated' },
+      snapshot.revision
+    )
+    expect(snapshot.locations[0]).toMatchObject({
+      displayName: 'New Saltmarsh',
+      notes: 'Updated'
+    })
+    snapshot = locations.delete(first?.id ?? '', snapshot.revision)
+    expect(snapshot.locations).toHaveLength(1)
+    campaigns.close()
+  })
+
+  it('persists choices and preserves a deleted scene reference as unresolved', () => {
+    const { campaigns, locations, play } = harness()
+    let world = locations.read()
+    world = locations.create(
+      { displayName: 'The Docks', notes: 'Fog and warehouses' },
+      world.revision
+    )
+    const locationId = world.locations[0]?.id ?? ''
+    let session = play.readSession()
+    const sceneId = session.scene.focusedSceneId
+    session = play.setSceneLocation(sceneId, locationId, session.scene.revision)
+    expect(session.scene.scenes[0]).toMatchObject({
+      locationId,
+      locationName: 'The Docks'
+    })
+    expect(session.scene.locationChoices).toEqual([
+      { id: locationId, displayName: 'The Docks' }
+    ])
+
+    locations.delete(locationId, world.revision)
+    session = play.readSession()
+    expect(session.scene.scenes[0]).toMatchObject({
+      locationId,
+      locationName: 'Nicht verfügbarer Ort'
+    })
+    expect(session.scene.locationChoices).toEqual([])
+    session = play.setSceneLocation(sceneId, null, session.scene.revision)
+    expect(session.scene.scenes[0]).toMatchObject({
+      locationId: null,
+      locationName: ''
+    })
+    campaigns.close()
+  })
+
+  it('resumes the exact location state after reopening the campaign', () => {
+    const { campaigns, locations } = harness()
+    const expected = locations.create(
+      { displayName: 'Abbey Isle', notes: 'Ruined cloister' },
+      locations.read().revision
+    )
+    const root = roots[0] ?? ''
+    campaigns.close()
+
+    const reopened = new CampaignStore(root)
+    const resumed = new WorldLocationService(() =>
+      reopened.activeCampaignPath()
+    ).read()
+    reopened.close()
+    expect(resumed).toEqual(expected)
+  })
+})

--- a/tests/unit/capability-contract.test.ts
+++ b/tests/unit/capability-contract.test.ts
@@ -12,6 +12,9 @@ describe('capability contract', () => {
       capabilityFailureSchema.parse({ code: 'not_found', retryable: false })
     ).toEqual({ code: 'not_found', retryable: false })
     expect(
+      capabilityFailureSchema.parse({ code: 'stale', retryable: false })
+    ).toEqual({ code: 'stale', retryable: false })
+    expect(
       capabilityFailureSchema.safeParse({ error: 'database unavailable' })
         .success
     ).toBe(false)

--- a/tests/unit/live-session-contract.test.ts
+++ b/tests/unit/live-session-contract.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import {
+  changeHpInputSchema,
+  prepareCombatInputSchema
+} from '../../src/shared/contracts/live-session.js'
+import {
+  evaluateSceneGroupDraftInputSchema,
+  saveSceneGroupInputSchema,
+  sceneGroupDraftGenerationRequestSchema
+} from '../../src/shared/contracts/scene.js'
+import {
+  defaultSessionLayoutPreference,
+  sessionLayoutPreferenceSchema
+} from '../../src/shared/contracts/session-layout.js'
+import {
+  createWorldLocationInputSchema,
+  updateWorldLocationInputSchema
+} from '../../src/shared/contracts/world-location.js'
+import {
+  createEncounterTableInputSchema,
+  createWorldFactionInputSchema
+} from '../../src/shared/contracts/encounter-source.js'
+
+describe('live session capability contracts', () => {
+  it('rejects empty groups, non-positive quantities and unknown fields', () => {
+    expect(
+      saveSceneGroupInputSchema.safeParse({
+        sceneId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+        groupId: null,
+        name: 'Goblins',
+        expectedRevision: 0,
+        entries: []
+      }).success
+    ).toBe(false)
+    expect(
+      saveSceneGroupInputSchema.safeParse({
+        sceneId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+        groupId: null,
+        name: 'Goblins',
+        expectedRevision: 0,
+        entries: [{ creatureId: 'goblin', quantity: 0 }]
+      }).success
+    ).toBe(false)
+    expect(
+      prepareCombatInputSchema.safeParse({
+        sceneId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+        expectedSceneRevision: 0,
+        groupIds: ['0184d1f4-bba7-7c9c-9d89-5f1c0f36a031'],
+        copiedStatblock: { hp: 7 }
+      }).success
+    ).toBe(false)
+  })
+
+  it('bounds HP commands and requires a displayed combat revision', () => {
+    expect(
+      changeHpInputSchema.safeParse({
+        cardId: 'monster-card:1',
+        amount: 4,
+        healing: false,
+        expectedRevision: 3
+      }).success
+    ).toBe(true)
+    expect(
+      changeHpInputSchema.safeParse({
+        cardId: 'monster-card:1',
+        amount: -1,
+        healing: false,
+        expectedRevision: 3
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates transient draft evaluation and generation modes', () => {
+    const base = {
+      sceneId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+      expectedRevision: 2
+    }
+    expect(
+      evaluateSceneGroupDraftInputSchema.safeParse({ ...base, entries: [] })
+        .success
+    ).toBe(true)
+    expect(
+      sceneGroupDraftGenerationRequestSchema.safeParse({
+        ...base,
+        entries: [{ creatureId: 'wolf', quantity: 2 }],
+        mode: 'fill',
+        filters: { types: ['Beast'] },
+        tuning: {
+          difficulty: 'medium',
+          amount: 'standard',
+          balance: 'even',
+          diversity: 'high'
+        },
+        seed: 3
+      }).success
+    ).toBe(true)
+    expect(
+      sceneGroupDraftGenerationRequestSchema.safeParse({
+        ...base,
+        entries: [{ creatureId: 'wolf', quantity: 0 }],
+        mode: 'append',
+        filters: {},
+        tuning: {},
+        seed: 0
+      }).success
+    ).toBe(false)
+  })
+
+  it('retains the two independent divider positions and bounds them', () => {
+    expect(
+      sessionLayoutPreferenceSchema.parse(defaultSessionLayoutPreference)
+    ).toEqual(defaultSessionLayoutPreference)
+    expect(
+      sessionLayoutPreferenceSchema.safeParse({
+        ...defaultSessionLayoutPreference,
+        leftFraction: 0.95
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates location drafts and revisioned updates', () => {
+    expect(
+      createWorldLocationInputSchema.safeParse({
+        location: { displayName: 'Saltmarsh', notes: 'Harbour town' },
+        expectedRevision: 0
+      }).success
+    ).toBe(true)
+    expect(
+      updateWorldLocationInputSchema.safeParse({
+        id: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+        location: { displayName: ' ', notes: '', copiedMap: true },
+        expectedRevision: 1
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates weighted tables and bounded faction inventory', () => {
+    expect(
+      createEncounterTableInputSchema.safeParse({
+        expectedRevision: 0,
+        table: {
+          displayName: 'Harbour Patrol',
+          description: '',
+          entries: [{ creatureId: 'guard', weight: 10 }]
+        }
+      }).success
+    ).toBe(true)
+    expect(
+      createEncounterTableInputSchema.safeParse({
+        expectedRevision: 0,
+        table: {
+          displayName: 'Broken',
+          description: '',
+          entries: [
+            { creatureId: 'guard', weight: 11 },
+            { creatureId: 'guard', weight: 1 }
+          ]
+        }
+      }).success
+    ).toBe(false)
+    expect(
+      createWorldFactionInputSchema.safeParse({
+        expectedRevision: 2,
+        faction: {
+          displayName: 'Watch',
+          notes: '',
+          disposition: -51,
+          primaryEncounterTableId: null,
+          inventory: [{ creatureId: 'guard', maximum: 1 }]
+        }
+      }).success
+    ).toBe(false)
+  })
+})

--- a/tests/unit/runtime-observation.test.ts
+++ b/tests/unit/runtime-observation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { runtimeObservationSchema } from '../../src/shared/qualification/runtime-observation.js'
+
+const samples = Array.from({ length: 100 }, () => 1)
+
+describe('runtime qualification observation', () => {
+  it('requires complete timing populations and preserves raw GPU evidence', () => {
+    const observation = runtimeObservationSchema.parse({
+      captureKind: 'm1-runtime-observation',
+      formatVersion: 'm1-runtime-observation-v1',
+      recordedAt: '2026-07-30T00:00:00.000Z',
+      configuration: 'normal',
+      environment: {
+        userAgent: 'test',
+        displayWidth: 1366,
+        displayHeight: 768,
+        devicePixelRatio: 1,
+        gpu: {
+          operatingSystem: 'linux',
+          architecture: 'x64',
+          electronVersion: '43.2.0',
+          featureStatus: { webgl: 'enabled' },
+          activeGpuDevices: [
+            {
+              active: true,
+              deviceId: '1',
+              vendorId: '2',
+              deviceName: 'integrated',
+              vendorName: 'vendor',
+              driverVendor: 'driver',
+              driverVersion: '1'
+            }
+          ],
+          softwareRendering: false
+        },
+        webgl: {
+          pixi: { version: 'WebGL 2.0', renderer: 'integrated' },
+          babylon: { version: 'WebGL 2.0', renderer: 'integrated' }
+        }
+      },
+      populations: {
+        pixiPan: samples,
+        babylonCamera: samples,
+        babylonHoverPick: samples,
+        babylonVoxelPreview: samples
+      },
+      contextLoss: { pixi: recovery(), babylon: recovery() },
+      resources: null
+    })
+    expect(observation.environment.gpu.activeGpuDevices[0]?.driverVersion).toBe(
+      '1'
+    )
+  })
+
+  it('rejects partial populations', () => {
+    expect(() =>
+      runtimeObservationSchema.parse({
+        captureKind: 'm1-runtime-observation',
+        formatVersion: 'm1-runtime-observation-v1',
+        recordedAt: '2026-07-30T00:00:00.000Z',
+        configuration: 'normal',
+        environment: {
+          userAgent: 'test',
+          displayWidth: 1,
+          displayHeight: 1,
+          devicePixelRatio: 1,
+          gpu: {
+            operatingSystem: 'linux',
+            architecture: 'x64',
+            electronVersion: '43.2.0',
+            featureStatus: {},
+            activeGpuDevices: [],
+            softwareRendering: false
+          },
+          webgl: {
+            pixi: { version: 'WebGL 2.0', renderer: 'test' },
+            babylon: { version: 'WebGL 2.0', renderer: 'test' }
+          }
+        },
+        populations: {
+          pixiPan: [],
+          babylonCamera: samples,
+          babylonHoverPick: samples,
+          babylonVoxelPreview: samples
+        },
+        contextLoss: { pixi: recovery(), babylon: recovery() },
+        resources: null
+      })
+    ).toThrow()
+  })
+})
+
+function recovery() {
+  return {
+    requestedCycles: 0,
+    observedLossCycles: 0,
+    restoredCycles: 0,
+    rerenderedCycles: 0,
+    nextInteractionSucceededCycles: 0,
+    completedCycles: 0
+  }
+}

--- a/tests/unit/webgl-context.test.ts
+++ b/tests/unit/webgl-context.test.ts
@@ -65,9 +65,18 @@ describe('WebGL context-loss exercise', () => {
       nextInteractionSucceeded: true
     })
     expect(recovery.completedCycles).toBe(1)
+    expect(recovery.observation).toEqual({
+      requestedCycles: 1,
+      observedLossCycles: 1,
+      restoredCycles: 1,
+      rerenderedCycles: 1,
+      nextInteractionSucceededCycles: 1,
+      completedCycles: 1
+    })
 
     recovery.requested()
     expect(recovery.record.lossObserved).toBe(false)
     expect(recovery.completedCycles).toBe(1)
+    expect(recovery.observation.requestedCycles).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
- add the four-panel live session workspace with controls, details/map, scenarios, and groups
- add location, faction, and encounter-table catalog workflows
- integrate encounter tables and factions into scene group generation and balancing

## Validation
- pnpm check
- Playwright create and restart flows