### PR TITLE
feat: add hex map travel vertical slice

### DIFF
--- a/docs/hex/contract/contract-hex-persistence.md
+++ b/docs/hex/contract/contract-hex-persistence.md
@@ -25,7 +25,10 @@ Hex persistence MUST store:
 - maps, including stable id, display name, and radius
 - tiles, including owning map id and axial coordinate
 - terrain overrides keyed by map and tile coordinate
-- markers keyed by map and marker id, with exactly one owning tile coordinate
+- World Planner location placements keyed by foreign logical location ID, with
+  exactly one owning tile coordinate
+- Scene-scoped runtime journeys with route, checkpoint, status, participants,
+  presentation multiplier, and restart state
 
 ## Schema Semantics
 
@@ -54,36 +57,27 @@ Terrain override rows MUST be scoped to one map and one tile coordinate. The
 terrain value MUST use the Hex terrain vocabulary exposed by the Hex editor
 requirements.
 
-### Markers
+### Location Placements
 
-Marker rows MUST include:
+Placement rows store only World Planner location ID, owning map ID, and axial
+coordinate. Unique constraints enforce one placement per location and at most
+one placed location per tile. Cross-owner database foreign keys are forbidden;
+the application command coordinates deletion while each owner retains its SQL.
 
-- stable marker id inside the map
-- owning map id
-- owning tile coordinate `q,r`
-- nonblank name
-- marker type
-- optional note
+### Runtime Journeys
 
-Marker type MUST be one of:
-
-- `SETTLEMENT`
-- `LANDMARK`
-- `DANGER`
-- `RESOURCE`
-
-Each marker row MUST belong to exactly one owning tile. A marker note MAY be
-stored as absent, null, or blank according to the chosen adapter convention, but
-that absence MUST round-trip as "no note" and MUST NOT change marker identity.
+Journey rows are keyed by Scene ID and store map ID, expanded adjacent path,
+current checkpoint, participant IDs, status, presentation multiplier, and
+segment start. Compact `Reise` context remains derived and is not stored again.
 
 ## Validation And Error Behavior
 
 Owner startup readiness validates the feature-declared target schema signature; semantic row validation remains on typed provider read/write paths and fails closed through the feature contract.
 
-- Loading malformed marker type, blank marker name, invalid map radius, or
-  out-of-radius tile coordinates MUST fail visibly to the caller instead of
+- Loading an unknown terrain ID, invalid map radius, malformed route, or
+  out-of-radius tile coordinate MUST fail visibly to the caller instead of
   silently repairing stored truth.
-- Saving a map MUST preserve marker ownership and terrain overrides for tiles
+- Saving a map MUST preserve location ownership and terrain overrides for tiles
   that remain inside the map radius.
 - Shrinking a map radius MAY delete out-of-radius tile-owned data only after
   the editor behavior has surfaced the destructive warning owned by

--- a/docs/hex/domain/domain-hex-map.md
+++ b/docs/hex/domain/domain-hex-map.md
@@ -10,7 +10,7 @@ semantics, and architecture owns system boundaries.
 
 The Hex context owns authored overworld-style hex maps used by Hex editor and
 Hex runtime surfaces. A Hex map is an authored map root with metadata,
-hex tiles, terrain overrides, and simple tile-owned markers.
+hex tiles, terrain overrides, and logical placements of World Planner locations.
 
 The Hex context does not own Dungeon topology, party roster truth, encounter
 simulation, campaign clocks, weather rules, or generic map-canvas rendering
@@ -23,7 +23,11 @@ overworld travel readback when the party location points at a Hex map.
 - `HexTile` is the authored coordinate inside one map.
 - `HexTerrainOverride` records the authored terrain chosen for one tile when
   the tile differs from default generation or empty-map state.
-- `HexMarker` is a simple authored marker owned by one tile.
+- `HexLocationPlacement` links one foreign World Planner location identity to
+  exactly one tile without copying its name or notes.
+- `HexJourney` owns one Scene-scoped runtime route, checkpoint, status, and
+  presentation multiplier. Party continues to own character positions and
+  Scene owns in-world time.
 
 ## Domain Vocabulary
 
@@ -48,26 +52,17 @@ travel positions.
 
 ### Terrain
 
-Terrain is authored per tile only when the editor stores an override. The V1
-terrain vocabulary is the editor palette from
-`docs/hex/requirements/requirements-hex-editor.md`.
+Terrain is authored per tile only when the editor stores an override. Maps store
+stable terrain IDs. A typed read-only V1 catalog resolves label, color,
+passability, and travel cost; later Terrain Catalog CRUD can replace that
+provider without rewriting map rows.
 
-### Marker
+### World Planner Location Placement
 
-A Hex marker is a simple place marker. It has:
-
-- required stable marker identity inside its map
-- required nonblank name
-- required marker type
-- optional note
-- exactly one owning Hex tile
-
-The V1 marker types are:
-
-- `SETTLEMENT`
-- `LANDMARK`
-- `DANGER`
-- `RESOURCE`
+A placement stores one World Planner location ID plus one map-owned axial
+coordinate. The referenced name and notes are resolved through the World
+Planner boundary. One location may occur globally at most once and one tile may
+own at most one placement.
 
 ## Invariants
 
@@ -77,14 +72,11 @@ The V1 marker types are:
 - A Hex tile MUST reference an existing Hex map.
 - A Hex tile coordinate MUST be inside the owning map radius.
 - A terrain override MUST reference exactly one valid Hex tile.
-- A marker MUST reference exactly one valid Hex tile.
-- A marker name MUST be nonblank after editor validation.
-- A marker type MUST be one of `SETTLEMENT`, `LANDMARK`, `DANGER`, or
-  `RESOURCE`.
-- A marker note MAY be absent or blank without changing marker identity or tile
-  ownership.
-- Hex markers MUST NOT reuse Dungeon feature-marker kinds, topology refs, or
-  runtime travel state.
+- A placement MUST reference exactly one valid Hex tile and one World Planner
+  location identity.
+- map rows MUST NOT copy World Planner location display facts.
+- a journey route remains inside one map and advances only through adjacent,
+  currently passable Hexes.
 - Hex runtime readback MAY interpret party-owned overworld travel positions as
   Hex coordinates only through the Hex stable tile-id convention.
 

--- a/docs/hex/requirements/requirements-hex-editor.md
+++ b/docs/hex/requirements/requirements-hex-editor.md
@@ -3,8 +3,8 @@
 ## Goal
 
 Define the required editor workflow over committed hex-map truth so the user
-can manage maps, inspect tiles, paint terrain, and place simple authored
-markers without inventing a second map source of truth.
+can manage maps, inspect tiles, paint terrain, and place existing World Planner
+locations without inventing a second place or map source of truth.
 
 ## Non-Goals
 
@@ -18,13 +18,12 @@ markers without inventing a second map source of truth.
 
 - a shared shell catalog CRUD surface for selecting, creating, renaming, and
   reloading Hex maps
-- compact tool controls for at least `Auswahl`, terrain painting, marker
-  placement, and party-token movement
+- compact tool controls for `Auswahl` and terrain painting
 - main content as the shared hex map surface in editor mode
 - state content for selected map metadata, radius changes, active status,
   selected tile details, and marker editing
 - terrain palette for the active paint tool
-- marker placement controls for name, type, and optional note in the state pane
+- World Planner location placement launched from `Katalog → Orte`
 
 ## Visible States
 
@@ -32,8 +31,7 @@ markers without inventing a second map source of truth.
 - loaded editable hex map
 - selected tile with visible details
 - active terrain-paint mode
-- active marker-placement mode
-- selected marker with visible name, type, note when present, and owning tile
+- selected placed World Planner location with its resolved name
 - save or validation failure during map edits
 - destructive radius-change warning before data loss
 
@@ -53,14 +51,12 @@ markers without inventing a second map source of truth.
 - the editor MUST support a selection tool for tile inspection
 - the editor MUST support a terrain-paint tool
 - the active terrain type MUST be visible while painting
-- the editor MUST support placing a simple marker on one selected or clicked
-  tile
-- marker creation MUST require a nonblank name
-- marker creation MUST require one marker type from the supported marker type
-  vocabulary
-- marker note text MUST be optional
-- every marker MUST belong to exactly one owning hex tile
-- marker feedback MUST be visible on the owning tile after placement
+- `Katalog → Orte → Platzieren` MUST open a map chooser and Hex placement view
+- one World Planner location MUST be placed globally at most once and one Hex
+  MUST carry at most one World Planner location
+- moving a placement MUST retain the World Planner location identity
+- deleting the World Planner location MUST remove its placement atomically
+- placement feedback MUST be visible on the owning tile
 - tile inspection MUST surface visible details for at least position, terrain,
   elevation, biome, exploration state, and notes when those values are
   available
@@ -81,14 +77,10 @@ The editor terrain palette exposes these visible labels:
 - `Wüste`
 - `Sumpf`
 
-## Supported Marker Types
-
-The V1 marker vocabulary exposes these visible marker types:
-
-- `SETTLEMENT`
-- `LANDMARK`
-- `DANGER`
-- `RESOURCE`
+The static V1 terrain catalog also publishes display color, passability, and
+travel cost. Maps store stable terrain IDs. Editing terrain definitions through
+Catalog CRUD is deliberately deferred without making those values hard-coded
+map truth.
 
 ## Acceptance Criteria
 
@@ -96,10 +88,8 @@ The V1 marker vocabulary exposes these visible marker types:
   immediately see it as an editable radius-2 map.
 - The user can select a tile and inspect visible tile details.
 - The user can paint terrain and see the changed terrain on the map.
-- The user can place a named marker with a supported type on exactly one tile.
-- The user can add or omit a marker note without changing marker ownership.
-- Marker validation failure produces a visible error outcome when name or type
-  is missing.
+- The user can place, move, reveal, and remove an existing World Planner
+  location from its Catalog detail.
 - Destructive radius shrink requires an explicit warning before commit.
 - Save failure produces a visible error outcome.
 - The visible Hex map surface remains available below the controls because the

--- a/docs/hex/requirements/requirements-hex-travel-state.md
+++ b/docs/hex/requirements/requirements-hex-travel-state.md
@@ -18,6 +18,8 @@ Define the compact read-mostly travel-state surface shown in the runtime
 - one travel-status badge
 - a small key-value block for weather, time of day, and pace
 - one concise interaction or context hint
+- compact controls for opening the map, presentation speed, pause, resume, and
+  abort
 
 ## Required Behavior
 
@@ -32,7 +34,8 @@ Define the compact read-mostly travel-state surface shown in the runtime
   empty state
 - the surface MUST consume an approved Hex runtime readback and MUST NOT infer
   Hex travel context from editor-only map selection
-- movement commands MUST remain outside the compact state tab
+- route planning, administrative placement, and route start MUST remain in the
+  map; runtime pause/resume/abort and presentation speed remain in this tab
 - Hex MUST publish its compact context as typed readback for the feature-neutral
   Travel capability; Hex MUST NOT remain the permanent owner of the global
   `travel` shell contribution

--- a/docs/hex/requirements/requirements-hex-travel.md
+++ b/docs/hex/requirements/requirements-hex-travel.md
@@ -14,7 +14,7 @@ party-owned runtime position.
 
 ## Visible Structure
 
-- controls that include the `Reisegruppe` movement tool
+- controls for administrative Party placement and explicit route planning
 - main content as the shared `Hex-Karte` map surface
 - one visible party token on the active hex
 - compact travel context in the runtime `Reise` state tab, including location,
@@ -31,7 +31,15 @@ party-owned runtime position.
 
 - the travel surface MUST load a visible hex map and current party position
 - the surface MUST show the party token on the current tile when one exists
-- travel MUST support direct party-token movement across the hex map
+- route planning MUST accept ordered manual waypoints and expand every segment
+  into deterministic adjacent Hex steps
+- route start MUST be explicit and MUST reject out-of-map or impassable steps
+- the travelling group MUST be the focused Scene's assigned active PCs and use
+  the slowest movement speed; missing speed assumes 30 ft with a visible warning
+- every reached Hex checkpoint MUST commit Party position and Scene time
+  together
+- the default 3-mile rule uses `mph = Speed / 10`, current terrain cost, and
+  one real second per in-game hour at 1x presentation speed
 - the surface MUST communicate current location or context plus visible travel
   status
 - the surface MUST communicate visible overworld travel context such as
@@ -45,8 +53,9 @@ party-owned runtime position.
 ## Acceptance Criteria
 
 - A user can identify the current party tile on the map.
-- Using the `Reisegruppe` tool to choose a destination tile updates visible
-  travel context when the move resolves.
+- Starting a waypoint route advances the token through its visible path.
+- Pause, resume, abort, 1x/2x/5x/10x presentation speed, and paused restart
+  preserve in-world duration and the last committed Hex.
 - The travel surface stays focused on interactive map travel rather than
   adding movement commands to the compact runtime `Reise` state tab.
 - Missing location context is shown explicitly.

--- a/docs/hex/requirements/requirements-hex.md
+++ b/docs/hex/requirements/requirements-hex.md
@@ -9,6 +9,7 @@ Provide one hex-map workflow that lets a GM:
 - read compact Hex travel state through the feature-neutral global travel-state
   surface shown in the runtime `Reise` tab
 - edit map metadata and hex terrain without duplicating map truth
+- place existing World Planner locations once on a Hex map
 
 ## Non-Goals
 
@@ -36,8 +37,11 @@ Provide one hex-map workflow that lets a GM:
 
 1. The user opens the `Hex-Karte` surface.
 2. The party token is shown on the current tile.
-3. The user selects the `Reisegruppe` tool and clicks a destination hex.
-4. The visible party token and Hex travel readback update.
+3. The user selects `Reise planen` and clicks one or more waypoints.
+4. The map expands those points into one adjacent Hex path and previews its
+   duration.
+5. The user starts the journey explicitly. The visible party token, Scene time,
+   and Hex travel readback advance checkpoint by checkpoint.
 
 ### Read Compact Hex Travel State
 
@@ -60,7 +64,7 @@ Provide one hex-map workflow that lets a GM:
 - compact travel context for overworld travel
 - terrain paint workflow
 - map creation and metadata editing
-- simple tile-owned marker placement
+- placement of one existing World Planner location from `Katalog → Orte`
 - destructive shrink warning when radius changes would remove authored tile
   data
 
@@ -76,6 +80,10 @@ Provide one hex-map workflow that lets a GM:
   does not infer active travel from editor-only map selection.
 - Editing terrain or map metadata never requires the user to infer hidden map
   state from implementation details.
+- travel can be paused, resumed, or aborted and resumes paused at the last
+  committed Hex after restart
+- V1 terrain definitions are replaceable static catalog data; editable Terrain
+  catalog CRUD remains a later slice
 
 ## Open Product Questions
 

--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -127,6 +127,11 @@ claiming completion of M3 or M5. Its approved expansion contains:
 - Scene groups and Encounter Tables share one two-pane creature-collection
   manager component rather than parallel look-alike dialogs; faction stock is
   edited only from the selected table's creature membership
+- one campaign-local Hex vertical slice now connects a Pixi editor, static
+  catalog-backed terrain IDs, World Planner location placement, focused-Scene
+  Party position, waypoint route planning, durable checkpoints and Scene time,
+  and the Session Karte/Reise surfaces; editable Terrain catalog CRUD remains a
+  later slice
 
 Encounter-table, faction, and location filter controls appear only when their
 owning providers publish real options. NPC membership, loot links, and stock

--- a/docs/project/requirements/requirements-travel-state-tab.md
+++ b/docs/project/requirements/requirements-travel-state-tab.md
@@ -29,8 +29,9 @@ travel workspaces.
 - Selecting the runtime tab labeled `Reise` switches the global state pane
   from Encounter content to the selected travel context or explicit no-context
   state.
-- The live compact state-tab surface remains read-mostly. Travel movement and
-  editing commands belong in the owning interactive travel or editor surface.
+- The live compact surface may dispatch provider-neutral pause, resume, abort,
+  presentation-speed, and open-map actions. Route planning, positioning,
+  starting, and editing remain in the owning map or editor surface.
 
 ## Visible States
 
@@ -48,7 +49,8 @@ travel workspaces.
   the navigable Travel left-bar tab
 - selecting the runtime tab labeled `Reise` swaps the state pane from
   Encounter content to compact travel content
-- the no-context and live compact states remain command-free in this surface
+- the no-context state remains command-free apart from opening an available map;
+  live context exposes only the bounded runtime controls above
 - a feature-owned live travel context can appear only through an approved
   readback surface and without adding movement commands to this state tab
 - Dungeon and Hex MUST NOT register separate global `travel` contribution keys;

--- a/docs/session/requirements/requirements-live-session.md
+++ b/docs/session/requirements/requirements-live-session.md
@@ -47,8 +47,9 @@ discard confirmation.
 - The upper-right panel switches between Details and Karte. Details has a
   scene-local backward/forward history and renders creature statblocks inline;
   later described scene objects use the same history surface.
-- Karte is a provider-ready route-planning shell. It does not fabricate a map,
-  locations, or routes when Hex/Dungeon has not published a context.
+- Karte consumes the approved Hex provider. It shows the current token, supports
+  administrative placement, ordered waypoint planning, explicit start, and an
+  honest empty state when no map exists.
 - The control panel uses only its required height and the group panel receives
   the remaining left-column space. One shared vertical divider changes both
   left/right panel widths. A separate horizontal divider changes only the
@@ -58,8 +59,8 @@ discard confirmation.
 ## Combat Scenario
 
 1. The GM selects `Encounter` from the scenario dropdown. `Reise` is the other
-   current option and publishes a read-only no-context state until an approved
-   Dungeon or Hex readback exists.
+   current option and publishes no-context or approved Hex readback plus bounded
+   runtime controls.
 2. The GM selects one or more groups belonging to the focused Scene. The
    assigned Scene Party is always selected.
 3. Every selection change shows base XP, adjusted XP, Party thresholds and the

--- a/src/core/encounter/live-combat.ts
+++ b/src/core/encounter/live-combat.ts
@@ -1,4 +1,6 @@
 import Database from 'better-sqlite3'
+import { HexMapStore, initializeHexSchema } from '../hex/hex-map-store.js'
+import { HexTravelStore } from '../hex/hex-travel.js'
 import { z } from 'zod'
 import {
   combatSnapshotSchema,
@@ -495,19 +497,45 @@ export class LivePlayService {
   private snapshotFrom(
     party: PartyStore,
     scene: SceneStore,
-    combat: CombatStore
+    combat: CombatStore,
+    hexTravel?: HexTravelStore
   ): LiveSessionSnapshot {
+    const travel = (
+      hexTravel ??
+      new HexTravelStore(
+        scene.database(),
+        new HexMapStore(scene.database()),
+        party,
+        scene
+      )
+    ).read(scene.focusedSceneId())
     const partySnapshot = party.read()
     const sceneSnapshot = scene.snapshot(partySnapshot.members)
     return liveSessionSnapshotSchema.parse({
       revision: sceneSnapshot.revision,
       party: partySnapshot,
       scene: sceneSnapshot,
-      travel: {
-        kind: 'none',
-        label: 'Kein aktiver Reisekontext',
-        hint: 'Dungeon oder Hex stellen derzeit keinen Live-Kontext bereit.'
-      },
+      travel: travel?.mapId
+        ? {
+            kind: 'hex',
+            status: travel.status,
+            mapId: travel.mapId,
+            mapName: travel.mapName,
+            currentLabel: travel.currentLabel,
+            locationName: travel.locationName,
+            progress: travel.progress,
+            remainingGameSeconds: travel.remainingGameSeconds,
+            gameTimeSeconds: travel.gameTimeSeconds,
+            effectiveSpeedFeet: travel.effectiveSpeedFeet,
+            assumedSpeedMemberNames: travel.assumedSpeedMemberNames,
+            multiplier: travel.multiplier,
+            hint: travel.hint
+          }
+        : {
+            kind: 'none',
+            label: 'Kein aktiver Reisekontext',
+            hint: 'Dungeon oder Hex stellen derzeit keinen Live-Kontext bereit.'
+          },
       combat: combat.snapshot(scene.assignedParty(partySnapshot.members))
     })
   }
@@ -529,11 +557,13 @@ export class LivePlayService {
       initializeCombatSchema(db)
       initializeWorldLocationSchema(db)
       initializeEncounterSourceSchema(db)
+      initializeHexSchema(db)
       const locations = new WorldLocationStore(db)
       const scene = new SceneStore(db, () => locations.read().locations)
       const combatFor = (sceneId: string) => new CombatStore(db, sceneId)
+      const party = new PartyStore(db)
       return work({
-        party: new PartyStore(db),
+        party,
         scene,
         combat: combatFor(scene.focusedSceneId()),
         combatFor,

--- a/src/core/hex/hex-map-store.ts
+++ b/src/core/hex/hex-map-store.ts
@@ -1,0 +1,411 @@
+import Database from 'better-sqlite3'
+import { z } from 'zod'
+import {
+  axialCoordinateSchema,
+  createHexMapInputSchema,
+  hexMapCatalogSnapshotSchema,
+  hexMapSnapshotSchema,
+  hexMapSummarySchema,
+  hexTerrainIdSchema,
+  paintHexTerrainInputSchema,
+  placeHexLocationInputSchema,
+  removeHexLocationInputSchema,
+  updateHexMapInputSchema,
+  type AxialCoordinate,
+  type HexMapCatalogSnapshot,
+  type HexMapSnapshot
+} from '../../shared/contracts/hex.js'
+import { uuidv7 } from '../../shared/ids/uuidv7.js'
+import { initializeWorldLocationSchema } from '../worldplanner/location-store.js'
+import { initializePartySchema } from '../party/party-store.js'
+
+export function initializeHexSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS hex_metadata (
+      singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+      revision INTEGER NOT NULL CHECK(revision >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS hex_map (
+      id TEXT PRIMARY KEY NOT NULL,
+      display_name TEXT NOT NULL,
+      radius INTEGER NOT NULL CHECK(radius BETWEEN 0 AND 99),
+      revision INTEGER NOT NULL CHECK(revision >= 0),
+      position INTEGER NOT NULL CHECK(position >= 0)
+    );
+    CREATE TABLE IF NOT EXISTS hex_terrain (
+      map_id TEXT NOT NULL REFERENCES hex_map(id) ON DELETE CASCADE,
+      q INTEGER NOT NULL,
+      r INTEGER NOT NULL,
+      terrain_id TEXT NOT NULL,
+      PRIMARY KEY(map_id, q, r)
+    );
+    CREATE TABLE IF NOT EXISTS hex_location_placement (
+      location_id TEXT PRIMARY KEY NOT NULL,
+      map_id TEXT NOT NULL REFERENCES hex_map(id) ON DELETE CASCADE,
+      q INTEGER NOT NULL,
+      r INTEGER NOT NULL,
+      UNIQUE(map_id, q, r)
+    );
+    CREATE TABLE IF NOT EXISTS hex_journey (
+      scene_id TEXT PRIMARY KEY NOT NULL,
+      revision INTEGER NOT NULL CHECK(revision >= 0),
+      map_id TEXT NOT NULL REFERENCES hex_map(id) ON DELETE CASCADE,
+      status TEXT NOT NULL,
+      path_json TEXT NOT NULL,
+      current_index INTEGER NOT NULL CHECK(current_index >= 0),
+      party_member_ids_json TEXT NOT NULL,
+      multiplier INTEGER NOT NULL CHECK(multiplier IN (1, 2, 5, 10)),
+      segment_started_at INTEGER,
+      hint TEXT NOT NULL
+    );
+  `)
+  db.prepare(
+    'INSERT OR IGNORE INTO hex_metadata (singleton, revision) VALUES (1, 0)'
+  ).run()
+}
+
+export function tileId(coordinate: AxialCoordinate): string {
+  return `${coordinate.q}:${coordinate.r}`
+}
+
+export function parseTileId(value: string): AxialCoordinate | null {
+  const match = /^(-?\d+):(-?\d+)$/.exec(value)
+  if (!match) return null
+  return axialCoordinateSchema.parse({
+    q: Number(match[1]),
+    r: Number(match[2])
+  })
+}
+
+export function tileLabel(coordinate: AxialCoordinate): string {
+  return `Hex q=${coordinate.q}, r=${coordinate.r}`
+}
+
+export function insideRadius(coordinate: AxialCoordinate, radius: number) {
+  return (
+    Math.max(
+      Math.abs(coordinate.q),
+      Math.abs(coordinate.r),
+      Math.abs(-coordinate.q - coordinate.r)
+    ) <= radius
+  )
+}
+
+export function coordinates(radius: number): readonly AxialCoordinate[] {
+  const result: AxialCoordinate[] = []
+  for (let q = -radius; q <= radius; q += 1) {
+    const minR = Math.max(-radius, -q - radius)
+    const maxR = Math.min(radius, -q + radius)
+    for (let r = minR; r <= maxR; r += 1)
+      result.push({ q: Object.is(q, -0) ? 0 : q, r: Object.is(r, -0) ? 0 : r })
+  }
+  return result
+}
+
+export class HexMapService {
+  constructor(private readonly campaignPath: () => string) {}
+
+  catalog(): HexMapCatalogSnapshot {
+    return this.withStore((store) => store.catalog())
+  }
+
+  read(mapId: string): HexMapSnapshot {
+    return this.withStore((store) => store.read(mapId))
+  }
+
+  create(displayName: string, expectedCatalogRevision: number) {
+    const input = createHexMapInputSchema.parse({
+      displayName,
+      expectedCatalogRevision
+    })
+    return this.withStore((store) => store.create(input))
+  }
+
+  update(input: unknown) {
+    const parsed = updateHexMapInputSchema.parse(input)
+    return this.withStore((store) => store.update(parsed))
+  }
+
+  paint(input: unknown) {
+    const parsed = paintHexTerrainInputSchema.parse(input)
+    return this.withStore((store) => store.paint(parsed))
+  }
+
+  placeLocation(input: unknown) {
+    const parsed = placeHexLocationInputSchema.parse(input)
+    return this.withStore((store) => store.placeLocation(parsed))
+  }
+
+  removeLocation(input: unknown) {
+    const parsed = removeHexLocationInputSchema.parse(input)
+    return this.withStore((store) => store.removeLocation(parsed))
+  }
+
+  private withStore<T>(work: (store: HexMapStore) => T): T {
+    const db = new Database(this.campaignPath())
+    db.pragma('foreign_keys = ON')
+    try {
+      initializeHexSchema(db)
+      initializeWorldLocationSchema(db)
+      initializePartySchema(db)
+      return work(new HexMapStore(db))
+    } finally {
+      db.close()
+    }
+  }
+}
+
+export class HexMapStore {
+  constructor(private readonly db: Database.Database) {}
+
+  catalog(): HexMapCatalogSnapshot {
+    const revision = (
+      this.db
+        .prepare('SELECT revision FROM hex_metadata WHERE singleton = 1')
+        .get() as { revision: number }
+    ).revision
+    const maps = this.db
+      .prepare(
+        'SELECT id, display_name AS displayName, radius, revision, position FROM hex_map ORDER BY position, id'
+      )
+      .all()
+    return hexMapCatalogSnapshotSchema.parse({ revision, maps })
+  }
+
+  read(mapId: string): HexMapSnapshot {
+    const map = this.map(mapId)
+    const terrainRows = this.db
+      .prepare(
+        'SELECT q, r, terrain_id AS terrainId FROM hex_terrain WHERE map_id = ?'
+      )
+      .all(mapId) as Array<{ q: number; r: number; terrainId: string }>
+    const terrain = new Map(
+      terrainRows.map((row) => [
+        tileId(row),
+        hexTerrainIdSchema.parse(row.terrainId)
+      ])
+    )
+    const placementRows = this.db
+      .prepare(
+        `SELECT p.location_id AS locationId, p.q, p.r,
+                l.display_name AS displayName
+         FROM hex_location_placement p
+         LEFT JOIN worldplanner_location l ON l.id = p.location_id
+         WHERE p.map_id = ?`
+      )
+      .all(mapId) as Array<{
+      locationId: string
+      q: number
+      r: number
+      displayName: string | null
+    }>
+    const placements = new Map(placementRows.map((row) => [tileId(row), row]))
+    return hexMapSnapshotSchema.parse({
+      map,
+      tiles: coordinates(map.radius).map((coordinate) => {
+        const placement = placements.get(tileId(coordinate))
+        return {
+          ...coordinate,
+          id: tileId(coordinate),
+          label: tileLabel(coordinate),
+          terrainId: terrain.get(tileId(coordinate)) ?? 'grassland',
+          location: placement
+            ? {
+                locationId: placement.locationId,
+                displayName: placement.displayName ?? 'Nicht verfügbarer Ort',
+                q: placement.q,
+                r: placement.r
+              }
+            : null
+        }
+      })
+    })
+  }
+
+  create(input: z.infer<typeof createHexMapInputSchema>) {
+    return this.db.transaction(() => {
+      this.assertCatalogRevision(input.expectedCatalogRevision)
+      const position = (
+        this.db
+          .prepare(
+            'SELECT COALESCE(MAX(position), -1) + 1 AS value FROM hex_map'
+          )
+          .get() as { value: number }
+      ).value
+      const id = uuidv7()
+      this.db
+        .prepare(
+          'INSERT INTO hex_map (id, display_name, radius, revision, position) VALUES (?, ?, 2, 0, ?)'
+        )
+        .run(id, input.displayName, position)
+      this.bumpCatalog()
+      return this.read(id)
+    })()
+  }
+
+  update(input: z.infer<typeof updateHexMapInputSchema>) {
+    return this.db.transaction(() => {
+      const current = this.map(input.mapId)
+      if (current.revision !== input.expectedRevision) throw new Error('stale')
+      if (input.radius < current.radius) {
+        const authored = this.db
+          .prepare(
+            `SELECT 1 FROM (
+              SELECT q, r FROM hex_terrain WHERE map_id = ?
+              UNION ALL
+              SELECT q, r FROM hex_location_placement WHERE map_id = ?
+            ) WHERE max(abs(q), abs(r), abs(-q-r)) > ? LIMIT 1`
+          )
+          .get(input.mapId, input.mapId, input.radius)
+        if (authored && !input.confirmDataLoss)
+          throw new Error('confirmation required')
+        const occupied = this.db
+          .prepare(
+            `SELECT 1 FROM player_characters
+             WHERE travel_map_id = ? AND attached_to_party_token = 1
+               AND max(abs(CAST(substr(travel_tile_id, 1, instr(travel_tile_id, ':') - 1) AS INTEGER)),
+                       abs(CAST(substr(travel_tile_id, instr(travel_tile_id, ':') + 1) AS INTEGER)),
+                       abs(-CAST(substr(travel_tile_id, 1, instr(travel_tile_id, ':') - 1) AS INTEGER)
+                           -CAST(substr(travel_tile_id, instr(travel_tile_id, ':') + 1) AS INTEGER))) > ?
+             LIMIT 1`
+          )
+          .get(input.mapId, input.radius)
+        if (occupied) throw new Error('party outside radius')
+        this.db
+          .prepare(
+            'DELETE FROM hex_terrain WHERE map_id = ? AND max(abs(q), abs(r), abs(-q-r)) > ?'
+          )
+          .run(input.mapId, input.radius)
+        this.db
+          .prepare(
+            'DELETE FROM hex_location_placement WHERE map_id = ? AND max(abs(q), abs(r), abs(-q-r)) > ?'
+          )
+          .run(input.mapId, input.radius)
+      }
+      this.db
+        .prepare(
+          'UPDATE hex_map SET display_name = ?, radius = ?, revision = revision + 1 WHERE id = ?'
+        )
+        .run(input.displayName, input.radius, input.mapId)
+      this.bumpCatalog()
+      return this.read(input.mapId)
+    })()
+  }
+
+  paint(input: z.infer<typeof paintHexTerrainInputSchema>) {
+    return this.db.transaction(() => {
+      this.assertMapCoordinate(
+        input.mapId,
+        input.coordinate,
+        input.expectedRevision
+      )
+      if (input.terrainId === 'grassland')
+        this.db
+          .prepare(
+            'DELETE FROM hex_terrain WHERE map_id = ? AND q = ? AND r = ?'
+          )
+          .run(input.mapId, input.coordinate.q, input.coordinate.r)
+      else
+        this.db
+          .prepare(
+            `INSERT INTO hex_terrain (map_id, q, r, terrain_id) VALUES (?, ?, ?, ?)
+             ON CONFLICT(map_id, q, r) DO UPDATE SET terrain_id = excluded.terrain_id`
+          )
+          .run(
+            input.mapId,
+            input.coordinate.q,
+            input.coordinate.r,
+            input.terrainId
+          )
+      this.bumpMap(input.mapId)
+      return this.read(input.mapId)
+    })()
+  }
+
+  placeLocation(input: z.infer<typeof placeHexLocationInputSchema>) {
+    return this.db.transaction(() => {
+      this.assertMapCoordinate(
+        input.mapId,
+        input.coordinate,
+        input.expectedRevision
+      )
+      const exists = this.db
+        .prepare('SELECT 1 FROM worldplanner_location WHERE id = ?')
+        .get(input.locationId)
+      if (!exists) throw new Error('not found')
+      this.db
+        .prepare('DELETE FROM hex_location_placement WHERE location_id = ?')
+        .run(input.locationId)
+      this.db
+        .prepare(
+          'INSERT INTO hex_location_placement (location_id, map_id, q, r) VALUES (?, ?, ?, ?)'
+        )
+        .run(
+          input.locationId,
+          input.mapId,
+          input.coordinate.q,
+          input.coordinate.r
+        )
+      this.bumpMap(input.mapId)
+      return this.read(input.mapId)
+    })()
+  }
+
+  removeLocation(input: z.infer<typeof removeHexLocationInputSchema>) {
+    return this.db.transaction(() => {
+      const placement = this.db
+        .prepare(
+          'SELECT map_id AS mapId FROM hex_location_placement WHERE location_id = ?'
+        )
+        .get(input.locationId) as { mapId: string } | undefined
+      if (!placement) throw new Error('not found')
+      const map = this.map(placement.mapId)
+      if (map.revision !== input.expectedMapRevision) throw new Error('stale')
+      this.db
+        .prepare('DELETE FROM hex_location_placement WHERE location_id = ?')
+        .run(input.locationId)
+      this.bumpMap(placement.mapId)
+      return this.read(placement.mapId)
+    })()
+  }
+
+  private map(id: string): z.infer<typeof hexMapSummarySchema> {
+    const row = this.db
+      .prepare(
+        'SELECT id, display_name AS displayName, radius, revision, position FROM hex_map WHERE id = ?'
+      )
+      .get(id)
+    if (!row) throw new Error('not found')
+    return hexMapSummarySchema.parse(row)
+  }
+
+  private assertMapCoordinate(
+    mapId: string,
+    coordinate: AxialCoordinate,
+    expectedRevision: number
+  ) {
+    const map = this.map(mapId)
+    if (map.revision !== expectedRevision) throw new Error('stale')
+    if (!insideRadius(coordinate, map.radius))
+      throw new Error('validation failed')
+  }
+
+  private assertCatalogRevision(expected: number) {
+    if (this.catalog().revision !== expected) throw new Error('stale')
+  }
+
+  private bumpMap(mapId: string) {
+    this.db
+      .prepare('UPDATE hex_map SET revision = revision + 1 WHERE id = ?')
+      .run(mapId)
+    this.bumpCatalog()
+  }
+
+  private bumpCatalog() {
+    this.db
+      .prepare(
+        'UPDATE hex_metadata SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
+  }
+}

--- a/src/core/hex/hex-travel.ts
+++ b/src/core/hex/hex-travel.ts
@@ -1,0 +1,648 @@
+import Database from 'better-sqlite3'
+import { z } from 'zod'
+import {
+  axialCoordinateSchema,
+  evaluateHexRouteInputSchema,
+  hexRouteEvaluationSchema,
+  hexTravelSnapshotSchema,
+  mutateHexTravelInputSchema,
+  positionHexPartyInputSchema,
+  setHexTravelMultiplierInputSchema,
+  startHexTravelInputSchema,
+  type AxialCoordinate,
+  type HexRouteEvaluation,
+  type HexTravelSnapshot
+} from '../../shared/contracts/hex.js'
+import { initializePartySchema, PartyStore } from '../party/party-store.js'
+import { initializeSceneSchema, SceneStore } from '../scene/scene-store.js'
+import {
+  initializeWorldLocationSchema,
+  WorldLocationStore
+} from '../worldplanner/location-store.js'
+import {
+  HexMapStore,
+  initializeHexSchema,
+  insideRadius,
+  parseTileId,
+  tileId,
+  tileLabel
+} from './hex-map-store.js'
+import { terrainDefinition } from './terrain-catalog.js'
+
+const hexDistanceMiles = 3
+const speedToMphDivisor = 10
+
+type JourneyStatus =
+  'travelling' | 'paused' | 'blocked' | 'completed' | 'aborted'
+
+interface JourneyRow {
+  sceneId: string
+  revision: number
+  mapId: string
+  status: JourneyStatus
+  pathJson: string
+  currentIndex: number
+  partyMemberIdsJson: string
+  multiplier: 1 | 2 | 5 | 10
+  segmentStartedAt: number | null
+  hint: string
+}
+
+export function axialDistance(a: AxialCoordinate, b: AxialCoordinate): number {
+  return Math.max(
+    Math.abs(a.q - b.q),
+    Math.abs(a.r - b.r),
+    Math.abs(-a.q - a.r + b.q + b.r)
+  )
+}
+
+const neighbors: readonly AxialCoordinate[] = [
+  { q: 1, r: 0 },
+  { q: 1, r: -1 },
+  { q: 0, r: -1 },
+  { q: -1, r: 0 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 }
+]
+
+export function axialLine(
+  start: AxialCoordinate,
+  destination: AxialCoordinate
+): readonly AxialCoordinate[] {
+  const result: AxialCoordinate[] = [{ ...start }]
+  let current = start
+  while (axialDistance(current, destination) > 0) {
+    const next = neighbors
+      .map((delta, order) => ({
+        q: current.q + delta.q,
+        r: current.r + delta.r,
+        order
+      }))
+      .sort(
+        (left, right) =>
+          axialDistance(left, destination) -
+            axialDistance(right, destination) || left.order - right.order
+      )[0]!
+    current = { q: next.q, r: next.r }
+    result.push(current)
+  }
+  return result
+}
+
+export function expandWaypoints(
+  start: AxialCoordinate,
+  waypoints: readonly AxialCoordinate[]
+): readonly AxialCoordinate[] {
+  const path: AxialCoordinate[] = [{ ...start }]
+  for (const waypoint of waypoints) {
+    const segment = axialLine(path[path.length - 1]!, waypoint)
+    path.push(...segment.slice(1))
+  }
+  return path
+}
+
+export function travelGameSeconds(speedFeet: number, cost: number): number {
+  if (speedFeet <= 0) return 0
+  const mph = speedFeet / speedToMphDivisor
+  return Math.round((hexDistanceMiles / mph) * 3600 * cost)
+}
+
+export class HexTravelService {
+  private readonly prepared = new Set<string>()
+
+  constructor(
+    private readonly campaignPath: () => string,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  read(sceneId?: string): HexTravelSnapshot {
+    return this.withStore((store) => store.read(sceneId))
+  }
+
+  evaluate(input: unknown): HexRouteEvaluation {
+    const parsed = evaluateHexRouteInputSchema.parse(input)
+    return this.withStore((store) => store.evaluate(parsed))
+  }
+
+  position(input: unknown): HexTravelSnapshot {
+    const parsed = positionHexPartyInputSchema.parse(input)
+    return this.withStore((store) => store.position(parsed))
+  }
+
+  start(input: unknown): HexTravelSnapshot {
+    const parsed = startHexTravelInputSchema.parse(input)
+    return this.withStore((store) => store.start(parsed))
+  }
+
+  pause(input: unknown): HexTravelSnapshot {
+    const parsed = mutateHexTravelInputSchema.parse(input)
+    return this.withStore((store) => store.pause(parsed))
+  }
+
+  resume(input: unknown): HexTravelSnapshot {
+    const parsed = mutateHexTravelInputSchema.parse(input)
+    return this.withStore((store) => store.resume(parsed))
+  }
+
+  abort(input: unknown): HexTravelSnapshot {
+    const parsed = mutateHexTravelInputSchema.parse(input)
+    return this.withStore((store) => store.abort(parsed))
+  }
+
+  setMultiplier(input: unknown): HexTravelSnapshot {
+    const parsed = setHexTravelMultiplierInputSchema.parse(input)
+    return this.withStore((store) => store.setMultiplier(parsed))
+  }
+
+  private withStore<T>(work: (store: HexTravelStore) => T): T {
+    const path = this.campaignPath()
+    const db = new Database(path)
+    db.pragma('foreign_keys = ON')
+    try {
+      initializePartySchema(db)
+      initializeWorldLocationSchema(db)
+      initializeSceneSchema(db)
+      initializeHexSchema(db)
+      if (!this.prepared.has(path)) {
+        db.prepare(
+          `UPDATE hex_journey SET status = 'paused', segment_started_at = NULL,
+           revision = revision + 1, hint = 'Nach dem Neustart pausiert.'
+           WHERE status = 'travelling'`
+        ).run()
+        this.prepared.add(path)
+      }
+      const locations = new WorldLocationStore(db)
+      return work(
+        new HexTravelStore(
+          db,
+          new HexMapStore(db),
+          new PartyStore(db),
+          new SceneStore(db, () => locations.read().locations),
+          this.now
+        )
+      )
+    } finally {
+      db.close()
+    }
+  }
+}
+
+export class HexTravelStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly maps: HexMapStore,
+    private readonly party: PartyStore,
+    private readonly scenes: SceneStore,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  read(requestedSceneId?: string): HexTravelSnapshot {
+    const sceneId = requestedSceneId ?? this.scenes.focusedSceneId()
+    const journey = this.journey(sceneId)
+    if (journey?.status === 'travelling') this.advance(journey)
+    return this.snapshot(sceneId, this.journey(sceneId))
+  }
+
+  evaluate(input: z.infer<typeof evaluateHexRouteInputSchema>) {
+    this.requireScene(input.sceneId)
+    const result = this.route(input.sceneId, input.mapId, input.waypoints)
+    return hexRouteEvaluationSchema.parse(result)
+  }
+
+  position(input: z.infer<typeof positionHexPartyInputSchema>) {
+    if (this.scenes.revision() !== input.expectedSceneRevision)
+      throw new Error('stale')
+    const map = this.maps.read(input.mapId).map
+    if (!insideRadius(input.coordinate, map.radius))
+      throw new Error('validation')
+    const ids = this.scenes.partyMemberIds(input.sceneId)
+    if (ids.length === 0) throw new Error('validation')
+    this.db.transaction(() => {
+      this.party.setTravelPosition(ids, input.mapId, tileId(input.coordinate))
+      this.setSceneLocation(input.sceneId, input.mapId, input.coordinate, 0)
+      this.db
+        .prepare('DELETE FROM hex_journey WHERE scene_id = ?')
+        .run(input.sceneId)
+    })()
+    return this.snapshot(input.sceneId, null)
+  }
+
+  start(input: z.infer<typeof startHexTravelInputSchema>) {
+    const current = this.journey(input.sceneId)
+    if ((current?.revision ?? 0) !== input.expectedRevision)
+      throw new Error('stale')
+    const evaluation = this.route(input.sceneId, input.mapId, input.waypoints)
+    if (!evaluation.canStart) throw new Error(evaluation.message)
+    const partyMemberIds = this.scenes.partyMemberIds(input.sceneId)
+    const status: JourneyStatus =
+      evaluation.path.length <= 1 ? 'completed' : 'travelling'
+    this.db.transaction(() => {
+      this.party.setTravelPosition(
+        partyMemberIds,
+        input.mapId,
+        tileId(evaluation.path[0]!)
+      )
+      this.setSceneLocation(input.sceneId, input.mapId, evaluation.path[0]!, 0)
+      this.db
+        .prepare(
+          `INSERT INTO hex_journey (
+             scene_id, revision, map_id, status, path_json, current_index,
+             party_member_ids_json, multiplier, segment_started_at, hint
+           ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+           ON CONFLICT(scene_id) DO UPDATE SET
+             revision = excluded.revision, map_id = excluded.map_id,
+             status = excluded.status, path_json = excluded.path_json,
+             current_index = 0,
+             party_member_ids_json = excluded.party_member_ids_json,
+             multiplier = excluded.multiplier,
+             segment_started_at = excluded.segment_started_at,
+             hint = excluded.hint`
+        )
+        .run(
+          input.sceneId,
+          (current?.revision ?? -1) + 1,
+          input.mapId,
+          status,
+          JSON.stringify(evaluation.path),
+          JSON.stringify(partyMemberIds),
+          input.multiplier,
+          status === 'travelling' ? this.now() : null,
+          status === 'travelling' ? 'Reise läuft.' : 'Ziel erreicht.'
+        )
+    })()
+    return this.snapshot(input.sceneId, this.journey(input.sceneId))
+  }
+
+  pause(input: z.infer<typeof mutateHexTravelInputSchema>) {
+    return this.mutate(input, 'paused', 'Reise pausiert.')
+  }
+
+  resume(input: z.infer<typeof mutateHexTravelInputSchema>) {
+    const journey = this.requireJourney(input.sceneId, input.expectedRevision)
+    const path = this.path(journey)
+    if (journey.currentIndex >= path.length - 1) throw new Error('validation')
+    const currentMembers = this.scenes.partyMemberIds(input.sceneId)
+    this.db
+      .prepare(
+        `UPDATE hex_journey SET status = 'travelling', revision = revision + 1,
+         party_member_ids_json = ?, segment_started_at = ?, hint = 'Reise läuft.'
+         WHERE scene_id = ?`
+      )
+      .run(JSON.stringify(currentMembers), this.now(), input.sceneId)
+    return this.snapshot(input.sceneId, this.journey(input.sceneId))
+  }
+
+  abort(input: z.infer<typeof mutateHexTravelInputSchema>) {
+    return this.mutate(input, 'aborted', 'Reise abgebrochen.')
+  }
+
+  setMultiplier(input: z.infer<typeof setHexTravelMultiplierInputSchema>) {
+    this.requireJourney(input.sceneId, input.expectedRevision)
+    this.db
+      .prepare(
+        `UPDATE hex_journey SET multiplier = ?, revision = revision + 1,
+         segment_started_at = CASE WHEN status = 'travelling' THEN ? ELSE segment_started_at END
+         WHERE scene_id = ?`
+      )
+      .run(input.multiplier, this.now(), input.sceneId)
+    return this.snapshot(input.sceneId, this.journey(input.sceneId))
+  }
+
+  private mutate(
+    input: z.infer<typeof mutateHexTravelInputSchema>,
+    status: JourneyStatus,
+    hint: string
+  ) {
+    this.requireJourney(input.sceneId, input.expectedRevision)
+    this.db
+      .prepare(
+        'UPDATE hex_journey SET status = ?, revision = revision + 1, segment_started_at = NULL, hint = ? WHERE scene_id = ?'
+      )
+      .run(status, hint, input.sceneId)
+    return this.snapshot(input.sceneId, this.journey(input.sceneId))
+  }
+
+  private route(
+    sceneId: string,
+    mapId: string,
+    waypoints: readonly AxialCoordinate[]
+  ): z.infer<typeof hexRouteEvaluationSchema> {
+    const map = this.maps.read(mapId)
+    const position = this.scenePosition(sceneId, mapId)
+    const speed = this.speed(sceneId)
+    if (!position)
+      return {
+        canStart: false,
+        message: 'Party zuerst auf der Karte platzieren.',
+        path: [],
+        totalGameSeconds: 0,
+        ...speed
+      }
+    if (waypoints.length === 0)
+      return {
+        canStart: false,
+        message: 'Mindestens ein Reiseziel wählen.',
+        path: [position],
+        totalGameSeconds: 0,
+        ...speed
+      }
+    const path = expandWaypoints(position, waypoints)
+    if (path.some((coordinate) => !insideRadius(coordinate, map.map.radius)))
+      return {
+        canStart: false,
+        message: 'Die Route verlässt die Karte.',
+        path: [...path],
+        totalGameSeconds: 0,
+        ...speed
+      }
+    if (speed.effectiveSpeedFeet <= 0)
+      return {
+        canStart: false,
+        message: 'Die Reisegruppe besitzt keine positive Bewegungsrate.',
+        path: [...path],
+        totalGameSeconds: 0,
+        ...speed
+      }
+    const tiles = new Map(map.tiles.map((tile) => [tile.id, tile]))
+    let totalGameSeconds = 0
+    for (const coordinate of path.slice(1)) {
+      const terrain = terrainDefinition(
+        tiles.get(tileId(coordinate))!.terrainId
+      )
+      if (!terrain.passable)
+        return {
+          canStart: false,
+          message: `${tileLabel(coordinate)} ist unpassierbar.`,
+          path: [...path],
+          totalGameSeconds: 0,
+          ...speed
+        }
+      totalGameSeconds += travelGameSeconds(
+        speed.effectiveSpeedFeet,
+        terrain.travelCost
+      )
+    }
+    return {
+      canStart: path.length > 1,
+      message:
+        path.length > 1 ? 'Route bereit.' : 'Das Ziel entspricht dem Start.',
+      path: [...path],
+      totalGameSeconds,
+      ...speed
+    }
+  }
+
+  private advance(journey: JourneyRow): void {
+    const storedMembers = this.memberIds(journey)
+    const currentMembers = this.scenes.partyMemberIds(journey.sceneId)
+    if (JSON.stringify(storedMembers) !== JSON.stringify(currentMembers)) {
+      this.db
+        .prepare(
+          `UPDATE hex_journey SET status = 'paused', revision = revision + 1,
+           segment_started_at = NULL, hint = 'Reisegruppe geändert; Fortsetzung bestätigen.'
+           WHERE scene_id = ?`
+        )
+        .run(journey.sceneId)
+      return
+    }
+    const path = this.path(journey)
+    let index = journey.currentIndex
+    let startedAt = journey.segmentStartedAt ?? this.now()
+    const map = this.maps.read(journey.mapId)
+    const tiles = new Map(map.tiles.map((tile) => [tile.id, tile]))
+    const speed = this.speed(journey.sceneId).effectiveSpeedFeet
+    while (index < path.length - 1) {
+      const next = path[index + 1]!
+      const terrain = terrainDefinition(tiles.get(tileId(next))!.terrainId)
+      if (!terrain.passable || speed <= 0) {
+        this.db
+          .prepare(
+            `UPDATE hex_journey SET status = 'blocked', revision = revision + 1,
+             segment_started_at = NULL, hint = ? WHERE scene_id = ?`
+          )
+          .run(
+            !terrain.passable
+              ? `${tileLabel(next)} ist nicht mehr passierbar.`
+              : 'Die Reisegruppe besitzt keine positive Bewegungsrate.',
+            journey.sceneId
+          )
+        return
+      }
+      const gameSeconds = travelGameSeconds(speed, terrain.travelCost)
+      const realMilliseconds = (gameSeconds * 1000) / 3600 / journey.multiplier
+      if (this.now() - startedAt < realMilliseconds) break
+      index += 1
+      startedAt += realMilliseconds
+      this.db.transaction(() => {
+        this.party.setTravelPosition(storedMembers, journey.mapId, tileId(next))
+        this.setSceneLocation(journey.sceneId, journey.mapId, next, gameSeconds)
+        const complete = index >= path.length - 1
+        this.db
+          .prepare(
+            `UPDATE hex_journey SET current_index = ?, revision = revision + 1,
+             status = ?, segment_started_at = ?, hint = ? WHERE scene_id = ?`
+          )
+          .run(
+            index,
+            complete ? 'completed' : 'travelling',
+            complete ? null : Math.round(startedAt),
+            complete ? 'Ziel erreicht.' : 'Reise läuft.',
+            journey.sceneId
+          )
+      })()
+      if (index >= path.length - 1) break
+    }
+  }
+
+  private snapshot(sceneId: string, journey: JourneyRow | null) {
+    const scene = this.requireScene(sceneId)
+    const position = journey
+      ? this.path(journey)[journey.currentIndex]!
+      : this.scenePosition(sceneId)
+    const mapId = journey?.mapId ?? this.positionMapId(sceneId)
+    const map = mapId ? this.maps.read(mapId) : null
+    const placement =
+      map && position
+        ? (map.tiles.find((tile) => tile.id === tileId(position))?.location ??
+          null)
+        : null
+    const speed = this.speed(sceneId)
+    const path = journey ? this.path(journey) : []
+    let remainingGameSeconds = 0
+    if (journey && map) {
+      const tiles = new Map(map.tiles.map((tile) => [tile.id, tile]))
+      for (const coordinate of path.slice(journey.currentIndex + 1)) {
+        const terrain = terrainDefinition(
+          tiles.get(tileId(coordinate))!.terrainId
+        )
+        if (terrain.passable && speed.effectiveSpeedFeet > 0)
+          remainingGameSeconds += travelGameSeconds(
+            speed.effectiveSpeedFeet,
+            terrain.travelCost
+          )
+      }
+    }
+    return hexTravelSnapshotSchema.parse({
+      revision: journey?.revision ?? 0,
+      sceneId,
+      status: journey?.status ?? (position ? 'ready' : 'unpositioned'),
+      mapId: mapId ?? null,
+      mapName: map?.map.displayName ?? '',
+      current: position ?? null,
+      currentLabel: position ? tileLabel(position) : '',
+      locationId: placement?.locationId ?? null,
+      locationName: placement?.displayName ?? '',
+      path,
+      currentIndex: journey?.currentIndex ?? 0,
+      progress:
+        path.length <= 1
+          ? position
+            ? 1
+            : 0
+          : (journey?.currentIndex ?? 0) / (path.length - 1),
+      remainingGameSeconds,
+      gameTimeSeconds: scene.gameTimeSeconds,
+      ...speed,
+      multiplier: journey?.multiplier ?? 1,
+      hint:
+        journey?.hint ??
+        (position
+          ? 'Reise planen oder Party neu platzieren.'
+          : 'Party zuerst auf einer Hex-Karte platzieren.')
+    })
+  }
+
+  private scenePosition(sceneId: string, requiredMapId?: string) {
+    const members = this.scenes.partyMemberIds(sceneId)
+    const party = this.party
+      .read()
+      .members.filter((member) => members.includes(member.id))
+    const positions = party
+      .filter((member) => member.attachedToPartyToken)
+      .map((member) => member.travelPosition)
+      .filter((position) => position !== null)
+    if (
+      positions.length === party.length &&
+      positions.length > 0 &&
+      positions.every(
+        (position) =>
+          position.mapId === positions[0]!.mapId &&
+          position.tileId === positions[0]!.tileId
+      ) &&
+      (!requiredMapId || positions[0]!.mapId === requiredMapId)
+    )
+      return parseTileId(positions[0]!.tileId)
+
+    const scene = this.requireScene(sceneId)
+    if (!scene.locationId) return null
+    const placement = this.db
+      .prepare(
+        'SELECT map_id AS mapId, q, r FROM hex_location_placement WHERE location_id = ?'
+      )
+      .get(scene.locationId) as
+      { mapId: string; q: number; r: number } | undefined
+    if (!placement || (requiredMapId && placement.mapId !== requiredMapId))
+      return null
+    return axialCoordinateSchema.parse({ q: placement.q, r: placement.r })
+  }
+
+  private positionMapId(sceneId: string): string | null {
+    const members = this.scenes.partyMemberIds(sceneId)
+    const member = this.party
+      .read()
+      .members.find(
+        (candidate) =>
+          members.includes(candidate.id) &&
+          candidate.attachedToPartyToken &&
+          candidate.travelPosition
+      )
+    if (member?.travelPosition) return member.travelPosition.mapId
+    const scene = this.requireScene(sceneId)
+    if (!scene.locationId) return null
+    const placement = this.db
+      .prepare(
+        'SELECT map_id AS mapId FROM hex_location_placement WHERE location_id = ?'
+      )
+      .get(scene.locationId) as { mapId: string } | undefined
+    return placement?.mapId ?? null
+  }
+
+  private speed(sceneId: string) {
+    const ids = this.scenes.partyMemberIds(sceneId)
+    const members = this.party
+      .read()
+      .members.filter((member) => ids.includes(member.id))
+    const assumedSpeedMemberNames = members
+      .filter((member) => member.movementSpeedFeet === null)
+      .map((member) => member.name)
+    return {
+      effectiveSpeedFeet:
+        members.length === 0
+          ? 0
+          : Math.min(
+              ...members.map((member) => member.movementSpeedFeet ?? 30)
+            ),
+      assumedSpeedMemberNames
+    }
+  }
+
+  private setSceneLocation(
+    sceneId: string,
+    mapId: string,
+    coordinate: AxialCoordinate,
+    gameSeconds: number
+  ) {
+    const placement = this.db
+      .prepare(
+        `SELECT p.location_id AS locationId, l.display_name AS displayName
+         FROM hex_location_placement p
+         JOIN worldplanner_location l ON l.id = p.location_id
+         WHERE p.map_id = ? AND p.q = ? AND p.r = ?`
+      )
+      .get(mapId, coordinate.q, coordinate.r) as
+      { locationId: string; displayName: string } | undefined
+    this.scenes.advanceTravel(
+      sceneId,
+      gameSeconds,
+      placement?.locationId ?? null,
+      placement?.displayName ?? ''
+    )
+  }
+
+  private requireScene(sceneId: string) {
+    const scene = this.scenes
+      .snapshot(this.party.read().members)
+      .scenes.find((candidate) => candidate.id === sceneId)
+    if (!scene) throw new Error('not found')
+    return scene
+  }
+
+  private journey(sceneId: string): JourneyRow | null {
+    return (
+      (this.db
+        .prepare(
+          `SELECT scene_id AS sceneId, revision, map_id AS mapId, status,
+                  path_json AS pathJson, current_index AS currentIndex,
+                  party_member_ids_json AS partyMemberIdsJson,
+                  multiplier, segment_started_at AS segmentStartedAt, hint
+           FROM hex_journey WHERE scene_id = ?`
+        )
+        .get(sceneId) as JourneyRow | undefined) ?? null
+    )
+  }
+
+  private requireJourney(sceneId: string, expectedRevision: number) {
+    const journey = this.journey(sceneId)
+    if (!journey) throw new Error('not found')
+    if (journey.revision !== expectedRevision) throw new Error('stale')
+    return journey
+  }
+
+  private path(journey: JourneyRow): readonly AxialCoordinate[] {
+    return axialCoordinateSchema.array().parse(JSON.parse(journey.pathJson))
+  }
+
+  private memberIds(journey: JourneyRow): readonly string[] {
+    return z.array(z.uuid()).parse(JSON.parse(journey.partyMemberIdsJson))
+  }
+}

--- a/src/core/hex/terrain-catalog.ts
+++ b/src/core/hex/terrain-catalog.ts
@@ -1,0 +1,58 @@
+import {
+  hexTerrainCatalogSchema,
+  type HexTerrainCatalog,
+  type HexTerrainId
+} from '../../shared/contracts/hex.js'
+
+export const hexTerrainCatalog: HexTerrainCatalog =
+  hexTerrainCatalogSchema.parse({
+    version: 'saltmarcher-v1',
+    terrains: [
+      {
+        id: 'grassland',
+        label: 'Grasland',
+        color: '#7f9b63',
+        passable: true,
+        travelCost: 1
+      },
+      {
+        id: 'desert',
+        label: 'Wüste',
+        color: '#c9a86a',
+        passable: true,
+        travelCost: 2
+      },
+      {
+        id: 'forest',
+        label: 'Wald',
+        color: '#3f704d',
+        passable: true,
+        travelCost: 4
+      },
+      {
+        id: 'swamp',
+        label: 'Sumpf',
+        color: '#536e62',
+        passable: true,
+        travelCost: 4
+      },
+      {
+        id: 'mountain',
+        label: 'Gebirge',
+        color: '#73777a',
+        passable: true,
+        travelCost: 8
+      },
+      {
+        id: 'water',
+        label: 'Wasser',
+        color: '#397aa1',
+        passable: false,
+        travelCost: 1
+      }
+    ]
+  })
+
+export function terrainDefinition(id: HexTerrainId) {
+  return hexTerrainCatalog.terrains.find((terrain) => terrain.id === id)!
+}

--- a/src/core/party/party-store.ts
+++ b/src/core/party/party-store.ts
@@ -45,6 +45,23 @@ export function initializePartySchema(db: Database.Database): void {
     })()
   } else createPartyTables(db)
 
+  const currentColumns = db
+    .prepare("PRAGMA table_info('player_characters')")
+    .all() as readonly { name: string }[]
+  const names = new Set(currentColumns.map((column) => column.name))
+  if (!names.has('movement_speed_feet'))
+    db.exec(
+      'ALTER TABLE player_characters ADD COLUMN movement_speed_feet INTEGER CHECK(movement_speed_feet BETWEEN 0 AND 999)'
+    )
+  if (!names.has('travel_map_id'))
+    db.exec('ALTER TABLE player_characters ADD COLUMN travel_map_id TEXT')
+  if (!names.has('travel_tile_id'))
+    db.exec('ALTER TABLE player_characters ADD COLUMN travel_tile_id TEXT')
+  if (!names.has('attached_to_party_token'))
+    db.exec(
+      'ALTER TABLE player_characters ADD COLUMN attached_to_party_token INTEGER NOT NULL DEFAULT 0 CHECK(attached_to_party_token IN (0, 1))'
+    )
+
   const metadata = db
     .prepare('SELECT 1 FROM party_roster_metadata WHERE singleton = 1')
     .get()
@@ -82,6 +99,10 @@ function createPartyTables(db: Database.Database): void {
       xp INTEGER NOT NULL CHECK(xp >= 0),
       xp_since_short_rest INTEGER NOT NULL CHECK(xp_since_short_rest >= 0),
       xp_since_long_rest INTEGER NOT NULL CHECK(xp_since_long_rest >= 0),
+      movement_speed_feet INTEGER CHECK(movement_speed_feet BETWEEN 0 AND 999),
+      travel_map_id TEXT,
+      travel_tile_id TEXT,
+      attached_to_party_token INTEGER NOT NULL DEFAULT 0 CHECK(attached_to_party_token IN (0, 1)),
       position INTEGER NOT NULL CHECK(position >= 0)
     );
     CREATE TABLE IF NOT EXISTS party_xp_awards (
@@ -102,7 +123,9 @@ export class PartyStore {
       .prepare(
         `
         SELECT id, name, player_name, level, passive_perception, armor_class,
-               active, xp, xp_since_short_rest, xp_since_long_rest
+               active, xp, xp_since_short_rest, xp_since_long_rest,
+               movement_speed_feet, travel_map_id, travel_tile_id,
+               attached_to_party_token
         FROM player_characters ORDER BY position, id
       `
       )
@@ -130,8 +153,9 @@ export class PartyStore {
           `
           INSERT INTO player_characters (
             id, name, player_name, level, passive_perception, armor_class,
-            active, xp, xp_since_short_rest, xp_since_long_rest, position
-          ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, 0, 0, ?)
+            active, xp, xp_since_short_rest, xp_since_long_rest,
+            movement_speed_feet, position
+          ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, 0, 0, ?, ?)
         `
         )
         .run(
@@ -142,6 +166,7 @@ export class PartyStore {
           draft.passivePerception,
           draft.armorClass,
           xp,
+          draft.movementSpeedFeet ?? null,
           position
         )
     })
@@ -167,7 +192,7 @@ export class PartyStore {
           `
           UPDATE player_characters
           SET name = ?, player_name = ?, level = ?, passive_perception = ?,
-              armor_class = ?, xp = ?
+              armor_class = ?, movement_speed_feet = ?, xp = ?
           WHERE id = ?
         `
         )
@@ -177,11 +202,29 @@ export class PartyStore {
           draft.level,
           draft.passivePerception,
           draft.armorClass,
+          draft.movementSpeedFeet ?? null,
           xp,
           id
         )
     })
     return this.read()
+  }
+
+  setTravelPosition(ids: readonly string[], mapId: string, tile: string): void {
+    const update = this.db.prepare(
+      `UPDATE player_characters
+       SET travel_map_id = ?, travel_tile_id = ?, attached_to_party_token = 1
+       WHERE id = ?`
+    )
+    for (const id of ids) {
+      if (update.run(mapId, tile, id).changes !== 1)
+        throw new Error('not found')
+    }
+    this.db
+      .prepare(
+        'UPDATE party_roster_metadata SET revision = revision + 1 WHERE singleton = 1'
+      )
+      .run()
   }
 
   delete(id: string, expectedRevision: number): PartySnapshot {
@@ -344,6 +387,20 @@ function rowPartyMember(row: unknown): PartyCharacter {
         : Number(value['passive_perception']),
     armorClass:
       value['armor_class'] === null ? null : Number(value['armor_class']),
+    movementSpeedFeet:
+      value['movement_speed_feet'] === null
+        ? null
+        : Number(value['movement_speed_feet']),
+    travelPosition:
+      typeof value['travel_map_id'] === 'string' &&
+      typeof value['travel_tile_id'] === 'string'
+        ? {
+            kind: 'hex',
+            mapId: value['travel_map_id'],
+            tileId: value['travel_tile_id']
+          }
+        : null,
+    attachedToPartyToken: Number(value['attached_to_party_token']) === 1,
     active: Number(value['active']) === 1,
     xp: Number(value['xp']),
     currentLevelFloor: level === null ? 0 : levelXp[level - 1]!,

--- a/src/core/scene/scene-store.ts
+++ b/src/core/scene/scene-store.ts
@@ -23,6 +23,7 @@ export function initializeSceneSchema(db: Database.Database): void {
       title TEXT NOT NULL,
       location_id TEXT,
       location_name TEXT NOT NULL DEFAULT '',
+      game_time_seconds INTEGER NOT NULL DEFAULT 28800 CHECK(game_time_seconds >= 0),
       position INTEGER NOT NULL CHECK(position >= 0)
     );
     CREATE TABLE IF NOT EXISTS scene_party_member (
@@ -46,6 +47,13 @@ export function initializeSceneSchema(db: Database.Database): void {
       UNIQUE(group_id, creature_id)
     );
   `)
+  const sceneColumns = db
+    .prepare("PRAGMA table_info('scene_running_scene')")
+    .all() as readonly { name: string }[]
+  if (!sceneColumns.some((column) => column.name === 'game_time_seconds'))
+    db.exec(
+      'ALTER TABLE scene_running_scene ADD COLUMN game_time_seconds INTEGER NOT NULL DEFAULT 28800 CHECK(game_time_seconds >= 0)'
+    )
   const exists = db
     .prepare('SELECT 1 FROM scene_workspace WHERE singleton = 1')
     .get()
@@ -95,12 +103,13 @@ export class SceneStore {
     const locations = this.locationProvider()
     const rows = this.db
       .prepare(
-        'SELECT id, title, location_id AS locationId, position FROM scene_running_scene ORDER BY position, id'
+        'SELECT id, title, location_id AS locationId, game_time_seconds AS gameTimeSeconds, position FROM scene_running_scene ORDER BY position, id'
       )
       .all() as Array<{
       id: string
       title: string
       locationId: string | null
+      gameTimeSeconds: number
       position: number
     }>
     const scenes = rows.map((row) => this.resolveScene(row, root, locations))
@@ -120,6 +129,35 @@ export class SceneStore {
         .filter((member) => member.active && !assigned.has(member.id))
         .map((member) => member.id)
     })
+  }
+
+  partyMemberIds(sceneId: string): readonly string[] {
+    return (
+      this.db
+        .prepare(
+          'SELECT party_member_id AS id FROM scene_party_member WHERE scene_id = ? ORDER BY position, party_member_id'
+        )
+        .all(sceneId) as Array<{ id: string }>
+    ).map((row) => row.id)
+  }
+
+  advanceTravel(
+    sceneId: string,
+    gameSeconds: number,
+    locationId: string | null,
+    locationName: string
+  ): void {
+    if (
+      this.db
+        .prepare(
+          `UPDATE scene_running_scene
+           SET game_time_seconds = game_time_seconds + ?, location_id = ?, location_name = ?
+           WHERE id = ?`
+        )
+        .run(gameSeconds, locationId, locationName, sceneId).changes !== 1
+    )
+      throw new Error('not found')
+    this.bump()
   }
 
   focused(party: readonly PartyMember[]): RunningScene {
@@ -280,6 +318,7 @@ export class SceneStore {
       id: string
       title: string
       locationId: string | null
+      gameTimeSeconds: number
       position: number
     },
     root: SceneRoot,
@@ -304,6 +343,7 @@ export class SceneStore {
       locationName: row.locationId
         ? (location?.displayName ?? 'Nicht verfügbarer Ort')
         : '',
+      gameTimeSeconds: row.gameTimeSeconds,
       partyMemberIds,
       groups: [...this.groups(row.id)]
     }

--- a/src/core/worldplanner/location-store.ts
+++ b/src/core/worldplanner/location-store.ts
@@ -119,6 +119,31 @@ export class WorldLocationStore {
 
   delete(id: string, expectedRevision: number): WorldLocationSnapshot {
     this.mutate(expectedRevision, () => {
+      const hexPlacementTable = this.db
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'hex_location_placement'"
+        )
+        .get()
+      if (hexPlacementTable) {
+        const placement = this.db
+          .prepare(
+            'SELECT map_id AS mapId FROM hex_location_placement WHERE location_id = ?'
+          )
+          .get(id) as { mapId: string } | undefined
+        this.db
+          .prepare('DELETE FROM hex_location_placement WHERE location_id = ?')
+          .run(id)
+        if (placement) {
+          this.db
+            .prepare('UPDATE hex_map SET revision = revision + 1 WHERE id = ?')
+            .run(placement.mapId)
+          this.db
+            .prepare(
+              'UPDATE hex_metadata SET revision = revision + 1 WHERE singleton = 1'
+            )
+            .run()
+        }
+      }
       if (
         this.db
           .prepare('DELETE FROM worldplanner_location WHERE id = ?')

--- a/src/main/application-lifecycle/application.ts
+++ b/src/main/application-lifecycle/application.ts
@@ -77,6 +77,23 @@ import {
   updateWorldFactionInputSchema,
   worldFactionSnapshotSchema
 } from '../../shared/contracts/encounter-source.js'
+import {
+  createHexMapInputSchema,
+  evaluateHexRouteInputSchema,
+  hexMapCatalogSnapshotSchema,
+  hexMapSnapshotSchema,
+  hexRouteEvaluationSchema,
+  hexTerrainCatalogSchema,
+  hexTravelSnapshotSchema,
+  mutateHexTravelInputSchema,
+  paintHexTerrainInputSchema,
+  placeHexLocationInputSchema,
+  positionHexPartyInputSchema,
+  removeHexLocationInputSchema,
+  setHexTravelMultiplierInputSchema,
+  startHexTravelInputSchema,
+  updateHexMapInputSchema
+} from '../../shared/contracts/hex.js'
 
 let core: CoreProcessClient | undefined
 
@@ -310,6 +327,141 @@ export async function startApplication(): Promise<void> {
     (v) => {
       const i = v as z.infer<typeof deleteWorldLocationInputSchema>
       return requireCore().locationsDelete(i.id, i.expectedRevision)
+    }
+  )
+  capability(
+    'hex:terrainCatalog',
+    hexTerrainCatalogSchema,
+    false,
+    z.undefined(),
+    () => requireCore().hexTerrainCatalog()
+  )
+  capability(
+    'hex:catalog',
+    hexMapCatalogSnapshotSchema,
+    false,
+    z.undefined(),
+    () => requireCore().hexCatalog()
+  )
+  capability(
+    'hex:read',
+    hexMapSnapshotSchema,
+    false,
+    z.object({ mapId: z.uuid() }).strict(),
+    (v) => requireCore().hexRead((v as { mapId: string }).mapId)
+  )
+  capability(
+    'hex:create',
+    hexMapSnapshotSchema,
+    true,
+    createHexMapInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof createHexMapInputSchema>
+      return requireCore().hexCreate(i.displayName, i.expectedCatalogRevision)
+    }
+  )
+  capability(
+    'hex:update',
+    hexMapSnapshotSchema,
+    true,
+    updateHexMapInputSchema,
+    (v) => requireCore().hexUpdate(v as z.infer<typeof updateHexMapInputSchema>)
+  )
+  capability(
+    'hex:paint',
+    hexMapSnapshotSchema,
+    true,
+    paintHexTerrainInputSchema,
+    (v) =>
+      requireCore().hexPaint(v as z.infer<typeof paintHexTerrainInputSchema>)
+  )
+  capability(
+    'hex:placeLocation',
+    hexMapSnapshotSchema,
+    true,
+    placeHexLocationInputSchema,
+    (v) =>
+      requireCore().hexPlaceLocation(
+        v as z.infer<typeof placeHexLocationInputSchema>
+      )
+  )
+  capability(
+    'hex:removeLocation',
+    hexMapSnapshotSchema,
+    true,
+    removeHexLocationInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof removeHexLocationInputSchema>
+      return requireCore().hexRemoveLocation(
+        i.locationId,
+        i.expectedMapRevision
+      )
+    }
+  )
+  capability(
+    'hex-travel:read',
+    hexTravelSnapshotSchema,
+    false,
+    z.object({ sceneId: z.uuid() }).strict(),
+    (v) => requireCore().hexTravelRead((v as { sceneId: string }).sceneId)
+  )
+  capability(
+    'hex-travel:evaluate',
+    hexRouteEvaluationSchema,
+    false,
+    evaluateHexRouteInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof evaluateHexRouteInputSchema>
+      return requireCore().hexTravelEvaluate(i.sceneId, i.mapId, i.waypoints)
+    }
+  )
+  capability(
+    'hex-travel:position',
+    hexTravelSnapshotSchema,
+    true,
+    positionHexPartyInputSchema,
+    (v) =>
+      requireCore().hexTravelPosition(
+        v as z.infer<typeof positionHexPartyInputSchema>
+      )
+  )
+  capability(
+    'hex-travel:start',
+    hexTravelSnapshotSchema,
+    true,
+    startHexTravelInputSchema,
+    (v) =>
+      requireCore().hexTravelStart(
+        v as z.infer<typeof startHexTravelInputSchema>
+      )
+  )
+  for (const action of ['pause', 'resume', 'abort'] as const)
+    capability(
+      `hex-travel:${action}`,
+      hexTravelSnapshotSchema,
+      true,
+      mutateHexTravelInputSchema,
+      (v) => {
+        const i = v as z.infer<typeof mutateHexTravelInputSchema>
+        return requireCore().hexTravelMutate(
+          action,
+          i.sceneId,
+          i.expectedRevision
+        )
+      }
+    )
+  capability(
+    'hex-travel:setMultiplier',
+    hexTravelSnapshotSchema,
+    true,
+    setHexTravelMultiplierInputSchema,
+    (v) => {
+      const i = v as z.infer<typeof setHexTravelMultiplierInputSchema>
+      return requireCore().hexTravelSetMultiplier(
+        i.sceneId,
+        i.multiplier,
+        i.expectedRevision
+      )
     }
   )
   capability(

--- a/src/main/core-process/core-process-client.ts
+++ b/src/main/core-process/core-process-client.ts
@@ -54,6 +54,15 @@ import {
   type WorldFactionDraft,
   type WorldFactionSnapshot
 } from '../../shared/contracts/encounter-source.js'
+import {
+  hexMapCatalogSnapshotSchema,
+  hexMapSnapshotSchema,
+  hexRouteEvaluationSchema,
+  hexTerrainCatalogSchema,
+  hexTravelSnapshotSchema,
+  type AxialCoordinate,
+  type HexTerrainId
+} from '../../shared/contracts/hex.js'
 
 export class CoreProcessClient {
   readonly #process: UtilityProcess
@@ -205,6 +214,132 @@ export class CoreProcessClient {
     return this.request(
       { kind: 'locations.delete', input: { id, expectedRevision } },
       worldLocationSnapshotSchema
+    )
+  }
+  hexTerrainCatalog() {
+    return this.request({ kind: 'hex.terrainCatalog' }, hexTerrainCatalogSchema)
+  }
+  hexCatalog() {
+    return this.request({ kind: 'hex.catalog' }, hexMapCatalogSnapshotSchema)
+  }
+  hexRead(mapId: string) {
+    return this.request(
+      { kind: 'hex.read', input: { mapId } },
+      hexMapSnapshotSchema
+    )
+  }
+  hexCreate(displayName: string, expectedCatalogRevision: number) {
+    return this.request(
+      { kind: 'hex.create', input: { displayName, expectedCatalogRevision } },
+      hexMapSnapshotSchema
+    )
+  }
+  hexUpdate(input: {
+    mapId: string
+    displayName: string
+    radius: number
+    confirmDataLoss: boolean
+    expectedRevision: number
+  }) {
+    return this.request({ kind: 'hex.update', input }, hexMapSnapshotSchema)
+  }
+  hexPaint(input: {
+    mapId: string
+    coordinate: AxialCoordinate
+    terrainId: HexTerrainId
+    expectedRevision: number
+  }) {
+    return this.request({ kind: 'hex.paint', input }, hexMapSnapshotSchema)
+  }
+  hexPlaceLocation(input: {
+    mapId: string
+    locationId: string
+    coordinate: AxialCoordinate
+    expectedRevision: number
+  }) {
+    return this.request(
+      { kind: 'hex.placeLocation', input },
+      hexMapSnapshotSchema
+    )
+  }
+  hexRemoveLocation(locationId: string, expectedMapRevision: number) {
+    return this.request(
+      {
+        kind: 'hex.removeLocation',
+        input: { locationId, expectedMapRevision }
+      },
+      hexMapSnapshotSchema
+    )
+  }
+  hexTravelRead(sceneId: string) {
+    return this.request(
+      { kind: 'hexTravel.read', input: { sceneId } },
+      hexTravelSnapshotSchema
+    )
+  }
+  hexTravelEvaluate(
+    sceneId: string,
+    mapId: string,
+    waypoints: readonly AxialCoordinate[]
+  ) {
+    return this.request(
+      {
+        kind: 'hexTravel.evaluate',
+        input: { sceneId, mapId, waypoints: [...waypoints] }
+      },
+      hexRouteEvaluationSchema
+    )
+  }
+  hexTravelPosition(input: {
+    sceneId: string
+    mapId: string
+    coordinate: AxialCoordinate
+    expectedSceneRevision: number
+  }) {
+    return this.request(
+      { kind: 'hexTravel.position', input },
+      hexTravelSnapshotSchema
+    )
+  }
+  hexTravelStart(input: {
+    sceneId: string
+    mapId: string
+    waypoints: readonly AxialCoordinate[]
+    multiplier: 1 | 2 | 5 | 10
+    expectedRevision: number
+  }) {
+    return this.request(
+      {
+        kind: 'hexTravel.start',
+        input: { ...input, waypoints: [...input.waypoints] }
+      },
+      hexTravelSnapshotSchema
+    )
+  }
+  hexTravelMutate(
+    kind: 'pause' | 'resume' | 'abort',
+    sceneId: string,
+    expectedRevision: number
+  ) {
+    return this.request(
+      {
+        kind: `hexTravel.${kind}` as const,
+        input: { sceneId, expectedRevision }
+      },
+      hexTravelSnapshotSchema
+    )
+  }
+  hexTravelSetMultiplier(
+    sceneId: string,
+    multiplier: 1 | 2 | 5 | 10,
+    expectedRevision: number
+  ) {
+    return this.request(
+      {
+        kind: 'hexTravel.setMultiplier',
+        input: { sceneId, multiplier, expectedRevision }
+      },
+      hexTravelSnapshotSchema
     )
   }
   encounterTablesRead(): Promise<EncounterTableSnapshot> {

--- a/src/main/core-process/utility.ts
+++ b/src/main/core-process/utility.ts
@@ -11,6 +11,9 @@ import { z } from 'zod'
 import { join } from 'node:path'
 import { WorldLocationService } from '../../core/worldplanner/location-store.js'
 import { EncounterSourceService } from '../../core/worldplanner/encounter-source-store.js'
+import { HexMapService } from '../../core/hex/hex-map-store.js'
+import { HexTravelService } from '../../core/hex/hex-travel.js'
+import { hexTerrainCatalog } from '../../core/hex/terrain-catalog.js'
 const root = process.argv[2]
 if (!root || !process.parentPort)
   throw new Error('Utility process requires a data root and parent port')
@@ -18,6 +21,8 @@ const campaigns = new CampaignStore(root)
 const play = new LivePlayService(() => campaigns.activeCampaignPath())
 const locations = new WorldLocationService(() => campaigns.activeCampaignPath())
 const sources = new EncounterSourceService(() => campaigns.activeCampaignPath())
+const hex = new HexMapService(() => campaigns.activeCampaignPath())
+const hexTravel = new HexTravelService(() => campaigns.activeCampaignPath())
 const creatures = new CreatureCatalogService(
   join(root, 'installation.sqlite'),
   (query) => sources.resolve(query),
@@ -158,8 +163,10 @@ process.parentPort.on('message', (event) => {
         r.requestId,
         sources.deleteFaction(r.input.id, r.input.expectedRevision)
       )
-    else if (r.kind === 'session.read') respond(r.requestId, play.readSession())
-    else if (r.kind === 'scene.focus')
+    else if (r.kind === 'session.read') {
+      hexTravel.read()
+      respond(r.requestId, play.readSession())
+    } else if (r.kind === 'scene.focus')
       respond(
         r.requestId,
         play.focusScene(r.input.sceneId, r.input.expectedRevision)
@@ -287,6 +294,38 @@ process.parentPort.on('message', (event) => {
       respond(r.requestId, play.awardXp(r.input.expectedRevision))
     else if (r.kind === 'combat.complete')
       respond(r.requestId, play.completeCombat(r.input.expectedRevision))
+    else if (r.kind === 'hex.terrainCatalog')
+      respond(r.requestId, hexTerrainCatalog)
+    else if (r.kind === 'hex.catalog') respond(r.requestId, hex.catalog())
+    else if (r.kind === 'hex.read')
+      respond(r.requestId, hex.read(r.input.mapId))
+    else if (r.kind === 'hex.create')
+      respond(
+        r.requestId,
+        hex.create(r.input.displayName, r.input.expectedCatalogRevision)
+      )
+    else if (r.kind === 'hex.update') respond(r.requestId, hex.update(r.input))
+    else if (r.kind === 'hex.paint') respond(r.requestId, hex.paint(r.input))
+    else if (r.kind === 'hex.placeLocation')
+      respond(r.requestId, hex.placeLocation(r.input))
+    else if (r.kind === 'hex.removeLocation')
+      respond(r.requestId, hex.removeLocation(r.input))
+    else if (r.kind === 'hexTravel.read')
+      respond(r.requestId, hexTravel.read(r.input.sceneId))
+    else if (r.kind === 'hexTravel.evaluate')
+      respond(r.requestId, hexTravel.evaluate(r.input))
+    else if (r.kind === 'hexTravel.position')
+      respond(r.requestId, hexTravel.position(r.input))
+    else if (r.kind === 'hexTravel.start')
+      respond(r.requestId, hexTravel.start(r.input))
+    else if (r.kind === 'hexTravel.pause')
+      respond(r.requestId, hexTravel.pause(r.input))
+    else if (r.kind === 'hexTravel.resume')
+      respond(r.requestId, hexTravel.resume(r.input))
+    else if (r.kind === 'hexTravel.abort')
+      respond(r.requestId, hexTravel.abort(r.input))
+    else if (r.kind === 'hexTravel.setMultiplier')
+      respond(r.requestId, hexTravel.setMultiplier(r.input))
   } catch (e) {
     failure(
       r.requestId,

--- a/src/preload/capability-bridge/index.ts
+++ b/src/preload/capability-bridge/index.ts
@@ -65,6 +65,23 @@ import {
   updateWorldFactionInputSchema,
   worldFactionSnapshotSchema
 } from '../../shared/contracts/encounter-source.js'
+import {
+  createHexMapInputSchema,
+  evaluateHexRouteInputSchema,
+  hexMapCatalogSnapshotSchema,
+  hexMapSnapshotSchema,
+  hexRouteEvaluationSchema,
+  hexTerrainCatalogSchema,
+  hexTravelSnapshotSchema,
+  mutateHexTravelInputSchema,
+  paintHexTerrainInputSchema,
+  placeHexLocationInputSchema,
+  positionHexPartyInputSchema,
+  removeHexLocationInputSchema,
+  setHexTravelMultiplierInputSchema,
+  startHexTravelInputSchema,
+  updateHexMapInputSchema
+} from '../../shared/contracts/hex.js'
 
 async function invoke<T>(
   channel: string,
@@ -325,6 +342,153 @@ const api: SaltMarcherApi = {
           deleteWorldFactionInputSchema.parse({ id, expectedRevision }),
           worldFactionSnapshotSchema
         )
+      )
+  },
+  hex: {
+    terrainCatalog: async () =>
+      freezeDeep(
+        await invoke('hex:terrainCatalog', undefined, hexTerrainCatalogSchema)
+      ),
+    catalog: async () =>
+      freezeDeep(
+        await invoke('hex:catalog', undefined, hexMapCatalogSnapshotSchema)
+      ),
+    read: async (mapId) =>
+      freezeDeep(await invoke('hex:read', { mapId }, hexMapSnapshotSchema)),
+    create: async (displayName, expectedCatalogRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex:create',
+          createHexMapInputSchema.parse({
+            displayName,
+            expectedCatalogRevision
+          }),
+          hexMapSnapshotSchema
+        )
+      ),
+    update: async (
+      mapId,
+      displayName,
+      radius,
+      confirmDataLoss,
+      expectedRevision
+    ) =>
+      freezeDeep(
+        await invoke(
+          'hex:update',
+          updateHexMapInputSchema.parse({
+            mapId,
+            displayName,
+            radius,
+            confirmDataLoss,
+            expectedRevision
+          }),
+          hexMapSnapshotSchema
+        )
+      ),
+    paint: async (mapId, coordinate, terrainId, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex:paint',
+          paintHexTerrainInputSchema.parse({
+            mapId,
+            coordinate,
+            terrainId,
+            expectedRevision
+          }),
+          hexMapSnapshotSchema
+        )
+      ),
+    placeLocation: async (mapId, locationId, coordinate, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex:placeLocation',
+          placeHexLocationInputSchema.parse({
+            mapId,
+            locationId,
+            coordinate,
+            expectedRevision
+          }),
+          hexMapSnapshotSchema
+        )
+      ),
+    removeLocation: async (locationId, expectedMapRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex:removeLocation',
+          removeHexLocationInputSchema.parse({
+            locationId,
+            expectedMapRevision
+          }),
+          hexMapSnapshotSchema
+        )
+      )
+  },
+  hexTravel: {
+    read: async (sceneId) =>
+      freezeDeep(
+        await invoke('hex-travel:read', { sceneId }, hexTravelSnapshotSchema)
+      ),
+    evaluate: (sceneId, mapId, waypoints) =>
+      invoke(
+        'hex-travel:evaluate',
+        evaluateHexRouteInputSchema.parse({ sceneId, mapId, waypoints }),
+        hexRouteEvaluationSchema
+      ),
+    position: async (sceneId, mapId, coordinate, expectedSceneRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex-travel:position',
+          positionHexPartyInputSchema.parse({
+            sceneId,
+            mapId,
+            coordinate,
+            expectedSceneRevision
+          }),
+          hexTravelSnapshotSchema
+        )
+      ),
+    start: async (sceneId, mapId, waypoints, multiplier, expectedRevision) =>
+      freezeDeep(
+        await invoke(
+          'hex-travel:start',
+          startHexTravelInputSchema.parse({
+            sceneId,
+            mapId,
+            waypoints,
+            multiplier,
+            expectedRevision
+          }),
+          hexTravelSnapshotSchema
+        )
+      ),
+    pause: (sceneId, expectedRevision) =>
+      invoke(
+        'hex-travel:pause',
+        mutateHexTravelInputSchema.parse({ sceneId, expectedRevision }),
+        hexTravelSnapshotSchema
+      ),
+    resume: (sceneId, expectedRevision) =>
+      invoke(
+        'hex-travel:resume',
+        mutateHexTravelInputSchema.parse({ sceneId, expectedRevision }),
+        hexTravelSnapshotSchema
+      ),
+    abort: (sceneId, expectedRevision) =>
+      invoke(
+        'hex-travel:abort',
+        mutateHexTravelInputSchema.parse({ sceneId, expectedRevision }),
+        hexTravelSnapshotSchema
+      ),
+    setMultiplier: (sceneId, multiplier, expectedRevision) =>
+      invoke(
+        'hex-travel:setMultiplier',
+        setHexTravelMultiplierInputSchema.parse({
+          sceneId,
+          multiplier,
+          expectedRevision
+        }),
+        hexTravelSnapshotSchema
       )
   },
   session: {

--- a/src/renderer/features/hex/hex-map-canvas.tsx
+++ b/src/renderer/features/hex/hex-map-canvas.tsx
@@ -1,0 +1,233 @@
+import { Application, Container, Graphics, Text } from 'pixi.js'
+import { useEffect, useRef, type ReactElement } from 'react'
+import type {
+  AxialCoordinate,
+  HexMapSnapshot,
+  HexTerrainCatalog
+} from '../../../shared/contracts/hex.js'
+
+const rootThree = Math.sqrt(3)
+
+function center(coordinate: AxialCoordinate, size: number) {
+  return {
+    x: size * rootThree * (coordinate.q + coordinate.r / 2),
+    y: size * 1.5 * coordinate.r
+  }
+}
+
+function polygon(x: number, y: number, size: number): number[] {
+  return Array.from({ length: 6 }, (_, index) => {
+    const angle = ((60 * index - 30) * Math.PI) / 180
+    return [x + size * Math.cos(angle), y + size * Math.sin(angle)]
+  }).flat()
+}
+
+function pixelToAxial(x: number, y: number, size: number): AxialCoordinate {
+  const q = ((rootThree / 3) * x - y / 3) / size
+  const r = ((2 / 3) * y) / size
+  const cube = { x: q, z: r, y: -q - r }
+  let rx = Math.round(cube.x)
+  const ry = Math.round(cube.y)
+  let rz = Math.round(cube.z)
+  const dx = Math.abs(rx - cube.x)
+  const dy = Math.abs(ry - cube.y)
+  const dz = Math.abs(rz - cube.z)
+  if (dx > dy && dx > dz) rx = -ry - rz
+  else if (dy <= dz) rz = -rx - ry
+  return { q: rx, r: rz }
+}
+
+export function HexMapCanvas(props: {
+  snapshot: HexMapSnapshot
+  terrains: HexTerrainCatalog
+  selected: AxialCoordinate | null
+  token?: AxialCoordinate | null
+  route?: readonly AxialCoordinate[]
+  onTileClick?: (coordinate: AxialCoordinate) => void
+  ariaLabel: string
+}): ReactElement {
+  const host = useRef<HTMLDivElement>(null)
+  const click = useRef(props.onTileClick)
+  useEffect(() => {
+    click.current = props.onTileClick
+  }, [props.onTileClick])
+
+  useEffect(() => {
+    const element = host.current
+    if (!element) return
+    const application = new Application()
+    let disposed = false
+    let dragging = false
+    let last = { x: 0, y: 0 }
+    const size = 27
+    const world = new Container()
+    const byTerrain = new Map(
+      props.terrains.terrains.map((terrain) => [terrain.id, terrain])
+    )
+
+    void application
+      .init({
+        resizeTo: element,
+        background: '#101a18',
+        antialias: true,
+        preference: 'webgl'
+      })
+      .then(() => {
+        if (disposed) return
+        element.append(application.canvas)
+        application.stage.addChild(world)
+        world.position.set(element.clientWidth / 2, element.clientHeight / 2)
+
+        const tiles = new Graphics()
+        for (const tile of props.snapshot.tiles) {
+          const point = center(tile, size)
+          const terrain = byTerrain.get(tile.terrainId)!
+          tiles.poly(polygon(point.x, point.y, size - 1))
+          tiles.fill(terrain.color)
+          tiles.stroke({ width: 1, color: '#263d38', alpha: 0.9 })
+        }
+        world.addChild(tiles)
+
+        if (props.route && props.route.length > 1) {
+          const route = new Graphics()
+          const first = center(props.route[0]!, size)
+          route.moveTo(first.x, first.y)
+          for (const coordinate of props.route.slice(1)) {
+            const point = center(coordinate, size)
+            route.lineTo(point.x, point.y)
+          }
+          route.stroke({ width: 5, color: '#f2cc70', alpha: 0.85 })
+          world.addChild(route)
+        }
+
+        for (const tile of props.snapshot.tiles.filter(
+          (tile) => tile.location
+        )) {
+          const point = center(tile, size)
+          const marker = new Graphics()
+          marker.circle(point.x, point.y, 7).fill('#f3d38a')
+          marker.stroke({ width: 2, color: '#3e2f1e' })
+          world.addChild(marker)
+          const label = new Text({
+            text: tile.location!.displayName,
+            style: { fontSize: 12, fill: '#fff4d1' }
+          })
+          label.position.set(point.x + 10, point.y - 18)
+          world.addChild(label)
+        }
+
+        if (props.selected) {
+          const point = center(props.selected, size)
+          const selection = new Graphics()
+          selection
+            .poly(polygon(point.x, point.y, size - 2))
+            .stroke({ width: 4, color: '#ffffff' })
+          world.addChild(selection)
+        }
+
+        if (props.token) {
+          const point = center(props.token, size)
+          const token = new Graphics()
+          token.circle(point.x, point.y, 11).fill('#d6594c')
+          token.circle(point.x, point.y, 4).fill('#fff4e8')
+          token.stroke({ width: 2, color: '#421c19' })
+          world.addChild(token)
+        }
+
+        const canvas = application.canvas
+        const pointerDown = (event: PointerEvent) => {
+          if (event.button !== 1) return
+          dragging = true
+          last = { x: event.clientX, y: event.clientY }
+          event.preventDefault()
+        }
+        const pointerMove = (event: PointerEvent) => {
+          if (!dragging) return
+          world.position.x += event.clientX - last.x
+          world.position.y += event.clientY - last.y
+          last = { x: event.clientX, y: event.clientY }
+        }
+        const pointerUp = () => {
+          dragging = false
+        }
+        const pointerClick = (event: MouseEvent) => {
+          if (event.button !== 0 || !click.current) return
+          const bounds = canvas.getBoundingClientRect()
+          const localX =
+            (event.clientX - bounds.left - world.position.x) / world.scale.x
+          const localY =
+            (event.clientY - bounds.top - world.position.y) / world.scale.y
+          const coordinate = pixelToAxial(localX, localY, size)
+          if (
+            props.snapshot.tiles.some(
+              (tile) => tile.q === coordinate.q && tile.r === coordinate.r
+            )
+          )
+            click.current(coordinate)
+        }
+        const wheel = (event: WheelEvent) => {
+          event.preventDefault()
+          const next = Math.max(
+            0.35,
+            Math.min(2.5, world.scale.x * (event.deltaY > 0 ? 0.9 : 1.1))
+          )
+          world.scale.set(next)
+        }
+        canvas.addEventListener('pointerdown', pointerDown)
+        window.addEventListener('pointermove', pointerMove)
+        window.addEventListener('pointerup', pointerUp)
+        canvas.addEventListener('click', pointerClick)
+        canvas.addEventListener('wheel', wheel, { passive: false })
+        ;(application as Application & { cleanup?: () => void }).cleanup =
+          () => {
+            canvas.removeEventListener('pointerdown', pointerDown)
+            window.removeEventListener('pointermove', pointerMove)
+            window.removeEventListener('pointerup', pointerUp)
+            canvas.removeEventListener('click', pointerClick)
+            canvas.removeEventListener('wheel', wheel)
+          }
+      })
+
+    return () => {
+      disposed = true
+      ;(application as Application & { cleanup?: () => void }).cleanup?.()
+      application.destroy(true, { children: true })
+    }
+  }, [props.snapshot, props.terrains, props.selected, props.token, props.route])
+
+  return (
+    <div className="hex-canvas-shell">
+      <div
+        className="hex-canvas"
+        ref={host}
+        role="img"
+        aria-label={props.ariaLabel}
+      />
+      <label className="hex-accessible-selection">
+        Hexfeld auswählen
+        <select
+          value={
+            props.selected ? `${props.selected.q}:${props.selected.r}` : ''
+          }
+          onChange={(event) => {
+            const [q, r] = event.target.value.split(':').map(Number)
+            if (Number.isFinite(q) && Number.isFinite(r))
+              props.onTileClick?.({ q: q!, r: r! })
+          }}
+        >
+          <option value="">Keine Auswahl</option>
+          {props.snapshot.tiles.map((tile) => (
+            <option key={tile.id} value={tile.id}>
+              {tile.label} · {byLabel(props.terrains, tile.terrainId)}
+              {tile.location ? ` · ${tile.location.displayName}` : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}
+
+function byLabel(catalog: HexTerrainCatalog, id: string) {
+  return catalog.terrains.find((terrain) => terrain.id === id)?.label ?? id
+}

--- a/src/renderer/shell/app.css
+++ b/src/renderer/shell/app.css
@@ -1566,6 +1566,150 @@ progress {
   }
 }
 
+.hex-editor-workspace {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr) minmax(
+      200px,
+      260px
+    );
+  min-height: 0;
+  height: 100%;
+  gap: 1px;
+  background: var(--line, #31423e);
+}
+
+.hex-editor-controls,
+.hex-editor-state {
+  min-width: 0;
+  padding: 1rem;
+  overflow: auto;
+  background: #15211f;
+}
+
+.hex-editor-controls form,
+.hex-editor-controls label,
+.hex-editor-state {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.hex-editor-controls input,
+.hex-editor-controls select {
+  width: 100%;
+}
+
+.hex-editor-map,
+.session-hex-map {
+  min-width: 0;
+  min-height: 0;
+  background: #101a18;
+}
+
+.hex-editor-map {
+  display: flex;
+}
+
+.hex-canvas-shell {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 260px;
+  overflow: hidden;
+}
+
+.hex-canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.hex-canvas canvas {
+  display: block;
+}
+
+.hex-accessible-selection {
+  position: absolute;
+  left: 0.7rem;
+  bottom: 0.7rem;
+  display: grid;
+  gap: 0.2rem;
+  max-width: min(28rem, calc(100% - 1.4rem));
+  padding: 0.45rem;
+  border-radius: 0.35rem;
+  background: rgb(10 18 16 / 88%);
+  font-size: 0.75rem;
+}
+
+.session-hex-map {
+  display: grid;
+  grid-template-rows: auto minmax(260px, 1fr) auto;
+  height: 100%;
+}
+
+.hex-map-toolbar,
+.hex-map-status,
+.tool-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.hex-map-toolbar,
+.hex-map-status {
+  padding: 0.55rem;
+  background: #172522;
+}
+
+.hex-map-status {
+  justify-content: flex-end;
+}
+
+.hex-map-status > span:first-child {
+  margin-right: auto;
+}
+
+.hex-placement-dialog {
+  display: grid;
+  grid-template-rows: auto auto minmax(320px, 1fr) auto;
+  width: min(92vw, 1050px);
+  height: min(90vh, 760px);
+  padding: 1rem;
+  border: 1px solid #40534e;
+  border-radius: 0.5rem;
+  background: #15211f;
+}
+
+.hex-placement-dialog header,
+.hex-placement-dialog footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.travel-facts {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.travel-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.travel-warning {
+  color: #f1c86f;
+}
+
+@media (max-width: 900px) {
+  .hex-editor-workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(400px, 1fr) auto;
+  }
+}
+
 @media (max-width: 480px) {
   .inline-form,
   .item-list li {

--- a/src/renderer/shell/app.tsx
+++ b/src/renderer/shell/app.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useCallback,
   useMemo,
   useRef,
   useState,
@@ -48,6 +49,16 @@ import type {
   WorldFactionDraft,
   WorldFactionSnapshot
 } from '../../shared/contracts/encounter-source.js'
+import type {
+  AxialCoordinate,
+  HexMapCatalogSnapshot,
+  HexMapSnapshot,
+  HexRouteEvaluation,
+  HexTerrainCatalog,
+  HexTerrainId,
+  HexTravelSnapshot
+} from '../../shared/contracts/hex.js'
+import { HexMapCanvas } from '../features/hex/hex-map-canvas.js'
 
 declare global {
   interface Window {
@@ -92,7 +103,9 @@ export function App() {
   const [campaigns, setCampaigns] = useState(emptyCampaigns)
   const [session, setSession] = useState<LiveSessionSnapshot | null>(null)
   const [campaignName, setCampaignName] = useState('')
-  const [workspace, setWorkspace] = useState<'session' | 'catalog'>('session')
+  const [workspace, setWorkspace] = useState<'session' | 'catalog' | 'hex'>(
+    'session'
+  )
   const [partyOpen, setPartyOpen] = useState(false)
   const [dayOpen, setDayOpen] = useState(false)
   const [groupDialogOpen, setGroupDialogOpen] = useState(false)
@@ -175,7 +188,9 @@ export function App() {
   const heading = active
     ? workspace === 'catalog'
       ? 'Katalog'
-      : 'Session'
+      : workspace === 'hex'
+        ? 'Hex-Editor'
+        : 'Session'
     : 'Campaigns'
 
   return (
@@ -243,6 +258,15 @@ export function App() {
               </button>
               <button
                 className="icon-button"
+                aria-label="Hex-Editor"
+                title="Hex-Editor"
+                aria-pressed={workspace === 'hex'}
+                onClick={() => setWorkspace('hex')}
+              >
+                <span aria-hidden="true">⬡</span>
+              </button>
+              <button
+                className="icon-button"
                 aria-label="Katalog"
                 title="Katalog"
                 aria-pressed={workspace === 'catalog'}
@@ -301,6 +325,9 @@ export function App() {
               inspect={setInspected}
               onError={setError}
             />
+          )}
+          {active && session && workspace === 'hex' && (
+            <HexEditor onError={setError} />
           )}
         </div>
       </div>
@@ -829,6 +856,9 @@ function PartyEditor(props: {
     props.member?.passivePerception?.toString() ?? ''
   )
   const [armor, setArmor] = useState(props.member?.armorClass?.toString() ?? '')
+  const [movementSpeed, setMovementSpeed] = useState(
+    props.member?.movementSpeedFeet?.toString() ?? ''
+  )
   const optional = (value: string) =>
     value.trim() === '' ? null : Number(value)
   return (
@@ -841,7 +871,8 @@ function PartyEditor(props: {
           playerName: player.trim() || null,
           level: optional(level),
           passivePerception: optional(perception),
-          armorClass: optional(armor)
+          armorClass: optional(armor),
+          movementSpeedFeet: optional(movementSpeed)
         })
       }}
     >
@@ -891,6 +922,18 @@ function PartyEditor(props: {
           onChange={(event) => setArmor(event.target.value)}
         />
       </div>
+      <label>
+        Bewegungsrate (ft/Runde)
+        <input
+          aria-label="Bewegungsrate"
+          type="number"
+          min="0"
+          max="999"
+          placeholder="30"
+          value={movementSpeed}
+          onChange={(event) => setMovementSpeed(event.target.value)}
+        />
+      </label>
       {props.member && !props.deleteConfirm && (
         <button
           type="button"
@@ -1132,13 +1175,11 @@ function SessionWorkspace(props: {
         </button>
       </div>
       {props.layout.upperRightTab === 'map' ? (
-        <div className="session-map-empty">
-          <strong>Reiseplanung</strong>
-          <p>
-            Sobald ein Hex- oder Dungeon-Provider verfügbar ist, können hier
-            Orte gewählt und Routen geplant werden.
-          </p>
-        </div>
+        <SessionHexMap
+          snapshot={props.snapshot}
+          setSnapshot={props.setSnapshot}
+          onError={props.onError}
+        />
       ) : (
         <>
           <nav className="detail-history" aria-label="Detail Verlauf">
@@ -1207,7 +1248,14 @@ function SessionWorkspace(props: {
       {!props.scenario ? (
         <div className="scenario-empty">Szenario Panel</div>
       ) : props.scenario === 'travel' ? (
-        <TravelScenario snapshot={props.snapshot} />
+        <TravelScenario
+          snapshot={props.snapshot}
+          setSnapshot={props.setSnapshot}
+          openMap={() =>
+            props.setLayout({ ...props.layout, upperRightTab: 'map' })
+          }
+          onError={props.onError}
+        />
       ) : (
         <SessionEncounterPanel
           {...props}
@@ -2008,15 +2056,714 @@ function groupDraftSignature(
   return JSON.stringify({ name, entries: groupDraftEntries(quantities) })
 }
 
-function TravelScenario({ snapshot }: { snapshot: LiveSessionSnapshot }) {
+function TravelScenario(props: {
+  snapshot: LiveSessionSnapshot
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+  openMap: () => void
+  onError: (message: string) => void
+}) {
+  const focusedSceneId = props.snapshot.scene.focusedSceneId
+  const onError = props.onError
+  const setSnapshot = props.setSnapshot
+  const [travel, setTravel] = useState<HexTravelSnapshot | null>(null)
+  const refresh = useCallback(async () => {
+    const next = await window.saltMarcher.hexTravel.read(focusedSceneId)
+    setTravel(next)
+    setSnapshot(await window.saltMarcher.session.read())
+  }, [focusedSceneId, setSnapshot])
+  useEffect(() => {
+    void Promise.resolve().then(refresh).catch(showError(onError))
+  }, [onError, refresh])
+  useEffect(() => {
+    if (travel?.status !== 'travelling') return
+    const timer = window.setInterval(
+      () => void refresh().catch(showError(onError)),
+      100
+    )
+    return () => window.clearInterval(timer)
+  }, [onError, refresh, travel?.status])
+  const mutate = async (action: 'pause' | 'resume' | 'abort') => {
+    if (!travel) return
+    try {
+      setTravel(
+        await window.saltMarcher.hexTravel[action](
+          focusedSceneId,
+          travel.revision
+        )
+      )
+      props.setSnapshot(await window.saltMarcher.session.read())
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const context = props.snapshot.travel
   return (
     <section className="scenario-content travel-context">
       <p className="section-kicker">Reise</p>
-      <h2>{snapshot.travel.label}</h2>
-      <p>{snapshot.travel.hint}</p>
-      <small>Dieser globale Zustand ist schreibgeschützt.</small>
+      <h2>
+        {context.kind === 'hex'
+          ? context.locationName || context.currentLabel
+          : context.label}
+      </h2>
+      {context.kind === 'hex' ? (
+        <>
+          <p>
+            {context.mapName} · {formatGameTime(context.gameTimeSeconds)}
+          </p>
+          <p>{context.hint}</p>
+          <dl className="travel-facts">
+            <div>
+              <dt>Status</dt>
+              <dd>{context.status}</dd>
+            </div>
+            <div>
+              <dt>Tempo</dt>
+              <dd>{context.effectiveSpeedFeet} ft/Runde</dd>
+            </div>
+            <div>
+              <dt>Rest</dt>
+              <dd>{formatDuration(context.remainingGameSeconds)}</dd>
+            </div>
+          </dl>
+          {context.assumedSpeedMemberNames.length > 0 && (
+            <p className="travel-warning">
+              30 ft angenommen für {context.assumedSpeedMemberNames.join(', ')}.
+            </p>
+          )}
+          {travel && (
+            <label>
+              Darstellungstempo
+              <select
+                value={travel.multiplier}
+                onChange={(event) =>
+                  void window.saltMarcher.hexTravel
+                    .setMultiplier(
+                      focusedSceneId,
+                      Number(event.target.value) as 1 | 2 | 5 | 10,
+                      travel.revision
+                    )
+                    .then(setTravel)
+                    .catch(showError(props.onError))
+                }
+              >
+                {[1, 2, 5, 10].map((value) => (
+                  <option key={value} value={value}>
+                    {value}×
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <div className="row-actions">
+            <button onClick={props.openMap}>Karte öffnen</button>
+            {travel?.status === 'travelling' && (
+              <button onClick={() => void mutate('pause')}>Pause</button>
+            )}
+            {(travel?.status === 'paused' || travel?.status === 'blocked') && (
+              <button onClick={() => void mutate('resume')}>Fortsetzen</button>
+            )}
+            {travel &&
+              ['travelling', 'paused', 'blocked'].includes(travel.status) && (
+                <button className="danger" onClick={() => void mutate('abort')}>
+                  Abbrechen
+                </button>
+              )}
+          </div>
+        </>
+      ) : (
+        <>
+          <p>{context.hint}</p>
+          <button onClick={props.openMap}>Karte öffnen</button>
+        </>
+      )}
     </section>
   )
+}
+
+function SessionHexMap(props: {
+  snapshot: LiveSessionSnapshot
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+  onError: (message: string) => void
+}) {
+  const sceneId = props.snapshot.scene.focusedSceneId
+  const onError = props.onError
+  const [catalog, setCatalog] = useState<HexMapCatalogSnapshot | null>(null)
+  const [terrains, setTerrains] = useState<HexTerrainCatalog | null>(null)
+  const [map, setMap] = useState<HexMapSnapshot | null>(null)
+  const [travel, setTravel] = useState<HexTravelSnapshot | null>(null)
+  const [selected, setSelected] = useState<AxialCoordinate | null>(null)
+  const [mode, setMode] = useState<'inspect' | 'position' | 'plan'>('inspect')
+  const [waypoints, setWaypoints] = useState<AxialCoordinate[]>([])
+  const [evaluation, setEvaluation] = useState<HexRouteEvaluation | null>(null)
+
+  useEffect(() => {
+    void Promise.all([
+      window.saltMarcher.hex.catalog(),
+      window.saltMarcher.hex.terrainCatalog(),
+      window.saltMarcher.hexTravel.read(sceneId)
+    ])
+      .then(async ([nextCatalog, nextTerrains, nextTravel]) => {
+        setCatalog(nextCatalog)
+        setTerrains(nextTerrains)
+        setTravel(nextTravel)
+        const mapId = nextTravel.mapId ?? nextCatalog.maps[0]?.id
+        setMap(mapId ? await window.saltMarcher.hex.read(mapId) : null)
+      })
+      .catch(showError(onError))
+  }, [onError, sceneId])
+
+  useEffect(() => {
+    if (!map || mode !== 'plan' || waypoints.length === 0) return
+    void Promise.resolve()
+      .then(() =>
+        window.saltMarcher.hexTravel.evaluate(sceneId, map.map.id, waypoints)
+      )
+      .then(setEvaluation)
+      .catch(showError(onError))
+  }, [map, mode, onError, sceneId, waypoints])
+
+  const selectMap = async (mapId: string) => {
+    try {
+      setMap(await window.saltMarcher.hex.read(mapId))
+      setSelected(null)
+      setWaypoints([])
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const clickTile = (coordinate: AxialCoordinate) => {
+    setSelected(coordinate)
+    if (mode === 'plan') {
+      setEvaluation(null)
+      setWaypoints((current) => [...current, coordinate])
+    }
+  }
+  const placeParty = async () => {
+    if (!map || !selected) return
+    try {
+      setTravel(
+        await window.saltMarcher.hexTravel.position(
+          sceneId,
+          map.map.id,
+          selected,
+          props.snapshot.scene.revision
+        )
+      )
+      props.setSnapshot(await window.saltMarcher.session.read())
+      setMode('inspect')
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const start = async () => {
+    if (!map || !travel || !evaluation?.canStart) return
+    try {
+      setTravel(
+        await window.saltMarcher.hexTravel.start(
+          sceneId,
+          map.map.id,
+          waypoints,
+          travel.multiplier,
+          travel.revision
+        )
+      )
+      props.setSnapshot(await window.saltMarcher.session.read())
+      setMode('inspect')
+      setWaypoints([])
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  if (!catalog || !terrains)
+    return <div className="session-map-empty">Karte wird geladen …</div>
+  if (catalog.maps.length === 0)
+    return (
+      <div className="session-map-empty">
+        <strong>Keine Hex-Karte</strong>
+        <p>Lege zuerst im Hex-Editor eine Karte an.</p>
+      </div>
+    )
+  if (!map) return <div className="session-map-empty">Karte wird geladen …</div>
+  const token = travel?.mapId === map.map.id ? travel.current : null
+  const route =
+    evaluation?.path ?? (travel?.mapId === map.map.id ? travel.path : [])
+  const selectedTile = selected
+    ? map.tiles.find((tile) => tile.q === selected.q && tile.r === selected.r)
+    : null
+  return (
+    <div className="session-hex-map">
+      <div className="hex-map-toolbar">
+        <select
+          aria-label="Hex-Karte"
+          value={map.map.id}
+          onChange={(event) => void selectMap(event.target.value)}
+        >
+          {catalog.maps.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.displayName}
+            </option>
+          ))}
+        </select>
+        <button
+          aria-pressed={mode === 'inspect'}
+          onClick={() => setMode('inspect')}
+        >
+          Auswahl
+        </button>
+        <button
+          aria-pressed={mode === 'position'}
+          onClick={() => setMode('position')}
+        >
+          Party platzieren
+        </button>
+        <button
+          aria-pressed={mode === 'plan'}
+          onClick={() => {
+            setMode('plan')
+            setWaypoints([])
+            setEvaluation(null)
+          }}
+        >
+          Reise planen
+        </button>
+        {mode === 'plan' && (
+          <button
+            disabled={waypoints.length === 0}
+            onClick={() => {
+              setEvaluation(null)
+              setWaypoints((current) => current.slice(0, -1))
+            }}
+          >
+            Letzten Punkt entfernen
+          </button>
+        )}
+      </div>
+      <HexMapCanvas
+        snapshot={map}
+        terrains={terrains}
+        selected={selected}
+        token={token}
+        route={route}
+        onTileClick={clickTile}
+        ariaLabel={`Hex-Karte ${map.map.displayName}`}
+      />
+      <div className="hex-map-status">
+        <span>
+          {selectedTile
+            ? `${selectedTile.label} · ${terrains.terrains.find((terrain) => terrain.id === selectedTile.terrainId)?.label}${selectedTile.location ? ` · ${selectedTile.location.displayName}` : ''}`
+            : (travel?.hint ?? 'Hexfeld auswählen.')}
+        </span>
+        {mode === 'position' && (
+          <button disabled={!selected} onClick={() => void placeParty()}>
+            Party hier platzieren
+          </button>
+        )}
+        {mode === 'plan' && (
+          <>
+            <span>
+              {evaluation?.message ?? 'Wegpunkte auf der Karte wählen.'}
+            </span>
+            {evaluation && (
+              <span>{formatDuration(evaluation.totalGameSeconds)}</span>
+            )}
+            <button
+              disabled={!evaluation?.canStart}
+              onClick={() => void start()}
+            >
+              Reise starten
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function HexEditor(props: { onError: (message: string) => void }) {
+  const onError = props.onError
+  const [catalog, setCatalog] = useState<HexMapCatalogSnapshot | null>(null)
+  const [terrains, setTerrains] = useState<HexTerrainCatalog | null>(null)
+  const [map, setMap] = useState<HexMapSnapshot | null>(null)
+  const [selected, setSelected] = useState<AxialCoordinate | null>(null)
+  const [tool, setTool] = useState<'select' | 'paint'>('select')
+  const [terrainId, setTerrainId] = useState<HexTerrainId>('grassland')
+  const [newName, setNewName] = useState('Neue Hex-Karte')
+  const [name, setName] = useState('')
+  const [radius, setRadius] = useState(2)
+
+  const refreshCatalog = async (preferred?: string) => {
+    const next = await window.saltMarcher.hex.catalog()
+    setCatalog(next)
+    const mapId = preferred ?? map?.map.id ?? next.maps[0]?.id
+    if (!mapId) {
+      setMap(null)
+      return
+    }
+    const nextMap = await window.saltMarcher.hex.read(mapId)
+    setMap(nextMap)
+    setName(nextMap.map.displayName)
+    setRadius(nextMap.map.radius)
+  }
+  useEffect(() => {
+    void Promise.all([
+      window.saltMarcher.hex.catalog(),
+      window.saltMarcher.hex.terrainCatalog()
+    ])
+      .then(async ([nextCatalog, nextTerrains]) => {
+        setCatalog(nextCatalog)
+        setTerrains(nextTerrains)
+        const first = nextCatalog.maps[0]
+        if (first) {
+          const nextMap = await window.saltMarcher.hex.read(first.id)
+          setMap(nextMap)
+          setName(nextMap.map.displayName)
+          setRadius(nextMap.map.radius)
+        }
+      })
+      .catch(showError(onError))
+  }, [onError])
+
+  const create = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!catalog) return
+    try {
+      const created = await window.saltMarcher.hex.create(
+        newName,
+        catalog.revision
+      )
+      await refreshCatalog(created.map.id)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const saveMetadata = async () => {
+    if (!map) return
+    const confirmDataLoss =
+      radius < map.map.radius
+        ? window.confirm(
+            'Beim Verkleinern können Terrain und Ortsplatzierungen verloren gehen. Fortfahren?'
+          )
+        : false
+    if (radius < map.map.radius && !confirmDataLoss) return
+    try {
+      const next = await window.saltMarcher.hex.update(
+        map.map.id,
+        name,
+        radius,
+        confirmDataLoss,
+        map.map.revision
+      )
+      setMap(next)
+      await refreshCatalog(next.map.id)
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const tileClick = async (coordinate: AxialCoordinate) => {
+    setSelected(coordinate)
+    if (!map || tool !== 'paint') return
+    try {
+      setMap(
+        await window.saltMarcher.hex.paint(
+          map.map.id,
+          coordinate,
+          terrainId,
+          map.map.revision
+        )
+      )
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+
+  if (!catalog || !terrains)
+    return (
+      <section className="workspace-panel">Hex-Editor wird geladen …</section>
+    )
+  const tile =
+    selected && map
+      ? map.tiles.find(
+          (candidate) =>
+            candidate.q === selected.q && candidate.r === selected.r
+        )
+      : null
+  return (
+    <section className="hex-editor-workspace">
+      <aside className="hex-editor-controls">
+        <form onSubmit={(event) => void create(event)}>
+          <h2>Hex-Karten</h2>
+          <input
+            aria-label="Neue Karte"
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+          />
+          <button disabled={!newName.trim()}>Neu</button>
+        </form>
+        <label>
+          Karte
+          <select
+            value={map?.map.id ?? ''}
+            onChange={(event) =>
+              void refreshCatalog(event.target.value).catch(
+                showError(props.onError)
+              )
+            }
+          >
+            <option value="">Keine Karte</option>
+            {catalog.maps.map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.displayName}
+              </option>
+            ))}
+          </select>
+        </label>
+        {map && (
+          <>
+            <label>
+              Name
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <label>
+              Radius
+              <input
+                type="number"
+                min="0"
+                max="99"
+                value={radius}
+                onChange={(event) => setRadius(Number(event.target.value))}
+              />
+            </label>
+            <button onClick={() => void saveMetadata()}>
+              Kartendaten speichern
+            </button>
+            <div className="tool-row">
+              <button
+                aria-pressed={tool === 'select'}
+                onClick={() => setTool('select')}
+              >
+                Auswahl
+              </button>
+              <button
+                aria-pressed={tool === 'paint'}
+                onClick={() => setTool('paint')}
+              >
+                Terrain malen
+              </button>
+            </div>
+            <label>
+              Terrain
+              <select
+                value={terrainId}
+                onChange={(event) =>
+                  setTerrainId(event.target.value as HexTerrainId)
+                }
+              >
+                {terrains.terrains.map((terrain) => (
+                  <option key={terrain.id} value={terrain.id}>
+                    {terrain.label} ·{' '}
+                    {terrain.passable
+                      ? `${terrain.travelCost}×`
+                      : 'unpassierbar'}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </>
+        )}
+      </aside>
+      <main className="hex-editor-map">
+        {map ? (
+          <HexMapCanvas
+            snapshot={map}
+            terrains={terrains}
+            selected={selected}
+            onTileClick={(coordinate) => void tileClick(coordinate)}
+            ariaLabel={`Hex-Editor ${map.map.displayName}`}
+          />
+        ) : (
+          <div className="session-map-empty">Erstelle eine Hex-Karte.</div>
+        )}
+      </main>
+      <aside className="hex-editor-state">
+        <h2>Hexfeld</h2>
+        {tile ? (
+          <>
+            <strong>{tile.label}</strong>
+            <p>
+              {
+                terrains.terrains.find(
+                  (terrain) => terrain.id === tile.terrainId
+                )?.label
+              }
+            </p>
+            <p>{tile.location?.displayName ?? 'Kein benannter Ort'}</p>
+          </>
+        ) : (
+          <p>Wähle ein Hexfeld aus.</p>
+        )}
+      </aside>
+    </section>
+  )
+}
+
+function HexLocationPlacementDialog(props: {
+  location: WorldLocation
+  close: () => void
+  onPlaced: () => void
+  onError: (message: string) => void
+}) {
+  const onError = props.onError
+  const [catalog, setCatalog] = useState<HexMapCatalogSnapshot | null>(null)
+  const [terrains, setTerrains] = useState<HexTerrainCatalog | null>(null)
+  const [map, setMap] = useState<HexMapSnapshot | null>(null)
+  const [selected, setSelected] = useState<AxialCoordinate | null>(null)
+  const [existing, setExisting] = useState<{
+    mapId: string
+    revision: number
+  } | null>(null)
+  useEffect(() => {
+    void Promise.all([
+      window.saltMarcher.hex.catalog(),
+      window.saltMarcher.hex.terrainCatalog()
+    ])
+      .then(async ([nextCatalog, nextTerrains]) => {
+        setCatalog(nextCatalog)
+        setTerrains(nextTerrains)
+        const snapshots = await Promise.all(
+          nextCatalog.maps.map((entry) => window.saltMarcher.hex.read(entry.id))
+        )
+        const found = snapshots.find((snapshot) =>
+          snapshot.tiles.some(
+            (tile) => tile.location?.locationId === props.location.id
+          )
+        )
+        const initial = found ?? snapshots[0] ?? null
+        setMap(initial)
+        if (found) {
+          const tile = found.tiles.find(
+            (candidate) => candidate.location?.locationId === props.location.id
+          )!
+          setSelected({ q: tile.q, r: tile.r })
+          setExisting({ mapId: found.map.id, revision: found.map.revision })
+        }
+      })
+      .catch(showError(onError))
+  }, [onError, props.location.id])
+  const changeMap = async (mapId: string) => {
+    setMap(await window.saltMarcher.hex.read(mapId))
+    setSelected(null)
+  }
+  const place = async () => {
+    if (!map || !selected) return
+    try {
+      await window.saltMarcher.hex.placeLocation(
+        map.map.id,
+        props.location.id,
+        selected,
+        map.map.revision
+      )
+      props.onPlaced()
+      props.close()
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  const remove = async () => {
+    if (!existing) return
+    try {
+      await window.saltMarcher.hex.removeLocation(
+        props.location.id,
+        existing.revision
+      )
+      props.onPlaced()
+      props.close()
+    } catch (cause) {
+      props.onError(errorText(cause))
+    }
+  }
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <section
+        className="hex-placement-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ort auf Hex-Karte platzieren"
+      >
+        <header>
+          <div>
+            <p className="section-kicker">Ort platzieren</p>
+            <h2>{props.location.displayName}</h2>
+          </div>
+          <button aria-label="Schließen" onClick={props.close}>
+            ×
+          </button>
+        </header>
+        {!catalog || !terrains ? (
+          <p>Karten werden geladen …</p>
+        ) : catalog.maps.length === 0 ? (
+          <p>Lege zuerst eine Hex-Karte an.</p>
+        ) : map ? (
+          <>
+            <select
+              aria-label="Zielkarte"
+              value={map.map.id}
+              onChange={(event) =>
+                void changeMap(event.target.value).catch(
+                  showError(props.onError)
+                )
+              }
+            >
+              {catalog.maps.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.displayName}
+                </option>
+              ))}
+            </select>
+            <HexMapCanvas
+              snapshot={map}
+              terrains={terrains}
+              selected={selected}
+              onTileClick={setSelected}
+              ariaLabel={`Platzierung von ${props.location.displayName}`}
+            />
+            <footer>
+              <button onClick={props.close}>Abbrechen</button>
+              {existing && (
+                <button className="danger" onClick={() => void remove()}>
+                  Von Karte entfernen
+                </button>
+              )}
+              <button disabled={!selected} onClick={() => void place()}>
+                Hier platzieren
+              </button>
+            </footer>
+          </>
+        ) : null}
+      </section>
+    </div>
+  )
+}
+
+function formatDuration(totalSeconds: number) {
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  return `${hours} Std. ${minutes} Min.`
+}
+
+function formatGameTime(totalSeconds: number) {
+  const day = Math.floor(totalSeconds / 86400) + 1
+  const inDay = totalSeconds % 86400
+  const hours = Math.floor(inDay / 3600)
+    .toString()
+    .padStart(2, '0')
+  const minutes = Math.floor((inDay % 3600) / 60)
+    .toString()
+    .padStart(2, '0')
+  return `Tag ${day}, ${hours}:${minutes}`
 }
 
 function CatalogWorkspace(
@@ -2045,6 +2792,9 @@ function CatalogWorkspace(
     WorldLocation | null | undefined
   >(undefined)
   const [deleteLocationConfirm, setDeleteLocationConfirm] = useState(false)
+  const [placingLocation, setPlacingLocation] = useState<WorldLocation | null>(
+    null
+  )
   const [locationTables, setLocationTables] = useState<EncounterTable[]>([])
   const [locationFactions, setLocationFactions] = useState<WorldFaction[]>([])
   const request = useRef(0)
@@ -2379,6 +3129,7 @@ function CatalogWorkspace(
             setEditingLocation(selectedLocation)
             setSelectedLocation(null)
           }}
+          place={() => setPlacingLocation(selectedLocation)}
           deleteConfirm={deleteLocationConfirm}
           setDeleteConfirm={setDeleteLocationConfirm}
           remove={() => void deleteLocation()}
@@ -2393,6 +3144,16 @@ function CatalogWorkspace(
           save={(draft) => void saveLocation(draft)}
         />
       )}
+      {placingLocation && (
+        <HexLocationPlacementDialog
+          location={placingLocation}
+          close={() => setPlacingLocation(null)}
+          onPlaced={() =>
+            void window.saltMarcher.session.read().then(props.setSnapshot)
+          }
+          onError={props.onError}
+        />
+      )}
     </section>
   )
 }
@@ -2401,6 +3162,7 @@ function LocationInspector(props: {
   location: WorldLocation
   close: () => void
   edit: () => void
+  place: () => void
   deleteConfirm: boolean
   setDeleteConfirm: (value: boolean) => void
   remove: () => void
@@ -2424,6 +3186,7 @@ function LocationInspector(props: {
         {props.location.encounterTableIds.length} direkte Encounter-Tabellen
       </p>
       <footer className="row-actions">
+        <button onClick={props.place}>Platzieren / verschieben</button>
         <button onClick={props.edit}>Bearbeiten</button>
         {!props.deleteConfirm ? (
           <button

--- a/src/shared/contracts/capability-api.ts
+++ b/src/shared/contracts/capability-api.ts
@@ -27,6 +27,15 @@ import type {
   WorldFactionDraft,
   WorldFactionSnapshot
 } from './encounter-source.js'
+import type {
+  AxialCoordinate,
+  HexMapCatalogSnapshot,
+  HexMapSnapshot,
+  HexRouteEvaluation,
+  HexTerrainCatalog,
+  HexTerrainId,
+  HexTravelSnapshot
+} from './hex.js'
 
 export interface CampaignReadCapability {
   list(): Promise<CampaignSnapshot>
@@ -122,6 +131,70 @@ export interface SaltMarcherApi {
       expectedRevision: number
     ): Promise<WorldFactionSnapshot>
     delete(id: string, expectedRevision: number): Promise<WorldFactionSnapshot>
+  }
+  hex: {
+    terrainCatalog(): Promise<HexTerrainCatalog>
+    catalog(): Promise<HexMapCatalogSnapshot>
+    read(mapId: string): Promise<HexMapSnapshot>
+    create(
+      displayName: string,
+      expectedCatalogRevision: number
+    ): Promise<HexMapSnapshot>
+    update(
+      mapId: string,
+      displayName: string,
+      radius: number,
+      confirmDataLoss: boolean,
+      expectedRevision: number
+    ): Promise<HexMapSnapshot>
+    paint(
+      mapId: string,
+      coordinate: AxialCoordinate,
+      terrainId: HexTerrainId,
+      expectedRevision: number
+    ): Promise<HexMapSnapshot>
+    placeLocation(
+      mapId: string,
+      locationId: string,
+      coordinate: AxialCoordinate,
+      expectedRevision: number
+    ): Promise<HexMapSnapshot>
+    removeLocation(
+      locationId: string,
+      expectedMapRevision: number
+    ): Promise<HexMapSnapshot>
+  }
+  hexTravel: {
+    read(sceneId: string): Promise<HexTravelSnapshot>
+    evaluate(
+      sceneId: string,
+      mapId: string,
+      waypoints: readonly AxialCoordinate[]
+    ): Promise<HexRouteEvaluation>
+    position(
+      sceneId: string,
+      mapId: string,
+      coordinate: AxialCoordinate,
+      expectedSceneRevision: number
+    ): Promise<HexTravelSnapshot>
+    start(
+      sceneId: string,
+      mapId: string,
+      waypoints: readonly AxialCoordinate[],
+      multiplier: 1 | 2 | 5 | 10,
+      expectedRevision: number
+    ): Promise<HexTravelSnapshot>
+    pause(sceneId: string, expectedRevision: number): Promise<HexTravelSnapshot>
+    resume(
+      sceneId: string,
+      expectedRevision: number
+    ): Promise<HexTravelSnapshot>
+    abort(sceneId: string, expectedRevision: number): Promise<HexTravelSnapshot>
+    setMultiplier(
+      sceneId: string,
+      multiplier: 1 | 2 | 5 | 10,
+      expectedRevision: number
+    ): Promise<HexTravelSnapshot>
   }
   session: {
     read(): Promise<LiveSessionSnapshot>

--- a/src/shared/contracts/core-protocol.ts
+++ b/src/shared/contracts/core-protocol.ts
@@ -40,6 +40,18 @@ import {
   updateEncounterTableInputSchema,
   updateWorldFactionInputSchema
 } from './encounter-source.js'
+import {
+  createHexMapInputSchema,
+  evaluateHexRouteInputSchema,
+  mutateHexTravelInputSchema,
+  paintHexTerrainInputSchema,
+  placeHexLocationInputSchema,
+  positionHexPartyInputSchema,
+  removeHexLocationInputSchema,
+  setHexTravelMultiplierInputSchema,
+  startHexTravelInputSchema,
+  updateHexMapInputSchema
+} from './hex.js'
 
 const id = z.uuid()
 const simple = <const K extends string>(kind: K) =>
@@ -318,6 +330,106 @@ export const coreRequestSchema = z.discriminatedUnion('kind', [
       requestId: id,
       kind: z.literal('combat.complete'),
       input: combatRevisionInputSchema
+    })
+    .strict(),
+  simple('hex.terrainCatalog'),
+  simple('hex.catalog'),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.read'),
+      input: z.object({ mapId: z.uuid() }).strict()
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.create'),
+      input: createHexMapInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.update'),
+      input: updateHexMapInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.paint'),
+      input: paintHexTerrainInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.placeLocation'),
+      input: placeHexLocationInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hex.removeLocation'),
+      input: removeHexLocationInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.read'),
+      input: z.object({ sceneId: z.uuid() }).strict()
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.evaluate'),
+      input: evaluateHexRouteInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.position'),
+      input: positionHexPartyInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.start'),
+      input: startHexTravelInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.pause'),
+      input: mutateHexTravelInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.resume'),
+      input: mutateHexTravelInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.abort'),
+      input: mutateHexTravelInputSchema
+    })
+    .strict(),
+  z
+    .object({
+      requestId: id,
+      kind: z.literal('hexTravel.setMultiplier'),
+      input: setHexTravelMultiplierInputSchema
     })
     .strict()
 ])

--- a/src/shared/contracts/hex.ts
+++ b/src/shared/contracts/hex.ts
@@ -1,0 +1,229 @@
+import { z } from 'zod'
+
+export const axialCoordinateSchema = z
+  .object({ q: z.number().int(), r: z.number().int() })
+  .strict()
+
+export const hexTerrainIdSchema = z.enum([
+  'grassland',
+  'desert',
+  'forest',
+  'swamp',
+  'mountain',
+  'water'
+])
+
+export const hexTerrainDefinitionSchema = z
+  .object({
+    id: hexTerrainIdSchema,
+    label: z.string().min(1),
+    color: z.string().regex(/^#[0-9a-f]{6}$/i),
+    passable: z.boolean(),
+    travelCost: z.number().positive()
+  })
+  .strict()
+
+export const hexTerrainCatalogSchema = z
+  .object({
+    version: z.literal('saltmarcher-v1'),
+    terrains: z.array(hexTerrainDefinitionSchema).length(6)
+  })
+  .strict()
+
+export const hexMapSummarySchema = z
+  .object({
+    id: z.uuid(),
+    displayName: z.string().min(1).max(100),
+    radius: z.number().int().min(0).max(99),
+    revision: z.number().int().nonnegative(),
+    position: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const hexLocationPlacementSchema = axialCoordinateSchema
+  .extend({
+    locationId: z.uuid(),
+    displayName: z.string().min(1).max(100)
+  })
+  .strict()
+
+export const hexTileSchema = axialCoordinateSchema
+  .extend({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    terrainId: hexTerrainIdSchema,
+    location: hexLocationPlacementSchema.nullable()
+  })
+  .strict()
+
+export const hexMapCatalogSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    maps: z.array(hexMapSummarySchema)
+  })
+  .strict()
+
+export const hexMapSnapshotSchema = z
+  .object({ map: hexMapSummarySchema, tiles: z.array(hexTileSchema) })
+  .strict()
+
+const expectedMapRevisionSchema = z
+  .object({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const createHexMapInputSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(100),
+    expectedCatalogRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const updateHexMapInputSchema = expectedMapRevisionSchema
+  .extend({
+    mapId: z.uuid(),
+    displayName: z.string().trim().min(1).max(100),
+    radius: z.number().int().min(0).max(99),
+    confirmDataLoss: z.boolean().default(false)
+  })
+  .strict()
+
+export const paintHexTerrainInputSchema = expectedMapRevisionSchema
+  .extend({
+    mapId: z.uuid(),
+    coordinate: axialCoordinateSchema,
+    terrainId: hexTerrainIdSchema
+  })
+  .strict()
+
+export const placeHexLocationInputSchema = expectedMapRevisionSchema
+  .extend({
+    mapId: z.uuid(),
+    locationId: z.uuid(),
+    coordinate: axialCoordinateSchema
+  })
+  .strict()
+
+export const removeHexLocationInputSchema = z
+  .object({
+    locationId: z.uuid(),
+    expectedMapRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const hexTravelStatusSchema = z.enum([
+  'unpositioned',
+  'ready',
+  'travelling',
+  'paused',
+  'blocked',
+  'completed',
+  'aborted'
+])
+
+export const hexTravelSnapshotSchema = z
+  .object({
+    revision: z.number().int().nonnegative(),
+    sceneId: z.uuid(),
+    status: hexTravelStatusSchema,
+    mapId: z.uuid().nullable(),
+    mapName: z.string(),
+    current: axialCoordinateSchema.nullable(),
+    currentLabel: z.string(),
+    locationId: z.uuid().nullable(),
+    locationName: z.string(),
+    path: z.array(axialCoordinateSchema),
+    currentIndex: z.number().int().nonnegative(),
+    progress: z.number().min(0).max(1),
+    remainingGameSeconds: z.number().int().nonnegative(),
+    gameTimeSeconds: z.number().int().nonnegative(),
+    effectiveSpeedFeet: z.number().int().nonnegative(),
+    assumedSpeedMemberNames: z.array(z.string()),
+    multiplier: z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(5),
+      z.literal(10)
+    ]),
+    hint: z.string()
+  })
+  .strict()
+
+export const evaluateHexRouteInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    mapId: z.uuid(),
+    waypoints: z.array(axialCoordinateSchema).max(200)
+  })
+  .strict()
+
+export const hexRouteEvaluationSchema = z
+  .object({
+    canStart: z.boolean(),
+    message: z.string(),
+    path: z.array(axialCoordinateSchema),
+    totalGameSeconds: z.number().int().nonnegative(),
+    effectiveSpeedFeet: z.number().int().nonnegative(),
+    assumedSpeedMemberNames: z.array(z.string())
+  })
+  .strict()
+
+export const positionHexPartyInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    mapId: z.uuid(),
+    coordinate: axialCoordinateSchema,
+    expectedSceneRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const startHexTravelInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    mapId: z.uuid(),
+    waypoints: z.array(axialCoordinateSchema).min(1).max(200),
+    multiplier: z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(5),
+      z.literal(10)
+    ]),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const mutateHexTravelInputSchema = z
+  .object({
+    sceneId: z.uuid(),
+    expectedRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const setHexTravelMultiplierInputSchema = mutateHexTravelInputSchema
+  .extend({
+    multiplier: z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(5),
+      z.literal(10)
+    ])
+  })
+  .strict()
+
+export type AxialCoordinate = Readonly<z.infer<typeof axialCoordinateSchema>>
+export type HexTerrainId = z.infer<typeof hexTerrainIdSchema>
+export type HexTerrainDefinition = Readonly<
+  z.infer<typeof hexTerrainDefinitionSchema>
+>
+export type HexTerrainCatalog = Readonly<
+  z.infer<typeof hexTerrainCatalogSchema>
+>
+export type HexMapCatalogSnapshot = Readonly<
+  z.infer<typeof hexMapCatalogSnapshotSchema>
+>
+export type HexMapSnapshot = Readonly<z.infer<typeof hexMapSnapshotSchema>>
+export type HexTravelSnapshot = Readonly<
+  z.infer<typeof hexTravelSnapshotSchema>
+>
+export type HexRouteEvaluation = Readonly<
+  z.infer<typeof hexRouteEvaluationSchema>
+>

--- a/src/shared/contracts/live-session.ts
+++ b/src/shared/contracts/live-session.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { partyCharacterSchema, partySnapshotSchema } from './party.js'
 import { sceneSnapshotSchema } from './scene.js'
+import { hexTravelSnapshotSchema } from './hex.js'
 
 export { partyCharacterSchema as partyMemberSchema, partySnapshotSchema }
 
@@ -73,13 +74,32 @@ export const liveSessionSnapshotSchema = z
     revision: z.number().int().nonnegative(),
     party: partySnapshotSchema,
     scene: sceneSnapshotSchema,
-    travel: z
-      .object({
-        kind: z.literal('none'),
-        label: z.string(),
-        hint: z.string()
-      })
-      .strict(),
+    travel: z.discriminatedUnion('kind', [
+      z
+        .object({
+          kind: z.literal('none'),
+          label: z.string(),
+          hint: z.string()
+        })
+        .strict(),
+      hexTravelSnapshotSchema
+        .pick({
+          status: true,
+          mapId: true,
+          mapName: true,
+          currentLabel: true,
+          locationName: true,
+          progress: true,
+          remainingGameSeconds: true,
+          gameTimeSeconds: true,
+          effectiveSpeedFeet: true,
+          assumedSpeedMemberNames: true,
+          multiplier: true,
+          hint: true
+        })
+        .extend({ kind: z.literal('hex') })
+        .strict()
+    ]),
     combat: combatSnapshotSchema.nullable()
   })
   .strict()

--- a/src/shared/contracts/party.ts
+++ b/src/shared/contracts/party.ts
@@ -8,6 +8,16 @@ export const partyCharacterSchema = z
     level: z.number().int().min(1).max(20).nullable(),
     passivePerception: z.number().int().min(0).max(99).nullable(),
     armorClass: z.number().int().min(0).max(99).nullable(),
+    movementSpeedFeet: z.number().int().min(0).max(999).nullable(),
+    travelPosition: z
+      .object({
+        kind: z.literal('hex'),
+        mapId: z.uuid(),
+        tileId: z.string().min(1)
+      })
+      .strict()
+      .nullable(),
+    attachedToPartyToken: z.boolean(),
     active: z.boolean(),
     xp: z.number().int().nonnegative(),
     currentLevelFloor: z.number().int().nonnegative(),
@@ -41,7 +51,8 @@ export const partyCharacterDraftSchema = z
     playerName: z.string().trim().max(100).nullable(),
     level: z.number().int().min(1).max(20).nullable(),
     passivePerception: z.number().int().min(0).max(99).nullable(),
-    armorClass: z.number().int().min(0).max(99).nullable()
+    armorClass: z.number().int().min(0).max(99).nullable(),
+    movementSpeedFeet: z.number().int().min(0).max(999).nullable().default(null)
   })
   .strict()
 
@@ -104,7 +115,7 @@ export const adventuringDayCalculationSchema = z
 export type PartyCharacter = Readonly<z.infer<typeof partyCharacterSchema>>
 export type PartySnapshot = Readonly<z.infer<typeof partySnapshotSchema>>
 export type PartyCharacterDraft = Readonly<
-  z.infer<typeof partyCharacterDraftSchema>
+  z.input<typeof partyCharacterDraftSchema>
 >
 export type AdventuringDaySummary = Readonly<
   z.infer<typeof adventuringDaySummarySchema>

--- a/src/shared/contracts/scene.ts
+++ b/src/shared/contracts/scene.ts
@@ -30,6 +30,7 @@ export const runningSceneSchema = z
     focused: z.boolean(),
     locationId: z.string().nullable(),
     locationName: z.string(),
+    gameTimeSeconds: z.number().int().nonnegative(),
     partyMemberIds: z.array(z.uuid()),
     groups: z.array(sceneGroupSchema)
   })

--- a/tests/integration/hex-vertical-slice.test.ts
+++ b/tests/integration/hex-vertical-slice.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { WorldLocationService } from '../../src/core/worldplanner/location-store.js'
+import { HexMapService } from '../../src/core/hex/hex-map-store.js'
+import { HexTravelService } from '../../src/core/hex/hex-travel.js'
+
+const roots: string[] = []
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-hex-'))
+  roots.push(root)
+  const campaigns = new CampaignStore(root)
+  campaigns.create('Hex campaign')
+  const path = () => campaigns.activeCampaignPath()
+  let now = 1_000
+  return {
+    campaigns,
+    play: new LivePlayService(path),
+    locations: new WorldLocationService(path),
+    maps: new HexMapService(path),
+    travel: new HexTravelService(path, () => now),
+    advance(milliseconds: number) {
+      now += milliseconds
+    },
+    path
+  }
+}
+
+describe('hex editor to session travel vertical slice', () => {
+  it('persists terrain and a globally unique World Planner placement', () => {
+    const { locations, maps } = harness()
+    const world = locations.create(
+      {
+        displayName: 'Salzhafen',
+        notes: '',
+        factionIds: [],
+        encounterTableIds: []
+      },
+      locations.read().revision
+    )
+    let map = maps.create('Küste', maps.catalog().revision)
+    map = maps.paint({
+      mapId: map.map.id,
+      coordinate: { q: 1, r: 0 },
+      terrainId: 'forest',
+      expectedRevision: map.map.revision
+    })
+    map = maps.placeLocation({
+      mapId: map.map.id,
+      locationId: world.locations[0]!.id,
+      coordinate: { q: 0, r: 0 },
+      expectedRevision: map.map.revision
+    })
+    expect(map.tiles.find((tile) => tile.id === '1:0')?.terrainId).toBe(
+      'forest'
+    )
+    expect(map.tiles.find((tile) => tile.id === '0:0')?.location).toMatchObject(
+      {
+        displayName: 'Salzhafen'
+      }
+    )
+
+    const reopened = maps.read(map.map.id)
+    expect(reopened).toEqual(map)
+    locations.delete(world.locations[0]!.id, world.revision)
+    expect(
+      maps.read(map.map.id).tiles.some((tile) => tile.location !== null)
+    ).toBe(false)
+  })
+
+  it('derives the scene start, advances the token and scene clock, and pauses after restart', () => {
+    const h = harness()
+    const world = h.locations.create(
+      {
+        displayName: 'Startort',
+        notes: '',
+        factionIds: [],
+        encounterTableIds: []
+      },
+      h.locations.read().revision
+    )
+    let map = h.maps.create('Marschland', h.maps.catalog().revision)
+    map = h.maps.placeLocation({
+      mapId: map.map.id,
+      locationId: world.locations[0]!.id,
+      coordinate: { q: 0, r: 0 },
+      expectedRevision: map.map.revision
+    })
+
+    let session = h.play.readSession()
+    const memberId = session.party.members[0]!.id
+    h.play.setMembership(memberId, true, session.party.revision)
+    session = h.play.readSession()
+    session = h.play.assignScenePartyMember(
+      session.scene.focusedSceneId,
+      memberId,
+      true,
+      session.scene.revision
+    )
+    session = h.play.setSceneLocation(
+      session.scene.focusedSceneId,
+      world.locations[0]!.id,
+      session.scene.revision
+    )
+    const sceneId = session.scene.focusedSceneId
+    const ready = h.travel.read(sceneId)
+    expect(ready).toMatchObject({
+      status: 'ready',
+      current: { q: 0, r: 0 },
+      effectiveSpeedFeet: 30,
+      assumedSpeedMemberNames: [session.party.members[0]!.name]
+    })
+    const evaluation = h.travel.evaluate({
+      sceneId,
+      mapId: map.map.id,
+      waypoints: [{ q: 1, r: 0 }]
+    })
+    expect(evaluation).toMatchObject({ canStart: true, totalGameSeconds: 3600 })
+    let journey = h.travel.start({
+      sceneId,
+      mapId: map.map.id,
+      waypoints: [{ q: 1, r: 0 }],
+      multiplier: 1,
+      expectedRevision: ready.revision
+    })
+    expect(journey.status).toBe('travelling')
+    h.advance(1_001)
+    journey = h.travel.read(sceneId)
+    expect(journey).toMatchObject({
+      status: 'completed',
+      current: { q: 1, r: 0 },
+      gameTimeSeconds: 32_400
+    })
+
+    journey = h.travel.start({
+      sceneId,
+      mapId: map.map.id,
+      waypoints: [{ q: 0, r: 0 }],
+      multiplier: 1,
+      expectedRevision: journey.revision
+    })
+    expect(journey.status).toBe('travelling')
+    const restarted = new HexTravelService(h.path, () => 99_000).read(sceneId)
+    expect(restarted).toMatchObject({
+      status: 'paused',
+      current: { q: 1, r: 0 }
+    })
+  })
+})

--- a/tests/unit/hex-travel.test.ts
+++ b/tests/unit/hex-travel.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  axialDistance,
+  axialLine,
+  expandWaypoints,
+  travelGameSeconds
+} from '../../src/core/hex/hex-travel.js'
+import {
+  coordinates,
+  insideRadius,
+  parseTileId,
+  tileId,
+  tileLabel
+} from '../../src/core/hex/hex-map-store.js'
+
+describe('hex geometry and travel rules', () => {
+  it('generates stable radius coordinates and tile identities', () => {
+    expect(coordinates(0)).toEqual([{ q: 0, r: 0 }])
+    expect(coordinates(2)).toHaveLength(19)
+    expect(insideRadius({ q: 2, r: -1 }, 2)).toBe(true)
+    expect(insideRadius({ q: 2, r: 1 }, 2)).toBe(false)
+    expect(parseTileId(tileId({ q: -2, r: 1 }))).toEqual({ q: -2, r: 1 })
+    expect(tileLabel({ q: -2, r: 1 })).toBe('Hex q=-2, r=1')
+  })
+
+  it('expands manual waypoints into deterministic adjacent paths', () => {
+    const line = axialLine({ q: 0, r: 0 }, { q: 2, r: -1 })
+    expect(line).toEqual([
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: -1 }
+    ])
+    expect(
+      line
+        .slice(1)
+        .every(
+          (coordinate, index) => axialDistance(line[index]!, coordinate) === 1
+        )
+    ).toBe(true)
+    expect(
+      expandWaypoints({ q: 0, r: 0 }, [
+        { q: 1, r: 0 },
+        { q: 1, r: 1 }
+      ])
+    ).toEqual([
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 1, r: 1 }
+    ])
+  })
+
+  it('uses the default 3-mile Speed-divided-by-10 rule', () => {
+    expect(travelGameSeconds(30, 1)).toBe(3600)
+    expect(travelGameSeconds(30, 4)).toBe(14_400)
+    expect(travelGameSeconds(0, 1)).toBe(0)
+  })
+})


### PR DESCRIPTION
Implements the rudimentary Hexcrawl vertical slice from Hex editor to session travel. Includes persistent maps and terrain, World Planner location placement, waypoint routing, party travel state, PixiJS map views, validated IPC contracts, documentation, and unit/integration coverage.\n\nValidation: pnpm check (18 test files, 69 tests, Electron smoke test).