### PR TITLE
Phase 5: explicit IPC result envelopes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: xvfb-run -a pnpm check:portable:fast
 
@@ -49,7 +49,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - name: Cache native Electron toolchain
         uses: actions/cache@v4
         with:
@@ -74,7 +74,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - name: Cache native Electron toolchain
         uses: actions/cache@v4
         with:
@@ -111,7 +111,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
           name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
@@ -147,7 +147,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - name: Cache native Electron toolchain
         uses: actions/cache@v4
         with:
@@ -173,7 +173,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
           name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
@@ -210,7 +210,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
           name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
@@ -244,7 +244,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - uses: actions/download-artifact@v4
         with:
           name: linux-app-${{ env.SALT_MARCHER_CHECKED_SHA }}-attempt-${{ github.run_attempt }}
@@ -273,7 +273,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm delivery:verify-exact-sha-aggregate
         env:
@@ -293,7 +293,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.15.1 }
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 22.23.2, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm delivery:verify-main-push
         env:

--- a/src/main/application-lifecycle/capability-registration.ts
+++ b/src/main/application-lifecycle/capability-registration.ts
@@ -23,7 +23,7 @@ export function registerCapabilities(core: CoreProcessSupervisor): void {
     if (definition.channel === null) continue
     const kind = rawKind as CoreOperationKind
     ipcMain.handle(definition.channel, (event, raw) =>
-      invokeGeneric(async () => {
+      invokeGeneric(() => {
         if (!roleCanInvoke(roleForEvent(event), kind))
           throw new CapabilityError('read_only', false)
         const input = definition.input.safeParse(raw)
@@ -38,16 +38,20 @@ export function registerCapabilities(core: CoreProcessSupervisor): void {
   for (const [rawKind, definition] of Object.entries(mainOperations)) {
     if (definition.channel === null) continue
     const kind = rawKind as MainOperationKind
-    ipcMain.handle(definition.channel, async (event, raw) => {
-      if (!operationAllowsRole(definition, roleForEvent(event)))
-        throw new CapabilityError('read_only', false)
-      const input = definition.input.parse(raw)
-      const handler = handlers[kind] as (
-        event: IpcMainInvokeEvent,
-        input: unknown
-      ) => unknown
-      return definition.output.parse(await handler(event, input))
-    })
+    ipcMain.handle(definition.channel, (event, raw) =>
+      invokeGeneric(async () => {
+        if (!operationAllowsRole(definition, roleForEvent(event)))
+          throw new CapabilityError('read_only', false)
+        const input = definition.input.safeParse(raw)
+        if (!input.success)
+          throw new CapabilityError('validation_failed', false)
+        const handler = handlers[kind] as (
+          event: IpcMainInvokeEvent,
+          input: unknown
+        ) => unknown
+        return Promise.resolve(handler(event, input.data))
+      }, definition.output)
+    )
   }
 }
 

--- a/src/preload/capability-bridge/index.ts
+++ b/src/preload/capability-bridge/index.ts
@@ -1,7 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { z } from 'zod'
-import { capabilityFailureSchema } from '../../shared/contracts/campaign.js'
-import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import type {
+  CapabilityBridge,
+  IpcResult
+} from '../../shared/contracts/ipc-result.js'
+import { ipcResultSchema } from '../../shared/contracts/ipc-result.js'
 import {
   capabilityEvents,
   type CapabilityEventKind,
@@ -17,7 +19,6 @@ import {
   type MainOperationKind,
   type MainOperationOutput
 } from '../../shared/contracts/operations.js'
-import { CapabilityError } from '../../shared/errors/capability-error.js'
 import {
   assertExactOperationKeys,
   operationAllowsRole,
@@ -30,53 +31,45 @@ const invokeIpc = (channel: string, input: unknown): Promise<unknown> =>
 async function invokeCore<K extends CoreOperationKind>(
   kind: K,
   input: CoreOperationInput<K>
-): Promise<CoreOperationOutput<K>> {
+): Promise<IpcResult<CoreOperationOutput<K>>> {
   const operation = coreOperations[kind]
-  if (operation.channel === null)
-    throw new CapabilityError('protocol_violation', false)
+  if (operation.channel === null) return failure('protocol_violation', false)
   const request = operation.input.safeParse(input)
-  if (!request.success) throw new CapabilityError('validation_failed', false)
+  if (!request.success) return failure('validation_failed', false)
   try {
     const raw = await invokeIpc(operation.channel, request.data)
-    const result = z
-      .discriminatedUnion('ok', [
-        z.object({ ok: z.literal(true), payload: z.unknown() }).passthrough(),
-        z
-          .object({ ok: z.literal(false), error: capabilityFailureSchema })
-          .passthrough()
-      ])
-      .parse(raw)
-    if (!result.ok)
-      throw new CapabilityError(
-        result.error.code,
-        result.error.retryable,
-        result.error.issues ?? []
-      )
+    const result = ipcResultSchema.parse(raw)
+    if (!result.ok) return freezeDeep(result)
     const value = operation.output.safeParse(result.payload)
-    if (!value.success) throw new CapabilityError('protocol_violation', false)
-    return freezeDeep(value.data) as CoreOperationOutput<K>
-  } catch (error) {
-    if (error instanceof CapabilityError) throw error
-    throw new CapabilityError('core_unavailable', true)
+    if (!value.success) return failure('protocol_violation', false)
+    return freezeDeep({ ok: true, payload: value.data }) as IpcResult<
+      CoreOperationOutput<K>
+    >
+  } catch {
+    return failure('core_unavailable', true)
   }
 }
 
 async function invokeMain<K extends MainOperationKind>(
   kind: K,
   input: MainOperationInput<K>
-): Promise<MainOperationOutput<K>> {
+): Promise<IpcResult<MainOperationOutput<K>>> {
   const operation = mainOperations[kind]
-  if (operation.channel === null)
-    throw new CapabilityError('protocol_violation', false)
+  if (operation.channel === null) return failure('protocol_violation', false)
   const request = operation.input.safeParse(input)
-  if (!request.success) throw new CapabilityError('validation_failed', false)
+  if (!request.success) return failure('validation_failed', false)
   try {
-    return freezeDeep(
-      operation.output.parse(await invokeIpc(operation.channel, request.data))
-    ) as MainOperationOutput<K>
-  } catch (error) {
-    if (error instanceof CapabilityError) throw error
-    throw new CapabilityError('core_unavailable', true)
+    const result = ipcResultSchema.parse(
+      await invokeIpc(operation.channel, request.data)
+    )
+    if (!result.ok) return freezeDeep(result)
+    const output = operation.output.safeParse(result.payload)
+    if (!output.success) return failure('protocol_violation', false)
+    return freezeDeep({ ok: true, payload: output.data }) as IpcResult<
+      MainOperationOutput<K>
+    >
+  } catch {
+    return failure('core_unavailable', true)
   }
 }
 
@@ -116,7 +109,7 @@ for (const [kind, event] of Object.entries(capabilityEvents)) {
   if (!event.roles.includes('gm')) continue
   installMethod(kind, (listener: unknown) => {
     if (typeof listener !== 'function')
-      throw new CapabilityError('validation_failed', false)
+      throw new TypeError('Capability event listener must be a function')
     const handler = (_event: Electron.IpcRendererEvent, raw: unknown): void => {
       const definition = capabilityEvents[kind as CapabilityEventKind]
       const notice = definition.payload.parse(
@@ -135,8 +128,8 @@ facade['runtime'] = Object.freeze({
   e2e: process.argv.includes('--salt-marcher-e2e')
 })
 
-const api = freezeDeep(facade) as SaltMarcherApi
-contextBridge.exposeInMainWorld('saltMarcher', api)
+const api = freezeDeep(facade) as CapabilityBridge
+contextBridge.exposeInMainWorld('saltMarcherBridge', api)
 if (process.argv.includes('--salt-marcher-e2e'))
   contextBridge.exposeInMainWorld(
     '__saltMarcherE2e',
@@ -169,4 +162,11 @@ function freezeDeep<T>(value: T): T {
     Object.freeze(value)
   }
   return value
+}
+
+function failure(
+  code: import('../../shared/errors/capability-error-code.js').CapabilityErrorCode,
+  retryable: boolean
+): IpcResult<never> {
+  return Object.freeze({ ok: false, error: Object.freeze({ code, retryable }) })
 }

--- a/src/preload/passive.ts
+++ b/src/preload/passive.ts
@@ -1,11 +1,10 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { z } from 'zod'
 import {
   passiveProjectionSchema,
   type PassiveDisplayApi
 } from '../shared/contracts/passive-display.js'
 import { coreProcessStatusSchema } from '../shared/contracts/runtime.js'
-import { capabilityFailureSchema } from '../shared/contracts/campaign.js'
+import { ipcResultSchema } from '../shared/contracts/ipc-result.js'
 import { CapabilityError } from '../shared/errors/capability-error.js'
 import {
   coreOperations,
@@ -17,11 +16,6 @@ import {
   operationAllowsRole,
   operationDefinitionsForRole
 } from '../shared/contracts/operations/registry.js'
-
-const responseSchema = z.discriminatedUnion('ok', [
-  z.object({ ok: z.literal(true), payload: z.unknown() }).strict(),
-  z.object({ ok: z.literal(false), error: capabilityFailureSchema }).strict()
-])
 
 type PassiveE2eApi = PassiveDisplayApi & {
   __e2eProbePrivilegedChannels?: () => Promise<
@@ -43,7 +37,7 @@ const passiveHandlers = defineOperationHandlers(
   {
     'projection.read': async () => {
       const operation = coreOperations['projection.read']
-      const result = responseSchema.parse(
+      const result = ipcResultSchema.parse(
         await invokeIpc(operation.channel!, operation.input.parse(undefined))
       )
       if (!result.ok)
@@ -58,9 +52,16 @@ const passiveHandlers = defineOperationHandlers(
       const operation = mainOperations['runtime.coreStatus']
       if (operation.channel === null)
         throw new CapabilityError('protocol_violation', false)
-      return coreProcessStatusSchema.parse(
+      const result = ipcResultSchema.parse(
         await invokeIpc(operation.channel, undefined)
       )
+      if (!result.ok)
+        throw new CapabilityError(
+          result.error.code,
+          result.error.retryable,
+          result.error.issues ?? []
+        )
+      return coreProcessStatusSchema.parse(result.payload)
     }
   }
 )

--- a/src/renderer/capabilities/capability-api.ts
+++ b/src/renderer/capabilities/capability-api.ts
@@ -52,11 +52,7 @@ function unwrapResult(raw: unknown): unknown {
   if (result['ok'] !== false || !isCapabilityFailure(result['error']))
     throw new CapabilityError('protocol_violation', false)
   const error = result['error']
-  throw new CapabilityError(
-    error.code,
-    error.retryable,
-    error.issues ?? []
-  )
+  throw new CapabilityError(error.code, error.retryable, error.issues ?? [])
 }
 
 function isCapabilityFailure(value: unknown): value is {

--- a/src/renderer/capabilities/capability-api.ts
+++ b/src/renderer/capabilities/capability-api.ts
@@ -1,0 +1,92 @@
+import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import {
+  capabilityErrorCodes,
+  type CapabilityErrorCode
+} from '../../shared/errors/capability-error-code.js'
+import { CapabilityError } from '../../shared/errors/capability-error.js'
+import type { CapabilityIssue } from '../../shared/errors/capability-issue.js'
+
+const capabilityErrorCodeSet = new Set<string>(capabilityErrorCodes)
+
+export function createCapabilityApi(
+  bridge: Readonly<Record<string, unknown>>
+): SaltMarcherApi {
+  return freezeDeep(wrapObject(bridge)) as SaltMarcherApi
+}
+
+let cachedCapabilityApi: SaltMarcherApi | undefined
+
+export function capabilityApi(): SaltMarcherApi {
+  return (cachedCapabilityApi ??= createCapabilityApi(window.saltMarcherBridge))
+}
+
+function wrapObject(
+  value: Readonly<Record<string, unknown>>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, wrapValue(child)])
+  )
+}
+
+function wrapValue(value: unknown): unknown {
+  if (typeof value === 'function')
+    return (...arguments_: unknown[]) => {
+      const returned = (value as (...values: unknown[]) => unknown)(
+        ...arguments_
+      )
+      return isPromiseLike(returned)
+        ? Promise.resolve(returned).then(unwrapResult)
+        : returned
+    }
+  if (value !== null && typeof value === 'object')
+    return wrapObject(value as Readonly<Record<string, unknown>>)
+  return value
+}
+
+function unwrapResult(raw: unknown): unknown {
+  if (raw === null || typeof raw !== 'object')
+    throw new CapabilityError('protocol_violation', false)
+  const result = raw as Record<string, unknown>
+  if (result['ok'] === true && 'payload' in result)
+    return freezeDeep(result['payload'])
+  if (result['ok'] !== false || !isCapabilityFailure(result['error']))
+    throw new CapabilityError('protocol_violation', false)
+  const error = result['error']
+  throw new CapabilityError(
+    error.code,
+    error.retryable,
+    error.issues ?? []
+  )
+}
+
+function isCapabilityFailure(value: unknown): value is {
+  code: CapabilityErrorCode
+  retryable: boolean
+  issues?: readonly CapabilityIssue[]
+} {
+  if (value === null || typeof value !== 'object') return false
+  const failure = value as Record<string, unknown>
+  return (
+    typeof failure['code'] === 'string' &&
+    capabilityErrorCodeSet.has(failure['code']) &&
+    typeof failure['retryable'] === 'boolean' &&
+    (failure['issues'] === undefined || Array.isArray(failure['issues']))
+  )
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'then' in value &&
+    typeof value.then === 'function'
+  )
+}
+
+function freezeDeep<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) freezeDeep(child)
+    Object.freeze(value)
+  }
+  return value
+}

--- a/src/renderer/qualification/qualification-app.tsx
+++ b/src/renderer/qualification/qualification-app.tsx
@@ -28,6 +28,7 @@ import {
   SpatialQualificationModel,
   type SpatialQualificationState
 } from '../spatial-qualification-model.js'
+import { capabilityApi } from '../capabilities/capability-api.js'
 
 type WebglObservation = Readonly<{ version: string; renderer: string }>
 
@@ -232,7 +233,7 @@ async function settledWorkingSetSamples(): Promise<readonly number[]> {
   const values: number[] = []
   for (let sample = 0; sample < 3; sample += 1) {
     await settleRenderer()
-    values.push(await window.saltMarcher.runtime.memory())
+    values.push(await capabilityApi().runtime.memory())
   }
   return values
 }
@@ -297,7 +298,7 @@ async function downloadRuntimeObservation(
       displayWidth: window.screen.width,
       displayHeight: window.screen.height,
       devicePixelRatio: window.devicePixelRatio,
-      gpu: await window.saltMarcher.runtime.gpuObservation(),
+      gpu: await capabilityApi().runtime.gpuObservation(),
       webgl
     },
     populations,

--- a/src/renderer/src.tsx
+++ b/src/renderer/src.tsx
@@ -4,12 +4,15 @@ import { App } from './shell/app.js'
 import './shell/app.css'
 import { CapabilityProvider } from './capabilities/capability-provider.js'
 import { ModalLayerProvider } from './shell/modal-layer.js'
+import { capabilityApi } from './capabilities/capability-api.js'
 
 document.documentElement.dataset['theme'] = 'light'
+const api = capabilityApi()
+window.saltMarcher = api
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <CapabilityProvider api={window.saltMarcher}>
+    <CapabilityProvider api={api}>
       <ModalLayerProvider>
         <App />
       </ModalLayerProvider>

--- a/src/shared/contracts/ipc-result.ts
+++ b/src/shared/contracts/ipc-result.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { capabilityFailureSchema } from './campaign.js'
+
+export const ipcResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), payload: z.unknown() }).strict(),
+  z.object({ ok: z.literal(false), error: capabilityFailureSchema }).strict()
+])
+
+export type IpcResult<T> =
+  | Readonly<{ ok: true; payload: T }>
+  | Readonly<{
+      ok: false
+      error: z.infer<typeof capabilityFailureSchema>
+    }>
+
+export type CapabilityBridge = Readonly<Record<string, unknown>>

--- a/src/shared/contracts/window.d.ts
+++ b/src/shared/contracts/window.d.ts
@@ -2,6 +2,8 @@ export {}
 
 declare global {
   interface Window {
+    saltMarcherBridge: import('./ipc-result.js').CapabilityBridge
+    /** Renderer-realm logical adapter; the preload exposes only saltMarcherBridge. */
     saltMarcher: import('./capability-api.js').SaltMarcherApi
   }
 }

--- a/src/shared/errors/capability-error.ts
+++ b/src/shared/errors/capability-error.ts
@@ -1,10 +1,5 @@
-import {
-  capabilityErrorCodes,
-  type CapabilityErrorCode
-} from './capability-error-code.js'
+import { type CapabilityErrorCode } from './capability-error-code.js'
 import type { CapabilityIssue } from './capability-issue.js'
-
-const capabilityErrorCodeSet = new Set<string>(capabilityErrorCodes)
 
 export class CapabilityError extends Error {
   public constructor(
@@ -35,11 +30,5 @@ export function capabilityErrorIssues(
 export function capabilityErrorCode(
   error: unknown
 ): CapabilityErrorCode | null {
-  if (error instanceof CapabilityError) return error.code
-  if (error === null || typeof error !== 'object') return null
-  const candidate = error as { code?: unknown; message?: unknown }
-  for (const value of [candidate.code, candidate.message])
-    if (typeof value === 'string' && capabilityErrorCodeSet.has(value))
-      return value as CapabilityErrorCode
-  return null
+  return error instanceof CapabilityError ? error.code : null
 }

--- a/tests/unit/capability-bridge-adapter.test.ts
+++ b/tests/unit/capability-bridge-adapter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createCapabilityApi } from '../../src/renderer/capabilities/capability-api.js'
+import { CapabilityError } from '../../src/shared/errors/capability-error.js'
+
+describe('renderer capability bridge adapter', () => {
+  it('unwraps immutable success results without changing the logical API', async () => {
+    const api = createCapabilityApi({
+      runtime: {
+        readOnly: false,
+        e2e: false,
+        memory: vi.fn().mockResolvedValue({ ok: true, payload: 42 })
+      }
+    })
+    await expect(api.runtime.memory()).resolves.toBe(42)
+  })
+
+  it('reconstructs capability failures in the renderer realm', async () => {
+    const api = createCapabilityApi({
+      runtime: {
+        readOnly: false,
+        e2e: false,
+        memory: vi.fn().mockResolvedValue({
+          ok: false,
+          error: { code: 'read_only', retryable: false }
+        })
+      }
+    })
+    const error = await api.runtime.memory().catch((cause: unknown) => cause)
+    expect(error).toBeInstanceOf(CapabilityError)
+    expect(error).toMatchObject({ code: 'read_only', retryable: false })
+  })
+
+  it('maps malformed bridge data to a protocol violation', async () => {
+    const api = createCapabilityApi({
+      runtime: {
+        readOnly: false,
+        e2e: false,
+        memory: vi.fn().mockResolvedValue(42)
+      }
+    })
+    await expect(api.runtime.memory()).rejects.toMatchObject({
+      code: 'protocol_violation'
+    })
+  })
+})

--- a/tests/unit/capability-errors.test.ts
+++ b/tests/unit/capability-errors.test.ts
@@ -23,9 +23,9 @@ describe('capability error presentation policy', () => {
     expect(report).toHaveBeenCalledWith(text)
   })
 
-  it('recovers a known code from Electron reduced Error messages', () => {
+  it('does not infer capability codes from arbitrary Error messages', () => {
     expect(capabilityErrorText(new Error('internal'))).toBe(
-      'Ein interner Fehler ist aufgetreten.'
+      'Unbekannter Fehler'
     )
     expect(capabilityErrorText(new Error('not-a-capability-code'))).toBe(
       'Unbekannter Fehler'

--- a/tests/unit/hex-command-executor.test.ts
+++ b/tests/unit/hex-command-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { executeRecoverableHexCommand } from '../../src/renderer/features/hex/hex-command-executor.js'
+import { CapabilityError } from '../../src/shared/errors/capability-error.js'
 
 const applied = {
   status: 'applied',
@@ -17,7 +18,7 @@ const applied = {
 
 describe('executeRecoverableHexCommand', () => {
   it('returns the receipt after an uncertain operation outcome', async () => {
-    const unknownOutcome = { code: 'outcome_unknown', retryable: true }
+    const unknownOutcome = new CapabilityError('outcome_unknown', true)
     const readReceipt = vi.fn().mockResolvedValue(applied)
 
     await expect(
@@ -31,8 +32,8 @@ describe('executeRecoverableHexCommand', () => {
   })
 
   it('does not hide a known failure or a missing receipt', async () => {
-    const knownFailure = { code: 'validation_failed', retryable: false }
-    const unknownOutcome = { code: 'outcome_unknown', retryable: true }
+    const knownFailure = new CapabilityError('validation_failed', false)
+    const unknownOutcome = new CapabilityError('outcome_unknown', true)
     const readReceipt = vi.fn().mockResolvedValue(null)
 
     await expect(


### PR DESCRIPTION
## Summary
- return one strict success or capability-failure DTO for both core-owned and main-owned IPC operations
- expose a raw saltMarcherBridge from preload and reconstruct the logical API in the renderer realm
- preserve the existing SaltMarcherApi surface while ensuring CapabilityError identity, retryability, and issues survive context isolation
- remove fallback inference from arbitrary Error code and message fields
- apply the same main-operation envelope to the passive window

## Verification
- architecture: 82 tests passed
- unit: 790 tests passed
- integration: 161 tests passed
- renderer-realm adapter tests cover success, capability failure, and malformed protocol data
- lint, both TypeScript checks, development build, and built Electron smoke passed