### PR TITLE
Phase 10: Group and catalog controller boundaries

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -56,8 +56,11 @@ Renderer Session mutations and Group management now share one instance-bound
 async command coordinator with scope/entity request identity, latest-only and
 queue modes, `AbortSignal` cancellation, and explicit pending/success/stale/
 failure state. Stale results and failures are rejected before they reach domain
-callbacks. Group query and write hooks own the asynchronous work, while the
-pure reducer and composition controller contain no request-token inventory.
+callbacks. Group query and write hooks receive the single coordinator owned by
+their thin composition controller. Loot commands, intent execution, and view
+projection are separate bounded modules, while the pure reducer and
+composition controller contain no request-token inventory. Focused-Scene
+cleanup cancels obsolete Group work.
 Hex and installation-preference writes now use that same coordinator instead
 of feature-local Promise tails. Hex creation is queued per Campaign and
 existing-map writes per map ID; different map keys can progress independently,
@@ -544,6 +547,12 @@ per-Group undo/redo caching and discard protection, an immutable-run-pinned
   sections; the shared creature-collection manager owns every named layout
   area and exposes fixed or accessible resizable divider models instead of an
   implicit child-order contract
+- NPC and Location Catalog controllers compose separate query, mutation, and
+  projection adapters around one coordinator per mounted section. Manual
+  request counters and Promise-based acceptance guards are gone; section
+  deactivation cancels pending work, independent Location reference retries
+  remain isolated, and stale page, detail, mutation, and error outcomes cannot
+  publish
 - one campaign-local Hex vertical slice now connects a Pixi editor, shared
   installation-owned biome IDs, World Planner location placement, focused-Scene
   Party position, waypoint route planning, durable checkpoints and Scene time,

--- a/docs/project/architecture/renderer-bundle-baseline.json
+++ b/docs/project/architecture/renderer-bundle-baseline.json
@@ -1,16 +1,16 @@
 {
-  "recordedAt": "2026-08-17",
-  "reason": "Record the versioned adaptive Session workspace, controller-owned UI state, and accessible layout primitives.",
-  "dependencyRationale": "No runtime dependency was added; growth is application-owned Session controls, NPC state, accessibility primitives, and scoped layout styling.",
-  "chunkRationale": "Session additions remain in the existing lazy session surface; reusable dialog and accessibility primitives remain in their existing shared or feature-lazy chunks, with no new eager shell route.",
+  "recordedAt": "2026-08-22",
+  "reason": "Record Phase 10 Group, NPC, and Location query-mutation-projection boundaries with coordinator-owned stale-result suppression.",
+  "dependencyRationale": "No runtime dependency was added; growth is application-owned adapter wiring and deterministic scope isolation.",
+  "chunkRationale": "Group adapters remain in the existing dynamic group-dialog leaf; NPC and Location adapters remain in the existing Catalog lazy graph, with no new eager shell route.",
   "graphs": {
-    "shell": 400451,
-    "workspace": 491771,
-    "session": 164347,
-    "catalog": 182319,
-    "hex": 174781,
+    "shell": 400513,
+    "workspace": 494655,
+    "session": 169019,
+    "catalog": 185465,
+    "hex": 176449,
     "reference": 39420,
     "pixi": 408625,
-    "reachable": 1482635
+    "reachable": 1503616
   }
 }

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -256,10 +256,18 @@ module identity rather than matching generated keys or hashes.
 Catalog is a composition root over Monster, Location, Faction, and Encounter
 Table controllers and views. Controller state remains mounted across section
 changes, while an explicit active flag prevents hidden sections from reading
-their providers. Narrow renderer-local capability ports make these rules
-testable without widening IPC. The creature-collection manager owns its header,
-named grid areas, catalog pane, draft pane, footer, and divider; consumers may
-choose only a fixed divider or the manager's accessible resizable model.
+their providers. NPC and Location each expose a thin composition controller
+over separate query, mutation, and immutable view-projection adapters. Each
+composition owns one instance-bound async coordinator; adapters receive it
+explicitly, and deactivation cancels the whole section scope. Query adapters
+use latest-only acceptance for pages, details, reference data, and independent
+reference retries. Mutation adapters retain command identity and receipt
+recovery but publish only coordinator-accepted results. Reducers contain no
+request epochs or infrastructure tokens. Narrow renderer-local capability
+ports make these rules testable without widening IPC. The creature-collection
+manager owns its header, named grid areas, catalog pane, draft pane, footer,
+and divider; consumers may choose only a fixed divider or the manager's
+accessible resizable model.
 The domain-owned World Location editor is shared by Catalog and Hex through a
 narrow application port. Location, Faction, Encounter Table, and Hex Map saves
 return both the next immutable projection and the exact saved entity; consumers
@@ -511,8 +519,12 @@ view. One `GroupManagerState` reducer owns per-Group sessions, Group and Loot
 histories, cached drafts, paired catalog/work views, serializable discard
 intents, and external conflicts. Its thin composition controller receives
 narrow Creature, Group, Loot, and lifecycle ports from the sole capability
-adapter and delegates reads to a query hook and writes to a command hook; views
-import neither live Session surface types nor capability hooks. All discarding
+adapter, creates one instance-bound async coordinator, and injects it into the
+existing query and command boundaries. Loot writes, intent execution, and the
+immutable view projection are separate modules; the composition controller
+only owns the reducer, derives its current inputs, and wires those boundaries.
+Views import neither live Session surface types nor capability hooks. Scene
+scope cleanup cancels pending reads and writes. All discarding
 transitions use one intent policy, and only coordinator-accepted asynchronous
 outcomes reach the reducer. The reusable Treasure editor receives messages,
 issues, commands, and an add policy instead of importing feature copy or

--- a/scripts/architecture/renderer-controller-boundary.ts
+++ b/scripts/architecture/renderer-controller-boundary.ts
@@ -44,6 +44,10 @@ const sessionMutations =
   'src/renderer/features/session/use-session-mutation-controller.ts'
 const plannerController =
   'src/renderer/features/session-planner/use-session-planner-controller.ts'
+const npcCatalogController =
+  'src/renderer/features/catalog/npc-catalog-controller.ts'
+const locationCatalogController =
+  'src/renderer/features/catalog/location-catalog-controller.ts'
 
 const passiveViews = new Set([
   'src/renderer/features/session/scene-party-card.tsx',
@@ -77,6 +81,7 @@ export function rendererControllerBoundaryViolations(
   inspectSessionWorkspace(factsByPath, violations)
   inspectPassiveViews(factsByPath, violations)
   inspectGroupManager(factsByPath, violations)
+  inspectCatalogAdapters(factsByPath, violations)
   inspectSessionPlanner(factsByPath, violations)
   inspectNarrowPorts(factsByPath, violations)
   inspectFeatureCapabilityAdapters(factsByPath, violations)
@@ -229,6 +234,10 @@ function inspectGroupManager(
           violation(controller, 1, 'group_controller_owns_local_state', hook)
         )
     for (const [binding, specifier] of [
+      [
+        'useAsyncCommandCoordinator',
+        '../../async/use-async-command-coordinator.js'
+      ],
       ['useGroupManagerCommands', './use-group-manager-commands.js'],
       ['useGroupManagerQueries', './use-group-manager-queries.js']
     ] as const) {
@@ -237,19 +246,37 @@ function inspectGroupManager(
     }
   }
 
-  for (const path of [sessionMutations, groupCommands, groupQueries]) {
+  const mutationOwner = requireSource(sessionMutations, factsByPath, violations)
+  if (
+    mutationOwner &&
+    (!hasImportFrom(
+      mutationOwner,
+      'useAsyncCommandCoordinator',
+      '../../async/use-async-command-coordinator.js'
+    ) ||
+      !hasImportedCall(
+        mutationOwner,
+        'useAsyncCommandCoordinator',
+        '../../async/use-async-command-coordinator.js'
+      ))
+  )
+    violations.push(
+      violation(
+        mutationOwner,
+        1,
+        'async_owner_missing_coordinator',
+        'useAsyncCommandCoordinator'
+      )
+    )
+
+  for (const path of [groupCommands, groupQueries]) {
     const module = requireSource(path, factsByPath, violations)
     if (!module) continue
     if (
       !hasImportFrom(
         module,
-        'useAsyncCommandCoordinator',
-        '../../async/use-async-command-coordinator.js'
-      ) ||
-      !hasImportedCall(
-        module,
-        'useAsyncCommandCoordinator',
-        '../../async/use-async-command-coordinator.js'
+        'AsyncCommandCoordinator',
+        '../../async/async-command-coordinator.js'
       )
     )
       violations.push(
@@ -257,9 +284,62 @@ function inspectGroupManager(
           module,
           1,
           'async_owner_missing_coordinator',
-          'useAsyncCommandCoordinator'
+          'AsyncCommandCoordinator injection'
         )
       )
+  }
+}
+
+function inspectCatalogAdapters(
+  factsByPath: ReadonlyMap<string, ModuleFacts>,
+  violations: RendererControllerBoundaryViolation[]
+): void {
+  for (const [path, boundaries] of [
+    [
+      npcCatalogController,
+      [
+        ['useNpcCatalogQueries', './use-npc-catalog-queries.js'],
+        ['useNpcCatalogMutations', './use-npc-catalog-mutations.js'],
+        ['projectNpcCatalog', './npc-catalog-projection.js']
+      ]
+    ],
+    [
+      locationCatalogController,
+      [
+        ['useLocationCatalogQueries', './use-location-catalog-queries.js'],
+        ['useLocationCatalogMutations', './use-location-catalog-mutations.js'],
+        ['useLocationCatalogProjection', './location-catalog-projection.js']
+      ]
+    ]
+  ] as const) {
+    const controller = requireSource(path, factsByPath, violations)
+    if (!controller) continue
+    requireImport(
+      controller,
+      'useAsyncCommandCoordinator',
+      '../../async/use-async-command-coordinator.js',
+      violations
+    )
+    requireCall(
+      controller,
+      'useAsyncCommandCoordinator',
+      '../../async/use-async-command-coordinator.js',
+      violations
+    )
+    for (const [binding, specifier] of boundaries) {
+      requireImport(controller, binding, specifier, violations)
+      requireCall(controller, binding, specifier, violations)
+    }
+    for (const infrastructure of ['useRef', 'AbortController'])
+      if (hasCall(controller, infrastructure))
+        violations.push(
+          violation(
+            controller,
+            1,
+            'async_owner_missing_coordinator',
+            infrastructure
+          )
+        )
   }
 }
 

--- a/src/renderer/features/catalog/location-catalog-controller.ts
+++ b/src/renderer/features/catalog/location-catalog-controller.ts
@@ -1,53 +1,19 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
-import type { SaltMarcherApi } from '../../../shared/contracts/capability-api.js'
-import type {
-  WorldLocation,
-  WorldLocationDraft,
-  WorldLocationSnapshot
-} from '../../../shared/contracts/world-location.js'
-import type {
-  EncounterTable,
-  WorldFaction
-} from '../../../shared/contracts/encounter-source.js'
+import { useEffect } from 'react'
+import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
 import {
-  capabilityErrorText,
-  presentCapabilityError
-} from '../../capabilities/capability-errors.js'
-import type {
-  WorldLocationPlacementCommitResult,
-  WorldLocationPlacementFailure,
-  WorldLocationPlacementIntent,
-  WorldLocationEditorReferences,
-  WorldLocationEditorResource
-} from '../worldplanner/world-location-editor-types.js'
+  createLocationCatalogPort,
+  type LocationCatalogPort
+} from './location-catalog-port.js'
+import { useLocationCatalogProjection } from './location-catalog-projection.js'
 import {
-  createWorldLocationApplicationPort,
-  type WorldLocationApplicationPort
-} from '../worldplanner/world-location-application.js'
+  useLocationCatalogMutations,
+  type LocationPlacementRecovery
+} from './use-location-catalog-mutations.js'
+import { useLocationCatalogQueries } from './use-location-catalog-queries.js'
 
-export type LocationCatalogPort = WorldLocationApplicationPort & {
-  readSession: () => Promise<LiveSessionSnapshot>
-}
-
-export type LocationPlacementRecovery = Readonly<{
-  locationId: string
-  failure: WorldLocationPlacementFailure
-  retry: () => Promise<WorldLocationPlacementCommitResult>
-}>
-
-export function createLocationCatalogPort(
-  api: Pick<
-    SaltMarcherApi,
-    'locations' | 'encounterTables' | 'factions' | 'session'
-  >
-): LocationCatalogPort {
-  const locations = createWorldLocationApplicationPort(api)
-  return {
-    ...locations,
-    readSession: () => api.session.read()
-  }
-}
+export { createLocationCatalogPort }
+export type { LocationCatalogPort, LocationPlacementRecovery }
 
 export function useLocationCatalogController(
   active: boolean,
@@ -55,262 +21,24 @@ export function useLocationCatalogController(
   setSession: (snapshot: LiveSessionSnapshot) => void,
   port: LocationCatalogPort
 ) {
-  const [snapshot, setSnapshot] = useState<WorldLocationSnapshot>({
-    revision: 0,
-    locations: []
+  const coordinator = useAsyncCommandCoordinator()
+  useEffect(() => {
+    if (!active) coordinator.cancelAll()
+  }, [active, coordinator])
+  const queries = useLocationCatalogQueries({
+    active,
+    onError,
+    port,
+    coordinator
   })
-  const [loading, setLoading] = useState(false)
-  const [searchInput, setSearchInput] = useState('')
-  const [search, setSearch] = useState('')
-  const [direction, setDirection] = useState<'asc' | 'desc'>('asc')
-  const [selected, setSelected] = useState<WorldLocation | null>(null)
-  const [editing, setEditing] = useState<WorldLocation | null | undefined>()
-  const [deleteConfirm, setDeleteConfirm] = useState(false)
-  const [placing, setPlacing] = useState<WorldLocation | null>(null)
-  const [tables, setTables] = useState<
-    WorldLocationEditorResource<readonly EncounterTable[]>
-  >({ status: 'loading' })
-  const [factions, setFactions] = useState<
-    WorldLocationEditorResource<readonly WorldFaction[]>
-  >({ status: 'loading' })
-  const tableRequest = useRef(0)
-  const factionRequest = useRef(0)
-  const [tableReload, setTableReload] = useState(0)
-  const [factionReload, setFactionReload] = useState(0)
-  const retryTables = useCallback(
-    () => setTableReload((value) => value + 1),
-    []
-  )
-  const retryFactions = useCallback(
-    () => setFactionReload((value) => value + 1),
-    []
-  )
-  const [placementRecovery, setPlacementRecovery] =
-    useState<LocationPlacementRecovery | null>(null)
-
-  useEffect(() => {
-    if (!active) return
-    let current = true
-    void Promise.resolve().then(async () => {
-      setLoading(true)
-      try {
-        const locations = await port.readLocations()
-        if (!current) return
-        setSnapshot((known) =>
-          locations.revision >= known.revision ? locations : known
-        )
-        setSelected((known) =>
-          known
-            ? (locations.locations.find((entry) => entry.id === known.id) ??
-              null)
-            : null
-        )
-      } catch (cause) {
-        if (current) onError(capabilityErrorText(cause))
-      } finally {
-        if (current) setLoading(false)
-      }
-    })
-    return () => {
-      current = false
-    }
-  }, [active, onError, port])
-
-  const loadTables = useCallback(() => {
-    if (!active) return
-    const request = ++tableRequest.current
-    setTables({ status: 'loading' })
-    void port
-      .readTables()
-      .then((loaded) => {
-        if (request === tableRequest.current)
-          setTables({ status: 'ready', value: loaded })
-      })
-      .catch((cause: unknown) => {
-        if (request === tableRequest.current)
-          setTables({
-            status: 'failed',
-            message: capabilityErrorText(cause),
-            retry: retryTables
-          })
-      })
-  }, [active, port, retryTables])
-
-  const loadFactions = useCallback(() => {
-    if (!active) return
-    const request = ++factionRequest.current
-    setFactions({ status: 'loading' })
-    void port
-      .readFactions()
-      .then((loaded) => {
-        if (request === factionRequest.current)
-          setFactions({ status: 'ready', value: loaded })
-      })
-      .catch((cause: unknown) => {
-        if (request === factionRequest.current)
-          setFactions({
-            status: 'failed',
-            message: capabilityErrorText(cause),
-            retry: retryFactions
-          })
-      })
-  }, [active, port, retryFactions])
-
-  useEffect(() => {
-    if (!active) return
-    void Promise.resolve().then(loadTables)
-    return () => {
-      tableRequest.current += 1
-    }
-  }, [active, loadTables, tableReload])
-  useEffect(() => {
-    if (!active) return
-    void Promise.resolve().then(loadFactions)
-    return () => {
-      factionRequest.current += 1
-    }
-  }, [active, factionReload, loadFactions])
-
-  useEffect(() => {
-    if (!active) return
-    const timer = window.setTimeout(() => setSearch(searchInput), 200)
-    return () => window.clearTimeout(timer)
-  }, [active, searchInput])
-
-  const visible = useMemo(() => {
-    const needle = search.trim().toLocaleLowerCase()
-    return snapshot.locations
-      .filter(
-        (location) =>
-          !needle ||
-          location.displayName.toLocaleLowerCase().includes(needle) ||
-          location.tags.some((tag) =>
-            tag.toLocaleLowerCase().includes(needle)
-          ) ||
-          location.readAloud.toLocaleLowerCase().includes(needle) ||
-          location.notes.toLocaleLowerCase().includes(needle)
-      )
-      .toSorted((left, right) => {
-        const order = left.displayName.localeCompare(right.displayName)
-        return direction === 'asc' ? order : -order
-      })
-  }, [direction, search, snapshot.locations])
-
-  async function save(
-    draft: WorldLocationDraft,
-    placement: WorldLocationPlacementIntent
-  ) {
-    let result: Awaited<ReturnType<LocationCatalogPort['save']>>
-    try {
-      result = await port.save(editing ?? null, draft, placement)
-    } catch (cause) {
-      return {
-        status: 'failed',
-        message: presentCapabilityError(cause, onError)
-      } as const
-    }
-    const next = result.receipt.snapshot
-    const selectedId = result.receipt.saved.id
-    setSnapshot(next)
-    setSelected(next.locations.find((entry) => entry.id === selectedId) ?? null)
-    if (result.receipt.status === 'partially-saved') {
-      const recovery: LocationPlacementRecovery = {
-        locationId: selectedId,
-        failure: result.receipt.placementFailure,
-        retry: result.retryPlacement
-      }
-      setPlacementRecovery(recovery)
-    } else {
-      setPlacementRecovery(null)
-      setEditing(undefined)
-    }
-    try {
-      setSession(await port.readSession())
-    } catch (cause) {
-      onError(capabilityErrorText(cause))
-    }
-    return result.receipt.status === 'partially-saved'
-      ? ({
-          status: 'partially-saved',
-          placementFailure: result.receipt.placementFailure,
-          retry: async () => {
-            const retried = await result.retryPlacement()
-            if (retried.status === 'rejected')
-              setPlacementRecovery({
-                locationId: selectedId,
-                failure: retried.failure,
-                retry: result.retryPlacement
-              })
-            else {
-              setPlacementRecovery(null)
-              setEditing(undefined)
-            }
-            return retried
-          }
-        } as const)
-      : ({ status: 'saved' } as const)
-  }
-
-  async function retryPlacement() {
-    if (!placementRecovery) return
-    const result = await placementRecovery.retry()
-    if (result.status === 'rejected') {
-      setPlacementRecovery({ ...placementRecovery, failure: result.failure })
-      return
-    }
-    setPlacementRecovery(null)
-    try {
-      setSession(await port.readSession())
-    } catch (cause) {
-      onError(capabilityErrorText(cause))
-    }
-  }
-
-  async function remove() {
-    if (!selected) return
-    try {
-      setSnapshot(await port.remove(selected))
-      setSelected(null)
-      setDeleteConfirm(false)
-      setSession(await port.readSession())
-    } catch (cause) {
-      onError(capabilityErrorText(cause))
-    }
-  }
-
-  async function placed() {
-    try {
-      setSession(await port.readSession())
-    } catch (cause) {
-      onError(capabilityErrorText(cause))
-    }
-  }
-
-  return {
-    snapshot,
-    loading,
-    searchInput,
-    direction,
-    selected,
-    editing,
-    deleteConfirm,
-    placing,
-    references: { tables, factions } satisfies WorldLocationEditorReferences,
-    placementRecovery,
-    visible,
-    setSearchInput,
-    commitSearch: () => setSearch(searchInput),
-    toggleDirection: () =>
-      setDirection((current) => (current === 'asc' ? 'desc' : 'asc')),
-    setSelected,
-    setEditing,
-    setDeleteConfirm,
-    setPlacing,
-    save,
-    retryPlacement,
-    remove,
-    placed
-  }
+  const mutations = useLocationCatalogMutations({
+    onError,
+    setSession,
+    port,
+    coordinator,
+    queries
+  })
+  return useLocationCatalogProjection({ queries, mutations })
 }
 
 export type LocationCatalogController = ReturnType<

--- a/src/renderer/features/catalog/location-catalog-port.ts
+++ b/src/renderer/features/catalog/location-catalog-port.ts
@@ -1,0 +1,23 @@
+import type { SaltMarcherApi } from '../../../shared/contracts/capability-api.js'
+import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
+import {
+  createWorldLocationApplicationPort,
+  type WorldLocationApplicationPort
+} from '../worldplanner/world-location-application.js'
+
+export type LocationCatalogPort = WorldLocationApplicationPort & {
+  readSession: () => Promise<LiveSessionSnapshot>
+}
+
+export function createLocationCatalogPort(
+  api: Pick<
+    SaltMarcherApi,
+    'locations' | 'encounterTables' | 'factions' | 'session'
+  >
+): LocationCatalogPort {
+  const locations = createWorldLocationApplicationPort(api)
+  return {
+    ...locations,
+    readSession: () => api.session.read()
+  }
+}

--- a/src/renderer/features/catalog/location-catalog-projection.ts
+++ b/src/renderer/features/catalog/location-catalog-projection.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react'
+import type { useLocationCatalogMutations } from './use-location-catalog-mutations.js'
+import type { useLocationCatalogQueries } from './use-location-catalog-queries.js'
+
+export function useLocationCatalogProjection(input: {
+  queries: ReturnType<typeof useLocationCatalogQueries>
+  mutations: ReturnType<typeof useLocationCatalogMutations>
+}) {
+  const { mutations, queries } = input
+  const visible = useMemo(() => {
+    const needle = queries.search.trim().toLocaleLowerCase()
+    return queries.snapshot.locations
+      .filter(
+        (location) =>
+          !needle ||
+          location.displayName.toLocaleLowerCase().includes(needle) ||
+          location.tags.some((tag) =>
+            tag.toLocaleLowerCase().includes(needle)
+          ) ||
+          location.readAloud.toLocaleLowerCase().includes(needle) ||
+          location.notes.toLocaleLowerCase().includes(needle)
+      )
+      .toSorted((left, right) => {
+        const order = left.displayName.localeCompare(right.displayName)
+        return queries.direction === 'asc' ? order : -order
+      })
+  }, [queries.direction, queries.search, queries.snapshot.locations])
+
+  return {
+    snapshot: queries.snapshot,
+    loading: queries.loading,
+    searchInput: queries.searchInput,
+    direction: queries.direction,
+    references: queries.references,
+    visible,
+    setSearchInput: queries.setSearchInput,
+    commitSearch: queries.commitSearch,
+    toggleDirection: queries.toggleDirection,
+    ...mutations
+  }
+}

--- a/src/renderer/features/catalog/npc-catalog-controller.ts
+++ b/src/renderer/features/catalog/npc-catalog-controller.ts
@@ -1,36 +1,19 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
-import type { CatalogCapabilities } from './catalog-capabilities.js'
-import type { WorldFactionSnapshot } from '../../../shared/contracts/encounter-source.js'
-import type { WorldLocation } from '../../../shared/contracts/world-location.js'
-import type {
-  WorldNpc,
-  WorldNpcDetailProjection,
-  WorldNpcDraft,
-  WorldNpcListRow,
-  WorldNpcPage
-} from '../../../shared/contracts/world-npc.js'
-import { capabilityErrorCode } from '../../../shared/errors/capability-error.js'
-import {
-  capabilityErrorText,
-  reportCapabilityError
-} from '../../capabilities/capability-errors.js'
+import { useEffect, useReducer } from 'react'
+import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
 import type { CreatureCapabilityPort } from '../creatures/creatures-capabilities.js'
-import { emptyQuery } from '../creatures/creature-state.js'
-import type { SearchableSelectOption } from '../../shell/searchable-select.js'
+import type { CatalogCapabilities } from './catalog-capabilities.js'
 import {
   initialNpcCatalogState,
   reduceNpcCatalogState
 } from './npc-catalog-state.js'
+import { projectNpcCatalog } from './npc-catalog-projection.js'
+import { useNpcCatalogMutations } from './use-npc-catalog-mutations.js'
+import {
+  useNpcCatalogQueries,
+  type NpcLifecycleFilter
+} from './use-npc-catalog-queries.js'
 
-export type NpcLifecycleFilter = 'all' | WorldNpc['lifecycle']
-
-const emptyPage: WorldNpcPage = {
-  revision: 0,
-  rows: [],
-  total: 0,
-  offset: 0,
-  limit: 50
-}
+export type { NpcLifecycleFilter }
 
 export function useNpcCatalogController(
   active: boolean,
@@ -38,305 +21,31 @@ export function useNpcCatalogController(
   api: CatalogCapabilities,
   creatures: CreatureCapabilityPort
 ) {
-  const [page, setPage] = useState<WorldNpcPage>(emptyPage)
-  const [factionSnapshot, setFactionSnapshot] = useState<WorldFactionSnapshot>({
-    revision: 0,
-    factions: []
-  })
-  const [locations, setLocations] = useState<readonly WorldLocation[]>([])
-  const [searchInput, setSearchInput] = useState('')
-  const [search, setSearch] = useState('')
-  const [lifecycle, setLifecycle] = useState<NpcLifecycleFilter>('all')
-  const [factionId, setFactionId] = useState<string>('all')
-  const [locationId, setLocationId] = useState<string>('all')
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [selectedProjection, setSelectedProjection] =
-    useState<WorldNpcDetailProjection | null>(null)
+  const coordinator = useAsyncCommandCoordinator()
   const [state, dispatch] = useReducer(
     reduceNpcCatalogState,
     initialNpcCatalogState
   )
-  const pageRequest = useRef(0)
-  const referenceRequest = useRef(0)
-  const detailRequest = useRef(0)
-  const loadRequest = useRef(0)
-  const mutationRequest = useRef(0)
-  const [creatureOptions, setCreatureOptions] = useState<
-    readonly SearchableSelectOption[]
-  >([])
-
-  const loadReferences = useCallback(async () => {
-    const token = ++referenceRequest.current
-    const [factions, locationSnapshot] = await Promise.all([
-      api.factions.read(),
-      api.locations.read()
-    ])
-    if (referenceRequest.current === token) {
-      setFactionSnapshot(factions)
-      setLocations(locationSnapshot.locations)
-    }
-  }, [api])
-
-  const loadPage = useCallback(async () => {
-    const token = ++pageRequest.current
-    const result = await api.npcs.search({
-      query: search,
-      lifecycle: lifecycle === 'all' ? null : lifecycle,
-      creatureId: null,
-      ...(factionId === 'all'
-        ? {}
-        : { factionId: factionId === 'none' ? null : factionId }),
-      ...(locationId === 'all'
-        ? {}
-        : { locationId: locationId === 'none' ? null : locationId }),
-      offset: 0,
-      limit: 50
-    })
-    if (pageRequest.current === token) setPage(result)
-  }, [api, factionId, lifecycle, locationId, search])
-
-  const loadSelected = useCallback(
-    async (id: string | null) => {
-      const token = ++detailRequest.current
-      if (id === null) {
-        setSelectedProjection(null)
-        return
-      }
-      const detail = await api.npcs.detail({ id })
-      if (detailRequest.current === token) setSelectedProjection(detail)
-    },
-    [api]
-  )
-
   useEffect(() => {
-    if (!active) return
-    let current = true
-    const token = ++loadRequest.current
-    dispatch({ type: 'load-started', token })
-    const load = async () => {
-      try {
-        await Promise.all([loadPage(), loadReferences()])
-        if (current && loadRequest.current === token)
-          dispatch({ type: 'load-completed', token })
-      } catch (cause) {
-        if (current) reportCapabilityError(onError)(cause)
-      }
-    }
-    void load()
-    const reload = () => {
-      if (!current) return
-      void Promise.all([
-        loadPage(),
-        loadReferences(),
-        loadSelected(selectedId)
-      ]).catch(reportCapabilityError(onError))
-    }
-    const unsubscribeNpcs = api.npcs.onChanged(reload)
-    const unsubscribeLocations = api.locations.onChanged(reload)
-    const unsubscribeFactions = api.factions.onChanged(reload)
-    return () => {
-      current = false
-      unsubscribeNpcs()
-      unsubscribeLocations()
-      unsubscribeFactions()
-    }
-  }, [active, api, loadPage, loadReferences, loadSelected, onError, selectedId])
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setSearch(searchInput), 200)
-    return () => window.clearTimeout(timer)
-  }, [searchInput])
-
-  const searchCreatures = useCallback(
-    async (query: string): Promise<readonly SearchableSelectOption[]> => {
-      try {
-        const result = await creatures.search({
-          ...emptyQuery,
-          name: query,
-          limit: 40
-        })
-        const options = result.rows.map((creature) => ({
-          id: creature.id,
-          label: creature.name,
-          searchText: `${creature.id} ${creature.type} ${creature.subtype ?? ''}`,
-          description: `CR ${creature.challengeRating}`
-        }))
-        setCreatureOptions((current) => mergeOptions(current, options))
-        return options
-      } catch (cause) {
-        onError(capabilityErrorText(cause))
-        return []
-      }
-    },
-    [creatures, onError]
-  )
-
-  async function save(draft: WorldNpcDraft) {
-    const commandId = crypto.randomUUID()
-    const token = ++mutationRequest.current
-    dispatch({ type: 'save-started', token })
-    const rejectSave = (cause: unknown) => {
-      dispatch({
-        type: 'save-conflicted',
-        token,
-        message: capabilityErrorText(cause)
-      })
-    }
-    try {
-      const editing = editableNpc(state)
-      const receipt = editing
-        ? await api.npcs.update({
-            commandId,
-            id: editing.id,
-            npc: draft,
-            expectedRevision: page.revision,
-            expectedFactionRevision: factionSnapshot.revision
-          })
-        : await api.npcs.create({
-            commandId,
-            npc: draft,
-            expectedRevision: page.revision,
-            expectedFactionRevision: factionSnapshot.revision
-          })
-      if (mutationRequest.current !== token) return
-      acceptMutation(receipt, token)
-      await Promise.all([loadPage(), loadReferences()])
-    } catch (cause) {
-      if (capabilityErrorCode(cause) !== 'outcome_unknown') {
-        rejectSave(cause)
-        throw cause
-      }
-      try {
-        const recovered = await api.npcs.commandReceipt({ commandId })
-        if (!recovered || !('saved' in recovered)) throw cause
-        if (mutationRequest.current !== token) return
-        acceptMutation(recovered, token)
-        await Promise.all([loadPage(), loadReferences()])
-      } catch (recoveryCause) {
-        rejectSave(recoveryCause)
-        throw recoveryCause
-      }
-    }
-  }
-
-  function acceptMutation(
-    receipt: {
-      revision: number
-      factionRevision: number
-      saved: WorldNpc
-    },
-    token: number
-  ) {
-    setPage((current) => ({ ...current, revision: receipt.revision }))
-    setFactionSnapshot((current) => ({
-      ...current,
-      revision: receipt.factionRevision
-    }))
-    setSelectedId(receipt.saved.id)
-    setSelectedProjection(null)
-    dispatch({ type: 'save-completed', token })
-    void loadSelected(receipt.saved.id).catch(reportCapabilityError(onError))
-  }
-
-  async function remove(id: string) {
-    const commandId = crypto.randomUUID()
-    const token = ++mutationRequest.current
-    dispatch({ type: 'delete-started', npcId: id, token })
-    try {
-      let receipt
-      try {
-        receipt = await api.npcs.delete({
-          commandId,
-          id,
-          expectedRevision: page.revision,
-          expectedFactionRevision: factionSnapshot.revision
-        })
-      } catch (cause) {
-        if (capabilityErrorCode(cause) !== 'outcome_unknown') throw cause
-        const recovered = await api.npcs.commandReceipt({ commandId })
-        if (!recovered || !('deletedId' in recovered)) throw cause
-        receipt = recovered
-      }
-      if (mutationRequest.current !== token) return
-      setPage((current) => ({ ...current, revision: receipt.revision }))
-      setFactionSnapshot((current) => ({
-        ...current,
-        revision: receipt.factionRevision
-      }))
-      setSelectedId((current) => (current === id ? null : current))
-      setSelectedProjection((current) =>
-        current?.npc.id === id ? null : current
-      )
-      dispatch({ type: 'delete-completed', token })
-      await Promise.all([loadPage(), loadReferences()])
-    } catch (cause) {
-      dispatch({ type: 'delete-canceled' })
-      reportCapabilityError(onError)(cause)
-    }
-  }
-
-  return {
-    snapshot: page,
-    visible: page.rows,
-    total: page.total,
-    factions: factionSnapshot.factions,
-    locations,
-    searchInput,
-    lifecycle,
-    factionId,
-    locationId,
-    selectedId,
-    selected: selectedProjection?.npc ?? null,
-    selectedProjection,
-    status: state.status,
-    editing: editableNpc(state),
-    conflict: state.status === 'conflict' ? state.message : null,
-    deleteId: state.status === 'deleting' ? state.npcId : null,
-    creatureOptions,
-    searchCreatures,
-    setSearchInput,
-    setLifecycle,
-    setFactionId,
-    setLocationId,
-    setSelected: (npc: WorldNpcListRow | null) => {
-      setSelectedId(npc?.id ?? null)
-      setSelectedProjection(null)
-      void loadSelected(npc?.id ?? null).catch(reportCapabilityError(onError))
-    },
-    setEditing: (npc: WorldNpc | null | undefined) =>
-      dispatch(
-        npc === undefined
-          ? { type: 'edit-canceled' }
-          : { type: 'edit-started', npc }
-      ),
-    setDeleteId: (id: string | null) =>
-      dispatch(
-        id === null
-          ? { type: 'delete-canceled' }
-          : { type: 'delete-requested', npcId: id }
-      ),
-    save,
-    remove
-  }
-}
-
-function editableNpc(
-  state: ReturnType<typeof reduceNpcCatalogState>
-): WorldNpc | null | undefined {
-  return state.status === 'editing' ||
-    state.status === 'saving' ||
-    state.status === 'conflict'
-    ? state.npc
-    : undefined
-}
-
-function mergeOptions(
-  current: readonly SearchableSelectOption[],
-  incoming: readonly SearchableSelectOption[]
-): readonly SearchableSelectOption[] {
-  const merged = new Map(current.map((option) => [option.id, option]))
-  for (const option of incoming) merged.set(option.id, option)
-  return [...merged.values()]
+    if (!active) coordinator.cancelAll()
+  }, [active, coordinator])
+  const queries = useNpcCatalogQueries({
+    active,
+    onError,
+    api,
+    creatures,
+    coordinator,
+    dispatch
+  })
+  const mutations = useNpcCatalogMutations({
+    api,
+    coordinator,
+    state,
+    dispatch,
+    queries,
+    onError
+  })
+  return projectNpcCatalog({ state, dispatch, queries, mutations })
 }
 
 export type NpcCatalogController = ReturnType<typeof useNpcCatalogController>

--- a/src/renderer/features/catalog/npc-catalog-projection.ts
+++ b/src/renderer/features/catalog/npc-catalog-projection.ts
@@ -1,0 +1,57 @@
+import type {
+  WorldNpc,
+  WorldNpcListRow
+} from '../../../shared/contracts/world-npc.js'
+import type { NpcCatalogEvent, NpcCatalogState } from './npc-catalog-state.js'
+import { editableNpc } from './npc-catalog-state.js'
+import type { useNpcCatalogMutations } from './use-npc-catalog-mutations.js'
+import type { useNpcCatalogQueries } from './use-npc-catalog-queries.js'
+import type { Dispatch } from 'react'
+
+export function projectNpcCatalog(input: {
+  state: NpcCatalogState
+  dispatch: Dispatch<NpcCatalogEvent>
+  queries: ReturnType<typeof useNpcCatalogQueries>
+  mutations: ReturnType<typeof useNpcCatalogMutations>
+}) {
+  const { dispatch, mutations, queries, state } = input
+  return {
+    snapshot: queries.page,
+    visible: queries.page.rows,
+    total: queries.page.total,
+    factions: queries.factionSnapshot.factions,
+    locations: queries.locations,
+    searchInput: queries.searchInput,
+    lifecycle: queries.lifecycle,
+    factionId: queries.factionId,
+    locationId: queries.locationId,
+    selectedId: queries.selectedId,
+    selected: queries.selectedProjection?.npc ?? null,
+    selectedProjection: queries.selectedProjection,
+    status: state.status,
+    editing: editableNpc(state),
+    conflict: state.status === 'conflict' ? state.message : null,
+    deleteId: state.status === 'deleting' ? state.npcId : null,
+    creatureOptions: queries.creatureOptions,
+    searchCreatures: queries.searchCreatures,
+    setSearchInput: queries.setSearchInput,
+    setLifecycle: queries.setLifecycle,
+    setFactionId: queries.setFactionId,
+    setLocationId: queries.setLocationId,
+    setSelected: (npc: WorldNpcListRow | null) => queries.setSelected(npc),
+    setEditing: (npc: WorldNpc | null | undefined) =>
+      dispatch(
+        npc === undefined
+          ? { type: 'edit-canceled' }
+          : { type: 'edit-started', npc }
+      ),
+    setDeleteId: (id: string | null) =>
+      dispatch(
+        id === null
+          ? { type: 'delete-canceled' }
+          : { type: 'delete-requested', npcId: id }
+      ),
+    save: mutations.save,
+    remove: mutations.remove
+  }
+}

--- a/src/renderer/features/catalog/npc-catalog-state.ts
+++ b/src/renderer/features/catalog/npc-catalog-state.ts
@@ -1,40 +1,31 @@
 import type { WorldNpc } from '../../../shared/contracts/world-npc.js'
 
 export type NpcCatalogState =
-  | Readonly<{ status: 'loading'; token: number }>
+  | Readonly<{ status: 'loading' }>
   | Readonly<{ status: 'ready' }>
   | Readonly<{ status: 'editing'; npc: WorldNpc | null }>
-  | Readonly<{ status: 'saving'; npc: WorldNpc | null; token: number }>
-  | Readonly<{
-      status: 'conflict'
-      npc: WorldNpc | null
-      token: number
-      message: string
-    }>
+  | Readonly<{ status: 'saving'; npc: WorldNpc | null }>
+  | Readonly<{ status: 'conflict'; npc: WorldNpc | null; message: string }>
   | Readonly<{
       status: 'deleting'
       npcId: string
       phase: 'confirming' | 'saving'
-      token: number | null
     }>
 
 export type NpcCatalogEvent =
-  | Readonly<{ type: 'load-started'; token: number }>
-  | Readonly<{ type: 'load-completed'; token: number }>
+  | Readonly<{ type: 'load-started' }>
+  | Readonly<{ type: 'load-completed' }>
   | Readonly<{ type: 'edit-started'; npc: WorldNpc | null }>
   | Readonly<{ type: 'edit-canceled' }>
-  | Readonly<{ type: 'save-started'; token: number }>
-  | Readonly<{ type: 'save-completed'; token: number }>
-  | Readonly<{ type: 'save-conflicted'; token: number; message: string }>
+  | Readonly<{ type: 'save-started' }>
+  | Readonly<{ type: 'save-completed' }>
+  | Readonly<{ type: 'save-conflicted'; message: string }>
   | Readonly<{ type: 'delete-requested'; npcId: string }>
   | Readonly<{ type: 'delete-canceled' }>
-  | Readonly<{ type: 'delete-started'; npcId: string; token: number }>
-  | Readonly<{ type: 'delete-completed'; token: number }>
+  | Readonly<{ type: 'delete-started'; npcId: string }>
+  | Readonly<{ type: 'delete-completed' }>
 
-export const initialNpcCatalogState: NpcCatalogState = {
-  status: 'loading',
-  token: 0
-}
+export const initialNpcCatalogState: NpcCatalogState = { status: 'loading' }
 
 export function reduceNpcCatalogState(
   state: NpcCatalogState,
@@ -42,55 +33,44 @@ export function reduceNpcCatalogState(
 ): NpcCatalogState {
   switch (event.type) {
     case 'load-started':
-      return state.status === 'loading'
-        ? { status: 'loading', token: event.token }
-        : state
+      return state
     case 'load-completed':
-      return state.status === 'loading' && state.token === event.token
-        ? { status: 'ready' }
-        : state
+      return state.status === 'loading' ? { status: 'ready' } : state
     case 'edit-started':
       return { status: 'editing', npc: event.npc }
     case 'edit-canceled':
       return { status: 'ready' }
     case 'save-started':
       return state.status === 'editing' || state.status === 'conflict'
-        ? { status: 'saving', npc: state.npc, token: event.token }
+        ? { status: 'saving', npc: state.npc }
         : state
     case 'save-completed':
-      return state.status === 'saving' && state.token === event.token
-        ? { status: 'ready' }
-        : state
+      return state.status === 'saving' ? { status: 'ready' } : state
     case 'save-conflicted':
-      return state.status === 'saving' && state.token === event.token
-        ? {
-            status: 'conflict',
-            npc: state.npc,
-            token: event.token,
-            message: event.message
-          }
+      return state.status === 'saving'
+        ? { status: 'conflict', npc: state.npc, message: event.message }
         : state
     case 'delete-requested':
       return {
         status: 'deleting',
         npcId: event.npcId,
-        phase: 'confirming',
-        token: null
+        phase: 'confirming'
       }
     case 'delete-canceled':
       return { status: 'ready' }
     case 'delete-started':
       return state.status === 'deleting' && state.npcId === event.npcId
-        ? {
-            status: 'deleting',
-            npcId: event.npcId,
-            phase: 'saving',
-            token: event.token
-          }
+        ? { status: 'deleting', npcId: event.npcId, phase: 'saving' }
         : state
     case 'delete-completed':
-      return state.status === 'deleting' && state.token === event.token
-        ? { status: 'ready' }
-        : state
+      return state.status === 'deleting' ? { status: 'ready' } : state
   }
+}
+
+export function editableNpc(state: NpcCatalogState) {
+  return state.status === 'editing' ||
+    state.status === 'saving' ||
+    state.status === 'conflict'
+    ? state.npc
+    : undefined
 }

--- a/src/renderer/features/catalog/use-location-catalog-mutations.ts
+++ b/src/renderer/features/catalog/use-location-catalog-mutations.ts
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
+import type {
+  WorldLocation,
+  WorldLocationDraft
+} from '../../../shared/contracts/world-location.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import {
+  capabilityErrorText,
+  presentCapabilityError
+} from '../../capabilities/capability-errors.js'
+import type {
+  WorldLocationPlacementCommitResult,
+  WorldLocationPlacementFailure,
+  WorldLocationPlacementIntent
+} from '../worldplanner/world-location-editor-types.js'
+import type { LocationCatalogPort } from './location-catalog-port.js'
+import type { useLocationCatalogQueries } from './use-location-catalog-queries.js'
+
+export type LocationPlacementRecovery = Readonly<{
+  locationId: string
+  failure: WorldLocationPlacementFailure
+  retry: () => Promise<WorldLocationPlacementCommitResult>
+}>
+
+export function useLocationCatalogMutations(input: {
+  onError: (message: string) => void
+  setSession: (snapshot: LiveSessionSnapshot) => void
+  port: LocationCatalogPort
+  coordinator: AsyncCommandCoordinator
+  queries: ReturnType<typeof useLocationCatalogQueries>
+}) {
+  const { coordinator, onError, port, queries, setSession } = input
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [editing, setEditing] = useState<WorldLocation | null | undefined>()
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [placing, setPlacing] = useState<WorldLocation | null>(null)
+  const [placementRecovery, setPlacementRecovery] =
+    useState<LocationPlacementRecovery | null>(null)
+
+  const selected =
+    queries.snapshot.locations.find((entry) => entry.id === selectedId) ?? null
+
+  async function refreshSession(): Promise<void> {
+    const outcome = await coordinator.run({
+      scope: 'location-catalog.session',
+      mode: 'latest-only',
+      execute: () => port.readSession()
+    })
+    if (outcome.status === 'success') setSession(outcome.value)
+    else if (outcome.status === 'failure')
+      onError(capabilityErrorText(outcome.cause))
+  }
+
+  async function save(
+    draft: WorldLocationDraft,
+    placement: WorldLocationPlacementIntent
+  ) {
+    const outcome = await coordinator.run({
+      scope: 'location-catalog.mutation',
+      entityKey: editing?.id ?? 'new',
+      mode: 'latest-only',
+      execute: () => port.save(editing ?? null, draft, placement)
+    })
+    if (outcome.status !== 'success') {
+      return {
+        status: 'failed',
+        message:
+          outcome.status === 'failure'
+            ? presentCapabilityError(outcome.cause, onError)
+            : capabilityErrorText(new Error('obsolete location save'))
+      } as const
+    }
+    const result = outcome.value
+    const next = result.receipt.snapshot
+    const savedId = result.receipt.saved.id
+    queries.setSnapshot(next)
+    setSelectedId(savedId)
+    if (result.receipt.status === 'partially-saved')
+      setPlacementRecovery({
+        locationId: savedId,
+        failure: result.receipt.placementFailure,
+        retry: result.retryPlacement
+      })
+    else {
+      setPlacementRecovery(null)
+      setEditing(undefined)
+    }
+    await refreshSession()
+    return result.receipt.status === 'partially-saved'
+      ? ({
+          status: 'partially-saved',
+          placementFailure: result.receipt.placementFailure,
+          retry: async () => {
+            const retried = await result.retryPlacement()
+            if (retried.status === 'rejected')
+              setPlacementRecovery({
+                locationId: savedId,
+                failure: retried.failure,
+                retry: result.retryPlacement
+              })
+            else {
+              setPlacementRecovery(null)
+              setEditing(undefined)
+            }
+            return retried
+          }
+        } as const)
+      : ({ status: 'saved' } as const)
+  }
+
+  async function retryPlacement(): Promise<void> {
+    if (!placementRecovery) return
+    const result = await placementRecovery.retry()
+    if (result.status === 'rejected') {
+      setPlacementRecovery({ ...placementRecovery, failure: result.failure })
+      return
+    }
+    setPlacementRecovery(null)
+    await refreshSession()
+  }
+
+  async function remove(): Promise<void> {
+    if (!selected) return
+    const outcome = await coordinator.run({
+      scope: 'location-catalog.mutation',
+      entityKey: selected.id,
+      mode: 'latest-only',
+      execute: () => port.remove(selected)
+    })
+    if (outcome.status === 'failure') {
+      onError(capabilityErrorText(outcome.cause))
+      return
+    }
+    if (outcome.status === 'stale') return
+    queries.setSnapshot(outcome.value)
+    setSelectedId(null)
+    setDeleteConfirm(false)
+    await refreshSession()
+  }
+
+  return {
+    selected,
+    setSelected: (location: WorldLocation | null) =>
+      setSelectedId(location?.id ?? null),
+    editing,
+    setEditing,
+    deleteConfirm,
+    setDeleteConfirm,
+    placing,
+    setPlacing,
+    placementRecovery,
+    save,
+    retryPlacement,
+    remove,
+    placed: refreshSession
+  }
+}

--- a/src/renderer/features/catalog/use-location-catalog-queries.ts
+++ b/src/renderer/features/catalog/use-location-catalog-queries.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react'
+import type {
+  EncounterTable,
+  WorldFaction
+} from '../../../shared/contracts/encounter-source.js'
+import type { WorldLocationSnapshot } from '../../../shared/contracts/world-location.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import type {
+  WorldLocationEditorReferences,
+  WorldLocationEditorResource
+} from '../worldplanner/world-location-editor-types.js'
+import type { LocationCatalogPort } from './location-catalog-port.js'
+
+export function useLocationCatalogQueries(input: {
+  active: boolean
+  onError: (message: string) => void
+  port: LocationCatalogPort
+  coordinator: AsyncCommandCoordinator
+}) {
+  const { active, coordinator, onError, port } = input
+  const [snapshot, setSnapshot] = useState<WorldLocationSnapshot>({
+    revision: 0,
+    locations: []
+  })
+  const [loading, setLoading] = useState(false)
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [direction, setDirection] = useState<'asc' | 'desc'>('asc')
+  const [tables, setTables] = useState<
+    WorldLocationEditorResource<readonly EncounterTable[]>
+  >({ status: 'loading' })
+  const [factions, setFactions] = useState<
+    WorldLocationEditorResource<readonly WorldFaction[]>
+  >({ status: 'loading' })
+  const [tableReload, setTableReload] = useState(0)
+  const [factionReload, setFactionReload] = useState(0)
+  const retryTables = useCallback(
+    () => setTableReload((value) => value + 1),
+    []
+  )
+  const retryFactions = useCallback(
+    () => setFactionReload((value) => value + 1),
+    []
+  )
+
+  useEffect(() => {
+    if (!active) return
+    const abort = new AbortController()
+    queueMicrotask(() => {
+      if (abort.signal.aborted) return
+      setLoading(true)
+      void coordinator
+        .run({
+          scope: 'location-catalog.snapshot',
+          mode: 'latest-only',
+          signal: abort.signal,
+          execute: () => port.readLocations()
+        })
+        .then((outcome) => {
+          if (outcome.status === 'success')
+            setSnapshot((known) =>
+              outcome.value.revision >= known.revision ? outcome.value : known
+            )
+          else if (outcome.status === 'failure')
+            onError(capabilityErrorText(outcome.cause))
+          if (outcome.status !== 'stale') setLoading(false)
+        })
+    })
+    return () => abort.abort()
+  }, [active, coordinator, onError, port])
+
+  useEffect(() => {
+    if (!active) return
+    const abort = new AbortController()
+    queueMicrotask(() => {
+      if (abort.signal.aborted) return
+      setTables({ status: 'loading' })
+      void coordinator
+        .run({
+          scope: 'location-catalog.tables',
+          mode: 'latest-only',
+          signal: abort.signal,
+          execute: () => port.readTables()
+        })
+        .then((outcome) => {
+          if (outcome.status === 'success')
+            setTables({ status: 'ready', value: outcome.value })
+          else if (outcome.status === 'failure')
+            setTables({
+              status: 'failed',
+              message: capabilityErrorText(outcome.cause),
+              retry: retryTables
+            })
+        })
+    })
+    return () => abort.abort()
+  }, [active, coordinator, port, retryTables, tableReload])
+
+  useEffect(() => {
+    if (!active) return
+    const abort = new AbortController()
+    queueMicrotask(() => {
+      if (abort.signal.aborted) return
+      setFactions({ status: 'loading' })
+      void coordinator
+        .run({
+          scope: 'location-catalog.factions',
+          mode: 'latest-only',
+          signal: abort.signal,
+          execute: () => port.readFactions()
+        })
+        .then((outcome) => {
+          if (outcome.status === 'success')
+            setFactions({ status: 'ready', value: outcome.value })
+          else if (outcome.status === 'failure')
+            setFactions({
+              status: 'failed',
+              message: capabilityErrorText(outcome.cause),
+              retry: retryFactions
+            })
+        })
+    })
+    return () => abort.abort()
+  }, [active, coordinator, factionReload, port, retryFactions])
+
+  useEffect(() => {
+    if (!active) return
+    const timer = window.setTimeout(() => setSearch(searchInput), 200)
+    return () => window.clearTimeout(timer)
+  }, [active, searchInput])
+
+  return {
+    snapshot,
+    setSnapshot,
+    loading,
+    searchInput,
+    search,
+    direction,
+    references: { tables, factions } satisfies WorldLocationEditorReferences,
+    setSearchInput,
+    commitSearch: () => setSearch(searchInput),
+    toggleDirection: () =>
+      setDirection((current) => (current === 'asc' ? 'desc' : 'asc'))
+  }
+}

--- a/src/renderer/features/catalog/use-npc-catalog-mutations.ts
+++ b/src/renderer/features/catalog/use-npc-catalog-mutations.ts
@@ -1,0 +1,134 @@
+import type { Dispatch } from 'react'
+import type {
+  WorldNpc,
+  WorldNpcDraft
+} from '../../../shared/contracts/world-npc.js'
+import { capabilityErrorCode } from '../../../shared/errors/capability-error.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import {
+  capabilityErrorText,
+  reportCapabilityError
+} from '../../capabilities/capability-errors.js'
+import type { CatalogCapabilities } from './catalog-capabilities.js'
+import {
+  editableNpc,
+  type NpcCatalogEvent,
+  type NpcCatalogState
+} from './npc-catalog-state.js'
+import type { useNpcCatalogQueries } from './use-npc-catalog-queries.js'
+
+export function useNpcCatalogMutations(input: {
+  api: CatalogCapabilities
+  coordinator: AsyncCommandCoordinator
+  state: NpcCatalogState
+  dispatch: Dispatch<NpcCatalogEvent>
+  queries: ReturnType<typeof useNpcCatalogQueries>
+  onError: (message: string) => void
+}) {
+  const { api, coordinator, dispatch, onError, queries, state } = input
+
+  async function save(draft: WorldNpcDraft): Promise<void> {
+    const editing = editableNpc(state)
+    const commandId = crypto.randomUUID()
+    dispatch({ type: 'save-started' })
+    const outcome = await coordinator.run({
+      scope: 'npc-catalog.mutation',
+      mode: 'latest-only',
+      execute: async () => {
+        try {
+          return editing
+            ? await api.npcs.update({
+                commandId,
+                id: editing.id,
+                npc: draft,
+                expectedRevision: queries.page.revision,
+                expectedFactionRevision: queries.factionSnapshot.revision
+              })
+            : await api.npcs.create({
+                commandId,
+                npc: draft,
+                expectedRevision: queries.page.revision,
+                expectedFactionRevision: queries.factionSnapshot.revision
+              })
+        } catch (cause) {
+          if (capabilityErrorCode(cause) !== 'outcome_unknown') throw cause
+          const recovered = await api.npcs.commandReceipt({ commandId })
+          if (!recovered || !('saved' in recovered)) throw cause
+          return recovered
+        }
+      }
+    })
+    if (outcome.status === 'stale') return
+    if (outcome.status === 'failure') {
+      dispatch({
+        type: 'save-conflicted',
+        message: capabilityErrorText(outcome.cause)
+      })
+      throw outcome.cause
+    }
+    acceptMutation(outcome.value)
+    dispatch({ type: 'save-completed' })
+    await Promise.all([queries.loadPage(), queries.loadReferences()])
+  }
+
+  function acceptMutation(receipt: {
+    revision: number
+    factionRevision: number
+    saved: WorldNpc
+  }): void {
+    queries.setPage((current) => ({ ...current, revision: receipt.revision }))
+    queries.setFactionSnapshot((current) => ({
+      ...current,
+      revision: receipt.factionRevision
+    }))
+    queries.setSelectedId(receipt.saved.id)
+    queries.setSelectedProjection(null)
+    void queries.loadSelected(receipt.saved.id)
+  }
+
+  async function remove(id: string): Promise<void> {
+    const commandId = crypto.randomUUID()
+    dispatch({ type: 'delete-started', npcId: id })
+    const outcome = await coordinator.run({
+      scope: 'npc-catalog.mutation',
+      mode: 'latest-only',
+      execute: async () => {
+        try {
+          return await api.npcs.delete({
+            commandId,
+            id,
+            expectedRevision: queries.page.revision,
+            expectedFactionRevision: queries.factionSnapshot.revision
+          })
+        } catch (cause) {
+          if (capabilityErrorCode(cause) !== 'outcome_unknown') throw cause
+          const recovered = await api.npcs.commandReceipt({ commandId })
+          if (!recovered || !('deletedId' in recovered)) throw cause
+          return recovered
+        }
+      }
+    })
+    if (outcome.status === 'stale') return
+    if (outcome.status === 'failure') {
+      dispatch({ type: 'delete-canceled' })
+      reportCapabilityError(onError)(outcome.cause)
+      return
+    }
+    queries.setPage((current) => ({
+      ...current,
+      revision: outcome.value.revision
+    }))
+    queries.setFactionSnapshot((current) => ({
+      ...current,
+      revision: outcome.value.factionRevision
+    }))
+    queries.setSelectedId((current) => (current === id ? null : current))
+    queries.setSelectedProjection((current) =>
+      current?.npc.id === id ? null : current
+    )
+    dispatch({ type: 'delete-completed' })
+    await Promise.all([queries.loadPage(), queries.loadReferences()])
+  }
+
+  return { save, remove }
+}

--- a/src/renderer/features/catalog/use-npc-catalog-queries.ts
+++ b/src/renderer/features/catalog/use-npc-catalog-queries.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useState, type Dispatch } from 'react'
+import type { WorldFactionSnapshot } from '../../../shared/contracts/encounter-source.js'
+import type { WorldLocation } from '../../../shared/contracts/world-location.js'
+import type {
+  WorldNpc,
+  WorldNpcDetailProjection,
+  WorldNpcListRow,
+  WorldNpcPage
+} from '../../../shared/contracts/world-npc.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import type { SearchableSelectOption } from '../../shell/searchable-select.js'
+import type { CreatureCapabilityPort } from '../creatures/creatures-capabilities.js'
+import { emptyQuery } from '../creatures/creature-state.js'
+import type { CatalogCapabilities } from './catalog-capabilities.js'
+import type { NpcCatalogEvent } from './npc-catalog-state.js'
+
+export type NpcLifecycleFilter = 'all' | WorldNpc['lifecycle']
+
+const emptyPage: WorldNpcPage = {
+  revision: 0,
+  rows: [],
+  total: 0,
+  offset: 0,
+  limit: 50
+}
+
+export function useNpcCatalogQueries(input: {
+  active: boolean
+  onError: (message: string) => void
+  api: CatalogCapabilities
+  creatures: CreatureCapabilityPort
+  coordinator: AsyncCommandCoordinator
+  dispatch: Dispatch<NpcCatalogEvent>
+}) {
+  const { active, api, coordinator, creatures, dispatch, onError } = input
+  const [page, setPage] = useState<WorldNpcPage>(emptyPage)
+  const [factionSnapshot, setFactionSnapshot] = useState<WorldFactionSnapshot>({
+    revision: 0,
+    factions: []
+  })
+  const [locations, setLocations] = useState<readonly WorldLocation[]>([])
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [lifecycle, setLifecycle] = useState<NpcLifecycleFilter>('all')
+  const [factionId, setFactionId] = useState('all')
+  const [locationId, setLocationId] = useState('all')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedProjection, setSelectedProjection] =
+    useState<WorldNpcDetailProjection | null>(null)
+  const [creatureOptions, setCreatureOptions] = useState<
+    readonly SearchableSelectOption[]
+  >([])
+
+  const loadPage = useCallback(
+    async (signal?: AbortSignal) => {
+      const outcome = await coordinator.run({
+        scope: 'npc-catalog.page',
+        mode: 'latest-only',
+        ...(signal ? { signal } : {}),
+        execute: () =>
+          api.npcs.search({
+            query: search,
+            lifecycle: lifecycle === 'all' ? null : lifecycle,
+            creatureId: null,
+            ...(factionId === 'all'
+              ? {}
+              : { factionId: factionId === 'none' ? null : factionId }),
+            ...(locationId === 'all'
+              ? {}
+              : { locationId: locationId === 'none' ? null : locationId }),
+            offset: 0,
+            limit: 50
+          })
+      })
+      if (outcome.status === 'success') setPage(outcome.value)
+      else if (outcome.status === 'failure')
+        onError(capabilityErrorText(outcome.cause))
+      return outcome.status === 'success'
+    },
+    [api.npcs, coordinator, factionId, lifecycle, locationId, onError, search]
+  )
+
+  const loadReferences = useCallback(
+    async (signal?: AbortSignal) => {
+      const outcome = await coordinator.run({
+        scope: 'npc-catalog.references',
+        mode: 'latest-only',
+        ...(signal ? { signal } : {}),
+        execute: () => Promise.all([api.factions.read(), api.locations.read()])
+      })
+      if (outcome.status === 'success') {
+        setFactionSnapshot(outcome.value[0])
+        setLocations(outcome.value[1].locations)
+      } else if (outcome.status === 'failure')
+        onError(capabilityErrorText(outcome.cause))
+      return outcome.status === 'success'
+    },
+    [api.factions, api.locations, coordinator, onError]
+  )
+
+  const loadSelected = useCallback(
+    async (id: string | null, signal?: AbortSignal) => {
+      if (id === null) {
+        setSelectedProjection(null)
+        return true
+      }
+      const outcome = await coordinator.run({
+        scope: 'npc-catalog.detail',
+        mode: 'latest-only',
+        ...(signal ? { signal } : {}),
+        execute: () => api.npcs.detail({ id })
+      })
+      if (outcome.status === 'success') setSelectedProjection(outcome.value)
+      else if (outcome.status === 'failure')
+        onError(capabilityErrorText(outcome.cause))
+      return outcome.status === 'success'
+    },
+    [api.npcs, coordinator, onError]
+  )
+
+  useEffect(() => {
+    if (!active) return
+    const abort = new AbortController()
+    dispatch({ type: 'load-started' })
+    queueMicrotask(() => {
+      if (abort.signal.aborted) return
+      void Promise.all([
+        loadPage(abort.signal),
+        loadReferences(abort.signal)
+      ]).then(([pageReady, referencesReady]) => {
+        if (pageReady && referencesReady) dispatch({ type: 'load-completed' })
+      })
+    })
+    const reload = () => {
+      void Promise.all([
+        loadPage(abort.signal),
+        loadReferences(abort.signal),
+        loadSelected(selectedId, abort.signal)
+      ])
+    }
+    const subscriptions = [
+      api.npcs.onChanged(reload),
+      api.locations.onChanged(reload),
+      api.factions.onChanged(reload)
+    ]
+    return () => {
+      abort.abort()
+      for (const unsubscribe of subscriptions) unsubscribe()
+    }
+  }, [
+    active,
+    api,
+    dispatch,
+    loadPage,
+    loadReferences,
+    loadSelected,
+    selectedId
+  ])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSearch(searchInput), 200)
+    return () => window.clearTimeout(timer)
+  }, [searchInput])
+
+  const searchCreatures = useCallback(
+    async (query: string): Promise<readonly SearchableSelectOption[]> => {
+      const outcome = await coordinator.run({
+        scope: 'npc-catalog.creature-options',
+        mode: 'latest-only',
+        execute: () =>
+          creatures.search({ ...emptyQuery, name: query, limit: 40 })
+      })
+      if (outcome.status !== 'success') {
+        if (outcome.status === 'failure')
+          onError(capabilityErrorText(outcome.cause))
+        return []
+      }
+      const options = outcome.value.rows.map((creature) => ({
+        id: creature.id,
+        label: creature.name,
+        searchText: `${creature.id} ${creature.type} ${creature.subtype ?? ''}`,
+        description: `CR ${creature.challengeRating}`
+      }))
+      setCreatureOptions((current) => mergeOptions(current, options))
+      return options
+    },
+    [coordinator, creatures, onError]
+  )
+
+  return {
+    page,
+    setPage,
+    factionSnapshot,
+    setFactionSnapshot,
+    locations,
+    searchInput,
+    lifecycle,
+    factionId,
+    locationId,
+    selectedId,
+    setSelectedId,
+    selectedProjection,
+    setSelectedProjection,
+    creatureOptions,
+    searchCreatures,
+    loadPage,
+    loadReferences,
+    loadSelected,
+    setSearchInput,
+    setLifecycle,
+    setFactionId,
+    setLocationId,
+    setSelected: (npc: WorldNpcListRow | null) => {
+      setSelectedId(npc?.id ?? null)
+      setSelectedProjection(null)
+      void loadSelected(npc?.id ?? null)
+    }
+  }
+}
+
+function mergeOptions(
+  current: readonly SearchableSelectOption[],
+  incoming: readonly SearchableSelectOption[]
+) {
+  const merged = new Map(current.map((option) => [option.id, option]))
+  for (const option of incoming) merged.set(option.id, option)
+  return [...merged.values()]
+}

--- a/src/renderer/features/session/group-manager-command-input.ts
+++ b/src/renderer/features/session/group-manager-command-input.ts
@@ -1,0 +1,26 @@
+import type { Dispatch } from 'react'
+import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
+import type { SceneGroup } from '../../../shared/contracts/scene.js'
+import type { groupDraftEntries, GroupDraftState } from './group-draft.js'
+import type {
+  GroupDraftSession,
+  GroupManagerAction,
+  GroupManagerState
+} from './group-manager-state.js'
+import type { GroupManagerPorts } from './use-group-manager-capability-ports.js'
+
+export type GroupManagerCommandInput = {
+  snapshot: LiveSessionSnapshot
+  focused: LiveSessionSnapshot['scene']['scenes'][number]
+  state: GroupManagerState
+  session: GroupDraftSession | null
+  group: GroupDraftState
+  entries: ReturnType<typeof groupDraftEntries>
+  selectedPersistedGroup: SceneGroup | undefined
+  rewardGroupId: string
+  canGenerate: boolean
+  ports: GroupManagerPorts
+  dispatch: Dispatch<GroupManagerAction>
+  saved: (snapshot: LiveSessionSnapshot) => void
+  lootChanged: () => void
+}

--- a/src/renderer/features/session/group-manager-interactions.ts
+++ b/src/renderer/features/session/group-manager-interactions.ts
@@ -1,0 +1,178 @@
+import type { Dispatch } from 'react'
+import type { Creature } from '../../../shared/contracts/encounter.js'
+import type { SceneGroupDisposition } from '../../../shared/contracts/scene.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import type { GroupLootDraftCommand } from '../loot/group-loot-draft.js'
+import {
+  creatureFact,
+  groupDraftEntries,
+  type GroupDraftMutation,
+  type GroupDraftState
+} from './group-draft.js'
+import {
+  groupManagerAnyDirty,
+  groupManagerCurrentLootDirty,
+  type GroupDraftSession,
+  type GroupManagerAction,
+  type GroupManagerState
+} from './group-manager-state.js'
+import {
+  groupManagerIntentGuard,
+  groupManagerIntentNeedsConfirmation,
+  type GroupManagerIntent
+} from './group-manager-intent.js'
+import { generationSeed } from './generation-seed.js'
+import type { useGroupManagerCommands } from './use-group-manager-commands.js'
+import type { GroupManagerPorts } from './use-group-manager-capability-ports.js'
+
+export function createGroupManagerInteractions(input: {
+  state: GroupManagerState
+  session: GroupDraftSession | null
+  group: GroupDraftState
+  entries: ReturnType<typeof groupDraftEntries>
+  commands: ReturnType<typeof useGroupManagerCommands>
+  ports: GroupManagerPorts
+  dispatch: Dispatch<GroupManagerAction>
+  close: () => void
+  inspect: (creature: Creature) => void
+}) {
+  const { commands, dispatch, entries, group, ports, session, state } = input
+
+  function requestIntent(intent: GroupManagerIntent) {
+    const guard = groupManagerIntentGuard(intent)
+    if (
+      groupManagerIntentNeedsConfirmation(guard, {
+        anyDraft: groupManagerAnyDirty(state),
+        currentLoot: groupManagerCurrentLootDirty(state)
+      })
+    ) {
+      dispatch({ kind: 'pending-intent', pending: { intent, guard } })
+      return
+    }
+    performIntent(intent)
+  }
+
+  function performIntent(intent: GroupManagerIntent) {
+    dispatch({ kind: 'pending-intent', pending: null })
+    switch (intent.kind) {
+      case 'close':
+        input.close()
+        return
+      case 'add-creature':
+        addCreature(intent.creature)
+        return
+      case 'change-quantity':
+        changeQuantity(intent.creatureId, intent.delta, intent.quantityKind)
+        return
+      case 'remove-creature':
+        removeCreature(intent.creatureId)
+        return
+      case 'roster-history':
+        mutateGroup({ kind: intent.direction })
+        return
+      case 'generate-roster':
+        void commands.generateRoster(intent.mode)
+        return
+      case 'regenerate-loot':
+        void commands.generateLoot(
+          entries,
+          intent.mode === 'retry'
+            ? (session?.loot.seed ?? generationSeed(ports.runtime.e2e))
+            : generationSeed(ports.runtime.e2e)
+        )
+        return
+      case 'save':
+        void commands.save()
+        return
+      case 'archive':
+        void commands.archive()
+        return
+      case 'join-combat':
+        void commands.joinCombat()
+    }
+  }
+
+  function mutateGroup(mutation: GroupDraftMutation): void {
+    dispatch({ kind: 'mutate-group', mutation })
+  }
+
+  function addCreature(creature: Creature): void {
+    if (!session) return
+    mutateGroup({
+      kind: 'roster',
+      update: {
+        quantities: {
+          ...group.quantities,
+          [creature.id]: Math.min(999, (group.quantities[creature.id] ?? 0) + 1)
+        },
+        deadQuantities: group.deadQuantities
+      }
+    })
+    mutateGroup({
+      kind: 'facts',
+      update: { ...group.facts, [creature.id]: creatureFact(creature) }
+    })
+  }
+
+  function changeQuantity(
+    creatureId: string,
+    delta: number,
+    quantityKind: 'alive' | 'dead'
+  ): void {
+    const current =
+      quantityKind === 'alive' ? group.quantities : group.deadQuantities
+    const quantity = Math.max(
+      0,
+      Math.min(999, (current[creatureId] ?? 0) + delta)
+    )
+    const next = { ...current }
+    if (quantity === 0) delete next[creatureId]
+    else next[creatureId] = quantity
+    mutateGroup({
+      kind: 'roster',
+      update: {
+        quantities: quantityKind === 'alive' ? next : group.quantities,
+        deadQuantities: quantityKind === 'dead' ? next : group.deadQuantities
+      }
+    })
+  }
+
+  function removeCreature(creatureId: string): void {
+    const quantities = { ...group.quantities }
+    const deadQuantities = { ...group.deadQuantities }
+    delete quantities[creatureId]
+    delete deadQuantities[creatureId]
+    mutateGroup({ kind: 'roster', update: { quantities, deadQuantities } })
+  }
+
+  async function inspectCreature(creature: Creature): Promise<void> {
+    try {
+      input.inspect(await ports.creatures.detail(creature.id))
+    } catch (cause) {
+      mutateGroup({ kind: 'message', update: capabilityErrorText(cause) })
+    }
+  }
+
+  return {
+    requestIntent,
+    performIntent,
+    mutateGroup,
+    inspectCreature,
+    setGroupField: <Kind extends 'name' | 'note' | 'disposition'>(
+      kind: Kind,
+      update: Kind extends 'disposition' ? SceneGroupDisposition : string
+    ) => mutateGroup({ kind, update } as GroupDraftMutation),
+    dispatchLoot: (command: GroupLootDraftCommand) => {
+      if (state.activeKey)
+        dispatch({ kind: 'loot-command', key: state.activeKey, command })
+    },
+    dispatchLootHistory: (direction: 'undo' | 'redo') => {
+      if (state.activeKey)
+        dispatch({ kind: 'loot-history', key: state.activeKey, direction })
+    }
+  }
+}
+
+export type GroupManagerInteractions = ReturnType<
+  typeof createGroupManagerInteractions
+>

--- a/src/renderer/features/session/group-manager-view-projection.ts
+++ b/src/renderer/features/session/group-manager-view-projection.ts
@@ -1,0 +1,212 @@
+import type { Dispatch } from 'react'
+import type { Creature } from '../../../shared/contracts/encounter.js'
+import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
+import type {
+  SceneGroup,
+  SceneGroupDisposition
+} from '../../../shared/contracts/scene.js'
+import { groupLootDraftDirty } from '../loot/group-loot-draft.js'
+import type {
+  TreasureContainerPatch,
+  TreasureItemPatch
+} from '../loot/treasure-draft-reducer.js'
+import {
+  groupDraftEntries,
+  groupDraftStateFromGroup,
+  type GroupDraftState
+} from './group-draft.js'
+import type { GroupManagerInteractions } from './group-manager-interactions.js'
+import {
+  groupDraftSessionDirty,
+  groupManagerAnyDirty,
+  groupManagerAnyLootDirty,
+  type GroupCatalogMode,
+  type GroupDraftSession,
+  type GroupManagerAction,
+  type GroupManagerState
+} from './group-manager-state.js'
+import type { useGroupManagerCommands } from './use-group-manager-commands.js'
+import type { useGroupManagerQueries } from './use-group-manager-queries.js'
+
+export function projectGroupManagerView(input: {
+  snapshot: LiveSessionSnapshot
+  reinforcementMode: boolean
+  state: GroupManagerState
+  dispatch: Dispatch<GroupManagerAction>
+  focused: LiveSessionSnapshot['scene']['scenes'][number]
+  activeGroups: readonly SceneGroup[]
+  group: GroupDraftState
+  session: GroupDraftSession | null
+  entries: ReturnType<typeof groupDraftEntries>
+  assigned: LiveSessionSnapshot['party']['members']
+  selectedPersistedGroup: SceneGroup | undefined
+  rewardGroupId: string
+  canGenerate: boolean
+  commands: ReturnType<typeof useGroupManagerCommands>
+  queries: ReturnType<typeof useGroupManagerQueries>
+  interactions: GroupManagerInteractions
+}) {
+  const {
+    activeGroups,
+    assigned,
+    canGenerate,
+    commands,
+    dispatch,
+    entries,
+    focused,
+    group,
+    interactions,
+    queries,
+    rewardGroupId,
+    selectedPersistedGroup,
+    session,
+    snapshot,
+    state
+  } = input
+  const loot = session?.loot ?? null
+  const lootHistory = loot?.history ?? null
+  const currentLootDirty = Boolean(
+    lootHistory && groupLootDraftDirty(lootHistory)
+  )
+
+  return {
+    state,
+    dispatch,
+    focused,
+    activeGroups,
+    selection: state.activeKey,
+    active: state.activeKey !== null,
+    group,
+    session,
+    entries,
+    assigned,
+    selectedPersistedGroup,
+    groupInCombat: (groupId: string) =>
+      Boolean(snapshot.combat?.selectedGroupIds.includes(groupId)),
+    canJoinCombat: Boolean(
+      input.reinforcementMode &&
+      snapshot.combat?.phase === 'combat' &&
+      selectedPersistedGroup &&
+      !snapshot.combat.selectedGroupIds.includes(selectedPersistedGroup.id)
+    ),
+    rewardGroupId,
+    canGenerate,
+    canGenerateLoot: canGenerate && entries.length > 0,
+    busy:
+      commands.busy ||
+      loot?.phase === 'generating' ||
+      loot?.phase === 'committing',
+    dirty: session ? groupDraftSessionDirty(session) : false,
+    anyDirty: groupManagerAnyDirty(state),
+    anyLootDirty: groupManagerAnyLootDirty(state),
+    currentLootDirty,
+    effectiveCatalogMode: (state.catalogMode === 'loot' && loot?.run
+      ? 'loot'
+      : 'creatures') as GroupCatalogMode,
+    loot: {
+      run: loot?.run ?? null,
+      draft: lootHistory?.draft ?? null,
+      phase: loot?.phase ?? 'idle',
+      error: loot?.error ?? '',
+      issues: loot?.issues ?? [],
+      dirty: currentLootDirty,
+      canUndo: (lootHistory?.past.length ?? 0) > 0,
+      canRedo: (lootHistory?.future.length ?? 0) > 0,
+      generate: () => commands.generateLoot(),
+      retry: () =>
+        interactions.requestIntent({ kind: 'regenerate-loot', mode: 'retry' }),
+      reroll: () =>
+        interactions.requestIntent({ kind: 'regenerate-loot', mode: 'reroll' }),
+      commit: () => void commands.commitLoot(),
+      patchLabel: (label: string) =>
+        interactions.dispatchLoot({ kind: 'set-label', label }),
+      patchItem: (id: string, patch: TreasureItemPatch) =>
+        interactions.dispatchLoot({ kind: 'patch-item', id, patch }),
+      patchContainer: (id: string, patch: TreasureContainerPatch) =>
+        interactions.dispatchLoot({ kind: 'patch-container', id, patch }),
+      removeItem: (id: string) =>
+        interactions.dispatchLoot({ kind: 'remove-item', id }),
+      removeContainer: (id: string) =>
+        interactions.dispatchLoot({ kind: 'remove-container', id }),
+      undo: () => interactions.dispatchLootHistory('undo'),
+      redo: () => interactions.dispatchLootHistory('redo'),
+      beginEdit: (editKey: string) => {
+        if (state.activeKey)
+          dispatch({ kind: 'loot-edit-began', key: state.activeKey, editKey })
+      },
+      endEdit: () => {
+        if (state.activeKey)
+          dispatch({ kind: 'loot-edit-ended', key: state.activeKey })
+      }
+    },
+    setName: (value: string) => interactions.setGroupField('name', value),
+    setNote: (value: string) => interactions.setGroupField('note', value),
+    setDisposition: (value: SceneGroupDisposition) =>
+      interactions.setGroupField('disposition', value),
+    setCreatureQuery: (query: typeof state.creatureCatalog.query) =>
+      dispatch({ kind: 'creature-query', query }),
+    setLootQuery: (
+      patch: Partial<typeof state.lootCatalog.query>,
+      preserveOffset?: boolean
+    ) =>
+      dispatch({
+        kind: 'loot-query',
+        patch,
+        ...(preserveOffset === undefined ? {} : { preserveOffset })
+      }),
+    searchBiomeOptions: queries.searchBiomeOptions,
+    setCatalogMode: (catalogMode: GroupCatalogMode) =>
+      dispatch({
+        kind: 'view',
+        catalogMode,
+        workspaceMode: catalogMode === 'loot' ? 'loot' : 'group'
+      }),
+    setWorkspaceMode: (workspaceMode: 'group' | 'loot') =>
+      dispatch({
+        kind: 'view',
+        workspaceMode,
+        catalogMode: workspaceMode === 'loot' ? 'loot' : 'creatures'
+      }),
+    setDraftPaneWidth: (width: number) =>
+      dispatch({ kind: 'draft-width', width }),
+    activate: (key: string | null) => {
+      const persisted = focused.groups.find((candidate) => candidate.id === key)
+      dispatch({
+        kind: 'activate',
+        key,
+        fallback: groupDraftStateFromGroup(persisted),
+        sourceRevision: persisted?.revision ?? null
+      })
+    },
+    addCreature: (creature: Creature) =>
+      interactions.requestIntent({ kind: 'add-creature', creature }),
+    changeQuantity: (
+      creatureId: string,
+      delta: number,
+      quantityKind: 'alive' | 'dead' = 'alive'
+    ) =>
+      interactions.requestIntent({
+        kind: 'change-quantity',
+        creatureId,
+        delta,
+        quantityKind
+      }),
+    removeCreature: (creatureId: string) =>
+      interactions.requestIntent({ kind: 'remove-creature', creatureId }),
+    moveRosterHistory: (direction: 'undo-roster' | 'redo-roster') =>
+      interactions.requestIntent({ kind: 'roster-history', direction }),
+    generateRoster: (mode: 'fill' | 'replace') =>
+      interactions.requestIntent({ kind: 'generate-roster', mode }),
+    inspectCreature: interactions.inspectCreature,
+    close: () => interactions.requestIntent({ kind: 'close' }),
+    save: () => interactions.requestIntent({ kind: 'save' }),
+    archive: () => interactions.requestIntent({ kind: 'archive' }),
+    joinCombat: () => interactions.requestIntent({ kind: 'join-combat' }),
+    cancelPendingIntent: () =>
+      dispatch({ kind: 'pending-intent', pending: null }),
+    confirmPendingIntent: () => {
+      const intent = state.pendingIntent?.intent
+      if (intent) interactions.performIntent(intent)
+    }
+  }
+}

--- a/src/renderer/features/session/use-group-manager-commands.ts
+++ b/src/renderer/features/session/use-group-manager-commands.ts
@@ -1,32 +1,15 @@
-import type { Dispatch } from 'react'
 import type { EncounterTuningOverride } from '../../../shared/contracts/encounter-tuning.js'
-import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
-import type { CommitGroupRewardResult } from '../../../shared/contracts/loot.js'
-import type { SceneGroup } from '../../../shared/contracts/scene.js'
-import { capabilityErrorIssues } from '../../../shared/errors/capability-error.js'
 import { capabilityErrorText } from '../../capabilities/capability-errors.js'
 import { formatMessage, message } from '../../i18n/session-runtime.de.js'
-import {
-  groupLootCommitDraft,
-  groupLootDraftFromRun
-} from '../loot/group-loot-draft.js'
-import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
 import { generationSeed } from './generation-seed.js'
-import {
-  groupDraftEntries,
-  newGroupDraftKey,
-  type GroupDraftState
-} from './group-draft.js'
-import type {
-  GroupDraftSession,
-  GroupManagerAction,
-  GroupManagerState
-} from './group-manager-state.js'
+import { groupDraftEntries, newGroupDraftKey } from './group-draft.js'
 import {
   applyCombatCommandResult,
   applySceneGroupCommandResult
 } from './session-patches.js'
-import type { GroupManagerPorts } from './use-group-manager-capability-ports.js'
+import type { GroupManagerCommandInput } from './group-manager-command-input.js'
+import { useGroupManagerLootCommands } from './use-group-manager-loot-commands.js'
 
 const tuning: EncounterTuningOverride = {
   difficulty: 'preset',
@@ -35,49 +18,35 @@ const tuning: EncounterTuningOverride = {
   diversity: 'preset'
 }
 
-export function useGroupManagerCommands(input: {
-  snapshot: LiveSessionSnapshot
-  focused: LiveSessionSnapshot['scene']['scenes'][number]
-  state: GroupManagerState
-  session: GroupDraftSession | null
-  group: GroupDraftState
-  entries: ReturnType<typeof groupDraftEntries>
-  selectedPersistedGroup: SceneGroup | undefined
-  rewardGroupId: string
-  canGenerate: boolean
-  ports: GroupManagerPorts
-  dispatch: Dispatch<GroupManagerAction>
-  saved: (snapshot: LiveSessionSnapshot) => void
-  lootChanged: () => void
-}): Readonly<{
+export function useGroupManagerCommands(
+  input: GroupManagerCommandInput,
+  commands: AsyncCommandCoordinator
+): Readonly<{
   generateRoster: (mode: 'fill' | 'replace') => Promise<void>
   generateLoot: (
     rewardEntries?: ReturnType<typeof groupDraftEntries>,
     seed?: number,
     key?: string | null
   ) => Promise<boolean>
-  commitLoot: () => Promise<CommitGroupRewardResult | null>
+  commitLoot: ReturnType<typeof useGroupManagerLootCommands>['commitLoot']
   save: () => Promise<void>
   archive: () => Promise<void>
   joinCombat: () => Promise<void>
   busy: boolean
 }> {
-  const commands = useAsyncCommandCoordinator()
   const {
     canGenerate,
     dispatch,
     entries,
     focused,
     group,
-    lootChanged,
     ports,
-    rewardGroupId,
     saved,
     selectedPersistedGroup,
-    session,
     snapshot,
     state
   } = input
+  const lootCommands = useGroupManagerLootCommands(input, commands)
 
   async function generateRoster(mode: 'fill' | 'replace'): Promise<void> {
     const key = state.activeKey
@@ -133,116 +102,12 @@ export function useGroupManagerCommands(input: {
           }
         )
       })
-      await generateLoot(
+      await lootCommands.generateLoot(
         groupDraftEntries(quantities, deadQuantities),
         generationSeed(ports.runtime.e2e),
         key
       )
     } else if (outcome.status === 'failure') failCommand(key, outcome.cause)
-  }
-
-  async function generateLoot(
-    rewardEntries = entries,
-    seed = generationSeed(ports.runtime.e2e),
-    key = state.activeKey
-  ): Promise<boolean> {
-    if (!key || rewardEntries.length === 0) return false
-    dispatch({
-      kind: 'loot-request-began',
-      key,
-      phase: 'generating',
-      seed
-    })
-    const outcome = await commands.run({
-      scope: 'group-manager.loot',
-      entityKey: key,
-      mode: 'latest-only',
-      execute: async () => {
-        const rules = await ports.campaignRules.read()
-        return ports.loot.generateForGroupDraft({
-          sceneId: focused.id,
-          groupId: rewardGroupId,
-          expectedSceneRevision: snapshot.scene.revision,
-          expectedGroupRevision: selectedPersistedGroup?.revision ?? null,
-          expectedPartyRevision: snapshot.party.revision,
-          expectedCampaignRulesRevision: rules.revision,
-          entries: [...rewardEntries],
-          seed
-        })
-      }
-    })
-    if (outcome.status === 'success') {
-      const result = outcome.value
-      if (result.status !== 'success') {
-        dispatch({
-          kind: 'loot-failed',
-          key,
-          error: result.issues[0]?.code ?? result.status,
-          issues: []
-        })
-        return false
-      }
-      const draft = groupLootDraftFromRun(result.run, () => crypto.randomUUID())
-      dispatch({
-        kind: 'loot-generated',
-        key,
-        run: result.run,
-        draft,
-        seed
-      })
-      return true
-    }
-    if (outcome.status === 'failure')
-      dispatch({
-        kind: 'loot-failed',
-        key,
-        error: capabilityErrorText(outcome.cause),
-        issues: capabilityErrorIssues(outcome.cause)
-      })
-    return false
-  }
-
-  async function commitLoot(): Promise<CommitGroupRewardResult | null> {
-    const key = state.activeKey
-    const run = session?.loot.run
-    const treasure = run?.treasures[0]
-    const history = session?.loot.history
-    if (!key || !run || !history || !validateAvailableMonster()) return null
-    dispatch({ kind: 'loot-request-began', key, phase: 'committing' })
-    const outcome = await commands.run({
-      scope: 'group-manager.loot',
-      entityKey: key,
-      mode: 'latest-only',
-      execute: () =>
-        ports.loot.commitGroupReward({
-          commandId: crypto.randomUUID(),
-          runId: run.id,
-          generatedTreasureId: treasure?.id ?? null,
-          treasureDraft: treasure ? groupLootCommitDraft(history.draft) : null,
-          sceneId: focused.id,
-          groupId: rewardGroupId,
-          expectedSceneRevision: snapshot.scene.revision,
-          expectedGroupRevision: selectedPersistedGroup?.revision ?? null,
-          name: group.name.trim(),
-          note: group.note.trim(),
-          disposition: group.disposition,
-          entries: [...entries]
-        })
-    })
-    if (outcome.status === 'success') {
-      dispatch({ kind: 'loot-committed', key })
-      if (outcome.value.treasure) lootChanged()
-      saved(applySceneGroupCommandResult(snapshot, outcome.value.groupResult))
-      return outcome.value
-    }
-    if (outcome.status === 'failure')
-      dispatch({
-        kind: 'loot-failed',
-        key,
-        error: capabilityErrorText(outcome.cause),
-        issues: capabilityErrorIssues(outcome.cause)
-      })
-    return null
   }
 
   async function save(): Promise<void> {
@@ -336,8 +201,8 @@ export function useGroupManagerCommands(input: {
 
   return {
     generateRoster,
-    generateLoot,
-    commitLoot,
+    generateLoot: lootCommands.generateLoot,
+    commitLoot: lootCommands.commitLoot,
     save,
     archive,
     joinCombat,

--- a/src/renderer/features/session/use-group-manager-controller.ts
+++ b/src/renderer/features/session/use-group-manager-controller.ts
@@ -1,39 +1,19 @@
 import { useEffect, useReducer } from 'react'
 import type { Creature } from '../../../shared/contracts/encounter.js'
-import type { SceneGroupDisposition } from '../../../shared/contracts/scene.js'
 import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
-import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
 import {
-  groupLootDraftDirty,
-  type GroupLootDraftCommand
-} from '../loot/group-loot-draft.js'
-import type {
-  TreasureContainerPatch,
-  TreasureItemPatch
-} from '../loot/treasure-draft-reducer.js'
-import {
-  creatureFact,
   groupDraftEntries,
   groupDraftStateFromGroup,
-  newGroupDraftKey,
-  type GroupDraftMutation
+  newGroupDraftKey
 } from './group-draft.js'
+import { createGroupManagerInteractions } from './group-manager-interactions.js'
 import {
   activeGroupSession,
   createGroupManagerState,
-  groupManagerAnyDirty,
-  groupManagerAnyLootDirty,
-  groupManagerCurrentLootDirty,
-  groupManagerReducer,
-  groupDraftSessionDirty,
-  type GroupCatalogMode
+  groupManagerReducer
 } from './group-manager-state.js'
-import {
-  groupManagerIntentGuard,
-  groupManagerIntentNeedsConfirmation,
-  type GroupManagerIntent
-} from './group-manager-intent.js'
-import { generationSeed } from './generation-seed.js'
+import { projectGroupManagerView } from './group-manager-view-projection.js'
 import type { GroupManagerPorts } from './use-group-manager-capability-ports.js'
 import { useGroupManagerCommands } from './use-group-manager-commands.js'
 import { useGroupManagerQueries } from './use-group-manager-queries.js'
@@ -52,7 +32,7 @@ export function useGroupManagerController(
   },
   ports: GroupManagerPorts
 ) {
-  const onError = props.onError
+  const coordinator = useAsyncCommandCoordinator()
   const focused = props.snapshot.scene.scenes.find(
     (scene) => scene.id === props.snapshot.scene.focusedSceneId
   )!
@@ -84,317 +64,74 @@ export function useGroupManagerController(
     state.activeKey !== null &&
     assigned.length > 0 &&
     assigned.every((member) => member.level !== null)
+
+  useEffect(() => () => coordinator.cancelAll(), [coordinator, focused.id])
+
   useEffect(() => {
     dispatch({ kind: 'sync-external', groups: focused.groups })
   }, [focused.groups])
 
-  const { searchBiomeOptions } = useGroupManagerQueries({
-    focused,
-    snapshot: props.snapshot,
-    state,
-    session,
-    group,
-    ports,
-    dispatch,
-    onError
-  })
-  const groupCommands = useGroupManagerCommands({
-    snapshot: props.snapshot,
-    focused,
+  const queries = useGroupManagerQueries(
+    {
+      focused,
+      snapshot: props.snapshot,
+      state,
+      session,
+      group,
+      ports,
+      dispatch,
+      onError: props.onError
+    },
+    coordinator
+  )
+  const commands = useGroupManagerCommands(
+    {
+      snapshot: props.snapshot,
+      focused,
+      state,
+      session,
+      group,
+      entries,
+      selectedPersistedGroup,
+      rewardGroupId,
+      canGenerate,
+      ports,
+      dispatch,
+      saved: props.saved,
+      lootChanged: props.lootChanged
+    },
+    coordinator
+  )
+  const interactions = createGroupManagerInteractions({
     state,
     session,
     group,
     entries,
-    selectedPersistedGroup,
-    rewardGroupId,
-    canGenerate,
+    commands,
     ports,
     dispatch,
-    saved: props.saved,
-    lootChanged: props.lootChanged
+    close: props.close,
+    inspect: props.inspect
   })
 
-  function requestIntent(intent: GroupManagerIntent) {
-    const guard = groupManagerIntentGuard(intent)
-    if (
-      groupManagerIntentNeedsConfirmation(guard, {
-        anyDraft: groupManagerAnyDirty(state),
-        currentLoot: groupManagerCurrentLootDirty(state)
-      })
-    ) {
-      dispatch({ kind: 'pending-intent', pending: { intent, guard } })
-      return
-    }
-    performIntent(intent)
-  }
-
-  function performIntent(intent: GroupManagerIntent) {
-    dispatch({ kind: 'pending-intent', pending: null })
-    switch (intent.kind) {
-      case 'close':
-        props.close()
-        return
-      case 'add-creature':
-        applyAddCreature(intent.creature)
-        return
-      case 'change-quantity':
-        applyQuantityChange(
-          intent.creatureId,
-          intent.delta,
-          intent.quantityKind
-        )
-        return
-      case 'remove-creature':
-        applyRemoveCreature(intent.creatureId)
-        return
-      case 'roster-history':
-        mutateGroup({ kind: intent.direction })
-        return
-      case 'generate-roster':
-        void groupCommands.generateRoster(intent.mode)
-        return
-      case 'regenerate-loot':
-        void groupCommands.generateLoot(
-          entries,
-          intent.mode === 'retry'
-            ? (session?.loot.seed ?? generationSeed(ports.runtime.e2e))
-            : generationSeed(ports.runtime.e2e)
-        )
-        return
-      case 'save':
-        void groupCommands.save()
-        return
-      case 'archive':
-        void groupCommands.archive()
-        return
-      case 'join-combat':
-        void groupCommands.joinCombat()
-    }
-  }
-
-  function mutateGroup(mutation: GroupDraftMutation): void {
-    dispatch({ kind: 'mutate-group', mutation })
-  }
-
-  function applyAddCreature(creature: Creature): void {
-    if (!session) return
-    mutateGroup({
-      kind: 'roster',
-      update: {
-        quantities: {
-          ...group.quantities,
-          [creature.id]: Math.min(999, (group.quantities[creature.id] ?? 0) + 1)
-        },
-        deadQuantities: group.deadQuantities
-      }
-    })
-    mutateGroup({
-      kind: 'facts',
-      update: { ...group.facts, [creature.id]: creatureFact(creature) }
-    })
-  }
-
-  function applyQuantityChange(
-    creatureId: string,
-    delta: number,
-    quantityKind: 'alive' | 'dead'
-  ): void {
-    const current =
-      quantityKind === 'alive' ? group.quantities : group.deadQuantities
-    const quantity = Math.max(
-      0,
-      Math.min(999, (current[creatureId] ?? 0) + delta)
-    )
-    const next = { ...current }
-    if (quantity === 0) delete next[creatureId]
-    else next[creatureId] = quantity
-    mutateGroup({
-      kind: 'roster',
-      update: {
-        quantities: quantityKind === 'alive' ? next : group.quantities,
-        deadQuantities: quantityKind === 'dead' ? next : group.deadQuantities
-      }
-    })
-  }
-
-  function applyRemoveCreature(creatureId: string): void {
-    const quantities = { ...group.quantities }
-    const deadQuantities = { ...group.deadQuantities }
-    delete quantities[creatureId]
-    delete deadQuantities[creatureId]
-    mutateGroup({ kind: 'roster', update: { quantities, deadQuantities } })
-  }
-
-  const setGroupField = <Kind extends 'name' | 'note' | 'disposition'>(
-    kind: Kind,
-    update: Kind extends 'disposition' ? SceneGroupDisposition : string
-  ) => mutateGroup({ kind, update } as GroupDraftMutation)
-
-  const loot = session?.loot ?? null
-  const lootHistory = loot?.history ?? null
-  const currentLootDirty = Boolean(
-    lootHistory && groupLootDraftDirty(lootHistory)
-  )
-  const busy =
-    groupCommands.busy ||
-    loot?.phase === 'generating' ||
-    loot?.phase === 'committing'
-
-  return {
+  return projectGroupManagerView({
+    snapshot: props.snapshot,
+    reinforcementMode: props.reinforcementMode,
     state,
     dispatch,
     focused,
     activeGroups,
-    selection: state.activeKey,
-    active: state.activeKey !== null,
     group,
     session,
     entries,
     assigned,
     selectedPersistedGroup,
-    groupInCombat: (groupId: string) =>
-      Boolean(props.snapshot.combat?.selectedGroupIds.includes(groupId)),
-    canJoinCombat: Boolean(
-      props.reinforcementMode &&
-      props.snapshot.combat?.phase === 'combat' &&
-      selectedPersistedGroup &&
-      !props.snapshot.combat.selectedGroupIds.includes(
-        selectedPersistedGroup.id
-      )
-    ),
     rewardGroupId,
     canGenerate,
-    canGenerateLoot: canGenerate && entries.length > 0,
-    busy,
-    dirty: session ? groupDraftSessionDirty(session) : false,
-    anyDirty: groupManagerAnyDirty(state),
-    anyLootDirty: groupManagerAnyLootDirty(state),
-    currentLootDirty,
-    effectiveCatalogMode: (state.catalogMode === 'loot' && loot?.run
-      ? 'loot'
-      : 'creatures') as GroupCatalogMode,
-    loot: {
-      run: loot?.run ?? null,
-      draft: lootHistory?.draft ?? null,
-      phase: loot?.phase ?? 'idle',
-      error: loot?.error ?? '',
-      issues: loot?.issues ?? [],
-      dirty: currentLootDirty,
-      canUndo: (lootHistory?.past.length ?? 0) > 0,
-      canRedo: (lootHistory?.future.length ?? 0) > 0,
-      generate: () => groupCommands.generateLoot(),
-      retry: () => requestIntent({ kind: 'regenerate-loot', mode: 'retry' }),
-      reroll: () => requestIntent({ kind: 'regenerate-loot', mode: 'reroll' }),
-      commit: () => void groupCommands.commitLoot(),
-      patchLabel: (label: string) => dispatchLoot({ kind: 'set-label', label }),
-      patchItem: (id: string, patch: TreasureItemPatch) =>
-        dispatchLoot({ kind: 'patch-item', id, patch }),
-      patchContainer: (id: string, patch: TreasureContainerPatch) =>
-        dispatchLoot({ kind: 'patch-container', id, patch }),
-      removeItem: (id: string) => dispatchLoot({ kind: 'remove-item', id }),
-      removeContainer: (id: string) =>
-        dispatchLoot({ kind: 'remove-container', id }),
-      undo: () => dispatchLootHistory('undo'),
-      redo: () => dispatchLootHistory('redo'),
-      beginEdit: (editKey: string) => {
-        if (state.activeKey)
-          dispatch({
-            kind: 'loot-edit-began',
-            key: state.activeKey,
-            editKey
-          })
-      },
-      endEdit: () => {
-        if (state.activeKey)
-          dispatch({ kind: 'loot-edit-ended', key: state.activeKey })
-      }
-    },
-    setName: (value: string) => setGroupField('name', value),
-    setNote: (value: string) => setGroupField('note', value),
-    setDisposition: (value: SceneGroupDisposition) =>
-      setGroupField('disposition', value),
-    setCreatureQuery: (query: typeof state.creatureCatalog.query) =>
-      dispatch({ kind: 'creature-query', query }),
-    setLootQuery: (
-      patch: Partial<typeof state.lootCatalog.query>,
-      preserveOffset?: boolean
-    ) =>
-      dispatch({
-        kind: 'loot-query',
-        patch,
-        ...(preserveOffset === undefined ? {} : { preserveOffset })
-      }),
-    searchBiomeOptions,
-    setCatalogMode: (catalogMode: GroupCatalogMode) =>
-      dispatch({
-        kind: 'view',
-        catalogMode,
-        workspaceMode: catalogMode === 'loot' ? 'loot' : 'group'
-      }),
-    setWorkspaceMode: (workspaceMode: 'group' | 'loot') =>
-      dispatch({
-        kind: 'view',
-        workspaceMode,
-        catalogMode: workspaceMode === 'loot' ? 'loot' : 'creatures'
-      }),
-    setDraftPaneWidth: (width: number) =>
-      dispatch({ kind: 'draft-width', width }),
-    activate: (key: string | null) => {
-      const persisted = focused.groups.find((candidate) => candidate.id === key)
-      dispatch({
-        kind: 'activate',
-        key,
-        fallback: groupDraftStateFromGroup(persisted),
-        sourceRevision: persisted?.revision ?? null
-      })
-    },
-    addCreature: (creature: Creature) =>
-      requestIntent({ kind: 'add-creature', creature }),
-    changeQuantity: (
-      creatureId: string,
-      delta: number,
-      quantityKind: 'alive' | 'dead' = 'alive'
-    ) =>
-      requestIntent({
-        kind: 'change-quantity',
-        creatureId,
-        delta,
-        quantityKind
-      }),
-    removeCreature: (creatureId: string) =>
-      requestIntent({ kind: 'remove-creature', creatureId }),
-    moveRosterHistory: (direction: 'undo-roster' | 'redo-roster') =>
-      requestIntent({ kind: 'roster-history', direction }),
-    generateRoster: (mode: 'fill' | 'replace') =>
-      requestIntent({ kind: 'generate-roster', mode }),
-    inspectCreature: async (creature: Creature) => {
-      try {
-        props.inspect(await ports.creatures.detail(creature.id))
-      } catch (cause) {
-        mutateGroup({ kind: 'message', update: capabilityErrorText(cause) })
-      }
-    },
-    close: () => requestIntent({ kind: 'close' }),
-    save: () => requestIntent({ kind: 'save' }),
-    archive: () => requestIntent({ kind: 'archive' }),
-    joinCombat: () => requestIntent({ kind: 'join-combat' }),
-    cancelPendingIntent: () =>
-      dispatch({ kind: 'pending-intent', pending: null }),
-    confirmPendingIntent: () => {
-      const intent = state.pendingIntent?.intent
-      if (intent) performIntent(intent)
-    }
-  }
-
-  function dispatchLoot(command: GroupLootDraftCommand): void {
-    if (state.activeKey)
-      dispatch({ kind: 'loot-command', key: state.activeKey, command })
-  }
-
-  function dispatchLootHistory(direction: 'undo' | 'redo'): void {
-    if (state.activeKey)
-      dispatch({ kind: 'loot-history', key: state.activeKey, direction })
-  }
+    commands,
+    queries,
+    interactions
+  })
 }
 
 export type GroupManagerController = ReturnType<

--- a/src/renderer/features/session/use-group-manager-loot-commands.ts
+++ b/src/renderer/features/session/use-group-manager-loot-commands.ts
@@ -1,0 +1,152 @@
+import type { CommitGroupRewardResult } from '../../../shared/contracts/loot.js'
+import { capabilityErrorIssues } from '../../../shared/errors/capability-error.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
+import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import { message } from '../../i18n/session-runtime.de.js'
+import {
+  groupLootCommitDraft,
+  groupLootDraftFromRun
+} from '../loot/group-loot-draft.js'
+import { generationSeed } from './generation-seed.js'
+import { applySceneGroupCommandResult } from './session-patches.js'
+import type { GroupManagerCommandInput } from './group-manager-command-input.js'
+
+export function useGroupManagerLootCommands(
+  input: GroupManagerCommandInput,
+  commands: AsyncCommandCoordinator
+): Readonly<{
+  generateLoot: (
+    rewardEntries?: GroupManagerCommandInput['entries'],
+    seed?: number,
+    key?: string | null
+  ) => Promise<boolean>
+  commitLoot: () => Promise<CommitGroupRewardResult | null>
+}> {
+  const {
+    dispatch,
+    entries,
+    focused,
+    group,
+    lootChanged,
+    ports,
+    rewardGroupId,
+    saved,
+    selectedPersistedGroup,
+    session,
+    snapshot,
+    state
+  } = input
+
+  async function generateLoot(
+    rewardEntries = entries,
+    seed = generationSeed(ports.runtime.e2e),
+    key = state.activeKey
+  ): Promise<boolean> {
+    if (!key || rewardEntries.length === 0) return false
+    dispatch({ kind: 'loot-request-began', key, phase: 'generating', seed })
+    const outcome = await commands.run({
+      scope: 'group-manager.loot',
+      entityKey: key,
+      mode: 'latest-only',
+      execute: async () => {
+        const rules = await ports.campaignRules.read()
+        return ports.loot.generateForGroupDraft({
+          sceneId: focused.id,
+          groupId: rewardGroupId,
+          expectedSceneRevision: snapshot.scene.revision,
+          expectedGroupRevision: selectedPersistedGroup?.revision ?? null,
+          expectedPartyRevision: snapshot.party.revision,
+          expectedCampaignRulesRevision: rules.revision,
+          entries: [...rewardEntries],
+          seed
+        })
+      }
+    })
+    if (outcome.status === 'success') {
+      const result = outcome.value
+      if (result.status !== 'success') {
+        dispatch({
+          kind: 'loot-failed',
+          key,
+          error: result.issues[0]?.code ?? result.status,
+          issues: []
+        })
+        return false
+      }
+      dispatch({
+        kind: 'loot-generated',
+        key,
+        run: result.run,
+        draft: groupLootDraftFromRun(result.run, () => crypto.randomUUID()),
+        seed
+      })
+      return true
+    }
+    if (outcome.status === 'failure')
+      dispatch({
+        kind: 'loot-failed',
+        key,
+        error: capabilityErrorText(outcome.cause),
+        issues: capabilityErrorIssues(outcome.cause)
+      })
+    return false
+  }
+
+  async function commitLoot(): Promise<CommitGroupRewardResult | null> {
+    const key = state.activeKey
+    const run = session?.loot.run
+    const treasure = run?.treasures[0]
+    const history = session?.loot.history
+    if (!key || !run || !history || !availableMonster()) return null
+    dispatch({ kind: 'loot-request-began', key, phase: 'committing' })
+    const outcome = await commands.run({
+      scope: 'group-manager.loot',
+      entityKey: key,
+      mode: 'latest-only',
+      execute: () =>
+        ports.loot.commitGroupReward({
+          commandId: crypto.randomUUID(),
+          runId: run.id,
+          generatedTreasureId: treasure?.id ?? null,
+          treasureDraft: treasure ? groupLootCommitDraft(history.draft) : null,
+          sceneId: focused.id,
+          groupId: rewardGroupId,
+          expectedSceneRevision: snapshot.scene.revision,
+          expectedGroupRevision: selectedPersistedGroup?.revision ?? null,
+          name: group.name.trim(),
+          note: group.note.trim(),
+          disposition: group.disposition,
+          entries: [...entries]
+        })
+    })
+    if (outcome.status === 'success') {
+      dispatch({ kind: 'loot-committed', key })
+      if (outcome.value.treasure) lootChanged()
+      saved(applySceneGroupCommandResult(snapshot, outcome.value.groupResult))
+      return outcome.value
+    }
+    if (outcome.status === 'failure')
+      dispatch({
+        kind: 'loot-failed',
+        key,
+        error: capabilityErrorText(outcome.cause),
+        issues: capabilityErrorIssues(outcome.cause)
+      })
+    return null
+  }
+
+  function availableMonster(): boolean {
+    const available =
+      entries.length === 0 ||
+      entries.some((entry) => group.facts[entry.creatureId]?.available === true)
+    if (!available && state.activeKey)
+      dispatch({
+        kind: 'group-message',
+        key: state.activeKey,
+        message: message('group.validation.availableMonster')
+      })
+    return available
+  }
+
+  return { generateLoot, commitLoot }
+}

--- a/src/renderer/features/session/use-group-manager-queries.ts
+++ b/src/renderer/features/session/use-group-manager-queries.ts
@@ -3,7 +3,7 @@ import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session
 import { capabilityErrorText } from '../../capabilities/capability-errors.js'
 import type { SearchableSelectOption } from '../../shell/searchable-select.js'
 import { emptyQuery } from '../creatures/creature-state.js'
-import { useAsyncCommandCoordinator } from '../../async/use-async-command-coordinator.js'
+import type { AsyncCommandCoordinator } from '../../async/async-command-coordinator.js'
 import {
   creatureFact,
   groupDraftEntries,
@@ -17,21 +17,23 @@ import type {
 } from './group-manager-state.js'
 import type { GroupManagerPorts } from './use-group-manager-capability-ports.js'
 
-export function useGroupManagerQueries(input: {
-  focused: LiveSessionSnapshot['scene']['scenes'][number]
-  snapshot: LiveSessionSnapshot
-  state: GroupManagerState
-  session: GroupDraftSession | null
-  group: GroupDraftState
-  ports: GroupManagerPorts
-  dispatch: Dispatch<GroupManagerAction>
-  onError: (message: string) => void
-}): Readonly<{
+export function useGroupManagerQueries(
+  input: {
+    focused: LiveSessionSnapshot['scene']['scenes'][number]
+    snapshot: LiveSessionSnapshot
+    state: GroupManagerState
+    session: GroupDraftSession | null
+    group: GroupDraftState
+    ports: GroupManagerPorts
+    dispatch: Dispatch<GroupManagerAction>
+    onError: (message: string) => void
+  },
+  commands: AsyncCommandCoordinator
+): Readonly<{
   searchBiomeOptions: (
     query: string
   ) => Promise<readonly SearchableSelectOption[]>
 }> {
-  const commands = useAsyncCommandCoordinator()
   const { dispatch, focused, onError, ports, session, snapshot, state } = input
 
   useEffect(() => {

--- a/tests/architecture/renderer-architecture.test.ts
+++ b/tests/architecture/renderer-architecture.test.ts
@@ -50,6 +50,65 @@ architectureGate(
 
 architectureGate(
   'behavior-integration',
+  'shares one Group coordinator across query and command boundaries',
+  () => {
+    const controller = readTypeScriptModule(
+      'src/renderer/features/session/use-group-manager-controller.ts'
+    )
+    for (const call of [
+      'useAsyncCommandCoordinator',
+      'useGroupManagerQueries',
+      'useGroupManagerCommands',
+      'createGroupManagerInteractions',
+      'projectGroupManagerView'
+    ])
+      expect(hasCall(controller, call), call).toBe(true)
+    for (const adapter of [
+      'src/renderer/features/session/use-group-manager-queries.ts',
+      'src/renderer/features/session/use-group-manager-commands.ts'
+    ]) {
+      const module = readTypeScriptModule(adapter)
+      expect(module.identifiers.has('AsyncCommandCoordinator')).toBe(true)
+      expect(module.identifiers.has('useAsyncCommandCoordinator')).toBe(false)
+    }
+  }
+)
+
+architectureGate(
+  'behavior-integration',
+  'splits NPC and Location catalogs into query, mutation and projection adapters',
+  () => {
+    for (const [path, calls] of [
+      [
+        'src/renderer/features/catalog/npc-catalog-controller.ts',
+        [
+          'useAsyncCommandCoordinator',
+          'useNpcCatalogQueries',
+          'useNpcCatalogMutations',
+          'projectNpcCatalog'
+        ]
+      ],
+      [
+        'src/renderer/features/catalog/location-catalog-controller.ts',
+        [
+          'useAsyncCommandCoordinator',
+          'useLocationCatalogQueries',
+          'useLocationCatalogMutations',
+          'useLocationCatalogProjection'
+        ]
+      ]
+    ] as const) {
+      const controller = readTypeScriptModule(path)
+      for (const call of calls)
+        expect(hasCall(controller, call), call).toBe(true)
+      expect(controller.identifiers.has('useRef')).toBe(false)
+      expect(controller.identifiers.has('AbortController')).toBe(false)
+    }
+  }
+)
+
+architectureGate(
+  'behavior-integration',
   'composes Hex writes from the shared async, transport and projection boundaries',
   () => {
     const controller = readTypeScriptModule(

--- a/tests/unit/catalog-controllers.test.tsx
+++ b/tests/unit/catalog-controllers.test.tsx
@@ -250,4 +250,43 @@ describe('catalog controllers', () => {
     expect(port.locations.readLocations).toHaveBeenCalledOnce()
     expect(port.locations.readTables).toHaveBeenCalledTimes(2)
   })
+
+  it('rejects a late Location result after the section becomes inactive', async () => {
+    const port = ports()
+    const pending = deferred<{
+      revision: number
+      locations: WorldLocation[]
+    }>()
+    vi.mocked(port.locations.readLocations).mockReturnValue(pending.promise)
+    const hook = renderHook(
+      ({ active }: { active: boolean }) =>
+        useLocationCatalogController(
+          active,
+          onError,
+          setSession,
+          port.locations
+        ),
+      { initialProps: { active: true } }
+    )
+    await waitFor(() =>
+      expect(port.locations.readLocations).toHaveBeenCalledOnce()
+    )
+    hook.rerender({ active: false })
+    await act(async () => {
+      pending.resolve({ revision: 9, locations: [location] })
+      await pending.promise
+    })
+    expect(hook.result.current.snapshot).toEqual({ revision: 0, locations: [] })
+    expect(onError).not.toHaveBeenCalled()
+  })
 })
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  let reject!: (cause?: unknown) => void
+  const promise = new Promise<Value>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}

--- a/tests/unit/group-manager-commands.test.tsx
+++ b/tests/unit/group-manager-commands.test.tsx
@@ -9,6 +9,7 @@ import {
   type GroupManagerAction
 } from '../../src/renderer/features/session/group-manager-state.js'
 import { useGroupManagerCommands } from '../../src/renderer/features/session/use-group-manager-commands.js'
+import { AsyncCommandCoordinator } from '../../src/renderer/async/async-command-coordinator.js'
 import type { GroupManagerPorts } from '../../src/renderer/features/session/use-group-manager-capability-ports.js'
 import type {
   LiveSessionSnapshot,
@@ -26,7 +27,10 @@ describe('group manager commands', () => {
     const saved = vi.fn()
     const dispatch = vi.fn<(action: GroupManagerAction) => void>()
     const input = commandInput(saveGroup, saved, dispatch)
-    const controller = renderHook(() => useGroupManagerCommands(input))
+    const coordinator = new AsyncCommandCoordinator()
+    const controller = renderHook(() =>
+      useGroupManagerCommands(input, coordinator)
+    )
 
     const first = controller.result.current.save()
     const second = controller.result.current.save()

--- a/tests/unit/npc-catalog.test.tsx
+++ b/tests/unit/npc-catalog.test.tsx
@@ -88,7 +88,17 @@ const locations = {
   ]
 }
 
-function setup(active = true) {
+function setup(
+  active = true,
+  searchOverride?: (input: {
+    query: string
+    lifecycle: WorldNpc['lifecycle'] | null
+    factionId?: string | null
+    locationId?: string | null
+    offset: number
+    limit: number
+  }) => Promise<unknown>
+) {
   const all = [erika, bandit]
   const create = vi.fn(
     (input: {
@@ -109,48 +119,45 @@ function setup(active = true) {
       })
     }
   )
-  const search = vi.fn(
-    (input: {
-      query: string
-      lifecycle: WorldNpc['lifecycle'] | null
-      factionId?: string | null
-      locationId?: string | null
-      offset: number
-      limit: number
-    }) => {
-      const rows = all.filter(
-        (npc) =>
-          (input.lifecycle === null || npc.lifecycle === input.lifecycle) &&
-          (input.factionId === undefined ||
-            npc.factionId === input.factionId) &&
-          (input.locationId === undefined ||
-            npc.locationId === input.locationId) &&
-          npc.displayName
-            .toLocaleLowerCase()
-            .includes(input.query.toLocaleLowerCase())
-      )
-      return Promise.resolve({
-        revision: all.length > 2 ? 4 : 3,
-        rows: rows.map((npc) => ({
-          id: npc.id,
-          displayName: npc.displayName,
-          creatureId: npc.creatureId,
-          creatureDisplayName:
-            npc.creatureId === 'sprite' ? 'Sprite' : 'Bandit',
-          lifecycle: npc.lifecycle,
-          dispositionModifier: npc.dispositionModifier,
-          factionId: npc.factionId,
-          factionDisplayName: npc.factionId ? 'Rosenhof' : null,
-          locationId: npc.locationId,
-          locationDisplayName: npc.locationId ? 'Flussuferhöhle' : null,
-          position: npc.position
-        })),
-        total: rows.length,
-        offset: input.offset,
-        limit: input.limit
-      })
-    }
-  )
+  const defaultSearch = (input: {
+    query: string
+    lifecycle: WorldNpc['lifecycle'] | null
+    factionId?: string | null
+    locationId?: string | null
+    offset: number
+    limit: number
+  }) => {
+    const rows = all.filter(
+      (npc) =>
+        (input.lifecycle === null || npc.lifecycle === input.lifecycle) &&
+        (input.factionId === undefined || npc.factionId === input.factionId) &&
+        (input.locationId === undefined ||
+          npc.locationId === input.locationId) &&
+        npc.displayName
+          .toLocaleLowerCase()
+          .includes(input.query.toLocaleLowerCase())
+    )
+    return Promise.resolve({
+      revision: all.length > 2 ? 4 : 3,
+      rows: rows.map((npc) => ({
+        id: npc.id,
+        displayName: npc.displayName,
+        creatureId: npc.creatureId,
+        creatureDisplayName: npc.creatureId === 'sprite' ? 'Sprite' : 'Bandit',
+        lifecycle: npc.lifecycle,
+        dispositionModifier: npc.dispositionModifier,
+        factionId: npc.factionId,
+        factionDisplayName: npc.factionId ? 'Rosenhof' : null,
+        locationId: npc.locationId,
+        locationDisplayName: npc.locationId ? 'Flussuferhöhle' : null,
+        position: npc.position
+      })),
+      total: rows.length,
+      offset: input.offset,
+      limit: input.limit
+    })
+  }
+  const search = vi.fn(searchOverride ?? defaultSearch)
   const api = {
     npcs: {
       search,
@@ -199,16 +206,32 @@ function setup(active = true) {
     })
   } as unknown as CreatureCapabilityPort
   const onError = vi.fn()
-  function Harness() {
-    const controller = useNpcCatalogController(active, onError, api, creatures)
+  function Harness(props: { active: boolean }) {
+    const controller = useNpcCatalogController(
+      props.active,
+      onError,
+      api,
+      creatures
+    )
     return <NpcCatalogSection controller={controller} />
   }
-  render(
+  const view = render(
     <ModalLayerProvider>
-      <Harness />
+      <Harness active={active} />
     </ModalLayerProvider>
   )
-  return { api, creatures, create }
+  return {
+    api,
+    creatures,
+    create,
+    onError,
+    rerenderActive: (next: boolean) =>
+      view.rerender(
+        <ModalLayerProvider>
+          <Harness active={next} />
+        </ModalLayerProvider>
+      )
+  }
 }
 
 afterEach(cleanup)
@@ -219,6 +242,40 @@ describe('NPC catalog UI', () => {
     expect(api.npcs.search).not.toHaveBeenCalled()
     expect(api.factions.read).not.toHaveBeenCalled()
     expect(api.locations.read).not.toHaveBeenCalled()
+  })
+
+  it('suppresses a late NPC failure after the section becomes inactive', async () => {
+    const pending = deferred<unknown>()
+    const { api, onError, rerenderActive } = setup(true, () => pending.promise)
+    await waitFor(() => expect(api.npcs.search).toHaveBeenCalledOnce())
+    rerenderActive(false)
+    pending.reject(new Error('obsolete NPC failure'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('publishes only the latest NPC page when searches complete out of order', async () => {
+    const older = deferred<unknown>()
+    const newer = deferred<unknown>()
+    const search = vi
+      .fn()
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    setup(true, search)
+    await waitFor(() => expect(search).toHaveBeenCalledOnce())
+    fireEvent.change(screen.getByLabelText('NPCs suchen'), {
+      target: { value: 'Erika' }
+    })
+    await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
+    newer.resolve(pageFor(erika))
+    expect(await screen.findByRole('button', { name: 'Erika' })).toBeVisible()
+    older.resolve(pageFor(bandit))
+    await older.promise
+    expect(screen.getByRole('button', { name: 'Erika' })).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: 'Überlebender Bandit' })
+    ).toBeNull()
   })
 
   it('debounces text search and combines status, faction and location filters', async () => {
@@ -324,18 +381,47 @@ describe('NPC catalog UI', () => {
   })
 })
 
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  let reject!: (cause?: unknown) => void
+  const promise = new Promise<Value>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+function pageFor(npc: WorldNpc) {
+  return {
+    revision: 3,
+    rows: [
+      {
+        id: npc.id,
+        displayName: npc.displayName,
+        creatureId: npc.creatureId,
+        creatureDisplayName: npc.creatureId === 'sprite' ? 'Sprite' : 'Bandit',
+        lifecycle: npc.lifecycle,
+        dispositionModifier: npc.dispositionModifier,
+        factionId: npc.factionId,
+        factionDisplayName: npc.factionId ? 'Rosenhof' : null,
+        locationId: npc.locationId,
+        locationDisplayName: npc.locationId ? 'Flussuferhöhle' : null,
+        position: npc.position
+      }
+    ],
+    total: 1,
+    offset: 0,
+    limit: 50
+  }
+}
+
 describe('NPC catalog lifecycle reducer', () => {
-  it('covers loading, ready, editing, saving and conflict with request tokens', () => {
+  it('covers loading, ready, editing, saving and conflict', () => {
     const loading = reduceNpcCatalogState(initialNpcCatalogState, {
-      type: 'load-started',
-      token: 2
+      type: 'load-started'
     })
-    expect(
-      reduceNpcCatalogState(loading, { type: 'load-completed', token: 1 })
-    ).toBe(loading)
     const ready = reduceNpcCatalogState(loading, {
-      type: 'load-completed',
-      token: 2
+      type: 'load-completed'
     })
     expect(ready).toEqual({ status: 'ready' })
     const editing = reduceNpcCatalogState(ready, {
@@ -343,53 +429,38 @@ describe('NPC catalog lifecycle reducer', () => {
       npc: erika
     })
     const saving = reduceNpcCatalogState(editing, {
-      type: 'save-started',
-      token: 5
+      type: 'save-started'
     })
-    expect(saving).toMatchObject({ status: 'saving', npc: erika, token: 5 })
-    expect(
-      reduceNpcCatalogState(saving, { type: 'save-completed', token: 4 })
-    ).toBe(saving)
+    expect(saving).toMatchObject({ status: 'saving', npc: erika })
     expect(
       reduceNpcCatalogState(saving, {
         type: 'save-conflicted',
-        token: 5,
         message: 'Revision geändert'
       })
     ).toEqual({
       status: 'conflict',
       npc: erika,
-      token: 5,
       message: 'Revision geändert'
     })
   })
 
-  it('covers confirming and token-guarded deletion', () => {
+  it('covers confirming and deletion', () => {
     const requested = reduceNpcCatalogState(
       { status: 'ready' },
       { type: 'delete-requested', npcId: erikaId }
     )
     const deleting = reduceNpcCatalogState(requested, {
       type: 'delete-started',
-      npcId: erikaId,
-      token: 8
+      npcId: erikaId
     })
     expect(deleting).toEqual({
       status: 'deleting',
       npcId: erikaId,
-      phase: 'saving',
-      token: 8
+      phase: 'saving'
     })
     expect(
       reduceNpcCatalogState(deleting, {
-        type: 'delete-completed',
-        token: 7
-      })
-    ).toBe(deleting)
-    expect(
-      reduceNpcCatalogState(deleting, {
-        type: 'delete-completed',
-        token: 8
+        type: 'delete-completed'
       })
     ).toEqual({ status: 'ready' })
   })


### PR DESCRIPTION
## Summary
- inject one coordinator into retained Group query and command boundaries
- split NPC and Location catalogs into query, mutation, and projection adapters
- remove manual request epochs and add deterministic scope-isolation coverage
- record the bounded lazy-chunk baseline with no new runtime dependency

## Verification
- pnpm check
- architecture 82/82
- portable unit 734/734
- integration 161/161
- Linux 32/32
- functional E2E 14/14, max attempts 1
- visual E2E 7/7, max attempts 1

Candidate SHA: 19f6bdfb3cacd6ac8f11a5d5541ccaaff5e01004