### PR TITLE
Phase 5: add conservative local storage retention

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -259,6 +259,12 @@ verifiable phases:
    reuses that artifact only after complete run, inventory, input, toolchain,
    manifest, and byte-hash validation; host smoke, data backup, installation,
    and runtime verification remain local.
+7. Local storage retention is a post-runtime, hash-chained handoff checkpoint.
+   It keeps the active deployment, two valid inactive predecessors, and every
+   nonterminal-journal reference; invalid or foreign entries remain untouched.
+   Campaign backups are never automatically deleted and require exact,
+   single-target manifest confirmation. Terminal invocation details are capped
+   at 100 while SHA state receipts and nonterminal attempts remain durable.
 
 The editor application-layer refactor tracks its normative evidence in
 `application-layer-refactor-acceptance-matrix.md`. It moves the two-step

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -357,14 +357,35 @@ next invocation, the journal and actual `current` pointer deterministically
 finish the new state or restore the old one. Backup copying hashes each source
 byte during its single copy pass and rereads only the backup for verification;
 backup manifests retain role-specific schema and both build identities.
-Backups and immutable deployments are never automatically deleted. The
-installer stages fingerprint-addressed deployments and atomically switches
+Campaign backups are never automatically deleted. They may be removed only by
+an explicit single-target maintenance command that proves the complete backup
+manifest and file inventory, refuses the five newest backups and backups under
+30 days old, and remains a dry-run without the exact manifest SHA. Crossing 50
+backups or 1 GiB produces a non-blocking storage warning only.
+`pnpm local-storage:inspect -- --json` is the read-only inventory boundary;
+`pnpm local-storage:prune -- --backup <name> --confirm-manifest-sha <sha>` is
+the sole deletion boundary and accepts exactly one direct-child backup name.
+
+Immutable deployments are eligible for automatic retention only after the
+installed runtime has been verified. Retention keeps the active deployment,
+the two newest valid inactive deployments, and every deployment referenced by
+a nonterminal installation journal. A deletion candidate must be a direct
+64-hex child whose directory fingerprint, artifact manifest, receipt hash,
+AppImage hash, icon hash, and ownership all validate immediately before
+removal. Unknown, damaged, ambiguous, journal-protected, or foreign entries are
+reported and preserved. Deletion failures fail the retention checkpoint but do
+not roll back the already verified installation.
+
+The installer stages fingerprint-addressed deployments and atomically switches
 one `current` symlink only after all deployment files are durable. For each
 immutable application SHA, the handoff advances one explicit state through
 `candidate-qualified`, `checked`, `packaged`, `packaged-smoke-passed`,
 `backup-created`, `deployment-staged`, `activated`, and
-`installed-runtime-verified`. Every phase binds its predecessor output and its
-own result by SHA-256 and is reusable only while current evidence still matches.
+`installed-runtime-verified`, then `storage-retention-applied`. The final
+checkpoint records retained and deleted deployment fingerprints, findings,
+warnings, and actually released bytes. Every phase binds its predecessor output
+and its own result by SHA-256 and is reusable only while current evidence still
+matches.
 Repeated invocations are safe and append audit attempts; they do not create a
 parallel state or replace the original state's provenance. Explicit `--resume`
 records recovery intent but follows the same validation rules. Auth, live
@@ -373,6 +394,11 @@ before a material state or attempt is created. The handoff downloads only the
 artifact belonging to the exact successful required-job run, verifies its
 closed three-file inventory and complete hash chain, and accepts it only when
 its clean SHA, workspace and app-input fingerprint match the local candidate.
+Final SHA-keyed state receipts are permanent. Invocation and per-attempt detail
+retention keeps the newest 100 terminal records and every nonterminal record;
+only detail files no longer referenced after that classification may be
+removed.
+
 Remote required-job evidence satisfies `checked`; the downloaded Local package
 satisfies `packaged`. The actual downloaded AppImage is still smoke-tested on
 the handoff host before any campaign backup, deployment, activation, or

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "package:release:built": "tsx scripts/package-app.ts --channel release",
     "install:local:built": "tsx scripts/install-local-app.ts",
     "handoff:app": "tsx scripts/handoff-local-app.ts",
+    "local-storage:inspect": "tsx scripts/inspect-local-storage.ts",
+    "local-storage:prune": "tsx scripts/prune-local-storage.ts",
     "candidate-artifact:write": "tsx scripts/write-candidate-artifact-receipt.ts",
     "delivery:verify-exact-sha-aggregate": "tsx scripts/verify-exact-sha-aggregate.ts",
     "delivery:verify-repository-policy": "tsx scripts/verify-repository-policy.ts",

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -14,7 +14,8 @@ export const handoffPhases = [
   'backup-created',
   'deployment-staged',
   'activated',
-  'installed-runtime-verified'
+  'installed-runtime-verified',
+  'storage-retention-applied'
 ] as const
 export const handoffPhaseNameSchema = z.enum(handoffPhases)
 export type HandoffPhaseName = z.infer<typeof handoffPhaseNameSchema>
@@ -150,6 +151,19 @@ export type InstalledRuntimeEvidence = z.infer<
   typeof installedRuntimeEvidenceSchema
 >
 
+export const storageRetentionEvidenceSchema = z
+  .object({
+    receiptSha256: fingerprintSchema,
+    activeDeploymentFingerprint: fingerprintSchema,
+    retainedDeploymentFingerprints: z.array(fingerprintSchema),
+    deletedDeploymentFingerprints: z.array(fingerprintSchema),
+    releasedBytes: z.number().int().nonnegative(),
+    retainedInvocations: z.number().int().nonnegative(),
+    removedInvocations: z.number().int().nonnegative(),
+    removedAttemptFiles: z.array(z.string())
+  })
+  .strict()
+
 export const handoffPhaseEvidenceSchema = z
   .object({
     workspaceFingerprint: fingerprintSchema,
@@ -165,7 +179,8 @@ export const handoffPhaseEvidenceSchema = z
     backupManifestSha256: fingerprintSchema.nullable(),
     deploymentManifestSha256: fingerprintSchema.nullable(),
     runtimeEvidenceSha256: fingerprintSchema.nullable(),
-    installedSha256: fingerprintSchema.nullable()
+    installedSha256: fingerprintSchema.nullable(),
+    storageRetention: storageRetentionEvidenceSchema.nullable()
   })
   .strict()
 
@@ -184,7 +199,7 @@ export const handoffPhaseSchema = z
 
 export const handoffReceiptSchema = z
   .object({
-    formatVersion: z.literal(5),
+    formatVersion: z.literal(6),
     stateId: z.uuid(),
     originAttemptId: z.uuid(),
     activeAttemptId: z.uuid(),
@@ -234,6 +249,25 @@ export const handoffReceiptSchema = z
     let predecessor = hashHandoffValue(receipt.identity)
     let incompleteSeen = false
     for (const [index, phase] of receipt.phases.entries()) {
+      if (
+        phase.phase === 'storage-retention-applied' &&
+        phase.status === 'completed' &&
+        phase.evidence?.storageRetention == null
+      )
+        context.addIssue({
+          code: 'custom',
+          message: 'Completed storage retention requires retention evidence',
+          path: ['phases', index, 'evidence', 'storageRetention']
+        })
+      if (
+        phase.phase !== 'storage-retention-applied' &&
+        phase.evidence?.storageRetention != null
+      )
+        context.addIssue({
+          code: 'custom',
+          message: 'Storage-retention evidence belongs only to its checkpoint',
+          path: ['phases', index, 'evidence', 'storageRetention']
+        })
       if (phase.status !== 'completed') {
         incompleteSeen = true
         continue
@@ -286,7 +320,7 @@ export function createHandoffReceipt(
   timestamp: string
 ): HandoffReceipt {
   return handoffReceiptSchema.parse({
-    formatVersion: 5,
+    formatVersion: 6,
     stateId,
     originAttemptId: attemptId,
     activeAttemptId: attemptId,

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -54,6 +54,11 @@ import {
   type LocalInstallationTarget
 } from './local-app-installation.js'
 import { removeSupersededLocalInstallation } from './local-installation-legacy.js'
+import {
+  applyStorageRetention,
+  collectStorageRetentionReceipt,
+  storageRetentionReceiptPath
+} from './local-storage/retention.js'
 
 if (process.platform !== 'linux')
   throw new Error('SaltMarcher Local handoff currently targets Linux AppImage')
@@ -256,6 +261,26 @@ function phaseDefinitions(): readonly HandoffPhaseDefinition[] {
         })
       },
       collect: collectRuntimeEvidence
+    },
+    {
+      phase: 'storage-retention-applied',
+      execute: () => {
+        const retention = applyStorageRetention({
+          paths: installation,
+          iconSourcePath: installOptions.iconSourcePath,
+          receiptDirectory,
+          applicationSha: workspace.commit
+        })
+        for (const warning of retention.deployment.warnings)
+          console.warn(
+            JSON.stringify({
+              component: 'local-storage',
+              event: 'capacity-warning',
+              ...warning
+            })
+          )
+      },
+      collect: collectStorageRetentionEvidence
     }
   ]
 }
@@ -335,6 +360,34 @@ function collectRuntimeEvidence(): HandoffPhaseEvidence {
   }
 }
 
+function collectStorageRetentionEvidence(): HandoffPhaseEvidence {
+  const installed = collectRuntimeEvidence()
+  const retained = collectStorageRetentionReceipt({
+    paths: installation,
+    iconSourcePath: installOptions.iconSourcePath,
+    receiptDirectory,
+    applicationSha: workspace.commit
+  })
+  return {
+    ...installed,
+    storageRetention: {
+      receiptSha256: sha256File(storageRetentionReceiptPath(receiptDirectory)),
+      activeDeploymentFingerprint:
+        retained.deployment.activeDeploymentFingerprint,
+      retainedDeploymentFingerprints: [
+        ...retained.deployment.retainedDeploymentFingerprints
+      ],
+      deletedDeploymentFingerprints: [
+        ...retained.deployment.deletedDeploymentFingerprints
+      ],
+      releasedBytes: retained.deployment.releasedBytes,
+      retainedInvocations: retained.audit.retainedInvocations,
+      removedInvocations: retained.audit.removedInvocations,
+      removedAttemptFiles: [...retained.audit.removedAttemptFiles]
+    }
+  }
+}
+
 function evidence(
   input: {
     readonly buildOutputHash?: string
@@ -344,6 +397,7 @@ function evidence(
     readonly deploymentManifestSha256?: string
     readonly runtimeEvidenceSha256?: string
     readonly installedSha256?: string
+    readonly storageRetention?: HandoffPhaseEvidence['storageRetention']
   } = {}
 ): HandoffPhaseEvidence {
   assertWorkspaceUnchanged()
@@ -361,7 +415,8 @@ function evidence(
     backupManifestSha256: input.backupManifestSha256 ?? null,
     deploymentManifestSha256: input.deploymentManifestSha256 ?? null,
     runtimeEvidenceSha256: input.runtimeEvidenceSha256 ?? null,
-    installedSha256: input.installedSha256 ?? null
+    installedSha256: input.installedSha256 ?? null,
+    storageRetention: input.storageRetention ?? null
   }
 }
 

--- a/scripts/inspect-local-storage.ts
+++ b/scripts/inspect-local-storage.ts
@@ -1,0 +1,31 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { localInstallationPaths } from './local-app-installation.js'
+import { inspectLocalStorage } from './local-storage/inspection.js'
+
+const rawArguments = process.argv.slice(2)
+const arguments_ =
+  rawArguments[0] === '--' ? rawArguments.slice(1) : rawArguments
+if (
+  arguments_.length > 1 ||
+  (arguments_.length === 1 && arguments_[0] !== '--json')
+)
+  throw new Error('Usage: local-storage:inspect -- [--json]')
+
+const workspaceRoot = process.cwd()
+const paths = localInstallationPaths(
+  process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
+)
+const inspection = inspectLocalStorage({
+  paths,
+  iconSourcePath: resolve(
+    workspaceRoot,
+    'resources',
+    'icons',
+    'salt-marcher.png'
+  )
+})
+
+console.info(
+  JSON.stringify(inspection, null, arguments_[0] === '--json' ? 2 : 0)
+)

--- a/scripts/local-storage/audit-retention.ts
+++ b/scripts/local-storage/audit-retention.ts
@@ -1,0 +1,166 @@
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  rmSync
+} from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+import {
+  handoffInvocationHistorySchema,
+  parseHandoffInvocationHistory,
+  type HandoffInvocationHistory
+} from '../delivery-contract.js'
+import {
+  retainedTerminalAuditEntries,
+  type AuditRetentionResult,
+  type StorageFinding
+} from './contract.js'
+import { atomicWrite, syncDirectory } from './filesystem.js'
+
+export interface ApplyAuditRetentionOptions {
+  readonly receiptDirectory: string
+  readonly removeFile?: (path: string) => void
+}
+
+const attemptReceiptStatusSchema = z
+  .object({
+    activeAttemptId: z.uuid(),
+    status: z.enum(['running', 'complete', 'failed'])
+  })
+  .passthrough()
+
+export function applyAuditRetention(
+  options: ApplyAuditRetentionOptions
+): AuditRetentionResult {
+  const historyPath = join(options.receiptDirectory, 'invocations.json')
+  if (!existsSync(historyPath))
+    return {
+      retainedInvocations: 0,
+      removedInvocations: 0,
+      removedAttemptFiles: [],
+      findings: []
+    }
+
+  const history = parseHandoffInvocationHistory(
+    JSON.parse(readFileSync(historyPath, 'utf8'))
+  )
+  const findings: StorageFinding[] = []
+  const terminal = new Map<string, boolean>()
+  for (const invocation of history.invocations) {
+    try {
+      const receipt = attemptReceiptStatusSchema.parse(
+        JSON.parse(readFileSync(invocation.auditPath, 'utf8'))
+      )
+      if (receipt.activeAttemptId !== invocation.attemptId)
+        throw new Error(
+          'Attempt receipt identity does not match its invocation'
+        )
+      terminal.set(
+        invocation.attemptId,
+        receipt.status === 'complete' || receipt.status === 'failed'
+      )
+    } catch (error) {
+      terminal.set(invocation.attemptId, false)
+      findings.push({
+        area: 'audit',
+        name: invocation.attemptId,
+        reason: errorMessage(error)
+      })
+    }
+  }
+
+  const retainedTerminalIds = new Set(
+    history.invocations
+      .filter(({ attemptId }) => terminal.get(attemptId) === true)
+      .sort(newestInvocationFirst)
+      .slice(0, retainedTerminalAuditEntries)
+      .map(({ attemptId }) => attemptId)
+  )
+  const retainedInvocations = history.invocations.filter(
+    ({ attemptId }) =>
+      terminal.get(attemptId) !== true || retainedTerminalIds.has(attemptId)
+  )
+  const removedInvocations = history.invocations.filter(
+    ({ attemptId }) =>
+      terminal.get(attemptId) === true && !retainedTerminalIds.has(attemptId)
+  )
+  const retainedIds = new Set(
+    retainedInvocations.map(({ attemptId }) => attemptId)
+  )
+
+  const next: HandoffInvocationHistory = handoffInvocationHistorySchema.parse({
+    formatVersion: 2,
+    invocations: retainedInvocations
+  })
+  if (removedInvocations.length > 0)
+    atomicWrite(historyPath, `${JSON.stringify(next, null, 2)}\n`)
+
+  const removeFile = options.removeFile ?? ((path: string) => rmSync(path))
+  const removedAttemptFiles: string[] = []
+  const attemptsDirectory = join(options.receiptDirectory, 'attempts')
+  if (existsSync(attemptsDirectory)) {
+    for (const name of readdirSync(attemptsDirectory).sort()) {
+      if (removedAttemptFiles.includes(name)) continue
+      const path = join(attemptsDirectory, name)
+      if (!/^[0-9a-f-]{36}\.json$/.test(name)) {
+        findings.push({
+          area: 'audit',
+          name,
+          reason: 'Unknown attempt-detail entry was preserved'
+        })
+        continue
+      }
+      let receipt: z.infer<typeof attemptReceiptStatusSchema>
+      try {
+        const stats = lstatSync(path)
+        if (!stats.isFile() || stats.isSymbolicLink())
+          throw new Error('Attempt detail is not an owned regular file')
+        receipt = attemptReceiptStatusSchema.parse(
+          JSON.parse(readFileSync(path, 'utf8'))
+        )
+        if (`${receipt.activeAttemptId}.json` !== name)
+          throw new Error('Attempt detail filename and identity differ')
+      } catch (error) {
+        findings.push({ area: 'audit', name, reason: errorMessage(error) })
+        continue
+      }
+      if (
+        !retainedIds.has(receipt.activeAttemptId) &&
+        (receipt.status === 'complete' || receipt.status === 'failed')
+      ) {
+        removeFile(path)
+        removedAttemptFiles.push(name)
+      }
+    }
+  }
+  if (removedAttemptFiles.length > 0) syncDirectory(attemptsDirectory)
+
+  return {
+    retainedInvocations: retainedInvocations.length,
+    removedInvocations: removedInvocations.length,
+    removedAttemptFiles,
+    findings: findings.sort(findingOrder)
+  }
+}
+
+function newestInvocationFirst(
+  left: HandoffInvocationHistory['invocations'][number],
+  right: HandoffInvocationHistory['invocations'][number]
+): number {
+  return right.createdAt === left.createdAt
+    ? right.attemptId.localeCompare(left.attemptId, 'en')
+    : right.createdAt.localeCompare(left.createdAt, 'en')
+}
+
+function findingOrder(left: StorageFinding, right: StorageFinding): number {
+  return `${left.name}:${left.reason}`.localeCompare(
+    `${right.name}:${right.reason}`,
+    'en'
+  )
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/scripts/local-storage/backup-prune.ts
+++ b/scripts/local-storage/backup-prune.ts
@@ -1,0 +1,111 @@
+import { existsSync, rmSync } from 'node:fs'
+import { basename } from 'node:path'
+import type { LocalInstallationPaths } from '../local-installation/contract.js'
+import { withInstallationLock } from '../local-installation/installation-lock.js'
+import {
+  sha256Pattern,
+  type BackupPruneResult,
+  type ValidBackup
+} from './contract.js'
+import { syncDirectory } from './filesystem.js'
+import { inspectLocalStorage, validateBackupDirectory } from './inspection.js'
+
+export interface PruneLocalBackupOptions {
+  readonly paths: LocalInstallationPaths
+  readonly iconSourcePath: string
+  readonly backup: string
+  readonly confirmManifestSha?: string
+  readonly now?: () => Date
+  readonly removeDirectory?: (path: string) => void
+}
+
+export function pruneLocalBackup(
+  options: PruneLocalBackupOptions
+): BackupPruneResult {
+  assertExactBackupName(options.backup)
+  const inspected = selectBackup(options)
+  if (typeof inspected === 'string') return refusal(options, inspected)
+  if (options.confirmManifestSha === undefined)
+    return {
+      backup: options.backup,
+      manifestSha256: inspected.manifestSha256,
+      dryRun: true,
+      deleted: false,
+      releasedBytes: inspected.bytes,
+      refusal: null
+    }
+  if (!sha256Pattern.test(options.confirmManifestSha))
+    return refusal(options, 'Confirmation is not a complete manifest SHA-256')
+
+  return withInstallationLock(options.paths, () => {
+    const current = selectBackup(options)
+    if (typeof current === 'string') return refusal(options, current)
+    if (current.manifestSha256 !== options.confirmManifestSha)
+      return refusal(options, 'Confirmation does not match the backup manifest')
+    const validated = validateBackupDirectory(
+      current.path,
+      current.name,
+      current.bytes
+    )
+    if (
+      validated.manifestSha256 !== current.manifestSha256 ||
+      validated.bytes !== current.bytes
+    )
+      return refusal(options, 'Backup changed immediately before deletion')
+    const removeDirectory =
+      options.removeDirectory ??
+      ((path: string) => rmSync(path, { recursive: true, force: false }))
+    removeDirectory(current.path)
+    if (existsSync(current.path))
+      throw new Error(`Backup removal was incomplete: ${current.name}`)
+    syncDirectory(options.paths.backups)
+    return {
+      backup: current.name,
+      manifestSha256: current.manifestSha256,
+      dryRun: false,
+      deleted: true,
+      releasedBytes: current.bytes,
+      refusal: null
+    }
+  })
+}
+
+function selectBackup(options: PruneLocalBackupOptions): ValidBackup | string {
+  const inspection = inspectLocalStorage(options)
+  const finding = inspection.findings.find(
+    ({ area, name }) => area === 'backups' && name === options.backup
+  )
+  if (finding !== undefined) return `Backup is invalid: ${finding.reason}`
+  const backup = inspection.backups.find(({ name }) => name === options.backup)
+  if (backup === undefined) return 'Backup does not exist'
+  if (backup.protectedByRecency)
+    return 'The five newest valid backups cannot be pruned'
+  if (backup.protectedByAge)
+    return 'Backups younger than 30 days cannot be pruned'
+  return backup
+}
+
+function assertExactBackupName(name: string): void {
+  if (
+    name.length === 0 ||
+    basename(name) !== name ||
+    name === '.' ||
+    name === '..' ||
+    ['*', '?', '[', ']', '{', '}'].some((character) => name.includes(character))
+  )
+    throw new Error('Backup pruning accepts one exact direct-child name only')
+}
+
+function refusal(
+  options: PruneLocalBackupOptions,
+  reason: string
+): BackupPruneResult {
+  return {
+    backup: options.backup,
+    manifestSha256: null,
+    dryRun: options.confirmManifestSha === undefined,
+    deleted: false,
+    releasedBytes: 0,
+    refusal: reason
+  }
+}

--- a/scripts/local-storage/contract.ts
+++ b/scripts/local-storage/contract.ts
@@ -1,0 +1,86 @@
+export interface StorageFinding {
+  readonly area: 'deployments' | 'backups' | 'audit'
+  readonly name: string
+  readonly reason: string
+}
+
+export interface StorageWarning {
+  readonly code: 'backup-count-high' | 'backup-bytes-high'
+  readonly message: string
+}
+
+export interface ValidDeployment {
+  readonly fingerprint: string
+  readonly path: string
+  readonly builtAt: string
+  readonly bytes: number
+  readonly manifestSha256: string
+  readonly active: boolean
+  readonly journalProtected: boolean
+  readonly retention: 'keep' | 'delete'
+}
+
+export interface ValidBackup {
+  readonly name: string
+  readonly path: string
+  readonly createdAt: string
+  readonly bytes: number
+  readonly manifestSha256: string
+  readonly protectedByRecency: boolean
+  readonly protectedByAge: boolean
+  readonly pruneEligible: boolean
+}
+
+export interface LocalStorageInspection {
+  readonly formatVersion: 1
+  readonly installationRoot: string
+  readonly activeDeploymentFingerprint: string | null
+  readonly deployments: readonly ValidDeployment[]
+  readonly backups: readonly ValidBackup[]
+  readonly backupEntryCount: number
+  readonly backupBytes: number
+  readonly findings: readonly StorageFinding[]
+  readonly warnings: readonly StorageWarning[]
+}
+
+export interface DeploymentRetentionResult {
+  readonly activeDeploymentFingerprint: string
+  readonly retainedDeploymentFingerprints: readonly string[]
+  readonly deletedDeploymentFingerprints: readonly string[]
+  readonly releasedBytes: number
+  readonly findings: readonly StorageFinding[]
+  readonly warnings: readonly StorageWarning[]
+}
+
+export interface AuditRetentionResult {
+  readonly retainedInvocations: number
+  readonly removedInvocations: number
+  readonly removedAttemptFiles: readonly string[]
+  readonly findings: readonly StorageFinding[]
+}
+
+export interface StorageRetentionReceipt {
+  readonly formatVersion: 1
+  readonly applicationSha: string
+  readonly createdAt: string
+  readonly deployment: DeploymentRetentionResult
+  readonly audit: AuditRetentionResult
+}
+
+export interface BackupPruneResult {
+  readonly backup: string
+  readonly manifestSha256: string | null
+  readonly dryRun: boolean
+  readonly deleted: boolean
+  readonly releasedBytes: number
+  readonly refusal: string | null
+}
+
+export const deploymentFingerprintPattern = /^[a-f0-9]{64}$/
+export const sha256Pattern = /^[a-f0-9]{64}$/
+export const backupCountWarningThreshold = 50
+export const backupBytesWarningThreshold = 1024 ** 3
+export const retainedInactiveDeployments = 2
+export const retainedRecentBackups = 5
+export const minimumBackupAgeMs = 30 * 24 * 60 * 60 * 1000
+export const retainedTerminalAuditEntries = 100

--- a/scripts/local-storage/filesystem.ts
+++ b/scripts/local-storage/filesystem.ts
@@ -1,0 +1,62 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { dirname, join } from 'node:path'
+
+export function treeBytes(root: string): number {
+  if (!existsSync(root)) return 0
+  const stats = lstatSync(root)
+  if (stats.isSymbolicLink())
+    throw new Error(`Symbolic links are not owned storage: ${root}`)
+  if (stats.isFile()) return stats.size
+  if (!stats.isDirectory())
+    throw new Error(`Unsupported owned storage entry: ${root}`)
+  return readdirSync(root).reduce(
+    (total, name) => total + treeBytes(join(root, name)),
+    0
+  )
+}
+
+export function directDirectoryNames(root: string): string[] {
+  if (!existsSync(root)) return []
+  return readdirSync(root).sort((left, right) =>
+    left.localeCompare(right, 'en')
+  )
+}
+
+export function syncDirectory(path: string): void {
+  const descriptor = openSync(path, 'r')
+  try {
+    fsyncSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+export function atomicWrite(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.${randomUUID()}.next`
+  const descriptor = openSync(temporary, 'wx', 0o600)
+  try {
+    writeFileSync(descriptor, content)
+    fsyncSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+  renameSync(temporary, path)
+  syncDirectory(dirname(path))
+}
+
+export function fileBytes(path: string): number {
+  return statSync(path).size
+}

--- a/scripts/local-storage/inspection.ts
+++ b/scripts/local-storage/inspection.ts
@@ -1,0 +1,351 @@
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync
+} from 'node:fs'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import { z } from 'zod'
+import { localArtifactManifestSchema } from '../../src/shared/contracts/build-info.js'
+import { sha256File } from '../file-hash.js'
+import { readInstallJournal } from '../local-install-journal.js'
+import type { LocalInstallationPaths } from '../local-installation/contract.js'
+import { hashTree } from '../local-installation/campaign-file-inventory.js'
+import {
+  backupBytesWarningThreshold,
+  backupCountWarningThreshold,
+  deploymentFingerprintPattern,
+  minimumBackupAgeMs,
+  retainedInactiveDeployments,
+  retainedRecentBackups,
+  type LocalStorageInspection,
+  type StorageFinding,
+  type StorageWarning,
+  type ValidBackup,
+  type ValidDeployment
+} from './contract.js'
+import { directDirectoryNames, treeBytes } from './filesystem.js'
+
+export interface InspectLocalStorageOptions {
+  readonly paths: LocalInstallationPaths
+  readonly iconSourcePath: string
+  readonly now?: () => Date
+}
+
+type InspectedDeployment = Omit<
+  ValidDeployment,
+  'active' | 'journalProtected' | 'retention'
+>
+
+const backupManifestSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    createdAt: z.iso.datetime(),
+    files: z.array(
+      z
+        .object({
+          path: z.string().min(1),
+          bytes: z.number().int().nonnegative(),
+          sha256: z.string().regex(/^[a-f0-9]{64}$/)
+        })
+        .strict()
+    )
+  })
+  .passthrough()
+
+export function inspectLocalStorage(
+  options: InspectLocalStorageOptions
+): LocalStorageInspection {
+  const now = options.now ?? (() => new Date())
+  const nowMs = now().getTime()
+  const findings: StorageFinding[] = []
+  const active = activeDeployment(options.paths, findings)
+  const journal = protectedDeployments(options.paths, findings)
+  const validDeployments: InspectedDeployment[] = []
+
+  for (const name of directDirectoryNames(options.paths.deployments)) {
+    const path = join(options.paths.deployments, name)
+    try {
+      validDeployments.push(
+        validateDeploymentDirectory(path, name, options.iconSourcePath)
+      )
+    } catch (error) {
+      findings.push({
+        area: 'deployments',
+        name,
+        reason: errorMessage(error)
+      })
+    }
+  }
+
+  const activeIsValid =
+    active !== null &&
+    validDeployments.some(({ fingerprint }) => fingerprint === active)
+  if (active !== null && !activeIsValid)
+    findings.push({
+      area: 'deployments',
+      name: active,
+      reason: 'The active deployment did not pass ownership validation'
+    })
+  const pruningBlocked = active === null || !activeIsValid || journal.unknown
+  const newestInactive = validDeployments
+    .filter(({ fingerprint }) => fingerprint !== active)
+    .sort(newestFirst)
+    .slice(0, retainedInactiveDeployments)
+    .map(({ fingerprint }) => fingerprint)
+  const retained = new Set([
+    ...(active === null ? [] : [active]),
+    ...newestInactive,
+    ...journal.fingerprints
+  ])
+  const deployments: ValidDeployment[] = validDeployments
+    .sort(newestFirst)
+    .map((deployment) => ({
+      ...deployment,
+      active: deployment.fingerprint === active,
+      journalProtected: journal.fingerprints.has(deployment.fingerprint),
+      retention:
+        pruningBlocked || retained.has(deployment.fingerprint)
+          ? 'keep'
+          : 'delete'
+    }))
+
+  const backupNames = directDirectoryNames(options.paths.backups)
+  let backupBytes = 0
+  const inspectedBackups: Array<
+    Omit<ValidBackup, 'protectedByRecency' | 'protectedByAge' | 'pruneEligible'>
+  > = []
+  for (const name of backupNames) {
+    const path = join(options.paths.backups, name)
+    try {
+      const bytes = treeBytes(path)
+      backupBytes += bytes
+      inspectedBackups.push(validateBackupDirectory(path, name, bytes))
+    } catch (error) {
+      backupBytes += bestEffortBytes(path)
+      findings.push({ area: 'backups', name, reason: errorMessage(error) })
+    }
+  }
+  const newestBackups = new Set(
+    [...inspectedBackups]
+      .sort((left, right) =>
+        right.createdAt === left.createdAt
+          ? right.name.localeCompare(left.name, 'en')
+          : right.createdAt.localeCompare(left.createdAt, 'en')
+      )
+      .slice(0, retainedRecentBackups)
+      .map(({ name }) => name)
+  )
+  const backups: ValidBackup[] = inspectedBackups
+    .sort((left, right) => left.name.localeCompare(right.name, 'en'))
+    .map((backup) => {
+      const protectedByRecency = newestBackups.has(backup.name)
+      const protectedByAge =
+        nowMs - new Date(backup.createdAt).getTime() < minimumBackupAgeMs
+      return {
+        ...backup,
+        protectedByRecency,
+        protectedByAge,
+        pruneEligible: !protectedByRecency && !protectedByAge
+      }
+    })
+  const warnings = storageWarnings(backupNames.length, backupBytes)
+
+  return {
+    formatVersion: 1,
+    installationRoot: options.paths.root,
+    activeDeploymentFingerprint: active,
+    deployments,
+    backups,
+    backupEntryCount: backupNames.length,
+    backupBytes,
+    findings: findings.sort(findingOrder),
+    warnings
+  }
+}
+
+export function validateDeploymentDirectory(
+  path: string,
+  fingerprint: string,
+  iconSourcePath: string
+): InspectedDeployment {
+  if (!deploymentFingerprintPattern.test(fingerprint))
+    throw new Error('Entry is not a 64-hex SaltMarcher deployment')
+  const stats = lstatSync(path)
+  if (!stats.isDirectory() || stats.isSymbolicLink())
+    throw new Error('Deployment entry is not an owned directory')
+  const expectedInventory = [
+    'SaltMarcher.AppImage',
+    'artifact-manifest.json',
+    'icon.png'
+  ]
+  if (
+    JSON.stringify(readdirSync(path).sort()) !==
+    JSON.stringify(expectedInventory)
+  )
+    throw new Error('Deployment contains an unexpected file inventory')
+  const manifestPath = join(path, 'artifact-manifest.json')
+  const manifest = localArtifactManifestSchema.parse(
+    JSON.parse(readFileSync(manifestPath, 'utf8'))
+  )
+  if (manifest.receipt.build.channel !== 'local')
+    throw new Error('Deployment manifest does not describe a Local build')
+  if (manifest.receipt.build.workspaceFingerprint !== fingerprint)
+    throw new Error('Deployment directory and workspace fingerprint differ')
+  if (
+    createHash('sha256')
+      .update(JSON.stringify(manifest.receipt))
+      .digest('hex') !== manifest.receiptSha256
+  )
+    throw new Error('Deployment receipt hash is invalid')
+  if (
+    sha256File(join(path, 'SaltMarcher.AppImage')) !== manifest.artifactSha256
+  )
+    throw new Error('Deployment AppImage hash is invalid')
+  if (sha256File(join(path, 'icon.png')) !== sha256File(iconSourcePath))
+    throw new Error('Deployment icon hash is invalid')
+  return {
+    fingerprint,
+    path,
+    builtAt: manifest.receipt.build.builtAt,
+    bytes: treeBytes(path),
+    manifestSha256: sha256File(manifestPath)
+  }
+}
+
+export function validateBackupDirectory(
+  path: string,
+  name: string,
+  knownBytes = treeBytes(path)
+): Omit<
+  ValidBackup,
+  'protectedByRecency' | 'protectedByAge' | 'pruneEligible'
+> {
+  const stats = lstatSync(path)
+  if (!stats.isDirectory() || stats.isSymbolicLink())
+    throw new Error('Backup entry is not an owned directory')
+  const manifestPath = join(path, 'backup-manifest.json')
+  if (!existsSync(manifestPath)) throw new Error('Backup manifest is missing')
+  const manifest = backupManifestSchema.parse(
+    JSON.parse(readFileSync(manifestPath, 'utf8'))
+  )
+  const actual = hashTree(path).filter(
+    ({ path: relativePath }) => relativePath !== 'backup-manifest.json'
+  )
+  if (JSON.stringify(actual) !== JSON.stringify(manifest.files))
+    throw new Error('Backup file inventory or hashes are invalid')
+  return {
+    name,
+    path,
+    createdAt: manifest.createdAt,
+    bytes: knownBytes,
+    manifestSha256: sha256File(manifestPath)
+  }
+}
+
+function activeDeployment(
+  paths: LocalInstallationPaths,
+  findings: StorageFinding[]
+): string | null {
+  try {
+    const selected = resolve(
+      dirname(paths.current),
+      readlinkSync(paths.current)
+    )
+    const relativePath = relative(paths.deployments, selected)
+    if (
+      relativePath.includes(sep) ||
+      relativePath.startsWith('..') ||
+      !deploymentFingerprintPattern.test(relativePath)
+    )
+      throw new Error('Current does not select a direct deployment child')
+    return relativePath
+  } catch (error) {
+    findings.push({
+      area: 'deployments',
+      name: 'current',
+      reason: errorMessage(error)
+    })
+    return null
+  }
+}
+
+function protectedDeployments(
+  paths: LocalInstallationPaths,
+  findings: StorageFinding[]
+): { readonly fingerprints: Set<string>; readonly unknown: boolean } {
+  try {
+    const journal = readInstallJournal(paths.journal)
+    if (
+      journal === null ||
+      journal.phase === 'completed' ||
+      journal.phase === 'rolled-back' ||
+      journal.deploymentPath === null
+    )
+      return { fingerprints: new Set(), unknown: false }
+    const relativePath = relative(paths.deployments, journal.deploymentPath)
+    if (
+      relativePath.includes(sep) ||
+      relativePath.startsWith('..') ||
+      !deploymentFingerprintPattern.test(relativePath)
+    )
+      throw new Error('Nonterminal journal has an invalid deployment reference')
+    return { fingerprints: new Set([relativePath]), unknown: false }
+  } catch (error) {
+    findings.push({
+      area: 'deployments',
+      name: 'install-journal.json',
+      reason: errorMessage(error)
+    })
+    return { fingerprints: new Set(), unknown: true }
+  }
+}
+
+export function storageWarnings(
+  backupCount: number,
+  backupBytes: number
+): StorageWarning[] {
+  const warnings: StorageWarning[] = []
+  if (backupCount > backupCountWarningThreshold)
+    warnings.push({
+      code: 'backup-count-high',
+      message: `${backupCount} campaign backups are retained; automatic deletion is disabled`
+    })
+  if (backupBytes > backupBytesWarningThreshold)
+    warnings.push({
+      code: 'backup-bytes-high',
+      message: `${backupBytes} campaign-backup bytes are retained; automatic deletion is disabled`
+    })
+  return warnings
+}
+
+function newestFirst(left: InspectedDeployment, right: InspectedDeployment) {
+  return right.builtAt === left.builtAt
+    ? right.fingerprint.localeCompare(left.fingerprint, 'en')
+    : right.builtAt.localeCompare(left.builtAt, 'en')
+}
+
+function findingOrder(left: StorageFinding, right: StorageFinding): number {
+  return `${left.area}:${left.name}:${left.reason}`.localeCompare(
+    `${right.area}:${right.name}:${right.reason}`,
+    'en'
+  )
+}
+
+function bestEffortBytes(path: string): number {
+  try {
+    return treeBytes(path)
+  } catch {
+    try {
+      return lstatSync(path).size
+    } catch {
+      return 0
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/scripts/local-storage/retention.ts
+++ b/scripts/local-storage/retention.ts
@@ -1,0 +1,288 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+import type { LocalInstallationPaths } from '../local-installation/contract.js'
+import { withInstallationLock } from '../local-installation/installation-lock.js'
+import { applyAuditRetention } from './audit-retention.js'
+import {
+  deploymentFingerprintPattern,
+  type DeploymentRetentionResult,
+  type StorageRetentionReceipt
+} from './contract.js'
+import { atomicWrite, syncDirectory } from './filesystem.js'
+import {
+  inspectLocalStorage,
+  validateDeploymentDirectory
+} from './inspection.js'
+
+export interface ApplyStorageRetentionOptions {
+  readonly paths: LocalInstallationPaths
+  readonly iconSourcePath: string
+  readonly receiptDirectory: string
+  readonly applicationSha: string
+  readonly now?: () => Date
+  readonly removeDirectory?: (path: string) => void
+  readonly removeAuditFile?: (path: string) => void
+}
+
+const findingSchema = z
+  .object({
+    area: z.enum(['deployments', 'backups', 'audit']),
+    name: z.string(),
+    reason: z.string()
+  })
+  .strict()
+const warningSchema = z
+  .object({
+    code: z.enum(['backup-count-high', 'backup-bytes-high']),
+    message: z.string()
+  })
+  .strict()
+const deploymentResultSchema = z
+  .object({
+    activeDeploymentFingerprint: z.string().regex(deploymentFingerprintPattern),
+    retainedDeploymentFingerprints: z.array(
+      z.string().regex(deploymentFingerprintPattern)
+    ),
+    deletedDeploymentFingerprints: z.array(
+      z.string().regex(deploymentFingerprintPattern)
+    ),
+    releasedBytes: z.number().int().nonnegative(),
+    findings: z.array(findingSchema),
+    warnings: z.array(warningSchema)
+  })
+  .strict()
+const progressSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    applicationSha: z.string().regex(/^[a-f0-9]{40}$/),
+    deployment: deploymentResultSchema
+  })
+  .strict()
+const receiptSchema = progressSchema
+  .extend({
+    createdAt: z.iso.datetime(),
+    audit: z
+      .object({
+        retainedInvocations: z.number().int().nonnegative(),
+        removedInvocations: z.number().int().nonnegative(),
+        removedAttemptFiles: z.array(z.string()),
+        findings: z.array(findingSchema)
+      })
+      .strict()
+  })
+  .strict()
+
+export function applyStorageRetention(
+  options: ApplyStorageRetentionOptions
+): StorageRetentionReceipt {
+  if (!/^[a-f0-9]{40}$/.test(options.applicationSha))
+    throw new Error('Storage retention requires an exact application SHA')
+  return withInstallationLock(options.paths, () => {
+    const progressPath = join(
+      options.receiptDirectory,
+      'storage-retention-progress.json'
+    )
+    const prior = readProgress(progressPath, options.applicationSha)
+    const current = applyDeploymentRetention({
+      ...options,
+      onProgress: (deployment) =>
+        atomicWrite(
+          progressPath,
+          `${JSON.stringify(
+            {
+              formatVersion: 1,
+              applicationSha: options.applicationSha,
+              deployment: combineDeploymentResults(prior, deployment)
+            },
+            null,
+            2
+          )}\n`
+        )
+    })
+    const deployment = combineDeploymentResults(prior, current)
+    atomicWrite(
+      progressPath,
+      `${JSON.stringify(
+        {
+          formatVersion: 1,
+          applicationSha: options.applicationSha,
+          deployment
+        },
+        null,
+        2
+      )}\n`
+    )
+    const audit = applyAuditRetention({
+      receiptDirectory: options.receiptDirectory,
+      ...(options.removeAuditFile === undefined
+        ? {}
+        : { removeFile: options.removeAuditFile })
+    })
+    const receipt = receiptSchema.parse({
+      formatVersion: 1,
+      applicationSha: options.applicationSha,
+      createdAt: (options.now ?? (() => new Date()))().toISOString(),
+      deployment,
+      audit
+    })
+    atomicWrite(
+      storageRetentionReceiptPath(options.receiptDirectory),
+      `${JSON.stringify(receipt, null, 2)}\n`
+    )
+    return receipt
+  })
+}
+
+export function collectStorageRetentionReceipt(
+  options: Omit<
+    ApplyStorageRetentionOptions,
+    'removeDirectory' | 'removeAuditFile'
+  >
+): StorageRetentionReceipt {
+  const receipt = receiptSchema.parse(
+    JSON.parse(
+      readFileSync(
+        storageRetentionReceiptPath(options.receiptDirectory),
+        'utf8'
+      )
+    )
+  )
+  if (receipt.applicationSha !== options.applicationSha)
+    throw new Error('Storage-retention receipt proves another application SHA')
+  const inspection = inspectLocalStorage(options)
+  if (inspection.activeDeploymentFingerprint === null)
+    throw new Error('Storage-retention receipt has no valid active deployment')
+  if (inspection.deployments.some(({ retention }) => retention === 'delete'))
+    throw new Error('Storage-retention receipt is stale; pruning remains')
+  const retained = inspection.deployments
+    .map(({ fingerprint }) => fingerprint)
+    .sort()
+  if (
+    JSON.stringify(retained) !==
+    JSON.stringify(
+      [...receipt.deployment.retainedDeploymentFingerprints].sort()
+    )
+  )
+    throw new Error('Retained deployment evidence differs from local storage')
+  for (const fingerprint of receipt.deployment.deletedDeploymentFingerprints)
+    if (existsSync(join(options.paths.deployments, fingerprint)))
+      throw new Error(`Deleted deployment is present again: ${fingerprint}`)
+  return receipt
+}
+
+export function applyDeploymentRetention(
+  options: ApplyStorageRetentionOptions & {
+    readonly onProgress?: (result: DeploymentRetentionResult) => void
+  }
+): DeploymentRetentionResult {
+  const first = inspectLocalStorage(options)
+  if (first.activeDeploymentFingerprint === null)
+    throw new Error(
+      'Automatic deployment pruning requires a valid active deployment'
+    )
+  const deleted: string[] = []
+  let releasedBytes = 0
+  const removeDirectory =
+    options.removeDirectory ??
+    ((path: string) => rmSync(path, { recursive: true, force: false }))
+
+  for (const candidate of first.deployments.filter(
+    ({ retention }) => retention === 'delete'
+  )) {
+    const live = inspectLocalStorage(options).deployments.find(
+      ({ fingerprint }) => fingerprint === candidate.fingerprint
+    )
+    if (
+      live === undefined ||
+      live.retention !== 'delete' ||
+      live.manifestSha256 !== candidate.manifestSha256 ||
+      live.bytes !== candidate.bytes
+    )
+      throw new Error(
+        `Deployment changed before pruning: ${candidate.fingerprint}`
+      )
+    const validated = validateDeploymentDirectory(
+      candidate.path,
+      candidate.fingerprint,
+      options.iconSourcePath
+    )
+    if (
+      validated.manifestSha256 !== candidate.manifestSha256 ||
+      validated.bytes !== candidate.bytes
+    )
+      throw new Error(
+        `Deployment ownership changed before pruning: ${candidate.fingerprint}`
+      )
+    removeDirectory(candidate.path)
+    if (existsSync(candidate.path))
+      throw new Error(
+        `Deployment removal was incomplete: ${candidate.fingerprint}`
+      )
+    deleted.push(candidate.fingerprint)
+    releasedBytes += candidate.bytes
+    options.onProgress?.(
+      deploymentResult(first, deleted, releasedBytes, options)
+    )
+  }
+  if (deleted.length > 0) syncDirectory(options.paths.deployments)
+  return deploymentResult(first, deleted, releasedBytes, options)
+}
+
+function deploymentResult(
+  initial: ReturnType<typeof inspectLocalStorage>,
+  deleted: readonly string[],
+  releasedBytes: number,
+  options: ApplyStorageRetentionOptions
+): DeploymentRetentionResult {
+  const final = inspectLocalStorage(options)
+  if (
+    final.activeDeploymentFingerprint === null ||
+    final.activeDeploymentFingerprint !== initial.activeDeploymentFingerprint
+  )
+    throw new Error('Active deployment changed during storage retention')
+  return {
+    activeDeploymentFingerprint: final.activeDeploymentFingerprint,
+    retainedDeploymentFingerprints: final.deployments.map(
+      ({ fingerprint }) => fingerprint
+    ),
+    deletedDeploymentFingerprints: [...deleted],
+    releasedBytes,
+    findings: final.findings,
+    warnings: final.warnings
+  }
+}
+
+function readProgress(
+  path: string,
+  applicationSha: string
+): DeploymentRetentionResult | null {
+  if (!existsSync(path)) return null
+  const progress = progressSchema.parse(JSON.parse(readFileSync(path, 'utf8')))
+  return progress.applicationSha === applicationSha ? progress.deployment : null
+}
+
+function combineDeploymentResults(
+  prior: DeploymentRetentionResult | null,
+  current: DeploymentRetentionResult
+): DeploymentRetentionResult {
+  if (prior === null) return current
+  if (prior.activeDeploymentFingerprint !== current.activeDeploymentFingerprint)
+    throw new Error(
+      'Storage-retention progress names another active deployment'
+    )
+  return {
+    ...current,
+    deletedDeploymentFingerprints: [
+      ...new Set([
+        ...prior.deletedDeploymentFingerprints,
+        ...current.deletedDeploymentFingerprints
+      ])
+    ],
+    releasedBytes: prior.releasedBytes + current.releasedBytes
+  }
+}
+
+export function storageRetentionReceiptPath(receiptDirectory: string): string {
+  return join(receiptDirectory, 'storage-retention-receipt.json')
+}

--- a/scripts/prune-local-storage.ts
+++ b/scripts/prune-local-storage.ts
@@ -1,0 +1,58 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { localInstallationPaths } from './local-app-installation.js'
+import { pruneLocalBackup } from './local-storage/backup-prune.js'
+
+const rawArguments = process.argv.slice(2)
+const parsed = parseArguments(
+  rawArguments[0] === '--' ? rawArguments.slice(1) : rawArguments
+)
+const workspaceRoot = process.cwd()
+const result = pruneLocalBackup({
+  paths: localInstallationPaths(
+    process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
+  ),
+  iconSourcePath: resolve(
+    workspaceRoot,
+    'resources',
+    'icons',
+    'salt-marcher.png'
+  ),
+  backup: parsed.backup,
+  ...(parsed.confirmManifestSha === undefined
+    ? {}
+    : { confirmManifestSha: parsed.confirmManifestSha })
+})
+console.info(JSON.stringify(result, null, 2))
+if (result.refusal !== null) process.exitCode = 1
+
+function parseArguments(arguments_: readonly string[]): {
+  readonly backup: string
+  readonly confirmManifestSha?: string
+} {
+  let backup: string | undefined
+  let confirmManifestSha: string | undefined
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const option = arguments_[index]
+    const value = arguments_[index + 1]
+    if (value === undefined)
+      throw new Error(
+        'Usage: local-storage:prune -- --backup <name> [--confirm-manifest-sha <sha>]'
+      )
+    if (option === '--backup' && backup === undefined) backup = value
+    else if (
+      option === '--confirm-manifest-sha' &&
+      confirmManifestSha === undefined
+    )
+      confirmManifestSha = value
+    else throw new Error(`Unsupported or repeated option: ${option}`)
+  }
+  if (backup === undefined)
+    throw new Error(
+      'Usage: local-storage:prune -- --backup <name> [--confirm-manifest-sha <sha>]'
+    )
+  return {
+    backup,
+    ...(confirmManifestSha === undefined ? {} : { confirmManifestSha })
+  }
+}

--- a/scripts/test-manifests/delivery.json
+++ b/scripts/test-manifests/delivery.json
@@ -14,6 +14,8 @@
     "tests/unit/candidate-artifact.test.ts",
     "tests/unit/local-app-installation.test.ts",
     "tests/unit/local-installation-legacy.test.ts",
+    "tests/unit/local-storage-retention.test.ts",
+    "tests/unit/local-storage-prune.test.ts",
     "tests/unit/local-profile-lock.test.ts",
     "tests/unit/ci-workflow-policy.test.ts"
   ],

--- a/tests/support/local-storage-fixture.ts
+++ b/tests/support/local-storage-fixture.ts
@@ -1,0 +1,136 @@
+import { createHash } from 'node:crypto'
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { BuildInfo } from '../../src/shared/contracts/build-info.js'
+import { databaseSchemaVersions } from '../../src/core/persistence/sqlite/database.js'
+import { sha256File } from '../../scripts/file-hash.js'
+import { createInstallJournal } from '../../scripts/local-install-journal.js'
+import { localInstallationPaths } from '../../scripts/local-app-installation.js'
+import { hashTree } from '../../scripts/local-installation/campaign-file-inventory.js'
+
+export interface LocalStorageFixture {
+  readonly root: string
+  readonly paths: ReturnType<typeof localInstallationPaths>
+  readonly iconSourcePath: string
+  readonly receiptDirectory: string
+  readonly cleanup: () => void
+  readonly deployment: (character: string, builtAt: string) => string
+  readonly activate: (fingerprint: string) => void
+  readonly protectWithJournal: (fingerprint: string) => void
+  readonly backup: (name: string, createdAt: string, content?: string) => string
+}
+
+export function createLocalStorageFixture(): LocalStorageFixture {
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-storage-'))
+  const xdg = join(root, 'xdg')
+  const paths = localInstallationPaths(xdg)
+  const iconSourcePath = join(root, 'icon.png')
+  const receiptDirectory = join(root, 'receipts')
+  mkdirSync(paths.deployments, { recursive: true })
+  mkdirSync(paths.backups, { recursive: true })
+  mkdirSync(receiptDirectory, { recursive: true })
+  writeFileSync(iconSourcePath, 'canonical-icon')
+
+  return {
+    root,
+    paths,
+    iconSourcePath,
+    receiptDirectory,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    deployment(character, builtAt) {
+      const fingerprint = character.repeat(64)
+      const path = join(paths.deployments, fingerprint)
+      mkdirSync(path)
+      const artifact = `artifact-${character}`
+      const receipt = {
+        formatVersion: 2 as const,
+        build: build(character, builtAt),
+        outputHash: 'f'.repeat(64),
+        files: []
+      }
+      writeFileSync(join(path, 'SaltMarcher.AppImage'), artifact)
+      writeFileSync(join(path, 'icon.png'), 'canonical-icon')
+      writeFileSync(
+        join(path, 'artifact-manifest.json'),
+        JSON.stringify({
+          formatVersion: 2,
+          artifactFile: 'SaltMarcher.AppImage',
+          artifactSha256: hash(artifact),
+          receiptSha256: hash(JSON.stringify(receipt)),
+          receipt
+        })
+      )
+      return fingerprint
+    },
+    activate(fingerprint) {
+      symlinkSync(join('deployments', fingerprint), paths.current)
+    },
+    protectWithJournal(fingerprint) {
+      const timestamp = () => new Date('2026-01-10T12:00:00.000Z')
+      const journal = createInstallJournal(
+        {
+          applicationSha: 'a'.repeat(40),
+          buildFingerprint: fingerprint,
+          appBuildInputFingerprint: fingerprint,
+          artifactSha256: 'b'.repeat(64)
+        },
+        timestamp
+      )
+      writeFileSync(
+        paths.journal,
+        JSON.stringify({
+          ...journal,
+          phase: 'deployment-staged',
+          deploymentPath: join(paths.deployments, fingerprint)
+        })
+      )
+    },
+    backup(name, createdAt, content = `backup-${name}`) {
+      const path = join(paths.backups, name)
+      mkdirSync(path)
+      writeFileSync(join(path, 'campaign.sqlite'), content)
+      writeFileSync(
+        join(path, 'backup-manifest.json'),
+        JSON.stringify({
+          formatVersion: 1,
+          createdAt,
+          files: hashTree(path)
+        })
+      )
+      return sha256File(join(path, 'backup-manifest.json'))
+    }
+  }
+}
+
+function build(character: string, builtAt: string): BuildInfo {
+  return {
+    channel: 'local',
+    commit: character.repeat(40),
+    dirty: false,
+    workspaceFingerprint: character.repeat(64),
+    appBuildInputFingerprint: character.repeat(64),
+    builtAt,
+    schemaVersions: databaseSchemaVersions,
+    migrationRegistryVersion: 1,
+    toolchain: {
+      node: 'v22.19.0',
+      pnpm: '10.15.1',
+      electron: '43.2.0',
+      electronVite: '5.0.0',
+      electronBuilder: '26.15.3',
+      platform: 'linux',
+      arch: 'x64'
+    }
+  }
+}
+
+function hash(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -171,7 +171,20 @@ describe('candidate delivery policy', () => {
         backupManifestSha256: hash,
         deploymentManifestSha256: hash,
         runtimeEvidenceSha256: hash,
-        installedSha256: hash
+        installedSha256: hash,
+        storageRetention:
+          phase === 'storage-retention-applied'
+            ? {
+                receiptSha256: hash,
+                activeDeploymentFingerprint: hash,
+                retainedDeploymentFingerprints: [hash],
+                deletedDeploymentFingerprints: [],
+                releasedBytes: 0,
+                retainedInvocations: 2,
+                removedInvocations: 0,
+                removedAttemptFiles: []
+              }
+            : null
       }
       const outputHash = hashHandoffValue({
         phase,

--- a/tests/unit/ci-workflow-policy.test.ts
+++ b/tests/unit/ci-workflow-policy.test.ts
@@ -82,6 +82,10 @@ describe('CI platform partitions', () => {
       expect(handoff).toContain("'test:packaged-local-smoke:built'")
       expect(handoff).toContain("installationDefinition('backup-created')")
       expect(handoff).toContain("phase: 'installed-runtime-verified'")
+      expect(handoff).toContain("phase: 'storage-retention-applied'")
+      expect(
+        handoff.indexOf("phase: 'storage-retention-applied'")
+      ).toBeGreaterThan(handoff.indexOf("phase: 'installed-runtime-verified'"))
     }
   )
 

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -197,7 +197,7 @@ function createFixture(failOnce?: HandoffPhaseName): {
   const evidence = new Map<HandoffPhaseName, HandoffPhaseEvidence>(
     handoffPhases.map((phase, index) => [
       phase,
-      phaseEvidence(index.toString(16))
+      phaseEvidence(index.toString(16), phase === 'storage-retention-applied')
     ])
   )
   let failed = false
@@ -215,7 +215,10 @@ function createFixture(failOnce?: HandoffPhaseName): {
   return { receipt, definitions, executions, evidence, now }
 }
 
-function phaseEvidence(character: string): HandoffPhaseEvidence {
+function phaseEvidence(
+  character: string,
+  storageRetention = false
+): HandoffPhaseEvidence {
   const hash = character.repeat(64)
   return {
     workspaceFingerprint: 'b'.repeat(64),
@@ -231,6 +234,18 @@ function phaseEvidence(character: string): HandoffPhaseEvidence {
     backupManifestSha256: hash,
     deploymentManifestSha256: hash,
     runtimeEvidenceSha256: hash,
-    installedSha256: hash
+    installedSha256: hash,
+    storageRetention: storageRetention
+      ? {
+          receiptSha256: hash,
+          activeDeploymentFingerprint: hash,
+          retainedDeploymentFingerprints: [hash],
+          deletedDeploymentFingerprints: [],
+          releasedBytes: 0,
+          retainedInvocations: 1,
+          removedInvocations: 0,
+          removedAttemptFiles: []
+        }
+      : null
   }
 }

--- a/tests/unit/local-storage-prune.test.ts
+++ b/tests/unit/local-storage-prune.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { pruneLocalBackup } from '../../scripts/local-storage/backup-prune.js'
+import {
+  backupBytesWarningThreshold,
+  backupCountWarningThreshold
+} from '../../scripts/local-storage/contract.js'
+import {
+  inspectLocalStorage,
+  storageWarnings
+} from '../../scripts/local-storage/inspection.js'
+import { createLocalStorageFixture } from '../support/local-storage-fixture.js'
+
+const cleanup: Array<() => void> = []
+afterEach(() => {
+  for (const remove of cleanup.splice(0)) remove()
+})
+
+describe('manual campaign-backup pruning', () => {
+  it('is a dry run without the exact hash and deletes at most one eligible backup', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const manifests = new Map<string, string>()
+    for (let day = 1; day <= 7; day += 1) {
+      const name = `backup-${day}`
+      manifests.set(name, fixture.backup(name, `2026-01-0${day}T12:00:00.000Z`))
+    }
+    const options = {
+      ...fixture,
+      backup: 'backup-1',
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    }
+
+    const dryRun = pruneLocalBackup(options)
+    expect(dryRun).toMatchObject({
+      backup: 'backup-1',
+      dryRun: true,
+      deleted: false,
+      refusal: null
+    })
+    expect(dryRun.releasedBytes).toBeGreaterThan(0)
+    expect(existsSync(join(fixture.paths.backups, 'backup-1'))).toBe(true)
+
+    const refused = pruneLocalBackup({
+      ...options,
+      confirmManifestSha: '0'.repeat(64)
+    })
+    expect(refused).toMatchObject({ deleted: false, dryRun: false })
+    expect(typeof refused.refusal).toBe('string')
+
+    const deleted = pruneLocalBackup({
+      ...options,
+      confirmManifestSha: manifests.get('backup-1')!
+    })
+    expect(deleted).toMatchObject({
+      deleted: true,
+      dryRun: false,
+      refusal: null
+    })
+    expect(existsSync(join(fixture.paths.backups, 'backup-1'))).toBe(false)
+    expect(existsSync(join(fixture.paths.backups, 'backup-2'))).toBe(true)
+  })
+
+  it('refuses the newest five, young, invalid, and non-exact targets', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    for (let day = 1; day <= 6; day += 1)
+      fixture.backup(`old-${day}`, `2026-01-0${day}T12:00:00.000Z`)
+    fixture.backup('young', '2026-03-10T12:00:00.000Z')
+    fixture.backup('invalid', '2026-01-01T12:00:00.000Z')
+    writeFileSync(
+      join(fixture.paths.backups, 'invalid', 'campaign.sqlite'),
+      'changed'
+    )
+    const base = {
+      ...fixture,
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    }
+
+    expect(pruneLocalBackup({ ...base, backup: 'young' }).refusal).toMatch(
+      /newest|younger/
+    )
+    expect(pruneLocalBackup({ ...base, backup: 'invalid' }).refusal).toMatch(
+      /invalid/
+    )
+    expect(() => pruneLocalBackup({ ...base, backup: '*' })).toThrow(/exact/)
+    expect(() => pruneLocalBackup({ ...base, backup: '../old-1' })).toThrow(
+      /exact/
+    )
+  })
+
+  it('never auto-deletes backups and emits advisory capacity warnings', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    fixture.backup('backup', '2026-01-01T12:00:00.000Z')
+    const before = inspectLocalStorage({
+      ...fixture,
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    })
+    expect(before.backups).toHaveLength(1)
+    expect(storageWarnings(backupCountWarningThreshold + 1, 0)).toEqual([
+      expect.objectContaining({ code: 'backup-count-high' })
+    ])
+    expect(storageWarnings(0, backupBytesWarningThreshold + 1)).toEqual([
+      expect.objectContaining({ code: 'backup-bytes-high' })
+    ])
+  })
+})

--- a/tests/unit/local-storage-retention.test.ts
+++ b/tests/unit/local-storage-retention.test.ts
@@ -1,0 +1,268 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { handoffInvocationHistorySchema } from '../../scripts/delivery-contract.js'
+import { applyAuditRetention } from '../../scripts/local-storage/audit-retention.js'
+import { inspectLocalStorage } from '../../scripts/local-storage/inspection.js'
+import {
+  applyDeploymentRetention,
+  applyStorageRetention,
+  collectStorageRetentionReceipt
+} from '../../scripts/local-storage/retention.js'
+import { createLocalStorageFixture } from '../support/local-storage-fixture.js'
+
+const cleanup: Array<() => void> = []
+afterEach(() => {
+  for (const remove of cleanup.splice(0)) remove()
+})
+
+describe('local deployment retention', () => {
+  it('keeps the active, two newest inactive, and journal-referenced deployments', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const fingerprints = ['a', 'b', 'c', 'd', 'e'].map((character, index) =>
+      fixture.deployment(character, `2026-01-0${index + 1}T12:00:00.000Z`)
+    )
+    fixture.activate(fingerprints[2]!)
+    fixture.protectWithJournal(fingerprints[0]!)
+    const invalid = '9'.repeat(64)
+    mkdirSync(join(fixture.paths.deployments, invalid))
+    writeFileSync(join(fixture.paths.deployments, invalid, 'foreign.txt'), 'x')
+    mkdirSync(join(fixture.paths.deployments, 'foreign-entry'))
+    fixture.backup('campaign-backup', '2026-01-01T12:00:00.000Z')
+
+    const before = inspectLocalStorage(fixture)
+    expect(
+      before.deployments
+        .filter(({ retention }) => retention === 'delete')
+        .map(({ fingerprint }) => fingerprint)
+    ).toEqual([fingerprints[1]])
+
+    const result = applyDeploymentRetention({
+      ...fixture,
+      receiptDirectory: fixture.receiptDirectory,
+      applicationSha: 'a'.repeat(40)
+    })
+    expect(result.deletedDeploymentFingerprints).toEqual([fingerprints[1]])
+    expect(result.retainedDeploymentFingerprints).toEqual([
+      fingerprints[4],
+      fingerprints[3],
+      fingerprints[2],
+      fingerprints[0]
+    ])
+    expect(result.releasedBytes).toBeGreaterThan(0)
+    expect(existsSync(join(fixture.paths.deployments, invalid))).toBe(true)
+    expect(existsSync(join(fixture.paths.deployments, 'foreign-entry'))).toBe(
+      true
+    )
+    expect(existsSync(join(fixture.paths.backups, 'campaign-backup'))).toBe(
+      true
+    )
+    expect(result.findings.map(({ name }) => name)).toEqual(
+      expect.arrayContaining([invalid, 'foreign-entry'])
+    )
+  })
+
+  it('blocks all automatic pruning when current or the journal is unreadable', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    fixture.deployment('a', '2026-01-01T12:00:00.000Z')
+    fixture.deployment('b', '2026-01-02T12:00:00.000Z')
+    writeFileSync(fixture.paths.journal, '{broken')
+
+    const inspection = inspectLocalStorage(fixture)
+    expect(inspection.activeDeploymentFingerprint).toBeNull()
+    expect(
+      inspection.deployments.every(({ retention }) => retention === 'keep')
+    ).toBe(true)
+    expect(() =>
+      applyDeploymentRetention({
+        ...fixture,
+        receiptDirectory: fixture.receiptDirectory,
+        applicationSha: 'a'.repeat(40)
+      })
+    ).toThrow(/valid active deployment/)
+  })
+
+  it('fails a deletion checkpoint without removing the verified active deployment', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const fingerprints = ['a', 'b', 'c', 'd'].map((character, index) =>
+      fixture.deployment(character, `2026-01-0${index + 1}T12:00:00.000Z`)
+    )
+    fixture.activate(fingerprints[3]!)
+
+    expect(() =>
+      applyDeploymentRetention({
+        ...fixture,
+        receiptDirectory: fixture.receiptDirectory,
+        applicationSha: 'a'.repeat(40),
+        removeDirectory: () => {
+          throw new Error('injected delete failure')
+        }
+      })
+    ).toThrow('injected delete failure')
+    expect(existsSync(fixture.paths.current)).toBe(true)
+    expect(existsSync(join(fixture.paths.deployments, fingerprints[0]!))).toBe(
+      true
+    )
+  })
+})
+
+describe('handoff audit retention', () => {
+  it('keeps all nonterminal details, the newest 100 terminal details, and every SHA state', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const attempts = join(fixture.receiptDirectory, 'attempts')
+    const states = join(fixture.receiptDirectory, 'states')
+    mkdirSync(attempts)
+    mkdirSync(states)
+    const invocations = []
+    for (let index = 0; index < 103; index += 1) {
+      const attemptId = `00000000-0000-4000-8000-${index
+        .toString(16)
+        .padStart(12, '0')}`
+      const auditPath = join(attempts, `${attemptId}.json`)
+      const status = index === 102 ? 'running' : 'complete'
+      writeFileSync(
+        auditPath,
+        JSON.stringify({ activeAttemptId: attemptId, status })
+      )
+      writeFileSync(
+        join(states, `${index.toString().padStart(3, '0')}.json`),
+        'state'
+      )
+      invocations.push({
+        attemptId,
+        applicationSha: 'a'.repeat(40),
+        intent: 'advance',
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        statePath: join(states, `${index.toString().padStart(3, '0')}.json`),
+        auditPath
+      })
+    }
+    writeFileSync(
+      join(fixture.receiptDirectory, 'invocations.json'),
+      JSON.stringify({ formatVersion: 2, invocations })
+    )
+
+    const result = applyAuditRetention({
+      receiptDirectory: fixture.receiptDirectory
+    })
+    expect(result).toMatchObject({
+      retainedInvocations: 101,
+      removedInvocations: 2
+    })
+    expect(result.removedAttemptFiles).toHaveLength(2)
+    const retainedHistory = handoffInvocationHistorySchema.parse(
+      JSON.parse(
+        readFileSync(join(fixture.receiptDirectory, 'invocations.json'), 'utf8')
+      )
+    )
+    expect(retainedHistory.invocations).toHaveLength(101)
+    expect(
+      existsSync(join(attempts, `${invocations[102]!.attemptId}.json`))
+    ).toBe(true)
+    expect(existsSync(join(states, '000.json'))).toBe(true)
+    expect(existsSync(join(states, '102.json'))).toBe(true)
+  })
+
+  it('fails the retention checkpoint when an owned attempt detail cannot be deleted', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const attempts = join(fixture.receiptDirectory, 'attempts')
+    mkdirSync(attempts)
+    const invocations = []
+    for (let index = 0; index < 101; index += 1) {
+      const attemptId = `00000000-0000-4000-8000-${index
+        .toString(16)
+        .padStart(12, '0')}`
+      const auditPath = join(attempts, `${attemptId}.json`)
+      writeFileSync(
+        auditPath,
+        JSON.stringify({ activeAttemptId: attemptId, status: 'failed' })
+      )
+      invocations.push({
+        attemptId,
+        applicationSha: 'a'.repeat(40),
+        intent: 'advance',
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        statePath: join(fixture.receiptDirectory, 'states', `${index}.json`),
+        auditPath
+      })
+    }
+    writeFileSync(
+      join(fixture.receiptDirectory, 'invocations.json'),
+      JSON.stringify({ formatVersion: 2, invocations })
+    )
+
+    expect(() =>
+      applyAuditRetention({
+        receiptDirectory: fixture.receiptDirectory,
+        removeFile: () => {
+          throw new Error('injected audit delete failure')
+        }
+      })
+    ).toThrow('injected audit delete failure')
+  })
+
+  it('resumes after audit failure without losing already released deployment evidence', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const fingerprints = ['a', 'b', 'c', 'd'].map((character, index) =>
+      fixture.deployment(character, `2026-01-0${index + 1}T12:00:00.000Z`)
+    )
+    fixture.activate(fingerprints[3]!)
+    const attempts = join(fixture.receiptDirectory, 'attempts')
+    mkdirSync(attempts)
+    const invocations = Array.from({ length: 101 }, (_, index) => {
+      const attemptId = `00000000-0000-4000-8000-${index
+        .toString(16)
+        .padStart(12, '0')}`
+      const auditPath = join(attempts, `${attemptId}.json`)
+      writeFileSync(
+        auditPath,
+        JSON.stringify({ activeAttemptId: attemptId, status: 'complete' })
+      )
+      return {
+        attemptId,
+        applicationSha: 'a'.repeat(40),
+        intent: 'advance',
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        statePath: join(fixture.receiptDirectory, 'states', `${index}.json`),
+        auditPath
+      }
+    })
+    writeFileSync(
+      join(fixture.receiptDirectory, 'invocations.json'),
+      JSON.stringify({ formatVersion: 2, invocations })
+    )
+    const options = {
+      ...fixture,
+      applicationSha: 'a'.repeat(40),
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    }
+
+    expect(() =>
+      applyStorageRetention({
+        ...options,
+        removeAuditFile: () => {
+          throw new Error('injected audit delete failure')
+        }
+      })
+    ).toThrow('injected audit delete failure')
+    expect(existsSync(join(fixture.paths.deployments, fingerprints[0]!))).toBe(
+      false
+    )
+    expect(existsSync(join(fixture.paths.deployments, fingerprints[3]!))).toBe(
+      true
+    )
+
+    const resumed = applyStorageRetention(options)
+    expect(resumed.deployment.deletedDeploymentFingerprints).toEqual([
+      fingerprints[0]
+    ])
+    expect(resumed.deployment.releasedBytes).toBeGreaterThan(0)
+    expect(collectStorageRetentionReceipt(options)).toEqual(resumed)
+  })
+})


### PR DESCRIPTION
Implements roadmap Phase 5 only: post-runtime deployment retention, read-only storage inspection, exact single-backup pruning, bounded terminal handoff audit details, durable architecture contracts, and failure/resume coverage.\n\nLocal verification: pnpm check (all functional and visual E2E suites passed; regression warning categories all zero).