### PR TITLE
Phase 6A: evacuate legacy compatibility formats

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -265,6 +265,12 @@ verifiable phases:
    Campaign backups are never automatically deleted and require exact,
    single-target manifest confirmation. Terminal invocation details are capped
    at 100 while SHA state receipts and nonterminal attempts remain durable.
+8. Compatibility evacuation runs within that post-runtime maintenance boundary
+   after the verified profile backup. Its read-only topology covers profile,
+   backups, deployments, installation journal, and Handoff audit state; known
+   reader-dependent formats are rewritten or succeeded without mutating
+   immutable backups, while unknown-invalid data remains quarantined by
+   validation and untouched.
 
 The editor application-layer refactor tracks its normative evidence in
 `application-layer-refactor-acceptance-matrix.md`. It moves the two-step

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -399,6 +399,27 @@ retention keeps the newest 100 terminal records and every nonterminal record;
 only detail files no longer referenced after that classification may be
 removed.
 
+The read-only storage inventory also owns the compatibility topology across
+profile databases and lifecycle journals, every retained backup, active and
+retained deployments, the installation journal, and Handoff state and
+invocation history. It distinguishes current, migratable, reader-dependent
+legacy, and unknown-invalid artifacts. Unknown or integrity-invalid artifacts
+are preserved and are never made application-reachable merely to classify
+them. Current version-one contracts such as campaign-backup manifests remain
+explicitly allowlisted and are not legacy by number alone.
+
+Known reader-dependent artifacts are evacuated only under the installation
+lock and after a verified current-profile backup. Mutable journals and audit
+indexes are atomically rewritten to their current contracts. Immutable backups
+are never rewritten in place: evacuation creates and verifies a current-format
+successor and records that provenance, while removal of the original remains
+an exact manual prune. A fresh current deployment must replace an active legacy
+deployment before the same ownership- and hash-validating retention boundary
+may remove obsolete inactive deployments. Handoff retention is reusable only
+when its post-operation compatibility scan reports that every
+application-reachable artifact is current; migratable or reader-dependent
+formats may remain only in verified immutable history.
+
 Remote required-job evidence satisfies `checked`; the downloaded Local package
 satisfies `packaged`. The actual downloaded AppImage is still smoke-tested on
 the handoff host before any campaign backup, deployment, activation, or

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -160,7 +160,10 @@ export const storageRetentionEvidenceSchema = z
     releasedBytes: z.number().int().nonnegative(),
     retainedInvocations: z.number().int().nonnegative(),
     removedInvocations: z.number().int().nonnegative(),
-    removedAttemptFiles: z.array(z.string())
+    removedAttemptFiles: z.array(z.string()),
+    reachableLegacyCount: z.literal(0),
+    reachableNonCurrentCount: z.literal(0),
+    unknownInvalidCount: z.number().int().nonnegative()
   })
   .strict()
 

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -368,6 +368,10 @@ function collectStorageRetentionEvidence(): HandoffPhaseEvidence {
     receiptDirectory,
     applicationSha: workspace.commit
   })
+  if (retained.compatibility.reachableNonCurrentCount !== 0)
+    throw new Error(
+      'Storage retention left application-reachable non-current storage'
+    )
   return {
     ...installed,
     storageRetention: {
@@ -383,7 +387,10 @@ function collectStorageRetentionEvidence(): HandoffPhaseEvidence {
       releasedBytes: retained.deployment.releasedBytes,
       retainedInvocations: retained.audit.retainedInvocations,
       removedInvocations: retained.audit.removedInvocations,
-      removedAttemptFiles: [...retained.audit.removedAttemptFiles]
+      removedAttemptFiles: [...retained.audit.removedAttemptFiles],
+      reachableLegacyCount: 0,
+      reachableNonCurrentCount: 0,
+      unknownInvalidCount: retained.compatibility.unknownInvalidCount
     }
   }
 }

--- a/scripts/inspect-local-storage.ts
+++ b/scripts/inspect-local-storage.ts
@@ -18,6 +18,7 @@ const paths = localInstallationPaths(
 )
 const inspection = inspectLocalStorage({
   paths,
+  receiptDirectory: resolve(workspaceRoot, '.tmp', 'handoff-local-app'),
   iconSourcePath: resolve(
     workspaceRoot,
     'resources',

--- a/scripts/local-storage/compatibility-evacuation.ts
+++ b/scripts/local-storage/compatibility-evacuation.ts
@@ -1,0 +1,214 @@
+import {
+  cpSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync
+} from 'node:fs'
+import { basename, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { parseCampaignLifecycleReceipt } from '../../src/core/persistence/sqlite/campaign-lifecycle-journal.js'
+import {
+  handoffInvocationHistorySchema,
+  parseHandoffInvocationHistory
+} from '../delivery-contract.js'
+import {
+  readInstallJournal,
+  writeInstallJournal
+} from '../local-install-journal.js'
+import { hashTree } from '../local-installation/campaign-file-inventory.js'
+import type { LocalInstallationPaths } from '../local-installation/contract.js'
+import { atomicWrite, syncDirectory } from './filesystem.js'
+import { inspectLocalStorage, validateBackupDirectory } from './inspection.js'
+
+export interface EvacuateCompatibilityOptions {
+  readonly paths: LocalInstallationPaths
+  readonly iconSourcePath: string
+  readonly receiptDirectory: string
+  readonly now?: () => Date
+}
+
+export function evacuateCompatibility(
+  options: EvacuateCompatibilityOptions
+): void {
+  const before = inspectLocalStorage(options)
+  const legacy = before.compatibility.artifacts.filter(
+    ({ status }) => status === 'legacy-reader-required'
+  )
+  if (legacy.length === 0) return
+  requireVerifiedHandoffBackup(options.paths)
+
+  rewriteLegacyJson(
+    options.paths.journal,
+    'formatVersion',
+    () => readInstallJournalFromValue(options.paths.journal),
+    (value) =>
+      writeInstallJournal(
+        options.paths.journal,
+        value,
+        options.now ?? (() => new Date())
+      )
+  )
+  rewriteHandoffHistory(options.receiptDirectory)
+  rewriteLifecycleDirectory(
+    join(options.paths.campaignData, 'campaigns', '.transitions')
+  )
+
+  for (const backup of before.backups)
+    if (backupHasLegacyLifecycle(backup.path))
+      createBackupSuccessor(backup.path, backup.manifestSha256, options)
+}
+
+function rewriteHandoffHistory(receiptDirectory: string): void {
+  const path = join(receiptDirectory, 'invocations.json')
+  if (!existsSync(path)) return
+  const history = parseHandoffInvocationHistory(
+    JSON.parse(readFileSync(path, 'utf8'))
+  )
+  let changed = false
+  const invocations = history.invocations.map((invocation) => {
+    const target = join(
+      receiptDirectory,
+      'attempts',
+      `${invocation.attemptId}.json`
+    )
+    if (invocation.auditPath === target) return invocation
+    if (!existsSync(invocation.auditPath))
+      throw new Error(
+        `Legacy Handoff attempt detail is missing: ${invocation.attemptId}`
+      )
+    atomicWrite(target, readFileSync(invocation.auditPath, 'utf8'))
+    changed = true
+    return { ...invocation, auditPath: target }
+  })
+  if (
+    changed ||
+    (JSON.parse(readFileSync(path, 'utf8')) as { formatVersion?: unknown })
+      .formatVersion !== 2
+  )
+    atomicWrite(
+      path,
+      `${JSON.stringify(
+        handoffInvocationHistorySchema.parse({
+          formatVersion: 2,
+          invocations
+        }),
+        null,
+        2
+      )}\n`
+    )
+}
+
+function requireVerifiedHandoffBackup(paths: LocalInstallationPaths): void {
+  const journal = readInstallJournal(paths.journal)
+  if (
+    journal === null ||
+    journal.phase !== 'completed' ||
+    journal.backupPath === null ||
+    journal.backupManifestSha256 === null
+  )
+    throw new Error(
+      'Compatibility evacuation requires a completed installation journal with verified backup evidence'
+    )
+  const verified = validateBackupDirectory(
+    journal.backupPath,
+    basename(journal.backupPath)
+  )
+  if (verified.manifestSha256 !== journal.backupManifestSha256)
+    throw new Error('Compatibility evacuation backup evidence changed')
+}
+
+function readInstallJournalFromValue(
+  path: string
+): NonNullable<ReturnType<typeof readInstallJournal>> {
+  const journal = readInstallJournal(path)
+  if (journal === null) throw new Error('Install journal disappeared')
+  return journal
+}
+
+function rewriteLegacyJson<T>(
+  path: string,
+  versionField: string,
+  parse: (value: unknown) => T,
+  write: (value: T) => unknown
+): void {
+  if (!existsSync(path)) return
+  const value = JSON.parse(readFileSync(path, 'utf8')) as Record<
+    string,
+    unknown
+  >
+  if (value[versionField] !== 1) return
+  write(parse(value))
+}
+
+function rewriteLifecycleDirectory(directory: string): void {
+  if (!existsSync(directory)) return
+  for (const name of readdirSync(directory).sort()) {
+    const path = join(directory, name)
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    if (value['schemaVersion'] !== 1) continue
+    const migrated = parseCampaignLifecycleReceipt(value)
+    atomicWrite(path, `${JSON.stringify(migrated, null, 2)}\n`)
+  }
+}
+
+function backupHasLegacyLifecycle(path: string): boolean {
+  const directory = join(path, 'campaigns', '.transitions')
+  if (!existsSync(directory)) return false
+  return readdirSync(directory).some((name) => {
+    const value = JSON.parse(
+      readFileSync(join(directory, name), 'utf8')
+    ) as Record<string, unknown>
+    return value['schemaVersion'] === 1
+  })
+}
+
+function createBackupSuccessor(
+  source: string,
+  sourceManifestSha256: string,
+  options: EvacuateCompatibilityOptions
+): void {
+  const name = `${basename(source)}-compat-v2-${sourceManifestSha256.slice(0, 8)}`
+  const target = join(options.paths.backups, name)
+  if (existsSync(target)) {
+    validateBackupDirectory(target, name)
+    return
+  }
+  const staging = join(options.paths.backups, `.compat-${randomUUID()}`)
+  try {
+    cpSync(source, staging, { recursive: true, errorOnExist: true })
+    rewriteLifecycleDirectory(join(staging, 'campaigns', '.transitions'))
+    const manifestPath = join(staging, 'backup-manifest.json')
+    const previous = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    atomicWrite(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          ...previous,
+          createdAt: (options.now ?? (() => new Date()))().toISOString(),
+          compatibilitySuccessorOf: {
+            name: basename(source),
+            manifestSha256: sourceManifestSha256
+          },
+          files: hashTree(staging).filter(
+            ({ path }) => path !== 'backup-manifest.json'
+          )
+        },
+        null,
+        2
+      )}\n`
+    )
+    validateBackupDirectory(staging, name)
+    renameSync(staging, target)
+    syncDirectory(options.paths.backups)
+  } finally {
+    rmSync(staging, { recursive: true, force: true })
+  }
+}

--- a/scripts/local-storage/compatibility.ts
+++ b/scripts/local-storage/compatibility.ts
@@ -1,0 +1,532 @@
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync
+} from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import {
+  databaseSchemaVersions,
+  type DatabaseRole
+} from '../../src/core/persistence/sqlite/database.js'
+import { resolveSchemaMigrationPath } from '../../src/core/persistence/sqlite/schema-migrations.js'
+import type { LocalInstallationPaths } from '../local-installation/contract.js'
+import { sha256File } from '../file-hash.js'
+import type {
+  CompatibilityArtifact,
+  CompatibilityInspection,
+  StorageFinding,
+  ValidBackup,
+  ValidDeployment
+} from './contract.js'
+
+export interface InspectCompatibilityOptions {
+  readonly paths: LocalInstallationPaths
+  readonly deployments: readonly ValidDeployment[]
+  readonly backups: readonly ValidBackup[]
+  readonly findings: readonly StorageFinding[]
+  readonly receiptDirectory?: string
+}
+
+/** Classifies owned bytes without opening SQLite or mutating an inspected root. */
+export function inspectCompatibility(
+  options: InspectCompatibilityOptions
+): CompatibilityInspection {
+  const artifacts: CompatibilityArtifact[] = []
+  scanDatabases(options.paths.campaignData, 'profile', true, artifacts)
+  scanLifecycleDirectory(
+    join(options.paths.campaignData, 'campaigns', '.transitions'),
+    'profile',
+    true,
+    artifacts
+  )
+
+  const succeededBackups = compatibilitySuccessorSources(options.backups)
+  for (const backup of options.backups) {
+    artifacts.push(
+      artifact(
+        'backup',
+        backup.name,
+        backup.path,
+        'current',
+        'campaign-backup-manifest-v1',
+        false,
+        'Version one is the current immutable backup envelope'
+      )
+    )
+    scanDatabases(backup.path, 'backup', false, artifacts)
+    scanLifecycleDirectory(
+      join(backup.path, 'campaigns', '.transitions'),
+      'backup',
+      false,
+      artifacts,
+      succeededBackups.has(backup.name) ? 'migratable' : undefined
+    )
+  }
+  for (const finding of options.findings.filter(
+    ({ area }) => area === 'backups'
+  ))
+    artifacts.push(
+      artifact(
+        'backup',
+        finding.name,
+        join(options.paths.backups, finding.name),
+        'unknown-invalid',
+        'unverified',
+        false,
+        finding.reason
+      )
+    )
+
+  for (const deployment of options.deployments)
+    artifacts.push(
+      artifact(
+        'deployment',
+        deployment.fingerprint,
+        deployment.path,
+        deployment.manifestFormatVersion === 2
+          ? 'current'
+          : 'legacy-reader-required',
+        `deployment-manifest-v${deployment.manifestFormatVersion}`,
+        deployment.retention === 'keep',
+        deployment.manifestFormatVersion === 2
+          ? 'Current receipt-backed deployment manifest'
+          : 'Known ownership-valid legacy deployment manifest'
+      )
+    )
+  for (const finding of options.findings.filter(
+    ({ area }) => area === 'deployments'
+  ))
+    artifacts.push(
+      artifact(
+        'deployment',
+        finding.name,
+        finding.name === 'current'
+          ? options.paths.current
+          : finding.name === 'install-journal.json'
+            ? options.paths.journal
+            : join(options.paths.deployments, finding.name),
+        'unknown-invalid',
+        'unverified',
+        finding.name === 'current' || finding.name === 'install-journal.json',
+        finding.reason
+      )
+    )
+
+  scanVersionedJson(
+    options.paths.journal,
+    'install-journal',
+    'install-journal.json',
+    2,
+    artifacts
+  )
+  scanLegacyRoot(options.paths, artifacts)
+  if (options.receiptDirectory !== undefined)
+    scanHandoff(options.receiptDirectory, artifacts)
+
+  const ordered = artifacts.sort((left, right) =>
+    `${left.area}:${left.path}:${left.format}`.localeCompare(
+      `${right.area}:${right.path}:${right.format}`,
+      'en'
+    )
+  )
+  return {
+    formatVersion: 1,
+    artifacts: ordered,
+    reachableLegacyCount: ordered.filter(
+      ({ status, applicationReachable }) =>
+        status === 'legacy-reader-required' && applicationReachable
+    ).length,
+    reachableNonCurrentCount: ordered.filter(
+      ({ status, applicationReachable }) =>
+        status !== 'current' && applicationReachable
+    ).length,
+    unknownInvalidCount: ordered.filter(
+      ({ status }) => status === 'unknown-invalid'
+    ).length
+  }
+}
+
+function compatibilitySuccessorSources(
+  backups: readonly ValidBackup[]
+): Set<string> {
+  const sources = new Set<string>()
+  const manifests = new Map(
+    backups.map((backup) => [backup.name, backup.manifestSha256])
+  )
+  for (const backup of backups) {
+    const manifest = JSON.parse(
+      readFileSync(join(backup.path, 'backup-manifest.json'), 'utf8')
+    ) as Record<string, unknown>
+    const provenance = manifest['compatibilitySuccessorOf']
+    if (
+      typeof provenance === 'object' &&
+      provenance !== null &&
+      'name' in provenance &&
+      typeof provenance.name === 'string' &&
+      'manifestSha256' in provenance &&
+      typeof provenance.manifestSha256 === 'string' &&
+      manifests.get(provenance.name) === provenance.manifestSha256 &&
+      !directoryHasLegacyLifecycle(backup.path)
+    )
+      sources.add(provenance.name)
+  }
+  return sources
+}
+
+function directoryHasLegacyLifecycle(backupPath: string): boolean {
+  const directory = join(backupPath, 'campaigns', '.transitions')
+  if (!existsSync(directory)) return false
+  return readdirSync(directory).some((name) => {
+    try {
+      const value = JSON.parse(
+        readFileSync(join(directory, name), 'utf8')
+      ) as Record<string, unknown>
+      return value['schemaVersion'] !== 2
+    } catch {
+      return true
+    }
+  })
+}
+
+function scanDatabases(
+  root: string,
+  area: 'profile' | 'backup',
+  reachable: boolean,
+  artifacts: CompatibilityArtifact[]
+): void {
+  for (const path of filesRecursively(root).filter((file) =>
+    file.endsWith('.sqlite')
+  )) {
+    const role = databaseRole(root, path)
+    if (role === null) {
+      artifacts.push(
+        artifact(
+          area,
+          relative(root, path),
+          path,
+          'unknown-invalid',
+          'sqlite',
+          reachable,
+          'SQLite path has no declared aggregate role'
+        )
+      )
+      continue
+    }
+    try {
+      const version = sqliteHeaderUserVersion(path)
+      const expected = databaseSchemaVersions[role]
+      const migrations = resolveSchemaMigrationPath(role, version)
+      artifacts.push(
+        artifact(
+          area,
+          relative(root, path),
+          path,
+          version === expected
+            ? 'current'
+            : migrations !== null
+              ? 'migratable'
+              : 'unknown-invalid',
+          `${role}-schema-v${version}`,
+          reachable,
+          version === expected
+            ? 'Database schema is current'
+            : migrations !== null
+              ? `Registered migration path has ${migrations.length} step(s)`
+              : `No migration path to schema ${expected}`
+        )
+      )
+    } catch (error) {
+      artifacts.push(
+        artifact(
+          area,
+          relative(root, path),
+          path,
+          'unknown-invalid',
+          'sqlite',
+          reachable,
+          errorMessage(error)
+        )
+      )
+    }
+  }
+}
+
+function scanLifecycleDirectory(
+  directory: string,
+  area: 'profile' | 'backup',
+  reachable: boolean,
+  artifacts: CompatibilityArtifact[],
+  legacyStatus?: 'migratable'
+): void {
+  if (!existsSync(directory)) return
+  for (const name of readdirSync(directory).sort())
+    scanVersionedJson(
+      join(directory, name),
+      area,
+      name,
+      2,
+      artifacts,
+      'schemaVersion',
+      reachable,
+      legacyStatus
+    )
+}
+
+function scanHandoff(
+  receiptDirectory: string,
+  artifacts: CompatibilityArtifact[]
+): void {
+  scanHandoffHistory(receiptDirectory, artifacts)
+  for (const directory of ['states', 'attempts'] as const)
+    for (const path of filesRecursively(join(receiptDirectory, directory)))
+      if (path.endsWith('.json'))
+        scanVersionedJson(
+          path,
+          'handoff-state',
+          relative(receiptDirectory, path),
+          6,
+          artifacts,
+          'formatVersion',
+          directory === 'states'
+        )
+}
+
+function scanHandoffHistory(
+  receiptDirectory: string,
+  artifacts: CompatibilityArtifact[]
+): void {
+  const path = join(receiptDirectory, 'invocations.json')
+  if (!existsSync(path)) return
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    if (value['formatVersion'] !== 2) {
+      scanVersionedJson(
+        path,
+        'handoff-history',
+        'invocations.json',
+        2,
+        artifacts
+      )
+      return
+    }
+    const rawInvocations: unknown = value['invocations']
+    const invocations: unknown[] = Array.isArray(rawInvocations)
+      ? (rawInvocations as unknown[])
+      : []
+    const attemptsRoot = `${join(receiptDirectory, 'attempts')}${sep}`
+    const oldLayout = invocations.some(
+      (entry) => !usesCurrentAttemptLayout(entry, attemptsRoot)
+    )
+    artifacts.push(
+      artifact(
+        'handoff-history',
+        'invocations.json',
+        path,
+        oldLayout ? 'legacy-reader-required' : 'current',
+        oldLayout ? 'invocation-history-v2-legacy-layout' : 'formatVersion-v2',
+        true,
+        oldLayout
+          ? 'Invocation detail paths still use pre-attempt storage'
+          : 'Current format and attempt-detail layout'
+      )
+    )
+  } catch (error) {
+    artifacts.push(
+      artifact(
+        'handoff-history',
+        'invocations.json',
+        path,
+        'unknown-invalid',
+        'unparseable-json',
+        true,
+        errorMessage(error)
+      )
+    )
+  }
+}
+
+function usesCurrentAttemptLayout(
+  value: unknown,
+  attemptsRoot: string
+): boolean {
+  if (typeof value !== 'object' || value === null) return false
+  const auditPath = (value as Record<string, unknown>)['auditPath']
+  return typeof auditPath === 'string' && auditPath.startsWith(attemptsRoot)
+}
+
+function scanVersionedJson(
+  path: string,
+  area: CompatibilityArtifact['area'],
+  name: string,
+  currentVersion: number,
+  artifacts: CompatibilityArtifact[],
+  field = 'formatVersion',
+  applicationReachable = true,
+  legacyStatus?: 'migratable'
+): void {
+  if (!existsSync(path)) return
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    const version = value[field]
+    if (typeof version !== 'number' || !Number.isInteger(version))
+      throw new Error(`Missing integer ${field}`)
+    artifacts.push(
+      artifact(
+        area,
+        name,
+        path,
+        version === currentVersion
+          ? 'current'
+          : version < currentVersion
+            ? (legacyStatus ?? 'legacy-reader-required')
+            : 'unknown-invalid',
+        `${field}-v${version}`,
+        applicationReachable,
+        version === currentVersion
+          ? 'Current format'
+          : version < currentVersion
+            ? legacyStatus === 'migratable'
+              ? 'Immutable source has a verified current-format successor'
+              : `Known reader may still map this to version ${currentVersion}`
+            : `Format is newer than supported version ${currentVersion}`
+      )
+    )
+  } catch (error) {
+    artifacts.push(
+      artifact(
+        area,
+        name,
+        path,
+        'unknown-invalid',
+        'unparseable-json',
+        applicationReachable,
+        errorMessage(error)
+      )
+    )
+  }
+}
+
+function scanLegacyRoot(
+  paths: LocalInstallationPaths,
+  artifacts: CompatibilityArtifact[]
+): void {
+  const marker = join(paths.root, 'installed-artifact.json')
+  const image = join(paths.root, 'SaltMarcher.AppImage')
+  if (!existsSync(marker) && !existsSync(image)) return
+  if (!existsSync(marker)) {
+    artifacts.push(
+      artifact(
+        'deployment',
+        'legacy-root-installation',
+        image,
+        'unknown-invalid',
+        'unowned-root-appimage',
+        false,
+        'Legacy root AppImage has no ownership marker'
+      )
+    )
+    return
+  }
+  try {
+    const value = JSON.parse(readFileSync(marker, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    const artifactSha256 = value['artifactSha256']
+    if (
+      value['formatVersion'] !== 1 ||
+      typeof artifactSha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(artifactSha256) ||
+      !existsSync(image) ||
+      sha256File(image) !== artifactSha256
+    )
+      throw new Error('Legacy root installation ownership or hash is invalid')
+    artifacts.push(
+      artifact(
+        'deployment',
+        'legacy-root-installation',
+        marker,
+        'legacy-reader-required',
+        'installed-artifact-v1',
+        false,
+        'Known ownership-valid pre-deployment installation'
+      )
+    )
+  } catch (error) {
+    artifacts.push(
+      artifact(
+        'deployment',
+        'legacy-root-installation',
+        marker,
+        'unknown-invalid',
+        'unverified-root-installation',
+        false,
+        errorMessage(error)
+      )
+    )
+  }
+}
+
+function sqliteHeaderUserVersion(path: string): number {
+  const descriptor = openSync(path, 'r')
+  try {
+    const bytes = Buffer.alloc(100)
+    if (readSync(descriptor, bytes, 0, bytes.length, 0) !== bytes.length)
+      throw new Error('Invalid SQLite header length')
+    if (bytes.subarray(0, 16).toString('binary') !== 'SQLite format 3\u0000')
+      throw new Error('Invalid SQLite header')
+    return bytes.readUInt32BE(60)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+function databaseRole(root: string, path: string): DatabaseRole | null {
+  const parts = relative(root, path).split(sep)
+  if (parts.length === 1 && parts[0] === 'installation.sqlite')
+    return 'installation'
+  if (
+    parts.length >= 3 &&
+    parts[0] === 'campaigns' &&
+    parts.at(-1) === 'campaign.sqlite'
+  )
+    return 'campaign'
+  return null
+}
+
+function filesRecursively(root: string): string[] {
+  if (!existsSync(root)) return []
+  const files: string[] = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name)
+    if (entry.isSymbolicLink()) continue
+    if (entry.isDirectory()) files.push(...filesRecursively(path))
+    else if (entry.isFile()) files.push(path)
+  }
+  return files.sort()
+}
+
+function artifact(
+  area: CompatibilityArtifact['area'],
+  name: string,
+  path: string,
+  status: CompatibilityArtifact['status'],
+  format: string,
+  applicationReachable: boolean,
+  reason: string
+): CompatibilityArtifact {
+  return { area, name, path, status, format, applicationReachable, reason }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/scripts/local-storage/contract.ts
+++ b/scripts/local-storage/contract.ts
@@ -1,5 +1,5 @@
 export interface StorageFinding {
-  readonly area: 'deployments' | 'backups' | 'audit'
+  readonly area: 'deployments' | 'backups' | 'audit' | 'compatibility'
   readonly name: string
   readonly reason: string
 }
@@ -15,9 +15,37 @@ export interface ValidDeployment {
   readonly builtAt: string
   readonly bytes: number
   readonly manifestSha256: string
+  readonly manifestFormatVersion: 1 | 2
   readonly active: boolean
   readonly journalProtected: boolean
   readonly retention: 'keep' | 'delete'
+}
+
+export type CompatibilityStatus =
+  'current' | 'migratable' | 'legacy-reader-required' | 'unknown-invalid'
+
+export interface CompatibilityArtifact {
+  readonly area:
+    | 'profile'
+    | 'backup'
+    | 'deployment'
+    | 'install-journal'
+    | 'handoff-state'
+    | 'handoff-history'
+  readonly name: string
+  readonly path: string
+  readonly status: CompatibilityStatus
+  readonly format: string
+  readonly applicationReachable: boolean
+  readonly reason: string
+}
+
+export interface CompatibilityInspection {
+  readonly formatVersion: 1
+  readonly artifacts: readonly CompatibilityArtifact[]
+  readonly reachableLegacyCount: number
+  readonly reachableNonCurrentCount: number
+  readonly unknownInvalidCount: number
 }
 
 export interface ValidBackup {
@@ -41,6 +69,7 @@ export interface LocalStorageInspection {
   readonly backupBytes: number
   readonly findings: readonly StorageFinding[]
   readonly warnings: readonly StorageWarning[]
+  readonly compatibility: CompatibilityInspection
 }
 
 export interface DeploymentRetentionResult {
@@ -65,6 +94,7 @@ export interface StorageRetentionReceipt {
   readonly createdAt: string
   readonly deployment: DeploymentRetentionResult
   readonly audit: AuditRetentionResult
+  readonly compatibility: CompatibilityInspection
 }
 
 export interface BackupPruneResult {

--- a/scripts/local-storage/inspection.ts
+++ b/scripts/local-storage/inspection.ts
@@ -26,12 +26,14 @@ import {
   type ValidBackup,
   type ValidDeployment
 } from './contract.js'
+import { inspectCompatibility } from './compatibility.js'
 import { directDirectoryNames, treeBytes } from './filesystem.js'
 
 export interface InspectLocalStorageOptions {
   readonly paths: LocalInstallationPaths
   readonly iconSourcePath: string
   readonly now?: () => Date
+  readonly receiptDirectory?: string
 }
 
 type InspectedDeployment = Omit<
@@ -152,6 +154,15 @@ export function inspectLocalStorage(
       }
     })
   const warnings = storageWarnings(backupNames.length, backupBytes)
+  const compatibility = inspectCompatibility({
+    paths: options.paths,
+    deployments,
+    backups,
+    findings,
+    ...(options.receiptDirectory === undefined
+      ? {}
+      : { receiptDirectory: options.receiptDirectory })
+  })
 
   return {
     formatVersion: 1,
@@ -162,7 +173,8 @@ export function inspectLocalStorage(
     backupEntryCount: backupNames.length,
     backupBytes,
     findings: findings.sort(findingOrder),
-    warnings
+    warnings,
+    compatibility
   }
 }
 
@@ -187,9 +199,17 @@ export function validateDeploymentDirectory(
   )
     throw new Error('Deployment contains an unexpected file inventory')
   const manifestPath = join(path, 'artifact-manifest.json')
-  const manifest = localArtifactManifestSchema.parse(
-    JSON.parse(readFileSync(manifestPath, 'utf8'))
-  )
+  const raw: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  const parsed = localArtifactManifestSchema.safeParse(raw)
+  if (!parsed.success)
+    return validateLegacyDeployment(
+      path,
+      fingerprint,
+      iconSourcePath,
+      manifestPath,
+      raw
+    )
+  const manifest = parsed.data
   if (manifest.receipt.build.channel !== 'local')
     throw new Error('Deployment manifest does not describe a Local build')
   if (manifest.receipt.build.workspaceFingerprint !== fingerprint)
@@ -211,7 +231,56 @@ export function validateDeploymentDirectory(
     path,
     builtAt: manifest.receipt.build.builtAt,
     bytes: treeBytes(path),
-    manifestSha256: sha256File(manifestPath)
+    manifestSha256: sha256File(manifestPath),
+    manifestFormatVersion: 2
+  }
+}
+
+const legacyDeploymentManifestSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    artifactFile: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(/^[^/\\]+$/),
+    artifactSha256: z.string().regex(/^[a-f0-9]{64}$/),
+    build: z
+      .object({
+        channel: z.literal('local'),
+        commit: z.string().regex(/^[a-f0-9]{40}$/),
+        sourceFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+        dirty: z.boolean(),
+        builtAt: z.iso.datetime(),
+        schemaVersion: z.number().int().nonnegative()
+      })
+      .strict()
+  })
+  .strict()
+
+function validateLegacyDeployment(
+  path: string,
+  fingerprint: string,
+  iconSourcePath: string,
+  manifestPath: string,
+  raw: unknown
+): InspectedDeployment {
+  const manifest = legacyDeploymentManifestSchema.parse(raw)
+  if (manifest.build.sourceFingerprint !== fingerprint)
+    throw new Error('Legacy deployment directory and source fingerprint differ')
+  if (
+    sha256File(join(path, 'SaltMarcher.AppImage')) !== manifest.artifactSha256
+  )
+    throw new Error('Legacy deployment AppImage hash is invalid')
+  if (sha256File(join(path, 'icon.png')) !== sha256File(iconSourcePath))
+    throw new Error('Legacy deployment icon hash is invalid')
+  return {
+    fingerprint,
+    path,
+    builtAt: manifest.build.builtAt,
+    bytes: treeBytes(path),
+    manifestSha256: sha256File(manifestPath),
+    manifestFormatVersion: 1
   }
 }
 

--- a/scripts/local-storage/retention.ts
+++ b/scripts/local-storage/retention.ts
@@ -10,6 +10,7 @@ import {
   type StorageRetentionReceipt
 } from './contract.js'
 import { atomicWrite, syncDirectory } from './filesystem.js'
+import { evacuateCompatibility } from './compatibility-evacuation.js'
 import {
   inspectLocalStorage,
   validateDeploymentDirectory
@@ -27,7 +28,7 @@ export interface ApplyStorageRetentionOptions {
 
 const findingSchema = z
   .object({
-    area: z.enum(['deployments', 'backups', 'audit']),
+    area: z.enum(['deployments', 'backups', 'audit', 'compatibility']),
     name: z.string(),
     reason: z.string()
   })
@@ -69,6 +70,39 @@ const receiptSchema = progressSchema
         removedAttemptFiles: z.array(z.string()),
         findings: z.array(findingSchema)
       })
+      .strict(),
+    compatibility: z
+      .object({
+        formatVersion: z.literal(1),
+        artifacts: z.array(
+          z
+            .object({
+              area: z.enum([
+                'profile',
+                'backup',
+                'deployment',
+                'install-journal',
+                'handoff-state',
+                'handoff-history'
+              ]),
+              name: z.string(),
+              path: z.string(),
+              status: z.enum([
+                'current',
+                'migratable',
+                'legacy-reader-required',
+                'unknown-invalid'
+              ]),
+              format: z.string(),
+              applicationReachable: z.boolean(),
+              reason: z.string()
+            })
+            .strict()
+        ),
+        reachableLegacyCount: z.number().int().nonnegative(),
+        reachableNonCurrentCount: z.number().int().nonnegative(),
+        unknownInvalidCount: z.number().int().nonnegative()
+      })
       .strict()
   })
   .strict()
@@ -83,6 +117,7 @@ export function applyStorageRetention(
       options.receiptDirectory,
       'storage-retention-progress.json'
     )
+    evacuateCompatibility(options)
     const prior = readProgress(progressPath, options.applicationSha)
     const current = applyDeploymentRetention({
       ...options,
@@ -119,12 +154,18 @@ export function applyStorageRetention(
         ? {}
         : { removeFile: options.removeAuditFile })
     })
+    const compatibility = inspectLocalStorage(options).compatibility
+    if (compatibility.reachableNonCurrentCount !== 0)
+      throw new Error(
+        `Storage retention left ${compatibility.reachableNonCurrentCount} application-reachable non-current artifact(s)`
+      )
     const receipt = receiptSchema.parse({
       formatVersion: 1,
       applicationSha: options.applicationSha,
       createdAt: (options.now ?? (() => new Date()))().toISOString(),
       deployment,
-      audit
+      audit,
+      compatibility
     })
     atomicWrite(
       storageRetentionReceiptPath(options.receiptDirectory),
@@ -168,6 +209,15 @@ export function collectStorageRetentionReceipt(
   for (const fingerprint of receipt.deployment.deletedDeploymentFingerprints)
     if (existsSync(join(options.paths.deployments, fingerprint)))
       throw new Error(`Deleted deployment is present again: ${fingerprint}`)
+  if (inspection.compatibility.reachableNonCurrentCount !== 0)
+    throw new Error(
+      'Storage-retention receipt is stale; non-current storage remains reachable'
+    )
+  if (
+    JSON.stringify(inspection.compatibility) !==
+    JSON.stringify(receipt.compatibility)
+  )
+    throw new Error('Compatibility evidence differs from local storage')
   return receipt
 }
 

--- a/src/core/persistence/sqlite/campaign-lifecycle-journal.ts
+++ b/src/core/persistence/sqlite/campaign-lifecycle-journal.ts
@@ -113,24 +113,7 @@ export class FileCampaignLifecycleJournal implements CampaignLifecycleJournal {
 
   private parse(path: string): CampaignLifecycleReceipt {
     const value = JSON.parse(readFileSync(path, 'utf8')) as unknown
-    const current = campaignLifecycleReceiptSchema.safeParse(value)
-    if (current.success) return Object.freeze(current.data)
-    const legacy = legacyReceiptSchema.parse(value)
-    return Object.freeze(
-      campaignLifecycleReceiptSchema.parse({
-        schemaVersion: 2,
-        lifecycleId: legacy.transitionId,
-        operation: { kind: 'replacement' },
-        mode: 'replace',
-        campaignId: legacy.campaignId,
-        previousName: legacy.previousName,
-        replacementName: legacy.replacementName,
-        previousActiveId: legacy.previousActiveId,
-        phase: migrateLegacyPhase(legacy.phase),
-        validation: { migratedFromSchemaVersion: 1 },
-        updatedAt: legacy.updatedAt
-      })
-    )
+    return parseCampaignLifecycleReceipt(value)
   }
 
   private persist(
@@ -163,6 +146,29 @@ export class FileCampaignLifecycleJournal implements CampaignLifecycleJournal {
     if (!safeCampaignId.test(campaignId))
       throw new Error('Unsafe Campaign lifecycle identifier')
   }
+}
+
+export function parseCampaignLifecycleReceipt(
+  value: unknown
+): CampaignLifecycleReceipt {
+  const current = campaignLifecycleReceiptSchema.safeParse(value)
+  if (current.success) return Object.freeze(current.data)
+  const legacy = legacyReceiptSchema.parse(value)
+  return Object.freeze(
+    campaignLifecycleReceiptSchema.parse({
+      schemaVersion: 2,
+      lifecycleId: legacy.transitionId,
+      operation: { kind: 'replacement' },
+      mode: 'replace',
+      campaignId: legacy.campaignId,
+      previousName: legacy.previousName,
+      replacementName: legacy.replacementName,
+      previousActiveId: legacy.previousActiveId,
+      phase: migrateLegacyPhase(legacy.phase),
+      validation: { migratedFromSchemaVersion: 1 },
+      updatedAt: legacy.updatedAt
+    })
+  )
 }
 
 const phases: readonly CampaignLifecyclePhase[] = [

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -182,7 +182,10 @@ describe('candidate delivery policy', () => {
                 releasedBytes: 0,
                 retainedInvocations: 2,
                 removedInvocations: 0,
-                removedAttemptFiles: []
+                removedAttemptFiles: [],
+                reachableLegacyCount: 0,
+                reachableNonCurrentCount: 0,
+                unknownInvalidCount: 0
               }
             : null
       }

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -244,7 +244,10 @@ function phaseEvidence(
           releasedBytes: 0,
           retainedInvocations: 1,
           removedInvocations: 0,
-          removedAttemptFiles: []
+          removedAttemptFiles: [],
+          reachableLegacyCount: 0,
+          reachableNonCurrentCount: 0,
+          unknownInvalidCount: 0
         }
       : null
   }

--- a/tests/unit/local-storage-retention.test.ts
+++ b/tests/unit/local-storage-retention.test.ts
@@ -1,7 +1,16 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync
+} from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { handoffInvocationHistorySchema } from '../../scripts/delivery-contract.js'
+import { sha256File } from '../../scripts/file-hash.js'
+import { createInstallJournal } from '../../scripts/local-install-journal.js'
+import { hashTree } from '../../scripts/local-installation/campaign-file-inventory.js'
 import { applyAuditRetention } from '../../scripts/local-storage/audit-retention.js'
 import { inspectLocalStorage } from '../../scripts/local-storage/inspection.js'
 import {
@@ -17,6 +26,54 @@ afterEach(() => {
 })
 
 describe('local deployment retention', () => {
+  it('classifies a hash-valid v1 deployment and removes it through normal retention', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const legacy = fixture.deployment('a', '2026-01-01T12:00:00.000Z')
+    const current = ['b', 'c', 'd'].map((character, index) =>
+      fixture.deployment(character, `2026-01-0${index + 2}T12:00:00.000Z`)
+    )
+    fixture.activate(current[2]!)
+    makeLegacyDeployment(fixture.paths.deployments, legacy)
+
+    const before = inspectLocalStorage(fixture)
+    expect(
+      before.compatibility.artifacts.find(({ name }) => name === legacy)
+    ).toMatchObject({
+      status: 'legacy-reader-required',
+      applicationReachable: false
+    })
+    expect(
+      before.deployments.find(({ fingerprint }) => fingerprint === legacy)
+    ).toMatchObject({ manifestFormatVersion: 1, retention: 'delete' })
+
+    applyDeploymentRetention({
+      ...fixture,
+      receiptDirectory: fixture.receiptDirectory,
+      applicationSha: 'a'.repeat(40)
+    })
+    expect(existsSync(join(fixture.paths.deployments, legacy))).toBe(false)
+  })
+
+  it('refuses compatibility evacuation without a verified Handoff backup', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const legacy = fixture.deployment('a', '2026-01-01T12:00:00.000Z')
+    const current = ['b', 'c', 'd'].map((character, index) =>
+      fixture.deployment(character, `2026-01-0${index + 2}T12:00:00.000Z`)
+    )
+    fixture.activate(current[2]!)
+    makeLegacyDeployment(fixture.paths.deployments, legacy)
+
+    expect(() =>
+      applyStorageRetention({
+        ...fixture,
+        applicationSha: 'a'.repeat(40)
+      })
+    ).toThrow(/verified backup evidence/)
+    expect(existsSync(join(fixture.paths.deployments, legacy))).toBe(true)
+  })
+
   it('keeps the active, two newest inactive, and journal-referenced deployments', () => {
     const fixture = createLocalStorageFixture()
     cleanup.push(fixture.cleanup)
@@ -109,6 +166,137 @@ describe('local deployment retention', () => {
   })
 })
 
+function makeLegacyDeployment(deployments: string, fingerprint: string): void {
+  const path = join(deployments, fingerprint)
+  const current = JSON.parse(
+    readFileSync(join(path, 'artifact-manifest.json'), 'utf8')
+  ) as {
+    artifactSha256: string
+    receipt: { build: { commit: string; dirty: boolean; builtAt: string } }
+  }
+  writeFileSync(
+    join(path, 'artifact-manifest.json'),
+    JSON.stringify({
+      formatVersion: 1,
+      artifactFile: 'SaltMarcher-Local-0.1.0.AppImage',
+      artifactSha256: current.artifactSha256,
+      build: {
+        channel: 'local',
+        commit: current.receipt.build.commit,
+        sourceFingerprint: fingerprint,
+        dirty: current.receipt.build.dirty,
+        builtAt: current.receipt.build.builtAt,
+        schemaVersion: 27
+      }
+    })
+  )
+}
+
+function completedJournalWithBackup(
+  fixture: ReturnType<typeof createLocalStorageFixture>,
+  backupPath: string,
+  manifestSha256: string
+): void {
+  const now = () => new Date('2026-03-15T12:00:00.000Z')
+  const journal = createInstallJournal(
+    {
+      applicationSha: 'a'.repeat(40),
+      buildFingerprint: 'd'.repeat(64),
+      appBuildInputFingerprint: 'd'.repeat(64),
+      artifactSha256: 'e'.repeat(64)
+    },
+    now
+  )
+  writeFileSync(
+    fixture.paths.journal,
+    JSON.stringify({
+      ...journal,
+      phase: 'completed',
+      backupPath,
+      backupManifestSha256: manifestSha256
+    })
+  )
+}
+
+describe('compatibility evacuation', () => {
+  it('creates a verified current successor without mutating an immutable backup', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    const active = fixture.deployment('d', '2026-03-15T12:00:00.000Z')
+    fixture.activate(active)
+    const backupName = 'legacy-lifecycle-backup'
+    fixture.backup(backupName, '2026-03-15T11:00:00.000Z')
+    const backupPath = join(fixture.paths.backups, backupName)
+    const transitionDirectory = join(backupPath, 'campaigns', '.transitions')
+    mkdirSync(transitionDirectory, { recursive: true })
+    const transitionName = '00000000-0000-4000-8000-000000000001.json'
+    writeFileSync(
+      join(transitionDirectory, transitionName),
+      JSON.stringify({
+        schemaVersion: 1,
+        transitionId: '00000000-0000-4000-8000-000000000002',
+        campaignId: '00000000-0000-4000-8000-000000000001',
+        previousName: 'old',
+        replacementName: 'new',
+        previousActiveId: null,
+        phase: 'staged',
+        updatedAt: '2026-03-15T11:00:00.000Z'
+      })
+    )
+    const manifestPath = join(backupPath, 'backup-manifest.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        ...manifest,
+        files: hashTree(backupPath).filter(
+          ({ path }) => path !== 'backup-manifest.json'
+        )
+      })
+    )
+    const sourceManifestSha = sha256File(manifestPath)
+    completedJournalWithBackup(fixture, backupPath, sourceManifestSha)
+
+    const receipt = applyStorageRetention({
+      ...fixture,
+      applicationSha: 'a'.repeat(40),
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    })
+
+    expect(sha256File(manifestPath)).toBe(sourceManifestSha)
+    const successor = readdirSync(fixture.paths.backups).find((name) =>
+      name.startsWith(`${backupName}-compat-v2-`)
+    )
+    expect(successor).toBeDefined()
+    const migrated = JSON.parse(
+      readFileSync(
+        join(
+          fixture.paths.backups,
+          successor!,
+          'campaigns',
+          '.transitions',
+          transitionName
+        ),
+        'utf8'
+      )
+    ) as { schemaVersion: number }
+    expect(migrated.schemaVersion).toBe(2)
+    expect(receipt.compatibility.reachableLegacyCount).toBe(0)
+    expect(receipt.compatibility.reachableNonCurrentCount).toBe(0)
+    expect(
+      receipt.compatibility.artifacts.find(
+        ({ area, name, path }) =>
+          area === 'backup' &&
+          name === transitionName &&
+          path.startsWith(`${backupPath}/`)
+      )
+    ).toMatchObject({ status: 'migratable', applicationReachable: false })
+  })
+})
+
 describe('handoff audit retention', () => {
   it('keeps all nonterminal details, the newest 100 terminal details, and every SHA state', () => {
     const fixture = createLocalStorageFixture()
@@ -126,7 +314,7 @@ describe('handoff audit retention', () => {
       const status = index === 102 ? 'running' : 'complete'
       writeFileSync(
         auditPath,
-        JSON.stringify({ activeAttemptId: attemptId, status })
+        JSON.stringify({ formatVersion: 6, activeAttemptId: attemptId, status })
       )
       writeFileSync(
         join(states, `${index.toString().padStart(3, '0')}.json`),
@@ -180,7 +368,11 @@ describe('handoff audit retention', () => {
       const auditPath = join(attempts, `${attemptId}.json`)
       writeFileSync(
         auditPath,
-        JSON.stringify({ activeAttemptId: attemptId, status: 'failed' })
+        JSON.stringify({
+          formatVersion: 6,
+          activeAttemptId: attemptId,
+          status: 'failed'
+        })
       )
       invocations.push({
         attemptId,
@@ -222,7 +414,11 @@ describe('handoff audit retention', () => {
       const auditPath = join(attempts, `${attemptId}.json`)
       writeFileSync(
         auditPath,
-        JSON.stringify({ activeAttemptId: attemptId, status: 'complete' })
+        JSON.stringify({
+          formatVersion: 6,
+          activeAttemptId: attemptId,
+          status: 'complete'
+        })
       )
       return {
         attemptId,


### PR DESCRIPTION
Implements roadmap phase 6A compatibility evacuation.\n\n- adds a read-only compatibility topology across profile, backups, deployments, install journal, and Handoff audit state\n- evacuates mutable legacy journals under the installation lock after verified backup evidence\n- creates hash-verified successors for immutable backups without mutating originals\n- validates and retires ownership-valid v1 deployments through normal retention\n- requires every application-reachable storage artifact to be current in Handoff evidence\n\nLocal verification: pnpm check (77 architecture, 709 portable unit, 161 integration, 32 Linux installer, all functional and visual E2E suites; no retries; forbidden warning categories zero).