### PR TITLE
Fix candidate artifact attempt qualification

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "package:release:built": "tsx scripts/package-app.ts --channel release",
     "install:local:built": "tsx scripts/install-local-app.ts",
     "handoff:app": "tsx scripts/handoff-local-app.ts",
+    "handoff:status": "tsx scripts/handoff-status.ts",
     "local-storage:inspect": "tsx scripts/inspect-local-storage.ts",
     "local-storage:prune": "tsx scripts/prune-local-storage.ts",
     "candidate-artifact:write": "tsx scripts/write-candidate-artifact-receipt.ts",

--- a/scripts/candidate-delivery.ts
+++ b/scripts/candidate-delivery.ts
@@ -11,9 +11,11 @@ import {
   handoffReceiptSchema,
   parseHandoffInvocationHistory,
   readRequiredJobManifest,
-  sameWorkflowQualification,
+  sameCandidateQualification,
   shaSchema,
   verifyRequiredJobs,
+  type CandidateArtifactEvidence,
+  type CandidateQualification,
   type GithubWorkflowRun,
   type WorkflowEvidence
 } from './delivery-contract.js'
@@ -29,7 +31,7 @@ export type CandidateState = Readonly<{
   remoteMain: string
   clean: boolean
   mainIsAncestor: boolean
-  candidate: WorkflowEvidence | null
+  candidate: CandidateQualification | null
 }>
 
 export function assertCandidateState(state: CandidateState): void {
@@ -46,8 +48,10 @@ export function assertCandidateState(state: CandidateState): void {
     throw new Error('Candidate is not based on the current remote main SHA.')
   if (!state.candidate)
     throw new Error('No complete required-job set proves this candidate SHA.')
-  if (state.candidate.headSha !== state.head)
+  if (state.candidate.workflow.headSha !== state.head)
     throw new Error('Candidate workflow evidence proves another SHA.')
+  if (state.candidate.artifact.applicationSha !== state.head)
+    throw new Error('Candidate artifact evidence proves another SHA.')
 }
 
 export function parseRemoteHead(output: string): string {
@@ -137,6 +141,94 @@ export function readSuccessfulWorkflowEvidence(
     if (evidence) return evidence
   }
   return null
+}
+
+export type GithubArtifact = Readonly<{
+  id: number
+  name: string
+  expired: boolean
+}>
+
+export function selectCandidateArtifactEvidence(
+  artifacts: readonly GithubArtifact[],
+  expected: Readonly<{
+    repository: string
+    workflowRunId: number
+    workflowRunAttempt: number
+    applicationSha: string
+  }>
+): CandidateArtifactEvidence | null {
+  const prefix = `salt-marcher-local-${expected.applicationSha}-attempt-`
+  const matches = artifacts
+    .flatMap((artifact) => {
+      if (artifact.expired || !artifact.name.startsWith(prefix)) return []
+      const rawAttempt = artifact.name.slice(prefix.length)
+      if (!/^[1-9][0-9]*$/.test(rawAttempt)) return []
+      const workflowRunAttempt = Number(rawAttempt)
+      if (
+        !Number.isSafeInteger(workflowRunAttempt) ||
+        workflowRunAttempt > expected.workflowRunAttempt
+      )
+        return []
+      return [{ artifact, workflowRunAttempt }]
+    })
+    .sort((left, right) => right.artifact.id - left.artifact.id)
+  const selected = matches[0]
+  if (!selected) return null
+  return {
+    repository: expected.repository,
+    artifactId: selected.artifact.id,
+    artifactName: selected.artifact.name,
+    workflowRunId: expected.workflowRunId,
+    workflowRunAttempt: selected.workflowRunAttempt,
+    applicationSha: expected.applicationSha
+  }
+}
+
+export function readCandidateQualification(
+  head: string
+): CandidateQualification | null {
+  const workflow = readSuccessfulWorkflowEvidence(head)
+  if (!workflow) return null
+  const repository = readRepositoryIdentity()
+  const pages = z
+    .array(
+      z
+        .object({
+          artifacts: z.array(
+            z
+              .object({
+                id: z.number().int().positive(),
+                name: z.string().min(1),
+                expired: z.boolean()
+              })
+              .passthrough()
+          )
+        })
+        .passthrough()
+    )
+    .parse(
+      JSON.parse(
+        command('gh', [
+          'api',
+          '--paginate',
+          '--slurp',
+          `repos/${repository}/actions/runs/${workflow.runId}/artifacts?per_page=100`
+        ])
+      )
+    )
+  const artifacts = pages.flatMap((page) => page.artifacts)
+  const artifact = selectCandidateArtifactEvidence(artifacts, {
+    repository,
+    workflowRunId: workflow.runId,
+    workflowRunAttempt: workflow.attempt,
+    applicationSha: head
+  })
+  if (!artifact)
+    throw new Error(
+      `No unexpired Local handoff artifact proves ${head} in workflow run ${workflow.runId}. Run the complete Check workflow again; rerunning only failed jobs cannot recreate an expired artifact.`
+    )
+  return { workflow, artifact }
 }
 
 export const postPromotionJobName = 'Main · promotion/evidence attestation'
@@ -254,7 +346,7 @@ export function readCandidateState(): CandidateState {
     remoteMain,
     head
   ])
-  const candidate = readSuccessfulWorkflowEvidence(head)
+  const candidate = readCandidateQualification(head)
   return {
     branch,
     upstream,
@@ -276,7 +368,7 @@ export function assertCandidateReady(): CandidateState {
 
 export function assertCompletedHandoffReceipt(
   head: string,
-  candidate: WorkflowEvidence,
+  candidate: CandidateQualification,
   workspaceRoot = process.cwd()
 ): void {
   const receiptDirectory = resolve(workspaceRoot, '.tmp', 'handoff-local-app')
@@ -299,7 +391,7 @@ export function assertCompletedHandoffReceipt(
     receipt.status !== 'complete' ||
     receipt.identity.commit !== head ||
     receipt.identity.dirty !== false ||
-    !sameWorkflowQualification(receipt.identity.candidate, candidate) ||
+    !sameCandidateQualification(receipt.identity.candidate, candidate) ||
     receipt.phases.some((phase) => phase.status !== 'completed') ||
     !attemptIds.has(receipt.originAttemptId) ||
     !attemptIds.has(receipt.activeAttemptId)
@@ -329,6 +421,20 @@ export function promoteCandidate(state: CandidateState): void {
 
 function git(arguments_: readonly string[]): string {
   return command('git', arguments_).trim()
+}
+
+function readRepositoryIdentity(): string {
+  const repository = command('gh', [
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner'
+  ]).trim()
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository))
+    throw new Error('GitHub returned an invalid repository identity')
+  return repository
 }
 
 function command(executable: string, arguments_: readonly string[]): string {

--- a/scripts/delivery-contract.ts
+++ b/scripts/delivery-contract.ts
@@ -101,6 +101,57 @@ export const workflowEvidenceSchema = z
 
 export type WorkflowEvidence = z.infer<typeof workflowEvidenceSchema>
 
+export const candidateArtifactEvidenceSchema = z
+  .object({
+    repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+    artifactId: z.number().int().positive(),
+    artifactName: z.string().min(1).max(255),
+    workflowRunId: z.number().int().positive(),
+    workflowRunAttempt: z.number().int().positive(),
+    applicationSha: shaSchema
+  })
+  .strict()
+
+export type CandidateArtifactEvidence = z.infer<
+  typeof candidateArtifactEvidenceSchema
+>
+
+export const candidateQualificationSchema = z
+  .object({
+    workflow: workflowEvidenceSchema,
+    artifact: candidateArtifactEvidenceSchema
+  })
+  .strict()
+  .superRefine((qualification, context) => {
+    if (qualification.artifact.workflowRunId !== qualification.workflow.runId)
+      context.addIssue({
+        code: 'custom',
+        message: 'Candidate artifact belongs to another workflow run',
+        path: ['artifact', 'workflowRunId']
+      })
+    if (
+      qualification.artifact.applicationSha !== qualification.workflow.headSha
+    )
+      context.addIssue({
+        code: 'custom',
+        message: 'Candidate artifact belongs to another application SHA',
+        path: ['artifact', 'applicationSha']
+      })
+    if (
+      qualification.artifact.workflowRunAttempt > qualification.workflow.attempt
+    )
+      context.addIssue({
+        code: 'custom',
+        message:
+          'Candidate artifact was produced after the qualified run attempt',
+        path: ['artifact', 'workflowRunAttempt']
+      })
+  })
+
+export type CandidateQualification = z.infer<
+  typeof candidateQualificationSchema
+>
+
 export function sameWorkflowQualification(
   existing: WorkflowEvidence,
   current: WorkflowEvidence
@@ -110,6 +161,16 @@ export function sameWorkflowQualification(
     existing.requiredJobManifestVersion ===
       current.requiredJobManifestVersion &&
     JSON.stringify(existing.jobs) === JSON.stringify(current.jobs)
+  )
+}
+
+export function sameCandidateQualification(
+  existing: CandidateQualification,
+  current: CandidateQualification
+): boolean {
+  return (
+    sameWorkflowQualification(existing.workflow, current.workflow) &&
+    JSON.stringify(existing.artifact) === JSON.stringify(current.artifact)
   )
 }
 
@@ -223,7 +284,7 @@ export const handoffReceiptSchema = z
         qualificationInputFingerprint: fingerprintSchema,
         deliveryInputFingerprint: fingerprintSchema,
         toolchainHash: fingerprintSchema,
-        candidate: workflowEvidenceSchema
+        candidate: candidateQualificationSchema
       })
       .strict(),
     phases: z.array(handoffPhaseSchema).length(handoffPhases.length)
@@ -316,7 +377,7 @@ export function sameHandoffApplicationIdentity(
   const { candidate: currentCandidate, ...currentInputs } = current
   return (
     JSON.stringify(existingInputs) === JSON.stringify(currentInputs) &&
-    sameWorkflowQualification(existingCandidate, currentCandidate)
+    sameCandidateQualification(existingCandidate, currentCandidate)
   )
 }
 

--- a/scripts/handoff-local-app.ts
+++ b/scripts/handoff-local-app.ts
@@ -19,7 +19,6 @@ import {
 } from './build-identity.js'
 import {
   acquireCandidateArtifact,
-  candidateArtifactName,
   verifyCandidateArtifactDirectory,
   type CandidateArtifactExpectation
 } from './candidate-artifact.js'
@@ -97,10 +96,10 @@ assertHandoffResourcePreflight(
   )
 )
 const artifactExpectation: CandidateArtifactExpectation = {
-  repository: githubRepository(),
+  repository: candidateState.candidate!.artifact.repository,
   workflowName: readRequiredJobManifest().workflowName,
-  workflowRunId: candidateState.candidate!.runId,
-  workflowRunAttempt: candidateState.candidate!.attempt,
+  workflowRunId: candidateState.candidate!.artifact.workflowRunId,
+  workflowRunAttempt: candidateState.candidate!.artifact.workflowRunAttempt,
   applicationSha: workspace.commit,
   workspaceFingerprint: workspace.workspaceFingerprint,
   appBuildInputFingerprint: workspace.appBuildInputFingerprint
@@ -494,12 +493,9 @@ function downloadCandidateArtifact(destination: string): void {
     [
       'run',
       'download',
-      String(candidateState.candidate!.runId),
+      String(candidateState.candidate!.artifact.workflowRunId),
       '--name',
-      candidateArtifactName(
-        workspace.commit,
-        candidateState.candidate!.attempt
-      ),
+      candidateState.candidate!.artifact.artifactName,
       '--dir',
       destination
     ],
@@ -512,28 +508,6 @@ function downloadCandidateArtifact(destination: string): void {
   if (result.error) throw result.error
   if (result.status !== 0)
     throw new Error(`Candidate artifact download failed with ${result.status}`)
-}
-
-function githubRepository(): string {
-  const result = spawnSync(
-    'gh',
-    ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
-    {
-      cwd: workspaceRoot,
-      env: process.env,
-      encoding: 'utf8'
-    }
-  )
-  if (result.error) throw result.error
-  if (result.status !== 0)
-    throw new Error(
-      result.stderr.trim() ||
-        'Could not resolve the authenticated GitHub repository'
-    )
-  const repository = result.stdout.trim()
-  if (!/^[^/\s]+\/[^/\s]+$/.test(repository))
-    throw new Error('GitHub returned an invalid repository identity')
-  return repository
 }
 
 function atomicWrite(path: string, content: string): void {

--- a/scripts/handoff-status.ts
+++ b/scripts/handoff-status.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { readCandidateState } from './candidate-delivery.js'
+import {
+  assertHandoffResourcePreflight,
+  readHandoffResourceSnapshot
+} from './handoff-preflight.js'
+import { localInstallationPaths } from './local-app-installation.js'
+
+const workspaceRoot = process.cwd()
+const xdgDataHome =
+  process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
+const installation = localInstallationPaths(xdgDataHome)
+let candidate: unknown = null
+let candidateError: string | null = null
+
+try {
+  candidate = readCandidateState()
+} catch (error) {
+  candidateError = error instanceof Error ? error.message : String(error)
+}
+
+const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: workspaceRoot,
+  encoding: 'utf8'
+}).trim()
+const resources = readHandoffResourceSnapshot(
+  workspaceRoot,
+  installation.root,
+  installation.campaignData
+)
+let resourceError: string | null = null
+try {
+  assertHandoffResourcePreflight(resources)
+} catch (error) {
+  resourceError = error instanceof Error ? error.message : String(error)
+}
+
+const statePath = resolve(
+  workspaceRoot,
+  '.tmp',
+  'handoff-local-app',
+  'states',
+  `${head}.json`
+)
+
+console.info(
+  JSON.stringify(
+    {
+      component: 'local-handoff',
+      event: 'status',
+      ready: candidateError === null && resourceError === null,
+      head,
+      candidate,
+      candidateError,
+      resources,
+      resourceError,
+      resume: {
+        available: existsSync(statePath),
+        statePath
+      }
+    },
+    null,
+    2
+  )
+)

--- a/scripts/promote-candidate.ts
+++ b/scripts/promote-candidate.ts
@@ -8,7 +8,8 @@ console.info(
     event: 'candidate-promoted',
     sha: state.head,
     previousMain: state.remoteMain,
-    check: state.candidate?.url,
-    requiredJobs: state.candidate?.jobs
+    check: state.candidate?.workflow.url,
+    requiredJobs: state.candidate?.workflow.jobs,
+    artifact: state.candidate?.artifact
   })
 )

--- a/scripts/verify-candidate.ts
+++ b/scripts/verify-candidate.ts
@@ -1,13 +1,55 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import {
+  acquireCandidateArtifact,
+  type CandidateArtifactExpectation
+} from './candidate-artifact.js'
 import { assertCandidateReady } from './candidate-delivery.js'
-import { readWorkspaceInputFingerprints } from './build-identity.js'
+import {
+  readWorkspaceIdentity,
+  readWorkspaceInputFingerprints
+} from './build-identity.js'
+import { readRequiredJobManifest } from './delivery-contract.js'
 
 const state = assertCandidateReady()
+const workspaceRoot = process.cwd()
+const workspace = readWorkspaceIdentity(workspaceRoot)
 const inputFingerprints = readWorkspaceInputFingerprints()
+const candidate = state.candidate!
+const expectation: CandidateArtifactExpectation = {
+  repository: candidate.artifact.repository,
+  workflowName: readRequiredJobManifest().workflowName,
+  workflowRunId: candidate.artifact.workflowRunId,
+  workflowRunAttempt: candidate.artifact.workflowRunAttempt,
+  applicationSha: workspace.commit,
+  workspaceFingerprint: workspace.workspaceFingerprint,
+  appBuildInputFingerprint: workspace.appBuildInputFingerprint
+}
+const artifact = acquireCandidateArtifact({
+  destinationRoot: resolve(workspaceRoot, 'release', 'local'),
+  expected: expectation,
+  download: (destination) =>
+    execFileSync(
+      'gh',
+      [
+        'run',
+        'download',
+        String(candidate.artifact.workflowRunId),
+        '--name',
+        candidate.artifact.artifactName,
+        '--dir',
+        destination
+      ],
+      { cwd: workspaceRoot, stdio: 'inherit' }
+    )
+})
 console.info(
   JSON.stringify({
     component: 'candidate-delivery',
     event: 'candidate-verified',
     ...state,
-    inputFingerprints
+    inputFingerprints,
+    artifactReceipt: artifact.receiptPath,
+    artifactSha256: artifact.receipt.artifactSha256
   })
 )

--- a/src/shared/contracts/local-persistence-format-versions.ts
+++ b/src/shared/contracts/local-persistence-format-versions.ts
@@ -3,7 +3,7 @@ export const localPersistenceFormatVersions = Object.freeze({
   localArtifactManifest: 2,
   campaignLifecycleReceipt: 2,
   localInstallJournal: 2,
-  handoffReceipt: 6,
+  handoffReceipt: 7,
   handoffInvocationHistory: 2,
   candidateArtifactReceipt: 1,
   campaignBackupManifest: 1,

--- a/tests/unit/candidate-delivery.test.ts
+++ b/tests/unit/candidate-delivery.test.ts
@@ -9,6 +9,7 @@ import {
   parseRemoteHead,
   postPromotionJobName,
   requiresApplicationHandoff,
+  selectCandidateArtifactEvidence,
   successfulCandidateEvidence,
   successfulPostPromotionEvidence,
   type CandidateState
@@ -37,15 +38,25 @@ const valid: CandidateState = {
   clean: true,
   mainIsAncestor: true,
   candidate: {
-    runId: 1,
-    url: 'https://github.example/check/1',
-    attempt: 1,
-    headSha: 'b'.repeat(40),
-    requiredJobManifestVersion: 4,
-    jobs: readRequiredJobManifest().jobs.map((job) => ({
-      ...job,
-      conclusion: 'success' as const
-    }))
+    workflow: {
+      runId: 1,
+      url: 'https://github.example/check/1',
+      attempt: 2,
+      headSha: 'b'.repeat(40),
+      requiredJobManifestVersion: 4,
+      jobs: readRequiredJobManifest().jobs.map((job) => ({
+        ...job,
+        conclusion: 'success' as const
+      }))
+    },
+    artifact: {
+      repository: 'owner/repository',
+      artifactId: 10,
+      artifactName: `salt-marcher-local-${'b'.repeat(40)}-attempt-1`,
+      workflowRunId: 1,
+      workflowRunAttempt: 1,
+      applicationSha: 'b'.repeat(40)
+    }
   }
 }
 
@@ -114,6 +125,54 @@ describe('candidate delivery policy', () => {
       successfulPostPromotionEvidence(
         { ...run, jobs: [{ ...run.jobs[0]!, conclusion: 'skipped' }] },
         valid.head
+      )
+    ).toBeNull()
+  })
+
+  it('selects an exact, unexpired artifact independently of the aggregate attempt', () => {
+    const sha = valid.head
+    expect(
+      selectCandidateArtifactEvidence(
+        [
+          {
+            id: 12,
+            name: `salt-marcher-local-${sha}-attempt-3`,
+            expired: false
+          },
+          {
+            id: 11,
+            name: `salt-marcher-local-${sha}-attempt-1`,
+            expired: false
+          },
+          {
+            id: 10,
+            name: `salt-marcher-local-${sha}-attempt-2`,
+            expired: true
+          }
+        ],
+        {
+          repository: 'owner/repository',
+          workflowRunId: 7,
+          workflowRunAttempt: 2,
+          applicationSha: sha
+        }
+      )
+    ).toMatchObject({ artifactId: 11, workflowRunAttempt: 1 })
+    expect(
+      selectCandidateArtifactEvidence(
+        [
+          {
+            id: 1,
+            name: `salt-marcher-local-${'c'.repeat(40)}-attempt-1`,
+            expired: false
+          }
+        ],
+        {
+          repository: 'owner/repository',
+          workflowRunId: 7,
+          workflowRunAttempt: 2,
+          applicationSha: sha
+        }
       )
     ).toBeNull()
   })
@@ -253,9 +312,11 @@ describe('candidate delivery policy', () => {
         valid.head,
         {
           ...valid.candidate!,
-          runId: 2,
-          url: 'https://github.example/check/2',
-          attempt: 2
+          workflow: {
+            ...valid.candidate!.workflow,
+            url: 'https://github.example/check/1?attempt=2',
+            attempt: 2
+          }
         },
         root
       )

--- a/tests/unit/ci-workflow-policy.test.ts
+++ b/tests/unit/ci-workflow-policy.test.ts
@@ -73,7 +73,12 @@ describe('CI platform partitions', () => {
     () => {
       expect(handoff).toContain("'gh'")
       expect(handoff).toContain("'download'")
-      expect(handoff).toContain('candidateArtifactName(')
+      expect(handoff).toContain(
+        'candidateState.candidate!.artifact.artifactName'
+      )
+      expect(handoff).toContain(
+        'candidateState.candidate!.artifact.workflowRunAttempt'
+      )
       expect(handoff).toContain('verifyCandidateArtifactDirectory')
       expect(handoff).not.toContain("run('checked', ['pnpm', 'check'])")
       expect(handoff).not.toContain(

--- a/tests/unit/delivery-contract.test.ts
+++ b/tests/unit/delivery-contract.test.ts
@@ -162,9 +162,11 @@ describe('delivery contract', () => {
       ...identity(),
       candidate: {
         ...identity().candidate,
-        runId: 456,
-        url: 'https://github.example/actions/runs/456',
-        attempt: 3
+        workflow: {
+          ...identity().candidate.workflow,
+          url: 'https://github.example/actions/runs/123?attempt=3',
+          attempt: 3
+        }
       }
     }
     expect(sameHandoffApplicationIdentity(existing, current)).toBe(true)
@@ -179,7 +181,19 @@ describe('delivery contract', () => {
         ...current,
         candidate: {
           ...current.candidate,
-          jobs: current.candidate.jobs.slice(1)
+          workflow: {
+            ...current.candidate.workflow,
+            jobs: current.candidate.workflow.jobs.slice(1)
+          }
+        }
+      })
+    ).toBe(false)
+    expect(
+      sameHandoffApplicationIdentity(existing, {
+        ...current,
+        candidate: {
+          ...current.candidate,
+          artifact: { ...current.candidate.artifact, artifactId: 999 }
         }
       })
     ).toBe(false)
@@ -225,10 +239,20 @@ function identity() {
     qualificationInputFingerprint: 'd'.repeat(64),
     deliveryInputFingerprint: 'e'.repeat(64),
     toolchainHash: 'f'.repeat(64),
-    candidate: verifyRequiredJobs(
-      readRequiredJobManifest(),
-      successfulRun(),
-      sha
-    )
+    candidate: {
+      workflow: verifyRequiredJobs(
+        readRequiredJobManifest(),
+        successfulRun(),
+        sha
+      ),
+      artifact: {
+        repository: 'owner/repository',
+        artifactId: 12,
+        artifactName: `salt-marcher-local-${sha}-attempt-1`,
+        workflowRunId: 123,
+        workflowRunAttempt: 1,
+        applicationSha: sha
+      }
+    }
   }
 }

--- a/tests/unit/handoff-state-machine.test.ts
+++ b/tests/unit/handoff-state-machine.test.ts
@@ -175,18 +175,28 @@ function createFixture(failOnce?: HandoffPhaseName): {
       deliveryInputFingerprint: 'e'.repeat(64),
       toolchainHash: 'f'.repeat(64),
       candidate: {
-        runId: 1,
-        url: 'https://github.example/runs/1',
-        attempt: 1,
-        headSha: 'a'.repeat(40),
-        requiredJobManifestVersion: 4,
-        jobs: [
-          {
-            name: 'required',
-            platformRole: 'test',
-            conclusion: 'success'
-          }
-        ]
+        workflow: {
+          runId: 1,
+          url: 'https://github.example/runs/1',
+          attempt: 1,
+          headSha: 'a'.repeat(40),
+          requiredJobManifestVersion: 4,
+          jobs: [
+            {
+              name: 'required',
+              platformRole: 'test',
+              conclusion: 'success'
+            }
+          ]
+        },
+        artifact: {
+          repository: 'owner/repository',
+          artifactId: 1,
+          artifactName: `salt-marcher-local-${'a'.repeat(40)}-attempt-1`,
+          workflowRunId: 1,
+          workflowRunAttempt: 1,
+          applicationSha: 'a'.repeat(40)
+        }
       }
     },
     '00000000-0000-4000-8000-000000000010',

--- a/tests/unit/local-persistence-format-versions.test.ts
+++ b/tests/unit/local-persistence-format-versions.test.ts
@@ -12,7 +12,7 @@ describe('local persistence format allowlist', () => {
       localArtifactManifest: 2,
       campaignLifecycleReceipt: 2,
       localInstallJournal: 2,
-      handoffReceipt: 6,
+      handoffReceipt: 7,
       handoffInvocationHistory: 2,
       candidateArtifactReceipt: 1,
       campaignBackupManifest: 1,


### PR DESCRIPTION
Implements roadmap phase 1.\n\n- separates successful Check aggregate evidence from artifact-producing attempt\n- validates and reuses the exact CI Local artifact\n- records both proofs in handoff receipt v7\n- adds read-only handoff status diagnostics\n\nLocal verification: pnpm check