### PR TITLE
FR1A: type renderer execution modes end to end

### DIFF
--- a/docs/project/evidence/frontend-robustness-fr1a-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr1a-audit.md
@@ -1,0 +1,120 @@
+# Frontend robustness FR1A audit
+
+- Date: 2026-08-24
+- Baseline: `origin/main@3a2ceabb5206dd0ba6acea71905b196659e7c0ec`
+- Sprint: `FR1A` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap, acceptance matrix, and FR0 audit;
+- the complete historical Electron roadmap and the current target-architecture
+  renderer, operation-registry, capability-adapter, async-ordering, and
+  architecture-gate boundaries;
+- `TN-11`, `TN-16`, `TN-21`, and `QS-01` through `QS-05`;
+- the current operation registry, derived `SaltMarcherApi`, capability wrapper,
+  async coordinator, positive Hex/Travel/Planner/settings queues, known
+  latest-only mutation owners, and their unit and architecture tests.
+
+## Implementation packet
+
+FR1A owns a compile-time renderer execution contract only:
+
+- preserve each registry operation's `read` or `write` mode in its derived API
+  function type without adding runtime metadata or importing schema-bearing
+  registry values into the renderer;
+- define explicit type-only descriptors for keyed read projections, FIFO
+  commands, long work, and receipt reconciliation;
+- require every authority key to state both scope and entity identity;
+- add controlled compile-time mutations proving that an untyped callback or a
+  write operation cannot enter a read descriptor, a read operation cannot enter
+  a FIFO descriptor, and receipt reconciliation cannot invert command/read
+  roles;
+- add a semantic architecture gate proving the contract remains type-only and
+  therefore adds no runtime implementation or parallel owner.
+
+Owned files are the shared derived capability type, one renderer async contract
+module, focused type/architecture tests, this audit, and the existing frontend
+robustness manifest. No feature adapter, coordinator behavior, React owner,
+IPC declaration, preload bridge, Utility handler, bundle dependency, or product
+behavior is changed.
+
+## Mental execution trace
+
+1. A shared operation fragment declares `mode: 'read'` or `mode: 'write'`.
+2. The mapped `SaltMarcherApi` function retains that literal mode in a nominal,
+   compile-time-only brand while remaining normally callable at runtime.
+3. A future application adapter selects a branded operation and declares its
+   explicit projection or authority key through the matching descriptor.
+4. TypeScript rejects a write selected for latest-only/read execution before
+   dispatch; no transport, commit, event, acceptance, recovery, or remount can
+   occur from that invalid wiring.
+5. Valid descriptors remain data-free types in FR1A. FR1B and FR1C must provide
+   the first vertical runtime entry points and their controlled result paths.
+
+## Exclusions and delivery classification
+
+FR1A does not cut over a consumer, select TanStack Query, implement a projection
+store, alter `AsyncCommandCoordinator`, remove current legacy paths, or claim
+FR-A02 through FR-A05 interaction evidence. Its implementation is erased from
+the emitted JavaScript, but it changes shared and renderer source under `src/`
+and therefore is app-build-input relevant. It requires the complete exact-SHA
+Candidate handoff even though expected runtime behavior is unchanged.
+
+## Post-implementation audit
+
+### Exit-condition review
+
+| FR1A condition | Evidence | Assessment |
+| --- | --- | --- |
+| Registry mode survives the derived API | literal-preserving registry generic, nominal API operation type, settings read/write type assertions | covered without exposing registry values or Zod schemas to the renderer |
+| Separate typed entry points exist | read projection, FIFO command, long-work, and receipt-reconciliation descriptors | covered as type-only descriptors; runtime entry points remain intentionally absent |
+| Invalid write/read wiring fails closed | unbranded, write-as-read, read-as-command, and inverted-receipt types resolve to `never` | controlled compile-time mutations cover each mode boundary |
+| No parallel runtime owner is introduced | semantic architecture gate over imports, calls, constructions, and renderer consumers | covered; the contract has no runtime import, call, construction, or consumer |
+| Existing baseline is ratcheted | the historical mode-erasure assertion is removed and replaced by target contract proof | covered without accepting any existing latest-only write as valid |
+
+### Negative findings and follow-up
+
+1. The first brand was required at the structural function boundary. That made
+   valid Vitest mocks fail assignment even though their context already proves
+   the operation type. The brand is now optional for structural compatibility,
+   while mode extraction first requires the brand key to exist on the declared
+   type. A plain callback therefore still resolves to no operation mode.
+2. The first conditional treated `never` as assignable to `read`, which let an
+   unbranded callback produce a read descriptor. `HasOperationMode` now handles
+   the no-mode case explicitly before comparing the literal mode.
+3. An exported `CapabilityOperationOfMode` convenience alias looked stricter
+   than it was under the optional brand. It was removed rather than leaving a
+   misleading public contract; consumers use the conditional descriptors.
+4. The initial focused manifest omitted the directly changed operation-registry
+   unit suite. It was added before closeout.
+5. Calling the slice “test/contract-only” initially obscured repository delivery
+   semantics. Runtime code is unchanged, but `src/` bytes are application build
+   inputs, so FR1A is app-relevant and must complete canonical handoff.
+6. The contract cannot stop a deliberate unsafe cast from forging an API type,
+   and it does not yet prove FIFO transport, acceptance, or receipt behavior.
+   Those are not weakened or declared complete: FR1B must provide the first
+   read runtime consumer, and FR1C the first write/receipt runtime consumer with
+   controlled interaction evidence.
+
+### Pre-candidate verification
+
+- `pnpm check:frontend-robustness`: passed both TypeScript configurations,
+  9 test files, and 59 tests.
+- formatting, all lint partitions, the complete TypeScript check, and the
+  architecture suite passed; the architecture suite covered 9 files and 87
+  tests.
+- the complete local `pnpm check` reached 188 of 190 passing portable unit test
+  files and 759 of 764 passing tests. Its five failures were confined to four
+  unchanged 30-second tests in `encounter-generator-settings.test.tsx` and the
+  unchanged 16-millisecond gate in `reference-matcher.test.ts`.
+- during that run, CPU 0 reported both current and maximum frequency as 800 MHz
+  (`scaling_cur_freq=800000`, `scaling_max_freq=800000`). This host therefore
+  does not qualify the portable timing gates. No timeout, threshold, test, or
+  implementation was weakened; exact-SHA Candidate CI remains the required
+  qualified-host proof.
+
+No remaining finding invalidates the bounded FR1A guarantee. Closeout requires
+the final focused check, complete repository check on a qualified host, exact-
+SHA Candidate jobs, canonical application handoff, unchanged promotion, and a
+green Main attestation.

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -4,11 +4,14 @@
   "typecheck": true,
   "tests": [
     "tests/unit/frontend-robustness-baseline.test.ts",
+    "tests/unit/renderer-execution-contract.test.ts",
+    "tests/unit/operation-registry.test.ts",
     "tests/unit/async-command-coordinator.test.ts",
     "tests/unit/capability-errors.test.ts",
     "tests/unit/session-mutation-controller.test.tsx",
     "tests/unit/renderer-async-boundary.test.ts",
-    "tests/architecture/renderer-architecture.test.ts"
+    "tests/architecture/renderer-architecture.test.ts",
+    "tests/architecture/frontend-robustness-architecture.test.ts"
   ],
   "maxWorkers": 2
 }

--- a/src/renderer/async/renderer-execution-contract.ts
+++ b/src/renderer/async/renderer-execution-contract.ts
@@ -1,0 +1,72 @@
+import type { CapabilityOperationMode } from '../../shared/contracts/capability-api.js'
+
+type AsyncOperation = (...arguments_: never[]) => Promise<unknown>
+
+type HasOperationMode<
+  Operation extends AsyncOperation,
+  Mode extends 'read' | 'write'
+> = [CapabilityOperationMode<Operation>] extends [never]
+  ? false
+  : CapabilityOperationMode<Operation> extends Mode
+    ? true
+    : false
+
+export type RendererAuthorityKey<Scope extends string = string> = Readonly<{
+  scope: Scope
+  entityKey: string | null
+}>
+
+export type ReadProjectionExecution<
+  Operation extends AsyncOperation,
+  Scope extends string = string
+> =
+  HasOperationMode<Operation, 'read'> extends true
+    ? Readonly<{
+        kind: 'read-projection'
+        authority: RendererAuthorityKey<Scope>
+        operation: Operation
+      }>
+    : never
+
+export type FifoCommandExecution<
+  Operation extends AsyncOperation,
+  Scope extends string = string
+> =
+  HasOperationMode<Operation, 'write'> extends true
+    ? Readonly<{
+        kind: 'fifo-command'
+        authority: RendererAuthorityKey<Scope>
+        operation: Operation
+      }>
+    : never
+
+export type LongWorkExecution<
+  Operation extends AsyncOperation,
+  Scope extends string = string
+> =
+  HasOperationMode<Operation, 'read' | 'write'> extends true
+    ? Readonly<{
+        kind: 'long-work'
+        authority: RendererAuthorityKey<Scope>
+        operationId: string
+        operation: Operation
+        operationMode: CapabilityOperationMode<Operation>
+      }>
+    : never
+
+export type ReceiptReconciliationExecution<
+  Command extends AsyncOperation,
+  ReceiptRead extends AsyncOperation,
+  Scope extends string = string
+> =
+  HasOperationMode<Command, 'write'> extends true
+    ? HasOperationMode<ReceiptRead, 'read'> extends true
+      ? Readonly<{
+          kind: 'receipt-reconciliation'
+          authority: RendererAuthorityKey<Scope>
+          commandId: string
+          command: Command
+          receiptRead: ReceiptRead
+        }>
+      : never
+    : never

--- a/src/shared/contracts/capability-api.ts
+++ b/src/shared/contracts/capability-api.ts
@@ -1,11 +1,31 @@
 import type { z } from 'zod'
 import type { capabilityEvents } from './events.js'
 import type { coreOperations, mainOperations } from './operations.js'
+import type { OperationMode } from './operations/registry.js'
+
+declare const capabilityOperation: unique symbol
+
+export type CapabilityOperation<
+  Mode extends OperationMode,
+  Arguments extends readonly unknown[],
+  Output
+> = ((...arguments_: Arguments) => Promise<Output>) &
+  Readonly<{ [capabilityOperation]?: Mode }>
+
+export type CapabilityOperationMode<Operation> =
+  typeof capabilityOperation extends keyof Operation
+    ? Operation extends Readonly<{
+        [capabilityOperation]?: infer Mode extends OperationMode
+      }>
+      ? Mode
+      : never
+    : never
 
 type AnyDefinition = Readonly<{
   channel: string | null
   input: z.ZodType
   output: z.ZodType
+  mode: OperationMode
 }>
 
 type AnyEventDefinition = Readonly<{ payload: z.ZodType }>
@@ -16,13 +36,13 @@ type Namespace<Kind> = Kind extends `${infer Value}.${string}` ? Value : never
 type Method<Kind> = Kind extends `${string}.${infer Value}` ? Value : never
 type PublicNamespace<Value> = Value extends 'campaign' ? 'campaigns' : Value
 
-type OperationFunction<Definition extends AnyDefinition> = [
-  z.output<Definition['input']>
-] extends [undefined]
-  ? () => Promise<z.output<Definition['output']>>
-  : (
-      input: z.output<Definition['input']>
-    ) => Promise<z.output<Definition['output']>>
+type OperationFunction<Definition extends AnyDefinition> = CapabilityOperation<
+  Definition['mode'],
+  [z.output<Definition['input']>] extends [undefined]
+    ? readonly []
+    : readonly [input: z.output<Definition['input']>],
+  z.output<Definition['output']>
+>
 
 type PublicOperationKind<
   Registry extends Readonly<Record<string, AnyDefinition>>

--- a/src/shared/contracts/operations/registry.ts
+++ b/src/shared/contracts/operations/registry.ts
@@ -13,12 +13,13 @@ export interface OperationDiagnostics {
 export interface OperationDeclaration<
   Input extends z.ZodType = z.ZodType,
   Output extends z.ZodType = z.ZodType,
-  Roles extends readonly WindowRole[] = readonly WindowRole[]
+  Roles extends readonly WindowRole[] = readonly WindowRole[],
+  Mode extends OperationMode = OperationMode
 > {
   readonly channel: string | null
   readonly input: Input
   readonly output: Output
-  readonly mode: OperationMode
+  readonly mode: Mode
   readonly roles: Roles
   readonly deadlineMs: number
   readonly travelReconciliation: TravelReconciliationReason | null
@@ -27,8 +28,9 @@ export interface OperationDeclaration<
 export interface OperationDefinition<
   Input extends z.ZodType = z.ZodType,
   Output extends z.ZodType = z.ZodType,
-  Roles extends readonly WindowRole[] = readonly WindowRole[]
-> extends OperationDeclaration<Input, Output, Roles> {
+  Roles extends readonly WindowRole[] = readonly WindowRole[],
+  Mode extends OperationMode = OperationMode
+> extends OperationDeclaration<Input, Output, Roles, Mode> {
   readonly key: string
   readonly handler: OperationHandlerOwner
   readonly diagnostics: OperationDiagnostics
@@ -47,7 +49,7 @@ export function read<Input extends z.ZodType, Output extends z.ZodType>(
   channel: string | null,
   input: Input,
   output: Output
-): OperationDeclaration<Input, Output, readonly ['gm']>
+): OperationDeclaration<Input, Output, readonly ['gm'], 'read'>
 export function read<
   Input extends z.ZodType,
   Output extends z.ZodType,
@@ -57,13 +59,13 @@ export function read<
   input: Input,
   output: Output,
   roles: Roles
-): OperationDeclaration<Input, Output, Roles>
+): OperationDeclaration<Input, Output, Roles, 'read'>
 export function read<Input extends z.ZodType, Output extends z.ZodType>(
   channel: string | null,
   input: Input,
   output: Output,
   roles: readonly WindowRole[] = ['gm']
-): OperationDeclaration<Input, Output> {
+): OperationDeclaration<Input, Output, readonly WindowRole[], 'read'> {
   return {
     channel,
     input,
@@ -79,7 +81,7 @@ export function write<Input extends z.ZodType, Output extends z.ZodType>(
   channel: string | null,
   input: Input,
   output: Output
-): OperationDeclaration<Input, Output, readonly ['gm']>
+): OperationDeclaration<Input, Output, readonly ['gm'], 'write'>
 export function write<
   Input extends z.ZodType,
   Output extends z.ZodType,
@@ -90,14 +92,14 @@ export function write<
   output: Output,
   roles: Roles,
   travelReconciliation?: TravelReconciliationReason | null
-): OperationDeclaration<Input, Output, Roles>
+): OperationDeclaration<Input, Output, Roles, 'write'>
 export function write<Input extends z.ZodType, Output extends z.ZodType>(
   channel: string | null,
   input: Input,
   output: Output,
   roles: readonly WindowRole[] = ['gm'],
   travelReconciliation: TravelReconciliationReason | null = 'travel-command'
-): OperationDeclaration<Input, Output> {
+): OperationDeclaration<Input, Output, readonly WindowRole[], 'write'> {
   return {
     channel,
     input,

--- a/tests/architecture/frontend-robustness-architecture.test.ts
+++ b/tests/architecture/frontend-robustness-architecture.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'vitest'
+import { architectureGate } from './support/architecture-gate.js'
+import { codeFiles, readTypeScriptModule } from './support/typescript-module.js'
+
+architectureGate(
+  'typed-contract',
+  'keeps renderer execution modes nominal and the FR1A contract type-only',
+  () => {
+    const capabilityApi = readTypeScriptModule(
+      'src/shared/contracts/capability-api.ts'
+    )
+    expect(capabilityApi.typeProperties).toContainEqual({
+      name: 'mode',
+      optional: false
+    })
+    for (const declaration of [
+      'CapabilityOperation',
+      'CapabilityOperationMode'
+    ])
+      expect(
+        capabilityApi.exportedDeclarations.has(declaration),
+        declaration
+      ).toBe(true)
+
+    const contractPath = 'src/renderer/async/renderer-execution-contract.ts'
+    const contract = readTypeScriptModule(contractPath)
+    expect(contract.imports.every(({ typeOnly }) => typeOnly)).toBe(true)
+    expect(contract.calls).toEqual([])
+    expect(contract.constructions).toEqual([])
+    for (const declaration of [
+      'RendererAuthorityKey',
+      'ReadProjectionExecution',
+      'FifoCommandExecution',
+      'LongWorkExecution',
+      'ReceiptReconciliationExecution'
+    ])
+      expect(contract.exportedDeclarations.has(declaration), declaration).toBe(
+        true
+      )
+
+    for (const path of codeFiles('src/renderer'))
+      for (const dependency of readTypeScriptModule(path).imports.filter(
+        ({ specifier }) => specifier.includes('renderer-execution-contract')
+      ))
+        expect(dependency.typeOnly, `${path} imports runtime contract`).toBe(
+          true
+        )
+  }
+)

--- a/tests/unit/frontend-robustness-baseline.test.ts
+++ b/tests/unit/frontend-robustness-baseline.test.ts
@@ -96,16 +96,4 @@ describe('FR0 frontend robustness baseline', () => {
       expect(module.stringLiterals, path).toContain('queue')
     }
   })
-
-  it('records that the derived renderer API erases operation mode metadata', () => {
-    const registry = readTypeScriptModule(
-      'src/shared/contracts/operations/registry.ts'
-    )
-    const api = readTypeScriptModule('src/shared/contracts/capability-api.ts')
-
-    expect(registry.stringLiterals).toEqual(
-      expect.arrayContaining(['read', 'write'])
-    )
-    expect(api.typeProperties.map(({ name }) => name)).not.toContain('mode')
-  })
 })

--- a/tests/unit/renderer-execution-contract.test.ts
+++ b/tests/unit/renderer-execution-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  CapabilityOperationMode,
+  SaltMarcherApi
+} from '../../src/shared/contracts/capability-api.js'
+import type {
+  FifoCommandExecution,
+  LongWorkExecution,
+  ReadProjectionExecution,
+  ReceiptReconciliationExecution,
+  RendererAuthorityKey
+} from '../../src/renderer/async/renderer-execution-contract.js'
+
+type SettingsRead = SaltMarcherApi['settings']['read']
+type SettingsUpdate = SaltMarcherApi['settings']['update']
+type NpcCreate = SaltMarcherApi['npcs']['create']
+type NpcReceiptRead = SaltMarcherApi['npcs']['commandReceipt']
+
+describe('renderer execution contract', () => {
+  it('preserves registry operation modes through the derived API', () => {
+    expectTypeOf<
+      CapabilityOperationMode<SettingsRead>
+    >().toEqualTypeOf<'read'>()
+    expectTypeOf<
+      CapabilityOperationMode<SettingsUpdate>
+    >().toEqualTypeOf<'write'>()
+  })
+
+  it('defines explicit authority and execution entry-point shapes', () => {
+    expectTypeOf<RendererAuthorityKey<'settings'>>().toEqualTypeOf<
+      Readonly<{ scope: 'settings'; entityKey: string | null }>
+    >()
+    expectTypeOf<
+      ReadProjectionExecution<SettingsRead, 'settings.read'>['kind']
+    >().toEqualTypeOf<'read-projection'>()
+    expectTypeOf<
+      FifoCommandExecution<SettingsUpdate, 'settings.write'>['kind']
+    >().toEqualTypeOf<'fifo-command'>()
+    expectTypeOf<
+      LongWorkExecution<NpcCreate>['operationMode']
+    >().toEqualTypeOf<'write'>()
+    expectTypeOf<
+      ReceiptReconciliationExecution<NpcCreate, NpcReceiptRead>['kind']
+    >().toEqualTypeOf<'receipt-reconciliation'>()
+  })
+
+  it('fails closed for untyped or mode-inverted execution wiring', () => {
+    expectTypeOf<
+      ReadProjectionExecution<() => Promise<unknown>>
+    >().toEqualTypeOf<never>()
+    expectTypeOf<
+      ReadProjectionExecution<SettingsUpdate>
+    >().toEqualTypeOf<never>()
+    expectTypeOf<FifoCommandExecution<SettingsRead>>().toEqualTypeOf<never>()
+    expectTypeOf<
+      ReceiptReconciliationExecution<SettingsRead, NpcReceiptRead>
+    >().toEqualTypeOf<never>()
+    expectTypeOf<
+      ReceiptReconciliationExecution<NpcCreate, SettingsUpdate>
+    >().toEqualTypeOf<never>()
+  })
+})


### PR DESCRIPTION
## Ergebnis

FR1A bewahrt den read/write-Modus jeder Registry-Operation bis in die abgeleitete Renderer-API und führt einen rein typbasierten Ausführungsvertrag ein. Ungültige Verdrahtungen lösen zu never auf; es entsteht kein Runtime-Owner und keine neue Renderer-Abhängigkeit.

## Scope

- literal-preserving OperationDeclaration und OperationDefinition
- nominaler, zur Laufzeit entfernter CapabilityOperation-Typ
- getrennte Deskriptoren für Read-Projektion, FIFO-Command, Long Work und Receipt-Reconciliation
- explizite Authority Keys mit Scope und Entity Key
- kontrollierte Negativfälle und semantisches Architektur-Gate
- FR0-Baseline von Mode-Erasure auf den Zielvertrag hochgeratscht
- vollständiges Audit unter docs/project/evidence/frontend-robustness-fr1a-audit.md

## Auditbefunde und Korrekturen

- Ein zunächst erforderliches Brand brach gültige Vitest-Mocks. Das Brand ist nun strukturell optional; die Mode-Extraktion verlangt dennoch den vorhandenen Brand-Key, sodass untypisierte Callbacks fail-closed bleiben.
- never wurde im ersten Conditional irrtümlich als read akzeptiert. HasOperationMode behandelt fehlenden Mode jetzt explizit.
- Ein irreführender Convenience-Alias wurde entfernt.
- Der direkt betroffene Operation-Registry-Test wurde in das fokussierte Manifest aufgenommen.
- Die Delivery-Klassifikation wurde korrigiert: keine Runtime-Verhaltensänderung, aber geänderte src-Build-Inputs, daher app-relevant und handoff-pflichtig.
- Bewusst offen: Unsichere Casts können Typen fälschen; echte Read-, FIFO- und Receipt-Interaktionen werden erst in FR1B und FR1C vertikal bewiesen.

## Nachweis vor Candidate CI

- pnpm check:frontend-robustness: grün, beide TypeScript-Konfigurationen, 9 Dateien, 59 Tests
- Formatierung, alle Lint-Partitionen, vollständiger Typecheck und Architektur-Suite grün
- Architektur-Suite: 9 Dateien, 87 Tests
- vollständiges lokales pnpm check: 188 von 190 Unit-Dateien und 759 von 764 Tests grün
- ausschließlich unveränderte Host-Timing-Gates fehlgeschlagen: vier Encounter-Generator-Tests mit 30-Sekunden-Timeout sowie Reference Matcher mit 54.699 ms gegen 16 ms
- gemessener Hostzustand während des Laufs: aktuelle und maximale CPU-Frequenz 800 MHz
- keine Schwelle, kein Timeout, kein Test und keine Implementierung wurde gelockert

## Delivery-Gates

- Candidate SHA: 97435eeb27454a204407169f2ed0ca536f14b8db
- Exact-SHA Candidate Check muss auf qualifiziertem CI-Host grün werden
- anschließend canonical pnpm handoff:app für denselben SHA
- erst danach unveränderte Promotion nach main und grüner Main-Check
