### PR TITLE
Phase 6: versioned preferences persistence

### DIFF
--- a/docs/project/architecture/version-truth.md
+++ b/docs/project/architecture/version-truth.md
@@ -8,10 +8,10 @@ canonical check.
 
 | Role | Current schema | Complete forward path | Migration owner |
 | --- | ---: | --- | --- |
-| installation | 36 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36` | `installation-schema-migrations.ts` |
+| installation | 37 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36 -> 37` | `installation-schema-migrations.ts` |
 | campaign | 34 | `27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34` | `campaign-schema-migrations.ts` |
 
-Migration registry contract: **8**.
+Migration registry contract: **9**.
 
 ## Generation
 

--- a/src/core/persistence/sqlite/database.ts
+++ b/src/core/persistence/sqlite/database.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3'
 export type DatabaseRole = 'installation' | 'campaign'
 
 export const databaseSchemaVersions: Readonly<Record<DatabaseRole, number>> =
-  Object.freeze({ installation: 36, campaign: 34 })
+  Object.freeze({ installation: 37, campaign: 34 })
 
 export const currentSchemaVersion = Math.max(
   ...Object.values(databaseSchemaVersions)

--- a/src/core/persistence/sqlite/installation-database-owner.ts
+++ b/src/core/persistence/sqlite/installation-database-owner.ts
@@ -11,6 +11,7 @@ import { preflightPersistence } from './persistence-preflight.js'
 import { initializeInstallationSchemaMetadata } from './installation-schema-migrations.js'
 import {
   defaultInstallationPreferences,
+  persistedInstallationPreferences,
   type InstallationPreferencesPatch,
   type InstallationSettings
 } from '../../../shared/contracts/settings.js'
@@ -122,7 +123,11 @@ export class InstallationDatabaseOwner {
       .prepare(
         'INSERT OR IGNORE INTO installation_settings (singleton, revision, preferences_json) VALUES (1, 0, ?)'
       )
-      .run(JSON.stringify(defaultInstallationPreferences))
+      .run(
+        JSON.stringify(
+          persistedInstallationPreferences(defaultInstallationPreferences)
+        )
+      )
     initializeCreatureSchema(this.database)
     initializeBiomeCatalogSchema(this.database)
     initializeLocationSymbolSchema(this.database)

--- a/src/core/persistence/sqlite/installation-schema-migrations.ts
+++ b/src/core/persistence/sqlite/installation-schema-migrations.ts
@@ -1,6 +1,9 @@
 import type Database from 'better-sqlite3'
 import { migrateSessionLayoutPreference } from '../../../shared/contracts/session-layout.js'
-import { installationPreferencesSchema } from '../../../shared/contracts/settings.js'
+import {
+  installationPreferencesSchema,
+  persistedInstallationPreferences
+} from '../../../shared/contracts/settings.js'
 import { defaultGeneratorLootRules } from '../../../shared/generator/default-loot-rules.js'
 import type { SchemaMigration } from './schema-migrations.js'
 import {
@@ -262,8 +265,52 @@ export const installationSchemaMigrations: readonly SchemaMigration[] =
             new Date().toISOString()
           )
       }
+    },
+    {
+      id: 'installation-36-to-37-preferences-envelope-v1',
+      role: 'installation',
+      fromVersion: 36,
+      toVersion: 37,
+      migrate(database) {
+        initializeInstallationSchemaMetadata(database)
+        wrapStoredInstallationPreferences(database)
+        database
+          .prepare(
+            'INSERT INTO installation_schema_migration (migration_id, applied_at) VALUES (?, ?)'
+          )
+          .run(
+            'installation-36-to-37-preferences-envelope-v1',
+            new Date().toISOString()
+          )
+      }
     }
   ])
+
+function wrapStoredInstallationPreferences(database: Database.Database): void {
+  const hasSettings = Boolean(
+    database
+      .prepare(
+        `SELECT 1 FROM sqlite_master
+          WHERE type = 'table' AND name = 'installation_settings'`
+      )
+      .get()
+  )
+  if (!hasSettings) return
+  const row = database
+    .prepare(
+      'SELECT preferences_json AS preferencesJson FROM installation_settings WHERE singleton = 1'
+    )
+    .get() as { preferencesJson: string } | undefined
+  if (!row) return
+  const preferences = installationPreferencesSchema.parse(
+    JSON.parse(row.preferencesJson) as unknown
+  )
+  database
+    .prepare(
+      'UPDATE installation_settings SET preferences_json = ? WHERE singleton = 1'
+    )
+    .run(JSON.stringify(persistedInstallationPreferences(preferences)))
+}
 
 function migrateStoredSessionLayout(database: Database.Database): void {
   const hasSettings = Boolean(

--- a/src/core/persistence/sqlite/installation-settings-store.ts
+++ b/src/core/persistence/sqlite/installation-settings-store.ts
@@ -2,6 +2,8 @@ import type Database from 'better-sqlite3'
 import {
   defaultInstallationPreferences,
   installationPreferencesSchema,
+  persistedInstallationPreferences,
+  persistedInstallationPreferencesSchema,
   installationSettingsSchema,
   type InstallationPreferencesPatch,
   type InstallationSettings
@@ -19,9 +21,9 @@ export class InstallationSettingsStore {
       .get() as { revision: number; preferencesJson: string }
     return installationSettingsSchema.parse({
       revision: row.revision,
-      preferences: installationPreferencesSchema.parse(
+      preferences: persistedInstallationPreferencesSchema.parse(
         JSON.parse(row.preferencesJson) as unknown
-      )
+      ).preferences
     })
   }
 
@@ -39,7 +41,10 @@ export class InstallationSettingsStore {
       .prepare(
         'UPDATE installation_settings SET revision = revision + 1, preferences_json = ? WHERE singleton = 1 AND revision = ?'
       )
-      .run(JSON.stringify(preferences), expectedRevision)
+      .run(
+        JSON.stringify(persistedInstallationPreferences(preferences)),
+        expectedRevision
+      )
     if (changed.changes !== 1) throw new CapabilityError('stale', true)
     return this.read()
   }

--- a/src/core/persistence/sqlite/schema-migrations.ts
+++ b/src/core/persistence/sqlite/schema-migrations.ts
@@ -7,7 +7,7 @@ import {
 import { installationSchemaMigrations } from './installation-schema-migrations.js'
 import { campaignSchemaMigrations } from './campaign-schema-migrations.js'
 
-export const migrationRegistryVersion = 8
+export const migrationRegistryVersion = 9
 
 export type SchemaMigrationContext = Readonly<{
   path: string

--- a/src/shared/contracts/settings.ts
+++ b/src/shared/contracts/settings.ts
@@ -11,6 +11,14 @@ export const installationPreferencesSchema = z
   })
   .strict()
 
+export const persistedInstallationPreferencesSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    preferences: installationPreferencesSchema
+  })
+  .strict()
+  .readonly()
+
 export const installationSettingsSchema = z
   .object({
     revision: z.number().int().nonnegative(),
@@ -35,11 +43,23 @@ export const defaultInstallationPreferences: InstallationPreferences =
     sessionLayout: defaultSessionLayoutPreference
   })
 
+export function persistedInstallationPreferences(
+  preferences: InstallationPreferences
+): PersistedInstallationPreferences {
+  return persistedInstallationPreferencesSchema.parse({
+    schemaVersion: 1,
+    preferences
+  })
+}
+
 export type InstallationPreferences = Readonly<
   z.infer<typeof installationPreferencesSchema>
 >
 export type InstallationPreferencesPatch = Readonly<
   z.infer<typeof installationPreferencesPatchSchema>
+>
+export type PersistedInstallationPreferences = Readonly<
+  z.infer<typeof persistedInstallationPreferencesSchema>
 >
 export type InstallationSettings = Readonly<
   z.infer<typeof installationSettingsSchema>

--- a/tests/integration/campaign-store.test.ts
+++ b/tests/integration/campaign-store.test.ts
@@ -374,6 +374,22 @@ describe('CampaignStore', () => {
     const reopened = new CampaignStore(root)
     expect(reopened.readSettings()).toEqual(updated)
     reopened.close()
+    const database = new Database(join(root, 'installation.sqlite'), {
+      readonly: true
+    })
+    const persisted: unknown = JSON.parse(
+      database
+        .prepare(
+          'SELECT preferences_json FROM installation_settings WHERE singleton = 1'
+        )
+        .pluck()
+        .get() as string
+    )
+    database.close()
+    expect(persisted).toEqual({
+      schemaVersion: 1,
+      preferences: updated.preferences
+    })
   })
 
   it('rebuilds incompatible development data without touching siblings', () => {

--- a/tests/unit/installation-preferences-envelope.test.ts
+++ b/tests/unit/installation-preferences-envelope.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultInstallationPreferences,
+  persistedInstallationPreferences,
+  persistedInstallationPreferencesSchema
+} from '../../src/shared/contracts/settings.js'
+
+describe('persisted installation preferences envelope', () => {
+  it('accepts only the strict current versioned shape', () => {
+    expect(
+      persistedInstallationPreferences(defaultInstallationPreferences)
+    ).toEqual({
+      schemaVersion: 1,
+      preferences: defaultInstallationPreferences
+    })
+    expect(() =>
+      persistedInstallationPreferencesSchema.parse(
+        defaultInstallationPreferences
+      )
+    ).toThrow()
+    expect(() =>
+      persistedInstallationPreferencesSchema.parse({
+        schemaVersion: 2,
+        preferences: defaultInstallationPreferences
+      })
+    ).toThrow()
+  })
+})

--- a/tests/unit/persistence-preflight.test.ts
+++ b/tests/unit/persistence-preflight.test.ts
@@ -140,7 +140,7 @@ describe('persistence preflight', () => {
     const planned = preflightPersistence(root)
 
     expect(planned.kind).toBe('migration-required')
-    expect(migrationRegistryVersion).toBe(8)
+    expect(migrationRegistryVersion).toBe(9)
     for (const entry of planned.databases) {
       const database = new Database(entry.path)
       applySchemaMigrations(database, {
@@ -154,7 +154,7 @@ describe('persistence preflight', () => {
     expect(restarted.kind).toBe('ready')
     expect(restarted.databases).toMatchObject([
       { path: campaign, role: 'campaign', schemaVersion: 34 },
-      { path: installation, role: 'installation', schemaVersion: 36 }
+      { path: installation, role: 'installation', schemaVersion: 37 }
     ])
     const installationDatabase = new Database(installation)
     expect(
@@ -168,7 +168,7 @@ describe('persistence preflight', () => {
         .prepare('SELECT COUNT(*) FROM installation_schema_migration')
         .pluck()
         .get()
-    ).toBe(9)
+    ).toBe(10)
     applySchemaMigrations(installationDatabase, {
       path: installation,
       role: 'installation'
@@ -178,7 +178,7 @@ describe('persistence preflight', () => {
         .prepare('SELECT COUNT(*) FROM installation_schema_migration')
         .pluck()
         .get()
-    ).toBe(9)
+    ).toBe(10)
     expect(
       installationDatabase
         .prepare(
@@ -238,12 +238,15 @@ describe('persistence preflight', () => {
       .get() as { revision: number; preferencesJson: string }
     expect(migrated.revision).toBe(8)
     expect(JSON.parse(migrated.preferencesJson)).toEqual({
-      theme: 'dark',
-      sessionLayout: {
-        schemaVersion: 2,
-        controlPaneWidth: 300,
-        scenarioPaneWidth: 264,
-        centerTab: 'details'
+      schemaVersion: 1,
+      preferences: {
+        theme: 'dark',
+        sessionLayout: {
+          schemaVersion: 2,
+          controlPaneWidth: 300,
+          scenarioPaneWidth: 264,
+          centerTab: 'details'
+        }
       }
     })
     expect(
@@ -266,7 +269,7 @@ describe('persistence preflight', () => {
     database.close()
   })
 
-  it('leaves current settings revisions unchanged during schema 35 to 36', () => {
+  it('wraps current settings without changing their logical revision', () => {
     const path = join(temporaryRoot(), 'installation.sqlite')
     const database = new Database(path)
     database.exec(`
@@ -300,6 +303,27 @@ describe('persistence preflight', () => {
         .pluck()
         .get()
     ).toBe(4)
+    expect(
+      JSON.parse(
+        database
+          .prepare(
+            'SELECT preferences_json FROM installation_settings WHERE singleton = 1'
+          )
+          .pluck()
+          .get() as string
+      )
+    ).toEqual({
+      schemaVersion: 1,
+      preferences: {
+        theme: 'light',
+        sessionLayout: {
+          schemaVersion: 2,
+          controlPaneWidth: 300,
+          scenarioPaneWidth: 264,
+          centerTab: 'catalog'
+        }
+      }
+    })
     database.close()
   })
 

--- a/tests/unit/version-truth.test.ts
+++ b/tests/unit/version-truth.test.ts
@@ -12,8 +12,8 @@ describe('version truth gate', () => {
     expect(truth.schemas).toEqual([
       {
         role: 'installation',
-        current: 36,
-        path: '27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36',
+        current: 37,
+        path: '27 -> 28 -> 29 -> 30 -> 31 -> 32 -> 33 -> 34 -> 35 -> 36 -> 37',
         owner: 'installation-schema-migrations.ts'
       },
       {


### PR DESCRIPTION
## Outcome
- persist installation preferences in a strict version-1 envelope
- migrate installation schema 36 to 37 without changing the optimistic revision
- retain the logical capability API while validating all current reads and writes

## Verification
- architecture: 82 passed
- unit: 791 passed
- integration: 161 passed
- lint, typecheck, formatting, and version truth passed

This is Phase 6 of the postmortem remediation roadmap.