### PR TITLE
Phase 10: consolidate delivery and retire legacy installation

### DIFF
--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -179,6 +179,11 @@ treated as diagnostic noise, while actual binary linkage failures remain
 visible. One app session is reused within a suite only. Suites keep fresh
 fixture-backed profiles and processes because even suites sharing a fixture
 mutate that profile.
+The Local handoff removes the superseded root-level AppImage and its version-one
+ownership marker only after the immutable `current` deployment has passed
+installed-runtime verification and the legacy executable matches its recorded
+hash. Missing or mismatched ownership evidence fails closed and preserves the
+legacy file for manual inspection.
 Workspace navigation is described by immutable `WorkspaceDefinition` records,
 including identity, label, icon, loader, neutral layout mode and recovery
 policy, rather than parallel conditionals in the shell. Its route host models

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -53,6 +53,7 @@ import {
   type InstallLocalAppOptions,
   type LocalInstallationTarget
 } from './local-app-installation.js'
+import { removeSupersededLocalInstallation } from './local-installation-legacy.js'
 
 if (process.platform !== 'linux')
   throw new Error('SaltMarcher Local handoff currently targets Linux AppImage')
@@ -240,13 +241,20 @@ function phaseDefinitions(): readonly HandoffPhaseDefinition[] {
     installationDefinition('activated'),
     {
       phase: 'installed-runtime-verified',
-      execute: () =>
+      execute: () => {
         run('installed-runtime-verified', [
           'pnpm',
           'exec',
           'tsx',
           'scripts/installed-runtime-verification.ts'
-        ]),
+        ])
+        removeSupersededLocalInstallation({
+          installationRoot: installation.root,
+          currentAppImage: installation.appImage,
+          currentManifest: installation.installedManifest,
+          runtimeEvidencePath
+        })
+      },
       collect: collectRuntimeEvidence
     }
   ]

--- a/scripts/local-installation-legacy.ts
+++ b/scripts/local-installation-legacy.ts
@@ -1,0 +1,85 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  rmSync
+} from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+import { installedRuntimeEvidenceSchema } from './delivery-contract.js'
+import { sha256File } from './file-hash.js'
+
+const fingerprintSchema = z.string().regex(/^[a-f0-9]{64}$/)
+
+const legacyInstalledArtifactSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    artifactSha256: fingerprintSchema
+  })
+  .passthrough()
+
+export type SupersededInstallationCleanup = Readonly<{
+  status: 'absent' | 'removed'
+  removed: readonly string[]
+}>
+
+/**
+ * Removes the pre-deployment-layout AppImage and marker only after the current
+ * immutable deployment has produced matching runtime evidence.
+ */
+export function removeSupersededLocalInstallation(input: {
+  readonly installationRoot: string
+  readonly currentAppImage: string
+  readonly currentManifest: string
+  readonly runtimeEvidencePath: string
+}): SupersededInstallationCleanup {
+  const evidence = installedRuntimeEvidenceSchema.parse(
+    JSON.parse(readFileSync(input.runtimeEvidencePath, 'utf8'))
+  )
+  if (
+    sha256File(input.currentAppImage) !== evidence.artifactSha256 ||
+    sha256File(input.currentManifest) !== evidence.manifestSha256
+  )
+    throw new Error(
+      'Current installation no longer matches its verified runtime evidence'
+    )
+
+  const legacyAppImage = join(input.installationRoot, 'SaltMarcher.AppImage')
+  const legacyMarker = join(input.installationRoot, 'installed-artifact.json')
+  const appImageExists = existsSync(legacyAppImage)
+  const markerExists = existsSync(legacyMarker)
+  if (!appImageExists && !markerExists) return { status: 'absent', removed: [] }
+  if (appImageExists && !markerExists)
+    throw new Error(
+      'Unverified legacy AppImage is missing its ownership marker and was preserved'
+    )
+
+  const marker = legacyInstalledArtifactSchema.parse(
+    JSON.parse(readFileSync(legacyMarker, 'utf8'))
+  )
+  if (appImageExists && sha256File(legacyAppImage) !== marker.artifactSha256)
+    throw new Error(
+      'Legacy AppImage does not match its ownership marker and was preserved'
+    )
+
+  const removed: string[] = []
+  if (appImageExists) {
+    rmSync(legacyAppImage)
+    removed.push(legacyAppImage)
+  }
+  rmSync(legacyMarker)
+  removed.push(legacyMarker)
+  syncDirectory(input.installationRoot)
+  return { status: 'removed', removed }
+}
+
+function syncDirectory(path: string): void {
+  const descriptor = openSync(path, 'r')
+  try {
+    fsyncSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+}

--- a/scripts/test-manifests/delivery.json
+++ b/scripts/test-manifests/delivery.json
@@ -11,6 +11,7 @@
     "tests/unit/build-receipt.test.ts",
     "tests/unit/candidate-artifact.test.ts",
     "tests/unit/local-app-installation.test.ts",
+    "tests/unit/local-installation-legacy.test.ts",
     "tests/unit/local-profile-lock.test.ts",
     "tests/unit/ci-workflow-policy.test.ts"
   ],

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -29,8 +29,8 @@ afterEach(() => {
 })
 
 const valid: CandidateState = {
-  branch: 'quality-reset/candidate',
-  upstream: 'origin/quality-reset/candidate',
+  branch: 'candidate/delivery-test',
+  upstream: 'origin/candidate/delivery-test',
   head: 'b'.repeat(40),
   upstreamHead: 'b'.repeat(40),
   remoteMain: 'a'.repeat(40),

--- a/tests/unit/local-installation-legacy.test.ts
+++ b/tests/unit/local-installation-legacy.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { removeSupersededLocalInstallation } from '../../scripts/local-installation-legacy.js'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+describe('superseded local installation cleanup', () => {
+  it('removes a hash-owned legacy pair after current runtime verification', () => {
+    const fixture = createFixture()
+    const legacyAppImage = join(fixture.root, 'SaltMarcher.AppImage')
+    const legacyMarker = join(fixture.root, 'installed-artifact.json')
+    writeFileSync(legacyAppImage, 'legacy-app')
+    writeFileSync(
+      legacyMarker,
+      JSON.stringify({
+        formatVersion: 1,
+        artifactSha256: hash('legacy-app')
+      })
+    )
+
+    expect(removeSupersededLocalInstallation(fixture.input)).toEqual({
+      status: 'removed',
+      removed: [legacyAppImage, legacyMarker]
+    })
+    expect(existsSync(legacyAppImage)).toBe(false)
+    expect(existsSync(legacyMarker)).toBe(false)
+  })
+
+  it('preserves legacy files when current runtime evidence is stale', () => {
+    const fixture = createFixture({ currentArtifactHash: hash('other-app') })
+    const legacyAppImage = join(fixture.root, 'SaltMarcher.AppImage')
+    const legacyMarker = join(fixture.root, 'installed-artifact.json')
+    writeFileSync(legacyAppImage, 'legacy-app')
+    writeFileSync(
+      legacyMarker,
+      JSON.stringify({
+        formatVersion: 1,
+        artifactSha256: hash('legacy-app')
+      })
+    )
+
+    expect(() => removeSupersededLocalInstallation(fixture.input)).toThrow(
+      /verified runtime evidence/
+    )
+    expect(existsSync(legacyAppImage)).toBe(true)
+    expect(existsSync(legacyMarker)).toBe(true)
+  })
+
+  it('preserves a legacy executable whose ownership hash does not match', () => {
+    const fixture = createFixture()
+    const legacyAppImage = join(fixture.root, 'SaltMarcher.AppImage')
+    const legacyMarker = join(fixture.root, 'installed-artifact.json')
+    writeFileSync(legacyAppImage, 'changed-legacy-app')
+    writeFileSync(
+      legacyMarker,
+      JSON.stringify({
+        formatVersion: 1,
+        artifactSha256: hash('original-legacy-app')
+      })
+    )
+
+    expect(() => removeSupersededLocalInstallation(fixture.input)).toThrow(
+      /does not match its ownership marker/
+    )
+    expect(existsSync(legacyAppImage)).toBe(true)
+    expect(existsSync(legacyMarker)).toBe(true)
+  })
+
+  it('preserves an unowned legacy executable and clears an orphaned marker', () => {
+    const unowned = createFixture()
+    const unownedAppImage = join(unowned.root, 'SaltMarcher.AppImage')
+    writeFileSync(unownedAppImage, 'unknown-app')
+    expect(() => removeSupersededLocalInstallation(unowned.input)).toThrow(
+      /missing its ownership marker/
+    )
+    expect(existsSync(unownedAppImage)).toBe(true)
+
+    const orphaned = createFixture()
+    const orphanedMarker = join(orphaned.root, 'installed-artifact.json')
+    writeFileSync(
+      orphanedMarker,
+      JSON.stringify({ formatVersion: 1, artifactSha256: hash('gone') })
+    )
+    expect(removeSupersededLocalInstallation(orphaned.input)).toEqual({
+      status: 'removed',
+      removed: [orphanedMarker]
+    })
+  })
+})
+
+function createFixture(
+  override: { readonly currentArtifactHash?: string } = {}
+): Readonly<{
+  root: string
+  input: Parameters<typeof removeSupersededLocalInstallation>[0]
+}> {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-legacy-cleanup-'))
+  roots.push(root)
+  const current = join(root, 'current')
+  mkdirSync(current)
+  const currentAppImage = join(current, 'SaltMarcher.AppImage')
+  const currentManifest = join(current, 'artifact-manifest.json')
+  const runtimeEvidencePath = join(root, 'installed-runtime-evidence.json')
+  writeFileSync(currentAppImage, 'current-app')
+  writeFileSync(currentManifest, 'current-manifest')
+  writeFileSync(
+    runtimeEvidencePath,
+    JSON.stringify({
+      artifactSha256: override.currentArtifactHash ?? hash('current-app'),
+      manifestSha256: hash('current-manifest'),
+      utilityReady: true,
+      generation: 1,
+      bootstrap: { totalMs: 1, phases: { configuration: 1 } },
+      quickChecks: [
+        { path: 'installation.sqlite', role: 'installation', result: 'ok' }
+      ],
+      domainReadbacks: [
+        {
+          name: 'installation.readyCampaignCount',
+          expected: 1,
+          actual: 1,
+          passed: true
+        }
+      ]
+    })
+  )
+  return {
+    root,
+    input: {
+      installationRoot: root,
+      currentAppImage,
+      currentManifest,
+      runtimeEvidencePath
+    }
+  }
+}
+
+function hash(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}


### PR DESCRIPTION
## Invariant

There is exactly one active source of truth for registries, delivery state, and the installed application. Superseded root-level installation files are removed only after the immutable current deployment has passed runtime verification and the legacy executable matches its recorded ownership hash.

## Changes

- add fail-closed cleanup for the pre-deployment-layout SaltMarcher.AppImage and version-one marker
- run cleanup only at the installed-runtime-verified handoff boundary
- preserve unowned, hash-mismatched, or unverifiable files for manual inspection
- register positive and negative cleanup tests in the delivery manifest
- remove the last stale quality-reset branch fixture
- record the durable installation ownership rule in the target architecture

## Consolidation audit

- no tracked live planning, progress, ledger, or completion-report structure remains
- no unresolved relative Markdown link or retired quality-reset reference remains outside the intentional regression guard
- no orphaned script or manifest entry was found
- src/utility/application.ts fell from 505 to 462 lines versus the pre-program baseline
- handoff-local-app.ts grew from 446 to 500 lines and local-app-installation.ts from 1021 to 1342 lines; the new 205-line handoff state machine and 184-line installation journal make recovery, provenance, and idempotency explicit, but delivery/install complexity remains the largest architectural debt
- app-build fingerprint is unchanged; qualification and delivery-tooling fingerprints change as intended

## Verification

- pnpm check: all format, lint, type, architecture, unit, integration, reference, build, smoke, bundle, Linux, functional Electron E2E, and visual Golden-Master suites
- pnpm check:delivery and four focused positive/negative cleanup tests
- exact-SHA candidate run 32464483157: all 12 required jobs successful
- fresh pnpm handoff:app: all eight phases completed; remote artifact and installed artifact share SHA-256 11b857afcddeebbe6fb4262cb2cfaf619ed04a64ad73289bc25509259a0b59d1
- installed runtime reports utility-ready, three SQLite quick checks, and five domain readbacks; the backup and live data hashes match for both campaigns and installation data
- the owned legacy AppImage and V1 marker were removed after runtime verification; current now points to immutable deployment 1801f826b79a3ab0ae4e06215d4b407feedf466f39e814a6db28b1ca3e1b73e3
- exact SHA 5d2837e2006c204a21fef6c047f6d1d218d7a2ec was fast-forwarded to main
- main run 32465742505 and post-promotion candidate attestation succeeded
- final worktree, candidate upstream, origin/main, installed manifest, and handoff identity all resolve to the expected exact SHA where applicable

## Architecture assessment

The program removed parallel evidence/status truth, separated build identity from qualification and delivery concerns, made delivery and Campaign replacement restartable, consolidated IPC declarations, and centralized renderer latest-only semantics. The remaining concentration of complexity is operational: local installation and delivery still encode many filesystem, provenance, backup, and recovery responsibilities in large modules. Future work should split those modules by checkpoint ownership without weakening the hash-linked state machine, define retention for immutable deployments/backups and V1 marker support, and continue replacing remaining literal CI policy checks with typed or behavioral gates.