### PR TITLE
Separate build, qualification, and delivery fingerprints

### DIFF
--- a/scripts/build-identity.ts
+++ b/scripts/build-identity.ts
@@ -9,6 +9,11 @@ import {
 import { spawnSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import type { BuildToolchain } from '../src/shared/contracts/build-info.js'
+import {
+  classifyWorkspaceInput,
+  projectWorkspaceInput,
+  type WorkspaceInputClass
+} from './workspace-input-classification.js'
 
 export interface WorkspaceIdentity {
   readonly commit: string
@@ -17,23 +22,11 @@ export interface WorkspaceIdentity {
   readonly appBuildInputFingerprint: string
 }
 
-const appBuildInputRoots = ['src/', 'resources/']
-const appBuildInputFiles = new Set([
-  'package.json',
-  'pnpm-lock.yaml',
-  'electron.vite.config.ts',
-  'tsconfig.json',
-  'tsconfig.node.json',
-  'tsconfig.renderer.json',
-  'scripts/build-passive-preload.ts',
-  'scripts/build-app.ts',
-  'scripts/build-qualification.ts',
-  'scripts/package-cli.ts',
-  'scripts/write-build-info.ts',
-  'scripts/write-build-receipt.ts',
-  'scripts/build-receipt.ts',
-  'scripts/build-identity.ts'
-])
+export interface WorkspaceInputFingerprints {
+  readonly appBuildInputFingerprint: string
+  readonly qualificationInputFingerprint: string
+  readonly deliveryInputFingerprint: string
+}
 
 export function readWorkspaceIdentity(
   workspaceRoot = process.cwd()
@@ -60,17 +53,43 @@ export function computeWorkspaceFingerprint(
 export function computeAppBuildInputFingerprint(
   workspaceRoot = process.cwd()
 ): string {
-  const files = workspaceFiles(workspaceRoot).filter(
-    (path) =>
-      appBuildInputFiles.has(path) ||
-      appBuildInputRoots.some((root) => path.startsWith(root))
-  )
-  return computeFilesFingerprint(workspaceRoot, files)
+  return computeWorkspaceInputFingerprint(workspaceRoot, 'app-build')
+}
+
+export function computeQualificationInputFingerprint(
+  workspaceRoot = process.cwd()
+): string {
+  return computeWorkspaceInputFingerprint(workspaceRoot, 'qualification')
+}
+
+export function computeDeliveryInputFingerprint(
+  workspaceRoot = process.cwd()
+): string {
+  return computeWorkspaceInputFingerprint(workspaceRoot, 'delivery-tooling')
+}
+
+export function readWorkspaceInputFingerprints(
+  workspaceRoot = process.cwd()
+): WorkspaceInputFingerprints {
+  return {
+    appBuildInputFingerprint: computeAppBuildInputFingerprint(workspaceRoot),
+    qualificationInputFingerprint:
+      computeQualificationInputFingerprint(workspaceRoot),
+    deliveryInputFingerprint: computeDeliveryInputFingerprint(workspaceRoot)
+  }
 }
 
 export function computeAppBuildInputFingerprintAtRef(
   workspaceRoot: string,
   ref: string
+): string {
+  return computeWorkspaceInputFingerprintAtRef(workspaceRoot, ref, 'app-build')
+}
+
+export function computeWorkspaceInputFingerprintAtRef(
+  workspaceRoot: string,
+  ref: string,
+  inputClass: WorkspaceInputClass
 ): string {
   const output = gitBuffer(workspaceRoot, [
     'ls-tree',
@@ -89,23 +108,36 @@ export function computeAppBuildInputFingerprintAtRef(
         throw new Error(`Unsupported Git tree entry: ${record}`)
       return { mode: match[1], object: match[2], path: match[3] }
     })
-    .filter(
-      ({ path }) =>
-        appBuildInputFiles.has(path) ||
-        appBuildInputRoots.some((root) => path.startsWith(root))
-    )
+    .filter(({ path }) => classifyWorkspaceInput(path).includes(inputClass))
     .sort((left, right) =>
       left.path < right.path ? -1 : left.path > right.path ? 1 : 0
     )
   const hash = createHash('sha256')
   for (const entry of entries) {
-    const content = gitBuffer(workspaceRoot, ['cat-file', 'blob', entry.object])
+    const content = projectWorkspaceInput(
+      entry.path,
+      gitBuffer(workspaceRoot, ['cat-file', 'blob', entry.object]),
+      inputClass
+    )
     hash.update(`${Buffer.byteLength(entry.path)}:`)
     hash.update(entry.path)
     hash.update(`:${entry.mode === '100755' ? 1 : 0}:${content.length}:`)
     hash.update(content)
   }
   return hash.digest('hex')
+}
+
+function computeWorkspaceInputFingerprint(
+  workspaceRoot: string,
+  inputClass: WorkspaceInputClass
+): string {
+  return computeFilesFingerprint(
+    workspaceRoot,
+    workspaceFiles(workspaceRoot).filter((path) =>
+      classifyWorkspaceInput(path).includes(inputClass)
+    ),
+    inputClass
+  )
 }
 
 export function readBuildToolchain(
@@ -152,7 +184,8 @@ function workspaceFiles(workspaceRoot: string): string[] {
 
 function computeFilesFingerprint(
   workspaceRoot: string,
-  files: readonly string[]
+  files: readonly string[],
+  inputClass?: WorkspaceInputClass
 ): string {
   const hash = createHash('sha256')
   for (const relativePath of files) {
@@ -164,7 +197,11 @@ function computeFilesFingerprint(
       continue
     }
     const stats = lstatSync(absolutePath)
-    const content = fileContent(absolutePath, stats)
+    const content = projectWorkspaceInput(
+      relativePath,
+      fileContent(absolutePath, stats),
+      inputClass ?? 'documentation'
+    )
     hash.update(`${Buffer.byteLength(relativePath)}:`)
     hash.update(relativePath)
     hash.update(`:${stats.mode & 0o111}:${content.length}:`)

--- a/scripts/installed-runtime-verification.ts
+++ b/scripts/installed-runtime-verification.ts
@@ -3,7 +3,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, relative } from 'node:path'
 import Database from 'better-sqlite3'
-import { localArtifactManifestSchema } from '../src/shared/contracts/build-info.js'
+import {
+  localArtifactManifestSchema,
+  shortBuildFingerprint
+} from '../src/shared/contracts/build-info.js'
 import { preflightPersistence } from '../src/core/persistence/sqlite/persistence-preflight.js'
 import { installedRuntimeEvidenceSchema } from './delivery-contract.js'
 import { sha256File } from './file-hash.js'
@@ -58,10 +61,7 @@ if (verification.length !== 1)
     `Expected one runtime verification record, found ${verification.length}`
   )
 const evidence = verification[0]!
-const expectedFingerprint = manifest.receipt.build.workspaceFingerprint.slice(
-  0,
-  12
-)
+const expectedFingerprint = shortBuildFingerprint(manifest.receipt.build)
 if (evidence['windowTitle'] !== `SaltMarcher Local · ${expectedFingerprint}`)
   throw new Error(
     'Installed window title does not contain the current fingerprint'

--- a/scripts/verify-candidate.ts
+++ b/scripts/verify-candidate.ts
@@ -1,10 +1,13 @@
 import { assertCandidateReady } from './candidate-delivery.js'
+import { readWorkspaceInputFingerprints } from './build-identity.js'
 
 const state = assertCandidateReady()
+const inputFingerprints = readWorkspaceInputFingerprints()
 console.info(
   JSON.stringify({
     component: 'candidate-delivery',
     event: 'candidate-verified',
-    ...state
+    ...state,
+    inputFingerprints
   })
 )

--- a/scripts/verify-post-promotion.ts
+++ b/scripts/verify-post-promotion.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from 'node:child_process'
 import { z } from 'zod'
-import { readWorkspaceIdentity } from './build-identity.js'
+import {
+  readWorkspaceIdentity,
+  readWorkspaceInputFingerprints
+} from './build-identity.js'
 import { readSuccessfulWorkflowEvidence } from './candidate-delivery.js'
 import { shaSchema } from './delivery-contract.js'
 
@@ -17,6 +20,7 @@ if (!candidate)
     'No successful exact-SHA candidate run contains every required job.'
   )
 const identity = readWorkspaceIdentity(process.cwd())
+const inputFingerprints = readWorkspaceInputFingerprints(process.cwd())
 if (identity.commit !== expectedSha || identity.dirty)
   throw new Error(
     'Post-promotion workspace identity is not the clean main SHA.'
@@ -27,7 +31,7 @@ console.info(
     component: 'post-promotion',
     event: 'candidate-attestation-verified',
     applicationSha: expectedSha,
-    appBuildInputFingerprint: identity.appBuildInputFingerprint,
+    inputFingerprints,
     candidate
   })
 )

--- a/scripts/workspace-input-classification.ts
+++ b/scripts/workspace-input-classification.ts
@@ -1,0 +1,239 @@
+export const workspaceInputClasses = [
+  'app-build',
+  'qualification',
+  'delivery-tooling',
+  'documentation'
+] as const
+
+export type WorkspaceInputClass = (typeof workspaceInputClasses)[number]
+
+const documentationRoots = ['docs/'] as const
+const documentationFiles = new Set(['AGENTS.md', 'NOTICE', 'README.md'])
+
+const appBuildRoots = ['src/', 'resources/'] as const
+const appBuildFiles = new Set([
+  'electron-builder.development.yml',
+  'electron-builder.local.yml',
+  'electron-builder.release.yml',
+  'electron-builder.yml',
+  'electron.vite.config.ts',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'scripts/build-app.ts',
+  'scripts/build-identity.ts',
+  'scripts/build-passive-preload.ts',
+  'scripts/build-qualification.ts',
+  'scripts/build-receipt.ts',
+  'scripts/file-hash.ts',
+  'scripts/package-app.ts',
+  'scripts/package-cli.ts',
+  'scripts/prepare-build-output.ts',
+  'scripts/workspace-input-classification.ts',
+  'scripts/write-build-info.ts',
+  'scripts/write-build-receipt.ts',
+  'tsconfig.json',
+  'tsconfig.renderer.json'
+])
+
+const qualificationRoots = ['tests/'] as const
+const qualificationFiles = new Set([
+  '.prettierignore',
+  '.prettierrc.json',
+  'eslint.config.js',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'scripts/build-qualification.ts',
+  'scripts/installed-runtime-verification.ts',
+  'tsconfig.json',
+  'tsconfig.renderer.json',
+  'vitest.config.ts',
+  'wdio.conf.ts',
+  'wdio.passive.conf.ts'
+])
+
+const deliveryFiles = new Set([
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'scripts/assert-built-workspace.ts',
+  'scripts/candidate-delivery.ts',
+  'scripts/delivery-contract.ts',
+  'scripts/handoff-local-app.ts',
+  'scripts/install-local-app.ts',
+  'scripts/installed-runtime-verification.ts',
+  'scripts/local-app-installation.ts',
+  'scripts/local-install-journal.ts',
+  'scripts/promote-candidate.ts',
+  'scripts/verify-candidate.ts',
+  'scripts/verify-main-push.ts',
+  'scripts/verify-post-promotion.ts',
+  'scripts/workspace-input-classification.ts',
+  'scripts/write-local-artifact-manifest.ts'
+])
+
+const qualificationScriptPatterns = [
+  /^scripts\/architecture\//,
+  /^scripts\/check-/,
+  /^scripts\/e2e-/,
+  /^scripts\/generate-render-qualification-/,
+  /^scripts\/lint-/,
+  /^scripts\/materialize-e2e-/,
+  /^scripts\/packaged-smoke\./,
+  /^scripts\/qualify-/,
+  /^scripts\/require-platform\./,
+  /^scripts\/run-(e2e-suites|focused-check|lint-partitions|render-qualification|smoke|visual-suites)\.ts$/,
+  /^scripts\/test-manifests\//,
+  /^scripts\/validate-render-qualification\./,
+  /^scripts\/update-(reference-goldens|renderer-bundle-baseline|visual-golden)\.ts$/,
+  /^scripts\/visual-golden-/,
+  /^scripts\/(bundle-baseline-update|bundle-budget-policy|bundle-manifest-entry)\.ts$/
+] as const
+
+/**
+ * Classifies repository inputs by the behavior they can invalidate. Classes
+ * intentionally overlap: for example the lockfile affects both emitted app
+ * bytes and the tools used to qualify and deliver those bytes.
+ */
+export function classifyWorkspaceInput(
+  path: string
+): readonly WorkspaceInputClass[] {
+  if (
+    documentationFiles.has(path) ||
+    documentationRoots.some((root) => path.startsWith(root))
+  )
+    return ['documentation']
+
+  const classes = new Set<WorkspaceInputClass>()
+  if (
+    appBuildFiles.has(path) ||
+    appBuildRoots.some((root) => path.startsWith(root))
+  )
+    classes.add('app-build')
+  if (
+    qualificationFiles.has(path) ||
+    qualificationRoots.some((root) => path.startsWith(root)) ||
+    qualificationScriptPatterns.some((pattern) => pattern.test(path))
+  )
+    classes.add('qualification')
+  if (
+    deliveryFiles.has(path) ||
+    path.startsWith('.github/workflows/') ||
+    path.startsWith('scripts/delivery/')
+  )
+    classes.add('delivery-tooling')
+
+  // Scripts not involved in the app build or qualification are administrative
+  // tooling. Keeping this default fail-closed prevents new delivery helpers
+  // from silently escaping the delivery identity.
+  if (path.startsWith('scripts/') && classes.size === 0)
+    classes.add('delivery-tooling')
+
+  return workspaceInputClasses.filter((candidate) => classes.has(candidate))
+}
+
+const appBuildPackageScripts = new Set([
+  'build',
+  'build:development',
+  'build:local',
+  'build:qualification',
+  'build:release',
+  'package',
+  'package:built',
+  'package:development:built',
+  'package:local',
+  'package:local:built',
+  'package:qualification',
+  'package:release',
+  'package:release:built'
+])
+
+const appBuildDevDependencies = new Set([
+  '@electron-toolkit/utils',
+  'electron',
+  'electron-builder',
+  'electron-vite',
+  'tsx',
+  'typescript',
+  'vite'
+])
+
+/**
+ * package.json is a mixed manifest, so hashing the whole file would make an
+ * unrelated script alias look like an app input. Each fingerprint receives a
+ * canonical semantic projection instead.
+ */
+export function projectWorkspaceInput(
+  path: string,
+  content: Buffer,
+  inputClass: WorkspaceInputClass
+): Buffer {
+  if (path !== 'package.json' || inputClass === 'documentation') return content
+  const manifest = asRecord(JSON.parse(content.toString('utf8')))
+  const scripts = asRecord(manifest['scripts'])
+  const devDependencies = asRecord(manifest['devDependencies'])
+  let projection: Record<string, unknown>
+
+  if (inputClass === 'app-build')
+    projection = {
+      name: manifest['name'],
+      version: manifest['version'],
+      type: manifest['type'],
+      main: manifest['main'],
+      packageManager: manifest['packageManager'],
+      dependencies: manifest['dependencies'],
+      devDependencies: selectKeys(devDependencies, appBuildDevDependencies),
+      scripts: selectKeys(scripts, appBuildPackageScripts),
+      pnpm: manifest['pnpm']
+    }
+  else if (inputClass === 'qualification')
+    projection = {
+      packageManager: manifest['packageManager'],
+      devDependencies,
+      scripts: selectEntries(scripts, ([name]) =>
+        /^(check|format|lint|qualify|test|typecheck)(:|$)/.test(name)
+      ),
+      pnpm: manifest['pnpm']
+    }
+  else
+    projection = {
+      version: manifest['version'],
+      packageManager: manifest['packageManager'],
+      scripts,
+      pnpm: manifest['pnpm']
+    }
+
+  return Buffer.from(JSON.stringify(canonicalize(projection)))
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function selectKeys(
+  source: Record<string, unknown>,
+  keys: ReadonlySet<string>
+): Record<string, unknown> {
+  return selectEntries(source, ([key]) => keys.has(key))
+}
+
+function selectEntries(
+  source: Record<string, unknown>,
+  predicate: (entry: readonly [string, unknown]) => boolean
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(source).filter(predicate))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (typeof value !== 'object' || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right, 'en'))
+      .map(([key, entry]) => [key, canonicalize(entry)])
+  )
+}

--- a/src/shared/contracts/build-info.ts
+++ b/src/shared/contracts/build-info.ts
@@ -78,5 +78,5 @@ export const localArtifactManifestSchema = z
 export type LocalArtifactManifest = z.infer<typeof localArtifactManifestSchema>
 
 export function shortBuildFingerprint(buildInfo: BuildInfo): string {
-  return buildInfo.workspaceFingerprint.slice(0, 12)
+  return buildInfo.appBuildInputFingerprint.slice(0, 12)
 }

--- a/tests/unit/build-identity.test.ts
+++ b/tests/unit/build-identity.test.ts
@@ -6,8 +6,11 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   computeAppBuildInputFingerprint,
   computeAppBuildInputFingerprintAtRef,
+  computeDeliveryInputFingerprint,
+  computeQualificationInputFingerprint,
   computeWorkspaceFingerprint
 } from '../../scripts/build-identity.js'
+import { classifyWorkspaceInput } from '../../scripts/workspace-input-classification.js'
 import {
   buildInfoSchema,
   shortBuildFingerprint
@@ -71,6 +74,92 @@ describe('build identity', () => {
     expect(computeAppBuildInputFingerprint(root)).not.toBe(firstApp)
   })
 
+  it('classifies build, qualification, delivery, and documentation inputs explicitly', () => {
+    expect(classifyWorkspaceInput('src/main/index.ts')).toEqual(['app-build'])
+    expect(classifyWorkspaceInput('resources/catalog/items.json')).toEqual([
+      'app-build'
+    ])
+    expect(classifyWorkspaceInput('tests/unit/build.test.ts')).toEqual([
+      'qualification'
+    ])
+    expect(classifyWorkspaceInput('.github/workflows/check.yml')).toEqual([
+      'delivery-tooling'
+    ])
+    expect(classifyWorkspaceInput('docs/project/vision.md')).toEqual([
+      'documentation'
+    ])
+    expect(classifyWorkspaceInput('pnpm-lock.yaml')).toEqual([
+      'app-build',
+      'qualification',
+      'delivery-tooling'
+    ])
+  })
+
+  it('changes only the fingerprints affected by representative mutations', () => {
+    const cases: readonly Readonly<{
+      path: string
+      changed: readonly ('app' | 'qualification' | 'delivery')[]
+    }>[] = [
+      { path: 'src/app.ts', changed: ['app'] },
+      { path: 'resources/catalog.json', changed: ['app'] },
+      { path: 'electron-builder.local.yml', changed: ['app'] },
+      { path: 'tests/unit/app.test.ts', changed: ['qualification'] },
+      { path: 'vitest.config.ts', changed: ['qualification'] },
+      { path: 'scripts/candidate-delivery.ts', changed: ['delivery'] },
+      { path: '.github/workflows/check.yml', changed: ['delivery'] },
+      { path: 'docs/note.md', changed: [] },
+      {
+        path: 'pnpm-lock.yaml',
+        changed: ['app', 'qualification', 'delivery']
+      }
+    ]
+
+    for (const mutation of cases) {
+      const root = classifiedFixture()
+      const before = inputFingerprints(root)
+      writeFileSync(join(root, mutation.path), 'mutated')
+      const after = inputFingerprints(root)
+      expect(changedFingerprints(before, after), mutation.path).toEqual(
+        mutation.changed
+      )
+    }
+  })
+
+  it('projects package metadata semantically for each input class', () => {
+    const productionRoot = classifiedFixture()
+    const productionBefore = inputFingerprints(productionRoot)
+    writePackage(productionRoot, {
+      dependencies: { react: '20.0.0' }
+    })
+    expect(
+      changedFingerprints(productionBefore, inputFingerprints(productionRoot))
+    ).toEqual(['app'])
+
+    const administrativeRoot = classifiedFixture()
+    const administrativeBefore = inputFingerprints(administrativeRoot)
+    writePackage(administrativeRoot, {
+      scripts: { maintenance: 'tsx scripts/maintenance.ts' }
+    })
+    expect(
+      changedFingerprints(
+        administrativeBefore,
+        inputFingerprints(administrativeRoot)
+      )
+    ).toEqual(['delivery'])
+
+    const qualificationRoot = classifiedFixture()
+    const qualificationBefore = inputFingerprints(qualificationRoot)
+    writePackage(qualificationRoot, {
+      scripts: { test: 'vitest run --changed' }
+    })
+    expect(
+      changedFingerprints(
+        qualificationBefore,
+        inputFingerprints(qualificationRoot)
+      )
+    ).toEqual(['qualification', 'delivery'])
+  })
+
   it('compares app inputs across immutable application and evidence commits', () => {
     const root = mkdtempSync(join(tmpdir(), 'salt-marcher-ref-identity-'))
     roots.push(root)
@@ -126,6 +215,54 @@ describe('build identity', () => {
     )
   })
 
+  it('uses the semantic package projection at immutable refs', () => {
+    const root = classifiedFixture()
+    git(
+      root,
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '-m',
+      'baseline'
+    )
+    const baseline = gitOutput(root, 'rev-parse', 'HEAD')
+
+    writePackage(root, { scripts: { maintenance: 'tsx scripts/other.ts' } })
+    git(root, 'add', 'package.json')
+    git(
+      root,
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '-m',
+      'administrative alias'
+    )
+    const administrative = gitOutput(root, 'rev-parse', 'HEAD')
+    expect(computeAppBuildInputFingerprintAtRef(root, administrative)).toBe(
+      computeAppBuildInputFingerprintAtRef(root, baseline)
+    )
+
+    writePackage(root, { dependencies: { react: '20.0.0' } })
+    git(root, 'add', 'package.json')
+    git(
+      root,
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '-m',
+      'production dependency'
+    )
+    expect(computeAppBuildInputFingerprintAtRef(root, 'HEAD')).not.toBe(
+      computeAppBuildInputFingerprintAtRef(root, administrative)
+    )
+  })
+
   it('validates and abbreviates embedded build information', () => {
     const info = buildInfoSchema.parse({
       channel: 'local',
@@ -138,9 +275,85 @@ describe('build identity', () => {
       migrationRegistryVersion: 1,
       toolchain: testToolchain()
     })
-    expect(shortBuildFingerprint(info)).toBe('b'.repeat(12))
+    expect(shortBuildFingerprint(info)).toBe('c'.repeat(12))
   })
 })
+
+function classifiedFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-classification-'))
+  roots.push(root)
+  git(root, 'init')
+  for (const directory of [
+    'src',
+    'resources',
+    'tests/unit',
+    'docs',
+    'scripts',
+    '.github/workflows'
+  ])
+    mkdirSync(join(root, directory), { recursive: true })
+  writeFileSync(join(root, 'src/app.ts'), 'app')
+  writeFileSync(join(root, 'resources/catalog.json'), '{}')
+  writeFileSync(join(root, 'tests/unit/app.test.ts'), 'test')
+  writeFileSync(join(root, 'docs/note.md'), 'documentation')
+  writeFileSync(join(root, 'scripts/candidate-delivery.ts'), 'delivery')
+  writeFileSync(join(root, '.github/workflows/check.yml'), 'workflow')
+  writeFileSync(join(root, 'electron-builder.local.yml'), 'extends: base')
+  writeFileSync(join(root, 'vitest.config.ts'), 'qualification')
+  writeFileSync(join(root, 'pnpm-lock.yaml'), 'lockfileVersion: 9')
+  writeFileSync(join(root, 'pnpm-workspace.yaml'), 'packages: []')
+  writePackage(root)
+  git(root, 'add', '.')
+  return root
+}
+
+function writePackage(
+  root: string,
+  patch: Readonly<{
+    dependencies?: Readonly<Record<string, string>>
+    scripts?: Readonly<Record<string, string>>
+  }> = {}
+): void {
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      type: 'module',
+      main: 'out/main.js',
+      packageManager: 'pnpm@10.15.1',
+      scripts: {
+        build: 'tsx scripts/build-app.ts',
+        test: 'vitest run',
+        ...patch.scripts
+      },
+      dependencies: { react: '19.0.0', ...patch.dependencies },
+      devDependencies: {
+        electron: '43.2.0',
+        'electron-builder': '26.15.3',
+        'electron-vite': '5.0.0',
+        vitest: '4.1.10'
+      }
+    })
+  )
+}
+
+function inputFingerprints(root: string) {
+  return {
+    app: computeAppBuildInputFingerprint(root),
+    qualification: computeQualificationInputFingerprint(root),
+    delivery: computeDeliveryInputFingerprint(root)
+  }
+}
+
+function changedFingerprints(
+  before: ReturnType<typeof inputFingerprints>,
+  after: ReturnType<typeof inputFingerprints>
+): ('app' | 'qualification' | 'delivery')[] {
+  return (['app', 'qualification', 'delivery'] as const).filter(
+    (name) => before[name] !== after[name]
+  )
+}
 
 function testToolchain() {
   return {

--- a/tests/unit/main-build-info.test.ts
+++ b/tests/unit/main-build-info.test.ts
@@ -8,7 +8,7 @@ vi.mock('electron', () => ({
 import { windowTitleForBuild } from '../../src/main/application-lifecycle/build-info.js'
 
 describe('main build identity', () => {
-  it('keeps the local workspace fingerprint visible in the window title', () => {
+  it('keeps the local app-build fingerprint visible in the window title', () => {
     const build: BuildInfo = {
       channel: 'local',
       commit: 'a'.repeat(40),
@@ -29,7 +29,9 @@ describe('main build identity', () => {
       }
     }
 
-    expect(windowTitleForBuild(build)).toBe('SaltMarcher Local · 0123456789ab')
+    expect(windowTitleForBuild(build)).toBe(
+      `SaltMarcher Local · ${'f'.repeat(12)}`
+    )
     expect(windowTitleForBuild({ ...build, channel: 'release' })).toBe(
       'SaltMarcher'
     )


### PR DESCRIPTION
## What changed

- introduce one explicit repository-input classification for app builds, qualification, delivery/tooling, and documentation
- compute independent app-build, qualification, and delivery fingerprints both from the working tree and immutable Git refs
- replace the whole-file `package.json` app hash with a canonical semantic projection
- include production dependencies, lock/workspace manifests, Electron/Vite/Builder configuration, resources, source, and actual build/package scripts as app inputs
- expose all three input identities in candidate and post-promotion verification output
- use the app-build fingerprint, rather than the all-workspace fingerprint, as the visible local-build identity

## Why

The prior app fingerprint hashed all of `package.json`, so an unrelated administrative script alias looked like a new app input. At the same time, Electron Builder configuration was absent from the app-input set. Qualification and delivery tooling had no independent identity, making safe reuse decisions unnecessarily coarse.

This change makes invalidation explicit and deterministic without changing persisted build-receipt or installation-manifest formats. Existing candidate, handoff, artifact-hash, backup, installation, and runtime-verification checks remain fail-closed.

## Mutation coverage

- `src/`, `resources/`, production dependencies, lockfile, and Electron Builder configuration invalidate app inputs
- tests and qualification configuration invalidate qualification inputs
- delivery scripts and CI workflow changes invalidate delivery inputs
- documentation and unrelated administrative script aliases do not invalidate app inputs
- the same semantic package projection is verified across immutable Git refs

## Validation

- `pnpm check:delivery` — 55 passed
- focused build/delivery/install suite — 51 passed
- `pnpm test:architecture` — 65 passed
- build, smoke, and bundle budget passed
- full `pnpm check` passed:
  - 65 architecture tests
  - 606 portable unit tests
  - 152 integration tests
  - 26 Linux installation/profile tests
  - all 14 functional E2E suites, one attempt each
  - all 7 visual E2E suites, one attempt each
