### PR TITLE
Reuse exact candidate artifacts during handoff

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -119,8 +119,6 @@ jobs:
       - run: pnpm package:local:built
       - run: xvfb-run -a pnpm test:packaged-local-smoke:built
       - run: pnpm candidate-artifact:write
-        env:
-          GITHUB_SHA: ${{ env.SALT_MARCHER_CHECKED_SHA }}
       - name: Upload immutable Local handoff artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
 permissions:
   contents: read
   actions: read
+env:
+  SALT_MARCHER_CHECKED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -18,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
@@ -42,6 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
@@ -63,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
@@ -83,7 +88,7 @@ jobs:
       - name: Upload hash-validated Linux app build
         uses: actions/upload-artifact@v4
         with:
-          name: linux-app-${{ github.sha }}
+          name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
           path: out
           include-hidden-files: true
           if-no-files-found: error
@@ -97,18 +102,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
-          name: linux-app-${{ github.sha }}
+          name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
       - run: pnpm package:development:built
       - run: xvfb-run -a pnpm test:packaged-smoke:built
+      - run: pnpm build:local
+      - run: pnpm package:local:built
+      - run: xvfb-run -a pnpm test:packaged-local-smoke:built
+      - run: pnpm candidate-artifact:write
+        env:
+          GITHUB_SHA: ${{ env.SALT_MARCHER_CHECKED_SHA }}
+      - name: Upload immutable Local handoff artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: salt-marcher-local-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
+          path: |
+            release/local/*.AppImage
+            release/local/*.AppImage.manifest.json
+            release/local/candidate-artifact-receipt.json
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
   linux-qualification:
     if: github.event_name == 'pull_request'
@@ -117,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
@@ -151,13 +175,14 @@ jobs:
             suites: --suite groupLoot --suite groupLootCommit --suite travel
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
-          name: linux-app-${{ github.sha }}
+          name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
@@ -184,13 +209,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
-          name: linux-app-${{ github.sha }}
+          name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
@@ -217,13 +243,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
         with: { node-version: 22, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
-          name: linux-app-${{ github.sha }}
+          name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
@@ -236,7 +263,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          ref: ${{ env.SALT_MARCHER_CHECKED_SHA }}
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,13 @@
 ## Canonical handoff
 
 - Finish app-relevant changes to `src/`, `resources/`, dependencies, or
-  Electron/build/packaging configuration with `pnpm handoff:app`. It runs the
-  canonical checks, packages the exact checked workspace, smoke-tests the
-  packaged application, backs up valuable local campaign data, and installs
-  the matching `SaltMarcher Local` AppImage, then verifies that installed
-  runtime. Handoff state is keyed by the immutable application SHA. Repeated
+  Electron/build/packaging configuration with `pnpm handoff:app`. It validates
+  the complete required-job set and exact-SHA CI-built Local artifact, verifies
+  its receipt, app inputs, toolchain identity, manifest and bytes, smoke-tests
+  that downloaded AppImage on the handoff host, backs up valuable local
+  campaign data, installs the matching `SaltMarcher Local` AppImage, and
+  verifies that installed runtime. Handoff state is keyed by the immutable
+  application SHA. Repeated
   invocations for the same SHA must validate and reuse hash-proven phases
   idempotently; `pnpm handoff:app -- --resume` remains an explicit recovery
   intent but may not replace the provenance of the invocation that created the

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ preserved as Git reference `javafx-final-2026-07-27`.
 
 ## Local application handoff
 
-For an app-relevant change, build, verify, package, smoke-test, back up and
-install the exact current workspace with:
+For an app-relevant change, validate and install the exact remotely qualified
+candidate with:
 
 ```bash
 pnpm handoff:app
@@ -21,6 +21,15 @@ the command safely revalidates and reuses completed phases whose input and
 output hashes still match. `pnpm handoff:app -- --resume` records explicit
 recovery intent without replacing the original state's provenance. Atomic state
 and per-attempt audit records live below `.tmp/handoff-local-app/`.
+
+The required candidate workflow builds and smoke-tests the Local AppImage once.
+Its immutable handoff artifact contains only that AppImage, its embedded Build
+Receipt manifest, and an outer receipt binding repository, workflow run and
+attempt, exact SHA, app-input fingerprint, toolchain identity, and all relevant
+hashes. Handoff downloads it from the exact successful run, rejects any extra or
+mismatched file or local app input, and smoke-tests the downloaded AppImage on
+the local host before touching campaign data. Backup, installation, and runtime
+verification are always local.
 
 Launch **SaltMarcher Local** from the desktop menu afterwards. Its title
 contains the first twelve characters of the embedded app-build fingerprint, so a

--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -118,9 +118,16 @@ copies, and promotes immutable fingerprint-addressed deployments through one
 atomic `current` link. Every clean-channel build has a receipt containing
 hashes for all output files and an aggregate hash; packaging verifies it
 against the workspace. The single `pnpm handoff:app` path advances the exact
-candidate SHA through candidate qualification, checks, a Local build/package
-pass, actual-AppImage smoke, backup creation, deployment staging, atomic
-activation, and installed-runtime verification in that order. Repeated calls
+candidate SHA through candidate qualification, remote-check attestation,
+validated acquisition of the exact CI-built Local package, local actual-AppImage
+smoke, backup creation, deployment staging, atomic activation, and
+installed-runtime verification in that order. Candidate CI binds the Local
+AppImage and embedded Build Receipt to its repository, run, attempt, SHA,
+app-input fingerprint, toolchain identity, manifest hash, and artifact hash in
+one strict immutable artifact. Every required PR job checks out that candidate
+head SHA explicitly rather than qualifying a synthetic merge commit. The
+handoff refuses extra files, another run or
+SHA, a changed local app input, or any broken hash link. Repeated calls
 revalidate and reuse only phases whose predecessor and output hashes still
 match the atomic SHA state. Explicit `--resume` records recovery intent without
 replacing the state's original provenance. `pnpm dev` remains HMR-only.
@@ -216,7 +223,12 @@ verifiable phases:
    artifact, backup, deployment, activation, and installation evidence before
    reusing it. Per-attempt audit records retain the original state's provenance,
    and every phase records status, duration, input/output hashes, evidence, and
-   errors before installed generation-one runtime acceptance.
+   errors before installed generation-one runtime acceptance. Required
+   candidate CI publishes a smoke-tested Local artifact whose outer receipt
+   binds the exact workflow run/attempt and the embedded Build Receipt. Handoff
+   reuses that artifact only after complete run, inventory, input, toolchain,
+   manifest, and byte-hash validation; host smoke, data backup, installation,
+   and runtime verification remain local.
 
 The editor application-layer refactor tracks its normative evidence in
 `application-layer-refactor-acceptance-matrix.md`. It moves the two-step

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -288,8 +288,16 @@ Packaging rechecks workspace, app inputs, toolchain, channel, and every output
 byte, then embeds the complete receipt plus its hash and the AppImage hash in
 the artifact manifest. Development, Local, and release packages use
 `release/development`, `release/local`, and `release/release`; Linux smoke tests
-execute the actual AppImage. Local installation is serialized by the same exclusive
-profile lock that Main holds for the complete Local application lifetime. A
+execute the actual AppImage. Candidate CI produces the Local package in the
+required Linux package job, smoke-tests it, and publishes exactly the AppImage,
+its artifact manifest, and a strict candidate-artifact receipt as one immutable
+run artifact. Every required pull-request job explicitly checks out the
+candidate head SHA recorded by the workflow run, never GitHub's synthetic merge
+commit. The outer receipt binds the GitHub repository, workflow run and
+attempt, exact application SHA, artifact name, app-input fingerprint, complete
+build-receipt hash, artifact-manifest hash, AppImage hash, and build-toolchain
+identity. Local installation is serialized by the same exclusive profile lock
+that Main holds for the complete Local application lifetime. A
 stale lock is reclaimed only when its PID and Linux process identity (boot,
 start tick, executable) no longer match. The installer is an explicitly
 authorized offline-maintenance component outside Main and the utility process;
@@ -313,8 +321,15 @@ Repeated invocations are safe and append audit attempts; they do not create a
 parallel state or replace the original state's provenance. Explicit `--resume`
 records recovery intent but follows the same validation rules. Auth, live
 candidate evidence, disk capacity, and installation availability are checked
-before a material state or attempt is created. Each phase records status,
-start, duration, hashes, and any terminal error.
+before a material state or attempt is created. The handoff downloads only the
+artifact belonging to the exact successful required-job run, verifies its
+closed three-file inventory and complete hash chain, and accepts it only when
+its clean SHA, workspace and app-input fingerprint match the local candidate.
+Remote required-job evidence satisfies `checked`; the downloaded Local package
+satisfies `packaged`. The actual downloaded AppImage is still smoke-tested on
+the handoff host before any campaign backup, deployment, activation, or
+installed-runtime verification. Each phase records status, start, duration,
+hashes, and any terminal error.
 Candidate promotion requires this completed exact-SHA state precisely when the
 candidate app-build fingerprint differs from `origin/main`; qualification,
 delivery-tooling, and documentation-only changes do not manufacture an

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "package:release:built": "tsx scripts/package-app.ts --channel release",
     "install:local:built": "tsx scripts/install-local-app.ts",
     "handoff:app": "tsx scripts/handoff-local-app.ts",
+    "candidate-artifact:write": "tsx scripts/write-candidate-artifact-receipt.ts",
     "delivery:verify-candidate": "tsx scripts/verify-candidate.ts",
     "delivery:promote": "tsx scripts/promote-candidate.ts",
     "delivery:verify-post-promotion": "tsx scripts/verify-post-promotion.ts",

--- a/scripts/candidate-artifact.ts
+++ b/scripts/candidate-artifact.ts
@@ -115,7 +115,7 @@ export function createCandidateArtifactReceipt(input: {
     build.commit !== input.applicationSha
   )
     throw new Error(
-      'Candidate artifact is not a clean Local build of GITHUB_SHA'
+      'Candidate artifact is not a clean Local build of the checked SHA'
     )
   const receipt = candidateArtifactReceiptSchema.parse({
     formatVersion: 1,

--- a/scripts/candidate-artifact.ts
+++ b/scripts/candidate-artifact.ts
@@ -1,0 +1,292 @@
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync
+} from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { z } from 'zod'
+import {
+  buildToolchainSchema,
+  localArtifactManifestSchema,
+  type LocalArtifactManifest
+} from '../src/shared/contracts/build-info.js'
+import { fingerprintSchema, shaSchema } from './delivery-contract.js'
+import { sha256File } from './file-hash.js'
+
+export const candidateArtifactReceiptFile = 'candidate-artifact-receipt.json'
+
+const fileNameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine(
+    (value) => basename(value) === value && value !== '.' && value !== '..',
+    {
+      message: 'Candidate artifact entries must be plain file names'
+    }
+  )
+
+export const candidateArtifactReceiptSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+    workflowName: z.string().min(1),
+    workflowRunId: z.number().int().positive(),
+    workflowRunAttempt: z.number().int().positive(),
+    artifactName: z.string().min(1).max(255),
+    applicationSha: shaSchema,
+    workspaceFingerprint: fingerprintSchema,
+    appBuildInputFingerprint: fingerprintSchema,
+    toolchain: buildToolchainSchema,
+    toolchainHash: fingerprintSchema,
+    buildReceiptSha256: fingerprintSchema,
+    artifactManifestFile: fileNameSchema,
+    artifactManifestSha256: fingerprintSchema,
+    artifactFile: fileNameSchema,
+    artifactSha256: fingerprintSchema
+  })
+  .strict()
+  .readonly()
+
+export type CandidateArtifactReceipt = z.infer<
+  typeof candidateArtifactReceiptSchema
+>
+
+export type CandidateArtifactExpectation = Readonly<{
+  repository: string
+  workflowName: string
+  workflowRunId: number
+  workflowRunAttempt: number
+  applicationSha: string
+  workspaceFingerprint: string
+  appBuildInputFingerprint: string
+}>
+
+export type VerifiedCandidateArtifact = Readonly<{
+  root: string
+  artifactPath: string
+  artifactManifestPath: string
+  receiptPath: string
+  receipt: CandidateArtifactReceipt
+  manifest: LocalArtifactManifest
+}>
+
+export function candidateArtifactName(
+  applicationSha: string,
+  workflowRunAttempt: number
+): string {
+  return `salt-marcher-local-${shaSchema.parse(applicationSha)}-attempt-${z.number().int().positive().parse(workflowRunAttempt)}`
+}
+
+export function createCandidateArtifactReceipt(input: {
+  root: string
+  repository: string
+  workflowName: string
+  workflowRunId: number
+  workflowRunAttempt: number
+  applicationSha: string
+}): CandidateArtifactReceipt {
+  const manifests = readdirSync(input.root).filter((entry) =>
+    entry.endsWith('.AppImage.manifest.json')
+  )
+  if (manifests.length !== 1)
+    throw new Error(
+      `Expected exactly one Local artifact manifest, found ${manifests.length}`
+    )
+  const artifactManifestFile = manifests[0]!
+  const artifactManifestPath = join(input.root, artifactManifestFile)
+  assertRegularFile(artifactManifestPath)
+  const manifest = localArtifactManifestSchema.parse(
+    JSON.parse(readFileSync(artifactManifestPath, 'utf8'))
+  )
+  const artifactPath = join(input.root, manifest.artifactFile)
+  assertRegularFile(artifactPath)
+  const build = manifest.receipt.build
+  if (
+    build.channel !== 'local' ||
+    build.dirty ||
+    build.commit !== input.applicationSha
+  )
+    throw new Error(
+      'Candidate artifact is not a clean Local build of GITHUB_SHA'
+    )
+  const receipt = candidateArtifactReceiptSchema.parse({
+    formatVersion: 1,
+    repository: input.repository,
+    workflowName: input.workflowName,
+    workflowRunId: input.workflowRunId,
+    workflowRunAttempt: input.workflowRunAttempt,
+    artifactName: candidateArtifactName(
+      input.applicationSha,
+      input.workflowRunAttempt
+    ),
+    applicationSha: input.applicationSha,
+    workspaceFingerprint: build.workspaceFingerprint,
+    appBuildInputFingerprint: build.appBuildInputFingerprint,
+    toolchain: build.toolchain,
+    toolchainHash: hashJson(build.toolchain),
+    buildReceiptSha256: hashJson(manifest.receipt),
+    artifactManifestFile,
+    artifactManifestSha256: sha256File(artifactManifestPath),
+    artifactFile: manifest.artifactFile,
+    artifactSha256: sha256File(artifactPath)
+  })
+  verifyManifestLinks(receipt, manifest, artifactManifestPath, artifactPath)
+  return receipt
+}
+
+export function verifyCandidateArtifactDirectory(
+  root: string,
+  expected: CandidateArtifactExpectation
+): VerifiedCandidateArtifact {
+  const receiptPath = join(root, candidateArtifactReceiptFile)
+  assertRegularFile(receiptPath)
+  const receipt = candidateArtifactReceiptSchema.parse(
+    JSON.parse(readFileSync(receiptPath, 'utf8'))
+  )
+  const expectedIdentity = {
+    repository: expected.repository,
+    workflowName: expected.workflowName,
+    workflowRunId: expected.workflowRunId,
+    workflowRunAttempt: expected.workflowRunAttempt,
+    artifactName: candidateArtifactName(
+      expected.applicationSha,
+      expected.workflowRunAttempt
+    ),
+    applicationSha: expected.applicationSha,
+    workspaceFingerprint: expected.workspaceFingerprint,
+    appBuildInputFingerprint: expected.appBuildInputFingerprint
+  }
+  const actualIdentity = {
+    repository: receipt.repository,
+    workflowName: receipt.workflowName,
+    workflowRunId: receipt.workflowRunId,
+    workflowRunAttempt: receipt.workflowRunAttempt,
+    artifactName: receipt.artifactName,
+    applicationSha: receipt.applicationSha,
+    workspaceFingerprint: receipt.workspaceFingerprint,
+    appBuildInputFingerprint: receipt.appBuildInputFingerprint
+  }
+  if (JSON.stringify(actualIdentity) !== JSON.stringify(expectedIdentity))
+    throw new Error(
+      'Candidate artifact receipt proves another run or workspace'
+    )
+
+  const entries = readdirSync(root).sort((left, right) =>
+    left.localeCompare(right, 'en')
+  )
+  const expectedEntries = [
+    candidateArtifactReceiptFile,
+    receipt.artifactFile,
+    receipt.artifactManifestFile
+  ].sort((left, right) => left.localeCompare(right, 'en'))
+  if (JSON.stringify(entries) !== JSON.stringify(expectedEntries))
+    throw new Error(
+      'Candidate artifact must contain exactly its three proved files'
+    )
+  for (const entry of entries) assertRegularFile(join(root, entry))
+
+  const artifactManifestPath = join(root, receipt.artifactManifestFile)
+  const artifactPath = join(root, receipt.artifactFile)
+  const manifest = localArtifactManifestSchema.parse(
+    JSON.parse(readFileSync(artifactManifestPath, 'utf8'))
+  )
+  verifyManifestLinks(receipt, manifest, artifactManifestPath, artifactPath)
+  const build = manifest.receipt.build
+  if (
+    build.channel !== 'local' ||
+    build.dirty ||
+    build.commit !== expected.applicationSha ||
+    build.workspaceFingerprint !== expected.workspaceFingerprint ||
+    build.appBuildInputFingerprint !== expected.appBuildInputFingerprint ||
+    JSON.stringify(build.toolchain) !== JSON.stringify(receipt.toolchain)
+  )
+    throw new Error('Embedded Build Receipt differs from candidate provenance')
+
+  return {
+    root,
+    artifactPath,
+    artifactManifestPath,
+    receiptPath,
+    receipt,
+    manifest
+  }
+}
+
+export function acquireCandidateArtifact(options: {
+  destinationRoot: string
+  expected: CandidateArtifactExpectation
+  download: (destination: string) => void
+}): VerifiedCandidateArtifact {
+  try {
+    return makeAppImageExecutable(
+      verifyCandidateArtifactDirectory(
+        options.destinationRoot,
+        options.expected
+      )
+    )
+  } catch {
+    // A stale or partial generated cache is replaceable. It is never accepted
+    // as evidence and is left untouched unless a complete replacement verifies.
+  }
+  const parent = dirname(options.destinationRoot)
+  mkdirSync(parent, { recursive: true })
+  const temporary = mkdtempSync(join(parent, '.candidate-artifact-'))
+  try {
+    options.download(temporary)
+    verifyCandidateArtifactDirectory(temporary, options.expected)
+    rmSync(options.destinationRoot, { recursive: true, force: true })
+    renameSync(temporary, options.destinationRoot)
+  } finally {
+    if (existsSync(temporary))
+      rmSync(temporary, { recursive: true, force: true })
+  }
+  return makeAppImageExecutable(
+    verifyCandidateArtifactDirectory(options.destinationRoot, options.expected)
+  )
+}
+
+function makeAppImageExecutable(
+  artifact: VerifiedCandidateArtifact
+): VerifiedCandidateArtifact {
+  // actions/upload-artifact intentionally does not preserve Unix file modes.
+  // Mode normalization happens only after the downloaded bytes and receipts
+  // have verified; chmod does not alter the proved content hash.
+  chmodSync(artifact.artifactPath, 0o755)
+  return artifact
+}
+
+function verifyManifestLinks(
+  receipt: CandidateArtifactReceipt,
+  manifest: LocalArtifactManifest,
+  artifactManifestPath: string,
+  artifactPath: string
+): void {
+  if (
+    receipt.artifactManifestSha256 !== sha256File(artifactManifestPath) ||
+    receipt.artifactFile !== manifest.artifactFile ||
+    receipt.artifactSha256 !== manifest.artifactSha256 ||
+    receipt.artifactSha256 !== sha256File(artifactPath) ||
+    receipt.buildReceiptSha256 !== hashJson(manifest.receipt) ||
+    receipt.buildReceiptSha256 !== manifest.receiptSha256 ||
+    receipt.toolchainHash !== hashJson(receipt.toolchain)
+  )
+    throw new Error('Candidate artifact hash chain is invalid')
+}
+
+function assertRegularFile(path: string): void {
+  const stats = lstatSync(path)
+  if (!stats.isFile() || stats.isSymbolicLink())
+    throw new Error(`Candidate artifact entry is not a regular file: ${path}`)
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -157,6 +157,8 @@ export const handoffPhaseEvidenceSchema = z
     qualificationInputFingerprint: fingerprintSchema,
     deliveryInputFingerprint: fingerprintSchema,
     toolchainHash: fingerprintSchema,
+    candidateArtifactReceiptSha256: fingerprintSchema,
+    artifactManifestSha256: fingerprintSchema,
     buildOutputHash: fingerprintSchema.nullable(),
     artifactSha256: fingerprintSchema.nullable(),
     sourceDataHash: fingerprintSchema.nullable(),
@@ -182,7 +184,7 @@ export const handoffPhaseSchema = z
 
 export const handoffReceiptSchema = z
   .object({
-    formatVersion: z.literal(4),
+    formatVersion: z.literal(5),
     stateId: z.uuid(),
     originAttemptId: z.uuid(),
     activeAttemptId: z.uuid(),
@@ -284,7 +286,7 @@ export function createHandoffReceipt(
   timestamp: string
 ): HandoffReceipt {
   return handoffReceiptSchema.parse({
-    formatVersion: 4,
+    formatVersion: 5,
     stateId,
     originAttemptId: attemptId,
     activeAttemptId: attemptId,
@@ -409,7 +411,7 @@ export function readRequiredJobManifest(
   return requiredJobManifestSchema.parse(
     JSON.parse(
       readFileSync(
-        resolve(workspaceRoot, 'scripts', 'delivery', 'required-jobs.v1.json'),
+        resolve(workspaceRoot, 'scripts', 'delivery', 'required-jobs.v2.json'),
         'utf8'
       )
     )

--- a/scripts/delivery/required-jobs.v2.json
+++ b/scripts/delivery/required-jobs.v2.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "workflowName": "Check",
   "jobs": [
     {
@@ -20,7 +20,7 @@
     },
     {
       "name": "Linux package · profile and AppImage",
-      "platformRole": "linux-package-runtime"
+      "platformRole": "linux-local-artifact-authority"
     },
     {
       "name": "Linux qualification · packaged harness",

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -13,15 +13,15 @@ import {
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import {
-  buildReceiptSchema,
-  localArtifactManifestSchema
-} from '../src/shared/contracts/build-info.js'
-import {
-  readBuildToolchain,
   readWorkspaceIdentity,
   readWorkspaceInputFingerprints
 } from './build-identity.js'
-import { verifyBuildReceipt } from './build-receipt.js'
+import {
+  acquireCandidateArtifact,
+  candidateArtifactName,
+  verifyCandidateArtifactDirectory,
+  type CandidateArtifactExpectation
+} from './candidate-artifact.js'
 import { assertCandidateReady } from './candidate-delivery.js'
 import {
   appendHandoffInvocation,
@@ -29,6 +29,7 @@ import {
   handoffReceiptSchema,
   installedRuntimeEvidenceSchema,
   parseHandoffInvocationHistory,
+  readRequiredJobManifest,
   sameHandoffApplicationIdentity,
   type HandoffIdentity,
   type HandoffInvocationHistory,
@@ -71,9 +72,49 @@ const artifactPath = resolve(
   `SaltMarcher-Local-${packageJson.version}.AppImage`
 )
 const artifactManifestPath = `${artifactPath}.manifest.json`
+const artifactRoot = dirname(artifactPath)
 const installation = localInstallationPaths(
   process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
 )
+// Auth, network, candidate, workspace, installation availability and disk
+// capacity are all checked before an attempt or state file is created.
+const candidateState = assertCandidateReady()
+const workspace = readWorkspaceIdentity(workspaceRoot)
+const inputFingerprints = readWorkspaceInputFingerprints(workspaceRoot)
+if (isInstalledLocalAppRunning(installation.appImage))
+  throw new Error('SaltMarcher Local is running; close it before handoff')
+assertHandoffResourcePreflight(
+  readHandoffResourceSnapshot(
+    workspaceRoot,
+    installation.root,
+    installation.campaignData
+  )
+)
+const artifactExpectation: CandidateArtifactExpectation = {
+  repository: githubRepository(),
+  workflowName: readRequiredJobManifest().workflowName,
+  workflowRunId: candidateState.candidate!.runId,
+  workflowRunAttempt: candidateState.candidate!.attempt,
+  applicationSha: workspace.commit,
+  workspaceFingerprint: workspace.workspaceFingerprint,
+  appBuildInputFingerprint: workspace.appBuildInputFingerprint
+}
+const candidateArtifact = acquireCandidateArtifact({
+  destinationRoot: artifactRoot,
+  expected: artifactExpectation,
+  download: downloadCandidateArtifact
+})
+if (
+  candidateArtifact.artifactPath !== artifactPath ||
+  candidateArtifact.artifactManifestPath !== artifactManifestPath
+)
+  throw new Error('Candidate artifact uses an unexpected Local package name')
+const identity: HandoffIdentity = {
+  ...workspace,
+  ...inputFingerprints,
+  toolchainHash: candidateArtifact.receipt.toolchainHash,
+  candidate: candidateState.candidate!
+}
 const installOptions: InstallLocalAppOptions = {
   workspaceRoot,
   xdgDataHome:
@@ -88,28 +129,6 @@ const installOptions: InstallLocalAppOptions = {
   )
 }
 
-// Auth, network, candidate, workspace, installation availability and disk
-// capacity are all checked before an attempt or state file is created.
-const candidateState = assertCandidateReady()
-const workspace = readWorkspaceIdentity(workspaceRoot)
-const inputFingerprints = readWorkspaceInputFingerprints(workspaceRoot)
-const toolchain = readBuildToolchain(workspaceRoot)
-const identity: HandoffIdentity = {
-  ...workspace,
-  ...inputFingerprints,
-  toolchainHash: hashJson(toolchain),
-  candidate: candidateState.candidate!
-}
-if (isInstalledLocalAppRunning(installation.appImage))
-  throw new Error('SaltMarcher Local is running; close it before handoff')
-assertHandoffResourcePreflight(
-  readHandoffResourceSnapshot(
-    workspaceRoot,
-    installation.root,
-    installation.campaignData
-  )
-)
-
 const receiptDirectory = resolve(workspaceRoot, '.tmp', 'handoff-local-app')
 const statePath = resolve(
   receiptDirectory,
@@ -118,11 +137,6 @@ const statePath = resolve(
 )
 const receiptPath = resolve(receiptDirectory, 'handoff-receipt.json')
 const invocationHistoryPath = resolve(receiptDirectory, 'invocations.json')
-const checkSnapshotPath = resolve(
-  receiptDirectory,
-  'states',
-  `${workspace.commit}.checked-build-receipt.json`
-)
 const runtimeEvidencePath = resolve(
   receiptDirectory,
   'installed-runtime-evidence.json'
@@ -200,16 +214,16 @@ function phaseDefinitions(): readonly HandoffPhaseDefinition[] {
     {
       phase: 'candidate-qualified',
       execute: () => undefined,
-      collect: () => evidence()
+      collect: collectCandidateEvidence
     },
     {
       phase: 'checked',
-      execute: () => run('checked', ['pnpm', 'check']),
+      execute: () => undefined,
       collect: collectCheckedEvidence
     },
     {
       phase: 'packaged',
-      execute: () => run('packaged', ['pnpm', 'package:local']),
+      execute: () => undefined,
       collect: collectPackagedEvidence
     },
     {
@@ -256,26 +270,14 @@ function installationDefinition(
   }
 }
 
+function collectCandidateEvidence(): HandoffPhaseEvidence {
+  validCandidateArtifact()
+  return evidence()
+}
+
 function collectCheckedEvidence(): HandoffPhaseEvidence {
-  assertWorkspaceUnchanged()
-  let snapshot
-  try {
-    const current = verifyBuildReceipt(resolve(workspaceRoot, 'out'))
-    if (current.build.channel !== 'development' || !buildMatches(current.build))
-      throw new Error('Current output is not the checked development build')
-    snapshot = current
-    atomicWrite(checkSnapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`)
-  } catch {
-    snapshot = buildReceiptSchema.parse(
-      JSON.parse(readFileSync(checkSnapshotPath, 'utf8'))
-    )
-    if (
-      snapshot.build.channel !== 'development' ||
-      !buildMatches(snapshot.build)
-    )
-      throw new Error('Checked build receipt snapshot is stale')
-  }
-  return evidence({ buildOutputHash: snapshot.outputHash })
+  const artifact = validCandidateArtifact()
+  return evidence({ buildOutputHash: artifact.receipt.outputHash })
 }
 
 function collectPackagedEvidence(): HandoffPhaseEvidence {
@@ -343,6 +345,8 @@ function evidence(
     qualificationInputFingerprint: identity.qualificationInputFingerprint,
     deliveryInputFingerprint: identity.deliveryInputFingerprint,
     toolchainHash: identity.toolchainHash,
+    candidateArtifactReceiptSha256: sha256File(candidateArtifact.receiptPath),
+    artifactManifestSha256: sha256File(artifactManifestPath),
     buildOutputHash: input.buildOutputHash ?? null,
     artifactSha256: input.artifactSha256 ?? null,
     sourceDataHash: input.sourceDataHash ?? null,
@@ -354,20 +358,16 @@ function evidence(
 }
 
 function validPackagedArtifact() {
-  assertWorkspaceUnchanged()
-  const output = verifyBuildReceipt(resolve(workspaceRoot, 'out'))
-  const manifest = localArtifactManifestSchema.parse(
-    JSON.parse(readFileSync(artifactManifestPath, 'utf8'))
-  )
-  if (
-    output.build.channel !== 'local' ||
-    !buildMatches(output.build) ||
-    JSON.stringify(manifest.receipt) !== JSON.stringify(output) ||
-    manifest.receiptSha256 !== hashJson(output) ||
-    manifest.artifactSha256 !== sha256File(artifactPath)
-  )
+  const artifact = validCandidateArtifact()
+  if (!buildMatches(artifact.receipt.build))
     throw new Error('Packaged Local artifact evidence is stale or inconsistent')
-  return manifest
+  return artifact
+}
+
+function validCandidateArtifact() {
+  assertWorkspaceUnchanged()
+  return verifyCandidateArtifactDirectory(artifactRoot, artifactExpectation)
+    .manifest
 }
 
 function buildMatches(build: {
@@ -418,6 +418,54 @@ function run(phase: string, arguments_: readonly string[]): void {
   if (result.error) throw result.error
   if (result.status !== 0)
     throw new Error(`Local handoff phase ${phase} failed with ${result.status}`)
+}
+
+function downloadCandidateArtifact(destination: string): void {
+  const result = spawnSync(
+    'gh',
+    [
+      'run',
+      'download',
+      String(candidateState.candidate!.runId),
+      '--name',
+      candidateArtifactName(
+        workspace.commit,
+        candidateState.candidate!.attempt
+      ),
+      '--dir',
+      destination
+    ],
+    {
+      cwd: workspaceRoot,
+      env: process.env,
+      stdio: 'inherit'
+    }
+  )
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(`Candidate artifact download failed with ${result.status}`)
+}
+
+function githubRepository(): string {
+  const result = spawnSync(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+    {
+      cwd: workspaceRoot,
+      env: process.env,
+      encoding: 'utf8'
+    }
+  )
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(
+      result.stderr.trim() ||
+        'Could not resolve the authenticated GitHub repository'
+    )
+  const repository = result.stdout.trim()
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository))
+    throw new Error('GitHub returned an invalid repository identity')
+  return repository
 }
 
 function atomicWrite(path: string, content: string): void {

--- a/scripts/test-manifests/delivery.json
+++ b/scripts/test-manifests/delivery.json
@@ -9,6 +9,7 @@
     "tests/unit/candidate-delivery.test.ts",
     "tests/unit/build-identity.test.ts",
     "tests/unit/build-receipt.test.ts",
+    "tests/unit/candidate-artifact.test.ts",
     "tests/unit/local-app-installation.test.ts",
     "tests/unit/local-profile-lock.test.ts",
     "tests/unit/ci-workflow-policy.test.ts"

--- a/scripts/write-candidate-artifact-receipt.ts
+++ b/scripts/write-candidate-artifact-receipt.ts
@@ -28,7 +28,7 @@ const environment = z
     workflowName: process.env['GITHUB_WORKFLOW'],
     workflowRunId: process.env['GITHUB_RUN_ID'],
     workflowRunAttempt: process.env['GITHUB_RUN_ATTEMPT'],
-    applicationSha: process.env['GITHUB_SHA']
+    applicationSha: process.env['SALT_MARCHER_CHECKED_SHA']
   })
 const root = resolve(workspaceRoot, 'release', 'local')
 const receipt = createCandidateArtifactReceipt({ root, ...environment })

--- a/scripts/write-candidate-artifact-receipt.ts
+++ b/scripts/write-candidate-artifact-receipt.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from 'node:crypto'
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  writeFileSync
+} from 'node:fs'
+import { resolve } from 'node:path'
+import { z } from 'zod'
+import {
+  candidateArtifactReceiptFile,
+  createCandidateArtifactReceipt
+} from './candidate-artifact.js'
+import { shaSchema } from './delivery-contract.js'
+
+const workspaceRoot = process.cwd()
+const environment = z
+  .object({
+    repository: z.string().min(1),
+    workflowName: z.string().min(1),
+    workflowRunId: z.coerce.number().int().positive(),
+    workflowRunAttempt: z.coerce.number().int().positive(),
+    applicationSha: shaSchema
+  })
+  .parse({
+    repository: process.env['GITHUB_REPOSITORY'],
+    workflowName: process.env['GITHUB_WORKFLOW'],
+    workflowRunId: process.env['GITHUB_RUN_ID'],
+    workflowRunAttempt: process.env['GITHUB_RUN_ATTEMPT'],
+    applicationSha: process.env['GITHUB_SHA']
+  })
+const root = resolve(workspaceRoot, 'release', 'local')
+const receipt = createCandidateArtifactReceipt({ root, ...environment })
+const target = resolve(root, candidateArtifactReceiptFile)
+const temporary = `${target}.${randomUUID()}.next`
+const descriptor = openSync(temporary, 'wx', 0o600)
+try {
+  writeFileSync(descriptor, `${JSON.stringify(receipt, null, 2)}\n`)
+  fsyncSync(descriptor)
+} finally {
+  closeSync(descriptor)
+}
+renameSync(temporary, target)
+console.info(
+  JSON.stringify({
+    component: 'candidate-artifact',
+    event: 'receipt-written',
+    artifactName: receipt.artifactName,
+    applicationSha: receipt.applicationSha,
+    artifactSha256: receipt.artifactSha256
+  })
+)

--- a/tests/unit/build-identity.test.ts
+++ b/tests/unit/build-identity.test.ts
@@ -85,6 +85,9 @@ describe('build identity', () => {
     expect(classifyWorkspaceInput('.github/workflows/check.yml')).toEqual([
       'delivery-tooling'
     ])
+    expect(classifyWorkspaceInput('scripts/candidate-artifact.ts')).toEqual([
+      'delivery-tooling'
+    ])
     expect(classifyWorkspaceInput('docs/project/vision.md')).toEqual([
       'documentation'
     ])

--- a/tests/unit/candidate-artifact.test.ts
+++ b/tests/unit/candidate-artifact.test.ts
@@ -1,0 +1,240 @@
+import { createHash } from 'node:crypto'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  acquireCandidateArtifact,
+  candidateArtifactName,
+  candidateArtifactReceiptFile,
+  candidateArtifactReceiptSchema,
+  createCandidateArtifactReceipt,
+  verifyCandidateArtifactDirectory,
+  type CandidateArtifactExpectation
+} from '../../scripts/candidate-artifact.js'
+
+const roots: string[] = []
+const sha = 'a'.repeat(40)
+const workspaceFingerprint = 'b'.repeat(64)
+const appBuildInputFingerprint = 'c'.repeat(64)
+const expected: CandidateArtifactExpectation = {
+  repository: 'ThonkTank/Salt-Marcher',
+  workflowName: 'Check',
+  workflowRunId: 42,
+  workflowRunAttempt: 2,
+  applicationSha: sha,
+  workspaceFingerprint,
+  appBuildInputFingerprint
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+describe('candidate Local artifact', () => {
+  it('binds the closed artifact inventory to the exact workflow and Build Receipt', () => {
+    const root = fixture()
+    const artifact = verifyCandidateArtifactDirectory(root, expected)
+
+    expect(artifact.receipt).toMatchObject({
+      artifactName: candidateArtifactName(sha, 2),
+      workflowRunId: 42,
+      workflowRunAttempt: 2,
+      applicationSha: sha,
+      workspaceFingerprint,
+      appBuildInputFingerprint
+    })
+    expect(readdirSync(root).sort()).toEqual(
+      [
+        'SaltMarcher-Local-0.1.0.AppImage',
+        'SaltMarcher-Local-0.1.0.AppImage.manifest.json',
+        candidateArtifactReceiptFile
+      ].sort()
+    )
+  })
+
+  it.each([
+    ['repository', 'Elsewhere/Salt-Marcher'],
+    ['workflowRunId', 41],
+    ['workflowRunAttempt', 1],
+    ['applicationSha', 'd'.repeat(40)],
+    ['workspaceFingerprint', 'd'.repeat(64)],
+    ['appBuildInputFingerprint', 'd'.repeat(64)]
+  ] as const)('rejects a mismatched %s', (field, value) => {
+    const root = fixture()
+    mutateReceipt(root, { [field]: value })
+    expect(() => verifyCandidateArtifactDirectory(root, expected)).toThrow(
+      /another run or workspace/
+    )
+  })
+
+  it('rejects extra files, changed artifact bytes, and a forged toolchain', () => {
+    const extra = fixture()
+    writeFileSync(join(extra, 'unproved.txt'), 'no')
+    expect(() => verifyCandidateArtifactDirectory(extra, expected)).toThrow(
+      /exactly its three proved files/
+    )
+
+    const changed = fixture()
+    writeFileSync(join(changed, 'SaltMarcher-Local-0.1.0.AppImage'), 'changed')
+    expect(() => verifyCandidateArtifactDirectory(changed, expected)).toThrow(
+      /hash chain/
+    )
+
+    const forged = fixture()
+    const receipt = readReceipt(forged)
+    mutateReceipt(forged, {
+      toolchain: { ...receipt.toolchain, node: 'v0.0.0' }
+    })
+    expect(() => verifyCandidateArtifactDirectory(forged, expected)).toThrow(
+      /hash chain/
+    )
+  })
+
+  it('reuses a valid cache without downloading', () => {
+    const root = fixture()
+    const artifactPath = join(root, 'SaltMarcher-Local-0.1.0.AppImage')
+    const download = vi.fn()
+    expect(
+      acquireCandidateArtifact({
+        destinationRoot: root,
+        expected,
+        download
+      }).receipt.applicationSha
+    ).toBe(sha)
+    expect(download).not.toHaveBeenCalled()
+    expect(statSync(artifactPath).mode & 0o111).toBe(0o111)
+  })
+
+  it('atomically replaces stale generated cache only after download verifies', () => {
+    const parent = temporaryRoot()
+    const source = fixture()
+    const destination = join(parent, 'local')
+    mkdirSync(destination)
+    writeFileSync(join(destination, 'partial'), 'stale')
+
+    const artifact = acquireCandidateArtifact({
+      destinationRoot: destination,
+      expected,
+      download: (target) => copyFiles(source, target)
+    })
+
+    expect(artifact.receipt.workflowRunId).toBe(42)
+    expect(readdirSync(destination)).not.toContain('partial')
+  })
+
+  it('does not destroy stale cache when a replacement fails validation', () => {
+    const parent = temporaryRoot()
+    const destination = join(parent, 'local')
+    mkdirSync(destination)
+    writeFileSync(join(destination, 'partial'), 'stale')
+
+    expect(() =>
+      acquireCandidateArtifact({
+        destinationRoot: destination,
+        expected,
+        download: (target) => writeFileSync(join(target, 'unproved'), 'bad')
+      })
+    ).toThrow()
+    expect(readFileSync(join(destination, 'partial'), 'utf8')).toBe('stale')
+  })
+})
+
+function fixture(): string {
+  const root = temporaryRoot()
+  const artifactFile = 'SaltMarcher-Local-0.1.0.AppImage'
+  const artifactPath = join(root, artifactFile)
+  writeFileSync(artifactPath, 'candidate-appimage')
+  const receipt = {
+    formatVersion: 2 as const,
+    build: {
+      channel: 'local' as const,
+      commit: sha,
+      dirty: false,
+      workspaceFingerprint,
+      appBuildInputFingerprint,
+      builtAt: '2026-08-20T00:00:00.000Z',
+      schemaVersions: { installation: 1, campaign: 35 },
+      migrationRegistryVersion: 35,
+      toolchain: {
+        node: 'v22.19.0',
+        pnpm: '10.15.1',
+        electron: '43.2.0',
+        electronVite: '5.0.0',
+        electronBuilder: '26.15.3',
+        platform: 'linux',
+        arch: 'x64'
+      }
+    },
+    outputHash: 'd'.repeat(64),
+    files: [
+      {
+        path: 'main/index.js',
+        bytes: 3,
+        sha256: 'e'.repeat(64)
+      }
+    ]
+  }
+  const manifest = {
+    formatVersion: 2 as const,
+    artifactFile,
+    artifactSha256: hash('candidate-appimage'),
+    receiptSha256: hash(JSON.stringify(receipt)),
+    receipt
+  }
+  writeFileSync(
+    join(root, `${artifactFile}.manifest.json`),
+    JSON.stringify(manifest)
+  )
+  const candidateReceipt = createCandidateArtifactReceipt({
+    root,
+    repository: expected.repository,
+    workflowName: expected.workflowName,
+    workflowRunId: expected.workflowRunId,
+    workflowRunAttempt: expected.workflowRunAttempt,
+    applicationSha: expected.applicationSha
+  })
+  writeFileSync(
+    join(root, candidateArtifactReceiptFile),
+    JSON.stringify(candidateReceipt)
+  )
+  return root
+}
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-candidate-artifact-'))
+  roots.push(root)
+  return root
+}
+
+function readReceipt(root: string) {
+  return candidateArtifactReceiptSchema.parse(
+    JSON.parse(readFileSync(join(root, candidateArtifactReceiptFile), 'utf8'))
+  )
+}
+
+function mutateReceipt(root: string, patch: Record<string, unknown>): void {
+  writeFileSync(
+    join(root, candidateArtifactReceiptFile),
+    JSON.stringify({ ...readReceipt(root), ...patch })
+  )
+}
+
+function copyFiles(source: string, destination: string): void {
+  for (const entry of readdirSync(source))
+    copyFileSync(join(source, entry), join(destination, entry))
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -41,7 +41,7 @@ const valid: CandidateState = {
     url: 'https://github.example/check/1',
     attempt: 1,
     headSha: 'b'.repeat(40),
-    requiredJobManifestVersion: 1,
+    requiredJobManifestVersion: 2,
     jobs: readRequiredJobManifest().jobs.map((job) => ({
       ...job,
       conclusion: 'success' as const
@@ -163,6 +163,8 @@ describe('candidate delivery policy', () => {
         qualificationInputFingerprint: hash,
         deliveryInputFingerprint: hash,
         toolchainHash: hash,
+        candidateArtifactReceiptSha256: hash,
+        artifactManifestSha256: hash,
         buildOutputHash: hash,
         artifactSha256: hash,
         sourceDataHash: hash,

--- a/tests/unit/ci-workflow-policy.test.ts
+++ b/tests/unit/ci-workflow-policy.test.ts
@@ -52,6 +52,7 @@ describe('CI platform partitions', () => {
     expect(packageJob).toContain('pnpm package:local:built')
     expect(packageJob).toContain('pnpm test:packaged-local-smoke:built')
     expect(packageJob).toContain('pnpm candidate-artifact:write')
+    expect(packageJob).not.toContain('GITHUB_SHA:')
     expect(packageJob).toContain(
       'name: salt-marcher-local-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}'
     )

--- a/tests/unit/ci-workflow-policy.test.ts
+++ b/tests/unit/ci-workflow-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 const workflow = readFileSync('.github/workflows/check.yml', 'utf8')
 const mainPushVerification = readFileSync('scripts/verify-main-push.ts', 'utf8')
+const handoff = readFileSync('scripts/handoff-local-app.ts', 'utf8')
 const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
   scripts: Record<string, string>
 }
@@ -47,8 +48,28 @@ describe('CI platform partitions', () => {
     )
     expect(packageJob).toContain('pnpm package:development:built')
     expect(packageJob).toContain('pnpm test:packaged-smoke:built')
+    expect(packageJob).toContain('pnpm build:local')
+    expect(packageJob).toContain('pnpm package:local:built')
+    expect(packageJob).toContain('pnpm test:packaged-local-smoke:built')
+    expect(packageJob).toContain('pnpm candidate-artifact:write')
+    expect(packageJob).toContain(
+      'name: salt-marcher-local-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}'
+    )
+    expect(packageJob).toContain('compression-level: 0')
     expect(workflow).toContain('name: Linux qualification · packaged harness')
     expect(workflow).toContain('pnpm test:packaged-qualification-smoke')
+  })
+
+  it('hands off the exact CI Local artifact without rebuilding it locally', () => {
+    expect(handoff).toContain("'gh'")
+    expect(handoff).toContain("'download'")
+    expect(handoff).toContain('candidateArtifactName(')
+    expect(handoff).toContain('verifyCandidateArtifactDirectory')
+    expect(handoff).not.toContain("run('checked', ['pnpm', 'check'])")
+    expect(handoff).not.toContain("run('packaged', ['pnpm', 'package:local'])")
+    expect(handoff).toContain("'test:packaged-local-smoke:built'")
+    expect(handoff).toContain("installationDefinition('backup-created')")
+    expect(handoff).toContain("phase: 'installed-runtime-verified'")
   })
 
   it('builds Linux once and validates the same receipt in every consumer', () => {
@@ -60,7 +81,15 @@ describe('CI platform partitions', () => {
     expect(linuxBuild).toContain('include-hidden-files: true')
     const consumers = workflow.slice(workflow.indexOf('  linux-package:'))
     expect(consumers).not.toMatch(/^\s+- run: pnpm build$/m)
-    expect(workflow).toContain('name: linux-app-${{ github.sha }}')
+    expect(workflow).toContain(
+      'SALT_MARCHER_CHECKED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}'
+    )
+    expect(workflow).toContain(
+      'name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}'
+    )
+    expect(
+      workflow.match(/ref: ['"]?\$\{\{ env\.SALT_MARCHER_CHECKED_SHA \}\}/g)
+    ).toHaveLength(9)
     expect(workflow.match(/actions\/download-artifact@v4/g)).toHaveLength(4)
     expect(
       workflow.match(/assert-built-workspace\.ts --channel development/g)

--- a/tests/unit/delivery-contract.test.ts
+++ b/tests/unit/delivery-contract.test.ts
@@ -18,7 +18,7 @@ const sha = 'a'.repeat(40)
 describe('delivery contract', () => {
   it('loads an ordered, unique required-job manifest', () => {
     const manifest = readRequiredJobManifest()
-    expect(manifest.schemaVersion).toBe(1)
+    expect(manifest.schemaVersion).toBe(2)
     expect(manifest.jobs).toHaveLength(12)
     expect(new Set(manifest.jobs.map(({ name }) => name)).size).toBe(12)
     expect(() =>
@@ -36,7 +36,7 @@ describe('delivery contract', () => {
       runId: 123,
       attempt: 2,
       headSha: sha,
-      requiredJobManifestVersion: 1
+      requiredJobManifestVersion: 2
     })
     expect(evidence.jobs.map(({ name }) => name)).toEqual(
       manifest.jobs.map(({ name }) => name)

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -179,7 +179,7 @@ function createFixture(failOnce?: HandoffPhaseName): {
         url: 'https://github.example/runs/1',
         attempt: 1,
         headSha: 'a'.repeat(40),
-        requiredJobManifestVersion: 1,
+        requiredJobManifestVersion: 2,
         jobs: [
           {
             name: 'required',
@@ -223,6 +223,8 @@ function phaseEvidence(character: string): HandoffPhaseEvidence {
     qualificationInputFingerprint: 'd'.repeat(64),
     deliveryInputFingerprint: 'e'.repeat(64),
     toolchainHash: 'f'.repeat(64),
+    candidateArtifactReceiptSha256: hash,
+    artifactManifestSha256: hash,
     buildOutputHash: hash,
     artifactSha256: hash,
     sourceDataHash: hash,


### PR DESCRIPTION
## Invariant
A local handoff may reuse a CI-built Local AppImage only when the successful required-job run, run attempt, candidate SHA, clean workspace fingerprint, app-input fingerprint, build toolchain, embedded Build Receipt, artifact manifest, closed file inventory, and all byte hashes agree. Local AppImage smoke, campaign backup, deployment, activation, and installed-runtime verification remain mandatory.

## What changed
- Required PR jobs explicitly check out the candidate head SHA instead of the synthetic merge commit.
- Linux package qualification now creates and smoke-tests a Local AppImage and uploads a three-file immutable handoff artifact keyed by SHA and run attempt.
- A strict candidate-artifact receipt binds GitHub repository/run/attempt, SHA, app inputs, toolchain, Build Receipt, manifest, and AppImage hashes.
- Handoff downloads only the artifact from the exact successful candidate run, validates the complete chain, restores the AppImage execute bit after validation, and reuses remote check/package work.
- Local check/build/package duplication was removed; local smoke, backup, install, and runtime verification remain.
- Required-job manifest is versioned from v1 to v2 and handoff evidence format from 4 to 5.

## Verification
- pnpm check:delivery: 10 files, 96 tests
- pnpm check: complete and green twice on the final source, including 65 architecture, 642 portable unit, 152 integration, 31 Linux installer/lock, all functional E2E, and all visual E2E
- Clean-commit Local build, package, actual AppImage smoke, candidate receipt generation, and exact three-file transport validation passed
- App-build fingerprint unchanged from origin/main: e2eb9077416d0ececaecd139c2f151842a003dbef0ba3513e9ed3d35e913c839

## Handoff
This phase changes delivery and qualification inputs only. Because the app-build fingerprint is unchanged, it must not manufacture a local application handoff.