### PR TITLE
Fix settings migration and workspace errors

### DIFF
--- a/docs/loot/contract/contract-loot-persistence.md
+++ b/docs/loot/contract/contract-loot-persistence.md
@@ -1,7 +1,7 @@
 # Loot Persistence Contract
 
-Campaign schema 34 and installation schema 35 are current. The migration registry is
-version 7; Loot's canonical-item change remains the 30-to-31 migration in that
+Campaign schema 34 and installation schema 36 are current. The migration registry is
+version 8; Loot's canonical-item change remains the 30-to-31 migration in that
 forward chain.
 
 ## Canonical Item Identity

--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -139,7 +139,7 @@ accounts for the bounded virtual biome catalog and CRUD surface added with
 schema 15; schema 16 replaced separate World Location kind and region fields
 with tags and read-aloud text, and schema 17 normalizes ordered location-owned
 tags into validated rows while all per-entry ceilings remain unchanged.
-Campaign schema 34, installation schema 35, migration registry 7, Generator Config V5, Encounter engine
+Campaign schema 34, installation schema 36, migration registry 8, Generator Config V5, Encounter engine
 `encounter-v5`, and Reward engine `reward-v3` are current. Persisted
 `reward-v2` runs remain readable. The checked
 [version-truth matrix](version-truth.md) owns these current values. Schema 25 is reset rather than migrated. The
@@ -313,14 +313,15 @@ verifiable phases:
 3. Persisted data is classified with a read-only preflight before any writable
    connection. Schema names are environment-neutral and forward migrations
    require one explicit registry chain and transactional contract tests. The
-   role contract is installation schema 35 at `installation.sqlite` and
-   campaign schema 34 at `campaigns/<id>/campaign.sqlite`; registry version 7
+   role contract is installation schema 36 at `installation.sqlite` and
+   campaign schema 34 at `campaigns/<id>/campaign.sqlite`; registry version 8
    supports the Golden-Master-backed 27 -> 28 path, the 28 -> 29
    NPC/structured-PC migration, the 29 -> 30 application migration, and the
    populated 30 -> 31 canonical-item migration, and the 31 -> 32 Config-V5 and
    raw reward-member migration, and the 32 -> 33 World Planner relational
    integrity migration, the 33 -> 34 import provenance/registry migration, and
-   the 34 -> 35 durable import-saga migration. The aggregate owners
+   the 34 -> 35 durable import-saga migration, and the 35 -> 36 canonical
+   Session-layout migration. The aggregate owners
    retain their SQL, and the installer is the only offline migration authority.
 4. Local installation uses a lock, permanent verified backups, staged data
    migration, immutable version deployments, atomic current selection, and

--- a/docs/project/architecture/renderer-bundle-baseline.json
+++ b/docs/project/architecture/renderer-bundle-baseline.json
@@ -1,16 +1,16 @@
 {
   "recordedAt": "2026-08-22",
-  "reason": "Record Phase 10 Group, NPC, and Location query-mutation-projection boundaries with coordinator-owned stale-result suppression.",
-  "dependencyRationale": "No runtime dependency was added; growth is application-owned adapter wiring and deterministic scope isolation.",
-  "chunkRationale": "Group adapters remain in the existing dynamic group-dialog leaf; NPC and Location adapters remain in the existing Catalog lazy graph, with no new eager shell route.",
+  "reason": "Move workspace errors out of the Session cockpit and handle replacement-confirmation dismissal without issuing a nonexistent durable cancellation.",
+  "dependencyRationale": "No dependency changes.",
+  "chunkRationale": "Global alert markup and styles move from the Session chunk into the persistent workspace shell, while the Session planner gains a bounded local confirmation-cancel branch; all graph budgets retain substantial reserve.",
   "graphs": {
-    "shell": 400513,
-    "workspace": 494655,
-    "session": 169019,
+    "shell": 401230,
+    "workspace": 495511,
+    "session": 168828,
     "catalog": 185465,
     "hex": 176449,
     "reference": 39420,
     "pixi": 408625,
-    "reachable": 1503616
+    "reachable": 1504429
   }
 }

--- a/docs/project/architecture/version-truth.md
+++ b/docs/project/architecture/version-truth.md
@@ -8,10 +8,10 @@ canonical check.
 
 | Role | Current schema | Complete forward path | Migration owner |
 | --- | ---: | --- | --- |
-| installation | 35 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35` | `installation-schema-migrations.ts` |
+| installation | 36 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36` | `installation-schema-migrations.ts` |
 | campaign | 34 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34` | `campaign-schema-migrations.ts` |
 
-Migration registry contract: **7**.
+Migration registry contract: **8**.
 
 ## Generation
 

--- a/scripts/local-installation/campaign-backup.ts
+++ b/scripts/local-installation/campaign-backup.ts
@@ -28,13 +28,16 @@ import {
 import {
   copyTreeWithHashes,
   directoryHasEntries,
+  durableCampaignFileInventory,
   hashFileInventory,
   hashTree,
   hashTreeOrEmpty
 } from './campaign-file-inventory.js'
 
 export function campaignDataHash(paths: LocalInstallationPaths): string {
-  return hashFileInventory(hashTreeOrEmpty(paths.campaignData))
+  return hashFileInventory(
+    durableCampaignFileInventory(hashTreeOrEmpty(paths.campaignData))
+  )
 }
 
 export function validateBackupCheckpoint(
@@ -111,7 +114,12 @@ export function backupCampaignData(
     `${timestamp}-${shortBuildFingerprint(nextBuild)}-${token.slice(0, 8)}`
   )
   try {
-    const sourceHashes = copyTreeWithHashes(paths.campaignData, staging)
+    const copiedHashes = copyTreeWithHashes(paths.campaignData, staging)
+    const sourceHashes = durableCampaignFileInventory(copiedHashes)
+    const durablePaths = new Set(sourceHashes.map(({ path }) => path))
+    for (const file of copiedHashes)
+      if (!durablePaths.has(file.path))
+        rmSync(join(staging, ...file.path.split('/')), { force: true })
     if (JSON.stringify(hashTree(staging)) !== JSON.stringify(sourceHashes))
       throw new Error('Backup hashes differ from campaign data')
     const copiedDatabases = sourceDatabases.map((database) =>

--- a/scripts/local-installation/campaign-file-inventory.ts
+++ b/scripts/local-installation/campaign-file-inventory.ts
@@ -32,6 +32,15 @@ export function hashTreeOrEmpty(root: string): FileHash[] {
   return existsSync(root) ? hashTree(root) : []
 }
 
+export function durableCampaignFileInventory(
+  files: readonly FileHash[]
+): FileHash[] {
+  return files.filter(
+    ({ path, bytes }) =>
+      !path.endsWith('-shm') && !(path.endsWith('-wal') && bytes === 0)
+  )
+}
+
 export function hashFileInventory(files: readonly FileHash[]): string {
   return createHash('sha256').update(JSON.stringify(files)).digest('hex')
 }

--- a/scripts/local-installation/campaign-migration.ts
+++ b/scripts/local-installation/campaign-migration.ts
@@ -21,6 +21,7 @@ import {
   type LocalInstallationPaths
 } from './contract.js'
 import {
+  durableCampaignFileInventory,
   hashFileInventory,
   hashTreeOrEmpty
 } from './campaign-file-inventory.js'
@@ -92,7 +93,9 @@ export function migrateCampaignData(
         throw new Error('Promoted persistence failed validation')
       updateJournal({ phase: 'data-promoted' })
       updateJournal({
-        campaignDataHash: hashFileInventory(hashTreeOrEmpty(paths.campaignData))
+        campaignDataHash: hashFileInventory(
+          durableCampaignFileInventory(hashTreeOrEmpty(paths.campaignData))
+        )
       })
       rmSync(rollback, { recursive: true, force: true })
     } catch (error) {

--- a/src/core/persistence/sqlite/database.ts
+++ b/src/core/persistence/sqlite/database.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3'
 export type DatabaseRole = 'installation' | 'campaign'
 
 export const databaseSchemaVersions: Readonly<Record<DatabaseRole, number>> =
-  Object.freeze({ installation: 35, campaign: 34 })
+  Object.freeze({ installation: 36, campaign: 34 })
 
 export const currentSchemaVersion = Math.max(
   ...Object.values(databaseSchemaVersions)

--- a/src/core/persistence/sqlite/installation-schema-migrations.ts
+++ b/src/core/persistence/sqlite/installation-schema-migrations.ts
@@ -1,4 +1,6 @@
 import type Database from 'better-sqlite3'
+import { migrateSessionLayoutPreference } from '../../../shared/contracts/session-layout.js'
+import { installationPreferencesSchema } from '../../../shared/contracts/settings.js'
 import { defaultGeneratorLootRules } from '../../../shared/generator/default-loot-rules.js'
 import type { SchemaMigration } from './schema-migrations.js'
 import {
@@ -242,8 +244,62 @@ export const installationSchemaMigrations: readonly SchemaMigration[] =
           )
           .run('installation-34-to-35-import-saga', new Date().toISOString())
       }
+    },
+    {
+      id: 'installation-35-to-36-session-layout-v2',
+      role: 'installation',
+      fromVersion: 35,
+      toVersion: 36,
+      migrate(database) {
+        initializeInstallationSchemaMetadata(database)
+        migrateStoredSessionLayout(database)
+        database
+          .prepare(
+            'INSERT INTO installation_schema_migration (migration_id, applied_at) VALUES (?, ?)'
+          )
+          .run(
+            'installation-35-to-36-session-layout-v2',
+            new Date().toISOString()
+          )
+      }
     }
   ])
+
+function migrateStoredSessionLayout(database: Database.Database): void {
+  const hasSettings = Boolean(
+    database
+      .prepare(
+        `SELECT 1 FROM sqlite_master
+          WHERE type = 'table' AND name = 'installation_settings'`
+      )
+      .get()
+  )
+  if (!hasSettings) return
+  const row = database
+    .prepare(
+      'SELECT preferences_json AS preferencesJson FROM installation_settings WHERE singleton = 1'
+    )
+    .get() as { preferencesJson: string } | undefined
+  if (!row) return
+  const stored = JSON.parse(row.preferencesJson) as unknown
+  if (stored === null || typeof stored !== 'object' || Array.isArray(stored))
+    throw new Error('Invalid stored installation preferences')
+  const preferences = stored as Record<string, unknown>
+  const layout = migrateSessionLayoutPreference(preferences['sessionLayout'])
+  if (layout.kind === 'invalid')
+    throw new Error('Invalid stored Session layout preference')
+  installationPreferencesSchema.parse(preferences)
+  if (layout.kind === 'current') return
+  const migrated = installationPreferencesSchema.parse({
+    ...preferences,
+    sessionLayout: layout.preference
+  })
+  database
+    .prepare(
+      'UPDATE installation_settings SET revision = revision + 1, preferences_json = ? WHERE singleton = 1'
+    )
+    .run(JSON.stringify(migrated))
+}
 
 function upcastGeneratorConfigV5(value: unknown): unknown {
   if (!value || typeof value !== 'object') return value

--- a/src/core/persistence/sqlite/schema-migrations.ts
+++ b/src/core/persistence/sqlite/schema-migrations.ts
@@ -7,7 +7,7 @@ import {
 import { installationSchemaMigrations } from './installation-schema-migrations.js'
 import { campaignSchemaMigrations } from './campaign-schema-migrations.js'
 
-export const migrationRegistryVersion = 7
+export const migrationRegistryVersion = 8
 
 export type SchemaMigrationContext = Readonly<{
   path: string

--- a/src/renderer/features/encounter/encounter.css
+++ b/src/renderer/features/encounter/encounter.css
@@ -31,16 +31,6 @@
     font-size: 0.85rem;
   }
 
-  .error-message {
-    width: min(100%, 72rem);
-    margin: 0 0 1rem;
-    border: 1px solid var(--border-error);
-    border-radius: var(--radius-0);
-    background: var(--surface-error);
-    color: var(--text-error);
-    padding: 0.75rem;
-  }
-
   .scenario-panel:has(.scenario-crumbs) {
     grid-template-rows: auto minmax(0, 1fr);
   }

--- a/src/renderer/features/session-planner/use-session-preparation.ts
+++ b/src/renderer/features/session-planner/use-session-preparation.ts
@@ -173,6 +173,15 @@ export function useSessionPreparation(options: {
   }, [read, requestPreparation, saveDraft, seed])
 
   const cancelPreparation = useCallback(async (): Promise<void> => {
+    if (confirmation) {
+      activeAbort.current?.abort('replacement-confirmation-canceled')
+      activeTarget.current = null
+      activeAbort.current = null
+      setConfirmation(null)
+      setStage('ready')
+      setStageMessage(message('planner.progressReady'))
+      return
+    }
     const target = activeTarget.current
     const signal = activeAbort.current?.signal
     if (!target || !signal) {
@@ -191,7 +200,7 @@ export function useSessionPreparation(options: {
     if (outcome.status === 'failure')
       onError(capabilityErrorText(outcome.cause))
     setConfirmation(null)
-  }, [coordinator, onError, planner, publishReceipt])
+  }, [confirmation, coordinator, onError, planner, publishReceipt])
 
   const authority = read()
   const sessionId = authority.workspace?.session.id ?? null

--- a/src/renderer/features/workspace/workspace-errors.tsx
+++ b/src/renderer/features/workspace/workspace-errors.tsx
@@ -5,18 +5,23 @@ export function WorkspaceErrors(props: {
   errors: readonly WorkspaceUiError[]
   dismiss: (id: number) => void
 }) {
-  return props.errors.map((error) => (
-    <p
-      className="error-message"
-      role="alert"
-      data-error-scope={error.scope}
-      data-error-code={error.code}
-      key={error.id}
-    >
-      {error.message}{' '}
-      <button className="compact" onClick={() => props.dismiss(error.id)}>
-        {message('action.close')}
-      </button>
-    </p>
-  ))
+  if (props.errors.length === 0) return null
+  return (
+    <div className="workspace-error-stack">
+      {props.errors.map((error) => (
+        <p
+          className="error-message"
+          role="alert"
+          data-error-scope={error.scope}
+          data-error-code={error.code}
+          key={error.id}
+        >
+          <span>{error.message}</span>
+          <button className="compact" onClick={() => props.dismiss(error.id)}>
+            {message('action.close')}
+          </button>
+        </p>
+      ))}
+    </div>
+  )
 }

--- a/src/renderer/features/workspace/workspace.tsx
+++ b/src/renderer/features/workspace/workspace.tsx
@@ -171,7 +171,6 @@ export function WorkspaceApp() {
           <div
             className={`work-area layout-${active ? definition.layout : 'scroll'}`}
           >
-            <WorkspaceErrors errors={errors} dismiss={dismiss} />
             <WorkspaceRouteHost
               active={active}
               workspace={coordinator.workspace}
@@ -181,6 +180,7 @@ export function WorkspaceApp() {
             />
           </div>
         </div>
+        <WorkspaceErrors errors={errors} dismiss={dismiss} />
         {inspected && (
           <CreatureInspector
             creature={inspected}

--- a/src/renderer/shell/app.css
+++ b/src/renderer/shell/app.css
@@ -254,6 +254,42 @@ input {
   padding: clamp(1.25rem, 3vw, 3rem);
 }
 
+.workspace-error-stack {
+  position: fixed;
+  z-index: 900;
+  top: calc(var(--topbar-h) + var(--space-5));
+  right: var(--space-7);
+  display: grid;
+  width: min(32rem, calc(100vw - var(--rail-w) - 2rem));
+  max-height: calc(100vh - var(--topbar-h) - 2rem);
+  gap: var(--space-3);
+  overflow-y: auto;
+  pointer-events: none;
+}
+
+.workspace-error-stack .error-message {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+  margin: 0;
+  border: 1px solid var(--border-error);
+  border-radius: var(--radius-0);
+  background: var(--surface-error);
+  box-shadow: var(--shadow-panel);
+  color: var(--text-error);
+  padding: var(--space-5);
+  pointer-events: auto;
+}
+
+.workspace-error-stack .error-message > span {
+  min-width: 0;
+}
+
+.workspace-error-stack .error-message > button {
+  flex: none;
+}
+
 .workspace-panel {
   width: min(100%, 72rem);
   border: 1px solid var(--border-1);

--- a/src/shared/contracts/session-layout.ts
+++ b/src/shared/contracts/session-layout.ts
@@ -21,9 +21,13 @@ const currentSessionLayoutPreferenceSchema = z
   })
   .strict()
 
-const unversionedPixelLayoutSchema = currentSessionLayoutPreferenceSchema.omit({
-  schemaVersion: true
-})
+const unversionedPixelLayoutSchema = z
+  .object({
+    controlPaneWidth: z.number().finite(),
+    scenarioPaneWidth: z.number().finite(),
+    centerTab: z.enum(['details', 'catalog', 'map'])
+  })
+  .strict()
 
 const legacyFractionLayoutSchema = z
   .object({
@@ -60,7 +64,18 @@ export function migrateSessionLayoutPreference(
     return {
       kind: 'migrated',
       migration: 'unversioned-pixels-to-v2',
-      preference: { schemaVersion: 2, ...pixels.data }
+      preference: {
+        schemaVersion: 2,
+        controlPaneWidth: fitPaneWidth(
+          pixels.data.controlPaneWidth,
+          sessionLayoutGeometry.controlPane
+        ),
+        scenarioPaneWidth: fitPaneWidth(
+          pixels.data.scenarioPaneWidth,
+          sessionLayoutGeometry.scenarioPane
+        ),
+        centerTab: pixels.data.centerTab
+      }
     }
   const fractions = legacyFractionLayoutSchema.safeParse(value)
   if (fractions.success)
@@ -91,3 +106,10 @@ export const defaultSessionLayoutPreference: SessionLayoutPreference =
   currentSessionLayoutPreferenceSchema.parse(
     defaultSessionLayoutPreferenceValue
   )
+
+function fitPaneWidth(
+  value: number,
+  bounds: Readonly<{ min: number; max: number }>
+): number {
+  return Math.min(bounds.max, Math.max(bounds.min, Math.round(value)))
+}

--- a/src/shared/errors/capability-error.ts
+++ b/src/shared/errors/capability-error.ts
@@ -37,8 +37,9 @@ export function capabilityErrorCode(
 ): CapabilityErrorCode | null {
   if (error instanceof CapabilityError) return error.code
   if (error === null || typeof error !== 'object') return null
-  const code = (error as { code?: unknown }).code
-  return typeof code === 'string' && capabilityErrorCodeSet.has(code)
-    ? (code as CapabilityErrorCode)
-    : null
+  const candidate = error as { code?: unknown; message?: unknown }
+  for (const value of [candidate.code, candidate.message])
+    if (typeof value === 'string' && capabilityErrorCodeSet.has(value))
+      return value as CapabilityErrorCode
+  return null
 }

--- a/tests/e2e/workspace-isolation.e2e.ts
+++ b/tests/e2e/workspace-isolation.e2e.ts
@@ -32,4 +32,65 @@ describe('isolated workspace routes', () => {
     ).toBeExisting()
     await expect(menu).toBeExisting()
   })
+
+  it('keeps workspace geometry stable while shell errors are visible', async () => {
+    const client = browser as unknown as WdioBrowser
+    const geometry = await client.execute(async () => {
+      const shell = document.querySelector<HTMLElement>('.app-shell')
+      const workspace = document.querySelector<HTMLElement>('.session-mockup')
+      if (!shell || !workspace) return null
+      const snapshot = () => {
+        const bounds = workspace.getBoundingClientRect()
+        return {
+          left: bounds.left,
+          top: bounds.top,
+          width: bounds.width,
+          height: bounds.height
+        }
+      }
+      const before = snapshot()
+      const stack = document.createElement('div')
+      stack.className = 'workspace-error-stack'
+      const alert = document.createElement('p')
+      alert.className = 'error-message'
+      alert.setAttribute('role', 'alert')
+      const message = document.createElement('span')
+      message.textContent = 'Ein interner Fehler ist aufgetreten.'
+      const close = document.createElement('button')
+      close.textContent = 'Schließen'
+      alert.append(message, close)
+      stack.append(alert)
+      shell.append(stack)
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      )
+      const after = snapshot()
+      const stackStyle = getComputedStyle(stack)
+      const stackBounds = stack.getBoundingClientRect()
+      const result = {
+        before,
+        after,
+        stackPosition: stackStyle.position,
+        stackHeight: stackBounds.height,
+        viewportHeight: window.innerHeight,
+        mountedOutsideWorkArea: stack.closest('.work-area') === null
+      }
+      stack.remove()
+      return result
+    })
+
+    if (!geometry) throw new Error('Session workspace geometry is unavailable')
+    if (JSON.stringify(geometry.before) !== JSON.stringify(geometry.after))
+      throw new Error(
+        `Workspace error changed cockpit geometry: ${JSON.stringify(geometry)}`
+      )
+    if (
+      geometry.stackPosition !== 'fixed' ||
+      !geometry.mountedOutsideWorkArea ||
+      geometry.stackHeight >= geometry.viewportHeight
+    )
+      throw new Error(
+        `Workspace error stack is not isolated: ${JSON.stringify(geometry)}`
+      )
+  })
 })

--- a/tests/unit/capability-errors.test.ts
+++ b/tests/unit/capability-errors.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from 'vitest'
-import { presentCapabilityError } from '../../src/renderer/capabilities/capability-errors.js'
+import {
+  capabilityErrorText,
+  presentCapabilityError
+} from '../../src/renderer/capabilities/capability-errors.js'
 import { CapabilityError } from '../../src/shared/errors/capability-error.js'
 
 describe('capability error presentation policy', () => {
@@ -18,6 +21,15 @@ describe('capability error presentation policy', () => {
     const text = presentCapabilityError(new Error('offline'), report)
     expect(report).toHaveBeenCalledOnce()
     expect(report).toHaveBeenCalledWith(text)
+  })
+
+  it('recovers a known code from Electron reduced Error messages', () => {
+    expect(capabilityErrorText(new Error('internal'))).toBe(
+      'Ein interner Fehler ist aufgetreten.'
+    )
+    expect(capabilityErrorText(new Error('not-a-capability-code'))).toBe(
+      'Unbekannter Fehler'
+    )
   })
 
   it('requests one readback and reports outcome-unknown exactly once', () => {

--- a/tests/unit/live-session-contract.test.ts
+++ b/tests/unit/live-session-contract.test.ts
@@ -178,6 +178,39 @@ describe('live session capability contracts', () => {
     })
     expect(
       migrateSessionLayoutPreference({
+        controlPaneWidth: 300.4,
+        scenarioPaneWidth: 242,
+        centerTab: 'details'
+      })
+    ).toEqual({
+      kind: 'migrated',
+      migration: 'unversioned-pixels-to-v2',
+      preference: {
+        schemaVersion: 2,
+        controlPaneWidth: 300,
+        scenarioPaneWidth: 264,
+        centerTab: 'details'
+      }
+    })
+    expect(
+      migrateSessionLayoutPreference({
+        controlPaneWidth: -10,
+        scenarioPaneWidth: 900,
+        centerTab: 'map'
+      })
+    ).toMatchObject({
+      kind: 'migrated',
+      preference: { controlPaneWidth: 280, scenarioPaneWidth: 420 }
+    })
+    expect(
+      migrateSessionLayoutPreference({
+        controlPaneWidth: Number.POSITIVE_INFINITY,
+        scenarioPaneWidth: 300,
+        centerTab: 'details'
+      })
+    ).toMatchObject({ kind: 'invalid' })
+    expect(
+      migrateSessionLayoutPreference({
         schemaVersion: 2,
         controlPaneWidth: 900,
         scenarioPaneWidth: 20,

--- a/tests/unit/local-app-installation.test.ts
+++ b/tests/unit/local-app-installation.test.ts
@@ -23,7 +23,10 @@ import {
   type InstallLocalAppOptions
 } from '../../scripts/local-app-installation.js'
 import type { BuildInfo } from '../../src/shared/contracts/build-info.js'
-import type { SchemaMigration } from '../../src/core/persistence/sqlite/schema-migrations.js'
+import {
+  schemaMigrations,
+  type SchemaMigration
+} from '../../src/core/persistence/sqlite/schema-migrations.js'
 import { databaseSchemaVersions } from '../../src/core/persistence/sqlite/database.js'
 
 const roots: string[] = []
@@ -323,7 +326,15 @@ describe('local AppImage installation', () => {
   it('refuses a schema change when no tested migration exists', () => {
     const fixture = createFixture(build('a'))
     const paths = localInstallationPaths(fixture.xdg)
-    const databasePath = createDatabase(paths.campaignData, schemaVersion - 9)
+    const earliestInstallationSchema = Math.min(
+      ...schemaMigrations
+        .filter((migration) => migration.role === 'installation')
+        .map((migration) => migration.fromVersion)
+    )
+    const databasePath = createDatabase(
+      paths.campaignData,
+      earliestInstallationSchema - 1
+    )
     const before = readFileSync(databasePath)
 
     expectFailure(() => installLocalApp(fixture.options), 'migration-missing')

--- a/tests/unit/local-app-installation.test.ts
+++ b/tests/unit/local-app-installation.test.ts
@@ -23,6 +23,7 @@ import {
   type InstallLocalAppOptions
 } from '../../scripts/local-app-installation.js'
 import type { BuildInfo } from '../../src/shared/contracts/build-info.js'
+import { campaignDataHash } from '../../scripts/local-installation/campaign-backup.js'
 import {
   schemaMigrations,
   type SchemaMigration
@@ -104,6 +105,74 @@ describe('local AppImage installation', () => {
       'backup-created'
     )
     expect(repeated.backupPath).toBe(backup.backupPath)
+  })
+
+  it('does not treat disposable SQLite sidecars as campaign data changes', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    const databasePath = createDatabase(paths.campaignData, schemaVersion, true)
+    const before = campaignDataHash(paths)
+
+    const database = new Database(databasePath, {
+      readonly: true,
+      fileMustExist: true
+    })
+    try {
+      expect(database.pragma('quick_check')).toEqual([{ quick_check: 'ok' }])
+    } finally {
+      database.close()
+    }
+
+    expect(existsSync(`${databasePath}-shm`)).toBe(true)
+    expect(existsSync(`${databasePath}-wal`)).toBe(true)
+    expect(readFileSync(`${databasePath}-wal`)).toHaveLength(0)
+    expect(campaignDataHash(paths)).toBe(before)
+  })
+
+  it('preserves a non-empty WAL without retaining its disposable SHM file', () => {
+    const fixture = createFixture(build('a'))
+    const paths = localInstallationPaths(fixture.xdg)
+    createDatabase(paths.campaignData, schemaVersion)
+    const campaignDirectory = join(
+      paths.campaignData,
+      'campaigns',
+      '00000000-0000-4000-8000-000000000001'
+    )
+    const campaignPath = createDatabase(
+      campaignDirectory,
+      databaseSchemaVersions.campaign,
+      true,
+      'campaign.sqlite'
+    )
+    const writer = new Database(campaignPath)
+    try {
+      writer.pragma('wal_autocheckpoint = 0')
+      writer.prepare('INSERT INTO valuable VALUES (?)').run('still in WAL')
+      expect(existsSync(`${campaignPath}-shm`)).toBe(true)
+      expect(existsSync(`${campaignPath}-wal`)).toBe(true)
+
+      const backup = advanceLocalAppInstallation(
+        fixture.options,
+        'backup-created'
+      )
+      const backupCampaign = join(
+        backup.backupPath!,
+        relative(paths.campaignData, campaignPath)
+      )
+      expect(existsSync(`${backupCampaign}-shm`)).toBe(false)
+      expect(existsSync(`${backupCampaign}-wal`)).toBe(true)
+      expect(readFileSync(`${backupCampaign}-wal`).byteLength).toBeGreaterThan(
+        0
+      )
+
+      const repeated = advanceLocalAppInstallation(
+        fixture.options,
+        'backup-created'
+      )
+      expect(repeated.backupPath).toBe(backup.backupPath)
+    } finally {
+      writer.close()
+    }
   })
 
   it('invalidates a backup checkpoint when campaign data changes', () => {

--- a/tests/unit/persistence-preflight.test.ts
+++ b/tests/unit/persistence-preflight.test.ts
@@ -140,7 +140,7 @@ describe('persistence preflight', () => {
     const planned = preflightPersistence(root)
 
     expect(planned.kind).toBe('migration-required')
-    expect(migrationRegistryVersion).toBe(7)
+    expect(migrationRegistryVersion).toBe(8)
     for (const entry of planned.databases) {
       const database = new Database(entry.path)
       applySchemaMigrations(database, {
@@ -154,7 +154,7 @@ describe('persistence preflight', () => {
     expect(restarted.kind).toBe('ready')
     expect(restarted.databases).toMatchObject([
       { path: campaign, role: 'campaign', schemaVersion: 34 },
-      { path: installation, role: 'installation', schemaVersion: 35 }
+      { path: installation, role: 'installation', schemaVersion: 36 }
     ])
     const installationDatabase = new Database(installation)
     expect(
@@ -168,7 +168,7 @@ describe('persistence preflight', () => {
         .prepare('SELECT COUNT(*) FROM installation_schema_migration')
         .pluck()
         .get()
-    ).toBe(8)
+    ).toBe(9)
     applySchemaMigrations(installationDatabase, {
       path: installation,
       role: 'installation'
@@ -178,7 +178,7 @@ describe('persistence preflight', () => {
         .prepare('SELECT COUNT(*) FROM installation_schema_migration')
         .pluck()
         .get()
-    ).toBe(8)
+    ).toBe(9)
     expect(
       installationDatabase
         .prepare(
@@ -204,6 +204,149 @@ describe('persistence preflight', () => {
         .all()
     ).toEqual(['campaign_import_entity', 'campaign_import_provenance'])
     campaignDatabase.close()
+  })
+
+  it('canonicalizes legacy Session layout settings during schema 35 to 36', () => {
+    const path = join(temporaryRoot(), 'installation.sqlite')
+    const database = new Database(path)
+    database.exec(`
+      CREATE TABLE installation_settings (
+        singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+        revision INTEGER NOT NULL CHECK(revision >= 0),
+        preferences_json TEXT NOT NULL
+      );
+    `)
+    database.prepare('INSERT INTO installation_settings VALUES (1, ?, ?)').run(
+      7,
+      JSON.stringify({
+        theme: 'dark',
+        sessionLayout: {
+          controlPaneWidth: 300,
+          scenarioPaneWidth: 242,
+          centerTab: 'details'
+        }
+      })
+    )
+    database.pragma('user_version = 35')
+
+    applySchemaMigrations(database, { path, role: 'installation' })
+
+    const migrated = database
+      .prepare(
+        'SELECT revision, preferences_json AS preferencesJson FROM installation_settings WHERE singleton = 1'
+      )
+      .get() as { revision: number; preferencesJson: string }
+    expect(migrated.revision).toBe(8)
+    expect(JSON.parse(migrated.preferencesJson)).toEqual({
+      theme: 'dark',
+      sessionLayout: {
+        schemaVersion: 2,
+        controlPaneWidth: 300,
+        scenarioPaneWidth: 264,
+        centerTab: 'details'
+      }
+    })
+    expect(
+      database
+        .prepare(
+          "SELECT migration_id FROM installation_schema_migration WHERE migration_id = 'installation-35-to-36-session-layout-v2'"
+        )
+        .pluck()
+        .get()
+    ).toBe('installation-35-to-36-session-layout-v2')
+    applySchemaMigrations(database, { path, role: 'installation' })
+    expect(
+      database
+        .prepare(
+          'SELECT revision FROM installation_settings WHERE singleton = 1'
+        )
+        .pluck()
+        .get()
+    ).toBe(8)
+    database.close()
+  })
+
+  it('leaves current settings revisions unchanged during schema 35 to 36', () => {
+    const path = join(temporaryRoot(), 'installation.sqlite')
+    const database = new Database(path)
+    database.exec(`
+      CREATE TABLE installation_settings (
+        singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+        revision INTEGER NOT NULL CHECK(revision >= 0),
+        preferences_json TEXT NOT NULL
+      );
+    `)
+    database.prepare('INSERT INTO installation_settings VALUES (1, ?, ?)').run(
+      4,
+      JSON.stringify({
+        theme: 'light',
+        sessionLayout: {
+          schemaVersion: 2,
+          controlPaneWidth: 300,
+          scenarioPaneWidth: 264,
+          centerTab: 'catalog'
+        }
+      })
+    )
+    database.pragma('user_version = 35')
+
+    applySchemaMigrations(database, { path, role: 'installation' })
+
+    expect(
+      database
+        .prepare(
+          'SELECT revision FROM installation_settings WHERE singleton = 1'
+        )
+        .pluck()
+        .get()
+    ).toBe(4)
+    database.close()
+  })
+
+  it('rolls back schema 35 when current-version layout settings are invalid', () => {
+    const path = join(temporaryRoot(), 'installation.sqlite')
+    const database = new Database(path)
+    database.exec(`
+      CREATE TABLE installation_settings (
+        singleton INTEGER PRIMARY KEY NOT NULL CHECK(singleton = 1),
+        revision INTEGER NOT NULL CHECK(revision >= 0),
+        preferences_json TEXT NOT NULL
+      );
+    `)
+    const preferencesJson = JSON.stringify({
+      theme: 'light',
+      sessionLayout: {
+        schemaVersion: 2,
+        controlPaneWidth: 300,
+        scenarioPaneWidth: 20,
+        centerTab: 'details'
+      }
+    })
+    database
+      .prepare('INSERT INTO installation_settings VALUES (1, 2, ?)')
+      .run(preferencesJson)
+    database.pragma('user_version = 35')
+
+    expect(() =>
+      applySchemaMigrations(database, { path, role: 'installation' })
+    ).toThrow(/Invalid stored Session layout/)
+
+    expect(database.pragma('user_version', { simple: true })).toBe(35)
+    expect(
+      database
+        .prepare(
+          'SELECT revision, preferences_json AS preferencesJson FROM installation_settings WHERE singleton = 1'
+        )
+        .get()
+    ).toEqual({ revision: 2, preferencesJson })
+    expect(
+      database
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'installation_schema_migration'"
+        )
+        .get()
+    ).toBeUndefined()
+    database.close()
   })
 
   it('upcasts Config V4 coin container names to Config V5 IDs', () => {

--- a/tests/unit/session-preparation-controller.test.tsx
+++ b/tests/unit/session-preparation-controller.test.tsx
@@ -89,6 +89,32 @@ describe('Session preparation controller', () => {
     expect(fixture.result.current.stage).toBe('failed')
     expect(fixture.onError).toHaveBeenCalledOnce()
   })
+
+  it('dismisses replacement confirmation without canceling missing durable work', async () => {
+    const fixture = renderPreparation({
+      startPreparation: () =>
+        Promise.resolve({
+          status: 'confirmation_required',
+          parameters: { sceneCount: 2 }
+        })
+    })
+    await act(async () =>
+      fixture.result.current.requestPreparation(
+        fixture.workspace,
+        operationId,
+        false,
+        17
+      )
+    )
+
+    expect(fixture.result.current.stage).toBe('confirming-replacement')
+    await act(async () => fixture.result.current.cancelPreparation())
+
+    expect(fixture.result.current.stage).toBe('ready')
+    expect(fixture.result.current.confirmation).toBeNull()
+    expect(fixture.planner.cancelPreparation).not.toHaveBeenCalled()
+    expect(fixture.onError).not.toHaveBeenCalled()
+  })
 })
 
 function renderPreparation(overrides: {
@@ -143,6 +169,7 @@ function renderPreparation(overrides: {
   return {
     ...hook,
     workspace,
+    planner,
     applyWorkspace,
     onError,
     get notice() {

--- a/tests/unit/version-truth.test.ts
+++ b/tests/unit/version-truth.test.ts
@@ -12,8 +12,8 @@ describe('version truth gate', () => {
     expect(truth.schemas).toEqual([
       {
         role: 'installation',
-        current: 35,
-        path: '27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35',
+        current: 36,
+        path: '27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36',
         owner: 'installation-schema-migrations.ts'
       },
       {

--- a/tests/unit/workspace-errors.test.tsx
+++ b/tests/unit/workspace-errors.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WorkspaceErrors } from '../../src/renderer/features/workspace/workspace-errors.js'
+
+afterEach(cleanup)
+
+describe('workspace error presentation', () => {
+  it('stacks immutable alerts and dismisses only the selected message', () => {
+    const dismiss = vi.fn()
+    const { container } = render(
+      <main>
+        <div className="work-area" />
+        <WorkspaceErrors
+          errors={[
+            {
+              id: 1,
+              scope: 'settings',
+              code: 'settings.operation',
+              message: 'Ein interner Fehler ist aufgetreten.'
+            },
+            {
+              id: 2,
+              scope: 'workspace',
+              code: 'feature.operation',
+              message: 'Der Katalog ist nicht erreichbar.'
+            }
+          ]}
+          dismiss={dismiss}
+        />
+      </main>
+    )
+
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(2)
+    expect(container.querySelector('.workspace-error-stack')).toContainElement(
+      alerts[0]!
+    )
+    expect(alerts[0]!.closest('.work-area')).toBeNull()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Schließen' })[1]!)
+    expect(dismiss).toHaveBeenCalledOnce()
+    expect(dismiss).toHaveBeenCalledWith(2)
+  })
+
+  it('renders no stack when there are no errors', () => {
+    const { container } = render(
+      <WorkspaceErrors errors={[]} dismiss={vi.fn()} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## Summary
- migrate legacy Session pane widths to the current versioned layout contract
- preserve capability error codes across Electron serialization and render bounded shell alerts outside cockpit geometry
- fix replacement-confirmation dismissal so it does not cancel nonexistent durable work

## Verification
- pnpm check
- migration exercised against a SQLite backup of the live schema-35 profile (242 px -> schema v2, 264 px)
