### PR TITLE
FR2A: bind Campaign Session reads to identity

### DIFF
--- a/docs/project/evidence/frontend-robustness-fr2a-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2a-audit.md
@@ -1,0 +1,194 @@
+# Frontend robustness FR2A audit
+
+- Date: 2026-08-24
+- Delivery baseline: `origin/main@8e00f1232eaddb047f32ec6d1ab4a6e2b1c59ba5`
+- Sprint: `FR2A` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap, acceptance matrix, FR0 inventory,
+  FR1A execution-contract audit, and FR1B/FR1C reference-slice audits;
+- the historical Electron migration roadmap, current target architecture, and
+  live frontend implementation architecture audit;
+- Campaign lifecycle and live Session requirements and contracts;
+- `TN-11`, `TN-16`, `TN-21`, and `QS-01` through `QS-05` in the program
+  technical needs;
+- current Campaign store, Utility composition, shared Zod registry, preload
+  bridge, renderer Capability Provider, Workspace root, Catalog session-read
+  adapter, and relevant unit, architecture, and Electron journeys;
+- the live repository state, application dependencies, focused-test manifest,
+  build configuration, and open pull requests.
+
+## Implementation packet
+
+FR2A owns the read side of the Campaign Workspace root. It replaces separate
+React-owned Campaign catalog and active-Session state with one provider-lived,
+identity-bound projection.
+
+- state class: read projection;
+- durable authorities: installation Campaign catalog and active Campaign's
+  Utility/SQLite live Session;
+- renderer authority keys:
+  `{ scope: 'installation.campaign-catalog', entityKey: null }` and
+  `{ scope: 'campaign.live-session', entityKey: campaignId }`;
+- ordering: latest-only independently per authority key;
+- acceptance: the visible Session is selected only from the cache whose
+  Campaign identity equals the accepted catalog's active identity;
+- lifecycle: one `CampaignWorkspaceProjection` per mounted top-level
+  `CapabilityProvider`, independent of Workspace consumer remounts;
+- transport identity: `session.read` requires an exact Campaign UUID, and the
+  Utility rejects an ID that is no longer active with a typed retryable
+  `stale` error before reading live state;
+- stale recovery: a typed active-identity mismatch refreshes the catalog and
+  then reads only the newly accepted active Campaign;
+- write boundary: Campaign lifecycle writes still execute directly and publish
+  their returned snapshot into the projection. Their FIFO/revision cutover is
+  deliberately reserved for `FR2B`.
+
+## Mental execution trace
+
+1. The top-level Capability Provider creates the Campaign Workspace projection
+   once and retains it while Workspace consumers mount and unmount.
+2. Initial load invalidates the installation catalog key. A later catalog read
+   supersedes an earlier one only for that same key.
+3. After catalog acceptance, the owner derives the active Campaign identity and
+   reads `session.read({ campaignId })` through that Campaign's own cache key.
+4. The composed root can publish a Session only from the cache matching the
+   currently accepted active Campaign. A late A result therefore remains in A's
+   inactive cache while B is visible.
+5. Switching B back to A immediately selects A's accepted cached Session. A
+   lower Session revision cannot replace it.
+6. If Utility reports that the requested Campaign is no longer active, the
+   owner refreshes the installation catalog. If the accepted identity changed,
+   it reads that identity's Session instead of retrying the obsolete A read.
+7. Unsubscribing the Workspace consumer does not cancel or recreate the
+   provider-owned request. A later consumer observes the same accepted cache.
+8. Disposal at provider shutdown aborts acceptance, clears listeners and
+   authority caches, and leaves no module-global mutable owner.
+
+## Exclusions and delivery classification
+
+FR2A does not serialize Campaign create, activate, rename, trash, restore, or
+permanent delete. It also does not remove the global `saltmarcher:readback`
+listener or `readbackKey` route remount, qualify `QS-05` timing, prove the
+post-switch next mutation, or define final per-Campaign authored view-state
+retention. Those guarantees belong respectively to `FR2B`, `FR2C`, and `FR2D`.
+
+The existing root `setSession` publication port remains for Running Play
+consumers. Replacing it with selectors and semantic actions is `FR3A`; removing
+it in FR2A would merge sprint rows and obscure the Campaign-read guarantee.
+
+Some feature-local Session reads remain outside the root projection, including
+the Location Catalog adapter and one post-write Workspace refresh. They now
+carry an explicit Campaign identity and cannot read another Campaign's active
+Session silently, but their broader projection/action consolidation remains in
+FR3/FR4.
+
+The Campaign catalog contract currently has no durable revision. The owner
+therefore uses request acceptance order for the installation catalog and uses
+the real `LiveSessionSnapshot.revision` for each Session key. Campaign command
+serialization in FR2B must ensure that exact write results are published in
+FIFO acceptance order; FR2A does not pretend a synthetic catalog revision is a
+durable oracle.
+
+Source, shared contract, Utility, Renderer, and E2E inputs change, so the
+Candidate SHA requires all remote checks and the canonical exact-SHA app
+handoff before unchanged promotion.
+
+## Post-implementation audit
+
+### Exit-condition review
+
+| FR2A condition | Evidence | Assessment |
+| --- | --- | --- |
+| Campaign catalog and active Session share one root owner | Capability Provider constructs one `CampaignWorkspaceProjection`; the Workspace hook consumes it via `useSyncExternalStore` | covered for the root read path |
+| active Session reads carry exact identity | strict Zod input, all call sites supply `campaignId`, Utility compares it with the active Campaign before live read | covered at both IPC boundaries and domain entry |
+| overlapping publication cannot mix Campaign and Session | controlled A/B promises resolve B then A; only B remains visible while A is retained by A's key | covered |
+| rapid A/B/A selects only matching accepted state | controlled publication restores A's cache and rejects an older A revision | covered at projection level |
+| active-identity drift converges | typed Utility `stale` result triggers catalog refresh and one read for the newly accepted Campaign | covered |
+| consumer remount does not restart ownership | pending read completes with zero subscribers; a later subscriber observes the same result and one transport call | covered across provider lifetime |
+| alternate React Campaign/Session state is absent | architecture scan requires `useSyncExternalStore`, rejects direct root reads and the old `setCampaigns` owner | covered for the Workspace root |
+
+### Negative findings and follow-up
+
+1. The first implementation still used implicit `session.read()` at feature and
+   Electron-test call sites. Making the shared input strict exposed every
+   caller; each now obtains or receives an exact Campaign ID.
+2. The first Workspace-hook callbacks returned `Promise<boolean>` from concise
+   projection publications where the command wrapper promised `Promise<void>`.
+   Block-bodied callbacks now make the effect boundary explicit without casts.
+3. The initial crossed-read tests advanced a fixed number of microtasks and
+   were timing-sensitive. They now wait for the semantic transport call before
+   resolving the controlled promises.
+4. The first stale-identity test rejected with an untyped object. It now uses
+   the real `CapabilityError('stale', true)`, exercising the production error
+   classifier.
+5. An early architecture assertion treated the retained `setSession` port name
+   as proof of a second React state owner. The assertion was removed after
+   source inspection: the port publishes into the keyed owner and is explicitly
+   retained for FR3, while the removed `setCampaigns` state owner remains gated.
+6. The Campaign catalog lacks a durable revision, so its read owner uses
+   revision `0`. Latest-only request tokens protect overlapping reads, but
+   unordered write-result publication is not solved by this value. FR2B must
+   queue all Campaign lifecycle commands and select/publish at transport-time
+   acceptance.
+7. The global readback event still increments `readbackKey` and remounts the
+   routed Workspace surface. FR2A retains this behavior visibly in the FR0
+   baseline; FR2C must replace it with targeted Campaign/Session reconciliation
+   and prove draft preservation.
+8. FR2A proves projection-level A/B/A coherence, not the full `QS-05` production
+   route, one-second p95, crash resume, or safe next mutation. FR2D remains the
+   go/no-go owner-acceptance gate for those claims.
+9. Inactive Campaign Session caches are in renderer memory only. They improve
+   warm switching during one provider lifetime but are intentionally discarded
+   at application shutdown; durable resume truth remains Utility/SQLite.
+10. Feature-local direct Session reads are identity-safe but not yet unified
+    under the Running Play projection. FR3 and FR4 must remove those alternate
+    read/publication paths rather than expanding this Campaign-root owner into
+    an unbounded application store.
+11. The first provider integration bound `api.campaigns.list` eagerly in the
+    owner constructor. The broader focused gate exposed this through existing
+    UI tests that intentionally mount inactive provider capabilities with
+    partial API doubles. The owner now captures a lazy operation closure and
+    dereferences the transport only on its first real load; inactive provider
+    capabilities remain side-effect free.
+12. Strict Renderer lint rejected a synchronous menu-state update derived in a
+    React effect. Empty-installation menu opening now occurs when the explicit
+    projection load settles successfully, and the initial effect schedules
+    that load in a microtask. This avoids an effect-driven cascading render
+    while preserving initial-load and readback behavior.
+13. The first Candidate build exceeded the 16-KiB reachable bundle-growth
+    allowance by 10 bytes. No baseline was raised for that marginal overage; a
+    renderer-internal missing-provider diagnostic was shortened, retaining the
+    same failure behavior while bringing the owner cutover back inside the
+    existing spike allowance. The final built graph and budget are repeated
+    before the Candidate is replaced.
+
+No remaining finding invalidates FR-A04 for the bounded Campaign root read
+slice. FR-A06 and FR-A07 remain open until FR2C/FR2D; FR2B is mandatory before
+the Campaign root can claim coherent switch-during-write behavior.
+
+### Pre-PR verification
+
+- focused TypeScript check passed for both main and Renderer configurations;
+- controlled proof: 4 files and 21 tests passed, including contract, Utility
+  identity rejection, crossed reads, A/B/A cache selection, stale recovery,
+  provider-lifetime ownership, baseline, and architecture gates;
+- no zero-argument `session.read()` call remains in `src/` or `tests/`;
+- `pnpm check:frontend-robustness`: both TypeScript configurations, 16 test
+  files, and 106 tests passed on the final pre-commit tree;
+- all Core, Electron-tooling, Renderer, and test lint partitions passed;
+- repository-wide Prettier check and `git diff --check` passed;
+- the Development Main/Utility, Preload, and Renderer production build passed;
+- final reachable bundle growth is 16,382 bytes, two bytes inside the 16-KiB
+  spike allowance; all shell, Workspace, lazy-route, Pixi, and total budgets
+  passed without changing their baselines;
+- the existing full `campaignCreate` Electron scenario was attempted on the
+  built output and timed out at its 180-second suite limit after repeated
+  30-second renderer script timeouts in its host-intensive visual/settings
+  section; failure screenshots also timed out, so the run provides no semantic
+  Campaign-switch verdict and is not counted as passing evidence;
+- exact Candidate remote jobs, canonical app handoff, installed-runtime proof,
+  unchanged promotion, and green Main evidence remain pending and must be
+  attached before promotion.

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -10,6 +10,7 @@
     "tests/unit/keyed-read-projection-owner.test.ts",
     "tests/unit/keyed-write-command-owner.test.ts",
     "tests/unit/installation-settings-projection.test.tsx",
+    "tests/unit/campaign-workspace-projection.test.ts",
     "tests/unit/generator-preset-application.test.ts",
     "tests/unit/generator-preset-reconciliation-ui.test.tsx",
     "tests/unit/core-process-supervisor.test.ts",

--- a/src/renderer/capabilities/campaign-workspace-projection.ts
+++ b/src/renderer/capabilities/campaign-workspace-projection.ts
@@ -1,0 +1,285 @@
+import type { CampaignSnapshot } from '../../shared/contracts/campaign.js'
+import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
+import type { LiveSessionSnapshot } from '../../shared/contracts/live-session.js'
+import { capabilityErrorCode } from '../../shared/errors/capability-error.js'
+import { AsyncCommandCoordinator } from '../async/async-command-coordinator.js'
+import {
+  KeyedReadProjectionOwner,
+  type ReadProjectionOutcome,
+  type ReadProjectionSnapshot
+} from '../async/keyed-read-projection-owner.js'
+import type {
+  ReadProjectionExecution,
+  RendererAuthorityKey
+} from '../async/renderer-execution-contract.js'
+
+export const campaignCatalogAuthority = Object.freeze({
+  scope: 'installation.campaign-catalog' as const,
+  entityKey: null
+})
+
+export function campaignSessionAuthority(
+  campaignId: string
+): RendererAuthorityKey<'campaign.live-session'> {
+  return Object.freeze({
+    scope: 'campaign.live-session',
+    entityKey: campaignId
+  })
+}
+
+export type CampaignWorkspaceProjectionSnapshot = Readonly<{
+  status: 'idle' | 'pending' | 'ready' | 'failure'
+  campaigns: CampaignSnapshot
+  sessionCampaignId: string | null
+  session: LiveSessionSnapshot | null
+  cause: unknown
+}>
+
+export type CampaignWorkspaceReadOutcome =
+  | Readonly<{
+      status: 'ready'
+      value: CampaignWorkspaceProjectionSnapshot
+    }>
+  | Readonly<{ status: 'stale' }>
+  | Readonly<{ status: 'failure'; cause: unknown }>
+
+const emptyCampaigns = Object.freeze({
+  activeCampaignId: null,
+  campaigns: Object.freeze([]),
+  trashedCampaigns: Object.freeze([])
+}) satisfies CampaignSnapshot
+
+const idleSnapshot = Object.freeze({
+  status: 'idle',
+  campaigns: emptyCampaigns,
+  sessionCampaignId: null,
+  session: null,
+  cause: null
+}) satisfies CampaignWorkspaceProjectionSnapshot
+
+/**
+ * Provider-lived owner for the Campaign catalog and per-Campaign active
+ * Session projections. Composite publication always selects the Session cache
+ * by the accepted catalog identity.
+ */
+export class CampaignWorkspaceProjection {
+  readonly #api: SaltMarcherApi
+  readonly #catalog: KeyedReadProjectionOwner<CampaignSnapshot>
+  readonly #sessions: KeyedReadProjectionOwner<LiveSessionSnapshot>
+  readonly #catalogExecution: ReadProjectionExecution<
+    SaltMarcherApi['campaigns']['list'],
+    'installation.campaign-catalog'
+  >
+  readonly #listeners = new Set<() => void>()
+  readonly #unsubscribeCatalog: () => void
+  #unsubscribeSession: (() => void) | null = null
+  #subscribedCampaignId: string | null = null
+  #snapshot: CampaignWorkspaceProjectionSnapshot = idleSnapshot
+  #disposed = false
+
+  public constructor(api: SaltMarcherApi) {
+    this.#api = api
+    const listCampaigns: SaltMarcherApi['campaigns']['list'] = () =>
+      api.campaigns.list()
+    this.#catalog = new KeyedReadProjectionOwner(
+      new AsyncCommandCoordinator(),
+      () => 0
+    )
+    this.#sessions = new KeyedReadProjectionOwner(
+      new AsyncCommandCoordinator(),
+      (session) => session.revision
+    )
+    this.#catalogExecution = Object.freeze({
+      kind: 'read-projection',
+      authority: campaignCatalogAuthority,
+      operation: listCampaigns
+    })
+    this.#unsubscribeCatalog = this.#catalog.subscribe(
+      campaignCatalogAuthority,
+      this.#synchronize
+    )
+  }
+
+  public readonly subscribe = (listener: () => void): (() => void) => {
+    if (this.#disposed) return () => undefined
+    this.#listeners.add(listener)
+    return () => this.#listeners.delete(listener)
+  }
+
+  public readonly snapshot = (): CampaignWorkspaceProjectionSnapshot =>
+    this.#snapshot
+
+  public async load(): Promise<CampaignWorkspaceReadOutcome> {
+    if (this.#disposed) return Object.freeze({ status: 'stale' })
+    const catalog = await settleRead(
+      this.#catalog.invalidate(this.#catalogExecution),
+      () => this.#catalog.ensure(this.#catalogExecution)
+    )
+    if (catalog.status === 'failure')
+      return Object.freeze({ status: 'failure', cause: catalog.cause })
+    if (catalog.status === 'stale') return Object.freeze({ status: 'stale' })
+    const campaignId = catalog.value.activeCampaignId
+    if (campaignId === null)
+      return Object.freeze({ status: 'ready', value: this.#snapshot })
+    const session = await this.#refreshSession(campaignId)
+    if (
+      session.status === 'failure' &&
+      capabilityErrorCode(session.cause) === 'stale'
+    ) {
+      const latest = await settleRead(
+        this.#catalog.invalidate(this.#catalogExecution),
+        () => this.#catalog.ensure(this.#catalogExecution)
+      )
+      if (latest.status === 'failure')
+        return Object.freeze({ status: 'failure', cause: latest.cause })
+      if (latest.status === 'stale') return Object.freeze({ status: 'stale' })
+      if (latest.value.activeCampaignId !== campaignId)
+        return this.refreshActiveSession()
+    }
+    return projectWorkspaceOutcome(session, this.#snapshot)
+  }
+
+  public async refreshActiveSession(): Promise<CampaignWorkspaceReadOutcome> {
+    if (this.#disposed) return Object.freeze({ status: 'stale' })
+    const campaignId = this.#catalog.current(
+      campaignCatalogAuthority
+    )?.activeCampaignId
+    if (!campaignId)
+      return Object.freeze({ status: 'ready', value: this.#snapshot })
+    return projectWorkspaceOutcome(
+      await this.#refreshSession(campaignId),
+      this.#snapshot
+    )
+  }
+
+  public publishCampaigns(campaigns: CampaignSnapshot): boolean {
+    return this.#catalog.publish(campaignCatalogAuthority, campaigns)
+  }
+
+  public publishSession(
+    campaignId: string,
+    update:
+      | LiveSessionSnapshot
+      | ((current: LiveSessionSnapshot) => LiveSessionSnapshot)
+  ): boolean {
+    const authority = campaignSessionAuthority(campaignId)
+    const current = this.#sessions.current(authority)
+    if (typeof update === 'function' && current === null) return false
+    const next = typeof update === 'function' ? update(current!) : update
+    return this.#sessions.publish(authority, next)
+  }
+
+  public dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#unsubscribeCatalog()
+    this.#unsubscribeSession?.()
+    this.#unsubscribeSession = null
+    this.#catalog.dispose()
+    this.#sessions.dispose()
+    this.#listeners.clear()
+    this.#snapshot = idleSnapshot
+  }
+
+  async #refreshSession(
+    campaignId: string
+  ): Promise<ReadProjectionOutcome<LiveSessionSnapshot>> {
+    const authority = campaignSessionAuthority(campaignId)
+    const execution: ReadProjectionExecution<
+      SaltMarcherApi['session']['read'],
+      'campaign.live-session'
+    > = Object.freeze({
+      kind: 'read-projection',
+      authority,
+      operation: this.#api.session.read
+    })
+    return settleRead(
+      this.#sessions.invalidate(execution, { campaignId }),
+      () => this.#sessions.ensure(execution, { campaignId })
+    )
+  }
+
+  readonly #synchronize = (): void => {
+    if (this.#disposed) return
+    const catalog = this.#catalog.snapshot(campaignCatalogAuthority)
+    const campaignId = catalog.value?.activeCampaignId ?? null
+    if (campaignId !== this.#subscribedCampaignId) {
+      this.#unsubscribeSession?.()
+      this.#unsubscribeSession = campaignId
+        ? this.#sessions.subscribe(
+            campaignSessionAuthority(campaignId),
+            this.#synchronize
+          )
+        : null
+      this.#subscribedCampaignId = campaignId
+    }
+    const session = campaignId
+      ? this.#sessions.snapshot(campaignSessionAuthority(campaignId))
+      : null
+    const next = composeSnapshot(catalog, campaignId, session)
+    if (sameSnapshot(this.#snapshot, next)) return
+    this.#snapshot = next
+    for (const listener of this.#listeners) listener()
+  }
+}
+
+async function settleRead<Value>(
+  pending: Promise<ReadProjectionOutcome<Value>>,
+  ensure: () => Promise<ReadProjectionOutcome<Value>>
+): Promise<ReadProjectionOutcome<Value>> {
+  let outcome = await pending
+  if (outcome.status === 'stale') outcome = await ensure()
+  return outcome
+}
+
+function projectWorkspaceOutcome(
+  outcome: ReadProjectionOutcome<LiveSessionSnapshot>,
+  snapshot: CampaignWorkspaceProjectionSnapshot
+): CampaignWorkspaceReadOutcome {
+  if (outcome.status === 'failure')
+    return Object.freeze({ status: 'failure', cause: outcome.cause })
+  if (outcome.status === 'stale') return Object.freeze({ status: 'stale' })
+  return Object.freeze({ status: 'ready', value: snapshot })
+}
+
+function composeSnapshot(
+  catalog: ReadProjectionSnapshot<CampaignSnapshot>,
+  campaignId: string | null,
+  session: ReadProjectionSnapshot<LiveSessionSnapshot> | null
+): CampaignWorkspaceProjectionSnapshot {
+  const campaigns = catalog.value ?? emptyCampaigns
+  const sessionValue = session?.value ?? null
+  const cause = catalog.status === 'failure' ? catalog.cause : session?.cause
+  const complete =
+    catalog.value !== null && (!campaignId || sessionValue !== null)
+  const failed =
+    (catalog.status === 'failure' && catalog.value === null) ||
+    (session?.status === 'failure' && session.value === null)
+  const status = failed
+    ? 'failure'
+    : complete
+      ? 'ready'
+      : catalog.status === 'idle'
+        ? 'idle'
+        : 'pending'
+  return Object.freeze({
+    status,
+    campaigns,
+    sessionCampaignId: campaignId,
+    session: sessionValue,
+    cause: cause ?? null
+  })
+}
+
+function sameSnapshot(
+  current: CampaignWorkspaceProjectionSnapshot,
+  next: CampaignWorkspaceProjectionSnapshot
+): boolean {
+  return (
+    current.status === next.status &&
+    current.campaigns === next.campaigns &&
+    current.sessionCampaignId === next.sessionCampaignId &&
+    current.session === next.session &&
+    current.cause === next.cause
+  )
+}

--- a/src/renderer/capabilities/capability-context.ts
+++ b/src/renderer/capabilities/capability-context.ts
@@ -1,10 +1,12 @@
 import { createContext } from 'react'
 import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
 import type { InstallationSettingsProjection } from './installation-settings-projection.js'
+import type { CampaignWorkspaceProjection } from './campaign-workspace-projection.js'
 
 export type CapabilityContextValue = Readonly<{
   api: SaltMarcherApi
   installationSettings: InstallationSettingsProjection
+  campaignWorkspace: CampaignWorkspaceProjection
 }>
 
 export const CapabilityContext = createContext<CapabilityContextValue | null>(

--- a/src/renderer/capabilities/capability-provider.tsx
+++ b/src/renderer/capabilities/capability-provider.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, type ReactNode } from 'react'
 import type { SaltMarcherApi } from '../../shared/contracts/capability-api.js'
 import { CapabilityContext } from './capability-context.js'
 import { InstallationSettingsProjection } from './installation-settings-projection.js'
+import { CampaignWorkspaceProjection } from './campaign-workspace-projection.js'
 
 export function CapabilityProvider(props: {
   api: SaltMarcherApi
@@ -11,13 +12,17 @@ export function CapabilityProvider(props: {
     () =>
       Object.freeze({
         api: props.api,
-        installationSettings: new InstallationSettingsProjection(props.api)
+        installationSettings: new InstallationSettingsProjection(props.api),
+        campaignWorkspace: new CampaignWorkspaceProjection(props.api)
       }),
     [props.api]
   )
   useEffect(
-    () => () => value.installationSettings.dispose(),
-    [value.installationSettings]
+    () => () => {
+      value.installationSettings.dispose()
+      value.campaignWorkspace.dispose()
+    },
+    [value]
   )
   return (
     <CapabilityContext.Provider value={value}>

--- a/src/renderer/features/catalog/catalog-workspace.tsx
+++ b/src/renderer/features/catalog/catalog-workspace.tsx
@@ -30,6 +30,7 @@ import {
 const LazyNpcCatalogSection = lazy(() => import('./npc-catalog-section.js'))
 
 type CatalogWorkspaceProps = {
+  campaignId: string
   setSnapshot: (snapshot: LiveSessionSnapshot) => void
   onError: (message: string) => void
   inspect: (creature: Creature) => void
@@ -46,8 +47,8 @@ export default function CatalogWorkspace(props: CatalogWorkspaceProps) {
     onError: props.onError
   })
   const locationPort = useMemo(
-    () => createLocationCatalogPort(catalog),
-    [catalog]
+    () => createLocationCatalogPort(catalog, props.campaignId),
+    [catalog, props.campaignId]
   )
   const factionPort = useMemo(
     () => createWorldFactionApplicationPort(catalog),

--- a/src/renderer/features/catalog/location-catalog-port.ts
+++ b/src/renderer/features/catalog/location-catalog-port.ts
@@ -13,11 +13,12 @@ export function createLocationCatalogPort(
   api: Pick<
     SaltMarcherApi,
     'locations' | 'encounterTables' | 'factions' | 'session'
-  >
+  >,
+  campaignId: string
 ): LocationCatalogPort {
   const locations = createWorldLocationApplicationPort(api)
   return {
     ...locations,
-    readSession: () => api.session.read()
+    readSession: () => api.session.read({ campaignId })
   }
 }

--- a/src/renderer/features/workspace/surfaces/catalog-surface.tsx
+++ b/src/renderer/features/workspace/surfaces/catalog-surface.tsx
@@ -9,6 +9,7 @@ export default function CatalogSurface(props: WorkspaceSurfaceProps) {
   })
   return (
     <CatalogWorkspace
+      campaignId={props.campaignId}
       setSnapshot={props.setSnapshot}
       inspect={props.inspect}
       onError={props.onError}

--- a/src/renderer/features/workspace/use-campaign-session-coordinator.ts
+++ b/src/renderer/features/workspace/use-campaign-session-coordinator.ts
@@ -1,54 +1,66 @@
-import { useCallback, useEffect, useState } from 'react'
-import type { CampaignSnapshot } from '../../../shared/contracts/campaign.js'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useSyncExternalStore
+} from 'react'
 import type { SaltMarcherApi } from '../../../shared/contracts/capability-api.js'
 import type { LiveSessionSnapshot } from '../../../shared/contracts/live-session.js'
 import { capabilityErrorText } from '../../capabilities/capability-errors.js'
+import { CapabilityContext } from '../../capabilities/capability-context.js'
+import type { CampaignWorkspaceReadOutcome } from '../../capabilities/campaign-workspace-projection.js'
 import type { WorkspaceId } from './workspace-definition.js'
-
-const emptyCampaigns: CampaignSnapshot = {
-  activeCampaignId: null,
-  campaigns: [],
-  trashedCampaigns: []
-}
 
 export function useCampaignSessionCoordinator(
   api: SaltMarcherApi,
   reportError: (message: string) => void,
   enabled = true
 ) {
-  const [campaigns, setCampaigns] = useState(emptyCampaigns)
-  const [session, setSession] = useState<LiveSessionSnapshot | null>(null)
+  const context = useContext(CapabilityContext)
+  if (!context) throw new Error('Capability provider missing')
+  const projection = context.campaignWorkspace
+  const root = useSyncExternalStore(
+    projection.subscribe,
+    projection.snapshot,
+    projection.snapshot
+  )
   const [campaignMenuOpen, setCampaignMenuOpen] = useState(false)
   const [workspace, setWorkspace] = useState<WorkspaceId>('session')
   const [readbackKey, setReadbackKey] = useState(0)
 
+  const reportRead = useCallback(
+    (outcome: CampaignWorkspaceReadOutcome) => {
+      if (outcome.status === 'failure')
+        reportError(capabilityErrorText(outcome.cause))
+    },
+    [reportError]
+  )
+
   const load = useCallback(async () => {
-    const next = await api.campaigns.list()
-    setCampaigns(next)
-    if (next.activeCampaignId === null) setCampaignMenuOpen(true)
-    setSession(next.activeCampaignId ? await api.session.read() : null)
-  }, [api])
+    const outcome = await projection.load()
+    reportRead(outcome)
+    if (
+      outcome.status === 'ready' &&
+      outcome.value.campaigns.activeCampaignId === null
+    )
+      setCampaignMenuOpen(true)
+  }, [projection, reportRead])
 
   useEffect(() => {
-    if (!enabled) return
-    void Promise.resolve()
-      .then(load)
-      .catch((cause: unknown) => reportError(capabilityErrorText(cause)))
-  }, [enabled, load, reportError])
+    if (enabled) void Promise.resolve().then(load)
+  }, [enabled, load])
 
   useEffect(() => {
     const readback = () => {
       if (!enabled) return
       setReadbackKey((current) => current + 1)
-      void load().catch((cause: unknown) =>
-        reportError(capabilityErrorText(cause))
-      )
+      void load()
     }
     window.addEventListener('saltmarcher:readback', readback)
     return () => window.removeEventListener('saltmarcher:readback', readback)
-  }, [enabled, load, reportError])
+  }, [enabled, load])
 
-  const campaignsWrite = api.campaigns
   async function run(operation: () => Promise<void>) {
     try {
       await operation()
@@ -57,10 +69,33 @@ export function useCampaignSessionCoordinator(
     }
   }
 
+  async function publishActiveCampaign(
+    campaigns: Awaited<ReturnType<SaltMarcherApi['campaigns']['create']>>
+  ): Promise<void> {
+    projection.publishCampaigns(campaigns)
+    reportRead(await projection.refreshActiveSession())
+  }
+
+  const activeCampaignId = root.campaigns.activeCampaignId
+
   return {
-    campaigns,
-    session,
-    setSession,
+    campaigns: root.campaigns,
+    session: root.session,
+    setSession: (
+      update:
+        | LiveSessionSnapshot
+        | ((current: LiveSessionSnapshot | null) => LiveSessionSnapshot | null)
+    ) => {
+      if (!activeCampaignId) return
+      if (typeof update === 'function') {
+        projection.publishSession(activeCampaignId, (current) => {
+          const next = update(current)
+          return next ?? current
+        })
+        return
+      }
+      projection.publishSession(activeCampaignId, update)
+    },
     campaignMenuOpen,
     setCampaignMenuOpen,
     workspace,
@@ -68,36 +103,35 @@ export function useCampaignSessionCoordinator(
     readbackKey,
     createCampaign: (name: string) =>
       run(async () => {
-        setCampaigns(await campaignsWrite.create({ name }))
-        setSession(await api.session.read())
+        await publishActiveCampaign(await api.campaigns.create({ name }))
         setWorkspace('session')
         setCampaignMenuOpen(false)
       }),
     switchCampaign: (id: string) =>
       run(async () => {
-        setCampaigns(await campaignsWrite.activate({ id }))
-        setSession(await api.session.read())
+        await publishActiveCampaign(await api.campaigns.activate({ id }))
         setWorkspace('session')
         setCampaignMenuOpen(false)
       }),
     renameCampaign: (id: string, name: string) =>
-      run(async () => setCampaigns(await campaignsWrite.rename({ id, name }))),
+      run(async () => {
+        projection.publishCampaigns(await api.campaigns.rename({ id, name }))
+      }),
     trashCampaign: (id: string) =>
       run(async () => {
-        const next = await campaignsWrite.trash({ id })
-        setCampaigns(next)
-        if (next.activeCampaignId === null) {
-          setSession(null)
-          setCampaignMenuOpen(true)
-        }
+        const next = await api.campaigns.trash({ id })
+        projection.publishCampaigns(next)
+        if (next.activeCampaignId === null) setCampaignMenuOpen(true)
       }),
     restoreCampaign: (id: string) =>
-      run(async () => setCampaigns(await campaignsWrite.restore({ id }))),
+      run(async () => {
+        projection.publishCampaigns(await api.campaigns.restore({ id }))
+      }),
     deleteCampaignForever: (id: string, confirmationName: string) =>
-      run(async () =>
-        setCampaigns(
-          await campaignsWrite.deleteForever({ id, confirmationName })
+      run(async () => {
+        projection.publishCampaigns(
+          await api.campaigns.deleteForever({ id, confirmationName })
         )
-      )
+      })
   }
 }

--- a/src/renderer/features/workspace/workspace.tsx
+++ b/src/renderer/features/workspace/workspace.tsx
@@ -174,7 +174,10 @@ export function WorkspaceApp() {
           setDayOpen={setDayOpen}
           setSession={(snapshot) => {
             coordinator.setSession(snapshot)
-            void api.session.read().then(coordinator.setSession)
+            if (activeCampaignId)
+              void api.session
+                .read({ campaignId: activeCampaignId })
+                .then(coordinator.setSession)
           }}
           startTravel={() => {
             if (focusedSceneId)

--- a/src/shared/contracts/operations/session.ts
+++ b/src/shared/contracts/operations/session.ts
@@ -1,6 +1,15 @@
+import { z } from 'zod'
 import { liveSessionSnapshotSchema } from '../live-session.js'
-import { none, read, utilityOperationFragment } from './registry.js'
+import { read, utilityOperationFragment } from './registry.js'
+
+export const activeCampaignSessionInputSchema = z
+  .object({ campaignId: z.uuid() })
+  .strict()
 
 export const sessionOperationDefinitions = utilityOperationFragment({
-  'session.read': read('session:read', none, liveSessionSnapshotSchema)
+  'session.read': read(
+    'session:read',
+    activeCampaignSessionInputSchema,
+    liveSessionSnapshotSchema
+  )
 })

--- a/src/utility/application.ts
+++ b/src/utility/application.ts
@@ -399,7 +399,9 @@ const worldPlannerHandlers = createWorldPlannerHandlers({
   publishFactionChange
 })
 
-const sessionHandlers = createSessionHandlers(play)
+const sessionHandlers = createSessionHandlers(play, () =>
+  campaigns.activeCampaignId()
+)
 const sessionPlannerHandlers = createSessionPlannerHandlers({
   encounterPlans,
   sessionPlanner

--- a/src/utility/composition/live-play.ts
+++ b/src/utility/composition/live-play.ts
@@ -9,6 +9,7 @@ import {
   type OperationHandlers
 } from '../../shared/contracts/operations/registry.js'
 import type { LivePlayService } from '../../core/encounter/live-combat.js'
+import { CapabilityError } from '../../shared/errors/capability-error.js'
 
 const sessionHandlerOperations = composeOperationDefinitions(
   sessionOperationDefinitions,
@@ -45,10 +46,15 @@ export function createPartyHandlers(
 }
 
 export function createSessionHandlers(
-  play: LivePlayService
+  play: LivePlayService,
+  activeCampaignId: () => string
 ): OperationHandlers<typeof sessionHandlerOperations> {
   return defineOperationHandlers('session_handlers', sessionHandlerOperations, {
-    'session.read': () => play.readSession(),
+    'session.read': (input) => {
+      if (input.campaignId !== activeCampaignId())
+        throw new CapabilityError('stale', true)
+      return play.readSession()
+    },
     'scene.focus': (input) =>
       play.focusScene(input.sceneId, input.expectedRevision),
     'scene.setLocation': (input) =>

--- a/tests/architecture/frontend-robustness-architecture.test.ts
+++ b/tests/architecture/frontend-robustness-architecture.test.ts
@@ -149,6 +149,49 @@ architectureGate(
   }
 )
 
+architectureGate(
+  'behavior-integration',
+  'binds Campaign catalog and active Session reads to one provider-owned projection',
+  () => {
+    const provider = readTypeScriptModule(
+      'src/renderer/capabilities/capability-provider.tsx'
+    )
+    expect(provider.constructions).toContain('CampaignWorkspaceProjection')
+
+    const projection = readTypeScriptModule(
+      'src/renderer/capabilities/campaign-workspace-projection.ts'
+    )
+    expect(
+      projection.constructions.filter(
+        (value) => value === 'KeyedReadProjectionOwner'
+      )
+    ).toHaveLength(2)
+    expect(projection.stringLiterals).toContain('installation.campaign-catalog')
+    expect(projection.stringLiterals).toContain('campaign.live-session')
+    expect(projection.stringLiterals).toContain('read-projection')
+
+    const coordinator = readTypeScriptModule(
+      'src/renderer/features/workspace/use-campaign-session-coordinator.ts'
+    )
+    expect(coordinator.calls).toContain('useSyncExternalStore')
+    expect(coordinator.propertyAccesses).not.toContain('api.campaigns.list')
+    expect(coordinator.propertyAccesses).not.toContain('api.session.read')
+    expect(coordinator.identifiers.has('setCampaigns')).toBe(false)
+
+    const sessionContract = readTypeScriptModule(
+      'src/shared/contracts/operations/session.ts'
+    )
+    expect(
+      sessionContract.identifiers.has('activeCampaignSessionInputSchema')
+    ).toBe(true)
+    expect(sessionContract.identifiers.has('none')).toBe(false)
+
+    const utility = readTypeScriptModule('src/utility/composition/live-play.ts')
+    expect(utility.constructions).toContain('CapabilityError')
+    expect(utility.propertyAccesses).toContain('input.campaignId')
+  }
+)
+
 function hasDirectSettingsRead(propertyAccesses: readonly string[]): boolean {
   return propertyAccesses.some((access) => access.endsWith('.settings.read'))
 }

--- a/tests/e2e/group-loot-commit.e2e.ts
+++ b/tests/e2e/group-loot-commit.e2e.ts
@@ -140,7 +140,8 @@ describe('Group Loot atomic commit', () => {
     await waitForGmRendererReady(client)
     const committed = await client.execute(async () => {
       const api = window.saltMarcher
-      const live = await api.session.read()
+      const campaignId = (await api.campaigns.list()).activeCampaignId!
+      const live = await api.session.read({ campaignId })
       const scene = live.scene.scenes.find(
         (candidate) => candidate.id === live.scene.focusedSceneId
       )!

--- a/tests/e2e/session-generation.e2e.ts
+++ b/tests/e2e/session-generation.e2e.ts
@@ -152,7 +152,8 @@ describe('generator preset integration', () => {
           active: true,
           expectedRevision: party.revision
         })
-      const live = await api.session.read()
+      const campaignId = (await api.campaigns.list()).activeCampaignId!
+      const live = await api.session.read({ campaignId })
       const scene = await api.scene.generateGroupDraft({
         sceneId: live.scene.focusedSceneId,
         entries: [],

--- a/tests/e2e/session-travel.e2e.ts
+++ b/tests/e2e/session-travel.e2e.ts
@@ -225,7 +225,9 @@ describe('Session map and travel console', () => {
     await client.waitUntil(
       () =>
         client.execute(async () => {
-          const session = await window.saltMarcher.session.read()
+          const campaignId = (await window.saltMarcher.campaigns.list())
+            .activeCampaignId!
+          const session = await window.saltMarcher.session.read({ campaignId })
           return session.travel.kind === 'hex'
             ? session.travel.status === 'travelling'
             : false
@@ -238,7 +240,9 @@ describe('Session map and travel console', () => {
     await client.waitUntil(
       () =>
         client.execute(async () => {
-          const session = await window.saltMarcher.session.read()
+          const campaignId = (await window.saltMarcher.campaigns.list())
+            .activeCampaignId!
+          const session = await window.saltMarcher.session.read({ campaignId })
           return session.travel.kind === 'hex'
             ? session.travel.status === 'aborted'
             : false
@@ -269,7 +273,9 @@ describe('Session map and travel console', () => {
     const completed = await client.waitUntil(
       () =>
         client.execute(async () => {
-          const session = await window.saltMarcher.session.read()
+          const campaignId = (await window.saltMarcher.campaigns.list())
+            .activeCampaignId!
+          const session = await window.saltMarcher.session.read({ campaignId })
           const context = await window.saltMarcher.hexTravel.read({
             sceneId: session.scene.focusedSceneId
           })

--- a/tests/unit/campaign-workspace-projection.test.ts
+++ b/tests/unit/campaign-workspace-projection.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CampaignWorkspaceProjection } from '../../src/renderer/capabilities/campaign-workspace-projection.js'
+import { createSessionHandlers } from '../../src/utility/composition/live-play.js'
+import type { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import type { SaltMarcherApi } from '../../src/shared/contracts/capability-api.js'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import { CapabilityError } from '../../src/shared/errors/capability-error.js'
+
+const campaignA = '00000000-0000-4000-8000-00000000000a'
+const campaignB = '00000000-0000-4000-8000-00000000000b'
+const now = '2026-08-24T16:00:00.000Z'
+
+describe('Campaign Workspace projection', () => {
+  it('keeps crossed A/B reads in their identity cache and shows only B', async () => {
+    const sessionA = deferred<LiveSessionSnapshot>()
+    const sessionB = deferred<LiveSessionSnapshot>()
+    const list = vi
+      .fn<SaltMarcherApi['campaigns']['list']>()
+      .mockResolvedValueOnce(catalog(campaignA))
+      .mockResolvedValueOnce(catalog(campaignB))
+    const read = vi.fn<SaltMarcherApi['session']['read']>(({ campaignId }) =>
+      campaignId === campaignA ? sessionA.promise : sessionB.promise
+    )
+    const projection = new CampaignWorkspaceProjection(api(list, read))
+
+    const first = projection.load()
+    await vi.waitFor(() =>
+      expect(read).toHaveBeenCalledWith({ campaignId: campaignA })
+    )
+    const second = projection.load()
+    await vi.waitFor(() =>
+      expect(read).toHaveBeenCalledWith({ campaignId: campaignB })
+    )
+
+    const acceptedB = session(2)
+    sessionB.resolve(acceptedB)
+    await expect(second).resolves.toMatchObject({ status: 'ready' })
+    expect(projection.snapshot()).toMatchObject({
+      status: 'ready',
+      sessionCampaignId: campaignB,
+      session: acceptedB
+    })
+
+    sessionA.resolve(session(1))
+    await expect(first).resolves.toMatchObject({ status: 'ready' })
+    expect(projection.snapshot()).toMatchObject({
+      sessionCampaignId: campaignB,
+      session: acceptedB
+    })
+  })
+
+  it('reuses only the matching cached Session across A/B/A publication', () => {
+    const projection = new CampaignWorkspaceProjection(
+      api(
+        vi.fn<SaltMarcherApi['campaigns']['list']>(),
+        vi.fn<SaltMarcherApi['session']['read']>()
+      )
+    )
+    const acceptedA = session(5)
+    const acceptedB = session(3)
+
+    projection.publishCampaigns(catalog(campaignA))
+    expect(projection.publishSession(campaignA, acceptedA)).toBe(true)
+    projection.publishCampaigns(catalog(campaignB))
+    expect(projection.snapshot()).toMatchObject({
+      sessionCampaignId: campaignB,
+      session: null
+    })
+    expect(projection.publishSession(campaignB, acceptedB)).toBe(true)
+    projection.publishCampaigns(catalog(campaignA))
+
+    expect(projection.snapshot()).toMatchObject({
+      status: 'ready',
+      sessionCampaignId: campaignA,
+      session: acceptedA
+    })
+    expect(projection.publishSession(campaignA, session(4))).toBe(false)
+    expect(projection.snapshot().session).toBe(acceptedA)
+  })
+
+  it('refreshes the catalog when an explicit active-Session identity is stale', async () => {
+    const list = vi
+      .fn<SaltMarcherApi['campaigns']['list']>()
+      .mockResolvedValueOnce(catalog(campaignA))
+      .mockResolvedValueOnce(catalog(campaignB))
+    const acceptedB = session(7)
+    const read = vi.fn<SaltMarcherApi['session']['read']>(({ campaignId }) =>
+      campaignId === campaignA
+        ? Promise.reject(new CapabilityError('stale', true))
+        : Promise.resolve(acceptedB)
+    )
+    const projection = new CampaignWorkspaceProjection(api(list, read))
+
+    await expect(projection.load()).resolves.toMatchObject({ status: 'ready' })
+    expect(read.mock.calls.map(([input]) => input.campaignId)).toEqual([
+      campaignA,
+      campaignB
+    ])
+    expect(projection.snapshot()).toMatchObject({
+      sessionCampaignId: campaignB,
+      session: acceptedB
+    })
+  })
+
+  it('keeps a provider-owned pending read alive without a consumer', async () => {
+    const pending = deferred<LiveSessionSnapshot>()
+    const read = vi.fn<SaltMarcherApi['session']['read']>(() => pending.promise)
+    const projection = new CampaignWorkspaceProjection(
+      api(
+        vi.fn(() => Promise.resolve(catalog(campaignA))),
+        read
+      )
+    )
+    const listener = vi.fn()
+    const unsubscribe = projection.subscribe(listener)
+    const loading = projection.load()
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+    unsubscribe()
+
+    const accepted = session(1)
+    pending.resolve(accepted)
+    await expect(loading).resolves.toMatchObject({ status: 'ready' })
+    expect(read).toHaveBeenCalledOnce()
+    expect(projection.snapshot().session).toBe(accepted)
+
+    const remounted = vi.fn()
+    projection.subscribe(remounted)
+    expect(projection.snapshot().session).toBe(accepted)
+    expect(read).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a Session read whose Campaign is not the Utility active identity', () => {
+    const readSession = vi.fn(() => session(1))
+    const handlers = createSessionHandlers(
+      { readSession } as unknown as LivePlayService,
+      () => campaignB
+    )
+
+    expect(() => handlers['session.read']({ campaignId: campaignA })).toThrow(
+      expect.objectContaining({ code: 'stale', retryable: true })
+    )
+    expect(readSession).not.toHaveBeenCalled()
+    expect(handlers['session.read']({ campaignId: campaignB })).toBe(
+      readSession.mock.results[0]?.value
+    )
+  })
+})
+
+function api(
+  list: SaltMarcherApi['campaigns']['list'],
+  read: SaltMarcherApi['session']['read']
+): SaltMarcherApi {
+  return {
+    campaigns: { list },
+    session: { read }
+  } as unknown as SaltMarcherApi
+}
+
+function catalog(
+  activeCampaignId: string | null
+): Awaited<ReturnType<SaltMarcherApi['campaigns']['list']>> {
+  return {
+    activeCampaignId,
+    campaigns: [campaignA, campaignB].map((id) => ({
+      id,
+      name: `Campaign ${id.at(-1)}`,
+      createdAt: now
+    })),
+    trashedCampaigns: []
+  }
+}
+
+function session(revision: number): LiveSessionSnapshot {
+  return Object.freeze({ revision }) as LiveSessionSnapshot
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value | PromiseLike<Value>) => void
+  const promise = new Promise<Value>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}

--- a/tests/unit/frontend-robustness-baseline.test.ts
+++ b/tests/unit/frontend-robustness-baseline.test.ts
@@ -22,7 +22,7 @@ describe('FR0 frontend robustness baseline', () => {
     expect(routeHost.identifiers.has('readbackKey')).toBe(true)
   })
 
-  it('records that the Campaign root has no instance-bound async ordering', () => {
+  it('records that Campaign writes remain unqueued until FR2B', () => {
     const coordinator = readTypeScriptModule(
       'src/renderer/features/workspace/use-campaign-session-coordinator.ts'
     )
@@ -31,12 +31,7 @@ describe('FR0 frontend robustness baseline', () => {
       false
     )
     expect(coordinator.calls).toEqual(
-      expect.arrayContaining([
-        'api.campaigns.list',
-        'api.session.read',
-        'campaignsWrite.create',
-        'campaignsWrite.activate'
-      ])
+      expect.arrayContaining(['api.campaigns.create', 'api.campaigns.activate'])
     )
   })
 

--- a/tests/unit/live-session-contract.test.ts
+++ b/tests/unit/live-session-contract.test.ts
@@ -24,8 +24,26 @@ import {
   createEncounterTableInputSchema,
   createWorldFactionInputSchema
 } from '../../src/shared/contracts/encounter-source.js'
+import { activeCampaignSessionInputSchema } from '../../src/shared/contracts/operations/session.js'
 
 describe('live session capability contracts', () => {
+  it('requires an explicit Campaign identity for the active Session read', () => {
+    expect(
+      activeCampaignSessionInputSchema.safeParse({
+        campaignId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030'
+      }).success
+    ).toBe(true)
+    expect(activeCampaignSessionInputSchema.safeParse(undefined).success).toBe(
+      false
+    )
+    expect(
+      activeCampaignSessionInputSchema.safeParse({
+        campaignId: '0184d1f4-bba7-7c9c-9d89-5f1c0f36a030',
+        active: true
+      }).success
+    ).toBe(false)
+  })
+
   it('allows empty groups with optional names and rejects invalid quantities', () => {
     expect(
       saveSceneGroupInputSchema.safeParse({


### PR DESCRIPTION
## Ergebnis

Schließt FR2A mit einem provider-lebenden, identitätsgebundenen Read-Owner für Campaign-Katalog und aktive Live-Session.

- Campaign-Katalog und Sessions werden über getrennte semantische Authority Keys latest-only gelesen
- sichtbare Session wird ausschließlich aus dem Cache der akzeptierten aktiven Campaign zusammengesetzt
- `session.read` verlangt eine exakte Campaign-ID; Utility weist eine nicht mehr aktive ID typisiert als `stale` zurück
- kontrollierte A/B- und A/B/A-Races belegen getrennte Caches, spätes Resultat-Isolation und Revision-Schutz
- der Owner überlebt Workspace-Consumer-Remounts innerhalb des Capability Providers
- React-eigene parallele Campaign-/Session-State-Owner sind aus dem Workspace-Root entfernt

## Audit

Vollständiger Phasenaudit mit Quellen, Implementation Packet, Mental Trace, Exit-Matrix, Exklusionen und 13 negativen Findings/Folgekorrekturen:

- `docs/project/evidence/frontend-robustness-fr2a-audit.md`

Bewusste Grenzen: Campaign-Writes bleiben bis FR2B unsequenziert; globaler `saltmarcher:readback`/`readbackKey`-Remount bleibt bis FR2C; QS-05-Produktionstiming, Restart und nächste sichere Mutation bleiben bis FR2D offen. Der Campaign-Katalog besitzt noch keine dauerhafte Revision, daher wird keine synthetische Write-Ordnung behauptet.

## Lokale Verifikation

- `pnpm check:frontend-robustness`: beide TypeScript-Konfigurationen, 16 Dateien, 106 Tests grün
- Lint: Core, Electron-Tooling, Renderer und Tests grün
- Prettier und `git diff --check` grün
- Development-Build: Main/Utility, Preload und Renderer grün
- Bundle-Gate: +16.382 Byte reachable; innerhalb der unveränderten 16-KiB-Spike-Grenze, alle Teilbudgets grün
- keine nullargumentige `session.read()`-Stelle mehr in `src/` oder `tests/`

Die bestehende vollständige `campaignCreate`-Electron-Journey wurde auf dem gebauten Output versucht, lief aber im hostintensiven visuellen Settings-Abschnitt in wiederholte 30-s-Renderer-Script-Timeouts und anschließend ins 180-s-Suite-Limit. Auch die Failure-Screenshots timeouteten; der Lauf liefert daher keinen semantischen Switch-Verdict und wird nicht als grüne Evidenz gezählt. Die exakten Candidate-Jobs bleiben für den Produktionspfad maßgeblich.

App-relevant: Promotion erst nach allen exakten Candidate-Jobs und vollständigem `pnpm handoff:app` für exakt `cee564c2714eb4bfa9eb66d81d5d2d05dee0d71e`.
