### PR TITLE
Phase 9: split Travel async controllers

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -81,6 +81,19 @@ active operation and recheck Session/intent authority after a succeeded
 workspace read, so late older preparation cannot replace a newer draft.
 Semantic architecture gates verify this composition and reject reintroduced
 manual Planner request epochs.
+The provider-neutral Travel renderer is now divided into view authority,
+latest-only queries, FIFO commands, and invalidation reconciliation. The
+former reducer-owned request factory and per-channel generations are removed;
+all Context, map, evaluation, and command work now reaches the shared,
+instance-bound async coordinator through explicit provider/Scene entity keys.
+Synchronous intent, map, and route revisions prevent an older remote response
+from replacing a newer local selection or route, while provider and Session
+revisions prevent an older read from replacing a newer command projection.
+Scope changes, deactivation, and unmount cancel pending acceptance and detach
+the subscription. Controlled-promise tests cover out-of-order reads, local
+intent during reconciliation, Scene changes, command FIFO/failure behavior,
+and unmount cancellation; semantic gates keep the composition split and reject
+the retired request factory.
 Application and workspace modules now load through shell-owned failure
 isolation with structured renderer incidents and Main-controlled reload.
 Renderer feature ports are injected from React context; the mutable capability

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -105,13 +105,22 @@ never blindly replayed.
 
 Session travel uses the same composition boundary. Session owns explicit map
 and scenario render slots and imports neither Hex nor Travel implementation.
-`features/travel` owns a provider-neutral reducer, request gates, and command
-protocol; `features/hex` adapts axial maps, chunk invalidations, evaluations,
-and commands; `features/workspace/integrations` lazily composes both. Hex is the
-only implemented provider. Dungeon remains future work. Route rejection crosses
-IPC as a reason code plus optional blocking coordinate, while localized copy
-stays in the renderer. Every successful Hex travel mutation returns the new
-travel and Session projections together from one utility command boundary.
+`features/travel` owns a provider-neutral reducer and separate view-projection,
+query, command, and remote-reconciliation modules; `features/hex` adapts axial
+maps, chunk invalidations, evaluations, and commands;
+`features/workspace/integrations` lazily composes both. The thin Travel
+composition hook owns only one instance-bound async coordinator and wires those
+modules. Context, map, and evaluation reads use latest-only scope/entity keys;
+commands use one FIFO key per provider and focused Scene. View publication is
+additionally bound to provider identity and renderer-local intent, map, and
+route revisions, so a remote result that began before a newer local decision
+may refresh newer provider truth but cannot replace that decision. Scope
+cleanup cancels pending work and removes the provider subscription; stale or
+aborted outcomes do not enter the user error channel. Hex is the only
+implemented provider. Dungeon remains future work. Route rejection crosses IPC
+as a reason code plus optional blocking coordinate, while localized copy stays
+in the renderer. Every successful Hex travel mutation returns the new travel
+and Session projections together from one utility command boundary.
 
 The editing state has one explicit owner at every phase:
 

--- a/src/renderer/features/travel/travel-controller.ts
+++ b/src/renderer/features/travel/travel-controller.ts
@@ -11,17 +11,8 @@ export type TravelScope = Readonly<{
   providerIdentity: object
 }>
 
-export type TravelRequest = TravelScope &
-  Readonly<{
-    channel: TravelRequestChannel
-    generation: number
-  }>
-
-type RequestGenerations = Readonly<Record<TravelRequestChannel, number>>
-
 export type TravelControllerState<P, S, M, E> = Readonly<{
   scope: TravelScope | null
-  requests: RequestGenerations
   lifecycle: TravelLifecycle
   error: string | null
   failureChannel: TravelRequestChannel | null
@@ -39,54 +30,41 @@ export type TravelControllerState<P, S, M, E> = Readonly<{
 export type TravelControllerEvent<P, S, M, E> =
   | Readonly<{ type: 'activated'; scope: TravelScope }>
   | Readonly<{ type: 'deactivated' }>
-  | Readonly<{ type: 'request-started'; request: TravelRequest }>
+  | Readonly<{ type: 'request-started'; channel: TravelRequestChannel }>
   | Readonly<{
       type: 'request-failed'
-      request: TravelRequest
+      channel: TravelRequestChannel
       message: string
     }>
   | Readonly<{
       type: 'projection-loaded'
-      request: TravelRequest
       providerState: S
       mapId: string | null
       map: M | null
       multiplier: TravelMultiplier
     }>
   | Readonly<{
-      type: 'provider-updated'
-      request: TravelRequest
+      type: 'provider-reconciled'
       providerState: S
       multiplier: TravelMultiplier
+      preserveLocal: boolean
     }>
-  | Readonly<{
-      type: 'map-selected'
-      request: TravelRequest
-      mapId: string
-      map: M
-    }>
-  | Readonly<{ type: 'map-refreshed'; request: TravelRequest; map: M }>
+  | Readonly<{ type: 'map-selected'; mapId: string; map: M }>
+  | Readonly<{ type: 'map-refreshed'; map: M }>
   | Readonly<{ type: 'selected'; position: P }>
   | Readonly<{ type: 'mode'; mode: TravelMode }>
   | Readonly<{ type: 'waypoint-added'; position: P }>
   | Readonly<{ type: 'route-cleared' }>
-  | Readonly<{ type: 'evaluated'; request: TravelRequest; evaluation: E }>
+  | Readonly<{ type: 'evaluated'; evaluation: E }>
   | Readonly<{ type: 'token-preview'; position: P | null }>
   | Readonly<{ type: 'local-multiplier'; multiplier: TravelMultiplier }>
   | Readonly<{
       type: 'command-applied'
-      request: TravelRequest
       providerState: S
       multiplier: TravelMultiplier
       clearDraft: boolean
+      preserveLocal: boolean
     }>
-
-const emptyRequests = (): RequestGenerations => ({
-  context: 0,
-  map: 0,
-  evaluation: 0,
-  command: 0
-})
 
 export function initialTravelControllerState<
   P,
@@ -96,7 +74,6 @@ export function initialTravelControllerState<
 >(): TravelControllerState<P, S, M, E> {
   return {
     scope: null,
-    requests: emptyRequests(),
     lifecycle: 'inactive',
     error: null,
     failureChannel: null,
@@ -117,56 +94,39 @@ export function travelControllerReducer<P, S, M, E>(
   event: TravelControllerEvent<P, S, M, E>
 ): TravelControllerState<P, S, M, E> {
   switch (event.type) {
-    case 'activated': {
-      if (!sameScope(state.scope, event.scope))
-        return {
-          ...initialTravelControllerState<P, S, M, E>(),
-          scope: event.scope,
-          lifecycle: 'loading'
-        }
-      return {
-        ...state,
-        lifecycle: state.providerState ? 'stale' : 'loading',
-        error: null
-      }
-    }
+    case 'activated':
+      return sameTravelScope(state.scope, event.scope)
+        ? {
+            ...state,
+            lifecycle: state.providerState ? 'stale' : 'loading',
+            error: null
+          }
+        : {
+            ...initialTravelControllerState<P, S, M, E>(),
+            scope: event.scope,
+            lifecycle: 'loading'
+          }
     case 'deactivated':
-      return {
-        ...state,
-        lifecycle: 'inactive',
-        requests: {
-          context: state.requests.context + 1,
-          map: state.requests.map + 1,
-          evaluation: state.requests.evaluation + 1,
-          command: state.requests.command + 1
-        }
-      }
+      return { ...state, lifecycle: 'inactive' }
     case 'request-started':
-      if (!sameScope(state.scope, event.request)) return state
       return {
         ...state,
-        requests: {
-          ...state.requests,
-          [event.request.channel]: event.request.generation
-        },
         lifecycle:
-          event.request.channel === 'context'
+          event.channel === 'context'
             ? state.providerState
               ? 'stale'
               : 'loading'
             : state.lifecycle,
-        error: null
+        error: event.channel === 'command' ? state.error : null
       }
     case 'request-failed':
-      if (!travelRequestIsCurrent(state, event.request)) return state
       return {
         ...state,
         lifecycle: state.providerState ? 'stale' : 'error',
         error: event.message,
-        failureChannel: event.request.channel
+        failureChannel: event.channel
       }
     case 'projection-loaded': {
-      if (!travelRequestIsCurrent(state, event.request)) return state
       const mapChanged = state.mapId !== event.mapId
       return {
         ...state,
@@ -184,35 +144,18 @@ export function travelControllerReducer<P, S, M, E>(
         tokenPreview: mapChanged ? null : state.tokenPreview
       }
     }
-    case 'provider-updated':
-      if (!travelRequestIsCurrent(state, event.request)) return state
-      return {
-        ...state,
-        lifecycle: successfulLifecycle(
-          state,
-          event.request.channel,
-          !!state.map
-        ),
-        error:
-          state.failureChannel === event.request.channel ? null : state.error,
-        failureChannel:
-          state.failureChannel === event.request.channel
-            ? null
-            : state.failureChannel,
-        providerState: event.providerState,
-        multiplier: event.multiplier
-      }
+    case 'provider-reconciled':
+      return successfulRequest(
+        state,
+        'context',
+        {
+          providerState: event.providerState,
+          multiplier: event.preserveLocal ? state.multiplier : event.multiplier
+        },
+        state.map !== null
+      )
     case 'map-selected':
-      if (!travelRequestIsCurrent(state, event.request)) return state
-      return {
-        ...state,
-        lifecycle: successfulLifecycle(state, event.request.channel, true),
-        error:
-          state.failureChannel === event.request.channel ? null : state.error,
-        failureChannel:
-          state.failureChannel === event.request.channel
-            ? null
-            : state.failureChannel,
+      return successfulRequest(state, 'map', {
         mapId: event.mapId,
         map: event.map,
         selected: null,
@@ -220,23 +163,9 @@ export function travelControllerReducer<P, S, M, E>(
         waypoints: [],
         evaluation: null,
         tokenPreview: null
-      }
+      })
     case 'map-refreshed':
-      return travelRequestIsCurrent(state, event.request)
-        ? {
-            ...state,
-            lifecycle: successfulLifecycle(state, event.request.channel, true),
-            error:
-              state.failureChannel === event.request.channel
-                ? null
-                : state.error,
-            failureChannel:
-              state.failureChannel === event.request.channel
-                ? null
-                : state.failureChannel,
-            map: event.map
-          }
-        : state
+      return successfulRequest(state, 'map', { map: event.map })
     case 'selected':
       return { ...state, selected: event.position }
     case 'mode':
@@ -257,79 +186,60 @@ export function travelControllerReducer<P, S, M, E>(
     case 'route-cleared':
       return { ...state, waypoints: [], evaluation: null }
     case 'evaluated':
-      return travelRequestIsCurrent(state, event.request)
-        ? {
-            ...state,
-            lifecycle: successfulLifecycle(state, event.request.channel, true),
-            error:
-              state.failureChannel === event.request.channel
-                ? null
-                : state.error,
-            failureChannel:
-              state.failureChannel === event.request.channel
-                ? null
-                : state.failureChannel,
-            evaluation: event.evaluation
-          }
-        : state
+      return successfulRequest(state, 'evaluation', {
+        evaluation: event.evaluation
+      })
     case 'token-preview':
       return { ...state, tokenPreview: event.position }
     case 'local-multiplier':
       return { ...state, multiplier: event.multiplier }
     case 'command-applied':
-      if (!travelRequestIsCurrent(state, event.request)) return state
       return {
-        ...state,
-        lifecycle: 'ready',
-        error: null,
-        failureChannel: null,
-        providerState: event.providerState,
-        multiplier: event.multiplier,
-        mode: event.clearDraft ? 'inspect' : state.mode,
-        waypoints: event.clearDraft ? [] : state.waypoints,
-        evaluation: event.clearDraft ? null : state.evaluation,
-        tokenPreview: null
+        ...successfulRequest(state, 'command', {
+          providerState: event.providerState,
+          multiplier: event.preserveLocal ? state.multiplier : event.multiplier
+        }),
+        mode: event.clearDraft && !event.preserveLocal ? 'inspect' : state.mode,
+        waypoints:
+          event.clearDraft && !event.preserveLocal ? [] : state.waypoints,
+        evaluation:
+          event.clearDraft && !event.preserveLocal ? null : state.evaluation,
+        tokenPreview: event.preserveLocal ? state.tokenPreview : null
       }
   }
 }
 
-export function travelRequestIsCurrent<P, S, M, E>(
-  state: TravelControllerState<P, S, M, E>,
-  request: TravelRequest
+export function sameTravelScope(
+  left: TravelScope | null,
+  right: TravelScope | null
 ): boolean {
   return (
-    sameScope(state.scope, request) &&
-    state.requests[request.channel] === request.generation
+    left?.sceneId === right?.sceneId &&
+    left?.providerKind === right?.providerKind &&
+    left?.providerIdentity === right?.providerIdentity
   )
 }
 
-function sameScope(left: TravelScope | null, right: TravelScope): boolean {
-  return (
-    left?.sceneId === right.sceneId &&
-    left.providerKind === right.providerKind &&
-    left.providerIdentity === right.providerIdentity
-  )
-}
-
-export class TravelRequestFactory {
-  private generation = 0
-
-  next(scope: TravelScope, channel: TravelRequestChannel): TravelRequest {
-    this.generation += 1
-    return { ...scope, channel, generation: this.generation }
-  }
-}
-
-function successfulLifecycle<P, S, M, E>(
+function successfulRequest<P, S, M, E>(
   state: TravelControllerState<P, S, M, E>,
   channel: TravelRequestChannel,
-  available: boolean
-): TravelLifecycle {
-  if (
+  patch: Partial<TravelControllerState<P, S, M, E>>,
+  available = true
+): TravelControllerState<P, S, M, E> {
+  const retainsOtherFailure =
     state.lifecycle === 'stale' &&
     state.failureChannel !== null &&
     state.failureChannel !== channel
-  )
-    return 'stale'
-  return available ? 'ready' : 'unavailable'
+  return {
+    ...state,
+    ...patch,
+    lifecycle: retainsOtherFailure
+      ? 'stale'
+      : available
+        ? 'ready'
+        : 'unavailable',
+    error: state.failureChannel === channel ? null : state.error,
+    failureChannel:
+      state.failureChannel === channel ? null : state.failureChannel
+  }
 }

--- a/src/renderer/features/travel/travel-view-projection.ts
+++ b/src/renderer/features/travel/travel-view-projection.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
+import {
+  initialTravelControllerState,
+  sameTravelScope,
+  travelControllerReducer,
+  type TravelControllerEvent,
+  type TravelRequestChannel,
+  type TravelScope
+} from './travel-controller.js'
+import type {
+  TravelProviderDescriptor,
+  TravelProviderReadResult
+} from './travel-provider-port.js'
+
+export type TravelAuthorityTarget = Readonly<{
+  scope: TravelScope
+  intentRevision: number
+  mapRevision: number
+  routeRevision: number
+  publicationRevision: number
+  mapId: string | null
+}>
+
+type AuthorityKind = 'scope' | 'intent' | 'map' | 'route'
+type LocalKind = 'intent' | 'map' | 'route' | 'transient'
+
+/** Owns the synchronous view state and the authority for publishing remote work. */
+export function useTravelViewProjection<P, S, M, E>(options: {
+  snapshot: LiveSessionSnapshot
+  setSnapshot: (snapshot: LiveSessionSnapshot) => void
+}) {
+  const [state, setState] = useState(() =>
+    initialTravelControllerState<P, S, M, E>()
+  )
+  const stateRef = useRef(state)
+  const snapshotRef = useRef(options.snapshot)
+  const setSnapshotRef = useRef(options.setSnapshot)
+  const revisions = useRef({ intent: 0, map: 0, route: 0, publication: 0 })
+  useEffect(() => {
+    if (
+      options.snapshot.scene.focusedSceneId !==
+        snapshotRef.current.scene.focusedSceneId ||
+      options.snapshot.scene.revision >= snapshotRef.current.scene.revision
+    )
+      snapshotRef.current = options.snapshot
+    setSnapshotRef.current = options.setSnapshot
+  }, [options.setSnapshot, options.snapshot])
+
+  const publish = useCallback((event: TravelControllerEvent<P, S, M, E>) => {
+    const next = travelControllerReducer(stateRef.current, event)
+    stateRef.current = next
+    setState(next)
+  }, [])
+
+  const capture = useCallback(
+    (mapId = stateRef.current.mapId): TravelAuthorityTarget | null => {
+      const scope = stateRef.current.scope
+      if (!scope || stateRef.current.lifecycle === 'inactive') return null
+      return Object.freeze({
+        scope,
+        intentRevision: revisions.current.intent,
+        mapRevision: revisions.current.map,
+        routeRevision: revisions.current.route,
+        publicationRevision: revisions.current.publication,
+        mapId
+      })
+    },
+    []
+  )
+
+  const read = useCallback(() => stateRef.current, [])
+  const sceneRevision = useCallback(
+    () => snapshotRef.current.scene.revision,
+    []
+  )
+
+  const isCurrent = useCallback(
+    (target: TravelAuthorityTarget, kind: AuthorityKind = 'scope') => {
+      const current = stateRef.current
+      if (
+        current.lifecycle === 'inactive' ||
+        !sameTravelScope(current.scope, target.scope)
+      )
+        return false
+      if (kind === 'intent')
+        return target.intentRevision === revisions.current.intent
+      if (kind === 'map')
+        return (
+          target.mapRevision === revisions.current.map &&
+          target.mapId === current.mapId
+        )
+      if (kind === 'route')
+        return (
+          target.routeRevision === revisions.current.route &&
+          target.mapId === current.mapId
+        )
+      return true
+    },
+    []
+  )
+
+  const local = useCallback(
+    (event: TravelControllerEvent<P, S, M, E>, kind: LocalKind) => {
+      if (kind !== 'transient') revisions.current.intent += 1
+      if (kind === 'map') {
+        revisions.current.map += 1
+        revisions.current.route += 1
+      } else if (kind === 'route') revisions.current.route += 1
+      publish(event)
+    },
+    [publish]
+  )
+
+  const activate = useCallback(
+    (scope: TravelScope) => {
+      if (!sameTravelScope(stateRef.current.scope, scope)) {
+        revisions.current.intent += 1
+        revisions.current.map += 1
+        revisions.current.route += 1
+      }
+      publish({ type: 'activated', scope })
+    },
+    [publish]
+  )
+
+  const deactivate = useCallback(() => {
+    revisions.current.intent += 1
+    revisions.current.map += 1
+    revisions.current.route += 1
+    publish({ type: 'deactivated' })
+  }, [publish])
+
+  const beginMapIntent = useCallback(() => {
+    revisions.current.intent += 1
+    revisions.current.map += 1
+    revisions.current.route += 1
+  }, [])
+
+  const beginIntent = useCallback(() => {
+    revisions.current.intent += 1
+  }, [])
+
+  const failed = useCallback(
+    (
+      target: TravelAuthorityTarget,
+      kind: AuthorityKind,
+      channel: TravelRequestChannel,
+      message: string
+    ): boolean => {
+      if (!isCurrent(target, kind)) return false
+      publish({ type: 'request-failed', channel, message })
+      return true
+    },
+    [isCurrent, publish]
+  )
+
+  const acceptContext = useCallback(
+    (input: {
+      target: TravelAuthorityTarget
+      result: TravelProviderReadResult<S>
+      descriptor: TravelProviderDescriptor<P>
+      mapId: string | null
+      map: M | null
+      describe: (state: S) => TravelProviderDescriptor<P>
+    }): boolean => {
+      if (!isCurrent(input.target)) return false
+      const intentIsCurrent = isCurrent(input.target, 'intent')
+      const publicationIsCurrent =
+        input.target.publicationRevision === revisions.current.publication
+      if (
+        remoteVersionIsOlder(
+          stateRef.current.providerState,
+          input.result.providerState,
+          snapshotRef.current,
+          input.result.session,
+          input.describe,
+          !intentIsCurrent || !publicationIsCurrent
+        )
+      )
+        return false
+      publishSessionIfCurrent(input.result.session, snapshotRef, setSnapshotRef)
+      if (intentIsCurrent)
+        publish({
+          type: 'projection-loaded',
+          providerState: input.result.providerState,
+          mapId: input.mapId,
+          map: input.map,
+          multiplier: input.descriptor.multiplier
+        })
+      else
+        publish({
+          type: 'provider-reconciled',
+          providerState: input.result.providerState,
+          multiplier: input.descriptor.multiplier,
+          preserveLocal: true
+        })
+      revisions.current.publication += 1
+      return true
+    },
+    [isCurrent, publish]
+  )
+
+  const acceptCommand = useCallback(
+    (input: {
+      target: TravelAuthorityTarget
+      result: TravelProviderReadResult<S>
+      descriptor: TravelProviderDescriptor<P>
+      clearDraft: boolean
+      describe: (state: S) => TravelProviderDescriptor<P>
+    }): boolean => {
+      if (!isCurrent(input.target)) return false
+      if (
+        remoteVersionIsOlder(
+          stateRef.current.providerState,
+          input.result.providerState,
+          snapshotRef.current,
+          input.result.session,
+          input.describe,
+          false
+        )
+      )
+        return false
+      publishSessionIfCurrent(input.result.session, snapshotRef, setSnapshotRef)
+      publish({
+        type: 'command-applied',
+        providerState: input.result.providerState,
+        multiplier: input.descriptor.multiplier,
+        clearDraft: input.clearDraft,
+        preserveLocal: !isCurrent(input.target, 'intent')
+      })
+      revisions.current.publication += 1
+      return true
+    },
+    [isCurrent, publish]
+  )
+
+  const started = useCallback(
+    (channel: TravelRequestChannel) =>
+      publish({ type: 'request-started', channel }),
+    [publish]
+  )
+
+  const acceptMap = useCallback(
+    (target: TravelAuthorityTarget, map: M, selected: boolean) => {
+      const kind = selected ? 'intent' : 'map'
+      if (!isCurrent(target, kind)) return false
+      publish(
+        selected
+          ? { type: 'map-selected', mapId: target.mapId!, map }
+          : { type: 'map-refreshed', map }
+      )
+      return true
+    },
+    [isCurrent, publish]
+  )
+
+  const acceptEvaluation = useCallback(
+    (target: TravelAuthorityTarget, evaluation: E) => {
+      if (!isCurrent(target, 'route')) return false
+      publish({ type: 'evaluated', evaluation })
+      return true
+    },
+    [isCurrent, publish]
+  )
+
+  return {
+    state,
+    read,
+    sceneRevision,
+    capture,
+    isCurrent,
+    activate,
+    deactivate,
+    beginIntent,
+    beginMapIntent,
+    started,
+    failed,
+    acceptContext,
+    acceptCommand,
+    acceptMap,
+    acceptEvaluation,
+    local
+  }
+}
+
+export type TravelViewProjection<P, S, M, E> = ReturnType<
+  typeof useTravelViewProjection<P, S, M, E>
+>
+
+function remoteVersionIsOlder<P, S>(
+  current: S | null,
+  next: S,
+  currentSession: LiveSessionSnapshot,
+  nextSession: LiveSessionSnapshot,
+  describe: (state: S) => TravelProviderDescriptor<P>,
+  requireNewer = false
+): boolean {
+  if (current === null) return false
+  const currentRevision = describe(current).revision
+  const nextRevision = describe(next).revision
+  if (nextRevision !== currentRevision) return nextRevision < currentRevision
+  if (nextSession.scene.focusedSceneId !== currentSession.scene.focusedSceneId)
+    return true
+  return requireNewer
+    ? nextSession.scene.revision <= currentSession.scene.revision
+    : nextSession.scene.revision < currentSession.scene.revision
+}
+
+function publishSessionIfCurrent(
+  next: LiveSessionSnapshot,
+  snapshotRef: React.RefObject<LiveSessionSnapshot>,
+  setSnapshotRef: React.RefObject<(snapshot: LiveSessionSnapshot) => void>
+): void {
+  const current = snapshotRef.current
+  if (
+    next.scene.focusedSceneId !== current.scene.focusedSceneId ||
+    next.scene.revision < current.scene.revision
+  )
+    return
+  snapshotRef.current = next
+  setSnapshotRef.current(next)
+}

--- a/src/renderer/features/travel/use-travel-commands.ts
+++ b/src/renderer/features/travel/use-travel-commands.ts
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import { sameTravelScope, type TravelScope } from './travel-controller.js'
+import type {
+  TravelProviderCommand,
+  TravelProviderPort,
+  TravelMultiplier
+} from './travel-provider-port.js'
+import type { TravelViewProjection } from './travel-view-projection.js'
+import { travelEntityKey } from './use-travel-queries.js'
+
+const multipliers = [1, 2, 5, 10] as const
+/** Owns Scene-scoped FIFO Travel mutations and their domain failures. */
+export function useTravelCommands<P, S, M, E>(options: {
+  coordinator: AsyncCommandCoordinator
+  port: TravelProviderPort<P, S, M, E> | null
+  scope: TravelScope | null
+  projection: TravelViewProjection<P, S, M, E>
+  onError: (message: string) => void
+}) {
+  const { coordinator, onError, port, projection, scope } = options
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    onErrorRef.current = onError
+  }, [onError])
+  const {
+    acceptCommand,
+    beginIntent,
+    capture,
+    failed,
+    local,
+    read,
+    sceneRevision,
+    started
+  } = projection
+
+  const applyCommand = useCallback(
+    async (
+      command: TravelProviderCommand<P>,
+      clearDraft: boolean
+    ): Promise<void> => {
+      if (
+        !port ||
+        !scope ||
+        read().lifecycle !== 'ready' ||
+        !sameTravelScope(read().scope, scope)
+      )
+        return
+      beginIntent()
+      const target = capture()
+      if (!target) return
+      started('command')
+      const outcome = await coordinator.run({
+        scope: 'travel.command',
+        entityKey: travelEntityKey(scope),
+        mode: 'queue',
+        execute: async ({ signal }) => {
+          const result = await port.execute(command)
+          signal.throwIfAborted()
+          return result
+        },
+        accept: (result) =>
+          acceptCommand({
+            target,
+            result,
+            descriptor: port.describe(result.providerState),
+            clearDraft,
+            describe: port.describe
+          })
+      })
+      if (outcome.status !== 'failure') return
+      const message = capabilityErrorText(outcome.cause)
+      if (failed(target, 'scope', 'command', message))
+        onErrorRef.current(message)
+    },
+    [
+      acceptCommand,
+      beginIntent,
+      capture,
+      coordinator,
+      failed,
+      port,
+      read,
+      scope,
+      started
+    ]
+  )
+
+  const positionParty = useCallback(
+    async (position: P): Promise<void> => {
+      const current = read()
+      local({ type: 'selected', position }, 'intent')
+      if (
+        current.lifecycle !== 'ready' ||
+        !port ||
+        !current.map ||
+        !current.mapId
+      )
+        return
+      if (!port.isAuthoredPosition(current.map, position)) {
+        local({ type: 'token-preview', position: null }, 'transient')
+        return
+      }
+      await applyCommand(
+        {
+          kind: 'position',
+          sceneId: current.scope!.sceneId,
+          mapId: current.mapId,
+          position,
+          expectedSceneRevision: sceneRevision()
+        },
+        true
+      )
+    },
+    [applyCommand, local, port, read, sceneRevision]
+  )
+
+  const start = useCallback(async (): Promise<void> => {
+    const current = read()
+    if (
+      current.lifecycle !== 'ready' ||
+      !port ||
+      !current.providerState ||
+      !current.mapId ||
+      !current.evaluation ||
+      !port.canStart(current.evaluation)
+    )
+      return
+    await applyCommand(
+      {
+        kind: 'start',
+        sceneId: current.scope!.sceneId,
+        mapId: current.mapId,
+        waypoints: current.waypoints,
+        multiplier: current.multiplier,
+        expectedRevision: port.describe(current.providerState).revision
+      },
+      true
+    )
+  }, [applyCommand, port, read])
+
+  const pauseOrResume = useCallback(async (): Promise<void> => {
+    const current = read()
+    if (current.lifecycle !== 'ready' || !port || !current.providerState) return
+    const descriptor = port.describe(current.providerState)
+    const kind =
+      descriptor.status === 'travelling'
+        ? 'pause'
+        : descriptor.status === 'paused' || descriptor.status === 'blocked'
+          ? 'resume'
+          : null
+    if (!kind) return
+    await applyCommand(
+      {
+        kind,
+        sceneId: current.scope!.sceneId,
+        expectedRevision: descriptor.revision
+      },
+      false
+    )
+  }, [applyCommand, port, read])
+
+  const abort = useCallback(async (): Promise<void> => {
+    const current = read()
+    if (current.lifecycle !== 'ready' || !port || !current.providerState) return
+    const descriptor = port.describe(current.providerState)
+    if (!['travelling', 'paused', 'blocked'].includes(descriptor.status)) return
+    await applyCommand(
+      {
+        kind: 'abort',
+        sceneId: current.scope!.sceneId,
+        expectedRevision: descriptor.revision
+      },
+      false
+    )
+  }, [applyCommand, port, read])
+
+  const stepMultiplier = useCallback(
+    async (direction: -1 | 1): Promise<void> => {
+      const current = read()
+      const index = multipliers.indexOf(current.multiplier)
+      const multiplier = multipliers[index + direction]
+      if (multiplier === undefined) return
+      if (!port || !current.providerState) {
+        publishLocalMultiplier(local, multiplier)
+        return
+      }
+      const descriptor = port.describe(current.providerState)
+      if (!hasPersistedJourneyStatus(descriptor.status)) {
+        publishLocalMultiplier(local, multiplier)
+        return
+      }
+      if (current.lifecycle !== 'ready') return
+      await applyCommand(
+        {
+          kind: 'set-multiplier',
+          sceneId: current.scope!.sceneId,
+          multiplier,
+          expectedRevision: descriptor.revision
+        },
+        false
+      )
+    },
+    [applyCommand, local, port, read]
+  )
+
+  return { positionParty, start, pauseOrResume, abort, stepMultiplier }
+}
+
+function publishLocalMultiplier<P, S, M, E>(
+  local: TravelViewProjection<P, S, M, E>['local'],
+  multiplier: TravelMultiplier
+): void {
+  local({ type: 'local-multiplier', multiplier }, 'intent')
+}
+
+function hasPersistedJourneyStatus(status: string): boolean {
+  return ['travelling', 'paused', 'blocked', 'completed', 'aborted'].includes(
+    status
+  )
+}

--- a/src/renderer/features/travel/use-travel-controller.ts
+++ b/src/renderer/features/travel/use-travel-controller.ts
@@ -1,30 +1,12 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
-import { capabilityErrorText } from '../../capabilities/capability-errors.js'
-import {
-  initialTravelControllerState,
-  travelControllerReducer,
-  travelRequestIsCurrent,
-  TravelRequestFactory,
-  type TravelControllerEvent,
-  type TravelControllerState,
-  type TravelRequest,
-  type TravelRequestChannel,
-  type TravelScope
-} from './travel-controller.js'
-import type {
-  TravelProviderCommand,
-  TravelProviderPort
-} from './travel-provider-port.js'
-
-const multipliers = [1, 2, 5, 10] as const
-const persistedJourneyStatuses = new Set([
-  'travelling',
-  'paused',
-  'blocked',
-  'completed',
-  'aborted'
-])
+import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
+import type { TravelControllerState, TravelScope } from './travel-controller.js'
+import type { TravelProviderPort } from './travel-provider-port.js'
+import { useTravelViewProjection } from './travel-view-projection.js'
+import { useTravelCommands } from './use-travel-commands.js'
+import { useTravelQueries } from './use-travel-queries.js'
+import { useTravelRemoteReconciliation } from './use-travel-remote-reconciliation.js'
 
 export type TravelController<P, S, M, E> = Readonly<{
   state: TravelControllerState<P, S, M, E>
@@ -43,6 +25,7 @@ export type TravelController<P, S, M, E> = Readonly<{
   stepMultiplier: (direction: -1 | 1) => Promise<void>
 }>
 
+/** Thin composition boundary for one active provider-neutral Travel view. */
 export function useTravelController<P, S, M, E>(options: {
   port: TravelProviderPort<P, S, M, E> | null
   snapshot: LiveSessionSnapshot
@@ -50,403 +33,95 @@ export function useTravelController<P, S, M, E>(options: {
   onError: (message: string) => void
   active: boolean
 }): TravelController<P, S, M, E> {
-  const [state, reactDispatch] = useReducer(
-    (
-      current: TravelControllerState<P, S, M, E>,
-      event: TravelControllerEvent<P, S, M, E>
-    ) => travelControllerReducer(current, event),
-    initialTravelControllerState<P, S, M, E>()
-  )
-  const stateRef = useRef(state)
-  const snapshotRef = useRef(options.snapshot)
-  const callbacksRef = useRef({
-    onError: options.onError,
+  const coordinator = useAsyncCommandCoordinator()
+  const projection = useTravelViewProjection<P, S, M, E>({
+    snapshot: options.snapshot,
     setSnapshot: options.setSnapshot
   })
-  const requestFactory = useRef(new TravelRequestFactory())
-  const dispatch = useCallback((event: TravelControllerEvent<P, S, M, E>) => {
-    stateRef.current = travelControllerReducer(stateRef.current, event)
-    reactDispatch(event)
-  }, [])
-  useEffect(() => {
-    snapshotRef.current = options.snapshot
-    callbacksRef.current = {
-      onError: options.onError,
-      setSnapshot: options.setSnapshot
-    }
-  }, [options.onError, options.setSnapshot, options.snapshot])
-
   const sceneId = options.snapshot.scene.focusedSceneId
-  const scope = useMemo<TravelScope | null>(() => {
-    if (!options.port) return null
-    return {
-      sceneId,
-      providerKind: options.port.kind,
-      providerIdentity: options.port
-    }
-  }, [options.port, sceneId])
-
-  const beginRequest = useCallback(
-    (currentScope: TravelScope, channel: TravelRequestChannel) => {
-      const request = requestFactory.current.next(currentScope, channel)
-      dispatch({ type: 'request-started', request })
-      return request
-    },
-    [dispatch]
+  const scope = useMemo<TravelScope | null>(
+    () =>
+      options.port
+        ? {
+            sceneId,
+            providerKind: options.port.kind,
+            providerIdentity: options.port
+          }
+        : null,
+    [options.port, sceneId]
   )
-  const accepts = useCallback(
-    (request: TravelRequest) =>
-      travelRequestIsCurrent(stateRef.current, request),
-    []
-  )
-  const reportFailure = useCallback(
-    (request: TravelRequest, cause: unknown) => {
-      if (!accepts(request)) return
-      const message = capabilityErrorText(cause)
-      callbacksRef.current.onError(message)
-      dispatch({ type: 'request-failed', request, message })
-    },
-    [accepts, dispatch]
-  )
-
-  const refreshProjection = useCallback(
-    async (forceMap: boolean) => {
-      const port = options.port
-      if (!options.active || !port || !scope) return
-      const request = beginRequest(scope, 'context')
-      try {
-        const result = await port.read({ sceneId: scope.sceneId })
-        if (!accepts(request)) return
-        const descriptor = port.describe(result.providerState)
-        const previousMapId = stateRef.current.mapId
-        const mapId =
-          descriptor.currentMapId ??
-          descriptor.mapOptions.find((entry) => entry.id === previousMapId)
-            ?.id ??
-          descriptor.mapOptions[0]?.id ??
-          null
-        const map = mapId
-          ? await port.readMap({
-              mapId,
-              ...(descriptor.currentPosition === null
-                ? {}
-                : { center: descriptor.currentPosition }),
-              force: forceMap
-            })
-          : null
-        if (!accepts(request)) return
-        callbacksRef.current.setSnapshot(result.session)
-        dispatch({
-          type: 'projection-loaded',
-          request,
-          providerState: result.providerState,
-          mapId,
-          map,
-          multiplier: descriptor.multiplier
-        })
-      } catch (cause) {
-        reportFailure(request, cause)
-      }
-    },
-    [
-      accepts,
-      beginRequest,
-      dispatch,
-      options.active,
-      options.port,
-      reportFailure,
-      scope
-    ]
-  )
-
-  const refreshMap = useCallback(
-    async (port: TravelProviderPort<P, S, M, E>, mapId: string) => {
-      if (!scope) return
-      const request = beginRequest(scope, 'map')
-      try {
-        const map = await port.readMap({ mapId, force: true })
-        if (accepts(request) && stateRef.current.mapId === mapId)
-          dispatch({ type: 'map-refreshed', request, map })
-      } catch (cause) {
-        reportFailure(request, cause)
-      }
-    },
-    [accepts, beginRequest, dispatch, reportFailure, scope]
-  )
-
-  useEffect(() => {
-    if (!options.active || !options.port || !scope) {
-      dispatch({ type: 'deactivated' })
-      return
-    }
-    dispatch({ type: 'activated', scope })
-    void refreshProjection(false)
-    return options.port.subscribe((invalidation) => {
-      if (
-        invalidation.kind === 'context' &&
-        invalidation.sceneId !== scope.sceneId
-      )
-        return
-      if (invalidation.kind === 'map') {
-        if (invalidation.mapId === stateRef.current.mapId)
-          void refreshMap(options.port!, invalidation.mapId)
-        return
-      }
-      void refreshProjection(true)
-    })
-  }, [
-    dispatch,
-    options.active,
-    options.port,
-    refreshMap,
-    refreshProjection,
-    scope
-  ])
-
-  useEffect(() => {
-    if (
-      !options.active ||
-      !options.port ||
-      !scope ||
-      state.mode !== 'plan' ||
-      !state.mapId ||
-      state.waypoints.length === 0
-    )
-      return
-    const request = beginRequest(scope, 'evaluation')
-    void options.port
-      .evaluate({
-        sceneId: scope.sceneId,
-        mapId: state.mapId,
-        waypoints: state.waypoints
-      })
-      .then((evaluation) => {
-        if (accepts(request))
-          dispatch({ type: 'evaluated', request, evaluation })
-      })
-      .catch((cause: unknown) => reportFailure(request, cause))
-  }, [
-    accepts,
-    beginRequest,
-    dispatch,
-    options.active,
-    options.port,
-    reportFailure,
+  const queries = useTravelQueries({
+    coordinator,
+    port: options.port,
     scope,
-    state.mapId,
-    state.mode,
-    state.waypoints
-  ])
-
-  const selectMap = useCallback(
-    async (mapId: string) => {
-      const port = options.port
-      if (!port || !scope) return
-      const request = beginRequest(scope, 'map')
-      try {
-        const map = await port.readMap({ mapId })
-        if (accepts(request))
-          dispatch({ type: 'map-selected', request, mapId, map })
-      } catch (cause) {
-        reportFailure(request, cause)
-      }
-    },
-    [accepts, beginRequest, dispatch, options.port, reportFailure, scope]
-  )
-
-  const applyCommand = useCallback(
-    async (command: TravelProviderCommand<P>, clearDraft: boolean) => {
-      const port = options.port
-      if (!port || !scope || stateRef.current.lifecycle !== 'ready') return
-      const request = beginRequest(scope, 'command')
-      try {
-        const result = await port.execute(command)
-        if (!accepts(request)) return
-        const descriptor = port.describe(result.providerState)
-        callbacksRef.current.setSnapshot(result.session)
-        dispatch({
-          type: 'command-applied',
-          request,
-          providerState: result.providerState,
-          multiplier: descriptor.multiplier,
-          clearDraft
-        })
-      } catch (cause) {
-        reportFailure(request, cause)
-      }
-    },
-    [accepts, beginRequest, dispatch, options.port, reportFailure, scope]
-  )
-
-  const positionParty = useCallback(
-    async (position: P) => {
-      const current = stateRef.current
-      const port = options.port
-      dispatch({ type: 'selected', position })
-      if (
-        current.lifecycle !== 'ready' ||
-        !port ||
-        !current.map ||
-        !current.mapId
-      )
-        return
-      if (!port.isAuthoredPosition(current.map, position)) {
-        dispatch({ type: 'token-preview', position: null })
-        return
-      }
-      await applyCommand(
-        {
-          kind: 'position',
-          sceneId,
-          mapId: current.mapId,
-          position,
-          expectedSceneRevision: snapshotRef.current.scene.revision
-        },
-        true
-      )
-    },
-    [applyCommand, dispatch, options.port, sceneId]
-  )
+    projection,
+    onError: options.onError
+  })
+  const commands = useTravelCommands({
+    coordinator,
+    port: options.port,
+    scope,
+    projection,
+    onError: options.onError
+  })
+  const { abort, pauseOrResume, positionParty, start, stepMultiplier } =
+    commands
+  useTravelRemoteReconciliation({
+    active: options.active,
+    coordinator,
+    port: options.port,
+    scope,
+    projection,
+    refreshContext: queries.refreshContext,
+    refreshMap: queries.refreshMap
+  })
 
   const activatePosition = useCallback(
     (position: P) => {
-      const current = stateRef.current
-      dispatch({ type: 'selected', position })
+      const current = projection.read()
       if (
         !options.port ||
         !current.map ||
         !options.port.isAuthoredPosition(current.map, position)
-      )
+      ) {
+        projection.local({ type: 'selected', position }, 'intent')
         return
+      }
       if (current.mode === 'plan')
-        dispatch({ type: 'waypoint-added', position })
+        projection.local({ type: 'waypoint-added', position }, 'route')
       else if (current.mode === 'position') void positionParty(position)
+      else projection.local({ type: 'selected', position }, 'intent')
     },
-    [dispatch, options.port, positionParty]
-  )
-
-  const readViewport = useCallback(
-    async (center: P) => {
-      const mapId = stateRef.current.mapId
-      const port = options.port
-      if (!port || !mapId || !scope) return
-      const request = beginRequest(scope, 'map')
-      try {
-        const map = await port.readMap({ mapId, center })
-        if (accepts(request) && stateRef.current.mapId === mapId)
-          dispatch({ type: 'map-refreshed', request, map })
-      } catch (cause) {
-        reportFailure(request, cause)
-      }
-    },
-    [accepts, beginRequest, dispatch, options.port, reportFailure, scope]
-  )
-
-  const start = useCallback(async () => {
-    const current = stateRef.current
-    const port = options.port
-    if (
-      current.lifecycle !== 'ready' ||
-      !port ||
-      !current.providerState ||
-      !current.mapId ||
-      !current.evaluation ||
-      !port.canStart(current.evaluation)
-    )
-      return
-    await applyCommand(
-      {
-        kind: 'start',
-        sceneId,
-        mapId: current.mapId,
-        waypoints: current.waypoints,
-        multiplier: current.multiplier,
-        expectedRevision: port.describe(current.providerState).revision
-      },
-      true
-    )
-  }, [applyCommand, options.port, sceneId])
-
-  const pauseOrResume = useCallback(async () => {
-    const current = stateRef.current
-    const port = options.port
-    if (current.lifecycle !== 'ready' || !port || !current.providerState) return
-    const descriptor = port.describe(current.providerState)
-    const kind =
-      descriptor.status === 'travelling'
-        ? 'pause'
-        : descriptor.status === 'paused' || descriptor.status === 'blocked'
-          ? 'resume'
-          : null
-    if (!kind) return
-    await applyCommand(
-      { kind, sceneId, expectedRevision: descriptor.revision },
-      false
-    )
-  }, [applyCommand, options.port, sceneId])
-
-  const abort = useCallback(async () => {
-    const current = stateRef.current
-    const port = options.port
-    if (current.lifecycle !== 'ready' || !port || !current.providerState) return
-    const descriptor = port.describe(current.providerState)
-    if (!['travelling', 'paused', 'blocked'].includes(descriptor.status)) return
-    await applyCommand(
-      { kind: 'abort', sceneId, expectedRevision: descriptor.revision },
-      false
-    )
-  }, [applyCommand, options.port, sceneId])
-
-  const stepMultiplier = useCallback(
-    async (direction: -1 | 1) => {
-      const current = stateRef.current
-      const index = multipliers.indexOf(current.multiplier)
-      const multiplier = multipliers[index + direction]
-      if (multiplier === undefined) return
-      const port = options.port
-      if (!port || !current.providerState) {
-        dispatch({ type: 'local-multiplier', multiplier })
-        return
-      }
-      const descriptor = port.describe(current.providerState)
-      if (!persistedJourneyStatuses.has(descriptor.status)) {
-        dispatch({ type: 'local-multiplier', multiplier })
-        return
-      }
-      if (current.lifecycle !== 'ready') return
-      await applyCommand(
-        {
-          kind: 'set-multiplier',
-          sceneId,
-          multiplier,
-          expectedRevision: descriptor.revision
-        },
-        false
-      )
-    },
-    [applyCommand, dispatch, options.port, sceneId]
+    [options.port, positionParty, projection]
   )
 
   return useMemo(
     () => ({
-      state,
-      selectMap,
-      selectPosition: (position: P) => dispatch({ type: 'selected', position }),
+      state: projection.state,
+      selectMap: queries.selectMap,
+      selectPosition: (position: P) =>
+        projection.local({ type: 'selected', position }, 'intent'),
       activatePosition,
       togglePlanning: () =>
-        dispatch({
-          type: 'mode',
-          mode: state.mode === 'plan' ? 'inspect' : 'plan'
-        }),
+        projection.local(
+          {
+            type: 'mode',
+            mode: projection.state.mode === 'plan' ? 'inspect' : 'plan'
+          },
+          'route'
+        ),
       togglePositioning: () =>
-        dispatch({
-          type: 'mode',
-          mode: state.mode === 'position' ? 'inspect' : 'position'
-        }),
-      clearRoute: () => dispatch({ type: 'route-cleared' }),
-      readViewport,
+        projection.local(
+          {
+            type: 'mode',
+            mode: projection.state.mode === 'position' ? 'inspect' : 'position'
+          },
+          'route'
+        ),
+      clearRoute: () => projection.local({ type: 'route-cleared' }, 'route'),
+      readViewport: queries.readViewport,
       previewToken: (position: P | null) =>
-        dispatch({ type: 'token-preview', position }),
+        projection.local({ type: 'token-preview', position }, 'transient'),
       dropToken: (position: P) => void positionParty(position),
       start,
       pauseOrResume,
@@ -454,15 +129,14 @@ export function useTravelController<P, S, M, E>(options: {
       stepMultiplier
     }),
     [
-      abort,
       activatePosition,
-      dispatch,
+      abort,
       pauseOrResume,
       positionParty,
-      readViewport,
-      selectMap,
+      projection,
+      queries.readViewport,
+      queries.selectMap,
       start,
-      state,
       stepMultiplier
     ]
   )

--- a/src/renderer/features/travel/use-travel-queries.ts
+++ b/src/renderer/features/travel/use-travel-queries.ts
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import { sameTravelScope, type TravelScope } from './travel-controller.js'
+import type { TravelProviderPort } from './travel-provider-port.js'
+import type { TravelViewProjection } from './travel-view-projection.js'
+
+/** Owns latest-only context, map and route-evaluation reads. */
+export function useTravelQueries<P, S, M, E>(options: {
+  coordinator: AsyncCommandCoordinator
+  port: TravelProviderPort<P, S, M, E> | null
+  scope: TravelScope | null
+  projection: TravelViewProjection<P, S, M, E>
+  onError: (message: string) => void
+}) {
+  const { coordinator, onError, port, projection, scope } = options
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    onErrorRef.current = onError
+  }, [onError])
+  const {
+    acceptContext,
+    acceptEvaluation,
+    acceptMap,
+    beginMapIntent,
+    capture,
+    failed,
+    read,
+    started
+  } = projection
+
+  const reportFailure = useCallback(
+    (
+      target: NonNullable<ReturnType<typeof capture>>,
+      authority: 'intent' | 'map' | 'route',
+      channel: 'context' | 'map' | 'evaluation',
+      cause: unknown
+    ) => {
+      const message = capabilityErrorText(cause)
+      if (failed(target, authority, channel, message))
+        onErrorRef.current(message)
+    },
+    [failed]
+  )
+
+  const refreshContext = useCallback(
+    async (forceMap: boolean): Promise<void> => {
+      if (!port || !scope) return
+      const target = capture()
+      if (!target || !sameTravelScope(target.scope, scope)) return
+      started('context')
+      const outcome = await coordinator.run({
+        scope: 'travel.context-query',
+        entityKey: travelEntityKey(scope),
+        mode: 'latest-only',
+        execute: async ({ signal }) => {
+          const result = await port.read({ sceneId: scope.sceneId })
+          signal.throwIfAborted()
+          const descriptor = port.describe(result.providerState)
+          const mapId =
+            descriptor.currentMapId ??
+            descriptor.mapOptions.find((entry) => entry.id === target.mapId)
+              ?.id ??
+            descriptor.mapOptions[0]?.id ??
+            null
+          const map = mapId
+            ? await port.readMap({
+                mapId,
+                ...(descriptor.currentPosition === null
+                  ? {}
+                  : { center: descriptor.currentPosition }),
+                force: forceMap
+              })
+            : null
+          signal.throwIfAborted()
+          return { result, descriptor, mapId, map }
+        },
+        accept: ({ result, descriptor, mapId, map }) =>
+          acceptContext({
+            target,
+            result,
+            descriptor,
+            mapId,
+            map,
+            describe: port.describe
+          })
+      })
+      if (outcome.status === 'failure')
+        reportFailure(target, 'intent', 'context', outcome.cause)
+    },
+    [acceptContext, capture, coordinator, port, reportFailure, scope, started]
+  )
+
+  const runMapRead = useCallback(
+    async (input: {
+      mapId: string
+      center?: P
+      force?: boolean
+      selected: boolean
+    }): Promise<void> => {
+      if (!port || !scope) return
+      if (input.selected) {
+        const current = capture()
+        if (!current || !sameTravelScope(current.scope, scope)) return
+        beginMapIntent()
+      }
+      const target = capture(input.mapId)
+      if (!target || !sameTravelScope(target.scope, scope)) return
+      started('map')
+      const outcome = await coordinator.run({
+        scope: 'travel.map-query',
+        entityKey: travelEntityKey(scope),
+        mode: 'latest-only',
+        execute: async ({ signal }) => {
+          const map = await port.readMap({
+            mapId: input.mapId,
+            ...(input.center === undefined ? {} : { center: input.center }),
+            ...(input.force === undefined ? {} : { force: input.force })
+          })
+          signal.throwIfAborted()
+          return map
+        },
+        accept: (map) => acceptMap(target, map, input.selected)
+      })
+      if (outcome.status === 'failure')
+        reportFailure(
+          target,
+          input.selected ? 'intent' : 'map',
+          'map',
+          outcome.cause
+        )
+    },
+    [
+      acceptMap,
+      beginMapIntent,
+      capture,
+      coordinator,
+      port,
+      reportFailure,
+      scope,
+      started
+    ]
+  )
+
+  const selectMap = useCallback(
+    (mapId: string) => runMapRead({ mapId, selected: true }),
+    [runMapRead]
+  )
+
+  const readViewport = useCallback(
+    (center: P) => {
+      const mapId = read().mapId
+      return mapId
+        ? runMapRead({ mapId, center, selected: false })
+        : Promise.resolve()
+    },
+    [read, runMapRead]
+  )
+
+  const refreshMap = useCallback(
+    (mapId: string) => runMapRead({ mapId, force: true, selected: false }),
+    [runMapRead]
+  )
+
+  const state = projection.state
+  useEffect(() => {
+    if (
+      !port ||
+      !scope ||
+      state.lifecycle !== 'ready' ||
+      !sameTravelScope(state.scope, scope) ||
+      state.mode !== 'plan' ||
+      !state.mapId ||
+      state.waypoints.length === 0
+    )
+      return
+    const abort = new AbortController()
+    const target = capture()
+    if (!target || !sameTravelScope(target.scope, scope)) return
+    started('evaluation')
+    void coordinator
+      .run({
+        scope: 'travel.evaluation-query',
+        entityKey: travelEntityKey(scope),
+        mode: 'latest-only',
+        signal: abort.signal,
+        execute: async ({ signal }) => {
+          const evaluation = await port.evaluate({
+            sceneId: scope.sceneId,
+            mapId: state.mapId!,
+            waypoints: state.waypoints
+          })
+          signal.throwIfAborted()
+          return evaluation
+        },
+        accept: (evaluation) => acceptEvaluation(target, evaluation)
+      })
+      .then((outcome) => {
+        if (outcome.status === 'failure')
+          reportFailure(target, 'route', 'evaluation', outcome.cause)
+      })
+    return () => abort.abort('travel-route-changed')
+  }, [
+    acceptEvaluation,
+    capture,
+    coordinator,
+    port,
+    reportFailure,
+    scope,
+    started,
+    state.mapId,
+    state.lifecycle,
+    state.mode,
+    state.scope,
+    state.waypoints
+  ])
+
+  return { refreshContext, refreshMap, selectMap, readViewport }
+}
+
+export function travelEntityKey(scope: TravelScope): string {
+  return JSON.stringify([scope.providerKind, scope.sceneId])
+}

--- a/src/renderer/features/travel/use-travel-remote-reconciliation.ts
+++ b/src/renderer/features/travel/use-travel-remote-reconciliation.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import type { TravelScope } from './travel-controller.js'
+import type { TravelProviderPort } from './travel-provider-port.js'
+import type { TravelViewProjection } from './travel-view-projection.js'
+
+/** Owns provider invalidations and the active Travel scope lifetime. */
+export function useTravelRemoteReconciliation<P, S, M, E>(options: {
+  active: boolean
+  coordinator: AsyncCommandCoordinator
+  port: TravelProviderPort<P, S, M, E> | null
+  scope: TravelScope | null
+  projection: TravelViewProjection<P, S, M, E>
+  refreshContext: (forceMap: boolean) => Promise<void>
+  refreshMap: (mapId: string) => Promise<void>
+}): void {
+  const {
+    active,
+    coordinator,
+    port,
+    projection,
+    refreshContext,
+    refreshMap,
+    scope
+  } = options
+  const { activate, deactivate, read } = projection
+
+  useEffect(() => {
+    coordinator.cancelAll()
+    if (!active || !port || !scope) {
+      deactivate()
+      return
+    }
+
+    activate(scope)
+    void refreshContext(false)
+    const unsubscribe = port.subscribe((invalidation) => {
+      if (
+        invalidation.kind === 'context' &&
+        invalidation.sceneId !== scope.sceneId
+      )
+        return
+      if (invalidation.kind === 'map') {
+        if (invalidation.mapId === read().mapId)
+          void refreshMap(invalidation.mapId)
+        return
+      }
+      void refreshContext(true)
+    })
+
+    return () => {
+      unsubscribe()
+      coordinator.cancelAll()
+    }
+  }, [
+    activate,
+    active,
+    coordinator,
+    deactivate,
+    port,
+    read,
+    refreshContext,
+    refreshMap,
+    scope
+  ])
+}

--- a/tests/architecture/renderer-architecture.test.ts
+++ b/tests/architecture/renderer-architecture.test.ts
@@ -88,6 +88,75 @@ architectureGate(
 )
 
 architectureGate(
+  'behavior-integration',
+  'splits Travel async work across coordinator-owned boundaries',
+  () => {
+    const path = 'src/renderer/features/travel/use-travel-controller.ts'
+    const controller = readTypeScriptModule(path)
+    for (const call of [
+      'useAsyncCommandCoordinator',
+      'useTravelViewProjection',
+      'useTravelQueries',
+      'useTravelCommands',
+      'useTravelRemoteReconciliation'
+    ])
+      expect(hasCall(controller, call), call).toBe(true)
+    for (const infrastructure of [
+      'useEffect',
+      'useRef',
+      'AbortController',
+      'TravelRequestFactory'
+    ])
+      expect(controller.identifiers.has(infrastructure), infrastructure).toBe(
+        false
+      )
+    const queries = readTypeScriptModule(
+      'src/renderer/features/travel/use-travel-queries.ts'
+    )
+    expect(queries.stringLiterals).toContain('latest-only')
+    for (const scope of [
+      'travel.context-query',
+      'travel.map-query',
+      'travel.evaluation-query'
+    ])
+      expect(queries.stringLiterals, scope).toContain(scope)
+
+    const commands = readTypeScriptModule(
+      'src/renderer/features/travel/use-travel-commands.ts'
+    )
+    expect(commands.stringLiterals).toContain('queue')
+    expect(commands.stringLiterals).toContain('travel.command')
+
+    const reconciliation = readTypeScriptModule(
+      'src/renderer/features/travel/use-travel-remote-reconciliation.ts'
+    )
+    expect(hasCall(reconciliation, 'useEffect')).toBe(true)
+    expect(hasCall(reconciliation, 'cancelAll')).toBe(true)
+    expect(hasCall(reconciliation, 'subscribe')).toBe(true)
+
+    const projection = readTypeScriptModule(
+      'src/renderer/features/travel/travel-view-projection.ts'
+    )
+    expect(hasCall(projection, 'useState')).toBe(true)
+    expect(
+      projection.imports.some(({ specifier }) =>
+        specifier.includes('async-command-coordinator')
+      )
+    ).toBe(false)
+
+    for (const travelPath of codeFiles('src/renderer/features/travel')) {
+      const module = readTypeScriptModule(travelPath)
+      expect(module.identifiers.has('TravelRequestFactory'), travelPath).toBe(
+        false
+      )
+      expect(module.constructions, travelPath).not.toContain(
+        'AsyncCommandCoordinator'
+      )
+    }
+  }
+)
+
+architectureGate(
   'import-dependency-boundary',
   'erases every renderer import from schema-bearing contracts',
   () => {

--- a/tests/unit/travel-controller-async.test.tsx
+++ b/tests/unit/travel-controller-async.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import type { TravelController } from '../../src/renderer/features/travel/use-travel-controller.js'
+import { useTravelController } from '../../src/renderer/features/travel/use-travel-controller.js'
+import type {
+  TravelProviderPort,
+  TravelProviderReadResult
+} from '../../src/renderer/features/travel/travel-provider-port.js'
+
+type Position = Readonly<{ id: string }>
+type ProviderState = Readonly<{
+  revision: number
+  status: string
+  currentMapId: string | null
+  mapIds: readonly string[]
+  multiplier: 1 | 2 | 5 | 10
+  marker: string
+}>
+type MapProjection = Readonly<{ id: string }>
+type Evaluation = Readonly<{ status: 'ready' }>
+type Port = TravelProviderPort<
+  Position,
+  ProviderState,
+  MapProjection,
+  Evaluation
+>
+type Controller = TravelController<
+  Position,
+  ProviderState,
+  MapProjection,
+  Evaluation
+>
+type ReadResult = TravelProviderReadResult<ProviderState>
+
+afterEach(cleanup)
+
+describe('Travel async controller boundaries', () => {
+  it('accepts only the newest out-of-order Context response', async () => {
+    const first = deferred<ReadResult>()
+    const second = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockImplementationOnce(() => first.promise)
+    fixture.read.mockImplementationOnce(() => second.promise)
+    render(fixture.harness())
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(1))
+
+    act(() => fixture.invalidate({ kind: 'context', sceneId: 'scene-a' }))
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(2))
+    second.resolve(result('scene-a', 2, 'map-b'))
+    await expectState('provider:2 map:map-b')
+
+    first.resolve(result('scene-a', 1, 'map-a'))
+    await act(async () => await first.promise)
+    expect(screen.getByTestId('travel-state')).toHaveTextContent(
+      'provider:2 map:map-b'
+    )
+    expect(fixture.setSnapshot).toHaveBeenLastCalledWith(snapshot('scene-a', 2))
+    expect(fixture.onError).not.toHaveBeenCalled()
+  })
+
+  it('reconciles provider truth without overwriting a newer local map decision', async () => {
+    const remote = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockResolvedValueOnce(result('scene-a', 1, 'map-a'))
+    fixture.read.mockImplementationOnce(() => remote.promise)
+    render(fixture.harness())
+    await expectState('provider:1 map:map-a')
+
+    act(() => fixture.invalidate({ kind: 'context', sceneId: 'scene-a' }))
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(2))
+    await act(async () => {
+      await fixture.controller().selectMap('map-c')
+    })
+    expect(screen.getByTestId('travel-state')).toHaveTextContent('map:map-c')
+
+    remote.resolve(result('scene-a', 2, 'map-b'))
+    await expectState('provider:2 map:map-c')
+    expect(fixture.onError).not.toHaveBeenCalled()
+  })
+
+  it('does not let an equal-revision read replace a newer local command', async () => {
+    const remote = deferred<ReadResult>()
+    const command = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockResolvedValueOnce(
+      result('scene-a', 0, 'map-a', 'initial', 1)
+    )
+    fixture.read.mockImplementationOnce(() => remote.promise)
+    fixture.execute.mockImplementationOnce(() => command.promise)
+    render(fixture.harness())
+    await expectState('marker:initial')
+
+    act(() => fixture.controller().dropToken({ id: 'position-1' }))
+    await waitFor(() => expect(fixture.execute).toHaveBeenCalledTimes(1))
+    act(() => fixture.invalidate({ kind: 'context', sceneId: 'scene-a' }))
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(2))
+    command.resolve(result('scene-a', 0, 'map-a', 'local-command', 2))
+    await expectState('marker:local-command')
+
+    remote.resolve(result('scene-a', 0, 'map-a', 'old-read', 1))
+    await act(async () => await remote.promise)
+    expect(screen.getByTestId('travel-state')).toHaveTextContent(
+      'marker:local-command'
+    )
+  })
+
+  it('aborts the old Scene scope and suppresses its obsolete failure', async () => {
+    const oldScene = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockImplementation(({ sceneId }) =>
+      sceneId === 'scene-a'
+        ? oldScene.promise
+        : Promise.resolve(result('scene-b', 4, 'map-b'))
+    )
+    const rendered = render(fixture.harness())
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(1))
+
+    rendered.rerender(fixture.harness(snapshot('scene-b', 4)))
+    await expectState('provider:4 map:map-b')
+    oldScene.reject(new Error('obsolete Scene failure'))
+    await act(async () => {
+      await oldScene.promise.catch(() => undefined)
+    })
+
+    expect(screen.getByTestId('travel-state')).toHaveTextContent(
+      'provider:4 map:map-b'
+    )
+    expect(fixture.onError).not.toHaveBeenCalled()
+    expect(fixture.unsubscribe).toHaveBeenCalled()
+  })
+
+  it('preserves FIFO command order and exposes a domain failure', async () => {
+    const first = deferred<ReadResult>()
+    const second = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockResolvedValue(result('scene-a', 1, 'map-a'))
+    fixture.execute.mockImplementationOnce(() => first.promise)
+    fixture.execute.mockImplementationOnce(() => second.promise)
+    render(fixture.harness())
+    await expectState('provider:1 map:map-a')
+
+    act(() => fixture.controller().dropToken({ id: 'position-1' }))
+    await waitFor(() => expect(fixture.execute).toHaveBeenCalledTimes(1))
+    act(() => fixture.controller().dropToken({ id: 'position-2' }))
+    await act(async () => await Promise.resolve())
+    expect(fixture.execute).toHaveBeenCalledTimes(1)
+
+    first.reject({ code: 'stale' })
+    await waitFor(() => expect(fixture.execute).toHaveBeenCalledTimes(2))
+    expect(fixture.onError).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('travel-state')).not.toHaveTextContent('error:-')
+
+    second.resolve(result('scene-a', 2, 'map-a'))
+    await expectState('provider:2 map:map-a')
+    expect(fixture.execute.mock.calls.map(([command]) => command)).toEqual([
+      expect.objectContaining({ position: { id: 'position-1' } }),
+      expect.objectContaining({ position: { id: 'position-2' } })
+    ])
+  })
+
+  it('terminates pending work on unmount without publishing late results', async () => {
+    const pending = deferred<ReadResult>()
+    const fixture = createFixture()
+    fixture.read.mockImplementation(() => pending.promise)
+    const rendered = render(fixture.harness())
+    await waitFor(() => expect(fixture.read).toHaveBeenCalledTimes(1))
+    rendered.unmount()
+
+    pending.resolve(result('scene-a', 9, 'map-a'))
+    await act(async () => await pending.promise)
+    expect(fixture.setSnapshot).not.toHaveBeenCalled()
+    expect(fixture.onError).not.toHaveBeenCalled()
+    expect(fixture.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})
+
+function createFixture() {
+  let listener:
+    | Parameters<
+        TravelProviderPort<
+          Position,
+          ProviderState,
+          MapProjection,
+          Evaluation
+        >['subscribe']
+      >[0]
+    | null = null
+  let currentController: Controller | null = null
+  const read = vi.fn<(input: { sceneId: string }) => Promise<ReadResult>>()
+  const execute = vi.fn<Port['execute']>()
+  const unsubscribe = vi.fn(() => {
+    listener = null
+  })
+  const setSnapshot = vi.fn()
+  const onError = vi.fn()
+  const port: Port = {
+    kind: 'hex',
+    read,
+    readMap: vi.fn<Port['readMap']>(({ mapId }) =>
+      Promise.resolve({ id: mapId })
+    ),
+    evaluate: vi.fn<Port['evaluate']>(() =>
+      Promise.resolve({ status: 'ready' })
+    ),
+    execute,
+    describe: (state) => ({
+      revision: state.revision,
+      status: state.status,
+      mapOptions: state.mapIds.map((id) => ({ id, label: id })),
+      currentMapId: state.currentMapId,
+      currentPosition: null,
+      multiplier: state.multiplier
+    }),
+    isAuthoredPosition: () => true,
+    canStart: () => true,
+    subscribe: (next) => {
+      listener = next
+      return unsubscribe
+    },
+    dispose: vi.fn()
+  }
+
+  function Harness(props: { snapshot: LiveSessionSnapshot }) {
+    currentController = useTravelController({
+      port,
+      snapshot: props.snapshot,
+      setSnapshot,
+      onError,
+      active: true
+    })
+    const state = currentController.state
+    return (
+      <output data-testid="travel-state">
+        provider:{state.providerState?.revision ?? '-'} map:{state.mapId ?? '-'}{' '}
+        marker:{state.providerState?.marker ?? '-'} error:{state.error ?? '-'}
+      </output>
+    )
+  }
+
+  return {
+    read,
+    execute,
+    setSnapshot,
+    onError,
+    unsubscribe,
+    controller: () => {
+      if (!currentController) throw new Error('Controller is not mounted.')
+      return currentController
+    },
+    invalidate: (event: Parameters<NonNullable<typeof listener>>[0]) =>
+      listener?.(event),
+    harness: (next = snapshot('scene-a', 1)) => <Harness snapshot={next} />
+  }
+}
+
+function result(
+  sceneId: string,
+  revision: number,
+  currentMapId: string,
+  marker = `revision-${revision}`,
+  sessionRevision = revision
+): ReadResult {
+  return {
+    providerState: {
+      revision,
+      status: 'ready',
+      currentMapId,
+      mapIds: ['map-a', 'map-b', 'map-c'],
+      multiplier: 1,
+      marker
+    },
+    session: snapshot(sceneId, sessionRevision)
+  }
+}
+
+function snapshot(sceneId: string, revision: number): LiveSessionSnapshot {
+  return {
+    scene: { focusedSceneId: sceneId, revision }
+  } as unknown as LiveSessionSnapshot
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  let reject!: (cause?: unknown) => void
+  const promise = new Promise<Value>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+async function expectState(text: string): Promise<void> {
+  await waitFor(() =>
+    expect(screen.getByTestId('travel-state')).toHaveTextContent(text)
+  )
+}

--- a/tests/unit/travel-controller.test.ts
+++ b/tests/unit/travel-controller.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   initialTravelControllerState,
   travelControllerReducer,
-  TravelRequestFactory,
   type TravelControllerState,
-  type TravelRequest,
   type TravelScope
 } from '../../src/renderer/features/travel/travel-controller.js'
 
@@ -25,20 +23,7 @@ const scope: TravelScope = {
   providerIdentity: {}
 }
 
-function begin(
-  state: State,
-  factory: TravelRequestFactory,
-  channel: TravelRequest['channel']
-) {
-  const request = factory.next(scope, channel)
-  return {
-    request,
-    state: travelControllerReducer(state, { type: 'request-started', request })
-  }
-}
-
-function readyState() {
-  const factory = new TravelRequestFactory()
+function readyState(): State {
   let state = travelControllerReducer(
     initialTravelControllerState<
       Position,
@@ -48,23 +33,22 @@ function readyState() {
     >(),
     { type: 'activated', scope }
   )
-  const pending = begin(state, factory, 'context')
-  state = travelControllerReducer(pending.state, {
+  state = travelControllerReducer(state, {
+    type: 'request-started',
+    channel: 'context'
+  })
+  return travelControllerReducer(state, {
     type: 'projection-loaded',
-    request: pending.request,
     providerState: { revision: 1, status: 'ready' },
     mapId: 'coast',
     map: { id: 'coast' },
     multiplier: 1
   })
-  return { state, factory }
 }
 
-describe('travel controller state', () => {
+describe('travel controller view state', () => {
   it('keeps provider truth separate from transient route and token state', () => {
-    const ready = readyState()
-    let state = ready.state
-    const factory = ready.factory
+    let state = readyState()
     state = travelControllerReducer(state, { type: 'mode', mode: 'plan' })
     state = travelControllerReducer(state, {
       type: 'waypoint-added',
@@ -74,12 +58,11 @@ describe('travel controller state', () => {
       type: 'token-preview',
       position: { q: 2, r: 0 }
     })
-    const pending = begin(state, factory, 'context')
-    state = travelControllerReducer(pending.state, {
-      type: 'provider-updated',
-      request: pending.request,
+    state = travelControllerReducer(state, {
+      type: 'provider-reconciled',
       providerState: { revision: 2, status: 'travelling' },
-      multiplier: 2
+      multiplier: 2,
+      preserveLocal: true
     })
 
     expect(state).toMatchObject({
@@ -89,23 +72,19 @@ describe('travel controller state', () => {
       mode: 'plan',
       waypoints: [{ q: 1, r: 0 }],
       tokenPreview: { q: 2, r: 0 },
-      multiplier: 2
+      multiplier: 1
     })
   })
 
-  it('resets every draft on scene/provider changes and only map draft on map changes', () => {
-    const ready = readyState()
-    let state = ready.state
-    const factory = ready.factory
+  it('resets every draft on scope changes and only map draft on map changes', () => {
+    let state = readyState()
     state = travelControllerReducer(state, { type: 'mode', mode: 'plan' })
     state = travelControllerReducer(state, {
       type: 'waypoint-added',
       position: { q: 1, r: 0 }
     })
-    const mapPending = begin(state, factory, 'map')
-    state = travelControllerReducer(mapPending.state, {
+    state = travelControllerReducer(state, {
       type: 'map-selected',
-      request: mapPending.request,
       mapId: 'islands',
       map: { id: 'islands' }
     })
@@ -133,8 +112,8 @@ describe('travel controller state', () => {
     })
   })
 
-  it('retains a scene draft while inactive and requires refresh before ready', () => {
-    let { state } = readyState()
+  it('retains a Scene draft while inactive and requires refresh before ready', () => {
+    let state = readyState()
     state = travelControllerReducer(state, { type: 'mode', mode: 'plan' })
     state = travelControllerReducer(state, {
       type: 'waypoint-added',
@@ -153,7 +132,6 @@ describe('travel controller state', () => {
   })
 
   it('covers unavailable, initial error, and stale projection lifecycles', () => {
-    const factory = new TravelRequestFactory()
     let state = travelControllerReducer(
       initialTravelControllerState<
         Position,
@@ -163,19 +141,16 @@ describe('travel controller state', () => {
       >(),
       { type: 'activated', scope }
     )
-    let pending = begin(state, factory, 'context')
-    state = travelControllerReducer(pending.state, {
+    state = travelControllerReducer(state, {
       type: 'request-failed',
-      request: pending.request,
+      channel: 'context',
       message: 'offline'
     })
     expect(state).toMatchObject({ lifecycle: 'error', error: 'offline' })
 
     state = travelControllerReducer(state, { type: 'activated', scope })
-    pending = begin(state, factory, 'context')
-    state = travelControllerReducer(pending.state, {
+    state = travelControllerReducer(state, {
       type: 'projection-loaded',
-      request: pending.request,
       providerState: { revision: 0, status: 'unpositioned' },
       mapId: null,
       map: null,
@@ -183,11 +158,10 @@ describe('travel controller state', () => {
     })
     expect(state.lifecycle).toBe('unavailable')
 
-    ;({ state } = readyState())
-    pending = begin(state, factory, 'map')
-    state = travelControllerReducer(pending.state, {
+    state = readyState()
+    state = travelControllerReducer(state, {
       type: 'request-failed',
-      request: pending.request,
+      channel: 'map',
       message: 'refresh failed'
     })
     expect(state).toMatchObject({
@@ -198,31 +172,30 @@ describe('travel controller state', () => {
     })
   })
 
-  it('discards stale results by scene, provider and request generation in the reducer', () => {
-    const ready = readyState()
-    let state = ready.state
-    const factory = ready.factory
-    const older = begin(state, factory, 'map')
-    const newer = begin(older.state, factory, 'map')
-    state = travelControllerReducer(newer.state, {
-      type: 'map-refreshed',
-      request: older.request,
-      map: { id: 'old' }
-    })
-    expect(state.map).toEqual({ id: 'coast' })
+  it('keeps a command domain error until that command channel succeeds', () => {
+    let state = readyState()
     state = travelControllerReducer(state, {
-      type: 'map-refreshed',
-      request: newer.request,
-      map: { id: 'new' }
+      type: 'request-failed',
+      channel: 'command',
+      message: 'revision conflict'
     })
-    expect(state.map).toEqual({ id: 'new' })
-
-    const wrongScope = { ...newer.request, providerIdentity: {} }
     state = travelControllerReducer(state, {
-      type: 'map-refreshed',
-      request: wrongScope,
-      map: { id: 'wrong-provider' }
+      type: 'request-started',
+      channel: 'command'
     })
-    expect(state.map).toEqual({ id: 'new' })
+    expect(state.error).toBe('revision conflict')
+    state = travelControllerReducer(state, {
+      type: 'command-applied',
+      providerState: { revision: 2, status: 'travelling' },
+      multiplier: 1,
+      clearDraft: false,
+      preserveLocal: false
+    })
+    expect(state).toMatchObject({
+      lifecycle: 'ready',
+      error: null,
+      failureChannel: null,
+      providerState: { revision: 2 }
+    })
   })
 })


### PR DESCRIPTION
Phase 9 of the architecture-debt roadmap.\n\n- separates Travel view authority, latest-only queries, FIFO commands, and remote reconciliation\n- replaces reducer-local request generations with the shared async coordinator\n- prevents stale reads from replacing newer local or command projections\n- adds deterministic out-of-order, scope, abort, and command-failure coverage\n- keeps the composition hook at 143 lines and updates canonical architecture docs\n\nLocal acceptance: pnpm check passed; functional E2E 14/14 and visual E2E 7/7 passed on first attempt; bundle baseline unchanged.