### PR TITLE
Make local handoff idempotent by SHA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,17 +28,25 @@
 
 - Finish app-relevant changes to `src/`, `resources/`, dependencies, or
   Electron/build/packaging configuration with `pnpm handoff:app`. It runs the
-  canonical checks, packages the exact checked workspace once, smoke-tests the
+  canonical checks, packages the exact checked workspace, smoke-tests the
   packaged application, backs up valuable local campaign data, and installs
   the matching `SaltMarcher Local` AppImage, then verifies that installed
-  runtime. The default is always fresh; only `pnpm handoff:app -- --resume`
-  may reuse hash-validated completed steps.
+  runtime. Handoff state is keyed by the immutable application SHA. Repeated
+  invocations for the same SHA must validate and reuse hash-proven phases
+  idempotently; `pnpm handoff:app -- --resume` remains an explicit recovery
+  intent but may not replace the provenance of the invocation that created the
+  SHA state.
 - Pure documentation or test-only changes finish with `pnpm check`.
+- Candidate promotion compares its app-build fingerprint with the current
+  `origin/main` app-build fingerprint. An unchanged app-build fingerprint does
+  not require a local application handoff; an app-relevant change cannot be
+  promoted without its completed exact-SHA handoff state.
 - `pnpm dev` is only the targeted HMR development loop; it is not a manual
   acceptance or handoff path.
 - Every implementation is committed to a clean candidate branch and pushed
   there first. The exact candidate SHA must pass all required remote `Check`
-  jobs before `pnpm handoff:app` is run once for that immutable SHA. Only then
-  may the same SHA be fast-forwarded to `origin/main`; rebuilding, amending, or
-  pushing an unchecked SHA directly to `main` is not a valid handoff. A green
-  implementation is not complete until the promoted SHA is green on `main`.
+  jobs before an app-relevant SHA may reach a completed canonical handoff.
+  Only then may the same SHA be fast-forwarded to `origin/main`; rebuilding,
+  amending, or pushing an unchecked SHA directly to `main` is not a valid
+  handoff. A green implementation is not complete until the promoted SHA is
+  green on `main`.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ install the exact current workspace with:
 pnpm handoff:app
 ```
 
-This command always starts a fresh five-step handoff. After an interrupted run,
-`pnpm handoff:app -- --resume` is the only resuming form; it reuses a completed
-step only when workspace, app inputs, toolchain, output, artifact, and installed
-hashes still match its atomic machine-readable receipt in
-`.tmp/handoff-local-app/handoff-receipt.json`.
+This command advances one idempotent handoff state for the immutable application
+SHA through candidate qualification, check, package, packaged smoke, backup,
+deployment staging, activation, and installed-runtime verification. Repeating
+the command safely revalidates and reuses completed phases whose input and
+output hashes still match. `pnpm handoff:app -- --resume` records explicit
+recovery intent without replacing the original state's provenance. Atomic state
+and per-attempt audit records live below `.tmp/handoff-local-app/`.
 
 Launch **SaltMarcher Local** from the desktop menu afterwards. Its title
-contains the first twelve characters of the embedded workspace fingerprint, so a
+contains the first twelve characters of the embedded app-build fingerprint, so a
 stale installation is visible. Packaging and installation refuse output whose
 workspace/app-input fingerprint, commit, dirty state, toolchain or output bytes
 differ from the receipt. Build channels are explicit: `pnpm build:development`,

--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -117,12 +117,13 @@ creates permanent hash-manifested campaign-data backups, migrates only staged
 copies, and promotes immutable fingerprint-addressed deployments through one
 atomic `current` link. Every clean-channel build has a receipt containing
 hashes for all output files and an aggregate hash; packaging verifies it
-against the workspace. The single `pnpm handoff:app` path performs checks, a
-Local build/package pass, actual-AppImage smoke, backup/installation, and
-installed-runtime verification in that order. It is fresh by default; only
-explicit `--resume` reuses steps whose workspace, toolchain, output, artifact,
-and installed evidence exactly matches the atomic final receipt. `pnpm dev`
-remains HMR-only.
+against the workspace. The single `pnpm handoff:app` path advances the exact
+candidate SHA through candidate qualification, checks, a Local build/package
+pass, actual-AppImage smoke, backup creation, deployment staging, atomic
+activation, and installed-runtime verification in that order. Repeated calls
+revalidate and reuse only phases whose predecessor and output hashes still
+match the atomic SHA state. Explicit `--resume` records recovery intent without
+replacing the state's original provenance. `pnpm dev` remains HMR-only.
 
 ## NPC catalog and preserved profile schema — 2026-08-16
 
@@ -210,10 +211,12 @@ verifiable phases:
    fingerprints, CLI-selected channel, role schemas, migration registry,
    toolchain, platform, and every emitted byte. Development, Local, and release
    outputs are isolated, and Linux qualification executes the actual AppImage.
-6. The five-step handoff is fresh by default. Explicit `--resume` validates
-   workspace, app-input, toolchain, output, artifact, and installation hashes;
-   every step records status, duration, evidence, and errors in one atomic
-   machine-readable receipt before installed generation-one runtime acceptance.
+6. The eight-phase, SHA-keyed handoff is idempotent. Every invocation validates
+   candidate, workspace, app-input, qualification, delivery, toolchain, output,
+   artifact, backup, deployment, activation, and installation evidence before
+   reusing it. Per-attempt audit records retain the original state's provenance,
+   and every phase records status, duration, input/output hashes, evidence, and
+   errors before installed generation-one runtime acceptance.
 
 The editor application-layer refactor tracks its normative evidence in
 `application-layer-refactor-acceptance-matrix.md`. It moves the two-step

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -303,13 +303,22 @@ byte during its single copy pass and rereads only the backup for verification;
 backup manifests retain role-specific schema and both build identities.
 Backups and immutable deployments are never automatically deleted. The
 installer stages fingerprint-addressed deployments and atomically switches
-one `current` symlink only after all deployment files are durable. The handoff
-records evidence-backed checkpoints for check, package, packaged smoke, and
-backup/install plus installed-runtime verification. The default handoff is
-always fresh. Only explicit `--resume` considers completed steps, and then only
-when workspace, app-input, toolchain, output, artifact, and installed hashes
-still equal the atomically written receipt. Each step records status, start,
-duration, hashes, and any terminal error.
+one `current` symlink only after all deployment files are durable. For each
+immutable application SHA, the handoff advances one explicit state through
+`candidate-qualified`, `checked`, `packaged`, `packaged-smoke-passed`,
+`backup-created`, `deployment-staged`, `activated`, and
+`installed-runtime-verified`. Every phase binds its predecessor output and its
+own result by SHA-256 and is reusable only while current evidence still matches.
+Repeated invocations are safe and append audit attempts; they do not create a
+parallel state or replace the original state's provenance. Explicit `--resume`
+records recovery intent but follows the same validation rules. Auth, live
+candidate evidence, disk capacity, and installation availability are checked
+before a material state or attempt is created. Each phase records status,
+start, duration, hashes, and any terminal error.
+Candidate promotion requires this completed exact-SHA state precisely when the
+candidate app-build fingerprint differs from `origin/main`; qualification,
+delivery-tooling, and documentation-only changes do not manufacture an
+application handoff.
 
 Installed-runtime acceptance requires utility generation 1 to reach `ready`.
 The total utility bootstrap budget is 5000 ms; phase budgets are configuration

--- a/scripts/candidate-delivery.ts
+++ b/scripts/candidate-delivery.ts
@@ -3,10 +3,15 @@ import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { z } from 'zod'
 import {
+  computeAppBuildInputFingerprint,
+  computeAppBuildInputFingerprintAtRef
+} from './build-identity.js'
+import {
   githubWorkflowRunSchema,
-  handoffInvocationHistorySchema,
   handoffReceiptSchema,
+  parseHandoffInvocationHistory,
   readRequiredJobManifest,
+  sameWorkflowQualification,
   shaSchema,
   verifyRequiredJobs,
   type GithubWorkflowRun,
@@ -282,7 +287,7 @@ export function assertCompletedHandoffReceipt(
   const receipt = handoffReceiptSchema.parse(
     JSON.parse(readFileSync(path, 'utf8'))
   )
-  const history = handoffInvocationHistorySchema.parse(
+  const history = parseHandoffInvocationHistory(
     JSON.parse(
       readFileSync(
         resolve(workspaceRoot, '.tmp', 'handoff-local-app', 'invocations.json'),
@@ -290,24 +295,38 @@ export function assertCompletedHandoffReceipt(
       )
     )
   )
-  const invocations = history.invocations.filter(
+  const attempts = history.invocations.filter(
     ({ applicationSha }) => applicationSha === head
   )
+  const attemptIds = new Set(attempts.map(({ attemptId }) => attemptId))
   if (
     receipt.status !== 'complete' ||
     receipt.identity.commit !== head ||
     receipt.identity.dirty !== false ||
-    JSON.stringify(receipt.identity.candidate) !== JSON.stringify(candidate) ||
-    receipt.steps.some((step) => step.status !== 'completed') ||
-    invocations.length !== 1 ||
-    invocations[0]?.invocationId !== receipt.invocationId
+    !sameWorkflowQualification(receipt.identity.candidate, candidate) ||
+    receipt.phases.some((phase) => phase.status !== 'completed') ||
+    !attemptIds.has(receipt.originAttemptId) ||
+    !attemptIds.has(receipt.activeAttemptId)
   )
     throw new Error('Final handoff receipt does not prove this clean SHA.')
 }
 
+export function requiresApplicationHandoff(
+  candidateAppBuildInputFingerprint: string,
+  mainAppBuildInputFingerprint: string
+): boolean {
+  return candidateAppBuildInputFingerprint !== mainAppBuildInputFingerprint
+}
+
 export function promoteCandidate(state: CandidateState): void {
   assertCandidateState(state)
-  assertCompletedHandoffReceipt(state.head, state.candidate!)
+  const workspaceRoot = process.cwd()
+  const applicationHandoffRequired = requiresApplicationHandoff(
+    computeAppBuildInputFingerprint(workspaceRoot),
+    computeAppBuildInputFingerprintAtRef(workspaceRoot, state.remoteMain)
+  )
+  if (applicationHandoffRequired)
+    assertCompletedHandoffReceipt(state.head, state.candidate!, workspaceRoot)
   command('git', ['push', 'origin', `${state.head}:refs/heads/main`])
 }
 

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { z } from 'zod'
@@ -5,15 +6,18 @@ import { z } from 'zod'
 export const shaSchema = z.string().regex(/^[0-9a-f]{40}$/)
 export const fingerprintSchema = z.string().regex(/^[0-9a-f]{64}$/)
 
-export const handoffSteps = [
-  'check',
-  'package',
-  'packaged-smoke',
-  'backup-and-install',
-  'installed-runtime-verification'
+export const handoffPhases = [
+  'candidate-qualified',
+  'checked',
+  'packaged',
+  'packaged-smoke-passed',
+  'backup-created',
+  'deployment-staged',
+  'activated',
+  'installed-runtime-verified'
 ] as const
-export const handoffStepNameSchema = z.enum(handoffSteps)
-export type HandoffStepName = z.infer<typeof handoffStepNameSchema>
+export const handoffPhaseNameSchema = z.enum(handoffPhases)
+export type HandoffPhaseName = z.infer<typeof handoffPhaseNameSchema>
 
 export const requiredJobManifestSchema = z
   .object({
@@ -92,6 +96,18 @@ export const workflowEvidenceSchema = z
 
 export type WorkflowEvidence = z.infer<typeof workflowEvidenceSchema>
 
+export function sameWorkflowQualification(
+  existing: WorkflowEvidence,
+  current: WorkflowEvidence
+): boolean {
+  return (
+    existing.headSha === current.headSha &&
+    existing.requiredJobManifestVersion ===
+      current.requiredJobManifestVersion &&
+    JSON.stringify(existing.jobs) === JSON.stringify(current.jobs)
+  )
+}
+
 export const installedRuntimeEvidenceSchema = z
   .object({
     artifactSha256: fingerprintSchema,
@@ -134,34 +150,43 @@ export type InstalledRuntimeEvidence = z.infer<
   typeof installedRuntimeEvidenceSchema
 >
 
-export const handoffStepEvidenceSchema = z
+export const handoffPhaseEvidenceSchema = z
   .object({
     workspaceFingerprint: fingerprintSchema,
     appBuildInputFingerprint: fingerprintSchema,
+    qualificationInputFingerprint: fingerprintSchema,
+    deliveryInputFingerprint: fingerprintSchema,
     toolchainHash: fingerprintSchema,
-    outputHash: fingerprintSchema.nullable(),
+    buildOutputHash: fingerprintSchema.nullable(),
     artifactSha256: fingerprintSchema.nullable(),
+    sourceDataHash: fingerprintSchema.nullable(),
+    backupManifestSha256: fingerprintSchema.nullable(),
+    deploymentManifestSha256: fingerprintSchema.nullable(),
+    runtimeEvidenceSha256: fingerprintSchema.nullable(),
     installedSha256: fingerprintSchema.nullable()
   })
   .strict()
 
-export const handoffStepSchema = z
+export const handoffPhaseSchema = z
   .object({
-    step: handoffStepNameSchema,
+    phase: handoffPhaseNameSchema,
     status: z.enum(['pending', 'running', 'completed', 'failed']),
     startedAt: z.iso.datetime().nullable(),
     durationMs: z.number().int().nonnegative().nullable(),
-    evidence: handoffStepEvidenceSchema.nullable(),
+    inputHash: fingerprintSchema.nullable(),
+    outputHash: fingerprintSchema.nullable(),
+    evidence: handoffPhaseEvidenceSchema.nullable(),
     error: z.string().nullable()
   })
   .strict()
 
 export const handoffReceiptSchema = z
   .object({
-    formatVersion: z.literal(3),
-    invocationId: z.uuid(),
+    formatVersion: z.literal(4),
+    stateId: z.uuid(),
+    originAttemptId: z.uuid(),
+    activeAttemptId: z.uuid(),
     status: z.enum(['running', 'complete', 'failed']),
-    mode: z.enum(['fresh', 'resume']),
     createdAt: z.iso.datetime(),
     updatedAt: z.iso.datetime(),
     completedAt: z.iso.datetime().nullable(),
@@ -171,32 +196,124 @@ export const handoffReceiptSchema = z
         dirty: z.boolean(),
         workspaceFingerprint: fingerprintSchema,
         appBuildInputFingerprint: fingerprintSchema,
+        qualificationInputFingerprint: fingerprintSchema,
+        deliveryInputFingerprint: fingerprintSchema,
         toolchainHash: fingerprintSchema,
         candidate: workflowEvidenceSchema
       })
       .strict(),
-    steps: z.array(handoffStepSchema).length(handoffSteps.length)
+    phases: z.array(handoffPhaseSchema).length(handoffPhases.length)
   })
   .strict()
   .superRefine((receipt, context) => {
-    const actual = receipt.steps.map(({ step }) => step)
-    if (JSON.stringify(actual) !== JSON.stringify(handoffSteps))
+    const actual = receipt.phases.map(({ phase }) => phase)
+    if (JSON.stringify(actual) !== JSON.stringify(handoffPhases))
       context.addIssue({
         code: 'custom',
-        message: 'Handoff steps must be complete, unique, and ordered',
-        path: ['steps']
+        message: 'Handoff phases must be complete, unique, and ordered',
+        path: ['phases']
       })
+    if (
+      receipt.status === 'complete' &&
+      (receipt.completedAt === null ||
+        receipt.phases.some(({ status }) => status !== 'completed'))
+    )
+      context.addIssue({
+        code: 'custom',
+        message: 'Complete handoff state requires every phase and completedAt',
+        path: ['status']
+      })
+    if (receipt.status !== 'complete' && receipt.completedAt !== null)
+      context.addIssue({
+        code: 'custom',
+        message: 'Incomplete handoff state cannot have completedAt',
+        path: ['completedAt']
+      })
+    let predecessor = hashHandoffValue(receipt.identity)
+    let incompleteSeen = false
+    for (const [index, phase] of receipt.phases.entries()) {
+      if (phase.status !== 'completed') {
+        incompleteSeen = true
+        continue
+      }
+      if (incompleteSeen)
+        context.addIssue({
+          code: 'custom',
+          message: `Completed handoff phase follows an incomplete predecessor: ${phase.phase}`,
+          path: ['phases', index]
+        })
+      if (
+        phase.inputHash !== predecessor ||
+        phase.evidence === null ||
+        phase.outputHash !==
+          hashHandoffValue({
+            phase: phase.phase,
+            inputHash: phase.inputHash,
+            evidence: phase.evidence
+          })
+      )
+        context.addIssue({
+          code: 'custom',
+          message: `Completed handoff phase has an invalid hash chain: ${phase.phase}`,
+          path: ['phases', index]
+        })
+      predecessor = phase.outputHash ?? predecessor
+    }
   })
 
 export type HandoffReceipt = z.infer<typeof handoffReceiptSchema>
-export type HandoffStepEvidence = z.infer<typeof handoffStepEvidenceSchema>
+export type HandoffIdentity = HandoffReceipt['identity']
+export type HandoffPhaseEvidence = z.infer<typeof handoffPhaseEvidenceSchema>
 
-export function resumeHandoffReceipt(
+export function sameHandoffApplicationIdentity(
+  existing: HandoffIdentity,
+  current: HandoffIdentity
+): boolean {
+  const { candidate: existingCandidate, ...existingInputs } = existing
+  const { candidate: currentCandidate, ...currentInputs } = current
+  return (
+    JSON.stringify(existingInputs) === JSON.stringify(currentInputs) &&
+    sameWorkflowQualification(existingCandidate, currentCandidate)
+  )
+}
+
+export function createHandoffReceipt(
+  identity: HandoffIdentity,
+  stateId: string,
+  attemptId: string,
+  timestamp: string
+): HandoffReceipt {
+  return handoffReceiptSchema.parse({
+    formatVersion: 4,
+    stateId,
+    originAttemptId: attemptId,
+    activeAttemptId: attemptId,
+    status: 'running',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    completedAt: null,
+    identity,
+    phases: handoffPhases.map((phase) => ({
+      phase,
+      status: 'pending',
+      startedAt: null,
+      durationMs: null,
+      inputHash: null,
+      outputHash: null,
+      evidence: null,
+      error: null
+    }))
+  })
+}
+
+export function continueHandoffReceipt(
   receipt: HandoffReceipt,
+  attemptId: string,
   updatedAt: string
 ): HandoffReceipt {
   return handoffReceiptSchema.parse({
     ...receipt,
+    activeAttemptId: attemptId,
     status: 'running',
     updatedAt,
     completedAt: null
@@ -204,6 +321,40 @@ export function resumeHandoffReceipt(
 }
 
 export const handoffInvocationHistorySchema = z
+  .object({
+    formatVersion: z.literal(2),
+    invocations: z.array(
+      z
+        .object({
+          attemptId: z.uuid(),
+          applicationSha: shaSchema,
+          intent: z.enum(['advance', 'resume']),
+          createdAt: z.iso.datetime(),
+          statePath: z.string().min(1),
+          auditPath: z.string().min(1)
+        })
+        .strict()
+    )
+  })
+  .strict()
+  .superRefine((history, context) => {
+    const ids = new Set<string>()
+    for (const invocation of history.invocations) {
+      if (ids.has(invocation.attemptId))
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate handoff attempt: ${invocation.attemptId}`,
+          path: ['invocations']
+        })
+      ids.add(invocation.attemptId)
+    }
+  })
+
+export type HandoffInvocationHistory = z.infer<
+  typeof handoffInvocationHistorySchema
+>
+
+const legacyHandoffInvocationHistorySchema = z
   .object({
     formatVersion: z.literal(1),
     invocations: z.array(
@@ -218,22 +369,25 @@ export const handoffInvocationHistorySchema = z
     )
   })
   .strict()
-  .superRefine((history, context) => {
-    const ids = new Set<string>()
-    for (const invocation of history.invocations) {
-      if (ids.has(invocation.invocationId))
-        context.addIssue({
-          code: 'custom',
-          message: `Duplicate handoff invocation: ${invocation.invocationId}`,
-          path: ['invocations']
-        })
-      ids.add(invocation.invocationId)
-    }
-  })
 
-export type HandoffInvocationHistory = z.infer<
-  typeof handoffInvocationHistorySchema
->
+export function parseHandoffInvocationHistory(
+  value: unknown
+): HandoffInvocationHistory {
+  const current = handoffInvocationHistorySchema.safeParse(value)
+  if (current.success) return current.data
+  const legacy = legacyHandoffInvocationHistorySchema.parse(value)
+  return handoffInvocationHistorySchema.parse({
+    formatVersion: 2,
+    invocations: legacy.invocations.map((invocation) => ({
+      attemptId: invocation.invocationId,
+      applicationSha: invocation.applicationSha,
+      intent: 'advance',
+      createdAt: invocation.createdAt,
+      statePath: invocation.receiptPath,
+      auditPath: invocation.receiptPath
+    }))
+  })
+}
 
 export function appendHandoffInvocation(
   history: HandoffInvocationHistory,
@@ -245,13 +399,8 @@ export function appendHandoffInvocation(
   })
 }
 
-export function freshInvocationCount(
-  history: HandoffInvocationHistory,
-  applicationSha: string
-): number {
-  return history.invocations.filter(
-    (invocation) => invocation.applicationSha === applicationSha
-  ).length
+export function hashHandoffValue(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
 }
 
 export function readRequiredJobManifest(

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -16,43 +16,54 @@ import {
   buildReceiptSchema,
   localArtifactManifestSchema
 } from '../src/shared/contracts/build-info.js'
-import { readBuildToolchain, readWorkspaceIdentity } from './build-identity.js'
+import {
+  readBuildToolchain,
+  readWorkspaceIdentity,
+  readWorkspaceInputFingerprints
+} from './build-identity.js'
 import { verifyBuildReceipt } from './build-receipt.js'
-import { sha256File } from './file-hash.js'
-import { localInstallationPaths } from './local-app-installation.js'
 import { assertCandidateReady } from './candidate-delivery.js'
 import {
   appendHandoffInvocation,
-  handoffInvocationHistorySchema,
+  createHandoffReceipt,
   handoffReceiptSchema,
-  handoffStepEvidenceSchema,
-  handoffSteps,
-  resumeHandoffReceipt,
+  installedRuntimeEvidenceSchema,
+  parseHandoffInvocationHistory,
+  sameHandoffApplicationIdentity,
+  type HandoffIdentity,
   type HandoffInvocationHistory,
-  type HandoffReceipt,
-  type HandoffStepEvidence,
-  type HandoffStepName
+  type HandoffPhaseEvidence,
+  type HandoffReceipt
 } from './delivery-contract.js'
+import { sha256File } from './file-hash.js'
+import {
+  attachHandoffAttempt,
+  runHandoffStateMachine,
+  type HandoffPhaseDefinition
+} from './handoff-state-machine.js'
+import {
+  assertHandoffResourcePreflight,
+  readHandoffResourceSnapshot
+} from './handoff-preflight.js'
+import {
+  inspectLocalAppInstallation,
+  isInstalledLocalAppRunning,
+  localInstallationPaths,
+  type InstallLocalAppOptions,
+  type LocalInstallationTarget
+} from './local-app-installation.js'
 
 if (process.platform !== 'linux')
   throw new Error('SaltMarcher Local handoff currently targets Linux AppImage')
 
-const candidateState = assertCandidateReady()
-
+const resume = parseArguments(process.argv.slice(2))
 const workspaceRoot = process.cwd()
-const workspace = readWorkspaceIdentity(workspaceRoot)
-const toolchain = readBuildToolchain(workspaceRoot)
-const toolchainHash = hashJson(toolchain)
-const identity = {
-  ...workspace,
-  toolchainHash,
-  candidate: candidateState.candidate!
-}
 const packageJson = JSON.parse(
   readFileSync(resolve(workspaceRoot, 'package.json'), 'utf8')
 ) as { version?: unknown }
 if (typeof packageJson.version !== 'string')
   throw new Error('package.json does not contain a version')
+
 const artifactPath = resolve(
   workspaceRoot,
   'release',
@@ -63,227 +74,294 @@ const artifactManifestPath = `${artifactPath}.manifest.json`
 const installation = localInstallationPaths(
   process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
 )
+const installOptions: InstallLocalAppOptions = {
+  workspaceRoot,
+  xdgDataHome:
+    process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share'),
+  artifactPath,
+  artifactManifestPath,
+  iconSourcePath: resolve(
+    workspaceRoot,
+    'resources',
+    'icons',
+    'salt-marcher.png'
+  )
+}
+
+// Auth, network, candidate, workspace, installation availability and disk
+// capacity are all checked before an attempt or state file is created.
+const candidateState = assertCandidateReady()
+const workspace = readWorkspaceIdentity(workspaceRoot)
+const inputFingerprints = readWorkspaceInputFingerprints(workspaceRoot)
+const toolchain = readBuildToolchain(workspaceRoot)
+const identity: HandoffIdentity = {
+  ...workspace,
+  ...inputFingerprints,
+  toolchainHash: hashJson(toolchain),
+  candidate: candidateState.candidate!
+}
+if (isInstalledLocalAppRunning(installation.appImage))
+  throw new Error('SaltMarcher Local is running; close it before handoff')
+assertHandoffResourcePreflight(
+  readHandoffResourceSnapshot(
+    workspaceRoot,
+    installation.root,
+    installation.campaignData
+  )
+)
+
 const receiptDirectory = resolve(workspaceRoot, '.tmp', 'handoff-local-app')
+const statePath = resolve(
+  receiptDirectory,
+  'states',
+  `${workspace.commit}.json`
+)
 const receiptPath = resolve(receiptDirectory, 'handoff-receipt.json')
 const invocationHistoryPath = resolve(receiptDirectory, 'invocations.json')
 const checkSnapshotPath = resolve(
   receiptDirectory,
-  'checked-build-receipt.json'
+  'states',
+  `${workspace.commit}.checked-build-receipt.json`
 )
-const resume = process.argv.includes('--resume')
-if (
-  process.argv.some(
-    (argument) => argument.startsWith('--') && argument !== '--resume'
+const runtimeEvidencePath = resolve(
+  receiptDirectory,
+  'installed-runtime-evidence.json'
+)
+
+const attemptId = randomUUID()
+const timestamp = new Date().toISOString()
+const auditPath = resolve(receiptDirectory, 'attempts', `${attemptId}.json`)
+let receipt: HandoffReceipt
+if (existsSync(statePath)) {
+  const existing = handoffReceiptSchema.parse(
+    JSON.parse(readFileSync(statePath, 'utf8'))
   )
-)
-  throw new Error('The only supported handoff option is --resume')
-
-let receipt = resume ? readResumableReceipt() : freshReceipt()
-writeReceipt()
-
-for (const definition of stepDefinitions()) {
-  const step = definition.name
-  if (resume && completedStepIsReusable(step)) {
-    console.info(
-      JSON.stringify({
-        component: 'local-handoff',
-        event: 'step-resumed',
-        step
-      })
+  if (!sameHandoffApplicationIdentity(existing.identity, identity))
+    throw new Error(
+      'Handoff SHA state identity differs from the live candidate'
     )
-    continue
-  }
-  resetFrom(step)
-  executeStep(definition)
+  receipt = attachHandoffAttempt(existing, attemptId, timestamp)
+} else {
+  if (resume) throw new Error('No SHA handoff state exists to resume')
+  receipt = createHandoffReceipt(identity, randomUUID(), attemptId, timestamp)
 }
-const completedAt = new Date().toISOString()
-receipt = {
-  ...receipt,
-  status: 'complete',
-  updatedAt: completedAt,
-  completedAt
+
+const history = existsSync(invocationHistoryPath)
+  ? parseHandoffInvocationHistory(
+      JSON.parse(readFileSync(invocationHistoryPath, 'utf8'))
+    )
+  : ({ formatVersion: 2, invocations: [] } satisfies HandoffInvocationHistory)
+atomicWrite(
+  invocationHistoryPath,
+  `${JSON.stringify(
+    appendHandoffInvocation(history, {
+      attemptId,
+      applicationSha: workspace.commit,
+      intent: resume ? 'resume' : 'advance',
+      createdAt: timestamp,
+      statePath,
+      auditPath
+    }),
+    null,
+    2
+  )}\n`
+)
+
+const persist = (next: HandoffReceipt): void => {
+  receipt = handoffReceiptSchema.parse(next)
+  const content = `${JSON.stringify(receipt, null, 2)}\n`
+  atomicWrite(auditPath, content)
+  atomicWrite(statePath, content)
+  atomicWrite(receiptPath, content)
 }
-writeReceipt()
+persist(receipt)
+
+receipt = runHandoffStateMachine({
+  receipt,
+  definitions: phaseDefinitions(),
+  persist
+})
+
 console.info(
   JSON.stringify({
     component: 'local-handoff',
     event: 'completed',
+    stateId: receipt.stateId,
+    originAttemptId: receipt.originAttemptId,
+    activeAttemptId: receipt.activeAttemptId,
     receipt: receiptPath,
     artifactSha256: sha256File(artifactPath),
     installedSha256: sha256File(installation.appImage)
   })
 )
 
-interface HandoffStepDefinition {
-  readonly name: HandoffStepName
-  readonly command: readonly string[]
-  readonly collect: () => HandoffStepEvidence
-  readonly collectReusable: () => HandoffStepEvidence
-}
-
-function executeStep(definition: HandoffStepDefinition): void {
-  const step = definition.name
-  const startedAt = new Date()
-  updateStep(step, {
-    status: 'running',
-    startedAt: startedAt.toISOString(),
-    durationMs: null,
-    evidence: null,
-    error: null
-  })
-  try {
-    run(step, definition.command)
-    const evidence = definition.collect()
-    updateStep(step, {
-      status: 'completed',
-      startedAt: startedAt.toISOString(),
-      durationMs: Math.max(0, Date.now() - startedAt.getTime()),
-      evidence,
-      error: null
-    })
-  } catch (error) {
-    updateStep(step, {
-      status: 'failed',
-      startedAt: startedAt.toISOString(),
-      durationMs: Math.max(0, Date.now() - startedAt.getTime()),
-      evidence: null,
-      error: error instanceof Error ? error.message : String(error)
-    })
-    receipt = {
-      ...receipt,
-      status: 'failed',
-      updatedAt: new Date().toISOString()
-    }
-    writeReceipt()
-    throw error
-  }
-}
-
-function stepDefinitions(): readonly HandoffStepDefinition[] {
+function phaseDefinitions(): readonly HandoffPhaseDefinition[] {
   return [
     {
-      name: 'check',
-      command: ['pnpm', 'check'],
-      collect: collectCheckEvidence,
-      collectReusable: collectReusableCheckEvidence
+      phase: 'candidate-qualified',
+      execute: () => undefined,
+      collect: () => evidence()
     },
     {
-      name: 'package',
-      command: ['pnpm', 'package:local'],
-      collect: collectPackagedEvidence,
-      collectReusable: collectPackagedEvidence
+      phase: 'checked',
+      execute: () => run('checked', ['pnpm', 'check']),
+      collect: collectCheckedEvidence
     },
     {
-      name: 'packaged-smoke',
-      command: ['pnpm', 'test:packaged-local-smoke:built'],
-      collect: collectPackagedEvidence,
-      collectReusable: collectPackagedEvidence
+      phase: 'packaged',
+      execute: () => run('packaged', ['pnpm', 'package:local']),
+      collect: collectPackagedEvidence
     },
     {
-      name: 'backup-and-install',
-      command: ['pnpm', 'install:local:built'],
-      collect: collectInstalledEvidence,
-      collectReusable: collectInstalledEvidence
+      phase: 'packaged-smoke-passed',
+      execute: () =>
+        run('packaged-smoke-passed', [
+          'pnpm',
+          'test:packaged-local-smoke:built'
+        ]),
+      collect: collectPackagedEvidence
     },
+    installationDefinition('backup-created'),
+    installationDefinition('deployment-staged'),
+    installationDefinition('activated'),
     {
-      name: 'installed-runtime-verification',
-      command: [
-        'pnpm',
-        'exec',
-        'tsx',
-        'scripts/installed-runtime-verification.ts'
-      ],
-      collect: collectInstalledEvidence,
-      collectReusable: collectInstalledEvidence
+      phase: 'installed-runtime-verified',
+      execute: () =>
+        run('installed-runtime-verified', [
+          'pnpm',
+          'exec',
+          'tsx',
+          'scripts/installed-runtime-verification.ts'
+        ]),
+      collect: collectRuntimeEvidence
     }
   ]
 }
 
-function collectCheckEvidence(): HandoffStepEvidence {
-  const build = verifyBuildReceipt(resolve(workspaceRoot, 'out'))
-  if (
-    build.build.channel !== 'development' ||
-    !buildMatchesWorkspace(build.build)
-  )
-    throw new Error('Canonical check did not leave matching development output')
-  atomicWrite(checkSnapshotPath, `${JSON.stringify(build, null, 2)}\n`)
-  return evidence({ outputHash: build.outputHash })
+function installationDefinition(
+  target: LocalInstallationTarget
+): HandoffPhaseDefinition {
+  return {
+    phase: target,
+    execute: () =>
+      run(target, [
+        'pnpm',
+        'exec',
+        'tsx',
+        'scripts/install-local-app.ts',
+        '--through',
+        target
+      ]),
+    collect: () => collectInstallationEvidence(target)
+  }
 }
 
-function collectReusableCheckEvidence(): HandoffStepEvidence {
-  const snapshot = buildReceiptSchema.parse(
-    JSON.parse(readFileSync(checkSnapshotPath, 'utf8'))
-  )
-  if (!buildMatchesWorkspace(snapshot.build))
-    throw new Error('Checked receipt snapshot is stale')
-  return evidence({ outputHash: snapshot.outputHash })
+function collectCheckedEvidence(): HandoffPhaseEvidence {
+  assertWorkspaceUnchanged()
+  let snapshot
+  try {
+    const current = verifyBuildReceipt(resolve(workspaceRoot, 'out'))
+    if (current.build.channel !== 'development' || !buildMatches(current.build))
+      throw new Error('Current output is not the checked development build')
+    snapshot = current
+    atomicWrite(checkSnapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`)
+  } catch {
+    snapshot = buildReceiptSchema.parse(
+      JSON.parse(readFileSync(checkSnapshotPath, 'utf8'))
+    )
+    if (
+      snapshot.build.channel !== 'development' ||
+      !buildMatches(snapshot.build)
+    )
+      throw new Error('Checked build receipt snapshot is stale')
+  }
+  return evidence({ buildOutputHash: snapshot.outputHash })
 }
 
-function collectPackagedEvidence(): HandoffStepEvidence {
+function collectPackagedEvidence(): HandoffPhaseEvidence {
   const manifest = validPackagedArtifact()
   return evidence({
-    outputHash: manifest.receipt.outputHash,
+    buildOutputHash: manifest.receipt.outputHash,
     artifactSha256: manifest.artifactSha256
   })
 }
 
-function collectInstalledEvidence(): HandoffStepEvidence {
-  const installed = localArtifactManifestSchema.parse(
-    JSON.parse(readFileSync(installation.installedManifest, 'utf8'))
-  )
+function collectInstallationEvidence(
+  target: LocalInstallationTarget
+): HandoffPhaseEvidence {
+  const installed = inspectLocalAppInstallation(installOptions, target)
+  if (installed === null)
+    throw new Error(`Local installation checkpoint is not reusable: ${target}`)
   const packaged = validPackagedArtifact()
-  if (JSON.stringify(installed) !== JSON.stringify(packaged))
-    throw new Error('Installed manifest does not equal the packaged manifest')
-  const installedSha256 = sha256File(installation.appImage)
-  if (installedSha256 !== packaged.artifactSha256)
-    throw new Error('Installed AppImage hash differs from packaged artifact')
   return evidence({
-    outputHash: packaged.receipt.outputHash,
+    buildOutputHash: packaged.receipt.outputHash,
     artifactSha256: packaged.artifactSha256,
-    installedSha256
+    sourceDataHash: installed.sourceDataHash,
+    ...(installed.backupManifestSha256 === undefined
+      ? {}
+      : { backupManifestSha256: installed.backupManifestSha256 }),
+    ...(installed.deploymentManifestSha256 === undefined
+      ? {}
+      : { deploymentManifestSha256: installed.deploymentManifestSha256 }),
+    ...(installed.installedSha256 === undefined
+      ? {}
+      : { installedSha256: installed.installedSha256 })
   })
 }
 
-function evidence(input: {
-  outputHash: string
-  artifactSha256?: string
-  installedSha256?: string
-}): HandoffStepEvidence {
-  return handoffStepEvidenceSchema.parse({
-    workspaceFingerprint: workspace.workspaceFingerprint,
-    appBuildInputFingerprint: workspace.appBuildInputFingerprint,
-    toolchainHash,
-    outputHash: input.outputHash,
-    artifactSha256: input.artifactSha256 ?? null,
-    installedSha256: input.installedSha256 ?? null
-  })
-}
-
-function completedStepIsReusable(step: HandoffStepName): boolean {
-  const record = receipt.steps.find((candidate) => candidate.step === step)
-  if (record?.status !== 'completed' || record.evidence === null) return false
-  try {
-    const current = definitionFor(step).collectReusable()
-    return JSON.stringify(current) === JSON.stringify(record.evidence)
-  } catch {
-    return false
+function collectRuntimeEvidence(): HandoffPhaseEvidence {
+  const installed = collectInstallationEvidence('activated')
+  const runtime = installedRuntimeEvidenceSchema.parse(
+    JSON.parse(readFileSync(runtimeEvidencePath, 'utf8'))
+  )
+  if (
+    runtime.artifactSha256 !== installed.artifactSha256 ||
+    runtime.manifestSha256 !== sha256File(installation.installedManifest)
+  )
+    throw new Error('Installed runtime evidence proves another artifact')
+  return {
+    ...installed,
+    runtimeEvidenceSha256: sha256File(runtimeEvidencePath)
   }
 }
 
-function definitionFor(step: HandoffStepName): HandoffStepDefinition {
-  const definition = stepDefinitions().find(({ name }) => name === step)
-  if (!definition) throw new Error(`Unknown handoff step: ${step}`)
-  return definition
+function evidence(
+  input: {
+    readonly buildOutputHash?: string
+    readonly artifactSha256?: string
+    readonly sourceDataHash?: string
+    readonly backupManifestSha256?: string
+    readonly deploymentManifestSha256?: string
+    readonly runtimeEvidenceSha256?: string
+    readonly installedSha256?: string
+  } = {}
+): HandoffPhaseEvidence {
+  assertWorkspaceUnchanged()
+  return {
+    workspaceFingerprint: identity.workspaceFingerprint,
+    appBuildInputFingerprint: identity.appBuildInputFingerprint,
+    qualificationInputFingerprint: identity.qualificationInputFingerprint,
+    deliveryInputFingerprint: identity.deliveryInputFingerprint,
+    toolchainHash: identity.toolchainHash,
+    buildOutputHash: input.buildOutputHash ?? null,
+    artifactSha256: input.artifactSha256 ?? null,
+    sourceDataHash: input.sourceDataHash ?? null,
+    backupManifestSha256: input.backupManifestSha256 ?? null,
+    deploymentManifestSha256: input.deploymentManifestSha256 ?? null,
+    runtimeEvidenceSha256: input.runtimeEvidenceSha256 ?? null,
+    installedSha256: input.installedSha256 ?? null
+  }
 }
 
 function validPackagedArtifact() {
+  assertWorkspaceUnchanged()
   const output = verifyBuildReceipt(resolve(workspaceRoot, 'out'))
   const manifest = localArtifactManifestSchema.parse(
     JSON.parse(readFileSync(artifactManifestPath, 'utf8'))
   )
   if (
     output.build.channel !== 'local' ||
-    !buildMatchesWorkspace(output.build) ||
+    !buildMatches(output.build) ||
     JSON.stringify(manifest.receipt) !== JSON.stringify(output) ||
     manifest.receiptSha256 !== hashJson(output) ||
     manifest.artifactSha256 !== sha256File(artifactPath)
@@ -292,7 +370,7 @@ function validPackagedArtifact() {
   return manifest
 }
 
-function buildMatchesWorkspace(build: {
+function buildMatches(build: {
   commit: string
   dirty: boolean
   workspaceFingerprint: string
@@ -300,118 +378,52 @@ function buildMatchesWorkspace(build: {
   toolchain: unknown
 }): boolean {
   return (
-    build.commit === workspace.commit &&
-    build.dirty === workspace.dirty &&
-    build.workspaceFingerprint === workspace.workspaceFingerprint &&
-    build.appBuildInputFingerprint === workspace.appBuildInputFingerprint &&
-    hashJson(build.toolchain) === toolchainHash
+    build.commit === identity.commit &&
+    build.dirty === identity.dirty &&
+    build.workspaceFingerprint === identity.workspaceFingerprint &&
+    build.appBuildInputFingerprint === identity.appBuildInputFingerprint &&
+    hashJson(build.toolchain) === identity.toolchainHash
   )
 }
 
-function freshReceipt(): HandoffReceipt {
-  const timestamp = new Date().toISOString()
-  const invocationId = randomUUID()
-  const fresh = handoffReceiptSchema.parse({
-    formatVersion: 3,
-    invocationId,
-    status: 'running',
-    mode: 'fresh',
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    completedAt: null,
-    identity,
-    steps: handoffSteps.map((step) => ({
-      step,
-      status: 'pending',
-      startedAt: null,
-      durationMs: null,
-      evidence: null,
-      error: null
-    }))
-  })
-  appendInvocation({
-    invocationId,
-    applicationSha: workspace.commit,
-    createdAt: timestamp,
-    receiptPath: invocationReceiptPath(invocationId)
-  })
-  return fresh
-}
-
-function readResumableReceipt(): HandoffReceipt {
-  if (!existsSync(receiptPath))
-    throw new Error('No handoff receipt exists to resume')
-  const existing = handoffReceiptSchema.parse(
-    JSON.parse(readFileSync(receiptPath, 'utf8'))
+function assertWorkspaceUnchanged(): void {
+  const current = readWorkspaceIdentity(workspaceRoot)
+  const inputs = readWorkspaceInputFingerprints(workspaceRoot)
+  if (
+    JSON.stringify({ ...current, ...inputs }) !==
+    JSON.stringify({
+      commit: identity.commit,
+      dirty: identity.dirty,
+      workspaceFingerprint: identity.workspaceFingerprint,
+      appBuildInputFingerprint: identity.appBuildInputFingerprint,
+      qualificationInputFingerprint: identity.qualificationInputFingerprint,
+      deliveryInputFingerprint: identity.deliveryInputFingerprint
+    })
   )
-  if (JSON.stringify(existing.identity) !== JSON.stringify(identity))
-    throw new Error('Handoff receipt identity differs; start a fresh handoff')
-  return resumeHandoffReceipt(existing, new Date().toISOString())
+    throw new Error('Workspace identity changed during handoff')
 }
 
-function resetFrom(step: HandoffStepName): void {
-  const index = handoffSteps.indexOf(step)
-  receipt = {
-    ...receipt,
-    status: 'running',
-    updatedAt: new Date().toISOString(),
-    steps: receipt.steps.map((record) =>
-      handoffSteps.indexOf(record.step) < index
-        ? record
-        : {
-            step: record.step,
-            status: 'pending' as const,
-            startedAt: null,
-            durationMs: null,
-            evidence: null,
-            error: null
-          }
-    )
-  }
-  writeReceipt()
+function parseArguments(arguments_: readonly string[]): boolean {
+  if (arguments_.length === 0) return false
+  if (arguments_.length === 1 && arguments_[0] === '--resume') return true
+  throw new Error('The only supported handoff option is --resume')
 }
 
-function updateStep(
-  step: HandoffStepName,
-  update: Omit<HandoffReceipt['steps'][number], 'step'>
-): void {
-  receipt = {
-    ...receipt,
-    updatedAt: new Date().toISOString(),
-    steps: receipt.steps.map((record) =>
-      record.step === step ? { step, ...update } : record
-    )
-  }
-  writeReceipt()
-}
-
-function writeReceipt(): void {
-  receipt = handoffReceiptSchema.parse(receipt)
-  const content = `${JSON.stringify(receipt, null, 2)}\n`
-  atomicWrite(invocationReceiptPath(receipt.invocationId), content)
-  atomicWrite(receiptPath, content)
-}
-
-function appendInvocation(
-  invocation: HandoffInvocationHistory['invocations'][number]
-): void {
-  const history = existsSync(invocationHistoryPath)
-    ? handoffInvocationHistorySchema.parse(
-        JSON.parse(readFileSync(invocationHistoryPath, 'utf8'))
-      )
-    : { formatVersion: 1 as const, invocations: [] }
-  const next = appendHandoffInvocation(history, invocation)
-  atomicWrite(invocationHistoryPath, `${JSON.stringify(next, null, 2)}\n`)
-}
-
-function invocationReceiptPath(invocationId: string): string {
-  return resolve(receiptDirectory, 'invocations', `${invocationId}.json`)
+function run(phase: string, arguments_: readonly string[]): void {
+  const result = spawnSync('corepack', arguments_, {
+    cwd: workspaceRoot,
+    env: process.env,
+    stdio: 'inherit'
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(`Local handoff phase ${phase} failed with ${result.status}`)
 }
 
 function atomicWrite(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true })
-  const temporary = `${path}.next`
-  const descriptor = openSync(temporary, 'w', 0o600)
+  const temporary = `${path}.${randomUUID()}.next`
+  const descriptor = openSync(temporary, 'wx', 0o600)
   try {
     writeFileSync(descriptor, content)
     fsyncSync(descriptor)
@@ -425,20 +437,6 @@ function atomicWrite(path: string, content: string): void {
   } finally {
     closeSync(directory)
   }
-}
-
-function run(step: HandoffStepName, arguments_: readonly string[]): void {
-  console.info(
-    JSON.stringify({ component: 'local-handoff', event: 'step-started', step })
-  )
-  const result = spawnSync('corepack', arguments_, {
-    cwd: workspaceRoot,
-    env: process.env,
-    stdio: 'inherit'
-  })
-  if (result.error) throw result.error
-  if (result.status !== 0)
-    throw new Error(`Local handoff step ${step} failed with ${result.status}`)
 }
 
 function hashJson(value: unknown): string {

--- a/scripts/handoff-preflight.ts
+++ b/scripts/handoff-preflight.ts
@@ -1,0 +1,70 @@
+import { existsSync, lstatSync, readdirSync, statfsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+const minimumWorkspaceBytes = 512 * 1024 * 1024
+const minimumInstallationReserveBytes = 256 * 1024 * 1024
+
+export interface HandoffResourceSnapshot {
+  readonly workspaceAvailableBytes: number
+  readonly installationAvailableBytes: number
+  readonly campaignDataBytes: number
+}
+
+export function readHandoffResourceSnapshot(
+  workspaceRoot: string,
+  installationRoot: string,
+  campaignDataRoot: string
+): HandoffResourceSnapshot {
+  return {
+    workspaceAvailableBytes: availableBytes(workspaceRoot),
+    installationAvailableBytes: availableBytes(
+      nearestExistingDirectory(installationRoot)
+    ),
+    campaignDataBytes: treeBytes(campaignDataRoot)
+  }
+}
+
+export function assertHandoffResourcePreflight(
+  snapshot: HandoffResourceSnapshot
+): void {
+  if (snapshot.workspaceAvailableBytes < minimumWorkspaceBytes)
+    throw new Error(
+      `Handoff workspace preflight requires ${minimumWorkspaceBytes} free bytes; found ${snapshot.workspaceAvailableBytes}`
+    )
+  const installationRequired =
+    minimumInstallationReserveBytes + snapshot.campaignDataBytes * 2
+  if (snapshot.installationAvailableBytes < installationRequired)
+    throw new Error(
+      `Handoff installation preflight requires ${installationRequired} free bytes; found ${snapshot.installationAvailableBytes}`
+    )
+}
+
+function availableBytes(path: string): number {
+  const stats = statfsSync(path)
+  return stats.bavail * stats.bsize
+}
+
+function nearestExistingDirectory(path: string): string {
+  let current = path
+  while (!existsSync(current)) {
+    const parent = dirname(current)
+    if (parent === current) throw new Error(`No existing parent for ${path}`)
+    current = parent
+  }
+  return current
+}
+
+function treeBytes(root: string): number {
+  if (!existsSync(root)) return 0
+  let total = 0
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name)
+    const stats = lstatSync(path)
+    if (stats.isSymbolicLink())
+      throw new Error(`Campaign data contains a symbolic link: ${path}`)
+    if (stats.isDirectory()) total += treeBytes(path)
+    else if (stats.isFile()) total += stats.size
+    else throw new Error(`Campaign data contains an unsupported entry: ${path}`)
+  }
+  return total
+}

--- a/scripts/handoff-state-machine.ts
+++ b/scripts/handoff-state-machine.ts
@@ -1,0 +1,205 @@
+import {
+  continueHandoffReceipt,
+  handoffPhases,
+  handoffReceiptSchema,
+  hashHandoffValue,
+  type HandoffPhaseEvidence,
+  type HandoffPhaseName,
+  type HandoffReceipt
+} from './delivery-contract.js'
+
+export interface HandoffPhaseDefinition {
+  readonly phase: HandoffPhaseName
+  readonly execute: () => void
+  readonly collect: () => HandoffPhaseEvidence
+}
+
+export interface HandoffStateMachineOptions {
+  readonly receipt: HandoffReceipt
+  readonly definitions: readonly HandoffPhaseDefinition[]
+  readonly persist: (receipt: HandoffReceipt) => void
+  readonly now?: () => Date
+  /** Test-only abrupt-termination seam after a durable phase boundary. */
+  readonly afterPhasePersistedForTest?: (phase: HandoffPhaseName) => void
+}
+
+export class HandoffCrashForTest extends Error {
+  override readonly name = 'HandoffCrashForTest'
+}
+
+export function runHandoffStateMachine(
+  options: HandoffStateMachineOptions
+): HandoffReceipt {
+  const now = options.now ?? (() => new Date())
+  assertDefinitions(options.definitions)
+  let receipt = handoffReceiptSchema.parse(options.receipt)
+
+  for (const definition of options.definitions) {
+    const phase = definition.phase
+    const index = handoffPhases.indexOf(phase)
+    const inputHash =
+      index === 0
+        ? hashHandoffValue(receipt.identity)
+        : receipt.phases[index - 1]?.outputHash
+    if (inputHash === null || inputHash === undefined)
+      throw new Error(`Handoff predecessor is not complete: ${phase}`)
+
+    const record = receipt.phases[index]!
+    if (phaseIsReusable(record, inputHash, definition)) {
+      console.info(
+        JSON.stringify({
+          component: 'local-handoff',
+          event: 'phase-reused',
+          phase
+        })
+      )
+      continue
+    }
+
+    receipt = resetFrom(receipt, phase, now().toISOString())
+    const started = now()
+    receipt = updatePhase(receipt, phase, {
+      status: 'running',
+      startedAt: started.toISOString(),
+      durationMs: null,
+      inputHash,
+      outputHash: null,
+      evidence: null,
+      error: null
+    })
+    options.persist(receipt)
+    console.info(
+      JSON.stringify({
+        component: 'local-handoff',
+        event: 'phase-started',
+        phase
+      })
+    )
+    try {
+      definition.execute()
+      const evidence = definition.collect()
+      const outputHash = hashHandoffValue({ phase, inputHash, evidence })
+      receipt = updatePhase(receipt, phase, {
+        status: 'completed',
+        startedAt: started.toISOString(),
+        durationMs: Math.max(0, now().getTime() - started.getTime()),
+        inputHash,
+        outputHash,
+        evidence,
+        error: null
+      })
+      options.persist(receipt)
+    } catch (error) {
+      if (error instanceof HandoffCrashForTest) throw error
+      receipt = updatePhase(receipt, phase, {
+        status: 'failed',
+        startedAt: started.toISOString(),
+        durationMs: Math.max(0, now().getTime() - started.getTime()),
+        inputHash,
+        outputHash: null,
+        evidence: null,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      receipt = handoffReceiptSchema.parse({
+        ...receipt,
+        status: 'failed',
+        updatedAt: now().toISOString(),
+        completedAt: null
+      })
+      options.persist(receipt)
+      throw error
+    }
+    options.afterPhasePersistedForTest?.(phase)
+  }
+
+  const completedAt = now().toISOString()
+  receipt = handoffReceiptSchema.parse({
+    ...receipt,
+    status: 'complete',
+    updatedAt: completedAt,
+    completedAt
+  })
+  options.persist(receipt)
+  return receipt
+}
+
+export function attachHandoffAttempt(
+  receipt: HandoffReceipt,
+  attemptId: string,
+  timestamp: string
+): HandoffReceipt {
+  return continueHandoffReceipt(receipt, attemptId, timestamp)
+}
+
+function phaseIsReusable(
+  record: HandoffReceipt['phases'][number],
+  inputHash: string,
+  definition: HandoffPhaseDefinition
+): boolean {
+  if (
+    record.status !== 'completed' ||
+    record.inputHash !== inputHash ||
+    record.outputHash === null ||
+    record.evidence === null
+  )
+    return false
+  try {
+    const evidence = definition.collect()
+    return (
+      JSON.stringify(evidence) === JSON.stringify(record.evidence) &&
+      record.outputHash ===
+        hashHandoffValue({ phase: record.phase, inputHash, evidence })
+    )
+  } catch {
+    return false
+  }
+}
+
+function resetFrom(
+  receipt: HandoffReceipt,
+  phase: HandoffPhaseName,
+  timestamp: string
+): HandoffReceipt {
+  const index = handoffPhases.indexOf(phase)
+  return handoffReceiptSchema.parse({
+    ...receipt,
+    status: 'running',
+    updatedAt: timestamp,
+    completedAt: null,
+    phases: receipt.phases.map((record) =>
+      handoffPhases.indexOf(record.phase) < index
+        ? record
+        : {
+            phase: record.phase,
+            status: 'pending',
+            startedAt: null,
+            durationMs: null,
+            inputHash: null,
+            outputHash: null,
+            evidence: null,
+            error: null
+          }
+    )
+  })
+}
+
+function updatePhase(
+  receipt: HandoffReceipt,
+  phase: HandoffPhaseName,
+  update: Omit<HandoffReceipt['phases'][number], 'phase'>
+): HandoffReceipt {
+  return handoffReceiptSchema.parse({
+    ...receipt,
+    phases: receipt.phases.map((record) =>
+      record.phase === phase ? { phase, ...update } : record
+    )
+  })
+}
+
+function assertDefinitions(
+  definitions: readonly HandoffPhaseDefinition[]
+): void {
+  const actual = definitions.map(({ phase }) => phase)
+  if (JSON.stringify(actual) !== JSON.stringify(handoffPhases))
+    throw new Error('Handoff phase definitions must be complete and ordered')
+}

--- a/scripts/install-local-app.ts
+++ b/scripts/install-local-app.ts
@@ -1,7 +1,11 @@
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
-import { installLocalApp } from './local-app-installation.js'
+import {
+  advanceLocalAppInstallation,
+  localInstallationTargets,
+  type LocalInstallationTarget
+} from './local-app-installation.js'
 import { shortBuildFingerprint } from '../src/shared/contracts/build-info.js'
 
 const workspaceRoot = process.cwd()
@@ -16,26 +20,47 @@ const artifactPath = resolve(
   'local',
   `SaltMarcher-Local-${packageJson.version}.AppImage`
 )
-const result = installLocalApp({
-  workspaceRoot,
-  xdgDataHome:
-    process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share'),
-  artifactPath,
-  artifactManifestPath: `${artifactPath}.manifest.json`,
-  iconSourcePath: resolve(
+const target = parseTarget(process.argv.slice(2))
+const result = advanceLocalAppInstallation(
+  {
     workspaceRoot,
-    'resources',
-    'icons',
-    'salt-marcher.png'
-  )
-})
+    xdgDataHome:
+      process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share'),
+    artifactPath,
+    artifactManifestPath: `${artifactPath}.manifest.json`,
+    iconSourcePath: resolve(
+      workspaceRoot,
+      'resources',
+      'icons',
+      'salt-marcher.png'
+    )
+  },
+  target
+)
 console.info(
   JSON.stringify({
     component: 'local-installer',
-    event: 'installed',
+    event: target,
     appImage: result.paths.appImage,
     profile: result.paths.profile,
     fingerprint: shortBuildFingerprint(result.build),
-    backup: result.backupPath ?? null
+    backup: result.backupPath ?? null,
+    backupManifestSha256: result.backupManifestSha256 ?? null,
+    deployment: result.deploymentPath ?? null,
+    deploymentManifestSha256: result.deploymentManifestSha256 ?? null,
+    installedSha256: result.installedSha256 ?? null
   })
 )
+
+function parseTarget(arguments_: readonly string[]): LocalInstallationTarget {
+  if (arguments_.length === 0) return 'activated'
+  if (
+    arguments_.length !== 2 ||
+    arguments_[0] !== '--through' ||
+    !localInstallationTargets.includes(arguments_[1] as LocalInstallationTarget)
+  )
+    throw new Error(
+      `Usage: install-local-app.ts [--through ${localInstallationTargets.join('|')}]`
+    )
+  return arguments_[1] as LocalInstallationTarget
+}

--- a/scripts/local-app-installation.ts
+++ b/scripts/local-app-installation.ts
@@ -20,7 +20,15 @@ import {
   writeFileSync,
   writeSync
 } from 'node:fs'
-import { basename, dirname, join, relative, resolve, sep } from 'node:path'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep
+} from 'node:path'
 import Database from 'better-sqlite3'
 import { z } from 'zod'
 import {
@@ -123,7 +131,19 @@ export interface LocalInstallationResult {
   readonly paths: LocalInstallationPaths
   readonly build: BuildInfo
   readonly backupPath: string | undefined
+  readonly sourceDataHash: string
+  readonly backupManifestSha256: string | undefined
+  readonly deploymentPath: string | undefined
+  readonly deploymentManifestSha256: string | undefined
+  readonly installedSha256: string | undefined
 }
+
+export const localInstallationTargets = [
+  'backup-created',
+  'deployment-staged',
+  'activated'
+] as const
+export type LocalInstallationTarget = (typeof localInstallationTargets)[number]
 
 interface FileHash {
   readonly path: string
@@ -176,6 +196,13 @@ export function localInstallationPaths(
 export function installLocalApp(
   options: InstallLocalAppOptions
 ): LocalInstallationResult {
+  return advanceLocalAppInstallation(options, 'activated')
+}
+
+export function advanceLocalAppInstallation(
+  options: InstallLocalAppOptions,
+  target: LocalInstallationTarget
+): LocalInstallationResult {
   const paths = localInstallationPaths(options.xdgDataHome)
   const manifest = readArtifactManifest(options)
   const workspaceIdentity = (
@@ -195,14 +222,15 @@ export function installLocalApp(
     )
   mkdirSync(paths.root, { recursive: true })
   return withInstallationLock(paths, () =>
-    installLocalAppLocked(options, paths, manifest)
+    advanceLocalAppInstallationLocked(options, paths, manifest, target)
   )
 }
 
-function installLocalAppLocked(
+function advanceLocalAppInstallationLocked(
   options: InstallLocalAppOptions,
   paths: LocalInstallationPaths,
-  manifest: LocalArtifactManifest
+  manifest: LocalArtifactManifest,
+  target: LocalInstallationTarget
 ): LocalInstallationResult {
   if ((options.isAppRunning ?? isInstalledLocalAppRunning)(paths.appImage))
     throw new LocalInstallationError(
@@ -211,55 +239,131 @@ function installLocalAppLocked(
     )
 
   const now = options.now ?? (() => new Date())
-  recoverInterruptedInstallation(paths, options.schemaMigrations, now)
-  let preflight
-  try {
-    preflight = preflightPersistence(
-      paths.campaignData,
-      options.schemaMigrations
-    )
-  } catch (error) {
-    if (error instanceof IncompatibleDataError)
-      throw new LocalInstallationError(
-        'migration-missing',
-        `No tested migration exists from schema ${String(error.actualVersion)} to ${error.expectedVersion}`,
-        { cause: error }
-      )
-    if (error instanceof CorruptDataError)
-      throw new LocalInstallationError(
-        'data-corrupt',
-        `Campaign database failed SQLite quick_check: ${error.dataPath}`,
-        { cause: error }
-      )
-    throw error
+  let journal = readInstallJournal(paths.journal)
+  const matches = (candidate: LocalInstallJournal | null): boolean =>
+    candidate?.applicationSha === manifest.receipt.build.commit &&
+    candidate.buildFingerprint ===
+      manifest.receipt.build.workspaceFingerprint &&
+    candidate.appBuildInputFingerprint ===
+      manifest.receipt.build.appBuildInputFingerprint &&
+    candidate.artifactSha256 === manifest.artifactSha256
+  if (
+    journal !== null &&
+    (!matches(journal) ||
+      !['backup-complete', 'deployment-staged', 'completed'].includes(
+        journal.phase
+      ))
+  ) {
+    recoverInterruptedInstallation(paths, options.schemaMigrations, now)
+    journal = readInstallJournal(paths.journal)
   }
-  let journal = writeInstallJournal(
-    paths.journal,
-    createInstallJournal(manifest.receipt.build.workspaceFingerprint, now),
-    now
-  )
-  options.afterJournalWriteForTest?.(journal)
+  if (matches(journal) && journal !== null)
+    try {
+      if (journal.phase === 'backup-complete')
+        validateBackupCheckpoint(paths, journal)
+      if (journal.phase === 'deployment-staged') {
+        validateBackupCheckpoint(paths, journal)
+        validateDeploymentCheckpoint(paths, manifest, options, journal)
+      }
+      if (journal.phase === 'completed') {
+        validateBackupCheckpoint(paths, journal)
+        validateDeploymentCheckpoint(paths, manifest, options, journal)
+        try {
+          validateCompletedInstallation(paths, manifest, options.iconSourcePath)
+        } catch {
+          journal = writeInstallJournal(
+            paths.journal,
+            { ...journal, phase: 'deployment-staged', replacements: [] },
+            now
+          )
+        }
+      }
+    } catch {
+      journal = writeInstallJournal(
+        paths.journal,
+        { ...journal, phase: 'rolled-back' },
+        now
+      )
+    }
+  if (!matches(journal) || journal?.phase === 'rolled-back') {
+    journal = writeInstallJournal(
+      paths.journal,
+      createInstallJournal(
+        {
+          applicationSha: manifest.receipt.build.commit,
+          buildFingerprint: manifest.receipt.build.workspaceFingerprint,
+          appBuildInputFingerprint:
+            manifest.receipt.build.appBuildInputFingerprint,
+          artifactSha256: manifest.artifactSha256
+        },
+        now
+      ),
+      now
+    )
+    options.afterJournalWriteForTest?.(journal)
+  }
+  if (journal === null) throw new Error('Installation journal was not created')
+  let activeJournal: LocalInstallJournal = journal
   const updateJournal = (
     changes: Partial<
       Omit<LocalInstallJournal, 'formatVersion' | 'transactionId'>
     >
   ): void => {
-    journal = writeInstallJournal(
+    activeJournal = writeInstallJournal(
       paths.journal,
-      { ...journal, ...changes },
+      { ...activeJournal, ...changes },
       now
     )
-    options.afterJournalWriteForTest?.(journal)
+    options.afterJournalWriteForTest?.(activeJournal)
   }
   try {
-    const backupPath = backupCampaignData(
-      paths,
-      manifest.receipt.build,
-      preflight.databases,
-      now
-    )
-    updateJournal({ phase: 'backup-complete', backupPath: backupPath ?? null })
+    if (activeJournal.phase === 'completed') {
+      validateCompletedInstallation(paths, manifest, options.iconSourcePath)
+      return installationResult(paths, manifest, activeJournal)
+    }
 
+    if (activeJournal.phase === 'prepared') {
+      const preflight = readPersistencePreflight(
+        paths,
+        options.schemaMigrations
+      )
+      const sourceDataHash = hashFileInventory(
+        hashTreeOrEmpty(paths.campaignData)
+      )
+      const backup = backupCampaignData(
+        paths,
+        manifest.receipt.build,
+        preflight.databases,
+        now
+      )
+      updateJournal({
+        phase: 'backup-complete',
+        backupPath: backup?.path ?? null,
+        sourceDataHash,
+        campaignDataHash: sourceDataHash,
+        backupManifestSha256: backup?.manifestSha256 ?? null
+      })
+    } else validateBackupCheckpoint(paths, activeJournal)
+
+    if (target === 'backup-created')
+      return installationResult(paths, manifest, activeJournal)
+
+    if (activeJournal.phase === 'backup-complete') {
+      const deployment = stageDeployment(paths, manifest, options)
+      updateJournal({
+        phase: 'deployment-staged',
+        deploymentPath: deployment,
+        deploymentManifestSha256: sha256File(
+          join(deployment, 'artifact-manifest.json')
+        )
+      })
+    } else validateDeploymentCheckpoint(paths, manifest, options, activeJournal)
+
+    if (target === 'deployment-staged')
+      return installationResult(paths, manifest, activeJournal)
+
+    validateBackupCheckpoint(paths, activeJournal)
+    const preflight = readPersistencePreflight(paths, options.schemaMigrations)
     if (preflight.kind === 'migration-required')
       migrateCampaignData(
         paths,
@@ -268,8 +372,9 @@ function installLocalAppLocked(
         updateJournal
       )
 
-    const deployment = stageDeployment(paths, manifest, options)
-    updateJournal({ phase: 'deployment-staged', deploymentPath: deployment })
+    const deployment = activeJournal.deploymentPath
+    if (deployment === null)
+      throw new Error('Installation journal has no staged deployment')
     const desktopEntry = renderDesktopEntry(paths, manifest.receipt.build)
     replaceAtomically(
       [
@@ -293,23 +398,204 @@ function installLocalAppLocked(
     )
     mkdirSync(paths.profile, { recursive: true })
     updateJournal({ phase: 'completed' })
-    return { paths, build: manifest.receipt.build, backupPath }
+    validateCompletedInstallation(paths, manifest, options.iconSourcePath)
+    return installationResult(paths, manifest, activeJournal)
   } catch (error) {
     if (error instanceof LocalInstallCrashForTest) throw error
     recoverInterruptedInstallation(paths, options.schemaMigrations, now)
-    const recovered = readInstallJournal(paths.journal)
-    if (recovered !== null && recovered.phase !== 'completed')
-      writeInstallJournal(
-        paths.journal,
-        { ...recovered, phase: 'rolled-back' },
-        now
-      )
     if (error instanceof LocalInstallationError) throw error
     throw new LocalInstallationError(
       'atomic-replace-failed',
       'The local application could not be replaced; the previous installation was restored',
       { cause: error }
     )
+  }
+}
+
+export function inspectLocalAppInstallation(
+  options: InstallLocalAppOptions,
+  target: LocalInstallationTarget
+): LocalInstallationResult | null {
+  try {
+    const paths = localInstallationPaths(options.xdgDataHome)
+    const manifest = readArtifactManifest(options)
+    const journal = readInstallJournal(paths.journal)
+    if (
+      journal === null ||
+      journal.applicationSha !== manifest.receipt.build.commit ||
+      journal.buildFingerprint !==
+        manifest.receipt.build.workspaceFingerprint ||
+      journal.appBuildInputFingerprint !==
+        manifest.receipt.build.appBuildInputFingerprint ||
+      journal.artifactSha256 !== manifest.artifactSha256
+    )
+      return null
+    validateBackupCheckpoint(paths, journal)
+    if (target !== 'backup-created')
+      validateDeploymentCheckpoint(paths, manifest, options, journal)
+    if (target === 'activated') {
+      if (journal.phase !== 'completed') return null
+      validateCompletedInstallation(paths, manifest, options.iconSourcePath)
+    } else if (
+      target === 'deployment-staged' &&
+      !['deployment-staged', 'completed'].includes(journal.phase)
+    )
+      return null
+    else if (
+      target === 'backup-created' &&
+      !['backup-complete', 'deployment-staged', 'completed'].includes(
+        journal.phase
+      )
+    )
+      return null
+    return installationResult(paths, manifest, journal)
+  } catch {
+    return null
+  }
+}
+
+function readPersistencePreflight(
+  paths: LocalInstallationPaths,
+  migrations?: readonly SchemaMigration[]
+): PersistencePreflight {
+  try {
+    return preflightPersistence(paths.campaignData, migrations)
+  } catch (error) {
+    if (error instanceof IncompatibleDataError)
+      throw new LocalInstallationError(
+        'migration-missing',
+        `No tested migration exists from schema ${String(error.actualVersion)} to ${error.expectedVersion}`,
+        { cause: error }
+      )
+    if (error instanceof CorruptDataError)
+      throw new LocalInstallationError(
+        'data-corrupt',
+        `Campaign database failed SQLite quick_check: ${error.dataPath}`,
+        { cause: error }
+      )
+    throw error
+  }
+}
+
+function validateBackupCheckpoint(
+  paths: LocalInstallationPaths,
+  journal: LocalInstallJournal
+): void {
+  const currentHash = hashFileInventory(hashTreeOrEmpty(paths.campaignData))
+  if (
+    journal.sourceDataHash === null ||
+    journal.campaignDataHash === null ||
+    journal.campaignDataHash !== currentHash
+  )
+    throw new LocalInstallationError(
+      'data-corrupt',
+      'Campaign data changed after the verified backup checkpoint'
+    )
+  if (journal.backupPath === null) {
+    if (journal.backupManifestSha256 !== null)
+      throw new Error('Backup checkpoint has a hash without a backup')
+    return
+  }
+  const manifestPath = join(journal.backupPath, 'backup-manifest.json')
+  if (
+    !existsSync(manifestPath) ||
+    journal.backupManifestSha256 !== sha256File(manifestPath)
+  )
+    throw new LocalInstallationError(
+      'data-corrupt',
+      'Verified campaign backup is missing or changed'
+    )
+  const backupManifest = z
+    .object({
+      files: z.array(
+        z
+          .object({
+            path: z.string().min(1),
+            bytes: z.number().int().nonnegative(),
+            sha256: z.string().regex(/^[a-f0-9]{64}$/)
+          })
+          .strict()
+      )
+    })
+    .passthrough()
+    .parse(JSON.parse(readFileSync(manifestPath, 'utf8')))
+  const actualFiles = hashTree(journal.backupPath).filter(
+    ({ path }) => path !== 'backup-manifest.json'
+  )
+  if (
+    JSON.stringify(actualFiles) !== JSON.stringify(backupManifest.files) ||
+    hashFileInventory(actualFiles) !== journal.sourceDataHash
+  )
+    throw new LocalInstallationError(
+      'data-corrupt',
+      'Verified campaign backup contents changed'
+    )
+}
+
+function validateDeploymentCheckpoint(
+  paths: LocalInstallationPaths,
+  manifest: LocalArtifactManifest,
+  options: InstallLocalAppOptions,
+  journal: LocalInstallJournal
+): void {
+  if (journal.deploymentPath === null)
+    throw new Error('Installation journal has no staged deployment')
+  validateDeployment(journal.deploymentPath, manifest, options.iconSourcePath)
+  const manifestHash = sha256File(
+    join(journal.deploymentPath, 'artifact-manifest.json')
+  )
+  if (journal.deploymentManifestSha256 !== manifestHash)
+    throw new Error('Staged deployment manifest hash changed')
+  const relativeDeployment = relative(paths.deployments, journal.deploymentPath)
+  if (
+    relativeDeployment === '' ||
+    relativeDeployment.startsWith(`..${sep}`) ||
+    relativeDeployment === '..' ||
+    isAbsolute(relativeDeployment)
+  )
+    throw new Error('Staged deployment escaped the deployment root')
+}
+
+function validateCompletedInstallation(
+  paths: LocalInstallationPaths,
+  manifest: LocalArtifactManifest,
+  iconSourcePath: string
+): void {
+  const deployment = join(
+    paths.deployments,
+    manifest.receipt.build.workspaceFingerprint
+  )
+  validateDeployment(deployment, manifest, iconSourcePath)
+  if (!currentSelectsDeployment(paths.current, deployment))
+    throw new Error(
+      'Current installation does not select the staged deployment'
+    )
+  if (sha256File(paths.appImage) !== manifest.artifactSha256)
+    throw new Error('Activated AppImage hash differs from its artifact')
+  if (sha256File(paths.icon) !== sha256File(iconSourcePath))
+    throw new Error('Activated desktop icon differs from its source')
+  if (
+    readFileSync(paths.desktopEntry, 'utf8') !==
+    renderDesktopEntry(paths, manifest.receipt.build)
+  )
+    throw new Error('Activated desktop entry differs from its build')
+}
+
+function installationResult(
+  paths: LocalInstallationPaths,
+  manifest: LocalArtifactManifest,
+  journal: LocalInstallJournal
+): LocalInstallationResult {
+  return {
+    paths,
+    build: manifest.receipt.build,
+    backupPath: journal.backupPath ?? undefined,
+    sourceDataHash: journal.sourceDataHash ?? hashFileInventory([]),
+    backupManifestSha256: journal.backupManifestSha256 ?? undefined,
+    deploymentPath: journal.deploymentPath ?? undefined,
+    deploymentManifestSha256: journal.deploymentManifestSha256 ?? undefined,
+    installedSha256:
+      journal.phase === 'completed' ? sha256File(paths.appImage) : undefined
   }
 }
 
@@ -411,10 +697,22 @@ function recoverInterruptedInstallation(
       recovered = { ...journal, phase: 'completed' }
     } else {
       rollbackReplacements(journal.replacements)
-      recovered = { ...journal, phase: 'rolled-back' }
+      recovered = {
+        ...journal,
+        phase:
+          journal.deploymentPath === null ? 'rolled-back' : 'deployment-staged',
+        replacements: []
+      }
     }
   } else {
-    recovered = { ...journal, phase: 'rolled-back' }
+    recovered = {
+      ...journal,
+      phase:
+        journal.deploymentPath === null ? 'rolled-back' : 'deployment-staged',
+      campaignDataHash: hashFileInventory(hashTreeOrEmpty(paths.campaignData)),
+      migration: null,
+      replacements: []
+    }
   }
   writeInstallJournal(paths.journal, recovered, now)
 }
@@ -462,6 +760,9 @@ function migrateCampaignData(
       if (preflightPersistence(paths.campaignData, migrations).kind !== 'ready')
         throw new Error('Promoted persistence failed validation')
       updateJournal({ phase: 'data-promoted' })
+      updateJournal({
+        campaignDataHash: hashFileInventory(hashTreeOrEmpty(paths.campaignData))
+      })
       rmSync(rollback, { recursive: true, force: true })
     } catch (error) {
       rmSync(paths.campaignData, { recursive: true, force: true })
@@ -595,7 +896,7 @@ function backupCampaignData(
   nextBuild: BuildInfo,
   sourceDatabases: readonly PreflightDatabase[],
   now: () => Date
-): string | undefined {
+): { readonly path: string; readonly manifestSha256: string } | undefined {
   if (!directoryHasEntries(paths.campaignData)) return undefined
   mkdirSync(paths.backups, { recursive: true })
   const token = randomUUID()
@@ -615,8 +916,9 @@ function backupCampaignData(
     )
     validateDatabases(copiedDatabases)
     const previousBuild = readPreviousInstalledBuild(paths.installedManifest)
+    const backupManifestPath = join(staging, 'backup-manifest.json')
     writeFileSync(
-      join(staging, 'backup-manifest.json'),
+      backupManifestPath,
       `${JSON.stringify(
         {
           formatVersion: 1,
@@ -639,7 +941,10 @@ function backupCampaignData(
       'utf8'
     )
     renameSync(staging, target)
-    return target
+    return {
+      path: target,
+      manifestSha256: sha256File(join(target, 'backup-manifest.json'))
+    }
   } catch (error) {
     rmSync(staging, { recursive: true, force: true })
     if (error instanceof LocalInstallationError) throw error
@@ -774,7 +1079,7 @@ function replaceAtomically(
       if (existsSync(target)) rmSync(target, { force: true })
       if (existsSync(previous)) renameSync(previous, target)
     }
-    updateJournal({ phase: 'rolled-back', replacements: [] })
+    updateJournal({ phase: 'deployment-staged', replacements: [] })
     throw error
   } finally {
     for (const path of staged.values()) rmSync(path, { force: true })
@@ -917,6 +1222,14 @@ function hashTree(root: string): FileHash[] {
     bytes: statSync(path).size,
     sha256: sha256File(path)
   }))
+}
+
+function hashTreeOrEmpty(root: string): FileHash[] {
+  return existsSync(root) ? hashTree(root) : []
+}
+
+function hashFileInventory(files: readonly FileHash[]): string {
+  return createHash('sha256').update(JSON.stringify(files)).digest('hex')
 }
 
 /** Copies and hashes each source byte in the same pass; verification rereads only the backup. */

--- a/scripts/local-install-journal.ts
+++ b/scripts/local-install-journal.ts
@@ -21,35 +21,74 @@ const replacementSchema = z
   })
   .strict()
 
-export const localInstallJournalSchema = z
+const journalFields = {
+  transactionId: z.uuid(),
+  buildFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+  phase: z.enum([
+    'prepared',
+    'backup-complete',
+    'migration-staged',
+    'data-rollback-created',
+    'data-promoted',
+    'deployment-staged',
+    'files-staged',
+    'files-promoting',
+    'completed',
+    'rolled-back'
+  ]),
+  backupPath: z.string().min(1).nullable(),
+  deploymentPath: z.string().min(1).nullable(),
+  migration: z
+    .object({
+      staging: z.string().min(1),
+      rollback: z.string().min(1)
+    })
+    .strict()
+    .nullable(),
+  replacements: z.array(replacementSchema).readonly(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime()
+} as const
+
+const legacyLocalInstallJournalSchema = z
   .object({
     formatVersion: z.literal(1),
-    transactionId: z.uuid(),
-    buildFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
-    phase: z.enum([
-      'prepared',
-      'backup-complete',
-      'migration-staged',
-      'data-rollback-created',
-      'data-promoted',
-      'deployment-staged',
-      'files-staged',
-      'files-promoting',
-      'completed',
-      'rolled-back'
-    ]),
-    backupPath: z.string().min(1).nullable(),
-    deploymentPath: z.string().min(1).nullable(),
-    migration: z
-      .object({
-        staging: z.string().min(1),
-        rollback: z.string().min(1)
-      })
-      .strict()
+    ...journalFields
+  })
+  .strict()
+
+export const localInstallJournalSchema = z
+  .object({
+    formatVersion: z.literal(2),
+    applicationSha: z
+      .string()
+      .regex(/^[a-f0-9]{40}$/)
       .nullable(),
-    replacements: z.array(replacementSchema).readonly(),
-    createdAt: z.iso.datetime(),
-    updatedAt: z.iso.datetime()
+    appBuildInputFingerprint: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    artifactSha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    sourceDataHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    campaignDataHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    backupManifestSha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    deploymentManifestSha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .nullable(),
+    ...journalFields
   })
   .strict()
 
@@ -57,14 +96,26 @@ export type LocalInstallJournal = z.infer<typeof localInstallJournalSchema>
 export type JournalReplacement = z.infer<typeof replacementSchema>
 
 export function createInstallJournal(
-  buildFingerprint: string,
+  identity: {
+    readonly applicationSha: string
+    readonly buildFingerprint: string
+    readonly appBuildInputFingerprint: string
+    readonly artifactSha256: string
+  },
   now: () => Date
 ): LocalInstallJournal {
   const timestamp = now().toISOString()
   return localInstallJournalSchema.parse({
-    formatVersion: 1,
+    formatVersion: 2,
     transactionId: randomUUID(),
-    buildFingerprint,
+    applicationSha: identity.applicationSha,
+    buildFingerprint: identity.buildFingerprint,
+    appBuildInputFingerprint: identity.appBuildInputFingerprint,
+    artifactSha256: identity.artifactSha256,
+    sourceDataHash: null,
+    campaignDataHash: null,
+    backupManifestSha256: null,
+    deploymentManifestSha256: null,
     phase: 'prepared',
     backupPath: null,
     deploymentPath: null,
@@ -77,7 +128,21 @@ export function createInstallJournal(
 
 export function readInstallJournal(path: string): LocalInstallJournal | null {
   if (!existsSync(path)) return null
-  return localInstallJournalSchema.parse(JSON.parse(readFileSync(path, 'utf8')))
+  const value: unknown = JSON.parse(readFileSync(path, 'utf8'))
+  const current = localInstallJournalSchema.safeParse(value)
+  if (current.success) return current.data
+  const legacy = legacyLocalInstallJournalSchema.parse(value)
+  return localInstallJournalSchema.parse({
+    ...legacy,
+    formatVersion: 2,
+    applicationSha: null,
+    appBuildInputFingerprint: null,
+    artifactSha256: null,
+    sourceDataHash: null,
+    campaignDataHash: null,
+    backupManifestSha256: null,
+    deploymentManifestSha256: null
+  })
 }
 
 export function writeInstallJournal(

--- a/scripts/test-manifests/delivery.json
+++ b/scripts/test-manifests/delivery.json
@@ -4,6 +4,8 @@
   "typecheck": true,
   "tests": [
     "tests/unit/delivery-contract.test.ts",
+    "tests/unit/handoff-state-machine.test.ts",
+    "tests/unit/handoff-preflight.test.ts",
     "tests/unit/candidate-delivery.test.ts",
     "tests/unit/build-identity.test.ts",
     "tests/unit/build-receipt.test.ts",

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -8,11 +8,18 @@ import {
   assertCandidateState,
   parseRemoteHead,
   postPromotionJobName,
+  requiresApplicationHandoff,
   successfulCandidateEvidence,
   successfulPostPromotionEvidence,
   type CandidateState
 } from '../../scripts/candidate-delivery.js'
-import { readRequiredJobManifest } from '../../scripts/delivery-contract.js'
+import {
+  createHandoffReceipt,
+  handoffPhases,
+  handoffReceiptSchema,
+  hashHandoffValue,
+  readRequiredJobManifest
+} from '../../scripts/delivery-contract.js'
 
 const roots: string[] = []
 
@@ -43,6 +50,11 @@ const valid: CandidateState = {
 }
 
 describe('candidate delivery policy', () => {
+  it('requires local application handoff only when app-build inputs changed', () => {
+    expect(requiresApplicationHandoff('same', 'same')).toBe(false)
+    expect(requiresApplicationHandoff('candidate', 'main')).toBe(true)
+  })
+
   it('parses the live remote head without consulting local main', () => {
     expect(parseRemoteHead(`${'a'.repeat(40)}\trefs/heads/main\n`)).toBe(
       'a'.repeat(40)
@@ -119,52 +131,72 @@ describe('candidate delivery policy', () => {
       expect(() => assertCandidateState({ ...valid, ...patch })).toThrow()
   })
 
-  it('uses the shared strict receipt and append-only history for promotion', () => {
+  it('uses the strict completed SHA state and permits multiple audited attempts', () => {
     const root = mkdtempSync(join(tmpdir(), 'salt-marcher-delivery-'))
     roots.push(root)
     const directory = join(root, '.tmp', 'handoff-local-app')
     mkdirSync(directory, { recursive: true })
-    const invocationId = '00000000-0000-4000-8000-000000000001'
+    const originAttemptId = '00000000-0000-4000-8000-000000000001'
+    const activeAttemptId = '00000000-0000-4000-8000-000000000002'
     const timestamp = '2026-08-18T12:00:00.000Z'
     const hash = 'c'.repeat(64)
-    const receipt = {
-      formatVersion: 3,
-      invocationId,
-      status: 'complete',
-      mode: 'fresh',
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      completedAt: timestamp,
-      identity: {
+    const initial = createHandoffReceipt(
+      {
         commit: valid.head,
         dirty: false,
         workspaceFingerprint: hash,
         appBuildInputFingerprint: hash,
+        qualificationInputFingerprint: hash,
+        deliveryInputFingerprint: hash,
         toolchainHash: hash,
-        candidate: valid.candidate
+        candidate: valid.candidate!
       },
-      steps: [
-        'check',
-        'package',
-        'packaged-smoke',
-        'backup-and-install',
-        'installed-runtime-verification'
-      ].map((step) => ({
-        step,
+      '00000000-0000-4000-8000-000000000010',
+      originAttemptId,
+      timestamp
+    )
+    let predecessor = hashHandoffValue(initial.identity)
+    const phases = handoffPhases.map((phase) => {
+      const evidence = {
+        workspaceFingerprint: hash,
+        appBuildInputFingerprint: hash,
+        qualificationInputFingerprint: hash,
+        deliveryInputFingerprint: hash,
+        toolchainHash: hash,
+        buildOutputHash: hash,
+        artifactSha256: hash,
+        sourceDataHash: hash,
+        backupManifestSha256: hash,
+        deploymentManifestSha256: hash,
+        runtimeEvidenceSha256: hash,
+        installedSha256: hash
+      }
+      const outputHash = hashHandoffValue({
+        phase,
+        inputHash: predecessor,
+        evidence
+      })
+      const record = {
+        phase,
         status: 'completed',
         startedAt: timestamp,
         durationMs: 1,
-        evidence: {
-          workspaceFingerprint: hash,
-          appBuildInputFingerprint: hash,
-          toolchainHash: hash,
-          outputHash: hash,
-          artifactSha256: hash,
-          installedSha256: hash
-        },
+        inputHash: predecessor,
+        outputHash,
+        evidence,
         error: null
-      }))
-    }
+      }
+      predecessor = outputHash
+      return record
+    })
+    const receipt = handoffReceiptSchema.parse({
+      ...initial,
+      activeAttemptId,
+      status: 'complete',
+      updatedAt: timestamp,
+      completedAt: timestamp,
+      phases
+    })
     writeFileSync(
       join(directory, 'handoff-receipt.json'),
       JSON.stringify(receipt)
@@ -172,13 +204,23 @@ describe('candidate delivery policy', () => {
     writeFileSync(
       join(directory, 'invocations.json'),
       JSON.stringify({
-        formatVersion: 1,
+        formatVersion: 2,
         invocations: [
           {
-            invocationId,
+            attemptId: originAttemptId,
             applicationSha: valid.head,
+            intent: 'advance',
             createdAt: timestamp,
-            receiptPath: 'receipt.json'
+            statePath: 'state.json',
+            auditPath: 'origin.json'
+          },
+          {
+            attemptId: activeAttemptId,
+            applicationSha: valid.head,
+            intent: 'resume',
+            createdAt: timestamp,
+            statePath: 'state.json',
+            auditPath: 'active.json'
           }
         ]
       })
@@ -186,6 +228,18 @@ describe('candidate delivery policy', () => {
 
     expect(() =>
       assertCompletedHandoffReceipt(valid.head, valid.candidate!, root)
+    ).not.toThrow()
+    expect(() =>
+      assertCompletedHandoffReceipt(
+        valid.head,
+        {
+          ...valid.candidate!,
+          runId: 2,
+          url: 'https://github.example/check/2',
+          attempt: 2
+        },
+        root
+      )
     ).not.toThrow()
     writeFileSync(
       join(directory, 'handoff-receipt.json'),

--- a/tests/unit/delivery-contract.test.ts
+++ b/tests/unit/delivery-contract.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   appendHandoffInvocation,
-  freshInvocationCount,
+  continueHandoffReceipt,
+  createHandoffReceipt,
   handoffInvocationHistorySchema,
-  handoffReceiptSchema,
-  handoffSteps,
+  handoffPhases,
+  parseHandoffInvocationHistory,
   readRequiredJobManifest,
   requiredJobManifestSchema,
-  resumeHandoffReceipt,
+  sameHandoffApplicationIdentity,
   verifyRequiredJobs,
   type GithubWorkflowRun
 } from '../../scripts/delivery-contract.js'
@@ -79,62 +80,95 @@ describe('delivery contract', () => {
     ).toThrow()
   })
 
-  it('retains every fresh invocation and makes exactly-once machine-checkable', () => {
+  it('retains every safe attempt without treating duplicates as a violation', () => {
     const empty = handoffInvocationHistorySchema.parse({
-      formatVersion: 1,
+      formatVersion: 2,
       invocations: []
     })
     const first = appendHandoffInvocation(empty, invocation('1'))
     const second = appendHandoffInvocation(first, invocation('2'))
-    expect(freshInvocationCount(first, sha)).toBe(1)
-    expect(freshInvocationCount(second, sha)).toBe(2)
-    expect(second.invocations.map(({ invocationId }) => invocationId)).toEqual([
+    expect(second.invocations).toHaveLength(2)
+    expect(second.invocations.map(({ attemptId }) => attemptId)).toEqual([
       '00000000-0000-4000-8000-000000000001',
       '00000000-0000-4000-8000-000000000002'
     ])
   })
 
-  it('preserves fresh invocation provenance across resume attempts', () => {
+  it('migrates the legacy invocation audit without losing provenance', () => {
+    const migrated = parseHandoffInvocationHistory({
+      formatVersion: 1,
+      invocations: [
+        {
+          invocationId: '00000000-0000-4000-8000-000000000001',
+          applicationSha: sha,
+          createdAt: '2026-08-18T12:00:00.000Z',
+          receiptPath: 'legacy-receipt.json'
+        }
+      ]
+    })
+    expect(migrated).toMatchObject({
+      formatVersion: 2,
+      invocations: [
+        {
+          attemptId: '00000000-0000-4000-8000-000000000001',
+          intent: 'advance',
+          auditPath: 'legacy-receipt.json'
+        }
+      ]
+    })
+  })
+
+  it('preserves original state provenance across later attempts', () => {
     const createdAt = '2026-08-18T12:00:00.000Z'
     const updatedAt = '2026-08-18T12:30:00.000Z'
-    const receipt = handoffReceiptSchema.parse({
-      formatVersion: 3,
-      invocationId: '00000000-0000-4000-8000-000000000001',
-      status: 'failed',
-      mode: 'fresh',
-      createdAt,
-      updatedAt: createdAt,
-      completedAt: null,
-      identity: {
-        commit: sha,
-        dirty: false,
-        workspaceFingerprint: 'b'.repeat(64),
-        appBuildInputFingerprint: 'c'.repeat(64),
-        toolchainHash: 'd'.repeat(64),
-        candidate: verifyRequiredJobs(
-          readRequiredJobManifest(),
-          successfulRun(),
-          sha
-        )
-      },
-      steps: handoffSteps.map((step) => ({
-        step,
-        status: 'pending',
-        startedAt: null,
-        durationMs: null,
-        evidence: null,
-        error: null
-      }))
-    })
+    const origin = '00000000-0000-4000-8000-000000000001'
+    const later = '00000000-0000-4000-8000-000000000002'
+    const receipt = createHandoffReceipt(
+      identity(),
+      '00000000-0000-4000-8000-000000000010',
+      origin,
+      createdAt
+    )
 
-    expect(resumeHandoffReceipt(receipt, updatedAt)).toMatchObject({
-      invocationId: receipt.invocationId,
+    expect(continueHandoffReceipt(receipt, later, updatedAt)).toMatchObject({
+      stateId: receipt.stateId,
+      originAttemptId: origin,
+      activeAttemptId: later,
       status: 'running',
-      mode: 'fresh',
       createdAt,
       updatedAt,
-      completedAt: null
+      completedAt: null,
+      phases: handoffPhases.map((phase) => ({ phase }))
     })
+  })
+
+  it('accepts a new successful CI attempt for the same application identity', () => {
+    const existing = identity()
+    const current = {
+      ...identity(),
+      candidate: {
+        ...identity().candidate,
+        runId: 456,
+        url: 'https://github.example/actions/runs/456',
+        attempt: 3
+      }
+    }
+    expect(sameHandoffApplicationIdentity(existing, current)).toBe(true)
+    expect(
+      sameHandoffApplicationIdentity(existing, {
+        ...current,
+        deliveryInputFingerprint: '0'.repeat(64)
+      })
+    ).toBe(false)
+    expect(
+      sameHandoffApplicationIdentity(existing, {
+        ...current,
+        candidate: {
+          ...current.candidate,
+          jobs: current.candidate.jobs.slice(1)
+        }
+      })
+    ).toBe(false)
   })
 })
 
@@ -157,11 +191,30 @@ function successfulRun(): GithubWorkflowRun {
 }
 
 function invocation(suffix: string) {
-  const invocationId = `00000000-0000-4000-8000-${suffix.padStart(12, '0')}`
+  const attemptId = `00000000-0000-4000-8000-${suffix.padStart(12, '0')}`
   return {
-    invocationId,
+    attemptId,
     applicationSha: sha,
+    intent: 'advance' as const,
     createdAt: '2026-08-18T12:00:00.000Z',
-    receiptPath: `.tmp/handoff-local-app/invocations/${invocationId}.json`
+    statePath: `.tmp/handoff-local-app/states/${sha}.json`,
+    auditPath: `.tmp/handoff-local-app/attempts/${attemptId}.json`
+  }
+}
+
+function identity() {
+  return {
+    commit: sha,
+    dirty: false,
+    workspaceFingerprint: 'b'.repeat(64),
+    appBuildInputFingerprint: 'c'.repeat(64),
+    qualificationInputFingerprint: 'd'.repeat(64),
+    deliveryInputFingerprint: 'e'.repeat(64),
+    toolchainHash: 'f'.repeat(64),
+    candidate: verifyRequiredJobs(
+      readRequiredJobManifest(),
+      successfulRun(),
+      sha
+    )
   }
 }

--- a/tests/unit/handoff-preflight.test.ts
+++ b/tests/unit/handoff-preflight.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { assertHandoffResourcePreflight } from '../../scripts/handoff-preflight.js'
+
+describe('handoff resource preflight', () => {
+  it('accepts capacity for build output plus two campaign-data copies', () => {
+    expect(() =>
+      assertHandoffResourcePreflight({
+        workspaceAvailableBytes: 2 * 1024 ** 3,
+        installationAvailableBytes: 3 * 1024 ** 3,
+        campaignDataBytes: 1024 ** 3
+      })
+    ).not.toThrow()
+  })
+
+  it('fails before material state when workspace capacity is insufficient', () => {
+    expect(() =>
+      assertHandoffResourcePreflight({
+        workspaceAvailableBytes: 512 * 1024 ** 2 - 1,
+        installationAvailableBytes: 4 * 1024 ** 3,
+        campaignDataBytes: 0
+      })
+    ).toThrow(/workspace preflight/)
+  })
+
+  it('fails before material state when backup capacity is insufficient', () => {
+    expect(() =>
+      assertHandoffResourcePreflight({
+        workspaceAvailableBytes: 2 * 1024 ** 3,
+        installationAvailableBytes: 2 * 1024 ** 3,
+        campaignDataBytes: 1024 ** 3
+      })
+    ).toThrow(/installation preflight/)
+  })
+})

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import {
+  continueHandoffReceipt,
+  createHandoffReceipt,
+  handoffPhases,
+  handoffReceiptSchema,
+  type HandoffPhaseEvidence,
+  type HandoffPhaseName,
+  type HandoffReceipt
+} from '../../scripts/delivery-contract.js'
+import {
+  HandoffCrashForTest,
+  runHandoffStateMachine,
+  type HandoffPhaseDefinition
+} from '../../scripts/handoff-state-machine.js'
+
+describe('SHA handoff state machine', () => {
+  it.each(handoffPhases)(
+    'resumes safely after the durable %s boundary',
+    (crashPhase) => {
+      const fixture = createFixture()
+      let persisted = fixture.receipt
+      expect(() =>
+        runHandoffStateMachine({
+          receipt: persisted,
+          definitions: fixture.definitions,
+          persist: (receipt) => {
+            persisted = receipt
+          },
+          now: fixture.now,
+          afterPhasePersistedForTest: (phase) => {
+            if (phase === crashPhase)
+              throw new HandoffCrashForTest(`crash after ${phase}`)
+          }
+        })
+      ).toThrowError(HandoffCrashForTest)
+
+      const resumed = runHandoffStateMachine({
+        receipt: continueHandoffReceipt(
+          persisted,
+          '00000000-0000-4000-8000-000000000002',
+          fixture.now().toISOString()
+        ),
+        definitions: fixture.definitions,
+        persist: (receipt) => {
+          persisted = receipt
+        },
+        now: fixture.now
+      })
+
+      expect(resumed.status).toBe('complete')
+      expect(resumed.originAttemptId).toBe(
+        '00000000-0000-4000-8000-000000000001'
+      )
+      expect(resumed.activeAttemptId).toBe(
+        '00000000-0000-4000-8000-000000000002'
+      )
+      expect(fixture.executions.get(crashPhase)).toBe(1)
+      expect(resumed.phases.every(({ status }) => status === 'completed')).toBe(
+        true
+      )
+    }
+  )
+
+  it.each(handoffPhases)(
+    'repeats only the idempotent %s operation after a pre-commit failure',
+    (failedPhase) => {
+      const fixture = createFixture(failedPhase)
+      let persisted = fixture.receipt
+      expect(() =>
+        runHandoffStateMachine({
+          receipt: persisted,
+          definitions: fixture.definitions,
+          persist: (receipt) => {
+            persisted = receipt
+          },
+          now: fixture.now
+        })
+      ).toThrow(`failure during ${failedPhase}`)
+
+      const completed = runHandoffStateMachine({
+        receipt: continueHandoffReceipt(
+          persisted,
+          '00000000-0000-4000-8000-000000000002',
+          fixture.now().toISOString()
+        ),
+        definitions: fixture.definitions,
+        persist: (receipt) => {
+          persisted = receipt
+        },
+        now: fixture.now
+      })
+
+      expect(completed.status).toBe('complete')
+      expect(fixture.executions.get(failedPhase)).toBe(2)
+      for (const phase of handoffPhases.slice(
+        0,
+        handoffPhases.indexOf(failedPhase)
+      ))
+        expect(fixture.executions.get(phase)).toBe(1)
+    }
+  )
+
+  it('invalidates the changed phase and every dependent successor', () => {
+    const fixture = createFixture()
+    let persisted = fixture.receipt
+    persisted = runHandoffStateMachine({
+      receipt: persisted,
+      definitions: fixture.definitions,
+      persist: (receipt) => {
+        persisted = receipt
+      },
+      now: fixture.now
+    })
+    const changed = 'packaged' satisfies HandoffPhaseName
+    fixture.evidence.set(changed, phaseEvidence('f'))
+
+    runHandoffStateMachine({
+      receipt: continueHandoffReceipt(
+        persisted,
+        '00000000-0000-4000-8000-000000000002',
+        fixture.now().toISOString()
+      ),
+      definitions: fixture.definitions,
+      persist: (receipt) => {
+        persisted = receipt
+      },
+      now: fixture.now
+    })
+
+    for (const phase of handoffPhases)
+      expect(fixture.executions.get(phase)).toBe(
+        handoffPhases.indexOf(phase) < handoffPhases.indexOf(changed) ? 1 : 2
+      )
+  })
+
+  it('rejects a tampered completed phase hash chain', () => {
+    const fixture = createFixture()
+    let persisted = fixture.receipt
+    persisted = runHandoffStateMachine({
+      receipt: persisted,
+      definitions: fixture.definitions,
+      persist: (receipt) => {
+        persisted = receipt
+      },
+      now: fixture.now
+    })
+    expect(() =>
+      handoffReceiptSchema.parse({
+        ...persisted,
+        phases: persisted.phases.map((phase, index) =>
+          index === 3 ? { ...phase, outputHash: '0'.repeat(64) } : phase
+        )
+      })
+    ).toThrow(/invalid hash chain/)
+  })
+})
+
+function createFixture(failOnce?: HandoffPhaseName): {
+  readonly receipt: HandoffReceipt
+  readonly definitions: readonly HandoffPhaseDefinition[]
+  readonly executions: Map<HandoffPhaseName, number>
+  readonly evidence: Map<HandoffPhaseName, HandoffPhaseEvidence>
+  readonly now: () => Date
+} {
+  let tick = 0
+  const now = (): Date => new Date(1_787_184_000_000 + tick++ * 10)
+  const receipt = createHandoffReceipt(
+    {
+      commit: 'a'.repeat(40),
+      dirty: false,
+      workspaceFingerprint: 'b'.repeat(64),
+      appBuildInputFingerprint: 'c'.repeat(64),
+      qualificationInputFingerprint: 'd'.repeat(64),
+      deliveryInputFingerprint: 'e'.repeat(64),
+      toolchainHash: 'f'.repeat(64),
+      candidate: {
+        runId: 1,
+        url: 'https://github.example/runs/1',
+        attempt: 1,
+        headSha: 'a'.repeat(40),
+        requiredJobManifestVersion: 1,
+        jobs: [
+          {
+            name: 'required',
+            platformRole: 'test',
+            conclusion: 'success'
+          }
+        ]
+      }
+    },
+    '00000000-0000-4000-8000-000000000010',
+    '00000000-0000-4000-8000-000000000001',
+    now().toISOString()
+  )
+  const executions = new Map<HandoffPhaseName, number>()
+  const evidence = new Map<HandoffPhaseName, HandoffPhaseEvidence>(
+    handoffPhases.map((phase, index) => [
+      phase,
+      phaseEvidence(index.toString(16))
+    ])
+  )
+  let failed = false
+  const definitions = handoffPhases.map((phase) => ({
+    phase,
+    execute: () => {
+      executions.set(phase, (executions.get(phase) ?? 0) + 1)
+      if (phase === failOnce && !failed) {
+        failed = true
+        throw new Error(`failure during ${phase}`)
+      }
+    },
+    collect: () => evidence.get(phase)!
+  }))
+  return { receipt, definitions, executions, evidence, now }
+}
+
+function phaseEvidence(character: string): HandoffPhaseEvidence {
+  const hash = character.repeat(64)
+  return {
+    workspaceFingerprint: 'b'.repeat(64),
+    appBuildInputFingerprint: 'c'.repeat(64),
+    qualificationInputFingerprint: 'd'.repeat(64),
+    deliveryInputFingerprint: 'e'.repeat(64),
+    toolchainHash: 'f'.repeat(64),
+    buildOutputHash: hash,
+    artifactSha256: hash,
+    sourceDataHash: hash,
+    backupManifestSha256: hash,
+    deploymentManifestSha256: hash,
+    runtimeEvidenceSha256: hash,
+    installedSha256: hash
+  }
+}

--- a/tests/unit/local-app-installation.test.ts
+++ b/tests/unit/local-app-installation.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path'
 import Database from 'better-sqlite3'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  advanceLocalAppInstallation,
   installLocalApp,
   LocalInstallCrashForTest,
   localInstallationPaths,
@@ -34,6 +35,123 @@ afterEach(() => {
 })
 
 describe('local AppImage installation', () => {
+  it('advances backup, deployment and activation idempotently', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    createDatabase(paths.campaignData, schemaVersion)
+
+    const backup = advanceLocalAppInstallation(
+      fixture.options,
+      'backup-created'
+    )
+    expect(backup.backupManifestSha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(existsSync(paths.appImage)).toBe(false)
+    const backupCount = readdirSync(paths.backups).length
+
+    const repeated = advanceLocalAppInstallation(
+      fixture.options,
+      'backup-created'
+    )
+    expect(repeated.backupPath).toBe(backup.backupPath)
+    expect(readdirSync(paths.backups)).toHaveLength(backupCount)
+
+    const staged = advanceLocalAppInstallation(
+      fixture.options,
+      'deployment-staged'
+    )
+    expect(staged.deploymentManifestSha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(existsSync(paths.appImage)).toBe(false)
+
+    const activated = advanceLocalAppInstallation(fixture.options, 'activated')
+    expect(activated.installedSha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(readFileSync(paths.appImage, 'utf8')).toBe('artifact-a')
+  })
+
+  it('invalidates a backup checkpoint when campaign data changes', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    createDatabase(paths.campaignData, schemaVersion)
+    const first = advanceLocalAppInstallation(fixture.options, 'backup-created')
+    writeFileSync(join(paths.campaignData, 'after-backup.txt'), 'changed')
+
+    const second = advanceLocalAppInstallation(
+      fixture.options,
+      'deployment-staged'
+    )
+    expect(second.sourceDataHash).not.toBe(first.sourceDataHash)
+    expect(second.backupPath).not.toBe(first.backupPath)
+    expect(readdirSync(paths.backups)).toHaveLength(2)
+  })
+
+  it('invalidates a backup checkpoint when verified backup bytes change', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    createDatabase(paths.campaignData, schemaVersion)
+    const first = advanceLocalAppInstallation(fixture.options, 'backup-created')
+    writeFileSync(join(first.backupPath!, 'installation.sqlite'), 'tampered')
+
+    const second = advanceLocalAppInstallation(
+      fixture.options,
+      'deployment-staged'
+    )
+    expect(second.backupPath).not.toBe(first.backupPath)
+    expect(readdirSync(paths.backups)).toHaveLength(2)
+  })
+
+  it('repairs changed activation metadata without repeating the backup', () => {
+    const fixture = createFixture(build('a'))
+    createDatabase(
+      localInstallationPaths(fixture.xdg).campaignData,
+      schemaVersion
+    )
+    const first = installLocalApp(fixture.options)
+    const backupCount = readdirSync(first.paths.backups).length
+    writeFileSync(first.paths.desktopEntry, 'tampered')
+
+    const repaired = advanceLocalAppInstallation(fixture.options, 'activated')
+
+    expect(readFileSync(repaired.paths.desktopEntry, 'utf8')).toContain(
+      `SaltMarcher Local (${'a'.repeat(12)})`
+    )
+    expect(readFileSync(repaired.paths.appImage, 'utf8')).toBe('artifact-a')
+    expect(repaired.backupPath).toBe(first.backupPath)
+    expect(readdirSync(first.paths.backups)).toHaveLength(backupCount)
+  })
+
+  it('normalizes a completed v1 install journal before starting v2 state', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    mkdirSync(paths.root, { recursive: true })
+    writeFileSync(
+      paths.journal,
+      JSON.stringify({
+        formatVersion: 1,
+        transactionId: '00000000-0000-4000-8000-000000000001',
+        buildFingerprint: '9'.repeat(64),
+        phase: 'completed',
+        backupPath: null,
+        deploymentPath: null,
+        migration: null,
+        replacements: [],
+        createdAt: '2026-08-15T11:00:00.000Z',
+        updatedAt: '2026-08-15T11:00:00.000Z'
+      })
+    )
+
+    installLocalApp(fixture.options)
+
+    const journal = JSON.parse(readFileSync(paths.journal, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    expect(journal).toMatchObject({
+      formatVersion: 2,
+      applicationSha: 'a'.repeat(40),
+      phase: 'completed'
+    })
+    expect(journal['artifactSha256']).toMatch(/^[a-f0-9]{64}$/)
+  })
+
   it('installs a fresh build into an isolated profile', () => {
     const fixture = createFixture(build('a'))
     const result = installLocalApp(fixture.options)
@@ -217,6 +335,9 @@ describe('local AppImage installation', () => {
     const result = installLocalApp(fixture.options)
 
     expect(result.backupPath).toBeDefined()
+    const repeated = installLocalApp(fixture.options)
+    expect(repeated.backupPath).toBe(result.backupPath)
+    expect(readdirSync(paths.backups)).toHaveLength(1)
     const database = new Database(databasePath, { readonly: true })
     expect(database.pragma('user_version', { simple: true })).toBe(
       schemaVersion


### PR DESCRIPTION
## What changed

- Replaces the five-step, fresh-invocation handoff with an eight-phase SHA-keyed state machine:
  `candidate-qualified → checked → packaged → packaged-smoke-passed → backup-created → deployment-staged → activated → installed-runtime-verified`.
- Binds every completed phase to predecessor, input, output, workspace, app, qualification, delivery, toolchain, artifact, backup, deployment, activation, and runtime evidence hashes.
- Adds durable per-SHA state and immutable per-attempt audit records. Repeated safe invocations are allowed; `--resume` records intent without overwriting original provenance.
- Moves auth/network/candidate, running-app, and disk-capacity preflights before material attempt/state creation.
- Splits local installation into idempotent backup, deployment, and activation checkpoints while preserving permanent verified backups, staged migration recovery, and atomic `current` symlink activation.
- Migrates legacy invocation history and install journals safely.
- Requires app handoff at promotion only when the candidate app-build fingerprint differs from `origin/main`; semantic CI reruns for the same exact SHA remain valid without replacing original run provenance.

## Why

The previous contract used process-start cardinality and a coarse resume flag as a proxy for safety. An interruption could make an otherwise valid SHA difficult to recover, while repeated hash-identical invocations were treated as violations. Installer recovery also coupled backup, migration, deployment, and activation too coarsely.

The new invariant is: a phase is reusable only while its current evidence and predecessor hash still prove the same immutable application SHA; any invalidated phase and its successors are repeated safely.

## Impact

Interrupted local handoffs can resume deterministically after every phase boundary. Campaign data remains protected by verified permanent backups, migration recovery retains the last safe data state, and activation stays atomic. Qualification-/delivery-only candidates no longer manufacture an application handoff.

## Validation

- `pnpm check:delivery`: 9 files, 84 tests
- Failure injection before commit and after every one of the eight durable phase boundaries
- Installer crash/recovery, backup-byte mutation, campaign-data mutation, migration, activation-tamper, and legacy-journal tests
- Full `pnpm check`: formatting, lint, typecheck, 65 architecture tests, 630 portable unit tests, 152 integration tests, 31 Linux installer/lock tests, build/smoke/bundle gates, all functional E2E suites, and all visual E2E suites
- Candidate app-build fingerprint equals `origin/main`: `e2eb9077416d0ececaecd139c2f151842a003dbef0ba3513e9ed3d35e913c839`; no app handoff is required for this delivery-only phase
