### PR TITLE
Phase 7: close postmortem architecture audit

### DIFF
--- a/docs/project/architecture/electron-greenfield-migration.md
+++ b/docs/project/architecture/electron-greenfield-migration.md
@@ -8,6 +8,50 @@
 > work status lives in active GitHub issues and pull requests, while durable
 > measurement evidence belongs in `../evidence/`.
 
+### Postmortem remediation closure — 2026-08-23
+
+The six implementation phases from the delivery and persistence postmortem are
+complete. Every final SHA below is an ancestor of
+`origin/main@52a0cc28cdb332406a4d03e0a14cc005eb7a0ff0`; each linked candidate
+run satisfied the exact-SHA aggregate, the matching CI-built AppImage passed
+one fresh local handoff, and the linked Main run attested the unchanged
+promotion.
+
+| Phase | Final SHA | Acceptance evidence |
+| --- | --- | --- |
+| 1 — candidate and artifact provenance | `335e2833f72febdead24be315942cb2d4d1f9837` | [PR #621](https://github.com/ThonkTank/Salt-Marcher/pull/621); [candidate 32597707414](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32597707414); [Main 32598200956](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32598200956) |
+| 2 — local preflight and resumable checks | `66be5981363dd610bc0de0e8ca74e108ea4a1913` | [PR #622](https://github.com/ThonkTank/Salt-Marcher/pull/622); [candidate 32600154649](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32600154649); [Main 32600755714](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32600755714) |
+| 3 — SQLite-consistent campaign backups | `e9583fecfe18f3f77c06ffe29e6c48f5c4fce679` | [PR #623](https://github.com/ThonkTank/Salt-Marcher/pull/623); [candidate 32600937641](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32600937641); [Main 32601523921](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32601523921) |
+| 4 — isolated handoff rehearsal | `98b2503bb6b9a3c8a32fefa96ca75a14d955ee5a` | [PR #624](https://github.com/ThonkTank/Salt-Marcher/pull/624); [candidate 32601609099](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32601609099); [Main 32602291097](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32602291097) |
+| 5 — explicit IPC results | `128d724291aa46baec5b9a949ee2ea2bf7c49145` | [PR #625](https://github.com/ThonkTank/Salt-Marcher/pull/625); [candidate 32603111507](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32603111507), attempt 2; installed artifact `b763dc01ec50…`; [Main 32603836742](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32603836742) |
+| 6 — versioned installation preferences | `52a0cc28cdb332406a4d03e0a14cc005eb7a0ff0` | [PR #626](https://github.com/ThonkTank/Salt-Marcher/pull/626); [candidate 32603878573](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32603878573); installed artifact `1b3bfd2e0283…`, live schema 37 and preference envelope v1; [Main 32604384764](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32604384764) |
+
+The delivery path now rejects insufficient local resources before expensive
+work, persists atomic hash-bound check progress for explicit resume, and can
+rehearse a dirty workspace and a snapshot of real campaign data under isolated
+temporary XDG roots without activation. Candidate artifacts and promotions
+remain immutable and exact-SHA-bound. CI pins the Node patch version because a
+floating major selector was observed to resolve two different patch releases
+between a reusable-build producer and consumer during one workflow run.
+
+Campaign backup manifest v2 records SQLite Online Backup as the snapshot
+method, validates the staged database, fingerprints logical source data, and
+owns only the exact declared SQLite sidecars. Format-one backups are preserved
+as historical bytes and are neither restored nor pruned automatically.
+
+Main-to-preload invocations now return strict success or failure DTOs. The GM
+preload exposes a validated raw `saltMarcherBridge`; the renderer adapter
+reconstructs `CapabilityError` locally, and arbitrary transported error
+properties no longer masquerade as domain codes. Installation preferences are
+stored in a strict version-one envelope. The 36-to-37 installation migration
+wraps the former logical value without incrementing its optimistic revision.
+
+The closing semantic audit guards these boundaries directly: online SQLite
+backup ownership, one exact CI Node runtime, explicit IPC results and
+renderer-realm errors, and versioned preference reads, bootstrap, migration,
+and writes. The target architecture carries the resulting normative contracts;
+the checks do not depend on raw regular expressions over TypeScript source.
+
 ### Architecture-debt closure — 2026-08-22
 
 The bounded architecture-debt program is complete through its implementation
@@ -139,7 +183,7 @@ accounts for the bounded virtual biome catalog and CRUD surface added with
 schema 15; schema 16 replaced separate World Location kind and region fields
 with tags and read-aloud text, and schema 17 normalizes ordered location-owned
 tags into validated rows while all per-entry ceilings remain unchanged.
-Campaign schema 34, installation schema 36, migration registry 8, Generator Config V5, Encounter engine
+Campaign schema 34, installation schema 37, migration registry 9, Generator Config V5, Encounter engine
 `encounter-v5`, and Reward engine `reward-v3` are current. Persisted
 `reward-v2` runs remain readable. The checked
 [version-truth matrix](version-truth.md) owns these current values. Schema 25 is reset rather than migrated. The

--- a/docs/project/architecture/target-architecture.md
+++ b/docs/project/architecture/target-architecture.md
@@ -82,6 +82,18 @@ maintaining parallel key unions. The Utility application root coordinates
 bootstrap, lifecycle, and composition and contains no aggregate operation-key
 inventory.
 
+Electron invocation failures never depend on JavaScript `Error` identity
+surviving context isolation. Main catches every registered invocation and
+returns one strict discriminated result DTO: immutable validated payload on
+success, or capability code, retryability, and bounded issues on failure. The
+preloads validate and freeze that DTO and expose the raw GM surface only as
+`saltMarcherBridge`; the renderer-owned capability adapter unwraps it and
+constructs the logical `CapabilityError` in the renderer realm. Error handling
+therefore uses `instanceof CapabilityError` only and never infers a domain code
+from arbitrary `message`, `name`, or `code` properties. The passive preload
+validates the same result envelope independently without acquiring the GM
+surface.
+
 Renderer features depend on shared renderer primitives, never on sibling
 workspaces. Creature search state and controls live in the `creatures` feature;
 the reusable two-pane editor lives in `creature-collection`; Session groups and
@@ -365,13 +377,25 @@ complete tree in one transaction per database, validated, then promoted by
 directory rename. Missing paths, missing migration chains, corruption, and
 access failures remain distinct terminal outcomes. Installation preferences,
 including theme and Session layout, use one revisions-protected SQLite record
-rather than renderer storage or Main-process JSON.
+rather than renderer storage or Main-process JSON. Its JSON column contains a
+strict version-one persistence envelope around the logical preferences value.
+Bootstrap, reads, and current writes accept only that envelope; the explicit
+installation-schema migration wraps the previous logical value without
+advancing its optimistic revision.
 
 Pixi rendering is invalidation-driven. Scene, camera, overlay, and resize
 changes coalesce into one animation frame; a static map never schedules its
 successor. Resize notifications are ignored when pixel dimensions are
 unchanged. The Travel acceptance fixture records render counters and reason
 counters and requires a zero-render idle interval.
+
+The canonical local check performs a read-only preflight before expensive
+work. It rejects insufficient memory plus swap headroom, workspace disk, or an
+incompatible Node/pnpm toolchain with measured reasons. A normal invocation is
+always fresh. Explicit `pnpm check --resume` may reuse only completed phases
+from an atomic state whose commit, workspace inputs, toolchain, check contract,
+and predecessor evidence still match; reusable build output is independently
+hash-validated before any built or packaged test is skipped.
 
 Every build starts with an empty output directory and writes receipt format 2.
 It binds commit/dirty state, the full workspace fingerprint, a separate
@@ -415,9 +439,16 @@ it is the sole component allowed to migrate an inactive Local profile.
 Every installation persists an fsync-backed journal before backup, migration,
 deployment, each previous-file move, each promotion, and completion. On the
 next invocation, the journal and actual `current` pointer deterministically
-finish the new state or restore the old one. Backup copying hashes each source
-byte during its single copy pass and rereads only the backup for verification;
-backup manifests retain role-specific schema and both build identities.
+finish the new state or restore the old one. Non-database files are copied and
+hashed in one pass. Each declared live SQLite database is instead captured
+through SQLite's Online Backup API into the staged backup, validated, stripped
+of SQLite-owned sidecars, and included in the manifest's logical data
+fingerprint. Exact declared `<database>-wal` and `<database>-shm` paths are
+excluded from the ordinary file copy; similarly named user files are not.
+Current backup manifests record this snapshot method, role-specific schema,
+both build identities, file hashes, and the logical source-data hash. Legacy
+format-one backups remain preserved and visible to inventory but are excluded
+from automatic restore and pruning.
 Campaign backups are never automatically deleted. They may be removed only by
 an explicit single-target maintenance command that proves the complete backup
 manifest and file inventory, refuses the five newest backups and backups under
@@ -459,6 +490,14 @@ Final SHA-keyed state receipts are permanent. Invocation and per-attempt detail
 retention keeps the newest 100 terminal records and every nonterminal record;
 only detail files no longer referenced after that classification may be
 removed.
+
+`pnpm handoff:app --dry-run` is a separate isolated rehearsal, not a handoff
+checkpoint. It may build a dirty workspace, snapshots a selected live profile
+with the same SQLite-online semantics, and exercises the actual packaged app
+under temporary XDG roots. It never creates canonical handoff receipts,
+retention state, permanent campaign backups, deployments, or a live
+activation, is incompatible with `--resume`, and removes its temporary root on
+success or failure.
 
 The read-only storage inventory also owns the compatibility topology across
 profile databases and lifecycle journals, every retained backup, active and

--- a/tests/architecture/delivery-build-architecture.test.ts
+++ b/tests/architecture/delivery-build-architecture.test.ts
@@ -9,11 +9,13 @@ import {
 } from './support/architecture-gate.js'
 import {
   codeFiles,
+  hasCall,
   hasImport,
   importCycles,
   parseTypeScriptModule,
   readTypeScriptModule,
-  relativeImportGraph
+  relativeImportGraph,
+  scope
 } from './support/typescript-module.js'
 
 legitimateLiteralGate({
@@ -80,6 +82,49 @@ architectureGate(
       expect(hasImport(deployment, campaignModule)).toBe(false)
   }
 )
+
+architectureGate(
+  'behavior-integration',
+  'snapshots live SQLite databases through the online backup API',
+  () => {
+    const backup = readTypeScriptModule(
+      'scripts/local-installation/campaign-backup.ts'
+    )
+    const snapshot = scope(backup, 'snapshotCampaignDataWithDatabases')
+    expect(snapshot?.calls).toContain('onlineBackupDatabase')
+    expect(snapshot?.calls).toContain('copyTreeWithHashes')
+    expect(snapshot?.identifiers.has('owned')).toBe(true)
+
+    const worker = readTypeScriptModule(
+      'scripts/sqlite-online-backup-worker.ts'
+    )
+    expect(hasImport(worker, 'better-sqlite3')).toBe(true)
+    expect(hasCall(worker, 'database.backup')).toBe(true)
+
+    const inventory = readTypeScriptModule(
+      'scripts/local-installation/campaign-file-inventory.ts'
+    )
+    expect(inventory.declarations.has('sqliteOwnedBackupInventory')).toBe(true)
+    expect(
+      scope(inventory, 'sqliteOwnedBackupInventory')?.identifiers.has('bytes')
+    ).toBe(false)
+  }
+)
+
+legitimateLiteralGate({
+  name: 'pins one exact Node runtime across reusable-build CI jobs',
+  path: '.github/workflows/check.yml',
+  owner: 'candidate-artifact-toolchain',
+  rationale:
+    'The reusable build receipt includes the Node patch version, so every producer and consumer job must resolve the same literal runtime.',
+  inspect: (workflow) => {
+    const versions = [...workflow.matchAll(/node-version:\s*([^, }\n]+)/g)].map(
+      (match) => match[1]
+    )
+    expect(versions.length).toBeGreaterThan(0)
+    expect(new Set(versions)).toEqual(new Set(['22.23.2']))
+  }
+})
 
 architectureGate(
   'typed-contract',

--- a/tests/architecture/persistence-architecture.test.ts
+++ b/tests/architecture/persistence-architecture.test.ts
@@ -17,8 +17,43 @@ import {
   hasCall,
   hasImport,
   readTypeScriptModule,
+  scope,
   type TypeScriptModule
 } from './support/typescript-module.js'
+
+architectureGate(
+  'typed-contract',
+  'versions every current installation-preference read and write',
+  () => {
+    const contract = readTypeScriptModule('src/shared/contracts/settings.ts')
+    expect(
+      contract.declarations.has('persistedInstallationPreferencesSchema')
+    ).toBe(true)
+
+    const store = readTypeScriptModule(
+      'src/core/persistence/sqlite/installation-settings-store.ts'
+    )
+    expect(hasCall(store, 'persistedInstallationPreferencesSchema.parse')).toBe(
+      true
+    )
+    expect(hasCall(store, 'persistedInstallationPreferences')).toBe(true)
+
+    const owner = readTypeScriptModule(
+      'src/core/persistence/sqlite/installation-database-owner.ts'
+    )
+    expect(hasCall(owner, 'persistedInstallationPreferences')).toBe(true)
+
+    const migrations = readTypeScriptModule(
+      'src/core/persistence/sqlite/installation-schema-migrations.ts'
+    )
+    const wrapper = scope(migrations, 'wrapStoredInstallationPreferences')
+    expect(wrapper?.calls).toContain('persistedInstallationPreferences')
+    expect(wrapper?.calls).toContain('installationPreferencesSchema.parse')
+    expect(migrations.stringLiterals).toContain(
+      'installation-36-to-37-preferences-envelope-v1'
+    )
+  }
+)
 
 architectureGate(
   'import-dependency-boundary',

--- a/tests/architecture/process-architecture.test.ts
+++ b/tests/architecture/process-architecture.test.ts
@@ -256,6 +256,41 @@ architectureGate(
   }
 )
 
+architectureGate(
+  'typed-contract',
+  'carries explicit IPC results and creates logical errors in the renderer realm',
+  () => {
+    const registration = readTypeScriptModule(
+      'src/main/application-lifecycle/capability-registration.ts'
+    )
+    expect(hasCall(registration, 'invokeGeneric')).toBe(true)
+    expect(scope(registration, 'invokeGeneric')?.identifiers.has('ok')).toBe(
+      true
+    )
+
+    const preload = readTypeScriptModule(
+      'src/preload/capability-bridge/index.ts'
+    )
+    expect(hasCall(preload, 'ipcResultSchema.parse')).toBe(true)
+    expect(preload.stringLiterals).toContain('saltMarcherBridge')
+    expect(preload.stringLiterals).not.toContain('saltMarcher')
+
+    const renderer = readTypeScriptModule(
+      'src/renderer/capabilities/capability-api.ts'
+    )
+    expect(renderer.constructions).toContain('CapabilityError')
+    expect(renderer.identifiers.has('unwrapResult')).toBe(true)
+    expect(hasImport(renderer, '../../shared/contracts/ipc-result.js')).toBe(
+      false
+    )
+
+    const errors = readTypeScriptModule('src/shared/errors/capability-error.ts')
+    expect(scope(errors, 'capabilityErrorCode')?.propertyAccesses).toEqual([
+      'error.code'
+    ])
+  }
+)
+
 legitimateLiteralGate({
   name: 'does not ship qualification code through the normal HTML entry',
   path: 'src/renderer/index.html',

--- a/tests/architecture/support/typescript-module.ts
+++ b/tests/architecture/support/typescript-module.ts
@@ -37,6 +37,7 @@ export type TypeScriptScope = Readonly<{
   name: string
   calls: readonly string[]
   constructions: readonly string[]
+  propertyAccesses: readonly string[]
   identifiers: ReadonlySet<string>
   stringLiterals: readonly string[]
 }>
@@ -382,6 +383,7 @@ function readScope(
 ): TypeScriptScope {
   const calls: string[] = []
   const constructions: string[] = []
+  const propertyAccesses: string[] = []
   const identifiers = new Set<string>()
   const stringLiterals: string[] = []
   const visit = (child: ts.Node): void => {
@@ -389,6 +391,8 @@ function readScope(
     if (ts.isCallExpression(child)) calls.push(expressionPath(child.expression))
     if (ts.isNewExpression(child))
       constructions.push(expressionPath(child.expression))
+    if (ts.isPropertyAccessExpression(child))
+      propertyAccesses.push(expressionPath(child))
     if (ts.isIdentifier(child)) identifiers.add(child.text)
     if (ts.isStringLiteralLike(child)) stringLiterals.push(child.text)
     ts.forEachChild(child, visit)
@@ -402,5 +406,12 @@ function readScope(
           ts.isIdentifier(node.parent.name)
         ? node.parent.name.text
         : '<anonymous>'
-  return { name, calls, constructions, identifiers, stringLiterals }
+  return {
+    name,
+    calls,
+    constructions,
+    propertyAccesses,
+    identifiers,
+    stringLiterals
+  }
 }


### PR DESCRIPTION
## Outcome
- add semantic architecture guards for explicit IPC results, renderer-realm errors, SQLite Online Backup ownership, exact CI Node pinning, and versioned preferences
- update target architecture with the delivered boundary contracts
- record PR, exact candidate, installed artifact, and main-attestation evidence for phases 1 through 6

## Verification
- canonical pnpm check passed locally
- architecture: 86 passed
- portable unit: 757 passed
- integration: 161 passed
- Linux installer/profile-lock: 34 passed
- all functional and visual E2E suites passed

This is the final documentation and test-only phase; no application handoff is required.