### PR TITLE
Phase 2: registry-driven isolated E2E orchestration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,6 +65,9 @@ jobs:
     name: Linux build · reusable app
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    outputs:
+      functional_e2e_matrix: ${{ steps.e2e_matrix.outputs.functional }}
+      visual_e2e_matrix: ${{ steps.e2e_matrix.outputs.visual }}
     steps:
       - uses: actions/checkout@v4
         with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
@@ -80,6 +83,8 @@ jobs:
             ~/.cache/electron-builder
           key: native-${{ runner.os }}-${{ runner.arch }}-node22-pnpm10-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm install --frozen-lockfile
+      - id: e2e_matrix
+        run: pnpm e2e:ci-matrix
       - run: pnpm check:linux
       - run: pnpm build
       - run: xvfb-run -a pnpm test:smoke:built
@@ -161,16 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - shard: campaign-workspaces
-            suites: --suite workspaces --suite campaignCreate --suite campaignHexMap --suite campaignCombat --suite campaignPseudoLocale
-          - shard: hex-npc-restart
-            suites: --suite hexLocation --suite npcCatalog --suite restart
-          - shard: dialogs-generation-loot
-            suites: --suite dialogs --suite sessionGeneration --suite loot
-          - shard: group-loot-travel
-            suites: --suite groupLoot --suite groupLootCommit --suite travel
+      matrix: ${{ fromJSON(needs.linux-build.outputs.functional_e2e_matrix) }}
     steps:
       - uses: actions/checkout@v4
         with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
@@ -184,7 +180,7 @@ jobs:
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
-      - run: xvfb-run -a pnpm test:e2e:built -- ${{ matrix.suites }}
+      - run: xvfb-run -a pnpm test:e2e:built -- --ci-shard "${{ matrix.shard }}"
         env:
           SALT_MARCHER_VISUAL_GOLDEN_VARIANT: ubuntu-24.04
       - name: Upload complete E2E failure evidence
@@ -201,10 +197,13 @@ jobs:
 
   visual:
     if: github.event_name == 'pull_request'
-    name: Linux Visual · goldens
+    name: Linux Visual · ${{ matrix.shard }}
     needs: linux-build
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.linux-build.outputs.visual_e2e_matrix) }}
     steps:
       - uses: actions/checkout@v4
         with: { ref: '${{ env.SALT_MARCHER_CHECKED_SHA }}' }
@@ -218,14 +217,14 @@ jobs:
           path: out
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/assert-built-workspace.ts --channel development
-      - run: xvfb-run -a pnpm test:visual:built
+      - run: xvfb-run -a pnpm test:visual:built -- --ci-shard "${{ matrix.shard }}"
         env:
           SALT_MARCHER_VISUAL_GOLDEN_VARIANT: ubuntu-24.04
       - name: Upload complete visual failure evidence
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: visual-evidence-${{ github.run_id }}
+          name: visual-evidence-${{ matrix.shard }}-${{ github.run_id }}
           path: |
             .tmp/e2e-runs
             .tmp/visual-diffs

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:packaged-qualification-smoke": "corepack pnpm package:qualification && tsx scripts/packaged-smoke.ts --channel release --qualification",
     "test:e2e": "corepack pnpm build && corepack pnpm test:e2e:built",
     "test:e2e:built": "tsx scripts/run-e2e-suites.ts",
+    "e2e:ci-matrix": "tsx scripts/e2e-ci-matrix-cli.ts",
     "test:create:built": "tsx scripts/run-e2e-suites.ts --suite campaignCreate --suite campaignHexMap --suite campaignCombat --suite campaignPseudoLocale",
     "test:hex-location:built": "wdio run wdio.conf.ts --suite hexLocation",
     "test:dialogs:built": "wdio run wdio.conf.ts --suite dialogs",

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -411,7 +411,7 @@ export function readRequiredJobManifest(
   return requiredJobManifestSchema.parse(
     JSON.parse(
       readFileSync(
-        resolve(workspaceRoot, 'scripts', 'delivery', 'required-jobs.v3.json'),
+        resolve(workspaceRoot, 'scripts', 'delivery', 'required-jobs.v4.json'),
         'utf8'
       )
     )

--- a/scripts/delivery/required-jobs.v4.json
+++ b/scripts/delivery/required-jobs.v4.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "workflowName": "Check",
   "jobs": [
     {
@@ -43,8 +43,16 @@
       "platformRole": "linux-e2e-group-loot-travel"
     },
     {
-      "name": "Linux Visual · goldens",
-      "platformRole": "linux-visual-goldens"
+      "name": "Linux Visual · goldens-campaign",
+      "platformRole": "linux-visual-goldens-campaign"
+    },
+    {
+      "name": "Linux Visual · goldens-dialog-travel-loot",
+      "platformRole": "linux-visual-goldens-dialog-travel-loot"
+    },
+    {
+      "name": "Linux Visual · goldens-world-create",
+      "platformRole": "linux-visual-goldens-world-create"
     },
     {
       "name": "Linux E2E · passive window",

--- a/scripts/e2e-ci-matrix-cli.ts
+++ b/scripts/e2e-ci-matrix-cli.ts
@@ -1,0 +1,14 @@
+import { appendFileSync } from 'node:fs'
+import { e2eCiMatrix } from './e2e-ci-matrix.js'
+
+const ciMatrices = {
+  functional: e2eCiMatrix('functional'),
+  visual: e2eCiMatrix('visual')
+}
+const githubOutput = process.env['GITHUB_OUTPUT']
+if (githubOutput)
+  appendFileSync(
+    githubOutput,
+    `functional=${JSON.stringify(ciMatrices.functional)}\nvisual=${JSON.stringify(ciMatrices.visual)}\n`
+  )
+console.log(JSON.stringify(ciMatrices))

--- a/scripts/e2e-ci-matrix.ts
+++ b/scripts/e2e-ci-matrix.ts
@@ -1,0 +1,67 @@
+import {
+  e2eSuiteRegistry,
+  functionalE2eCiShards,
+  visualE2eCiShards,
+  type E2eSuiteName,
+  type E2eSuiteType,
+  type FunctionalE2eCiShard,
+  type VisualE2eCiShard
+} from './e2e-suite-registry.js'
+
+export type E2eCiShard = FunctionalE2eCiShard | VisualE2eCiShard
+
+export type E2eCiMatrix<Shard extends E2eCiShard = E2eCiShard> = Readonly<{
+  include: readonly Readonly<{ shard: Shard }>[]
+}>
+
+export function e2eCiMatrix(
+  type: 'functional'
+): E2eCiMatrix<FunctionalE2eCiShard>
+export function e2eCiMatrix(type: 'visual'): E2eCiMatrix<VisualE2eCiShard>
+export function e2eCiMatrix(type: E2eSuiteType): E2eCiMatrix {
+  const shards =
+    type === 'functional' ? functionalE2eCiShards : visualE2eCiShards
+  return { include: shards.map((shard) => ({ shard })) }
+}
+
+export function e2eCiSuites(
+  type: E2eSuiteType,
+  shard: string
+): readonly E2eSuiteName[] {
+  if (!isE2eCiShard(type, shard))
+    throw new Error(`Unknown ${type} E2E CI shard: ${shard}`)
+  const suites = e2eSuiteRegistry
+    .filter((suite) =>
+      type === 'functional'
+        ? suite.ci.functional.shard === shard
+        : 'visual' in suite.ci && suite.ci.visual.shard === shard
+    )
+    .map((suite) => suite.name)
+  if (suites.length === 0)
+    throw new Error(`${type} E2E CI shard has no suites: ${shard}`)
+  return suites
+}
+
+export function measuredE2eCiSeconds(
+  type: E2eSuiteType,
+  shard: string
+): number {
+  return e2eSuiteRegistry.reduce((total, suite) => {
+    if (type === 'functional')
+      return suite.ci.functional.shard === shard
+        ? total + suite.ci.functional.measuredSeconds
+        : total
+    return 'visual' in suite.ci && suite.ci.visual.shard === shard
+      ? total + suite.ci.visual.measuredSeconds
+      : total
+  }, 0)
+}
+
+export function isE2eCiShard(
+  type: E2eSuiteType,
+  value: string
+): value is E2eCiShard {
+  const shards: readonly string[] =
+    type === 'functional' ? functionalE2eCiShards : visualE2eCiShards
+  return shards.includes(value)
+}

--- a/scripts/e2e-run-receipt.ts
+++ b/scripts/e2e-run-receipt.ts
@@ -1,6 +1,12 @@
 import type { E2eFailureKind } from './e2e-failure-diagnostics.js'
 import type { E2eResourcePreflight } from './e2e-resource-preflight.js'
 
+export type E2eRegressionWarnings = Readonly<{
+  windowRect: number
+  scrollFallback: number
+  staleElement: number
+}>
+
 export type E2eSuiteAttempt = Readonly<{
   attempt: number
   status: 'passed' | 'failed'
@@ -10,6 +16,7 @@ export type E2eSuiteAttempt = Readonly<{
   artifactDirectory: string
   failureKind?: E2eFailureKind
   knownNoise?: number
+  regressionWarnings?: E2eRegressionWarnings
 }>
 
 export type E2eSuiteResult<Name extends string = string> = Readonly<{
@@ -26,6 +33,8 @@ export type E2eRunSummary<Name extends string = string> = Readonly<{
   buildIdentity: string
   registryIdentity: string
   selectedSuites: readonly Name[]
+  ciShard?: string
+  shardDurationMs?: number
   resourcePreflight?: E2eResourcePreflight
   updatedAt: string
   results: readonly E2eSuiteResult<Name>[]
@@ -65,17 +74,25 @@ export function recordE2eAttempt<Name extends string>(
   )
 }
 
+export function e2eShardDurationMs<Name extends string>(
+  results: readonly E2eSuiteResult<Name>[]
+): number {
+  return results.reduce((total, result) => total + (result.durationMs ?? 0), 0)
+}
+
 export function validateE2eResumeIdentity<Name extends string>(
   summary: E2eRunSummary<Name>,
   expected: Readonly<{
     buildIdentity: string
     registryIdentity: string
     selectedSuites: readonly Name[]
+    ciShard?: string
   }>
 ): void {
   if (
     summary.buildIdentity !== expected.buildIdentity ||
     summary.registryIdentity !== expected.registryIdentity ||
+    summary.ciShard !== expected.ciShard ||
     JSON.stringify(summary.selectedSuites) !==
       JSON.stringify(expected.selectedSuites)
   )

--- a/scripts/e2e-runner-core.ts
+++ b/scripts/e2e-runner-core.ts
@@ -23,9 +23,11 @@ import {
   readRecentKernelOomLines
 } from './e2e-resource-preflight.js'
 import {
+  e2eShardDurationMs,
   initializeE2eResults,
   recordE2eAttempt,
   validateE2eResumeIdentity,
+  type E2eRegressionWarnings,
   type E2eRunSummary,
   type E2eSuiteResult
 } from './e2e-run-receipt.js'
@@ -46,6 +48,7 @@ export async function executeE2eRun(input: {
   mode: E2eRunMode
   selectedSuites: readonly E2eSuiteName[]
   registry: unknown
+  ciShard?: string
   resumePath?: string
   grepBySuite?: ReadonlyMap<E2eSuiteName, string>
 }): Promise<void> {
@@ -67,7 +70,8 @@ export async function executeE2eRun(input: {
     validateE2eResumeIdentity(resumed, {
       buildIdentity,
       registryIdentity,
-      selectedSuites: input.selectedSuites
+      selectedSuites: input.selectedSuites,
+      ...(input.ciShard ? { ciShard: input.ciShard } : {})
     })
 
   const runId = resumed?.runId ?? `${input.mode}-${Date.now()}-${process.pid}`
@@ -115,6 +119,7 @@ export async function executeE2eRun(input: {
       durationMs: Date.now() - startedAt,
       failureKind: execution.failureKind,
       knownNoise: execution.knownNoise,
+      regressionWarnings: execution.regressionWarnings,
       ...paths
     })
     writeSuiteResult(results.find((result) => result.name === suite)!)
@@ -158,6 +163,12 @@ export async function executeE2eRun(input: {
       buildIdentity,
       registryIdentity,
       selectedSuites: input.selectedSuites,
+      ...(input.ciShard
+        ? {
+            ciShard: input.ciShard,
+            shardDurationMs: e2eShardDurationMs(results)
+          }
+        : {}),
       resourcePreflight,
       updatedAt: new Date().toISOString(),
       results
@@ -179,11 +190,42 @@ export async function executeE2eRun(input: {
 }
 
 export function classifyE2eLogLine(line: string): 'known-noise' | 'diagnostic' {
-  return /(?:Browser\.getWindowForTarget.*(?:not supported|unsupported|fallback)|unknown command:\s*'Browser\.getWindowForTarget' wasn't found|Linux Dependencies:.*packages may be missing|Missing:\s*libgtk-3-0|Install with:\s*sudo apt-get install libgtk-3-0)/i.test(
+  return /(?:Linux Dependencies:.*packages may be missing|Missing:\s*libgtk-3-0|Install with:\s*sudo apt-get install libgtk-3-0)/i.test(
     line
   )
     ? 'known-noise'
     : 'diagnostic'
+}
+
+export function countE2eRegressionWarnings(
+  output: string
+): E2eRegressionWarnings {
+  const counts = {
+    windowRect: 0,
+    scrollFallback: 0,
+    staleElement: 0
+  }
+  for (const line of output.split('\n')) {
+    if (/when running ["']window\/rect["']/i.test(line)) counts.windowRect += 1
+    if (/Re-attempting using .*Element\.scrollIntoView.*Web API/i.test(line))
+      counts.scrollFallback += 1
+    if (
+      /\bWARN\s+webdriver:\s+Request encountered a stale element\s+-\s+terminating request\b/i.test(
+        line
+      )
+    )
+      counts.staleElement += 1
+  }
+  return counts
+}
+
+export function e2eExitCodeWithWarningRegressions(
+  exitCode: number,
+  warnings: E2eRegressionWarnings
+): number {
+  return exitCode === 0 && Object.values(warnings).some((count) => count > 0)
+    ? 1
+    : exitCode
 }
 
 async function runWdioSuite(input: {
@@ -198,6 +240,7 @@ async function runWdioSuite(input: {
     exitCode: number
     failureKind: E2eFailureKind
     knownNoise: number
+    regressionWarnings: E2eRegressionWarnings
   }>
 > {
   return new Promise((resolveExit) => {
@@ -253,17 +296,18 @@ async function runWdioSuite(input: {
         resolveExit({
           exitCode: 1,
           failureKind: 'infrastructure-runner',
-          knownNoise
+          knownNoise,
+          regressionWarnings: countE2eRegressionWarnings(diagnosticTail)
         })
       )
     })
     child.once('exit', (code) => {
       if (settled) return
       settled = true
-      const exitCode = code ?? 1
+      const processExitCode = code ?? 1
       const cgroupAfter = readCgroupMemoryEvents()
       const kernelLines =
-        exitCode === 0 ? [] : readRecentKernelOomLines(startedAt)
+        processExitCode === 0 ? [] : readRecentKernelOomLines(startedAt)
       const cgroupOom = cgroupOomKillAdvanced(cgroupBefore, cgroupAfter)
       const resourceDiagnostics = [
         ...(cgroupOom
@@ -278,6 +322,17 @@ async function runWdioSuite(input: {
         diagnosticTail = `${diagnosticTail}${evidence}`.slice(-200_000)
         log.write(evidence)
       }
+      const regressionWarnings = countE2eRegressionWarnings(diagnosticTail)
+      const exitCode = e2eExitCodeWithWarningRegressions(
+        processExitCode,
+        regressionWarnings
+      )
+      if (exitCode !== processExitCode) {
+        const evidence = `\n[e2e-warning-regression] ${JSON.stringify(regressionWarnings)}\n`
+        diagnosticTail = `${diagnosticTail}${evidence}`.slice(-200_000)
+        log.write(evidence)
+        console.error(evidence.trim())
+      }
       log.end(() =>
         resolveExit({
           exitCode,
@@ -286,7 +341,8 @@ async function runWdioSuite(input: {
             diagnosticTail,
             cgroupOom || kernelLines.length > 0
           ),
-          knownNoise
+          knownNoise,
+          regressionWarnings
         })
       )
     })

--- a/scripts/e2e-suite-registry.ts
+++ b/scripts/e2e-suite-registry.ts
@@ -1,79 +1,180 @@
-type E2eSuiteRegistration = Readonly<{
+export const e2eSuiteTypes = ['functional', 'visual'] as const
+export type E2eSuiteType = (typeof e2eSuiteTypes)[number]
+
+export const functionalE2eCiShards = [
+  'campaign-workspaces',
+  'hex-npc-restart',
+  'dialogs-generation-loot',
+  'group-loot-travel'
+] as const
+export type FunctionalE2eCiShard = (typeof functionalE2eCiShards)[number]
+
+export const visualE2eCiShards = [
+  'goldens-campaign',
+  'goldens-dialog-travel-loot',
+  'goldens-world-create'
+] as const
+export type VisualE2eCiShard = (typeof visualE2eCiShards)[number]
+
+export type E2eSuiteRegistration = Readonly<{
   name: string
   spec: `./tests/e2e/${string}.e2e.ts`
   fixture: `v${number}/${string}`
+  types: readonly E2eSuiteType[]
+  ci: Readonly<{
+    functional: Readonly<{
+      shard: FunctionalE2eCiShard
+      measuredSeconds: number
+    }>
+    visual?: Readonly<{
+      shard: VisualE2eCiShard
+      measuredSeconds: number
+    }>
+  }>
 }>
 
 export const e2eSuiteRegistry = [
   {
     name: 'workspaces',
     spec: './tests/e2e/workspace-isolation.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'campaign-workspaces', measuredSeconds: 80 }
+    }
   },
   {
     name: 'campaignCreate',
     spec: './tests/e2e/campaign-create.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'campaign-workspaces', measuredSeconds: 82 },
+      visual: { shard: 'goldens-world-create', measuredSeconds: 90 }
+    }
   },
   {
     name: 'campaignHexMap',
     spec: './tests/e2e/campaign-hex-map.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'campaign-workspaces', measuredSeconds: 79 },
+      visual: { shard: 'goldens-campaign', measuredSeconds: 81 }
+    }
   },
   {
     name: 'campaignCombat',
     spec: './tests/e2e/campaign-combat.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'campaign-workspaces', measuredSeconds: 93 },
+      visual: { shard: 'goldens-campaign', measuredSeconds: 100 }
+    }
   },
   {
     name: 'campaignPseudoLocale',
     spec: './tests/e2e/campaign-pseudo-locale.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'campaign-workspaces', measuredSeconds: 74 }
+    }
   },
   {
     name: 'hexLocation',
     spec: './tests/e2e/hex-location-workflow.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'hex-npc-restart', measuredSeconds: 91 },
+      visual: { shard: 'goldens-world-create', measuredSeconds: 92 }
+    }
   },
   {
     name: 'npcCatalog',
     spec: './tests/e2e/npc-catalog.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'hex-npc-restart', measuredSeconds: 80 }
+    }
   },
   {
     name: 'restart',
     spec: './tests/e2e/campaign-restart.e2e.ts',
-    fixture: 'v1/editor-data'
+    fixture: 'v1/editor-data',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'hex-npc-restart', measuredSeconds: 73 }
+    }
   },
   {
     name: 'dialogs',
     spec: './tests/e2e/dialog-architecture.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'dialogs-generation-loot', measuredSeconds: 99 },
+      visual: {
+        shard: 'goldens-dialog-travel-loot',
+        measuredSeconds: 96
+      }
+    }
   },
   {
     name: 'sessionGeneration',
     spec: './tests/e2e/session-generation.e2e.ts',
-    fixture: 'v1/empty-installation'
+    fixture: 'v1/empty-installation',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'dialogs-generation-loot', measuredSeconds: 89 }
+    }
   },
   {
     name: 'loot',
     spec: './tests/e2e/session-loot.e2e.ts',
-    fixture: 'v4/loot-distribution'
+    fixture: 'v4/loot-distribution',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'dialogs-generation-loot', measuredSeconds: 76 }
+    }
   },
   {
     name: 'groupLoot',
     spec: './tests/e2e/group-loot.e2e.ts',
-    fixture: 'v3/group-loot'
+    fixture: 'v3/group-loot',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'group-loot-travel', measuredSeconds: 82 },
+      visual: {
+        shard: 'goldens-dialog-travel-loot',
+        measuredSeconds: 77
+      }
+    }
   },
   {
     name: 'groupLootCommit',
     spec: './tests/e2e/group-loot-commit.e2e.ts',
-    fixture: 'v3/group-loot'
+    fixture: 'v3/group-loot',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'group-loot-travel', measuredSeconds: 75 }
+    }
   },
   {
     name: 'travel',
     spec: './tests/e2e/session-travel.e2e.ts',
-    fixture: 'v2/travel-scenario'
+    fixture: 'v2/travel-scenario',
+    types: ['functional', 'visual'],
+    ci: {
+      functional: { shard: 'group-loot-travel', measuredSeconds: 79 },
+      visual: {
+        shard: 'goldens-dialog-travel-loot',
+        measuredSeconds: 82
+      }
+    }
   }
 ] as const satisfies readonly E2eSuiteRegistration[]
 
@@ -85,4 +186,11 @@ export function isE2eSuiteName(value: string): value is E2eSuiteName {
 
 export function e2eSuite(name: E2eSuiteName) {
   return e2eSuiteRegistry.find((suite) => suite.name === name)!
+}
+
+export function e2eSuiteHasType(
+  suite: E2eSuiteRegistration,
+  type: E2eSuiteType
+): boolean {
+  return suite.types.includes(type)
 }

--- a/scripts/run-e2e-suites.ts
+++ b/scripts/run-e2e-suites.ts
@@ -3,19 +3,25 @@ import {
   isE2eSuiteName,
   type E2eSuiteName
 } from './e2e-suite-registry.js'
+import { e2eCiSuites } from './e2e-ci-matrix.js'
 import { executeE2eRun } from './e2e-runner-core.js'
 import { shuffledSuiteOrder } from './e2e-suite-order.js'
 
 const arguments_ = process.argv.slice(2).filter((entry) => entry !== '--')
 const resumePath = argumentAfter('--resume')
 const shuffleSeedValue = argumentAfter('--shuffle-seed')
+const ciShard = argumentAfter('--ci-shard')
 const requested = repeatedArguments('--suite')
+if (ciShard && requested.length > 0)
+  throw new Error('--ci-shard and --suite cannot be combined')
 for (const name of requested)
   if (!isE2eSuiteName(name)) throw new Error(`Unknown E2E suite: ${name}`)
 const registeredSuites = (
-  requested.length > 0
-    ? [...new Set(requested)]
-    : e2eSuiteRegistry.map((suite) => suite.name)
+  ciShard
+    ? e2eCiSuites('functional', ciShard)
+    : requested.length > 0
+      ? [...new Set(requested)]
+      : e2eSuiteRegistry.map((suite) => suite.name)
 ) as E2eSuiteName[]
 const selectedSuites = shuffleSeedValue
   ? shuffledSuiteOrder(registeredSuites, Number(shuffleSeedValue))
@@ -25,6 +31,7 @@ await executeE2eRun({
   mode: 'functional',
   selectedSuites,
   registry: e2eSuiteRegistry,
+  ...(ciShard ? { ciShard } : {}),
   ...(resumePath ? { resumePath } : {})
 })
 

--- a/scripts/run-visual-suites.ts
+++ b/scripts/run-visual-suites.ts
@@ -2,9 +2,11 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   e2eSuiteRegistry,
+  e2eSuiteHasType,
   isE2eSuiteName,
   type E2eSuiteName
 } from './e2e-suite-registry.js'
+import { e2eCiSuites } from './e2e-ci-matrix.js'
 import { executeE2eRun } from './e2e-runner-core.js'
 import type { VisualGoldenEntry } from './visual-golden-policy.js'
 
@@ -29,21 +31,29 @@ const grepBySuite = new Map(
   ])
 )
 const requestedSuites = repeatedArguments('--suite')
+const ciShard = argumentAfter('--ci-shard')
+if (ciShard && requestedSuites.length > 0)
+  throw new Error('--ci-shard and --suite cannot be combined')
 for (const suite of requestedSuites)
   if (!isE2eSuiteName(suite) || !grepBySuite.has(suite))
     throw new Error(`Unknown visual E2E suite: ${suite}`)
-const selectedSuites =
-  requestedSuites.length > 0
+const selectedSuites = ciShard
+  ? e2eCiSuites('visual', ciShard)
+  : requestedSuites.length > 0
     ? ([...new Set(requestedSuites)] as E2eSuiteName[])
-    : [...grepBySuite.keys()]
-const resumeIndex = process.argv.indexOf('--resume')
-const resumePath = resumeIndex >= 0 ? process.argv[resumeIndex + 1] : undefined
-if (resumeIndex >= 0 && !resumePath) throw new Error('--resume needs a value')
+    : e2eSuiteRegistry
+        .filter((suite) => e2eSuiteHasType(suite, 'visual'))
+        .map((suite) => suite.name)
+for (const suite of selectedSuites)
+  if (!grepBySuite.has(suite))
+    throw new Error(`Visual E2E suite has no golden patterns: ${suite}`)
+const resumePath = argumentAfter('--resume')
 
 await executeE2eRun({
   mode: 'visual',
   selectedSuites,
   registry: e2eSuiteRegistry,
+  ...(ciShard ? { ciShard } : {}),
   grepBySuite,
   ...(resumePath ? { resumePath } : {})
 })
@@ -63,4 +73,12 @@ function repeatedArguments(name: string): string[] {
     index += 1
   }
   return values
+}
+
+function argumentAfter(name: string): string | undefined {
+  const index = process.argv.indexOf(name)
+  if (index < 0) return undefined
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${name} needs a value`)
+  return value
 }

--- a/tests/e2e/dialog-architecture.e2e.ts
+++ b/tests/e2e/dialog-architecture.e2e.ts
@@ -4,13 +4,13 @@ import type {
   ChainablePromiseElement
 } from 'webdriverio'
 import {
-  clickWhenInteractable,
   expectEditorFrameGeometry,
   expectAccessibleInBothThemes,
   expectElementGolden,
   setElectronWindowSize,
   setWindowToMinimumResponsiveSize
 } from './support/e2e-assertions.js'
+import { clickWhenInteractable } from './support/e2e-interactions.js'
 
 describe('dialog architecture', () => {
   it('stacks, guards and responsively lays out direct and nested table managers', async () => {
@@ -36,8 +36,10 @@ describe('dialog architecture', () => {
       'input[role="combobox"][aria-label="Größe"]'
     )
     await sizeFilter.setValue('hu')
-    const huge = await client.$('[role="option"]*=Huge')
-    await clickWhenInteractable(huge)
+    await clickWhenInteractable(
+      client,
+      async () => await client.$('[role="option"]*=Huge')
+    )
     const hugeChip = await manager.$('button=Huge ×')
     await expect(hugeChip).toBeExisting()
     await hugeChip.click()
@@ -96,7 +98,10 @@ describe('dialog architecture', () => {
       await faction.$('input[aria-label="Fraktionsname"]')
     ).setValue('Hafenwache')
     await (await faction.$('button.faction-table-card')).click()
-    await clickWhenInteractable(await client.$('button=Neue Encounter-Tabelle'))
+    await clickWhenInteractable(
+      client,
+      async () => await client.$('button=Neue Encounter-Tabelle')
+    )
     manager = await client.$('section.encounter-table-manager')
     await manager.waitForDisplayed()
 
@@ -174,7 +179,10 @@ describe('dialog architecture', () => {
     expect(factionLayout.right).toBeLessThanOrEqual(factionLayout.viewportWidth)
     await expectAccessibleInBothThemes(client)
     await (await faction.$('button.faction-table-card')).click()
-    await clickWhenInteractable(await client.$('button=Neue Encounter-Tabelle'))
+    await clickWhenInteractable(
+      client,
+      async () => await client.$('button=Neue Encounter-Tabelle')
+    )
     manager = await client.$('section.encounter-table-manager')
     await manager.waitForDisplayed()
     await assertManagerLayout(client, 'stacked')
@@ -216,8 +224,13 @@ async function openCatalogSection(client: WdioBrowser, label: string) {
 async function clickVisibleCatalogCreate(client: WdioBrowser) {
   const host = await client.$('.catalog-section-host:not([hidden])')
   await host.waitForDisplayed()
-  const create = await host.$('button=Erstellen')
-  await clickWhenInteractable(create)
+  await clickWhenInteractable(
+    client,
+    async () =>
+      await (
+        await client.$('.catalog-section-host:not([hidden])')
+      ).$('button=Erstellen')
+  )
 }
 
 async function assertManagerLayout(

--- a/tests/e2e/group-loot-commit.e2e.ts
+++ b/tests/e2e/group-loot-commit.e2e.ts
@@ -8,6 +8,10 @@ import {
   replaceFieldValue,
   setElectronWindowSize
 } from './support/e2e-assertions.js'
+import {
+  clickWhenInteractable,
+  selectByVisibleTextWhenInteractable
+} from './support/e2e-interactions.js'
 import { waitForGmRendererReady } from './support/e2e-ready.js'
 
 describe('Group Loot atomic commit', () => {
@@ -17,18 +21,39 @@ describe('Group Loot atomic commit', () => {
     await (
       await client.$('h1=Session · Gruppenloot-Abnahme')
     ).waitForExist({ timeout: 15_000 })
-    await (await client.$('button=Gruppen managen')).click()
-    const dialog = await client.$(
-      'section[aria-labelledby="group-builder-title"]'
+    await clickWhenInteractable(
+      client,
+      async () => await client.$('button=Gruppen managen')
     )
+    const dialogSelector = 'section[aria-labelledby="group-builder-title"]'
+    let dialog = await client.$(dialogSelector)
     await dialog.waitForDisplayed({ timeout: 10_000 })
-    await (
-      await dialog.$('select[aria-label="Gruppe auswählen"]')
-    ).selectByVisibleText('E2E Gruppenbeute')
-    await (await dialog.$('[role="tab"]=Schatz-Draft')).click()
-    const generate = await dialog.$('button=Loot erzeugen')
-    await client.waitUntil(() => generate.isEnabled(), { timeout: 10_000 })
-    await generate.click()
+    await selectByVisibleTextWhenInteractable(
+      client,
+      async () =>
+        await (
+          await client.$(dialogSelector)
+        ).$('select[aria-label="Gruppe auswählen"]'),
+      'E2E Gruppenbeute'
+    )
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (await client.$(dialogSelector)).$('[role="tab"]=Schatz-Draft')
+    )
+    await client.waitUntil(
+      async () =>
+        await (
+          await (await client.$(dialogSelector)).$('button=Loot erzeugen')
+        ).isEnabled(),
+      { timeout: 10_000 }
+    )
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (await client.$(dialogSelector)).$('button=Loot erzeugen')
+    )
+    dialog = await client.$(dialogSelector)
     const panel = await dialog.$('.group-loot-inline-panel')
     await (
       await panel.$('.generated-loot-results')
@@ -57,32 +82,60 @@ describe('Group Loot atomic commit', () => {
     const containerName = await (
       await container.$('input[aria-label="Behälter"]')
     ).getValue()
-    const assignment = await item.$('select[aria-label="Behälter"]')
-    await assignment.selectByVisibleText(containerName)
+    await selectByVisibleTextWhenInteractable(
+      client,
+      async () => {
+        const currentDialog = await client.$(dialogSelector)
+        const currentPanel = await currentDialog.$('.group-loot-inline-panel')
+        const currentItem = await findStackableItem(
+          await currentPanel.$$('.treasure-item-editor-row')
+        )
+        return await currentItem.$('select[aria-label="Behälter"]')
+      },
+      containerName
+    )
 
     const commit = await panel.$('button=Gruppe & Loot übernehmen')
     expect(await commit.isEnabled()).toBe(true)
-    await commit.click()
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (
+          await (await client.$(dialogSelector)).$('.group-loot-inline-panel')
+        ).$('button=Gruppe & Loot übernehmen')
+    )
+    const readCommitState = async (): Promise<'pending' | 'closed' | 'error'> =>
+      await client.execute((selector) => {
+        const currentDialog = document.querySelector(selector)
+        if (!currentDialog) return 'closed'
+        const error = currentDialog.querySelector('.group-loot-inline-error')
+        return error && error.getClientRects().length > 0 ? 'error' : 'pending'
+      }, dialogSelector)
     try {
       await client.waitUntil(
-        async () =>
-          !(await dialog.isExisting()) ||
-          (await (await panel.$('.group-loot-inline-error')).isDisplayed()),
+        async () => (await readCommitState()) !== 'pending',
         { timeout: 10_000, timeoutMsg: 'Group Loot commit did not settle.' }
       )
     } catch (cause) {
+      const currentPanel = await (
+        await client.$(dialogSelector)
+      ).$('.group-loot-inline-panel')
       throw new Error(
-        `Group Loot commit did not settle: ${await panel.getText()}`,
+        `Group Loot commit did not settle: ${await currentPanel.getText()}`,
         { cause }
       )
     }
-    if (await dialog.isExisting())
+    const commitState = await readCommitState()
+    if (commitState === 'error')
       throw new Error(
-        `Group Loot commit failed: ${await (
-          await panel.$('.group-loot-inline-error')
-        ).getText()}`
+        `Group Loot commit failed: ${await client.execute(
+          (selector) =>
+            document
+              .querySelector(selector)
+              ?.querySelector('.group-loot-inline-error')?.textContent ?? '',
+          dialogSelector
+        )}`
       )
-    await dialog.waitForExist({ reverse: true, timeout: 10_000 })
     await client.reloadSession()
     await waitForGmRendererReady(client)
     const committed = await client.execute(async () => {

--- a/tests/e2e/hex-location-workflow.e2e.ts
+++ b/tests/e2e/hex-location-workflow.e2e.ts
@@ -1,13 +1,13 @@
 import { browser, expect } from '@wdio/globals'
 import type { Browser as WdioBrowser } from 'webdriverio'
 import {
-  clickWhenInteractable,
   expectEditorFrameGeometry,
   expectAccessible,
   expectElementGolden,
   setElectronWindowSize,
   setWindowToMinimumResponsiveSize
 } from './support/e2e-assertions.js'
+import { clickWhenInteractable } from './support/e2e-interactions.js'
 
 describe('Hex World Location creation workflow', () => {
   it('creates, selects and safely auto-places complete World Locations', async () => {
@@ -140,7 +140,10 @@ async function createAndLinkRelatedRecords(client: WdioBrowser) {
     '.modal-backdrop[data-modal-bottom="true"]'
   )
   await (await faction.$('button.faction-table-card')).click()
-  await clickWhenInteractable(await client.$('button=Neue Encounter-Tabelle'))
+  await clickWhenInteractable(
+    client,
+    async () => await client.$('button=Neue Encounter-Tabelle')
+  )
   const factionTable = await client.$('section.encounter-table-manager')
   await (
     await factionTable.$('input[aria-label="Tabellenname"]')

--- a/tests/e2e/session-generation.e2e.ts
+++ b/tests/e2e/session-generation.e2e.ts
@@ -1,6 +1,7 @@
 import { browser, expect } from '@wdio/globals'
 import type { Browser as WdioBrowser } from 'webdriverio'
 import { expectAccessible } from './support/e2e-assertions.js'
+import { clickWhenInteractable } from './support/e2e-interactions.js'
 
 describe('generator preset integration', () => {
   it('resumes durable Planner work across active process restarts', async () => {
@@ -259,8 +260,14 @@ describe('generator preset integration', () => {
       true
     )
 
-    await (await plannerSurface.$('button=Vorbereiten')).click()
-    const confirmation = await client.$('.planner-confirm-dialog')
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (
+          await client.$('section[aria-label="Session-Planer"]')
+        ).$('button=Vorbereiten')
+    )
+    let confirmation = await client.$('.planner-confirm-dialog')
     await confirmation.waitForDisplayed({ timeout: 5_000 })
     await expectAccessible(client)
     expect(
@@ -274,11 +281,26 @@ describe('generator preset integration', () => {
       })
     ).toBe(true)
     await client.keys('Escape')
-    await confirmation.waitForExist({ reverse: true, timeout: 5_000 })
+    await (
+      await client.$('.planner-confirm-dialog')
+    ).waitForExist({ reverse: true, timeout: 5_000 })
 
-    await (await plannerSurface.$('button=Vorbereiten')).click()
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (
+          await client.$('section[aria-label="Session-Planer"]')
+        ).$('button=Vorbereiten')
+    )
+    confirmation = await client.$('.planner-confirm-dialog')
     await confirmation.waitForDisplayed({ timeout: 5_000 })
-    await (await confirmation.$('button=Ersetzen und vorbereiten')).click()
+    await clickWhenInteractable(
+      client,
+      async () =>
+        await (
+          await client.$('.planner-confirm-dialog')
+        ).$('button=Ersetzen und vorbereiten')
+    )
     await (
       await plannerSurface.$('.planner-progress.state-generating')
     ).waitForDisplayed({ timeout: 10_000 })

--- a/tests/e2e/support/campaign-walking-scenarios.ts
+++ b/tests/e2e/support/campaign-walking-scenarios.ts
@@ -1,7 +1,6 @@
 import { browser, expect } from '@wdio/globals'
 import type { Browser as WdioBrowser } from 'webdriverio'
 import {
-  clickWhenInteractable,
   expectAccessible,
   expectAccessibleInBothThemes,
   expectElementGolden,
@@ -9,6 +8,7 @@ import {
   setElectronWindowSize,
   setWindowToMinimumResponsiveSize
 } from './e2e-assertions.js'
+import { clickWhenInteractable } from './e2e-interactions.js'
 
 export async function runCampaignCreationScenario(): Promise<void> {
   const client = browser as unknown as WdioBrowser
@@ -471,7 +471,10 @@ export async function runCampaignCombatScenario(): Promise<void> {
     await factionDialog.$('input[aria-label="Fraktionsname"]')
   ).setValue('Hafenwache')
   await (await factionDialog.$('button.faction-table-card')).click()
-  await clickWhenInteractable(await client.$('button=Neue Encounter-Tabelle'))
+  await clickWhenInteractable(
+    client,
+    async () => await client.$('button=Neue Encounter-Tabelle')
+  )
   const tableDialog = await client.$('section.encounter-table-manager')
   const tableGeometry = await client.execute(() => {
     const layout = document.querySelector('.creature-collection-layout')!

--- a/tests/e2e/support/e2e-assertions.ts
+++ b/tests/e2e/support/e2e-assertions.ts
@@ -233,15 +233,6 @@ export function setWindowToMinimumResponsiveSize(
   )
 }
 
-export async function clickWhenInteractable(
-  element: ChainablePromiseElement
-): Promise<void> {
-  await element.waitForExist({ timeout: 15_000 })
-  await element.scrollIntoView({ block: 'center', inline: 'nearest' })
-  await element.waitForClickable({ timeout: 15_000 })
-  await element.click()
-}
-
 export async function replaceFieldValue(
   client: WdioBrowser,
   input: ChainablePromiseElement,

--- a/tests/e2e/support/e2e-interactions.ts
+++ b/tests/e2e/support/e2e-interactions.ts
@@ -1,0 +1,81 @@
+import type {
+  Browser as WdioBrowser,
+  ChainablePromiseElement
+} from 'webdriverio'
+
+export type E2eElementLocator = () => Promise<ChainablePromiseElement>
+
+export async function clickWhenInteractable(
+  client: WdioBrowser,
+  locate: E2eElementLocator
+): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      let element = await locate()
+      await element.waitForExist({ timeout: 15_000 })
+      await client.execute((target) => {
+        ;(target as unknown as HTMLElement).scrollIntoView({
+          block: 'center',
+          inline: 'nearest'
+        })
+      }, element)
+      element = await locate()
+      await element.waitForClickable({ timeout: 15_000 })
+      await element.click()
+      return
+    } catch (error) {
+      if (attempt === 0 && isStaleElementError(error)) continue
+      throw error
+    }
+  }
+}
+
+export async function selectByVisibleTextWhenInteractable(
+  client: WdioBrowser,
+  locate: E2eElementLocator,
+  visibleText: string
+): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const element = await locate()
+      await element.waitForExist({ timeout: 15_000 })
+      const selectedValue = await client.execute(
+        (target, nextVisibleText) => {
+          const select = target as unknown as HTMLSelectElement
+          const option = [...select.options].find(
+            (candidate) => candidate.text.trim() === nextVisibleText
+          )
+          if (!option)
+            throw new Error(`Select option is missing: ${nextVisibleText}`)
+          select.value = option.value
+          select.dispatchEvent(new Event('input', { bubbles: true }))
+          select.dispatchEvent(new Event('change', { bubbles: true }))
+          return option.value
+        },
+        element,
+        visibleText
+      )
+      await client.waitUntil(
+        async () => (await (await locate()).getValue()) === selectedValue,
+        {
+          timeout: 15_000,
+          timeoutMsg: `Select did not accept ${JSON.stringify(visibleText)}.`
+        }
+      )
+      return
+    } catch (error) {
+      if (attempt === 0 && isStaleElementError(error)) continue
+      throw error
+    }
+  }
+}
+
+export function isStaleElementError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : typeof error === 'string'
+        ? error
+        : JSON.stringify(error)
+  return /stale element(?: reference)?/i.test(message)
+}

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -41,7 +41,7 @@ const valid: CandidateState = {
     url: 'https://github.example/check/1',
     attempt: 1,
     headSha: 'b'.repeat(40),
-    requiredJobManifestVersion: 3,
+    requiredJobManifestVersion: 4,
     jobs: readRequiredJobManifest().jobs.map((job) => ({
       ...job,
       conclusion: 'success' as const

--- a/tests/unit/ci-workflow-policy.test.ts
+++ b/tests/unit/ci-workflow-policy.test.ts
@@ -125,7 +125,7 @@ describe('CI platform partitions', () => {
     expect(aggregate).toContain('SALT_MARCHER_NEEDS_JSON: ${{ toJSON(needs) }}')
   })
 
-  it('shards isolated functional and visual E2E while retaining evidence', () => {
+  it('consumes only registry-generated functional and visual E2E matrices', () => {
     for (const path of [
       '.tmp/e2e-runs',
       '.tmp/visual-diffs',
@@ -133,9 +133,22 @@ describe('CI platform partitions', () => {
     ])
       expect(workflow).toContain(path)
     expect(workflow).toContain('if-no-files-found: error')
-    expect(workflow).toContain('--suite workspaces --suite campaignCreate')
-    expect(workflow).toContain('name: Linux Visual · goldens')
-    expect(workflow).toContain('pnpm test:visual:built')
+    expect(workflow).toContain('id: e2e_matrix')
+    expect(workflow).toContain('run: pnpm e2e:ci-matrix')
+    expect(workflow).toContain(
+      'matrix: ${{ fromJSON(needs.linux-build.outputs.functional_e2e_matrix) }}'
+    )
+    expect(workflow).toContain(
+      'matrix: ${{ fromJSON(needs.linux-build.outputs.visual_e2e_matrix) }}'
+    )
+    expect(workflow).toContain('name: Linux Visual · ${{ matrix.shard }}')
+    expect(workflow).toContain(
+      'pnpm test:e2e:built -- --ci-shard "${{ matrix.shard }}"'
+    )
+    expect(workflow).toContain(
+      'pnpm test:visual:built -- --ci-shard "${{ matrix.shard }}"'
+    )
+    expect(workflow).not.toMatch(/--suite\s+(?:workspaces|campaignCreate)/)
   })
 
   it('runs only candidate attestation after the exact SHA reaches main', () => {

--- a/tests/unit/delivery-contract.test.ts
+++ b/tests/unit/delivery-contract.test.ts
@@ -18,9 +18,9 @@ const sha = 'a'.repeat(40)
 describe('delivery contract', () => {
   it('loads an ordered, unique required-job manifest', () => {
     const manifest = readRequiredJobManifest()
-    expect(manifest.schemaVersion).toBe(3)
-    expect(manifest.jobs).toHaveLength(13)
-    expect(new Set(manifest.jobs.map(({ name }) => name)).size).toBe(13)
+    expect(manifest.schemaVersion).toBe(4)
+    expect(manifest.jobs).toHaveLength(15)
+    expect(new Set(manifest.jobs.map(({ name }) => name)).size).toBe(15)
     expect(() =>
       requiredJobManifestSchema.parse({
         ...manifest,
@@ -36,7 +36,7 @@ describe('delivery contract', () => {
       runId: 123,
       attempt: 2,
       headSha: sha,
-      requiredJobManifestVersion: 3
+      requiredJobManifestVersion: 4
     })
     expect(evidence.jobs.map(({ name }) => name)).toEqual(
       manifest.jobs.map(({ name }) => name)

--- a/tests/unit/e2e-ci-matrix.test.ts
+++ b/tests/unit/e2e-ci-matrix.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  e2eCiMatrix,
+  e2eCiSuites,
+  measuredE2eCiSeconds
+} from '../../scripts/e2e-ci-matrix.js'
+import {
+  e2eSuiteHasType,
+  e2eSuiteRegistry
+} from '../../scripts/e2e-suite-registry.js'
+
+describe('E2E CI matrix', () => {
+  it('derives four functional shards exclusively from the suite registry', () => {
+    const matrix = e2eCiMatrix('functional')
+    expect(matrix.include).toHaveLength(4)
+    expect(
+      matrix.include.flatMap(({ shard }) => e2eCiSuites('functional', shard))
+    ).toEqual(e2eSuiteRegistry.map((suite) => suite.name))
+  })
+
+  it('balances measured visual suites across three typed shards', () => {
+    const matrix = e2eCiMatrix('visual')
+    expect(matrix.include).toHaveLength(3)
+    const selected = matrix.include.flatMap(({ shard }) =>
+      e2eCiSuites('visual', shard)
+    )
+    expect(selected.toSorted()).toEqual(
+      e2eSuiteRegistry
+        .filter((suite) => e2eSuiteHasType(suite, 'visual'))
+        .map((suite) => suite.name)
+        .toSorted()
+    )
+    expect(
+      matrix.include.map(({ shard }) => measuredE2eCiSeconds('visual', shard))
+    ).toEqual([181, 255, 182])
+  })
+
+  it('fails closed for unknown shard names', () => {
+    expect(() => e2eCiSuites('functional', 'unknown')).toThrow(
+      'Unknown functional E2E CI shard'
+    )
+    expect(() => e2eCiSuites('visual', 'unknown')).toThrow(
+      'Unknown visual E2E CI shard'
+    )
+  })
+})

--- a/tests/unit/e2e-interactions.test.ts
+++ b/tests/unit/e2e-interactions.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  Browser as WdioBrowser,
+  ChainablePromiseElement
+} from 'webdriverio'
+import {
+  clickWhenInteractable,
+  isStaleElementError,
+  selectByVisibleTextWhenInteractable,
+  type E2eElementLocator
+} from '../e2e/support/e2e-interactions.js'
+
+describe('E2E interactions', () => {
+  it('waits, DOM-scrolls, resolves again, checks clickability and clicks', async () => {
+    const events: string[] = []
+    const first = element(events, 'first')
+    const refreshed = element(events, 'refreshed')
+    const locate = vi
+      .fn<E2eElementLocator>()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(refreshed)
+    const client = browser(events)
+
+    await clickWhenInteractable(client, locate)
+
+    expect(events).toEqual([
+      'first:exist',
+      'browser:execute',
+      'first:dom-scroll',
+      'refreshed:clickable',
+      'refreshed:click'
+    ])
+    expect(locate).toHaveBeenCalledTimes(2)
+  })
+
+  it('repeats the bounded sequence exactly once for a stale element', async () => {
+    const events: string[] = []
+    const stale = element(events, 'stale', new Error('stale element reference'))
+    const locate = vi
+      .fn<E2eElementLocator>()
+      .mockReturnValueOnce(element(events, 'first'))
+      .mockReturnValueOnce(stale)
+      .mockReturnValueOnce(element(events, 'retry-first'))
+      .mockReturnValueOnce(element(events, 'retry-refreshed'))
+
+    await clickWhenInteractable(browser(events), locate)
+
+    expect(locate).toHaveBeenCalledTimes(4)
+    expect(events.filter((event) => event === 'browser:execute')).toHaveLength(
+      2
+    )
+  })
+
+  it('does not repeat non-stale failures or a second stale failure', async () => {
+    const nonStale = new Error('element is not clickable')
+    const nonStaleLocator = vi
+      .fn<E2eElementLocator>()
+      .mockReturnValue(element([], 'non-stale', nonStale))
+    await expect(
+      clickWhenInteractable(browser([]), nonStaleLocator)
+    ).rejects.toBe(nonStale)
+    expect(nonStaleLocator).toHaveBeenCalledTimes(2)
+
+    const stale = new Error('stale element reference')
+    const staleLocator = vi
+      .fn<E2eElementLocator>()
+      .mockReturnValue(element([], 'stale', stale))
+    await expect(clickWhenInteractable(browser([]), staleLocator)).rejects.toBe(
+      stale
+    )
+    expect(staleLocator).toHaveBeenCalledTimes(4)
+    expect(isStaleElementError(stale)).toBe(true)
+  })
+
+  it('selects through the DOM and confirms through a fresh element', async () => {
+    const events: string[] = []
+    const state = { value: '' }
+    const locate = vi
+      .fn<E2eElementLocator>()
+      .mockImplementation(() => selectElement(events, state))
+
+    await selectByVisibleTextWhenInteractable(
+      browser(events),
+      locate,
+      'Expected option'
+    )
+
+    expect(state.value).toBe('expected')
+    expect(locate).toHaveBeenCalledTimes(2)
+    expect(events).toEqual([
+      'select:exist',
+      'browser:execute',
+      'select:input',
+      'select:change',
+      'browser:wait',
+      'select:value'
+    ])
+  })
+})
+
+function browser(events: string[]): WdioBrowser {
+  return {
+    execute: (
+      script: (...arguments_: unknown[]) => unknown,
+      ...arguments_: unknown[]
+    ) => {
+      events.push('browser:execute')
+      return Promise.resolve(script(...arguments_))
+    },
+    waitUntil: (condition: () => Promise<boolean>) => {
+      events.push('browser:wait')
+      return condition().then((result) => {
+        if (!result) throw new Error('Mock condition did not pass')
+        return true
+      })
+    }
+  } as unknown as WdioBrowser
+}
+
+function element(
+  events: string[],
+  name: string,
+  clickError?: Error
+): Promise<ChainablePromiseElement> {
+  const value = {
+    waitForExist: () => {
+      events.push(`${name}:exist`)
+      return Promise.resolve(true)
+    },
+    scrollIntoView: () => events.push(`${name}:dom-scroll`),
+    waitForClickable: () => {
+      events.push(`${name}:clickable`)
+      return Promise.resolve(true)
+    },
+    click: () => {
+      events.push(`${name}:click`)
+      return clickError ? Promise.reject(clickError) : Promise.resolve()
+    }
+  } as unknown as ChainablePromiseElement
+  return Promise.resolve(value)
+}
+
+function selectElement(
+  events: string[],
+  state: { value: string }
+): Promise<ChainablePromiseElement> {
+  const value = {
+    options: [{ text: 'Expected option', value: 'expected' }],
+    get value() {
+      return state.value
+    },
+    set value(next: string) {
+      state.value = next
+    },
+    dispatchEvent: (event: Event) => {
+      events.push(`select:${event.type}`)
+      return true
+    },
+    waitForExist: () => {
+      events.push('select:exist')
+      return Promise.resolve(true)
+    },
+    getValue: () => {
+      events.push('select:value')
+      return Promise.resolve(state.value)
+    }
+  } as unknown as ChainablePromiseElement
+  return Promise.resolve(value)
+}

--- a/tests/unit/e2e-run-receipt.test.ts
+++ b/tests/unit/e2e-run-receipt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  e2eShardDurationMs,
   initializeE2eResults,
   recordE2eAttempt,
   validateE2eResumeIdentity,
@@ -47,6 +48,7 @@ describe('E2E run receipt resume', () => {
       'flaky-suite.attempt-2.log'
     ])
     expect(completed.every((result) => result.status === 'passed')).toBe(true)
+    expect(e2eShardDurationMs(completed)).toBe(22)
   })
 
   it('rejects reuse after any build, registry, or suite-set change', () => {
@@ -56,6 +58,21 @@ describe('E2E run receipt resume', () => {
         buildIdentity: 'changed',
         registryIdentity: value.registryIdentity,
         selectedSuites: value.selectedSuites
+      })
+    ).toThrow('Cannot resume')
+  })
+
+  it('binds resume identity to the generated CI shard', () => {
+    const value = {
+      ...summary(initializeE2eResults(['one'], null)),
+      ciShard: 'a'
+    }
+    expect(() =>
+      validateE2eResumeIdentity(value, {
+        buildIdentity: value.buildIdentity,
+        registryIdentity: value.registryIdentity,
+        selectedSuites: value.selectedSuites,
+        ciShard: 'b'
       })
     ).toThrow('Cannot resume')
   })

--- a/tests/unit/e2e-runner-core.test.ts
+++ b/tests/unit/e2e-runner-core.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   classifyE2eFailure,
-  classifyE2eLogLine
+  classifyE2eLogLine,
+  countE2eRegressionWarnings,
+  e2eExitCodeWithWarningRegressions
 } from '../../scripts/e2e-runner-core.js'
 import {
   shouldAbortE2eRun,
@@ -9,17 +11,17 @@ import {
 } from '../../scripts/e2e-failure-diagnostics.js'
 
 describe('E2E runner diagnostics', () => {
-  it('filters only the known Webdriver compatibility fallback', () => {
+  it('does not hide Webdriver interaction regressions as known noise', () => {
     expect(
       classifyE2eLogLine(
         'WARN Browser.getWindowForTarget is not supported; using fallback'
       )
-    ).toBe('known-noise')
+    ).toBe('diagnostic')
     expect(
       classifyE2eLogLine(
         "WebDriverError: unknown command: 'Browser.getWindowForTarget' wasn't found"
       )
-    ).toBe('known-noise')
+    ).toBe('diagnostic')
     expect(
       classifyE2eLogLine('ERROR Browser.getWindowForTarget destroyed the app')
     ).toBe('diagnostic')
@@ -37,6 +39,36 @@ describe('E2E runner diagnostics', () => {
     expect(
       classifyE2eLogLine('Could not verify fuse configuration: invalid binary')
     ).toBe('diagnostic')
+  })
+
+  it('requires zero window/rect, scroll fallback and stale-element warnings', () => {
+    const clean = countE2eRegressionWarnings('ordinary Webdriver output')
+    expect(clean).toEqual({
+      windowRect: 0,
+      scrollFallback: 0,
+      staleElement: 0
+    })
+    expect(e2eExitCodeWithWarningRegressions(0, clean)).toBe(0)
+
+    const warnings = countE2eRegressionWarnings(
+      [
+        'when running "window/rect" with method "GET"',
+        'Re-attempting using `Element.scrollIntoView` via Web API.',
+        'WARN webdriver: Request encountered a stale element - terminating request'
+      ].join('\n')
+    )
+    expect(warnings).toEqual({
+      windowRect: 1,
+      scrollFallback: 1,
+      staleElement: 1
+    })
+    expect(e2eExitCodeWithWarningRegressions(0, warnings)).toBe(1)
+    expect(e2eExitCodeWithWarningRegressions(7, warnings)).toBe(7)
+    expect(
+      countE2eRegressionWarnings(
+        'INFO webdriver: DATA {"script":"throw new Error(\\"stale element reference\\")"}'
+      ).staleElement
+    ).toBe(0)
   })
 
   it('distinguishes runner infrastructure from product failures', () => {

--- a/tests/unit/e2e-suite-registry.test.ts
+++ b/tests/unit/e2e-suite-registry.test.ts
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { e2eSuiteRegistry } from '../../scripts/e2e-suite-registry.js'
+import {
+  e2eSuiteHasType,
+  e2eSuiteRegistry
+} from '../../scripts/e2e-suite-registry.js'
 import {
   validateVisualGoldenSuites,
   type VisualGoldenEntry
@@ -51,6 +54,14 @@ describe('E2E suite registry', () => {
       ).toContain(`'${golden.name}'`)
     for (const golden of manifest.goldens)
       expect(e2eSources).toContain(golden.testPattern)
+    expect(
+      [...new Set(manifest.goldens.map((golden) => golden.suite))].toSorted()
+    ).toEqual(
+      e2eSuiteRegistry
+        .filter((suite) => e2eSuiteHasType(suite, 'visual'))
+        .map((suite) => suite.name)
+        .toSorted()
+    )
   })
 
   it('keeps behavior selectors free of positional DOM coupling', () => {

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -179,7 +179,7 @@ function createFixture(failOnce?: HandoffPhaseName): {
         url: 'https://github.example/runs/1',
         attempt: 1,
         headSha: 'a'.repeat(40),
-        requiredJobManifestVersion: 3,
+        requiredJobManifestVersion: 4,
         jobs: [
           {
             name: 'required',


### PR DESCRIPTION
## Summary
- derive functional and visual CI matrices from the typed E2E suite registry
- keep local suites serial with fresh Electron/profile isolation and factory-based interactions
- fail on window/rect, scroll-fallback, or stale-element warning regressions and record atomic suite/shard timings
- update the exact required-check manifest for three measured visual shards

## Local qualification
- pnpm check
- 14 functional E2E suites, all warning categories zero
- 7 visual E2E suites, all warning categories zero
- app-build input fingerprint unchanged: 46492a32f2e5c0b4eded345333a54932566e3141589d5715ddf0deb9209e9f6f