### PR TITLE
Phase 3: SQLite online backup snapshots

### DIFF
--- a/scripts/local-app-installation.ts
+++ b/scripts/local-app-installation.ts
@@ -186,7 +186,6 @@ function advanceLocalAppInstallationLocked(
         paths,
         options.schemaMigrations
       )
-      const sourceDataHash = campaignDataHash(paths)
       const backup = backupCampaignData(
         paths,
         manifest.receipt.build,
@@ -194,6 +193,7 @@ function advanceLocalAppInstallationLocked(
         preflight.databases,
         now
       )
+      const sourceDataHash = backup?.sourceDataHash ?? campaignDataHash(paths)
       updateJournal({
         phase: 'backup-complete',
         backupPath: backup?.path ?? null,

--- a/scripts/local-installation/campaign-backup.ts
+++ b/scripts/local-installation/campaign-backup.ts
@@ -2,11 +2,15 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   renameSync,
   writeFileSync
 } from 'node:fs'
-import { join, relative, sep } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { randomUUID } from 'node:crypto'
 import Database from 'better-sqlite3'
 import { z } from 'zod'
@@ -28,16 +32,32 @@ import {
 import {
   copyTreeWithHashes,
   directoryHasEntries,
-  durableCampaignFileInventory,
   hashFileInventory,
   hashTree,
-  hashTreeOrEmpty
+  sqliteOwnedBackupInventory
 } from './campaign-file-inventory.js'
 
 export function campaignDataHash(paths: LocalInstallationPaths): string {
-  return hashFileInventory(
-    durableCampaignFileInventory(hashTreeOrEmpty(paths.campaignData))
-  )
+  if (!directoryHasEntries(paths.campaignData)) return hashFileInventory([])
+  const snapshot = join(tmpdir(), `salt-marcher-backup-hash-${randomUUID()}`)
+  try {
+    return hashFileInventory(
+      snapshotCampaignData(
+        paths.campaignData,
+        snapshot,
+        sqliteDatabasePaths(paths.campaignData)
+      )
+    )
+  } catch (error) {
+    if (error instanceof LocalInstallationError) throw error
+    throw new LocalInstallationError(
+      'data-corrupt',
+      'Campaign data could not be fingerprinted through SQLite snapshots',
+      { cause: error }
+    )
+  } finally {
+    rmSync(snapshot, { recursive: true, force: true })
+  }
 }
 
 export function validateBackupCheckpoint(
@@ -72,6 +92,9 @@ export function validateBackupCheckpoint(
   assertCurrentLocalPersistenceVersion(raw, 'campaignBackupManifest')
   const backupManifest = z
     .object({
+      snapshotMethod: z.literal('sqlite-online-backup'),
+      sourceDataHash: z.string().regex(/^[a-f0-9]{64}$/),
+      databases: z.array(z.object({ path: z.string().min(1) }).passthrough()),
       files: z.array(
         z
           .object({
@@ -84,10 +107,14 @@ export function validateBackupCheckpoint(
     })
     .passthrough()
     .parse(raw)
-  const actualFiles = hashTree(journal.backupPath).filter(
-    ({ path }) => path !== 'backup-manifest.json'
+  const actualFiles = sqliteOwnedBackupInventory(
+    hashTree(journal.backupPath).filter(
+      ({ path }) => path !== 'backup-manifest.json'
+    ),
+    backupManifest.databases.map(({ path }) => path)
   )
   if (
+    backupManifest.sourceDataHash !== journal.sourceDataHash ||
     JSON.stringify(actualFiles) !== JSON.stringify(backupManifest.files) ||
     hashFileInventory(actualFiles) !== journal.sourceDataHash
   )
@@ -103,7 +130,13 @@ export function backupCampaignData(
   previousBuild: unknown,
   sourceDatabases: readonly PreflightDatabase[],
   now: () => Date
-): { readonly path: string; readonly manifestSha256: string } | undefined {
+):
+  | {
+      readonly path: string
+      readonly manifestSha256: string
+      readonly sourceDataHash: string
+    }
+  | undefined {
   if (!directoryHasEntries(paths.campaignData)) return undefined
   mkdirSync(paths.backups, { recursive: true })
   const token = randomUUID()
@@ -114,33 +147,22 @@ export function backupCampaignData(
     `${timestamp}-${shortBuildFingerprint(nextBuild)}-${token.slice(0, 8)}`
   )
   try {
-    const copiedHashes = copyTreeWithHashes(paths.campaignData, staging)
-    const sourceHashes = durableCampaignFileInventory(copiedHashes)
-    const durablePaths = new Set(sourceHashes.map(({ path }) => path))
-    for (const file of copiedHashes)
-      if (!durablePaths.has(file.path))
-        rmSync(join(staging, ...file.path.split('/')), { force: true })
-    if (JSON.stringify(hashTree(staging)) !== JSON.stringify(sourceHashes))
-      throw new Error('Backup hashes differ from campaign data')
+    const databasePaths = sourceDatabases.map(({ path }) => path)
+    snapshotCampaignData(paths.campaignData, staging, databasePaths)
     const copiedDatabases = sourceDatabases.map((database) =>
       join(staging, relative(paths.campaignData, database.path))
     )
     validateDatabases(copiedDatabases)
-    // Opening a copied WAL database read-only may create SQLite sidecars in
-    // the backup. They are validation artifacts, not source bytes. Remove only
-    // paths absent from the source inventory, then prove exact equality again.
-    const sourcePaths = new Set(sourceHashes.map(({ path }) => path))
-    for (const file of hashTree(staging))
-      if (!sourcePaths.has(file.path))
-        rmSync(join(staging, ...file.path.split('/')), { force: true })
-    if (JSON.stringify(hashTree(staging)) !== JSON.stringify(sourceHashes))
-      throw new Error('Database validation changed verified backup bytes')
+    removeDatabaseSidecars(copiedDatabases)
+    const sourceHashes = hashTree(staging)
+    const sourceDataHash = hashFileInventory(sourceHashes)
     const backupManifestPath = join(staging, 'backup-manifest.json')
     writeFileSync(
       backupManifestPath,
       `${JSON.stringify(
         {
           formatVersion: localPersistenceFormatVersions.campaignBackupManifest,
+          snapshotMethod: 'sqlite-online-backup',
           createdAt: now().toISOString(),
           previousBuild,
           nextBuild,
@@ -152,6 +174,7 @@ export function backupCampaignData(
             schemaVersion: database.schemaVersion,
             expectedVersion: database.expectedVersion
           })),
+          sourceDataHash,
           files: sourceHashes
         },
         null,
@@ -162,7 +185,8 @@ export function backupCampaignData(
     renameSync(staging, target)
     return {
       path: target,
-      manifestSha256: sha256File(join(target, 'backup-manifest.json'))
+      manifestSha256: sha256File(join(target, 'backup-manifest.json')),
+      sourceDataHash
     }
   } catch (error) {
     rmSync(staging, { recursive: true, force: true })
@@ -173,6 +197,68 @@ export function backupCampaignData(
       { cause: error }
     )
   }
+}
+
+function removeDatabaseSidecars(databasePaths: readonly string[]): void {
+  for (const databasePath of databasePaths)
+    for (const suffix of ['-wal', '-shm'])
+      rmSync(`${databasePath}${suffix}`, { force: true })
+}
+
+function snapshotCampaignData(
+  sourceRoot: string,
+  targetRoot: string,
+  databasePaths: readonly string[]
+): ReturnType<typeof hashTree> {
+  const owned = new Set(
+    databasePaths.flatMap((path) => {
+      const relativePath = relative(sourceRoot, path).split(sep).join('/')
+      return [relativePath, `${relativePath}-wal`, `${relativePath}-shm`]
+    })
+  )
+  copyTreeWithHashes(sourceRoot, targetRoot, (path) => !owned.has(path))
+  for (const source of databasePaths) {
+    const destination = join(targetRoot, relative(sourceRoot, source))
+    mkdirSync(dirname(destination), { recursive: true })
+    onlineBackupDatabase(source, destination)
+  }
+  return hashTree(targetRoot)
+}
+
+function onlineBackupDatabase(source: string, destination: string): void {
+  const worker = fileURLToPath(
+    new URL('../sqlite-online-backup-worker.ts', import.meta.url)
+  )
+  const result = spawnSync(
+    process.execPath,
+    ['--import', 'tsx', worker, source, destination],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+  )
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(
+      `SQLite online backup failed for ${source}: ${result.stderr.trim() || `exit ${result.status}`}`
+    )
+}
+
+function sqliteDatabasePaths(root: string): string[] {
+  if (!existsSync(root)) return []
+  const paths: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      if (entry.isSymbolicLink())
+        throw new LocalInstallationError(
+          'data-corrupt',
+          `Campaign data must not contain symbolic links: ${path}`
+        )
+      if (entry.isDirectory()) visit(path)
+      else if (entry.isFile() && entry.name.endsWith('.sqlite'))
+        paths.push(path)
+    }
+  }
+  visit(root)
+  return paths.sort((left, right) => left.localeCompare(right, 'en'))
 }
 
 function validateDatabases(paths: readonly string[]): void {

--- a/scripts/local-installation/campaign-file-inventory.ts
+++ b/scripts/local-installation/campaign-file-inventory.ts
@@ -32,27 +32,29 @@ export function hashTreeOrEmpty(root: string): FileHash[] {
   return existsSync(root) ? hashTree(root) : []
 }
 
-export function durableCampaignFileInventory(
-  files: readonly FileHash[]
-): FileHash[] {
-  return files.filter(
-    ({ path, bytes }) =>
-      !path.endsWith('-shm') && !(path.endsWith('-wal') && bytes === 0)
-  )
-}
-
 export function hashFileInventory(files: readonly FileHash[]): string {
   return createHash('sha256').update(JSON.stringify(files)).digest('hex')
+}
+
+export function sqliteOwnedBackupInventory(
+  files: readonly FileHash[],
+  databasePaths: readonly string[]
+): FileHash[] {
+  const sidecars = new Set(
+    databasePaths.flatMap((path) => [`${path}-wal`, `${path}-shm`])
+  )
+  return files.filter(({ path }) => !sidecars.has(path))
 }
 
 /** Copies and hashes each source byte in the same pass; verification rereads only the backup. */
 export function copyTreeWithHashes(
   sourceRoot: string,
-  targetRoot: string
+  targetRoot: string,
+  include: (relativePath: string) => boolean = () => true
 ): FileHash[] {
   mkdirSync(targetRoot, { recursive: false })
   const hashes: FileHash[] = []
-  copyDirectory(sourceRoot, targetRoot, sourceRoot, hashes)
+  copyDirectory(sourceRoot, targetRoot, sourceRoot, hashes, include)
   syncPath(targetRoot)
   return hashes.sort((left, right) => left.path.localeCompare(right.path, 'en'))
 }
@@ -65,7 +67,8 @@ function copyDirectory(
   sourceDirectory: string,
   targetDirectory: string,
   sourceRoot: string,
-  hashes: FileHash[]
+  hashes: FileHash[],
+  include: (relativePath: string) => boolean
 ): void {
   for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
     const source = join(sourceDirectory, entry.name)
@@ -77,7 +80,7 @@ function copyDirectory(
       )
     if (entry.isDirectory()) {
       mkdirSync(target)
-      copyDirectory(source, target, sourceRoot, hashes)
+      copyDirectory(source, target, sourceRoot, hashes, include)
       syncPath(target)
       continue
     }
@@ -86,7 +89,9 @@ function copyDirectory(
         'data-corrupt',
         `Unsupported campaign data entry: ${source}`
       )
-    hashes.push(copyFileWithHash(source, target, sourceRoot))
+    const relativePath = relative(sourceRoot, source).split(sep).join('/')
+    if (include(relativePath))
+      hashes.push(copyFileWithHash(source, target, sourceRoot))
   }
 }
 

--- a/scripts/local-installation/campaign-migration.ts
+++ b/scripts/local-installation/campaign-migration.ts
@@ -20,11 +20,7 @@ import {
   LocalInstallationError,
   type LocalInstallationPaths
 } from './contract.js'
-import {
-  durableCampaignFileInventory,
-  hashFileInventory,
-  hashTreeOrEmpty
-} from './campaign-file-inventory.js'
+import { campaignDataHash } from './campaign-backup.js'
 
 export function readPersistencePreflight(
   paths: LocalInstallationPaths,
@@ -93,9 +89,7 @@ export function migrateCampaignData(
         throw new Error('Promoted persistence failed validation')
       updateJournal({ phase: 'data-promoted' })
       updateJournal({
-        campaignDataHash: hashFileInventory(
-          durableCampaignFileInventory(hashTreeOrEmpty(paths.campaignData))
-        )
+        campaignDataHash: campaignDataHash(paths)
       })
       rmSync(rollback, { recursive: true, force: true })
     } catch (error) {

--- a/scripts/local-storage/compatibility.ts
+++ b/scripts/local-storage/compatibility.ts
@@ -51,9 +51,9 @@ export function inspectCompatibility(
         backup.name,
         backup.path,
         'current',
-        'campaign-backup-manifest-v1',
+        'campaign-backup-manifest-v2',
         false,
-        'Version one is the current immutable backup envelope'
+        'Version two is the current SQLite snapshot backup envelope'
       )
     )
     scanDatabases(backup.path, 'backup', false, artifacts)
@@ -67,18 +67,22 @@ export function inspectCompatibility(
   }
   for (const finding of options.findings.filter(
     ({ area }) => area === 'backups'
-  ))
+  )) {
+    const legacy = finding.reason.startsWith(
+      'Legacy campaign backup manifest v1'
+    )
     artifacts.push(
       artifact(
         'backup',
         finding.name,
         join(options.paths.backups, finding.name),
-        'unknown-invalid',
-        'unverified',
+        legacy ? 'unsupported-obsolete' : 'unknown-invalid',
+        legacy ? 'campaign-backup-manifest-v1' : 'unverified',
         false,
         finding.reason
       )
     )
+  }
 
   for (const deployment of options.deployments)
     artifacts.push(

--- a/scripts/local-storage/inspection.ts
+++ b/scripts/local-storage/inspection.ts
@@ -16,7 +16,11 @@ import {
 import { sha256File } from '../file-hash.js'
 import { readInstallJournal } from '../local-install-journal.js'
 import type { LocalInstallationPaths } from '../local-installation/contract.js'
-import { hashTree } from '../local-installation/campaign-file-inventory.js'
+import {
+  hashFileInventory,
+  hashTree,
+  sqliteOwnedBackupInventory
+} from '../local-installation/campaign-file-inventory.js'
 import {
   backupBytesWarningThreshold,
   backupCountWarningThreshold,
@@ -51,6 +55,9 @@ const backupManifestSchema = z
       localPersistenceFormatVersions.campaignBackupManifest
     ),
     createdAt: z.iso.datetime(),
+    snapshotMethod: z.literal('sqlite-online-backup'),
+    sourceDataHash: z.string().regex(/^[a-f0-9]{64}$/),
+    databases: z.array(z.object({ path: z.string().min(1) }).passthrough()),
     files: z.array(
       z
         .object({
@@ -133,7 +140,11 @@ export function inspectLocalStorage(
       inspectedBackups.push(validateBackupDirectory(path, name, bytes))
     } catch (error) {
       backupBytes += bestEffortBytes(path)
-      findings.push({ area: 'backups', name, reason: errorMessage(error) })
+      findings.push({
+        area: 'backups',
+        name,
+        reason: backupFindingReason(path, error)
+      })
     }
   }
   const newestBackups = new Set(
@@ -182,6 +193,19 @@ export function inspectLocalStorage(
     warnings,
     compatibility
   }
+}
+
+function backupFindingReason(path: string, error: unknown): string {
+  try {
+    const value = JSON.parse(
+      readFileSync(join(path, 'backup-manifest.json'), 'utf8')
+    ) as Record<string, unknown>
+    if (value['formatVersion'] === 1)
+      return 'Legacy campaign backup manifest v1 is preserved; automatic restore and pruning are unsupported'
+  } catch {
+    // Preserve the original ownership/validation failure below.
+  }
+  return errorMessage(error)
 }
 
 export function validateDeploymentDirectory(
@@ -250,11 +274,16 @@ export function validateBackupDirectory(
   const raw: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'))
   assertCurrentLocalPersistenceVersion(raw, 'campaignBackupManifest')
   const manifest = backupManifestSchema.parse(raw)
-  const actual = hashTree(path).filter(
-    ({ path: relativePath }) => relativePath !== 'backup-manifest.json'
+  const actual = sqliteOwnedBackupInventory(
+    hashTree(path).filter(
+      ({ path: relativePath }) => relativePath !== 'backup-manifest.json'
+    ),
+    manifest.databases.map((database) => database.path)
   )
   if (JSON.stringify(actual) !== JSON.stringify(manifest.files))
     throw new Error('Backup file inventory or hashes are invalid')
+  if (hashFileInventory(actual) !== manifest.sourceDataHash)
+    throw new Error('Backup logical data fingerprint is invalid')
   return {
     name,
     path,

--- a/scripts/sqlite-online-backup-worker.ts
+++ b/scripts/sqlite-online-backup-worker.ts
@@ -1,0 +1,12 @@
+import Database from 'better-sqlite3'
+
+const [source, destination] = process.argv.slice(2)
+if (!source || !destination)
+  throw new Error('SQLite online backup requires source and destination paths')
+
+const database = new Database(source, { readonly: true, fileMustExist: true })
+try {
+  await database.backup(destination)
+} finally {
+  database.close()
+}

--- a/src/shared/contracts/local-persistence-format-versions.ts
+++ b/src/shared/contracts/local-persistence-format-versions.ts
@@ -6,7 +6,7 @@ export const localPersistenceFormatVersions = Object.freeze({
   handoffReceipt: 7,
   handoffInvocationHistory: 2,
   candidateArtifactReceipt: 1,
-  campaignBackupManifest: 1,
+  campaignBackupManifest: 2,
   localProfileLock: 1,
   localStorageInspection: 1,
   localStorageCompatibilityInspection: 1,

--- a/tests/support/local-storage-fixture.ts
+++ b/tests/support/local-storage-fixture.ts
@@ -99,8 +99,11 @@ export function createLocalStorageFixture(): LocalStorageFixture {
       writeFileSync(
         join(path, 'backup-manifest.json'),
         JSON.stringify({
-          formatVersion: 1,
+          formatVersion: 2,
+          snapshotMethod: 'sqlite-online-backup',
           createdAt,
+          sourceDataHash: hash(JSON.stringify(hashTree(path))),
+          databases: [{ path: 'campaign.sqlite' }],
           files: hashTree(path)
         })
       )

--- a/tests/unit/local-app-installation.test.ts
+++ b/tests/unit/local-app-installation.test.ts
@@ -129,7 +129,7 @@ describe('local AppImage installation', () => {
     expect(campaignDataHash(paths)).toBe(before)
   })
 
-  it('preserves a non-empty WAL without retaining its disposable SHM file', () => {
+  it('captures committed WAL data in one standalone SQLite snapshot', () => {
     const fixture = createFixture(build('a'))
     const paths = localInstallationPaths(fixture.xdg)
     createDatabase(paths.campaignData, schemaVersion)
@@ -160,10 +160,18 @@ describe('local AppImage installation', () => {
         relative(paths.campaignData, campaignPath)
       )
       expect(existsSync(`${backupCampaign}-shm`)).toBe(false)
-      expect(existsSync(`${backupCampaign}-wal`)).toBe(true)
-      expect(readFileSync(`${backupCampaign}-wal`).byteLength).toBeGreaterThan(
-        0
-      )
+      expect(existsSync(`${backupCampaign}-wal`)).toBe(false)
+      const snapshot = new Database(backupCampaign, {
+        readonly: true,
+        fileMustExist: true
+      })
+      try {
+        expect(
+          snapshot.prepare('SELECT content FROM valuable').pluck().all()
+        ).toContain('still in WAL')
+      } finally {
+        snapshot.close()
+      }
 
       const repeated = advanceLocalAppInstallation(
         fixture.options,
@@ -277,16 +285,25 @@ describe('local AppImage installation', () => {
     fixture.useBuild(build('b'))
     const second = installLocalApp(fixture.options)
     expect(second.backupPath).toBeDefined()
-    expect(
-      readFileSync(join(second.backupPath!, 'installation.sqlite'))
-    ).toEqual(originalDatabase)
+    const backupDatabase = readFileSync(
+      join(second.backupPath!, 'installation.sqlite')
+    )
+    expect(backupDatabase).not.toHaveLength(0)
     const backupManifest = JSON.parse(
       readFileSync(join(second.backupPath!, 'backup-manifest.json'), 'utf8')
-    ) as { files: Array<{ path: string; sha256: string }> }
+    ) as {
+      formatVersion: number
+      snapshotMethod: string
+      files: Array<{ path: string; bytes: number; sha256: string }>
+    }
+    expect(backupManifest).toMatchObject({
+      formatVersion: 2,
+      snapshotMethod: 'sqlite-online-backup'
+    })
     expect(backupManifest.files).toContainEqual({
       path: 'installation.sqlite',
-      bytes: originalDatabase.length,
-      sha256: hash(originalDatabase)
+      bytes: backupDatabase.length,
+      sha256: hash(backupDatabase)
     })
     expect(backupManifest.files).toContainEqual({
       path: 'notes.txt',

--- a/tests/unit/local-persistence-format-versions.test.ts
+++ b/tests/unit/local-persistence-format-versions.test.ts
@@ -15,7 +15,7 @@ describe('local persistence format allowlist', () => {
       handoffReceipt: 7,
       handoffInvocationHistory: 2,
       candidateArtifactReceipt: 1,
-      campaignBackupManifest: 1,
+      campaignBackupManifest: 2,
       localProfileLock: 1,
       localStorageInspection: 1,
       localStorageCompatibilityInspection: 1,
@@ -24,7 +24,6 @@ describe('local persistence format allowlist', () => {
     })
     expect(currentVersionOneLocalPersistenceContracts).toEqual([
       'candidateArtifactReceipt',
-      'campaignBackupManifest',
       'localProfileLock',
       'localStorageInspection',
       'localStorageCompatibilityInspection',
@@ -33,13 +32,13 @@ describe('local persistence format allowlist', () => {
     ])
   })
 
-  it('distinguishes an allowlisted version one from an obsolete version one', () => {
+  it('rejects obsolete version-one envelopes after a format advances', () => {
     expect(() =>
       assertCurrentLocalPersistenceVersion(
         { formatVersion: 1 },
         'campaignBackupManifest'
       )
-    ).not.toThrow()
+    ).toThrow('Unsupported campaignBackupManifest formatVersion 1; expected 2')
     expect(() =>
       assertCurrentLocalPersistenceVersion(
         { formatVersion: 1 },

--- a/tests/unit/local-storage-prune.test.ts
+++ b/tests/unit/local-storage-prune.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { pruneLocalBackup } from '../../scripts/local-storage/backup-prune.js'
@@ -105,5 +105,42 @@ describe('manual campaign-backup pruning', () => {
     expect(storageWarnings(0, backupBytesWarningThreshold + 1)).toEqual([
       expect.objectContaining({ code: 'backup-bytes-high' })
     ])
+  })
+
+  it('recognizes and preserves legacy v1 backups without offering restore or pruning', () => {
+    const fixture = createLocalStorageFixture()
+    cleanup.push(fixture.cleanup)
+    fixture.backup('legacy', '2025-01-01T12:00:00.000Z')
+    const manifestPath = join(
+      fixture.paths.backups,
+      'legacy',
+      'backup-manifest.json'
+    )
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...manifest, formatVersion: 1 })
+    )
+
+    const inspection = inspectLocalStorage({
+      ...fixture,
+      now: () => new Date('2026-03-15T12:00:00.000Z')
+    })
+    expect(inspection.backups).toEqual([])
+    const finding = inspection.findings.find(
+      ({ area, name }) => area === 'backups' && name === 'legacy'
+    )
+    expect(finding?.reason).toContain('is preserved')
+    expect(
+      pruneLocalBackup({
+        ...fixture,
+        backup: 'legacy',
+        now: () => new Date('2026-03-15T12:00:00.000Z')
+      }).refusal
+    ).toContain('automatic restore and pruning are unsupported')
+    expect(existsSync(join(fixture.paths.backups, 'legacy'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- replace byte-copying of live SQLite databases and WAL sidecars with the better-sqlite3 Online Backup API
- introduce campaign backup manifest v2 with snapshot provenance and a logical data fingerprint
- preserve legacy v1 backup directories while explicitly excluding them from automatic restore and pruning
- validate sidecars by declared SQLite ownership instead of filename and size heuristics

## Verification
- architecture: 82 tests passed
- unit: 784 tests passed
- integration: 161 tests passed
- lint and both TypeScript checks passed
- concurrent WAL writer coverage proves committed WAL data is present in a standalone backup database