### PR TITLE
FR1B: cut over installation settings read projection

### DIFF
--- a/docs/project/evidence/frontend-robustness-fr1b-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr1b-audit.md
@@ -1,0 +1,178 @@
+# Frontend robustness FR1B audit
+
+- Date: 2026-08-24
+- Baseline: `origin/main@97435eeb27454a204407169f2ed0ca536f14b8db`
+- Sprint: `FR1B` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap, acceptance matrix, and FR1A audit;
+- the complete historical Electron roadmap and current target architecture;
+- `TN-11`, `TN-16`, `TN-21`, and `QS-01` through `QS-05` in the program
+  technical needs;
+- the live capability provider, installation settings API, preference hook,
+  async coordinator, operation/event registries, tests, build dependencies, and
+  open pull requests;
+- the current official TanStack Query invalidation/default-policy documentation
+  and npm package metadata for `@tanstack/react-query` and
+  `@tanstack/query-core`.
+
+## Implementation packet
+
+FR1B owns one complete, low-risk reference read projection:
+
+- state class: immutable read projection;
+- durable authority: Utility/SQLite installation settings;
+- renderer authority key: `{ scope: 'installation.settings', entityKey: null }`;
+- ordering: latest-only reads through the existing `AsyncCommandCoordinator`;
+- cache lifetime: one `InstallationSettingsProjection` per
+  `CapabilityProvider`, independent of individual consumer mounts;
+- acceptance: exact-key publication with monotonic settings revision;
+- invalidation: explicit `refresh()` of only the installation settings key;
+- consumer cutover: `useInstallationPreferences` no longer calls
+  `settings.read()` directly.
+
+The existing preference draft/view state and queued update/reconciliation path
+remain separate. An accepted settings update may publish its returned immutable
+settings into the projection, but the read owner neither dispatches nor queues
+writes.
+
+## Bounded cache spike
+
+The comparison was performed on 2026-08-24. The npm version observed for
+`@tanstack/react-query` was `5.102.2`; no package was installed for the spike.
+
+| Candidate | Useful behavior | Required local policy | Cost and removal path |
+| --- | --- | --- | --- |
+| TanStack Query | mature request deduplication, exact query-key invalidation, subscription lifecycle, stale/refetch and garbage-collection policy | disable or configure automatic freshness/refetch behavior; wrap monotonic revision acceptance and the renderer authority descriptor; keep mutation ownership outside Query | adds React Query and Query Core plus a provider/query adapter; removal would touch provider, query client, hooks, dependency lock, and every migrated key |
+| Minimal `useSyncExternalStore` owner | React-native external-store subscription with the existing coordinator's latest-only tokens and cancellation | implement same-key in-flight deduplication, exact authority-key storage, monotonic revision rejection, retained-value failure state, and provider disposal | no new dependency or bundle input; removal is isolated to the generic owner, one settings adapter, one hook, and provider context field |
+
+The minimal owner was selected. This slice has one singleton, explicitly
+invalidated, revisioned value and intentionally needs none of Query's automatic
+server-state policy. The required custom behavior is small and is exercised by
+controlled promises. FR2 may still reject the approach if the more complex
+Campaign/Workspace key topology demonstrates that this lifecycle does not
+scale. The explicit removal path above prevents FR1B from becoming an implicit
+platform commitment.
+
+Reference material used for the spike:
+
+- [TanStack Query invalidation guide](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation)
+- [TanStack Query important defaults](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults)
+- [`@tanstack/react-query` npm package](https://www.npmjs.com/package/%40tanstack/react-query)
+
+## Mental execution trace
+
+1. The provider constructs one settings projection and owns its lifecycle.
+2. The first preference consumer subscribes and requests the installation key.
+3. Further consumers join the same in-flight promise; no second IPC read is
+   dispatched.
+4. A result is published only if its coordinator token is current and its
+   revision is not below the accepted key revision.
+5. A newer invalidation aborts visible acceptance of the older request. An old
+   transport that ignores cancellation may finish, but cannot replace the new
+   value.
+6. Consumer unmount removes only its subscription. A pending read and accepted
+   cache survive while the provider remains mounted, so remount does not issue
+   a duplicate read.
+7. Provider unmount cancels acceptance and clears the cache. A late transport
+   result cannot recreate visible state.
+8. Read failure retains the last accepted immutable value while exposing a
+   failure snapshot. Preference error presentation remains at the consumer
+   boundary.
+
+## Exclusions and delivery classification
+
+FR1B does not add settings events or IPC, migrate any write to a new command
+owner, claim FIFO/receipt guarantees from FR1C, replace preference view state,
+or generalize the settings key to Campaign/Session topology. There is currently
+no `settings.changed` event, so invalidation is deliberately explicit rather
+than simulated through polling or a renderer-global signal.
+
+The generic owner exists only because the chosen settings adapter exercises it
+end to end. It is not an independent singleton, generic domain store, write
+cache, or draft owner. The changes affect renderer source and are therefore
+application-build-input relevant: exact-SHA Candidate checks and canonical
+`pnpm handoff:app` remain mandatory before promotion.
+
+## Post-implementation audit
+
+### Exit-condition review
+
+| FR1B condition | Evidence | Assessment |
+| --- | --- | --- |
+| one reference read is cut over end to end | provider-owned settings adapter, external-store hook, preference consumer, controlled React test | covered; the old direct initial read is absent |
+| same-key reads deduplicate | two simultaneous preference consumers and generic controlled promise | covered with one transport invocation |
+| stale visible acceptance is rejected | older read resolves after the newer invalidation result | covered; only revision 2 remains current |
+| invalidation is exact-keyed | authority-key map and unrelated-key subscription test | covered without global remount or broadcast |
+| revision regression fails closed | accepted revision 5 followed by transport revision 4 | covered; the ready revision 5 snapshot is restored |
+| consumer and provider lifetime differ | unmount/remount under a live provider plus provider disposal during a pending read | covered for the reference owner |
+| no write or draft enters the read owner | adapter API exposes only load/refresh/publish and architecture gate removes direct reads | covered for FR1B; FR1C remains open |
+| bounded dependency decision and removal path exist | dated comparison above; package manifest and lock unchanged | covered; normal bundle budget remains a Candidate gate |
+
+### Negative findings and follow-up
+
+1. The first hook result recreated a frozen method bundle on every render. That
+   would have changed the existing save callback identity and repeatedly reset
+   the layout debounce. The hook now returns the stable provider projection
+   separately from its changing snapshot.
+2. The first lower-revision path rejected publication but left the projection
+   snapshot in `pending`. It now restores the previously accepted `ready`
+   snapshot, and a controlled revision-regression test locks that behavior.
+3. Promise cleanup initially used an ignored `finally()` chain. Although the
+   coordinator resolves failures as outcomes, a future thrown projection step
+   could have created an unhandled rejected child promise. Symmetric `then`
+   cleanup now clears the in-flight slot without that risk.
+4. The initial architecture test used a new unregistered gate label. The
+   repository's typed gate registry rejected it during the focused check; the
+   assertion is now correctly classified under the existing
+   `behavior-integration` gate.
+5. A failed reconciliation read first reached both the projection failure
+   snapshot and the enclosing command failure callback, which could show the
+   same error twice. Command reporting now suppresses only the identical cause
+   already owned by the projection snapshot; a React test covers the combined
+   stale-write/read-failure path.
+6. The first snapshot type declared `cause` as `unknown | null`, although
+   `unknown` already includes `null`. The renderer lint partition rejected that
+   misleading redundancy; the field is now simply `unknown`, while idle and
+   successful snapshots still carry the runtime sentinel `null`.
+7. Two React test wrappers were initially marked `async` without awaiting work;
+   the focused test run passed, but the stricter renderer lint correctly
+   rejected the misleading wrappers. They now resolve the controlled promise
+   synchronously inside `act` and wait semantically for the resulting state.
+8. Final lifecycle review found that `refresh()` retries a stale read by design,
+   which could have started a new transport after provider disposal. Disposal
+   is now a terminal owner state: subscriptions become no-ops, reads return an
+   aborted outcome, publication is rejected, and the disposal test proves no
+   second transport starts.
+9. A retained failure snapshot could be reported again whenever a parent
+   supplied a new `onError` callback identity. Each preference consumer now
+   records the exact failure snapshot it has presented; a genuinely new failure
+   still has a new snapshot and remains visible.
+10. The adapter intentionally defers access to `api.settings.read` until a load.
+   Several unrelated renderer unit tests provide narrow API doubles under the
+   shared provider. Eager access would make provider construction depend on an
+   unused capability and would be a broader test/runtime coupling.
+11. Settings has no change event. External-process changes are therefore not
+   automatically invalidated in FR1B. Inventing a renderer event or polling
+   loop would expand the boundary; exact explicit refresh and accepted-write
+   publication are the bounded behavior. FR7 retains the zero-alternate-owner
+   and final recovery review.
+12. The React proof covers deduplication and consumer remount; crossed revisions,
+   key isolation, failure retention, and provider disposal use the same runtime
+   owner directly with controlled promises. No unit result is presented as the
+   still-open FR1C write/receipt or later Electron interaction guarantee.
+
+No remaining finding threatens the bounded FR1B row. The cache choice remains
+provisional until the FR2 go/no-go review, and all FR1 write conditions remain
+open for FR1C.
+
+### Pre-PR verification
+
+- focused controlled tests: 3 files and 11 tests passed;
+- `pnpm check:frontend-robustness`: both TypeScript configurations, 11 test
+  files, and 69 tests passed;
+- exact Candidate remote jobs, canonical app handoff, installed-runtime proof,
+  unchanged promotion, and green Main evidence are intentionally pending at PR
+  creation and must be attached before promotion.

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -7,6 +7,8 @@
     "tests/unit/renderer-execution-contract.test.ts",
     "tests/unit/operation-registry.test.ts",
     "tests/unit/async-command-coordinator.test.ts",
+    "tests/unit/keyed-read-projection-owner.test.ts",
+    "tests/unit/installation-settings-projection.test.tsx",
     "tests/unit/capability-errors.test.ts",
     "tests/unit/session-mutation-controller.test.tsx",
     "tests/unit/renderer-async-boundary.test.ts",

--- a/src/renderer/async/keyed-read-projection-owner.ts
+++ b/src/renderer/async/keyed-read-projection-owner.ts
@@ -1,0 +1,246 @@
+import type {
+  ReadProjectionExecution,
+  RendererAuthorityKey
+} from './renderer-execution-contract.js'
+import type { AsyncCommandOutcome } from './async-command-coordinator.js'
+import { AsyncCommandCoordinator } from './async-command-coordinator.js'
+
+type AsyncReadOperation<Value> = (...arguments_: never[]) => Promise<Value>
+
+type ExecutableReadProjection<
+  Operation extends AsyncReadOperation<Value>,
+  Scope extends string,
+  Value
+> = ReadProjectionExecution<Operation, Scope> &
+  Readonly<{
+    authority: RendererAuthorityKey<Scope>
+    operation: Operation
+  }>
+
+export type ReadProjectionSnapshot<Value> = Readonly<{
+  status: 'idle' | 'pending' | 'ready' | 'failure'
+  value: Value | null
+  revision: number | null
+  cause: unknown
+}>
+
+export type ReadProjectionOutcome<Value> =
+  | Readonly<{ status: 'cached' | 'accepted'; value: Value }>
+  | Readonly<{
+      status: 'stale'
+      reason: 'superseded' | 'aborted' | 'older-revision'
+    }>
+  | Readonly<{ status: 'failure'; cause: unknown }>
+
+type ProjectionEntry<Value> = {
+  snapshot: ReadProjectionSnapshot<Value>
+  inFlight: Promise<ReadProjectionOutcome<Value>> | null
+  listeners: Set<() => void>
+}
+
+const idleSnapshot = Object.freeze({
+  status: 'idle',
+  value: null,
+  revision: null,
+  cause: null
+}) satisfies ReadProjectionSnapshot<never>
+
+/**
+ * Owns immutable renderer read projections while delegating request ordering,
+ * cancellation and acceptance tokens to the shared async coordinator.
+ */
+export class KeyedReadProjectionOwner<Value> {
+  readonly #entries = new Map<string, ProjectionEntry<Value>>()
+  readonly #coordinator: AsyncCommandCoordinator
+  readonly #revisionOf: (value: Value) => number
+  #disposed = false
+
+  public constructor(
+    coordinator: AsyncCommandCoordinator,
+    revisionOf: (value: Value) => number
+  ) {
+    this.#coordinator = coordinator
+    this.#revisionOf = revisionOf
+  }
+
+  public subscribe(
+    authority: RendererAuthorityKey,
+    listener: () => void
+  ): () => void {
+    if (this.#disposed) return () => undefined
+    const entry = this.#entry(authority)
+    entry.listeners.add(listener)
+    return () => entry.listeners.delete(listener)
+  }
+
+  public snapshot(
+    authority: RendererAuthorityKey
+  ): ReadProjectionSnapshot<Value> {
+    if (this.#disposed) return idleSnapshot
+    return this.#entry(authority).snapshot
+  }
+
+  public current(authority: RendererAuthorityKey): Value | null {
+    if (this.#disposed) return null
+    return this.#entry(authority).snapshot.value
+  }
+
+  public ensure<
+    Operation extends AsyncReadOperation<Value>,
+    Scope extends string
+  >(
+    execution: ExecutableReadProjection<Operation, Scope, Value>,
+    ...arguments_: Parameters<Operation>
+  ): Promise<ReadProjectionOutcome<Value>> {
+    if (this.#disposed) return Promise.resolve(abortedOutcome)
+    const entry = this.#entry(execution.authority)
+    if (entry.snapshot.status === 'ready' && entry.snapshot.value !== null)
+      return Promise.resolve(
+        Object.freeze({ status: 'cached', value: entry.snapshot.value })
+      )
+    if (entry.inFlight) return entry.inFlight
+    return this.#start(entry, execution, arguments_)
+  }
+
+  public invalidate<
+    Operation extends AsyncReadOperation<Value>,
+    Scope extends string
+  >(
+    execution: ExecutableReadProjection<Operation, Scope, Value>,
+    ...arguments_: Parameters<Operation>
+  ): Promise<ReadProjectionOutcome<Value>> {
+    if (this.#disposed) return Promise.resolve(abortedOutcome)
+    return this.#start(this.#entry(execution.authority), execution, arguments_)
+  }
+
+  public publish(authority: RendererAuthorityKey, value: Value): boolean {
+    if (this.#disposed) return false
+    const entry = this.#entry(authority)
+    const revision = this.#revisionOf(value)
+    if (entry.snapshot.revision !== null && revision < entry.snapshot.revision)
+      return false
+    this.#setSnapshot(
+      entry,
+      Object.freeze({
+        status: 'ready',
+        value,
+        revision,
+        cause: null
+      })
+    )
+    return true
+  }
+
+  public dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#coordinator.cancelAll()
+    for (const entry of this.#entries.values()) {
+      entry.inFlight = null
+      entry.listeners.clear()
+    }
+    this.#entries.clear()
+  }
+
+  #start<Operation extends AsyncReadOperation<Value>, Scope extends string>(
+    entry: ProjectionEntry<Value>,
+    execution: ExecutableReadProjection<Operation, Scope, Value>,
+    arguments_: Parameters<Operation>
+  ): Promise<ReadProjectionOutcome<Value>> {
+    this.#setSnapshot(
+      entry,
+      Object.freeze({
+        status: 'pending',
+        value: entry.snapshot.value,
+        revision: entry.snapshot.revision,
+        cause: null
+      })
+    )
+    let accepted = false
+    const coordinated = this.#coordinator.run({
+      ...execution.authority,
+      mode: 'latest-only',
+      execute: () => execution.operation(...arguments_),
+      accept: (value) => {
+        accepted = this.publish(execution.authority, value)
+      }
+    })
+    const outcome = coordinated.then((result) =>
+      this.#projectOutcome(entry, result, accepted)
+    )
+    entry.inFlight = outcome
+    void outcome.then(
+      () => {
+        if (entry.inFlight === outcome) entry.inFlight = null
+      },
+      () => {
+        if (entry.inFlight === outcome) entry.inFlight = null
+      }
+    )
+    return outcome
+  }
+
+  #projectOutcome(
+    entry: ProjectionEntry<Value>,
+    result: AsyncCommandOutcome<Value>,
+    accepted: boolean
+  ): ReadProjectionOutcome<Value> {
+    if (result.status === 'success') {
+      if (accepted)
+        return Object.freeze({ status: 'accepted', value: result.value })
+      if (entry.snapshot.value !== null && entry.snapshot.revision !== null)
+        this.#setSnapshot(
+          entry,
+          Object.freeze({
+            status: 'ready',
+            value: entry.snapshot.value,
+            revision: entry.snapshot.revision,
+            cause: null
+          })
+        )
+      return Object.freeze({ status: 'stale', reason: 'older-revision' })
+    }
+    if (result.status === 'stale')
+      return Object.freeze({ status: 'stale', reason: result.reason })
+    this.#setSnapshot(
+      entry,
+      Object.freeze({
+        status: 'failure',
+        value: entry.snapshot.value,
+        revision: entry.snapshot.revision,
+        cause: result.cause
+      })
+    )
+    return Object.freeze({ status: 'failure', cause: result.cause })
+  }
+
+  #entry(authority: RendererAuthorityKey): ProjectionEntry<Value> {
+    const key = authorityKey(authority)
+    const existing = this.#entries.get(key)
+    if (existing) return existing
+    const entry: ProjectionEntry<Value> = {
+      snapshot: idleSnapshot,
+      inFlight: null,
+      listeners: new Set()
+    }
+    this.#entries.set(key, entry)
+    return entry
+  }
+
+  #setSnapshot(
+    entry: ProjectionEntry<Value>,
+    snapshot: ReadProjectionSnapshot<Value>
+  ): void {
+    entry.snapshot = snapshot
+    for (const listener of entry.listeners) listener()
+  }
+}
+
+function authorityKey(authority: RendererAuthorityKey): string {
+  return JSON.stringify([authority.scope, authority.entityKey])
+}
+
+const abortedOutcome = Object.freeze({
+  status: 'stale',
+  reason: 'aborted'
+}) satisfies ReadProjectionOutcome<never>

--- a/src/renderer/capabilities/capability-context.ts
+++ b/src/renderer/capabilities/capability-context.ts
@@ -1,4 +1,12 @@
 import { createContext } from 'react'
 import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import type { InstallationSettingsProjection } from './installation-settings-projection.js'
 
-export const CapabilityContext = createContext<SaltMarcherApi | null>(null)
+export type CapabilityContextValue = Readonly<{
+  api: SaltMarcherApi
+  installationSettings: InstallationSettingsProjection
+}>
+
+export const CapabilityContext = createContext<CapabilityContextValue | null>(
+  null
+)

--- a/src/renderer/capabilities/capability-provider.tsx
+++ b/src/renderer/capabilities/capability-provider.tsx
@@ -1,13 +1,26 @@
-import type { ReactNode } from 'react'
+import { useEffect, useMemo, type ReactNode } from 'react'
 import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
 import { CapabilityContext } from './capability-context.js'
+import { InstallationSettingsProjection } from './installation-settings-projection.js'
 
 export function CapabilityProvider(props: {
   api: SaltMarcherApi
   children: ReactNode
 }) {
+  const value = useMemo(
+    () =>
+      Object.freeze({
+        api: props.api,
+        installationSettings: new InstallationSettingsProjection(props.api)
+      }),
+    [props.api]
+  )
+  useEffect(
+    () => () => value.installationSettings.dispose(),
+    [value.installationSettings]
+  )
   return (
-    <CapabilityContext.Provider value={props.api}>
+    <CapabilityContext.Provider value={value}>
       {props.children}
     </CapabilityContext.Provider>
   )

--- a/src/renderer/capabilities/installation-settings-projection.ts
+++ b/src/renderer/capabilities/installation-settings-projection.ts
@@ -1,0 +1,58 @@
+import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import type { InstallationSettings } from '../../shared/contracts/settings.js'
+import { AsyncCommandCoordinator } from '../async/async-command-coordinator.js'
+import { KeyedReadProjectionOwner } from '../async/keyed-read-projection-owner.js'
+import type { ReadProjectionExecution } from '../async/renderer-execution-contract.js'
+
+export const installationSettingsAuthority = Object.freeze({
+  scope: 'installation.settings',
+  entityKey: null
+})
+
+export class InstallationSettingsProjection {
+  readonly #owner: KeyedReadProjectionOwner<InstallationSettings>
+  readonly #execution: ReadProjectionExecution<
+    SaltMarcherApi['settings']['read'],
+    'installation.settings'
+  >
+
+  public constructor(api: SaltMarcherApi) {
+    const operation: SaltMarcherApi['settings']['read'] = () =>
+      api.settings.read()
+    this.#owner = new KeyedReadProjectionOwner(
+      new AsyncCommandCoordinator(),
+      (settings) => settings.revision
+    )
+    this.#execution = Object.freeze({
+      kind: 'read-projection',
+      authority: installationSettingsAuthority,
+      operation
+    })
+  }
+
+  public readonly subscribe = (listener: () => void): (() => void) =>
+    this.#owner.subscribe(installationSettingsAuthority, listener)
+
+  public readonly snapshot = () =>
+    this.#owner.snapshot(installationSettingsAuthority)
+
+  public readonly current = (): InstallationSettings | null =>
+    this.#owner.current(installationSettingsAuthority)
+
+  public readonly load = () => this.#owner.ensure(this.#execution)
+
+  public readonly refresh = async (): Promise<InstallationSettings> => {
+    let outcome = await this.#owner.invalidate(this.#execution)
+    if (outcome.status === 'stale')
+      outcome = await this.#owner.ensure(this.#execution)
+    if (outcome.status === 'accepted' || outcome.status === 'cached')
+      return outcome.value
+    if (outcome.status === 'failure') throw outcome.cause
+    throw new Error('Installation settings projection remained stale')
+  }
+
+  public readonly publish = (settings: InstallationSettings): boolean =>
+    this.#owner.publish(installationSettingsAuthority, settings)
+
+  public readonly dispose = (): void => this.#owner.dispose()
+}

--- a/src/renderer/capabilities/use-capability-api.ts
+++ b/src/renderer/capabilities/use-capability-api.ts
@@ -3,7 +3,7 @@ import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
 import { CapabilityContext } from './capability-context.js'
 
 export function useCapabilityApi(): SaltMarcherApi {
-  const api = useContext(CapabilityContext)
-  if (!api) throw new Error('Renderer capability provider is missing')
-  return api
+  const context = useContext(CapabilityContext)
+  if (!context) throw new Error('Renderer capability provider is missing')
+  return context.api
 }

--- a/src/renderer/shell/use-installation-preferences.ts
+++ b/src/renderer/shell/use-installation-preferences.ts
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SessionLayoutPreference } from '../../shared/contracts/session-layout.js'
-import type {
-  InstallationPreferences,
-  InstallationSettings
-} from '../../shared/contracts/settings.js'
+import type { InstallationPreferences } from '../../shared/contracts/settings.js'
 import { defaultSessionLayoutPreferenceValue } from '../../shared/values/session-layout-values.js'
 import { capabilityErrorCode } from '../../shared/errors/capability-error.js'
 import { capabilityErrorMessage, message } from '../i18n/messages.de.js'
 import { useCapabilityApi } from '../capabilities/use-capability-api.js'
 import { useAsyncCommandCoordinator } from '../async/use-async-command-coordinator.js'
+import { useInstallationSettingsProjection } from './use-installation-settings-projection.js'
 
 export function useInstallationPreferences(
   onError: (message: string) => void,
@@ -16,27 +14,34 @@ export function useInstallationPreferences(
 ) {
   const capabilityApi = useCapabilityApi()
   const commands = useAsyncCommandCoordinator()
+  const { snapshot: projectionSnapshot, projection } =
+    useInstallationSettingsProjection(enabled)
   const [theme, setTheme] = useState<'light' | 'dark'>('light')
   const [sessionLayout, setSessionLayout] = useState<SessionLayoutPreference>(
     defaultSessionLayoutPreferenceValue
   )
   const loaded = useRef(false)
   const savedLayout = useRef('')
-  const settings = useRef<InstallationSettings | null>(null)
+  const reportedFailure = useRef<unknown>(null)
 
   useEffect(() => {
-    if (!enabled) return
-    void capabilityApi.settings
-      .read()
-      .then((value) => {
-        settings.current = value
-        loaded.current = true
-        savedLayout.current = JSON.stringify(value.preferences.sessionLayout)
-        setSessionLayout(value.preferences.sessionLayout)
-        setTheme(value.preferences.theme)
-      })
-      .catch((cause: unknown) => onError(capabilityErrorMessage(cause)))
-  }, [capabilityApi, enabled, onError])
+    const value = projectionSnapshot.value
+    if (loaded.current || value === null) return
+    loaded.current = true
+    savedLayout.current = JSON.stringify(value.preferences.sessionLayout)
+    setSessionLayout(value.preferences.sessionLayout)
+    setTheme(value.preferences.theme)
+  }, [projectionSnapshot.value])
+
+  useEffect(() => {
+    if (
+      projectionSnapshot.status === 'failure' &&
+      reportedFailure.current !== projectionSnapshot
+    ) {
+      reportedFailure.current = projectionSnapshot
+      onError(capabilityErrorMessage(projectionSnapshot.cause))
+    }
+  }, [onError, projectionSnapshot])
 
   useEffect(() => {
     document.documentElement.dataset['theme'] = theme
@@ -49,7 +54,7 @@ export function useInstallationPreferences(
           scope: 'installation.preferences',
           mode: 'queue',
           execute: async () => {
-            let current = settings.current
+            let current = projection.current()
             if (current === null) return null
             let notice: string | null = null
             try {
@@ -58,7 +63,7 @@ export function useInstallationPreferences(
                 expectedRevision: current.revision
               })
             } catch (cause) {
-              const fresh = await capabilityApi.settings.read()
+              const fresh = await projection.refresh()
               if (capabilityErrorCode(cause) === 'outcome_unknown') {
                 current = fresh
                 const committed = Object.entries(patch).every(
@@ -83,16 +88,19 @@ export function useInstallationPreferences(
           },
           accept: (result) => {
             if (result === null) return
-            settings.current = result.settings
+            projection.publish(result.settings)
             if (result.notice) onError(result.notice)
           }
         })
         .then((outcome) => {
-          if (outcome.status === 'failure')
+          if (
+            outcome.status === 'failure' &&
+            projection.snapshot().cause !== outcome.cause
+          )
             onError(capabilityErrorMessage(outcome.cause))
         })
     },
-    [capabilityApi, commands, onError]
+    [capabilityApi, commands, onError, projection]
   )
 
   useEffect(() => {

--- a/src/renderer/shell/use-installation-settings-projection.ts
+++ b/src/renderer/shell/use-installation-settings-projection.ts
@@ -1,0 +1,22 @@
+import { useContext, useEffect, useSyncExternalStore } from 'react'
+import { CapabilityContext } from '../capabilities/capability-context.js'
+
+export function useInstallationSettingsProjection(enabled: boolean) {
+  const context = useContext(CapabilityContext)
+  if (!context) throw new Error('Renderer capability provider is missing')
+  const projection = context.installationSettings
+  const snapshot = useSyncExternalStore(
+    projection.subscribe,
+    projection.snapshot,
+    projection.snapshot
+  )
+
+  useEffect(() => {
+    if (enabled) void projection.load()
+  }, [enabled, projection])
+
+  return Object.freeze({
+    snapshot,
+    projection
+  })
+}

--- a/tests/architecture/frontend-robustness-architecture.test.ts
+++ b/tests/architecture/frontend-robustness-architecture.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'vitest'
 import { architectureGate } from './support/architecture-gate.js'
-import { codeFiles, readTypeScriptModule } from './support/typescript-module.js'
+import {
+  codeFiles,
+  parseTypeScriptModule,
+  readTypeScriptModule
+} from './support/typescript-module.js'
 
 architectureGate(
   'typed-contract',
@@ -47,3 +51,53 @@ architectureGate(
         )
   }
 )
+
+architectureGate(
+  'behavior-integration',
+  'keeps installation settings reads behind the provider-owned keyed projection',
+  () => {
+    const provider = readTypeScriptModule(
+      'src/renderer/capabilities/capability-provider.tsx'
+    )
+    expect(provider.constructions).toContain('InstallationSettingsProjection')
+
+    const adapter = readTypeScriptModule(
+      'src/renderer/capabilities/installation-settings-projection.ts'
+    )
+    expect(adapter.constructions).toContain('AsyncCommandCoordinator')
+    expect(adapter.constructions).toContain('KeyedReadProjectionOwner')
+    expect(adapter.stringLiterals).toContain('installation.settings')
+    expect(adapter.stringLiterals).toContain('read-projection')
+
+    const owner = readTypeScriptModule(
+      'src/renderer/async/keyed-read-projection-owner.ts'
+    )
+    expect(owner.exportedDeclarations.has('KeyedReadProjectionOwner')).toBe(
+      true
+    )
+    expect(owner.stringLiterals).toContain('latest-only')
+
+    const hook = readTypeScriptModule(
+      'src/renderer/shell/use-installation-settings-projection.ts'
+    )
+    expect(hook.calls).toContain('useSyncExternalStore')
+
+    const preferences = readTypeScriptModule(
+      'src/renderer/shell/use-installation-preferences.ts'
+    )
+    expect(preferences.calls).toContain('useInstallationSettingsProjection')
+    expect(hasDirectSettingsRead(preferences.propertyAccesses)).toBe(false)
+
+    const controlledMutation = parseTypeScriptModule(
+      'controlled-direct-settings-read.ts',
+      'void capabilityApi.settings.read()'
+    )
+    expect(hasDirectSettingsRead(controlledMutation.propertyAccesses)).toBe(
+      true
+    )
+  }
+)
+
+function hasDirectSettingsRead(propertyAccesses: readonly string[]): boolean {
+  return propertyAccesses.some((access) => access.endsWith('.settings.read'))
+}

--- a/tests/unit/installation-settings-projection.test.tsx
+++ b/tests/unit/installation-settings-projection.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { act, render, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { CapabilityProvider } from '../../src/renderer/capabilities/capability-provider.js'
+import { useInstallationPreferences } from '../../src/renderer/shell/use-installation-preferences.js'
+import type { SaltMarcherApi } from '../../src/shared/contracts/capability-api.js'
+import type { InstallationSettings } from '../../src/shared/contracts/settings.js'
+import { CapabilityError } from '../../src/shared/errors/capability-error.js'
+import { defaultSessionLayoutPreferenceValue } from '../../src/shared/values/session-layout-values.js'
+
+describe('Installation settings projection', () => {
+  it('deduplicates the initial read across two preference consumers', async () => {
+    const pending = deferred<InstallationSettings>()
+    const read = vi.fn(() => pending.promise)
+    const onError = vi.fn()
+    const hook = renderHook(
+      () => [
+        useInstallationPreferences(onError),
+        useInstallationPreferences(onError)
+      ],
+      { wrapper: provider(settingsApi(read)) }
+    )
+
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+    act(() => pending.resolve(settings(1, 'dark')))
+    await waitFor(() => {
+      expect(hook.result.current[0]?.theme).toBe('dark')
+      expect(hook.result.current[1]?.theme).toBe('dark')
+    })
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('keeps a provider-owned read alive across consumer unmount and remount', async () => {
+    const pending = deferred<InstallationSettings>()
+    const read = vi.fn(() => pending.promise)
+    const api = settingsApi(read)
+    const onError = vi.fn()
+    const view = render(
+      <CapabilityProvider api={api}>
+        <PreferenceProbe visible onError={onError} />
+      </CapabilityProvider>
+    )
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+
+    view.rerender(
+      <CapabilityProvider api={api}>
+        <PreferenceProbe visible={false} onError={onError} />
+      </CapabilityProvider>
+    )
+    act(() => pending.resolve(settings(2, 'dark')))
+    view.rerender(
+      <CapabilityProvider api={api}>
+        <PreferenceProbe visible onError={onError} />
+      </CapabilityProvider>
+    )
+
+    await waitFor(() =>
+      expect(view.getByTestId('theme').textContent).toBe('dark')
+    )
+    expect(read).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed write reconciliation read only once', async () => {
+    const readFailure = new Error('settings read failed')
+    const read = vi
+      .fn<() => Promise<InstallationSettings>>()
+      .mockResolvedValueOnce(settings(1, 'dark'))
+      .mockRejectedValueOnce(readFailure)
+    const update = vi.fn().mockRejectedValue(new CapabilityError('stale', true))
+    const onError = vi.fn()
+    const hook = renderHook(
+      (props: { onError: (message: string) => void }) =>
+        useInstallationPreferences(props.onError),
+      {
+        initialProps: { onError },
+        wrapper: provider(settingsApi(read, update))
+      }
+    )
+    await waitFor(() => expect(hook.result.current.theme).toBe('dark'))
+
+    act(() => hook.result.current.toggleTheme())
+
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+    await act(async () => Promise.resolve())
+    expect(onError).toHaveBeenCalledTimes(1)
+    const replacementOnError = vi.fn()
+    hook.rerender({ onError: replacementOnError })
+    expect(replacementOnError).not.toHaveBeenCalled()
+  })
+})
+
+function PreferenceProbe(props: {
+  visible: boolean
+  onError: (message: string) => void
+}) {
+  if (!props.visible) return null
+  return <PreferenceValue onError={props.onError} />
+}
+
+function PreferenceValue(props: { onError: (message: string) => void }) {
+  const preferences = useInstallationPreferences(props.onError)
+  return <span data-testid="theme">{preferences.theme}</span>
+}
+
+function provider(api: SaltMarcherApi) {
+  return function TestCapabilityProvider(props: { children: ReactNode }) {
+    return <CapabilityProvider api={api}>{props.children}</CapabilityProvider>
+  }
+}
+
+function settingsApi(
+  read: () => Promise<InstallationSettings>,
+  update = vi.fn()
+): SaltMarcherApi {
+  return {
+    settings: {
+      read,
+      update
+    }
+  } as unknown as SaltMarcherApi
+}
+
+function settings(
+  revision: number,
+  theme: InstallationSettings['preferences']['theme']
+): InstallationSettings {
+  return Object.freeze({
+    revision,
+    preferences: Object.freeze({
+      theme,
+      sessionLayout: defaultSessionLayoutPreferenceValue
+    })
+  })
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  const promise = new Promise<Value>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}

--- a/tests/unit/keyed-read-projection-owner.test.ts
+++ b/tests/unit/keyed-read-projection-owner.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AsyncCommandCoordinator } from '../../src/renderer/async/async-command-coordinator.js'
+import { KeyedReadProjectionOwner } from '../../src/renderer/async/keyed-read-projection-owner.js'
+import type { ReadProjectionExecution } from '../../src/renderer/async/renderer-execution-contract.js'
+import type { CapabilityOperation } from '../../src/shared/contracts/capability-api.js'
+
+type Projection = Readonly<{ revision: number; label: string }>
+type ReadProjection = CapabilityOperation<'read', readonly [], Projection>
+
+describe('Keyed read projection owner', () => {
+  it('deduplicates concurrent reads for the same authority', async () => {
+    const pending = deferred<Projection>()
+    const read = vi.fn(() => pending.promise) as ReadProjection
+    const owner = projectionOwner()
+    const descriptor = execution('a', read)
+
+    const first = owner.ensure(descriptor)
+    const second = owner.ensure(descriptor)
+
+    expect(first).toBe(second)
+    expect(read).toHaveBeenCalledTimes(1)
+    pending.resolve(projection(1, 'accepted'))
+    await expect(first).resolves.toMatchObject({
+      status: 'accepted',
+      value: projection(1, 'accepted')
+    })
+    await expect(second).resolves.toMatchObject({ status: 'accepted' })
+    expect(owner.snapshot(descriptor.authority)).toMatchObject({
+      status: 'ready',
+      revision: 1,
+      value: projection(1, 'accepted')
+    })
+  })
+
+  it('keeps a newer invalidation result when the older transport settles last', async () => {
+    const older = deferred<Projection>()
+    const newer = deferred<Projection>()
+    const read = vi
+      .fn<ReadProjection>()
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const owner = projectionOwner()
+    const descriptor = execution('a', read)
+
+    const first = owner.ensure(descriptor)
+    const second = owner.invalidate(descriptor)
+    newer.resolve(projection(2, 'newer'))
+    await expect(second).resolves.toMatchObject({ status: 'accepted' })
+    older.resolve(projection(1, 'older'))
+    await expect(first).resolves.toMatchObject({ status: 'stale' })
+    expect(owner.current(descriptor.authority)).toEqual(projection(2, 'newer'))
+  })
+
+  it('isolates entity keys and their subscriptions', () => {
+    const owner = projectionOwner()
+    const authorityA = execution('a', vi.fn() as ReadProjection).authority
+    const authorityB = execution('b', vi.fn() as ReadProjection).authority
+    const notifiedA = vi.fn()
+    owner.subscribe(authorityA, notifiedA)
+
+    owner.publish(authorityB, projection(1, 'b'))
+
+    expect(notifiedA).not.toHaveBeenCalled()
+    expect(owner.current(authorityA)).toBeNull()
+    expect(owner.current(authorityB)).toEqual(projection(1, 'b'))
+  })
+
+  it('rejects a lower revision and restores the accepted cached snapshot', async () => {
+    const read = vi.fn(() =>
+      Promise.resolve(projection(4, 'old'))
+    ) as ReadProjection
+    const owner = projectionOwner()
+    const descriptor = execution('a', read)
+    owner.publish(descriptor.authority, projection(5, 'current'))
+
+    await expect(owner.invalidate(descriptor)).resolves.toEqual({
+      status: 'stale',
+      reason: 'older-revision'
+    })
+    expect(owner.snapshot(descriptor.authority)).toMatchObject({
+      status: 'ready',
+      revision: 5,
+      value: projection(5, 'current')
+    })
+  })
+
+  it('retains the last accepted value when a refresh fails', async () => {
+    const cause = new Error('offline')
+    const read = vi.fn(() => Promise.reject(cause)) as ReadProjection
+    const owner = projectionOwner()
+    const descriptor = execution('a', read)
+    owner.publish(descriptor.authority, projection(3, 'cached'))
+
+    await expect(owner.invalidate(descriptor)).resolves.toEqual({
+      status: 'failure',
+      cause
+    })
+    expect(owner.snapshot(descriptor.authority)).toMatchObject({
+      status: 'failure',
+      revision: 3,
+      value: projection(3, 'cached'),
+      cause
+    })
+  })
+
+  it('does not publish a pending read after owner disposal', async () => {
+    const pending = deferred<Projection>()
+    const read = vi.fn(() => pending.promise) as ReadProjection
+    const owner = projectionOwner()
+    const descriptor = execution('a', read)
+    const outcome = owner.ensure(descriptor)
+
+    owner.dispose()
+    pending.resolve(projection(1, 'late'))
+
+    await expect(outcome).resolves.toMatchObject({
+      status: 'stale',
+      reason: 'aborted'
+    })
+    expect(owner.current(descriptor.authority)).toBeNull()
+    await expect(owner.ensure(descriptor)).resolves.toEqual({
+      status: 'stale',
+      reason: 'aborted'
+    })
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+})
+
+function projectionOwner(): KeyedReadProjectionOwner<Projection> {
+  return new KeyedReadProjectionOwner(
+    new AsyncCommandCoordinator(),
+    (value) => value.revision
+  )
+}
+
+function execution(
+  entityKey: string,
+  operation: ReadProjection
+): ReadProjectionExecution<ReadProjection, 'test.projection'> {
+  return Object.freeze({
+    kind: 'read-projection',
+    authority: Object.freeze({ scope: 'test.projection', entityKey }),
+    operation
+  })
+}
+
+function projection(revision: number, label: string): Projection {
+  return Object.freeze({ revision, label })
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  const promise = new Promise<Value>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}


### PR DESCRIPTION
## Ergebnis

FR1B führt den ersten providergebundenen, keyed Read-Projection-Owner ein und stellt Installation Settings end-to-end darauf um. Direkte `settings.read()`-Aufrufe im Preferences-Consumer entfallen; Writes und Draft/View-State bleiben getrennte Owner.

Der vollständige, versionierte Nachweis steht in `docs/project/evidence/frontend-robustness-fr1b-audit.md`.

## Auditdetails

- Vor Implementierung vollständig erneut gelesen: Frontend-Robustness-Roadmap und Acceptance-Matrix, FR1A-Audit, historische Electron-Roadmap, Target Architecture, relevante Technical Needs sowie aktuelle Provider-, Settings-, Coordinator-, Registry-, Test- und Dependency-Grenzen.
- Authority: `{ scope: "installation.settings", entityKey: null }`; durable Wahrheit bleibt Utility/SQLite.
- Cache-Spike: TanStack Query 5.102.2 gegen minimalen `useSyncExternalStore`-Owner verglichen. Gewählt wurde der minimale Owner ohne neue Dependency, mit explizitem FR2-Go/No-Go und isoliertem Removal Path.
- Semantik: Same-key In-flight-Deduplizierung, latest-only Acceptance, monotone Revisionen, exakte Key-Invalidierung, retained-value Failure, unterschiedlicher Provider-/Consumer-Lifetime und terminaler Dispose.
- Architektur-Ratchet: `useInstallationPreferences` darf keinen direkten Settings-Read mehr enthalten; eine kontrollierte Mutation beweist, dass das Gate den Rückfall erkennt.
- Bewusst offen: kein neues IPC/Event, keine Write-/Receipt-Migration, kein FR1C- oder späteres Electron-Interaktions-Claim.

## Negative Findings und umgesetzte Follow-ups

1. Instabile Hook-Rückgabe hätte bestehendes Debounce zurückgesetzt; auf stabile Provider-Instanz korrigiert.
2. Niedrigere Revision blieb zunächst als `pending` sichtbar; Accepted Snapshot wird jetzt korrekt wiederhergestellt.
3. Promise-`finally` hätte bei zukünftigem Throw einen unbeobachteten Rejection-Child erzeugen können; symmetrische Cleanup-Pfade eingesetzt.
4. Doppeltes Error Reporting zwischen Projection und Command wurde dedupliziert.
5. Dispose konnte über den Stale-Retry erneut Transport starten; Dispose ist jetzt terminal und getestet.
6. Retained Failure konnte bei neuer `onError`-Identität erneut erscheinen; Reporting ist an die konkrete Failure-Snapshot-Instanz gebunden.
7. Typ- und Test-Wrapper-Lintfunde wurden nicht unterdrückt, sondern korrigiert und im Audit festgehalten.

Kein verbleibender Fund bedroht die begrenzte FR1B-Garantie. Die Cache-Entscheidung bleibt bis FR2 ausdrücklich provisorisch; FR1-Write-Garantien bleiben FR1C.

## Lokale Verifikation

- `pnpm check:frontend-robustness`: beide TypeScript-Konfigurationen, 11 Testdateien, 69 Tests grün.
- Gezielter ESLint über alle geänderten TypeScript-/TSX-Dateien: grün.
- Vollständiger Prettier-Check: grün.
- `git diff --check`: grün.

## Delivery Gate

App-build-input relevant. Exact-SHA Candidate Checks, `pnpm handoff:app`, installierter Runtime-Nachweis, unveränderte Promotion und grüner Main-Lauf sind bei PR-Erstellung noch offen und dürfen vor Merge/Promotion nicht übersprungen werden.