### PR TITLE
Phase 4: isolated handoff dry run

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "package:release": "corepack pnpm build:release && corepack pnpm package:release:built",
     "package:release:built": "tsx scripts/package-app.ts --channel release",
     "install:local:built": "tsx scripts/install-local-app.ts",
-    "handoff:app": "tsx scripts/handoff-local-app.ts",
+    "handoff:app": "tsx scripts/run-handoff.ts",
     "handoff:status": "tsx scripts/handoff-status.ts",
     "local-storage:inspect": "tsx scripts/inspect-local-storage.ts",
     "local-storage:prune": "tsx scripts/prune-local-storage.ts",

--- a/scripts/handoff-arguments.ts
+++ b/scripts/handoff-arguments.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path'
+
+export type HandoffArguments =
+  | Readonly<{ mode: 'canonical'; resume: boolean }>
+  | Readonly<{ mode: 'dry-run'; source: string | null }>
+
+export function parseHandoffArguments(
+  arguments_: readonly string[]
+): HandoffArguments {
+  if (arguments_.length === 0) return { mode: 'canonical', resume: false }
+  if (arguments_.length === 1 && arguments_[0] === '--resume')
+    return { mode: 'canonical', resume: true }
+  if (arguments_[0] !== '--dry-run')
+    throw new Error(
+      'Usage: pnpm handoff:app [--resume | --dry-run [--source <campaign-data-path>]]'
+    )
+  if (arguments_.includes('--resume'))
+    throw new Error('--dry-run and --resume cannot be combined')
+  if (arguments_.length === 1) return { mode: 'dry-run', source: null }
+  if (
+    arguments_.length === 3 &&
+    arguments_[1] === '--source' &&
+    arguments_[2] !== undefined
+  )
+    return { mode: 'dry-run', source: resolve(arguments_[2]) }
+  throw new Error(
+    'Usage: pnpm handoff:app --dry-run [--source <campaign-data-path>]'
+  )
+}

--- a/scripts/handoff-dry-run.ts
+++ b/scripts/handoff-dry-run.ts
@@ -1,0 +1,162 @@
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync
+} from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { localArtifactManifestSchema } from '../src/shared/contracts/build-info.js'
+import { installedRuntimeEvidenceSchema } from './delivery-contract.js'
+import { sha256File } from './file-hash.js'
+import { localInstallationPaths } from './local-app-installation.js'
+import { snapshotCampaignData } from './local-installation/campaign-backup.js'
+
+export interface HandoffDryRunOptions {
+  readonly workspaceRoot: string
+  readonly sourceCampaignData: string
+  readonly snapshot?: (source: string, destination: string) => unknown
+  readonly run?: (
+    phase: string,
+    arguments_: readonly string[],
+    environment: NodeJS.ProcessEnv
+  ) => void
+}
+
+export interface HandoffDryRunResult {
+  readonly sourceCampaignData: string
+  readonly sourceDataHash: string
+  readonly artifactSha256: string
+  readonly installedSha256: string
+  readonly runtimeEvidenceSha256: string
+}
+
+export interface HandoffDryRunCommand {
+  readonly phase: string
+  readonly arguments: readonly string[]
+}
+
+export function dryRunEnvironment(
+  root: string,
+  base: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return {
+    ...base,
+    COREPACK_HOME:
+      base['COREPACK_HOME'] ?? join(homedir(), '.cache', 'node', 'corepack'),
+    XDG_DATA_HOME: join(root, 'xdg-data'),
+    XDG_CONFIG_HOME: join(root, 'xdg-config'),
+    XDG_CACHE_HOME: join(root, 'xdg-cache'),
+    XDG_STATE_HOME: join(root, 'xdg-state'),
+    XDG_RUNTIME_DIR: join(root, 'xdg-runtime')
+  }
+}
+
+export function dryRunCommands(
+  runtimeEvidencePath: string
+): readonly HandoffDryRunCommand[] {
+  return [
+    { phase: 'build', arguments: ['pnpm', 'build:local'] },
+    {
+      phase: 'package',
+      arguments: ['pnpm', 'package:local:built']
+    },
+    {
+      phase: 'packaged-smoke',
+      arguments: ['pnpm', 'test:packaged-local-smoke:built']
+    },
+    {
+      phase: 'isolated-install',
+      arguments: ['pnpm', 'exec', 'tsx', 'scripts/install-local-app.ts']
+    },
+    {
+      phase: 'isolated-runtime',
+      arguments: [
+        'pnpm',
+        'exec',
+        'tsx',
+        'scripts/installed-runtime-verification.ts',
+        '--evidence-path',
+        runtimeEvidencePath
+      ]
+    }
+  ]
+}
+
+export function runHandoffDryRun(
+  options: HandoffDryRunOptions
+): HandoffDryRunResult {
+  if (!existsSync(options.sourceCampaignData))
+    throw new Error(
+      `Dry-run campaign data source does not exist: ${options.sourceCampaignData}`
+    )
+  const root = mkdtempSync(join(tmpdir(), 'salt-marcher-handoff-dry-run-'))
+  const xdgDataHome = join(root, 'xdg-data')
+  const paths = localInstallationPaths(xdgDataHome)
+  const runtimeEvidencePath = join(root, 'installed-runtime-evidence.json')
+  const snapshot = options.snapshot ?? snapshotCampaignData
+  const run: NonNullable<HandoffDryRunOptions['run']> =
+    options.run ?? runCommand(options.workspaceRoot)
+  const environment = dryRunEnvironment(root)
+  try {
+    mkdirSync(root, { recursive: true })
+    mkdirSync(dirname(paths.campaignData), { recursive: true })
+    const inventory = snapshot(options.sourceCampaignData, paths.campaignData)
+    const sourceDataHash = hashJson(inventory)
+    for (const directory of [
+      environment['XDG_CONFIG_HOME'],
+      environment['XDG_CACHE_HOME'],
+      environment['XDG_STATE_HOME'],
+      environment['XDG_RUNTIME_DIR']
+    ])
+      if (directory) mkdirSync(directory, { recursive: true })
+    chmodSync(environment['XDG_RUNTIME_DIR']!, 0o700)
+
+    for (const command of dryRunCommands(runtimeEvidencePath))
+      run(command.phase, command.arguments, environment)
+
+    const manifest = localArtifactManifestSchema.parse(
+      JSON.parse(readFileSync(paths.installedManifest, 'utf8'))
+    )
+    installedRuntimeEvidenceSchema.parse(
+      JSON.parse(readFileSync(runtimeEvidencePath, 'utf8'))
+    )
+    const result: HandoffDryRunResult = {
+      sourceCampaignData: resolve(options.sourceCampaignData),
+      sourceDataHash,
+      artifactSha256: manifest.artifactSha256,
+      installedSha256: sha256File(paths.appImage),
+      runtimeEvidenceSha256: sha256File(runtimeEvidencePath)
+    }
+    if (result.artifactSha256 !== result.installedSha256)
+      throw new Error('Dry-run installation did not preserve the artifact hash')
+    return result
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function runCommand(
+  workspaceRoot: string
+): NonNullable<HandoffDryRunOptions['run']> {
+  return (phase, arguments_, environment) => {
+    const result = spawnSync('corepack', arguments_, {
+      cwd: workspaceRoot,
+      env: environment,
+      stdio: 'inherit'
+    })
+    if (result.error) throw result.error
+    if (result.status !== 0)
+      throw new Error(
+        `Dry-run handoff phase ${phase} failed with ${result.status}`
+      )
+  }
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}

--- a/scripts/installed-runtime-verification.ts
+++ b/scripts/installed-runtime-verification.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, relative } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import Database from 'better-sqlite3'
 import {
   localArtifactManifestSchema,
@@ -19,6 +19,7 @@ import { atomicWrite } from './safe-file-write.js'
 const paths = localInstallationPaths(
   process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
 )
+const evidencePath = parseEvidencePath(process.argv.slice(2))
 const manifest = localArtifactManifestSchema.parse(
   JSON.parse(readFileSync(paths.installedManifest, 'utf8'))
 )
@@ -173,15 +174,26 @@ const persisted = installedRuntimeEvidenceSchema.parse({
   })),
   domainReadbacks
 })
-atomicWrite(
-  join(
-    process.cwd(),
-    '.tmp',
-    'handoff-local-app',
-    'installed-runtime-evidence.json'
-  ),
-  `${JSON.stringify(persisted, null, 2)}\n`
-)
+atomicWrite(evidencePath, `${JSON.stringify(persisted, null, 2)}\n`)
+
+function parseEvidencePath(arguments_: readonly string[]): string {
+  if (arguments_.length === 0)
+    return join(
+      process.cwd(),
+      '.tmp',
+      'handoff-local-app',
+      'installed-runtime-evidence.json'
+    )
+  if (
+    arguments_.length === 2 &&
+    arguments_[0] === '--evidence-path' &&
+    arguments_[1] !== undefined
+  )
+    return resolve(arguments_[1])
+  throw new Error(
+    'Usage: installed-runtime-verification.ts [--evidence-path <path>]'
+  )
+}
 
 console.info(
   JSON.stringify({

--- a/scripts/local-installation/campaign-backup.ts
+++ b/scripts/local-installation/campaign-backup.ts
@@ -41,13 +41,7 @@ export function campaignDataHash(paths: LocalInstallationPaths): string {
   if (!directoryHasEntries(paths.campaignData)) return hashFileInventory([])
   const snapshot = join(tmpdir(), `salt-marcher-backup-hash-${randomUUID()}`)
   try {
-    return hashFileInventory(
-      snapshotCampaignData(
-        paths.campaignData,
-        snapshot,
-        sqliteDatabasePaths(paths.campaignData)
-      )
-    )
+    return hashFileInventory(snapshotCampaignData(paths.campaignData, snapshot))
   } catch (error) {
     if (error instanceof LocalInstallationError) throw error
     throw new LocalInstallationError(
@@ -148,7 +142,11 @@ export function backupCampaignData(
   )
   try {
     const databasePaths = sourceDatabases.map(({ path }) => path)
-    snapshotCampaignData(paths.campaignData, staging, databasePaths)
+    snapshotCampaignDataWithDatabases(
+      paths.campaignData,
+      staging,
+      databasePaths
+    )
     const copiedDatabases = sourceDatabases.map((database) =>
       join(staging, relative(paths.campaignData, database.path))
     )
@@ -205,7 +203,18 @@ function removeDatabaseSidecars(databasePaths: readonly string[]): void {
       rmSync(`${databasePath}${suffix}`, { force: true })
 }
 
-function snapshotCampaignData(
+export function snapshotCampaignData(
+  sourceRoot: string,
+  targetRoot: string
+): ReturnType<typeof hashTree> {
+  return snapshotCampaignDataWithDatabases(
+    sourceRoot,
+    targetRoot,
+    sqliteDatabasePaths(sourceRoot)
+  )
+}
+
+function snapshotCampaignDataWithDatabases(
   sourceRoot: string,
   targetRoot: string,
   databasePaths: readonly string[]

--- a/scripts/run-handoff.ts
+++ b/scripts/run-handoff.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { parseHandoffArguments } from './handoff-arguments.js'
+import { runHandoffDryRun } from './handoff-dry-run.js'
+import { localInstallationPaths } from './local-app-installation.js'
+
+const workspaceRoot = process.cwd()
+const parsed = parseHandoffArguments(process.argv.slice(2))
+if (parsed.mode === 'dry-run') {
+  const live = localInstallationPaths(
+    process.env['XDG_DATA_HOME'] ?? join(homedir(), '.local', 'share')
+  )
+  const result = runHandoffDryRun({
+    workspaceRoot,
+    sourceCampaignData: parsed.source ?? live.campaignData
+  })
+  console.info(
+    JSON.stringify({
+      component: 'local-handoff-dry-run',
+      event: 'passed',
+      ...result
+    })
+  )
+} else {
+  const arguments_ = [
+    '--import',
+    'tsx',
+    resolve(workspaceRoot, 'scripts', 'handoff-local-app.ts'),
+    ...(parsed.resume ? ['--resume'] : [])
+  ]
+  const result = spawnSync(process.execPath, arguments_, {
+    cwd: workspaceRoot,
+    env: process.env,
+    stdio: 'inherit'
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0)
+    throw new Error(`Canonical handoff failed with ${result.status}`)
+}

--- a/tests/unit/handoff-dry-run.test.ts
+++ b/tests/unit/handoff-dry-run.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { parseHandoffArguments } from '../../scripts/handoff-arguments.js'
+import {
+  dryRunCommands,
+  dryRunEnvironment
+} from '../../scripts/handoff-dry-run.js'
+
+describe('isolated handoff dry run', () => {
+  it('keeps canonical resume and dry-run inputs mutually exclusive', () => {
+    expect(parseHandoffArguments([])).toEqual({
+      mode: 'canonical',
+      resume: false
+    })
+    expect(parseHandoffArguments(['--resume'])).toEqual({
+      mode: 'canonical',
+      resume: true
+    })
+    expect(parseHandoffArguments(['--dry-run'])).toEqual({
+      mode: 'dry-run',
+      source: null
+    })
+    expect(() => parseHandoffArguments(['--dry-run', '--resume'])).toThrow(
+      'cannot be combined'
+    )
+  })
+
+  it('routes every mutable runtime directory into the isolated root', () => {
+    const environment = dryRunEnvironment('/tmp/isolated', {
+      PATH: '/usr/bin'
+    })
+    expect(environment).toMatchObject({
+      PATH: '/usr/bin',
+      XDG_DATA_HOME: '/tmp/isolated/xdg-data',
+      XDG_CONFIG_HOME: '/tmp/isolated/xdg-config',
+      XDG_CACHE_HOME: '/tmp/isolated/xdg-cache',
+      XDG_STATE_HOME: '/tmp/isolated/xdg-state',
+      XDG_RUNTIME_DIR: '/tmp/isolated/xdg-runtime'
+    })
+    expect(environment['COREPACK_HOME']).toMatch(/\.cache\/node\/corepack$/)
+  })
+
+  it('builds, packages, installs and verifies without a canonical receipt phase', () => {
+    const commands = dryRunCommands('/tmp/isolated/evidence.json')
+    expect(commands.map(({ phase }) => phase)).toEqual([
+      'build',
+      'package',
+      'packaged-smoke',
+      'isolated-install',
+      'isolated-runtime'
+    ])
+    expect(JSON.stringify(commands)).not.toContain('storage-retention')
+    expect(JSON.stringify(commands)).not.toContain('handoff-receipt')
+    expect(commands.at(-1)?.arguments).toContain('/tmp/isolated/evidence.json')
+  })
+})


### PR DESCRIPTION
## Summary
- add handoff dry-run mode with an optional campaign-data source
- build and package dirty local workspaces, snapshot campaign data, install, and verify runtime under isolated temporary XDG roots
- keep dry-run incompatible with resume and outside canonical handoff receipts and storage retention
- allow runtime evidence to target an explicit isolated path

## Verification
- real dry run against the live campaign profile passed build, package, packaged smoke, isolated install, three SQLite quick checks, and five domain readbacks
- temporary profile was removed after the run
- active installed AppImage remained byte-identical at e025b2c05a3b8e86ca41477002f9b24dcb2688cb058df1ef77eec1fd9bf8b468
- no canonical handoff receipt was created in the dry-run workspace
- 82 architecture tests and focused dry-run/installer tests passed; lint and TypeScript checks passed