### PR TITLE
Harden Electron E2E resource diagnostics

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -46,6 +46,12 @@ from regressing.
 Renderer controller ownership now derives from imports, hook calls, and the
 structurally discovered reducer owner; line-count gates, symbol-spelling checks,
 and duplicate controller inventories are not architectural contracts.
+Electron E2E execution now preflights memory/swap, resolves the actual Electron
+binary for native diagnostics, preserves artifacts per attempt, and classifies
+kernel OOM, tab crash, runner failure, and product assertion separately. A
+confirmed OOM stops remaining suites; a confirmed tab crash suppresses further
+renderer screenshot attempts. Cross-suite session reuse remains disallowed by
+fresh fixture/profile isolation, while tests inside one suite share its session.
 Renderer Session mutations and Group management now share one instance-bound
 async command coordinator with scope/entity request identity, latest-only and
 queue modes, `AbortSignal` cancellation, and explicit pending/success/stale/

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -169,6 +169,16 @@ imports, calls, and structurally discovered owners. They do not encode file
 length, formatting, or local import aliases as architecture. Every semantic
 gate that replaces a source-text assertion carries a controlled mutation that
 demonstrates the protected boundary still fails closed.
+Local Electron E2E runs require explicit available-memory and free-swap
+headroom before launch. They preserve per-attempt logs and screenshots, use
+cgroup/kernel evidence to distinguish OOM from renderer tab crashes and product
+assertions, and stop the run after a confirmed OOM. WDIO receives the real
+Electron executable rather than its package shim, making `ldd` and fuse checks
+authoritative; package-name-only dependency hints are retained in raw logs but
+treated as diagnostic noise, while actual binary linkage failures remain
+visible. One app session is reused within a suite only. Suites keep fresh
+fixture-backed profiles and processes because even suites sharing a fixture
+mutate that profile.
 Workspace navigation is described by immutable `WorkspaceDefinition` records,
 including identity, label, icon, loader, neutral layout mode and recovery
 policy, rather than parallel conditionals in the shell. Its route host models

--- a/scripts/e2e-failure-diagnostics.ts
+++ b/scripts/e2e-failure-diagnostics.ts
@@ -1,0 +1,51 @@
+export type E2eFailureKind =
+  | 'product'
+  | 'product-assertion'
+  | 'infrastructure-runner'
+  | 'infrastructure-tab-crash'
+  | 'infrastructure-oom'
+  | null
+
+const tabCrashPattern =
+  /(?:tab crashed|target crashed|session deleted because of page crash)/i
+
+const runnerInfrastructurePattern =
+  /(?:session not created|operation was aborted due to timeout[^\n]*\/session[^\n]*method "POST"|ECONNREFUSED|ENOSPC|Xvfb|Electron[^\n]*exited before|unable to connect[^\n]*webdriver)/i
+
+const assertionPattern =
+  /(?:AssertionError|expect(?:ed)?\b[^\n]*(?:to|but)|assertion failed)/i
+
+export function classifyE2eFailure(
+  exitCode: number,
+  log: string,
+  kernelOomDetected = false
+): E2eFailureKind {
+  if (exitCode === 0) return null
+  if (kernelOomDetected) return 'infrastructure-oom'
+  if (isConfirmedTabCrash(log)) return 'infrastructure-tab-crash'
+  if (runnerInfrastructurePattern.test(log)) return 'infrastructure-runner'
+  return assertionPattern.test(log) ? 'product-assertion' : 'product'
+}
+
+export function isConfirmedTabCrash(value: unknown): boolean {
+  return tabCrashPattern.test(errorText(value))
+}
+
+export function shouldAttemptFailureScreenshot(
+  rendererUnavailable: boolean,
+  error: unknown
+): boolean {
+  return !rendererUnavailable && !isConfirmedTabCrash(error)
+}
+
+export function shouldAbortE2eRun(kind: E2eFailureKind): boolean {
+  return kind === 'infrastructure-oom'
+}
+
+function errorText(value: unknown): string {
+  if (value instanceof Error) return value.stack ?? value.message
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && 'message' in value)
+    return String(value.message)
+  return ''
+}

--- a/scripts/e2e-resource-preflight.ts
+++ b/scripts/e2e-resource-preflight.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { freemem } from 'node:os'
+import { resolve } from 'node:path'
+
+const MEBIBYTE = 1024 * 1024
+
+export const e2eResourceRequirements = Object.freeze({
+  minimumMemoryAvailableBytes: 768 * MEBIBYTE,
+  minimumCombinedHeadroomBytes: 2_048 * MEBIBYTE
+})
+
+export type E2eResourceSnapshot = Readonly<{
+  source: 'linux-proc-meminfo' | 'os-fallback'
+  memoryAvailableBytes: number
+  swapFreeBytes: number
+}>
+
+export type E2eResourcePreflight = Readonly<{
+  status: 'passed' | 'failed'
+  snapshot: E2eResourceSnapshot
+  requirements: typeof e2eResourceRequirements
+  reason: string | null
+}>
+
+export type CgroupMemoryEvents = Readonly<{
+  oom: number
+  oomKill: number
+}>
+
+export function readE2eResourceSnapshot(): E2eResourceSnapshot {
+  if (process.platform === 'linux')
+    try {
+      return parseLinuxMeminfo(readFileSync('/proc/meminfo', 'utf8'))
+    } catch {
+      // Portable fallback still fails closed against the same memory limit.
+    }
+  return {
+    source: 'os-fallback',
+    memoryAvailableBytes: freemem(),
+    swapFreeBytes: 0
+  }
+}
+
+export function parseLinuxMeminfo(content: string): E2eResourceSnapshot {
+  const values = new Map(
+    content.split('\n').flatMap((line) => {
+      const match = /^(MemAvailable|SwapFree):\s+(\d+)\s+kB$/.exec(line)
+      return match ? [[match[1]!, Number(match[2]) * 1024] as const] : []
+    })
+  )
+  const memoryAvailableBytes = values.get('MemAvailable')
+  const swapFreeBytes = values.get('SwapFree')
+  if (memoryAvailableBytes === undefined || swapFreeBytes === undefined)
+    throw new Error('Linux memory information is incomplete.')
+  return {
+    source: 'linux-proc-meminfo',
+    memoryAvailableBytes,
+    swapFreeBytes
+  }
+}
+
+export function evaluateE2eResourcePreflight(
+  snapshot: E2eResourceSnapshot
+): E2eResourcePreflight {
+  const combined = snapshot.memoryAvailableBytes + snapshot.swapFreeBytes
+  const reason =
+    snapshot.memoryAvailableBytes <
+    e2eResourceRequirements.minimumMemoryAvailableBytes
+      ? `available memory ${formatMebibytes(snapshot.memoryAvailableBytes)} is below ${formatMebibytes(e2eResourceRequirements.minimumMemoryAvailableBytes)}`
+      : combined < e2eResourceRequirements.minimumCombinedHeadroomBytes
+        ? `memory plus free swap ${formatMebibytes(combined)} is below ${formatMebibytes(e2eResourceRequirements.minimumCombinedHeadroomBytes)}`
+        : null
+  return {
+    status: reason ? 'failed' : 'passed',
+    snapshot,
+    requirements: e2eResourceRequirements,
+    reason
+  }
+}
+
+export function readCgroupMemoryEvents(): CgroupMemoryEvents | null {
+  if (process.platform !== 'linux') return null
+  try {
+    return parseCgroupMemoryEvents(
+      readFileSync(
+        cgroupMemoryEventsPath(readFileSync('/proc/self/cgroup', 'utf8')),
+        'utf8'
+      )
+    )
+  } catch {
+    return null
+  }
+}
+
+export function cgroupMemoryEventsPath(content: string): string {
+  const unified = content
+    .split('\n')
+    .map((line) => /^0::(\/.*)$/.exec(line)?.[1])
+    .find((path) => path !== undefined)
+  if (!unified) throw new Error('No unified cgroup v2 path is available.')
+  return resolve('/sys/fs/cgroup', unified.replace(/^\/+/, ''), 'memory.events')
+}
+
+export function parseCgroupMemoryEvents(content: string): CgroupMemoryEvents {
+  const values = new Map(
+    content.split('\n').flatMap((line) => {
+      const match = /^(oom|oom_kill)\s+(\d+)$/.exec(line)
+      return match ? [[match[1]!, Number(match[2])] as const] : []
+    })
+  )
+  return { oom: values.get('oom') ?? 0, oomKill: values.get('oom_kill') ?? 0 }
+}
+
+export function cgroupOomKillAdvanced(
+  before: CgroupMemoryEvents | null,
+  after: CgroupMemoryEvents | null
+): boolean {
+  return before !== null && after !== null && after.oomKill > before.oomKill
+}
+
+export function readRecentKernelOomLines(startedAt: number): string[] {
+  if (process.platform !== 'linux') return []
+  try {
+    const output = execFileSync(
+      'journalctl',
+      [
+        '--dmesg',
+        '--since',
+        `@${Math.floor(startedAt / 1000)}`,
+        '--no-pager',
+        '--output=cat'
+      ],
+      {
+        encoding: 'utf8',
+        timeout: 2_000,
+        maxBuffer: 2 * MEBIBYTE,
+        stdio: ['ignore', 'pipe', 'ignore']
+      }
+    )
+    return kernelOomLines(output)
+  } catch {
+    return []
+  }
+}
+
+export function kernelOomLines(content: string): string[] {
+  return content
+    .split('\n')
+    .filter(
+      (line) =>
+        /(?:out of memory|oom-kill|killed process|memory cgroup out of memory)/i.test(
+          line
+        ) && /(?:electron|chrome|chromedriver|node)/i.test(line)
+    )
+}
+
+function formatMebibytes(value: number): string {
+  return `${Math.floor(value / MEBIBYTE)} MiB`
+}

--- a/scripts/e2e-run-receipt.ts
+++ b/scripts/e2e-run-receipt.ts
@@ -1,3 +1,6 @@
+import type { E2eFailureKind } from './e2e-failure-diagnostics.js'
+import type { E2eResourcePreflight } from './e2e-resource-preflight.js'
+
 export type E2eSuiteAttempt = Readonly<{
   attempt: number
   status: 'passed' | 'failed'
@@ -5,7 +8,7 @@ export type E2eSuiteAttempt = Readonly<{
   durationMs: number
   logPath: string
   artifactDirectory: string
-  failureKind?: 'product' | 'infrastructure' | null
+  failureKind?: E2eFailureKind
   knownNoise?: number
 }>
 
@@ -23,6 +26,7 @@ export type E2eRunSummary<Name extends string = string> = Readonly<{
   buildIdentity: string
   registryIdentity: string
   selectedSuites: readonly Name[]
+  resourcePreflight?: E2eResourcePreflight
   updatedAt: string
   results: readonly E2eSuiteResult<Name>[]
 }>

--- a/scripts/e2e-runner-core.ts
+++ b/scripts/e2e-runner-core.ts
@@ -11,6 +11,18 @@ import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import type { E2eSuiteName } from './e2e-suite-registry.js'
 import {
+  classifyE2eFailure,
+  shouldAbortE2eRun,
+  type E2eFailureKind
+} from './e2e-failure-diagnostics.js'
+import {
+  cgroupOomKillAdvanced,
+  evaluateE2eResourcePreflight,
+  readCgroupMemoryEvents,
+  readE2eResourceSnapshot,
+  readRecentKernelOomLines
+} from './e2e-resource-preflight.js'
+import {
   initializeE2eResults,
   recordE2eAttempt,
   validateE2eResumeIdentity,
@@ -25,6 +37,8 @@ const wdioEntry = join(
   'bin',
   'wdio.js'
 )
+
+export { classifyE2eFailure } from './e2e-failure-diagnostics.js'
 
 export type E2eRunMode = 'functional' | 'visual'
 
@@ -62,7 +76,18 @@ export async function executeE2eRun(input: {
     : resolve('.tmp', 'e2e-runs', runId, 'summary.json')
   const resultDirectory = join(dirname(summaryPath), 'suites')
   let results = initializeE2eResults(input.selectedSuites, resumed)
+  const resourcePreflight = evaluateE2eResourcePreflight(
+    readE2eResourceSnapshot()
+  )
   writeSummary()
+  if (resourcePreflight.status === 'failed') {
+    console.error(
+      `Electron E2E resource preflight failed: ${resourcePreflight.reason}`
+    )
+    console.error(`Summary: ${summaryPath}`)
+    process.exitCode = 1
+    return
+  }
 
   for (const suite of input.selectedSuites) {
     const current = results.find((result) => result.name === suite)!
@@ -78,6 +103,7 @@ export async function executeE2eRun(input: {
       runId,
       mode: input.mode,
       logPath: paths.logPath,
+      artifactDirectory: paths.artifactDirectory,
       ...(input.grepBySuite?.get(suite)
         ? { grep: input.grepBySuite.get(suite)! }
         : {})
@@ -93,9 +119,16 @@ export async function executeE2eRun(input: {
     })
     writeSuiteResult(results.find((result) => result.name === suite)!)
     writeSummary()
+    if (shouldAbortE2eRun(execution.failureKind)) {
+      console.error(
+        `Stopping ${input.mode} E2E after ${suite}: ${execution.failureKind}`
+      )
+      break
+    }
   }
 
-  const failures = results.filter((result) => result.status !== 'passed')
+  const failures = results.filter((result) => result.status === 'failed')
+  const pending = results.filter((result) => result.status === 'pending')
   if (failures.length > 0) {
     console.error(
       `${input.mode} E2E failures: ${failures
@@ -105,6 +138,12 @@ export async function executeE2eRun(input: {
         })
         .join(', ')}`
     )
+    if (pending.length > 0)
+      console.error(
+        `Not started after terminal infrastructure failure: ${pending
+          .map(({ name }) => name)
+          .join(', ')}`
+      )
     console.error(`Resume with: --resume ${summaryPath}`)
     process.exitCode =
       failures.find((failure) => failure.exitCode)?.exitCode ?? 1
@@ -119,6 +158,7 @@ export async function executeE2eRun(input: {
       buildIdentity,
       registryIdentity,
       selectedSuites: input.selectedSuites,
+      resourcePreflight,
       updatedAt: new Date().toISOString(),
       results
     }
@@ -139,23 +179,11 @@ export async function executeE2eRun(input: {
 }
 
 export function classifyE2eLogLine(line: string): 'known-noise' | 'diagnostic' {
-  return /(?:Browser\.getWindowForTarget.*(?:not supported|unsupported|fallback)|unknown command:\s*'Browser\.getWindowForTarget' wasn't found)/i.test(
+  return /(?:Browser\.getWindowForTarget.*(?:not supported|unsupported|fallback)|unknown command:\s*'Browser\.getWindowForTarget' wasn't found|Linux Dependencies:.*packages may be missing|Missing:\s*libgtk-3-0|Install with:\s*sudo apt-get install libgtk-3-0)/i.test(
     line
   )
     ? 'known-noise'
     : 'diagnostic'
-}
-
-export function classifyE2eFailure(
-  exitCode: number,
-  log: string
-): 'product' | 'infrastructure' | null {
-  if (exitCode === 0) return null
-  return /(?:session not created|operation was aborted due to timeout[^\n]*\/session[^\n]*method "POST"|tab crashed|ECONNREFUSED|ENOSPC|Xvfb|Electron[^\n]*exited before|unable to connect[^\n]*webdriver)/i.test(
-    log
-  )
-    ? 'infrastructure'
-    : 'product'
 }
 
 async function runWdioSuite(input: {
@@ -163,19 +191,24 @@ async function runWdioSuite(input: {
   runId: string
   mode: E2eRunMode
   logPath: string
+  artifactDirectory: string
   grep?: string
 }): Promise<
   Readonly<{
     exitCode: number
-    failureKind: 'product' | 'infrastructure' | null
+    failureKind: E2eFailureKind
     knownNoise: number
   }>
 > {
   return new Promise((resolveExit) => {
     mkdirSync(dirname(input.logPath), { recursive: true })
+    mkdirSync(input.artifactDirectory, { recursive: true })
     const log = createWriteStream(input.logPath, { flags: 'w' })
     let diagnosticTail = ''
     let knownNoise = 0
+    let settled = false
+    const startedAt = Date.now()
+    const cgroupBefore = readCgroupMemoryEvents()
     const child = spawn(
       process.execPath,
       [wdioEntry, 'run', 'wdio.conf.ts', '--suite', input.suite],
@@ -185,6 +218,7 @@ async function runWdioSuite(input: {
           ...process.env,
           SALT_MARCHER_E2E_SUITE: input.suite,
           SALT_MARCHER_E2E_RUN_ID: input.runId,
+          SALT_MARCHER_E2E_ARTIFACT_DIR: input.artifactDirectory,
           ...(input.mode === 'visual'
             ? {
                 SALT_MARCHER_VISUAL_MODE: 'true',
@@ -212,21 +246,46 @@ async function runWdioSuite(input: {
     child.stdout.on('data', (chunk: Buffer) => forward(chunk, process.stdout))
     child.stderr.on('data', (chunk: Buffer) => forward(chunk, process.stderr))
     child.once('error', (error) => {
+      if (settled) return
+      settled = true
       diagnosticTail = `${diagnosticTail}\n${error.stack ?? error.message}`
       log.end(`${error.stack ?? error.message}\n`, () =>
         resolveExit({
           exitCode: 1,
-          failureKind: 'infrastructure',
+          failureKind: 'infrastructure-runner',
           knownNoise
         })
       )
     })
     child.once('exit', (code) => {
+      if (settled) return
+      settled = true
       const exitCode = code ?? 1
+      const cgroupAfter = readCgroupMemoryEvents()
+      const kernelLines =
+        exitCode === 0 ? [] : readRecentKernelOomLines(startedAt)
+      const cgroupOom = cgroupOomKillAdvanced(cgroupBefore, cgroupAfter)
+      const resourceDiagnostics = [
+        ...(cgroupOom
+          ? [
+              `cgroup oom_kill advanced from ${cgroupBefore?.oomKill} to ${cgroupAfter?.oomKill}`
+            ]
+          : []),
+        ...kernelLines
+      ]
+      if (resourceDiagnostics.length > 0) {
+        const evidence = `\n[e2e-resource-diagnostics]\n${resourceDiagnostics.join('\n')}\n`
+        diagnosticTail = `${diagnosticTail}${evidence}`.slice(-200_000)
+        log.write(evidence)
+      }
       log.end(() =>
         resolveExit({
           exitCode,
-          failureKind: classifyE2eFailure(exitCode, diagnosticTail),
+          failureKind: classifyE2eFailure(
+            exitCode,
+            diagnosticTail,
+            cgroupOom || kernelLines.length > 0
+          ),
           knownNoise
         })
       )
@@ -241,7 +300,10 @@ function suiteAttemptPaths(
 ): Readonly<{ logPath: string; artifactDirectory: string }> {
   return {
     logPath: join(resultDirectory, `${suite}.attempt-${attempt}.log`),
-    artifactDirectory: resolve('.tmp', 'visual-diffs')
+    artifactDirectory: join(
+      resultDirectory,
+      `${suite}.attempt-${attempt}.artifacts`
+    )
   }
 }
 

--- a/scripts/electron-test-application.ts
+++ b/scripts/electron-test-application.ts
@@ -1,0 +1,17 @@
+import { existsSync, realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const packageRequire = createRequire(import.meta.url)
+
+export function electronTestApplication(
+  appEntryPoint: string,
+  appArgs: readonly string[]
+): Readonly<{ appBinaryPath: string; appArgs: string[] }> {
+  const resolved = packageRequire('electron') as unknown
+  if (typeof resolved !== 'string' || !existsSync(resolved))
+    throw new Error('The Electron package did not resolve to an executable.')
+  return {
+    appBinaryPath: realpathSync(resolved),
+    appArgs: [`--app=${appEntryPoint}`, ...appArgs]
+  }
+}

--- a/tests/e2e/support/e2e-assertions.ts
+++ b/tests/e2e/support/e2e-assertions.ts
@@ -346,7 +346,9 @@ export async function expectElementGolden(
     )
   })
   const goldensDirectory = join(process.cwd(), 'tests', 'e2e', 'goldens')
-  const artifacts = join(process.cwd(), '.tmp', 'visual-diffs')
+  const artifacts =
+    process.env['SALT_MARCHER_E2E_ARTIFACT_DIR'] ??
+    join(process.cwd(), '.tmp', 'visual-diffs')
   mkdirSync(artifacts, { recursive: true })
   const actualPath = join(artifacts, `${name}.png`)
   const defaultBaselinePath = join(goldensDirectory, 'linux', `${name}.png`)

--- a/tests/unit/e2e-resource-preflight.test.ts
+++ b/tests/unit/e2e-resource-preflight.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cgroupMemoryEventsPath,
+  cgroupOomKillAdvanced,
+  evaluateE2eResourcePreflight,
+  kernelOomLines,
+  parseCgroupMemoryEvents,
+  parseLinuxMeminfo
+} from '../../scripts/e2e-resource-preflight.js'
+
+const MEBIBYTE = 1024 * 1024
+
+describe('Electron E2E resource diagnostics', () => {
+  it('passes with sufficient memory/swap headroom and rejects both deficits', () => {
+    const healthy = parseLinuxMeminfo(
+      'MemAvailable:    1572864 kB\nSwapFree:        1048576 kB\n'
+    )
+    expect(evaluateE2eResourcePreflight(healthy)).toMatchObject({
+      status: 'passed',
+      reason: null
+    })
+    const lowMemory = evaluateE2eResourcePreflight({
+      source: 'linux-proc-meminfo',
+      memoryAvailableBytes: 512 * MEBIBYTE,
+      swapFreeBytes: 4_096 * MEBIBYTE
+    })
+    expect(lowMemory.status).toBe('failed')
+    expect(lowMemory.reason).toContain('memory')
+    const lowCombinedHeadroom = evaluateE2eResourcePreflight({
+      source: 'linux-proc-meminfo',
+      memoryAvailableBytes: 1_024 * MEBIBYTE,
+      swapFreeBytes: 512 * MEBIBYTE
+    })
+    expect(lowCombinedHeadroom.status).toBe('failed')
+    expect(lowCombinedHeadroom.reason).toContain('memory plus free swap')
+  })
+
+  it('detects a cgroup OOM increment and keeps only relevant kernel lines', () => {
+    expect(cgroupMemoryEventsPath('0::/user.slice/e2e.scope\n')).toBe(
+      '/sys/fs/cgroup/user.slice/e2e.scope/memory.events'
+    )
+    const before = parseCgroupMemoryEvents('oom 2\noom_kill 1\n')
+    const after = parseCgroupMemoryEvents('oom 3\noom_kill 2\n')
+    expect(cgroupOomKillAdvanced(before, after)).toBe(true)
+    expect(cgroupOomKillAdvanced(after, after)).toBe(false)
+    expect(
+      kernelOomLines(
+        [
+          'Out of memory: Killed process 42 (electron)',
+          'Out of memory: Killed process 43 (unrelated-daemon)',
+          'electron exited normally'
+        ].join('\n')
+      )
+    ).toEqual(['Out of memory: Killed process 42 (electron)'])
+  })
+})

--- a/tests/unit/e2e-runner-core.test.ts
+++ b/tests/unit/e2e-runner-core.test.ts
@@ -3,6 +3,10 @@ import {
   classifyE2eFailure,
   classifyE2eLogLine
 } from '../../scripts/e2e-runner-core.js'
+import {
+  shouldAbortE2eRun,
+  shouldAttemptFailureScreenshot
+} from '../../scripts/e2e-failure-diagnostics.js'
 
 describe('E2E runner diagnostics', () => {
   it('filters only the known Webdriver compatibility fallback', () => {
@@ -22,24 +26,50 @@ describe('E2E runner diagnostics', () => {
     expect(classifyE2eLogLine('WARN unexpected renderer warning')).toBe(
       'diagnostic'
     )
+    expect(
+      classifyE2eLogLine(
+        'WARN electron-service: Linux Dependencies: 13 packages may be missing'
+      )
+    ).toBe('known-noise')
+    expect(classifyE2eLogLine('WARN Shared Libraries: 1 missing library')).toBe(
+      'diagnostic'
+    )
+    expect(
+      classifyE2eLogLine('Could not verify fuse configuration: invalid binary')
+    ).toBe('diagnostic')
   })
 
   it('distinguishes runner infrastructure from product failures', () => {
     expect(classifyE2eFailure(0, 'anything')).toBeNull()
     expect(classifyE2eFailure(1, 'session not created: Electron exited')).toBe(
-      'infrastructure'
+      'infrastructure-runner'
     )
     expect(
       classifyE2eFailure(
         1,
         'WebDriverError: The operation was aborted due to timeout when running "http://localhost:44289/session" with method "POST"'
       )
-    ).toBe('infrastructure')
+    ).toBe('infrastructure-runner')
     expect(classifyE2eFailure(1, 'WebDriverError: tab crashed')).toBe(
-      'infrastructure'
+      'infrastructure-tab-crash'
     )
     expect(classifyE2eFailure(1, 'AssertionError: expected button')).toBe(
-      'product'
+      'product-assertion'
     )
+    expect(classifyE2eFailure(137, 'renderer disappeared', true)).toBe(
+      'infrastructure-oom'
+    )
+  })
+
+  it('stops after OOM and never asks a crashed renderer for screenshots', () => {
+    expect(shouldAbortE2eRun('infrastructure-oom')).toBe(true)
+    expect(shouldAbortE2eRun('infrastructure-tab-crash')).toBe(false)
+    expect(
+      shouldAttemptFailureScreenshot(false, new Error('tab crashed'))
+    ).toBe(false)
+    expect(
+      shouldAttemptFailureScreenshot(false, new Error('expected button'))
+    ).toBe(true)
+    expect(shouldAttemptFailureScreenshot(true, undefined)).toBe(false)
   })
 })

--- a/tests/unit/e2e-suite-registry.test.ts
+++ b/tests/unit/e2e-suite-registry.test.ts
@@ -79,6 +79,7 @@ describe('E2E suite registry', () => {
 
   it('materializes a fresh per-suite profile and supports shuffled order', () => {
     const configuration = readFileSync('wdio.conf.ts', 'utf8')
+    const passiveConfiguration = readFileSync('wdio.passive.conf.ts', 'utf8')
     const runner = readFileSync('scripts/run-e2e-suites.ts', 'utf8')
     expect(configuration).toContain('`${suite}-${runId}-${process.pid}`')
     expect(configuration).toContain(
@@ -87,6 +88,11 @@ describe('E2E suite registry', () => {
     expect(configuration).toContain(
       "cpSync(join(process.cwd(), 'tests', 'e2e', 'fixtures', fixture)"
     )
+    expect(configuration).toContain('electronTestApplication(')
+    expect(configuration).not.toContain('appEntryPoint:')
+    expect(passiveConfiguration).toContain('evaluateE2eResourcePreflight(')
+    expect(passiveConfiguration).toContain('electronTestApplication(')
+    expect(passiveConfiguration).not.toContain('appEntryPoint:')
     expect(runner).toContain("argumentAfter('--shuffle-seed')")
     expect(runner).toContain('shuffledSuiteOrder')
   })

--- a/tests/unit/electron-test-application.test.ts
+++ b/tests/unit/electron-test-application.test.ts
@@ -1,0 +1,24 @@
+import { existsSync, realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { electronTestApplication } from '../../scripts/electron-test-application.js'
+
+describe('Electron test application', () => {
+  it('launches the entry point through the real package binary', () => {
+    const application = electronTestApplication(
+      '/workspace/out/main/index.js',
+      ['--no-sandbox']
+    )
+    expect(existsSync(application.appBinaryPath)).toBe(true)
+    expect(realpathSync(application.appBinaryPath)).toBe(
+      application.appBinaryPath
+    )
+    expect(application.appBinaryPath).not.toBe(
+      resolve('node_modules', '.bin', 'electron')
+    )
+    expect(application.appArgs).toEqual([
+      '--app=/workspace/out/main/index.js',
+      '--no-sandbox'
+    ])
+  })
+})

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -10,6 +10,11 @@ import {
   e2eSuiteRegistry,
   isE2eSuiteName
 } from './scripts/e2e-suite-registry.js'
+import {
+  isConfirmedTabCrash,
+  shouldAttemptFailureScreenshot
+} from './scripts/e2e-failure-diagnostics.js'
+import { electronTestApplication } from './scripts/electron-test-application.js'
 
 const packageRequire = createRequire(import.meta.url)
 
@@ -52,6 +57,18 @@ if (materialized.status !== 0)
     `Could not materialize E2E fixture ${fixture}: ${materialized.stderr}`
   )
 
+const testApplication = electronTestApplication(
+  join(process.cwd(), 'out', 'main', 'index.js'),
+  [
+    '--no-sandbox',
+    '--salt-marcher-e2e-runtime',
+    `--user-data-dir=${userData}`,
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader'
+  ]
+)
+let rendererUnavailable = false
+
 export const config = {
   runner: 'local',
   specs: ['./tests/e2e/**/*.e2e.ts'],
@@ -66,16 +83,7 @@ export const config = {
   capabilities: [
     {
       browserName: 'electron',
-      'wdio:electronServiceOptions': {
-        appEntryPoint: join(process.cwd(), 'out', 'main', 'index.js'),
-        appArgs: [
-          '--no-sandbox',
-          '--salt-marcher-e2e-runtime',
-          `--user-data-dir=${userData}`,
-          '--use-angle=swiftshader',
-          '--enable-unsafe-swiftshader'
-        ]
-      }
+      'wdio:electronServiceOptions': testApplication
     }
   ],
   logLevel: process.env['WDIO_LOG_LEVEL'] ?? 'warn',
@@ -91,15 +99,23 @@ export const config = {
   afterTest: async (
     test: { title: string },
     _context: unknown,
-    result: { passed: boolean }
+    result: { passed: boolean; error?: unknown }
   ) => {
     if (result.passed) return
-    const directory = join(process.cwd(), '.tmp', 'visual-diffs')
+    if (!shouldAttemptFailureScreenshot(rendererUnavailable, result.error)) {
+      rendererUnavailable = true
+      return
+    }
+    const directory =
+      process.env['SALT_MARCHER_E2E_ARTIFACT_DIR'] ??
+      join(process.cwd(), '.tmp', 'visual-diffs')
     mkdirSync(directory, { recursive: true })
     const title = test.title.replaceAll(/[^a-zA-Z0-9_-]+/g, '-').slice(0, 80)
-    await browser
-      .saveScreenshot(join(directory, `${suite}-${title}.png`))
-      .catch(() => undefined)
+    try {
+      await browser.saveScreenshot(join(directory, `${suite}-${title}.png`))
+    } catch (error) {
+      rendererUnavailable ||= isConfirmedTabCrash(error)
+    }
   },
   mochaOpts: {
     ui: 'bdd',

--- a/wdio.passive.conf.ts
+++ b/wdio.passive.conf.ts
@@ -1,9 +1,33 @@
 import { mkdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
+import { electronTestApplication } from './scripts/electron-test-application.js'
+import {
+  evaluateE2eResourcePreflight,
+  readE2eResourceSnapshot
+} from './scripts/e2e-resource-preflight.js'
+
+const resourcePreflight = evaluateE2eResourcePreflight(
+  readE2eResourceSnapshot()
+)
+if (resourcePreflight.status === 'failed')
+  throw new Error(
+    `Electron E2E resource preflight failed: ${resourcePreflight.reason}`
+  )
 
 const userData = join(process.cwd(), '.tmp', 'wdio-passive-user-data')
 rmSync(userData, { recursive: true, force: true })
 mkdirSync(userData, { recursive: true })
+
+const testApplication = electronTestApplication(
+  join(process.cwd(), 'out', 'main', 'index.js'),
+  [
+    '--no-sandbox',
+    '--salt-marcher-e2e-runtime',
+    '--passive-e2e',
+    `--user-data-dir=${userData}`,
+    '--disable-gpu'
+  ]
+)
 
 export const config = {
   runner: 'local',
@@ -16,19 +40,13 @@ export const config = {
   capabilities: [
     {
       browserName: 'electron',
-      'wdio:electronServiceOptions': {
-        appEntryPoint: join(process.cwd(), 'out', 'main', 'index.js'),
-        appArgs: [
-          '--no-sandbox',
-          '--salt-marcher-e2e-runtime',
-          '--passive-e2e',
-          `--user-data-dir=${userData}`,
-          '--disable-gpu'
-        ]
-      }
+      'wdio:electronServiceOptions': testApplication
     }
   ],
-  logLevel: process.env['WDIO_LOG_LEVEL'] ?? 'warn',
+  // The service's dpkg package-name hints are not linkage checks. This direct
+  // path keeps actionable startup/CDP failures while the real binary is still
+  // validated and exercised above.
+  logLevel: process.env['WDIO_LOG_LEVEL'] ?? 'error',
   framework: 'mocha',
   reporters: ['spec'],
   mochaOpts: { ui: 'bdd', timeout: 30_000 }


### PR DESCRIPTION
## Summary
- preflight Electron E2E memory and swap headroom and record the result atomically
- classify product assertions, runner failures, tab crashes, and kernel/cgroup OOM evidence separately
- launch WDIO through the real Electron binary, preserve per-attempt artifacts, and stop screenshot retries after renderer loss
- document the E2E process/session isolation boundary

## Validation
- pnpm check
- focused diagnostics and Electron application unit tests
- functional and passive Electron E2E runs
- app-build fingerprint unchanged; no app handoff required