### PR TITLE
test(frontend): qualify FR2D Campaign production route

### DIFF
--- a/docs/project/evidence/frontend-robustness-fr2d-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2d-audit.md
@@ -1,0 +1,165 @@
+# Frontend robustness FR2D qualification audit
+
+- Date: 2026-08-25
+- Delivery baseline: `origin/main@6527d08008c09b4084b21709a208a2af834750d1`
+- Sprint: `FR2D` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+- Gate verdict: **open / no-go for FR3**
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap and normative acceptance matrix;
+- the current Electron target architecture and historical greenfield migration
+  record;
+- the Campaign Management and Live Session requirements plus Live Session
+  persistence contract;
+- `program-technical-needs.md`, in particular the population rule, `RP-H`,
+  `RP-R`, `RP-L`, `TN-11`, `TN-16`, `TN-21`, and `QS-05`;
+- the FR2A, FR2B, and FR2C audit records, current Campaign Workspace projection,
+  Campaign coordinator, Workspace root, installation preference owner,
+  Reference owner, E2E registry, current production-route journeys, and live
+  delivery state;
+- live `origin/main`, the clean candidate branch, and open pull requests were
+  compared before editing.
+
+## Implementation packet
+
+FR2D adds a bounded qualification route without introducing another state
+owner.
+
+- durable truth remains the Utility-owned Campaign registry and each
+  Campaign-owned Live Session;
+- the provider-lived `CampaignWorkspaceProjection` remains the only renderer
+  owner for the installation Campaign catalog and Campaign-ID-keyed Session
+  projections;
+- the production root exposes only bounded readiness facts:
+  `data-active-campaign-id`, `data-session-campaign-id`,
+  `data-session-revision`, and `data-active-workspace`;
+- useful Session state is accepted only when Campaign identity and Session
+  authority identity match, a non-empty Session revision is published, the
+  active workspace is Session, and the real `.session-mockup` exists;
+- the functional journey creates A and B through the UI, performs five
+  unrecorded warmups and 100 recorded alternating UI activations, applies a
+  ten-second timeout to every sample, computes sorted-value p95, compares both
+  complete active Session snapshots with their pre-population values, performs
+  one subsequent Campaign rename through the UI, restarts Electron, and reads
+  the renamed active Campaign back through the rendered Session heading;
+- timing starts immediately before the Campaign-selection click. Opening the
+  Campaign dialog is not part of the warm-switch stimulus;
+- the existing receipt-reconciliation journey now performs a rename after the
+  interrupted committed Create, restarts Electron, and verifies exactly one
+  renamed Campaign;
+- delivery class is app-relevant because production Renderer readiness markers
+  changed. Canonical exact-SHA handoff is required before promotion.
+
+## Product-truth resolution for view state
+
+The pre-phase review found that an initially considered per-Campaign Rail and
+layout map would contradict current product requirements. It was therefore not
+implemented.
+
+| View state | Normative scope | Campaign-switch behavior |
+| --- | --- | --- |
+| active Rail workspace | shell view state | Create and Activate explicitly open Session; a prior non-Session workspace is not restored. |
+| Session preferred widths and center tab | installation-wide schema-v2 preference | Shared app-wide; never copied into Campaign truth or silently made per-Campaign. |
+| selected Encounter/Reise scenario | focused Scene ID in the mounted Workspace root | Keyed by Scene identity for the app lifetime; it is not durable Session truth. |
+| Reference navigation and pinned cards | Campaign/Scene scope in `ReferenceProvider` | Navigation is identity-keyed; pins remain memory-only as required. |
+| Campaign and Session projections | installation authority plus Campaign ID | Immutable accepted projection; never treated as view state. |
+
+This matrix is intentionally narrower than the roadmap shorthand
+“per-Campaign view-state retention”. Product requirements remain authoritative:
+selecting or creating a Campaign opens Session, and Session layout is app-wide.
+
+## Local production-route evidence
+
+The final built Electron run used the empty-installation fixture on Linux,
+Electron `43.2.0` / Chrome `150.0.7871.129`, and the repository's SwiftShader
+E2E route.
+
+- warmups: `5`;
+- recorded switches: `100`;
+- p95: `530.138 ms`;
+- maximum: `638.266 ms`;
+- samples at or above the one-second target: `0`;
+- samples at or above the ten-second timeout: `0`;
+- A and B complete active `LiveSessionSnapshot` values after the population:
+  byte-for-byte equivalent to their respective pre-population values;
+- next mutation: active Campaign A renamed to
+  `Qualification A confirmed` through the UI;
+- restart oracle: the exact renamed Campaign identity reopened as the active
+  Session after a real Electron restart;
+- the separate reconciliation route retained the same Campaign dialog and
+  draft across an interrupted committed Create, reconciled by receipt, then
+  renamed and restored that result after restart.
+
+The development build completed with 80 output files and output hash
+`f9a76cab430bfad09dd4084d6c1dbca11e99ec990ec86429995ffdb21a8239a1`.
+Canonical candidate, installed-artifact, and Main evidence remain delivery
+steps after commit.
+
+Focused local proof after the final source change:
+
+- `pnpm check:frontend-robustness`: 23 files and 159 tests passed;
+- E2E registry plus CI-matrix gates: 8/8 passed after placing the suite at its
+  actual shard boundary; measured shard totals are approximately 503 seconds
+  for `campaign-workspaces` and 494 seconds for `hex-npc-restart`;
+- built `campaignQualification`: 1/1 passed in 4m08s with the 100-sample JSON
+  record above;
+- built `campaignReconciliation`: 1/1 passed in 1m42s, including the added
+  rename and restart oracle.
+
+The complete local `pnpm check` reached the portable unit phase. Format, all
+lint partitions, both TypeScript projects, and 91/91 architecture tests passed.
+The first run found one real registry-order error, fixed and verified above.
+It also reproduced four unrelated host-sensitive historical failures: three
+Encounter Generator settings cases exceeded their 30-second test timeout, and
+the 16-ms Reference Matcher gate measured 30.899 ms. Single-worker isolation
+still measured 31.589 ms for the Matcher and the same three settings timeouts.
+No touched production path imports either feature. Those thresholds were not
+weakened; clean-host remote `Check` remains authoritative for the broad gate.
+
+## Findings and weaker-than-required evidence
+
+1. The empty-installation fixture is not `RP-R` or `RP-L`. It contains neither
+   the required object/record/media populations nor active Scenes, masks,
+   travel, overrides, and pending reconciliation.
+2. The run covers one Linux host only. `QS-05` requires separate populations on
+   every supported Linux, Windows, and macOS environment calibrated to `RP-H`.
+3. The post-population mutation is an installation-authority Campaign rename.
+   It proves that a subsequent serialized mutation is durable, but it is weaker
+   than `TN-16`'s safely rendered focused-Scene mutation.
+4. The empty new Campaign published no inactive Roster population in the Live
+   Session snapshot, so the planned Party-membership next-action oracle could
+   not be executed from this fixture. That mismatch needs a product/fixture
+   decision before it can serve as normative evidence.
+5. An attempted `Reise` view-state assertion on the empty SwiftShader route
+   exceeded the ten-second WebDriver renderer channel. The attempt was removed
+   from this Campaign-only population rather than hiding it behind a longer
+   timeout. It is not yet isolated sufficiently to classify as a Travel/Pixi
+   product defect and belongs to FR6 qualification follow-up.
+6. The Journey initially attempted inactive-Campaign Session reads. The
+   capability correctly rejected that authority violation. The final oracle
+   switches visibly to each Campaign before reading its active Session.
+7. Manual owner acceptance of the installed exact-SHA artifact is absent.
+
+## Gate decision and required follow-up
+
+This slice establishes the production readiness marker, the normative
+population mechanics, a green 100-sample Linux empty-profile result, complete
+A/B Session equivalence, and two durable post-switch/post-recovery Campaign
+mutations. It does **not** close `FR-A07`, `TN-16`, or `QS-05`.
+
+FR2D remains no-go until all of the following are current and attached:
+
+1. reproducible `RP-R` and `RP-L` fixtures containing the exact Campaign,
+   Running Scene, mask, travel, override, media, and pending-reconciliation
+   truth required by the technical-needs profile;
+2. separate 5+100 warm populations on calibrated `RP-H` Linux, Windows, and
+   macOS hosts;
+3. complete useful-state equivalence plus a focused-Scene next mutation that is
+   durable after restart for every population;
+4. an isolated disposition for the empty-profile Travel/SwiftShader timeout;
+5. canonical exact-SHA handoff, installed-runtime evidence, green Main, and
+   explicit owner go/no-go.
+
+FR3 must not start while those conditions remain open.

--- a/scripts/e2e-suite-registry.ts
+++ b/scripts/e2e-suite-registry.ts
@@ -92,6 +92,15 @@ export const e2eSuiteRegistry = [
     }
   },
   {
+    name: 'campaignQualification',
+    spec: './tests/e2e/campaign-qualification.e2e.ts',
+    fixture: 'v1/empty-installation',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'hex-npc-restart', measuredSeconds: 250 }
+    }
+  },
+  {
     name: 'hexLocation',
     spec: './tests/e2e/hex-location-workflow.e2e.ts',
     fixture: 'v1/empty-installation',

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -13,6 +13,7 @@
     "tests/unit/campaign-workspace-projection.test.ts",
     "tests/unit/campaign-registry-repository.test.ts",
     "tests/unit/campaign-reconciliation-ui.test.tsx",
+    "tests/unit/e2e-suite-registry.test.ts",
     "tests/unit/capability-contract.test.ts",
     "tests/unit/persistence-preflight.test.ts",
     "tests/integration/campaign-command-receipts.test.ts",

--- a/src/renderer/features/workspace/use-campaign-session-coordinator.ts
+++ b/src/renderer/features/workspace/use-campaign-session-coordinator.ts
@@ -86,6 +86,7 @@ export function useCampaignSessionCoordinator(
 
   return {
     campaigns: root.campaigns,
+    sessionCampaignId: root.sessionCampaignId,
     session: root.session,
     setSession: (
       update:

--- a/src/renderer/features/workspace/workspace.tsx
+++ b/src/renderer/features/workspace/workspace.tsx
@@ -156,6 +156,10 @@ export function WorkspaceApp() {
       <main
         className="app-shell"
         data-renderer-ready="gm"
+        data-active-campaign-id={activeCampaignId ?? ''}
+        data-session-campaign-id={coordinator.sessionCampaignId ?? ''}
+        data-session-revision={coordinator.session?.revision ?? ''}
+        data-active-workspace={coordinator.workspace}
         aria-busy={coreStatus !== 'ready' || undefined}
       >
         {coreStatus !== 'ready' && (

--- a/tests/architecture/frontend-robustness-architecture.test.ts
+++ b/tests/architecture/frontend-robustness-architecture.test.ts
@@ -217,6 +217,28 @@ architectureGate(
   }
 )
 
+architectureGate(
+  'behavior-integration',
+  'exposes identity-bound Campaign and Session readiness on the production root',
+  () => {
+    const workspace = readTypeScriptModule(
+      'src/renderer/features/workspace/workspace.tsx'
+    )
+    for (const marker of [
+      'data-active-campaign-id',
+      'data-session-campaign-id',
+      'data-session-revision',
+      'data-active-workspace'
+    ])
+      expect(workspace.jsxAttributeNames, marker).toContain(marker)
+
+    const coordinator = readTypeScriptModule(
+      'src/renderer/features/workspace/use-campaign-session-coordinator.ts'
+    )
+    expect(coordinator.identifiers.has('sessionCampaignId')).toBe(true)
+  }
+)
+
 function hasDirectSettingsRead(propertyAccesses: readonly string[]): boolean {
   return propertyAccesses.some((access) => access.endsWith('.settings.read'))
 }

--- a/tests/e2e/campaign-qualification.e2e.ts
+++ b/tests/e2e/campaign-qualification.e2e.ts
@@ -1,0 +1,244 @@
+import { browser, expect } from '@wdio/globals'
+import { performance } from 'node:perf_hooks'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import type { Browser as WdioBrowser } from 'webdriverio'
+
+const switchTimeoutMs = 10_000
+
+describe('Campaign production-route qualification', () => {
+  it('keeps A/B truth coherent across a warm population and persists the next action', async () => {
+    const client = browser as unknown as WdioBrowser
+    progress('create-a')
+    await createCampaign(client, 'Qualification A')
+    const campaignA = await activeCampaign(client)
+    const beforeA = await readSession(client, campaignA.id)
+
+    progress('create-b')
+    await createCampaign(client, 'Qualification B')
+    const campaignB = await activeCampaign(client)
+    const beforeB = await readSession(client, campaignB.id)
+
+    progress('initial-switch-a')
+    await switchCampaign(client, campaignA.id, campaignA.name)
+
+    for (let index = 0; index < 5; index += 1) {
+      progress(`warmup-${index}`)
+      const target = index % 2 === 0 ? campaignB : campaignA
+      await switchCampaign(client, target.id, target.name)
+    }
+
+    const samples: number[] = []
+    for (let index = 0; index < 100; index += 1) {
+      if (index % 10 === 0) progress(`sample-${index}`)
+      const target = index % 2 === 0 ? campaignA : campaignB
+      samples.push(await switchCampaign(client, target.id, target.name))
+    }
+
+    const sorted = [...samples].sort((left, right) => left - right)
+    const p95Ms = sorted[94]!
+    const maximumMs = sorted.at(-1)!
+    expect(samples).toHaveLength(100)
+    expect(maximumMs).toBeLessThan(switchTimeoutMs)
+    expect(p95Ms).toBeLessThan(1_000)
+
+    progress('population-complete')
+    progress('read-b')
+    expect(await readSession(client, campaignB.id)).toEqual(beforeB)
+
+    progress('switch-a-for-oracle')
+    await switchCampaign(client, campaignA.id, campaignA.name)
+    progress('read-a')
+    const beforeMutation = await readSession(client, campaignA.id)
+    expect(beforeMutation).toEqual(beforeA)
+    const renamedCampaign = 'Qualification A confirmed'
+    progress('rename-after-population')
+    await renameActiveCampaign(client, campaignA.name, renamedCampaign)
+
+    progress('restart-after-mutation')
+    await client.reloadSession()
+    await waitForCampaignReady(client, campaignA.id)
+    progress('restart-after-mutation-ready')
+    await (
+      await client.$(`h1=Session · ${renamedCampaign}`)
+    ).waitForExist({ timeout: switchTimeoutMs })
+
+    process.stdout.write(
+      `${JSON.stringify({
+        kind: 'campaign-warm-switch-qualification',
+        profile: 'empty-installation-functional-route',
+        warmups: 5,
+        samples: samples.map((value) => Number(value.toFixed(3))),
+        p95Ms: Number(p95Ms.toFixed(3)),
+        maximumMs: Number(maximumMs.toFixed(3)),
+        timeoutMs: switchTimeoutMs,
+        semanticEquivalence: true,
+        nextMutation: {
+          kind: 'campaign-rename',
+          campaignId: campaignA.id,
+          name: renamedCampaign,
+          restartReadback: true
+        }
+      })}\n`
+    )
+  })
+})
+
+function progress(stage: string): void {
+  process.stdout.write(`[campaign-qualification] ${stage}\n`)
+}
+
+async function createCampaign(
+  client: WdioBrowser,
+  name: string
+): Promise<void> {
+  let field = await client.$('#campaign-name')
+  try {
+    await field.waitForDisplayed({ timeout: 5_000 })
+  } catch {
+    await openCampaignDialog(client)
+    field = await client.$('#campaign-name')
+  }
+  await field.waitForDisplayed({ timeout: 5_000 })
+  await field.setValue(name)
+  await (await client.$('button=Anlegen')).click()
+  await (
+    await client.$(`h1=Session · ${name}`)
+  ).waitForExist({
+    timeout: switchTimeoutMs
+  })
+  await waitForCampaignDialogClosed(client)
+}
+
+async function activeCampaign(
+  client: WdioBrowser
+): Promise<Readonly<{ id: string; name: string }>> {
+  return client.execute(async () => {
+    const snapshot = await window.saltMarcher.campaigns.list()
+    const campaign = snapshot.campaigns.find(
+      (entry) => entry.id === snapshot.activeCampaignId
+    )
+    if (!campaign) throw new Error('Active E2E Campaign is missing.')
+    return { id: campaign.id, name: campaign.name }
+  })
+}
+
+async function readSession(
+  client: WdioBrowser,
+  campaignId: string
+): Promise<LiveSessionSnapshot> {
+  const serialized = await client.execute(async (id) => {
+    try {
+      return JSON.stringify({
+        status: 'ready',
+        value: await window.saltMarcher.session.read({ campaignId: id })
+      })
+    } catch (cause) {
+      return JSON.stringify({
+        status: 'failure',
+        name: cause instanceof Error ? cause.name : typeof cause,
+        message: cause instanceof Error ? cause.message : String(cause)
+      })
+    }
+  }, campaignId)
+  const outcome = JSON.parse(serialized) as
+    | Readonly<{ status: 'ready'; value: LiveSessionSnapshot }>
+    | Readonly<{ status: 'failure'; name: string; message: string }>
+  if (outcome.status === 'failure')
+    throw new Error(
+      `Session read failed for ${campaignId}: ${outcome.name}: ${outcome.message}`
+    )
+  return outcome.value
+}
+
+async function switchCampaign(
+  client: WdioBrowser,
+  campaignId: string,
+  campaignName: string
+): Promise<number> {
+  await openCampaignDialog(client)
+  const target = await client.$(`button[aria-label="${campaignName}"]`)
+  await target.waitForClickable({ timeout: 5_000 })
+  const startedAt = performance.now()
+  await target.click()
+  await waitForCampaignReady(client, campaignId)
+  await waitForCampaignDialogClosed(client)
+  const finishedAt = performance.now()
+  return finishedAt - startedAt
+}
+
+async function openCampaignDialog(client: WdioBrowser): Promise<void> {
+  const button = await client.$('button[aria-label="Menü"]')
+  if ((await button.getAttribute('aria-expanded')) === 'true') {
+    const field = await client.$('#campaign-name')
+    if (await field.isDisplayed()) return
+    const openMenu = await client.$('nav#campaign-menu')
+    if (await openMenu.isDisplayed()) {
+      await (await openMenu.$('button=Kampagnen')).click()
+      await field.waitForDisplayed({ timeout: 5_000 })
+      return
+    }
+    await field.waitForDisplayed({ timeout: 5_000 })
+    return
+  }
+  await button.click()
+  const menu = await client.$('nav#campaign-menu')
+  await menu.waitForDisplayed({ timeout: 5_000 })
+  await (await menu.$('button=Kampagnen')).click()
+  await (await client.$('#campaign-name')).waitForDisplayed({ timeout: 5_000 })
+}
+
+async function waitForCampaignDialogClosed(client: WdioBrowser): Promise<void> {
+  const button = await client.$('button[aria-label="Menü"]')
+  await client.waitUntil(
+    async () => (await button.getAttribute('aria-expanded')) === 'false',
+    {
+      timeout: 5_000,
+      interval: 25,
+      timeoutMsg: 'Campaign dialog did not close after activation.'
+    }
+  )
+  await button.waitForClickable({ timeout: 5_000 })
+}
+
+async function waitForCampaignReady(
+  client: WdioBrowser,
+  campaignId: string
+): Promise<void> {
+  const session = await client.$(
+    `main[data-renderer-ready="gm"]` +
+      `[data-active-campaign-id="${campaignId}"]` +
+      `[data-session-campaign-id="${campaignId}"]` +
+      '[data-session-revision]:not([data-session-revision=""])' +
+      '[data-active-workspace="session"] .session-mockup'
+  )
+  await session.waitForExist({
+    timeout: switchTimeoutMs,
+    interval: 25,
+    timeoutMsg: `Campaign ${campaignId} did not reach useful Session state.`
+  })
+}
+
+async function renameActiveCampaign(
+  client: WdioBrowser,
+  currentName: string,
+  nextName: string
+): Promise<void> {
+  await openCampaignDialog(client)
+  let row = await (
+    await client.$(`button[aria-label="${currentName}"]`)
+  ).$('..')
+  await (await row.$('button=Umbenennen')).click()
+  const field = await row.$('input[aria-label="Umbenennen"]')
+  await field.setValue(nextName)
+  row = await field.$('..')
+  await (await row.$('button=Speichern')).click()
+  await (
+    await client.$(`h1=Session · ${nextName}`)
+  ).waitForExist({
+    timeout: switchTimeoutMs
+  })
+  await (
+    await client.$('#campaign-menu button[aria-label="Schließen"]')
+  ).click()
+  await waitForCampaignDialogClosed(client)
+}

--- a/tests/e2e/campaign-reconciliation.e2e.ts
+++ b/tests/e2e/campaign-reconciliation.e2e.ts
@@ -66,6 +66,33 @@ describe('Campaign receipt reconciliation', () => {
       ).length
     })
     expect(matchingCampaigns).toBe(1)
+
+    await (await client.$('button[aria-label="Menü"]')).click()
+    const menu = await client.$('nav#campaign-menu')
+    await menu.waitForDisplayed({ timeout: 5_000 })
+    await (await menu.$('button=Kampagnen')).click()
+    let row = await (await client.$('button[aria-label="Receipt E2E"]')).$('..')
+    await (await row.$('button=Umbenennen')).click()
+    await (
+      await row.$('input[aria-label="Umbenennen"]')
+    ).setValue('Receipt E2E confirmed')
+    row = await (await client.$('input[aria-label="Umbenennen"]')).$('..')
+    await (await row.$('button=Speichern')).click()
+    await (
+      await client.$('h1=Session · Receipt E2E confirmed')
+    ).waitForExist({ timeout: 10_000 })
+
+    await client.reloadSession()
+    await (
+      await client.$('h1=Session · Receipt E2E confirmed')
+    ).waitForExist({ timeout: 30_000 })
+    const renamed = await client.execute(async () => {
+      const snapshot = await window.saltMarcher.campaigns.list()
+      return snapshot.campaigns.filter(
+        (campaign) => campaign.name === 'Receipt E2E confirmed'
+      ).length
+    })
+    expect(renamed).toBe(1)
   })
 })
 

--- a/tests/unit/e2e-suite-registry.test.ts
+++ b/tests/unit/e2e-suite-registry.test.ts
@@ -104,7 +104,7 @@ describe('E2E suite registry', () => {
       const campaigns = e2eSuiteRegistry.filter((suite) =>
         suite.name.startsWith('campaign')
       )
-      expect(campaigns).toHaveLength(5)
+      expect(campaigns).toHaveLength(6)
       for (const campaign of campaigns) {
         expect(campaign.fixture).toBe('v1/empty-installation')
         expect(callCount(readTypeScriptModule(campaign.spec), 'it')).toBe(1)

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -119,7 +119,12 @@ export const config = {
   },
   mochaOpts: {
     ui: 'bdd',
-    timeout: suite === 'sessionGeneration' ? 360_000 : 180_000,
+    timeout:
+      suite === 'sessionGeneration'
+        ? 360_000
+        : suite === 'campaignQualification'
+          ? 300_000
+          : 180_000,
     ...(process.env['SALT_MARCHER_E2E_GREP']
       ? { grep: process.env['SALT_MARCHER_E2E_GREP'] }
       : {})


### PR DESCRIPTION
## Scope

- expose Campaign-ID, Session-ID, revision, and active-workspace readiness on the real Workspace root
- add the FR2D built-Electron Campaign qualification journey with 5 warmups and 100 recorded A/B switches
- compare complete active Session snapshots, then persist and restart-read a representative Campaign rename
- extend receipt reconciliation with a subsequent rename and restart oracle
- record the product-truth view-state decision and the remaining FR2D blockers in docs/project/evidence/frontend-robustness-fr2d-audit.md

## Local evidence

- pnpm check:frontend-robustness: 23 files, 159 tests passed
- campaignQualification built Electron: 100/100 switches, p95 530.138 ms, max 638.266 ms, exact A/B Session equivalence, rename plus restart readback
- campaignReconciliation built Electron: passed with interrupted committed Create, receipt recovery, rename, and restart readback
- E2E registry and CI matrix: 8/8 passed
- development build: 80 files, output hash f9a76cab430bfad09dd4084d6c1dbca11e99ec990ec86429995ffdb21a8239a1

## Honest gate status

FR2D remains open and FR3 remains no-go. This run uses the Linux empty-installation SwiftShader route, not calibrated RP-R/RP-L populations on every supported OS. The next mutation is a Campaign rename, weaker than the required focused-Scene mutation, and owner acceptance is pending.

The broad local pnpm check reached portable units. Format, lint, typecheck, and 91 architecture tests passed. One real registry-order failure was fixed. Three unrelated Encounter Generator settings tests still exceeded their historical 30-second timeout and the unrelated 16-ms Reference Matcher measured 31.589 ms in isolation; thresholds were not relaxed. Remote clean-host Check is authoritative.