### PR TITLE
docs: correct frontend qualification gate

### DIFF
--- a/docs/project/architecture/frontend-robustness-acceptance-matrix.md
+++ b/docs/project/architecture/frontend-robustness-acceptance-matrix.md
@@ -41,7 +41,7 @@ as target behavior.
 | FR-A04 | A stale result updates at most its own cache key and never newer visible authored state | FR1 | authority-key controlled promises |
 | FR-A05 | Unknown write outcome reconciles by the same command identity and never blindly replays | FR1 | receipt present/absent/interrupted matrices |
 | FR-A06 | Data reconciliation never remounts an unrelated workspace or discards its draft | FR2 | mounted sentinel and draft-preservation Electron journey |
-| FR-A07 | Rapid Campaign switching restores coherent useful state and safely persists the next mutation | FR2 | `QS-05` A/B/A production timing and semantic oracle |
+| FR-A07 | Rapid Campaign switching restores coherent useful state and safely persists the next mutation | FR2 | FR2 current-format A/B/A production timing and semantic oracle; FR7 exact cross-OS `RP-R`/`RP-L` `QS-05` completion |
 | FR-A08 | Running Play has one visible projection and exposes stale dependents as pending | FR3 | Scene/Party/Encounter/Loot fault matrix |
 | FR-A09 | Catalog/editor search, selection, draft, submission, and persisted projection have separate owners | FR4 | crossed reads/writes and draft survival matrix |
 | FR-A10 | Long work has one linear cancel result and cannot publish into a different authored authority | FR5 | early/mid/commit cancel plus switch/restart cases |

--- a/docs/project/architecture/frontend-robustness-roadmap.md
+++ b/docs/project/architecture/frontend-robustness-roadmap.md
@@ -92,6 +92,22 @@ After every phase:
 5. deliver every app-relevant exact Candidate SHA through remote `Check`,
    `pnpm handoff:app`, unchanged promotion, and a green Main run.
 
+### Qualification maturity
+
+Migration gates and final product qualification are deliberately separate.
+An early renderer migration gate uses all truth that the current product format
+can represent and exists to prove that the proposed ownership model is safer
+than the mechanism it replaces. It MUST NOT claim that a later technical-needs
+profile passed when the product does not yet implement every data class in that
+profile.
+
+The exact `RP-R`/`RP-L` populations, every supported operating system, and all
+state named by `QS-05` remain binding final qualification. They close in `FR7B`
+after the owning product phases have made those data classes representable.
+Deferring that final verdict does not permit scaled-down populations to be
+reported as `RP-R` or `RP-L`, and it does not permit a migration phase to omit a
+current-format production-route oracle.
+
 ## FR0 — baseline and acceptance contract
 
 ### Scope
@@ -159,10 +175,15 @@ After every phase:
 - rapid `A -> B -> A`, overlapping reads, switch-during-write, readback, restart,
   and the next mutation produce one coherent Campaign/Session truth;
 - no data recovery remounts a workspace or silently discards a draft;
-- `QS-05` warm-switch equivalence and the one-second p95 budget have production-
-  route evidence;
+- the complete current Campaign format has a reproducible applicability
+  manifest, production-route warm-switch population, complete useful-state
+  equivalence, and a focused-Scene next-action/restart oracle;
+- this reference population meets the one-second p95 budget but is labelled as
+  preliminary evidence, not as `RP-R`, `RP-L`, or completed `QS-05` evidence;
 - FR2 is a go/no-go gate. Later migration does not start until the reference
-  slice reduces lifecycle complexity and passes owner acceptance.
+  slice reduces lifecycle complexity and passes owner architecture acceptance;
+- exact `QS-05` qualification remains an `FR7B` exit condition after every
+  required Campaign data class exists.
 
 ## FR3 — live Session, Party, Encounter, Group, and Loot
 
@@ -301,7 +322,10 @@ decision.
 | `FR2A` | Identity-bound Campaign catalog and active-Session reads without overlapping publication |
 | `FR2B` | FIFO Campaign lifecycle commands with transport-time authority/revision selection |
 | `FR2C` | Targeted Campaign/Session reconciliation and removal of their readback remount path |
-| `FR2D` | Warm-switch production timing, next-action oracle, and owner go/no-go |
+| `FR2D` | Preliminary empty-profile warm-switch mechanics and evidence audit; never a gate-closing population |
+| `FR2E` | Correctly separate the current-format architecture gate from final `QS-05`, with an explicit applicability and absence record |
+| `FR2F` | Reproducible complete current-format fixture, focused-Scene next-action/restart oracle, and isolated Travel disposition |
+| `FR2G` | Current-format production timing and owner architecture go/no-go; exact `QS-05` remains open for `FR7B` |
 | `FR3A` | Running Play projection owner and selector/action boundary; no behavior migration yet |
 | `FR3B` | Scene and Party commands, patches, and dependent-pending behavior |
 | `FR3C` | Group and Combat command authorities, including crossed rapid actions |
@@ -317,7 +341,7 @@ decision.
 | `FR6B` | Travel read/write projection cutover and joint Session publication |
 | `FR6C` | Pixi/context-loss resource isolation and complete spatial journey gate |
 | `FR7A` | Semantic zero-inventory gates and removal of every legacy state path |
-| `FR7B` | Complete functional, failure, latency, scaling, and resource qualification |
+| `FR7B` | Complete functional, failure, latency, scaling, resource, and exact cross-OS `RP-R`/`RP-L` `QS-05` qualification |
 | `FR7C` | Exact-SHA handoff, installed-runtime audit, Main promotion, and owner acceptance |
 
 `FR1A` and `FR3A` may be test/contract-only only when they add no unused runtime

--- a/docs/project/evidence/frontend-robustness-fr2d-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2d-audit.md
@@ -163,3 +163,15 @@ FR2D remains no-go until all of the following are current and attached:
    explicit owner go/no-go.
 
 FR3 must not start while those conditions remain open.
+
+## Post-audit gate correction
+
+The evidence findings above remain valid, but the final sentence coupled the
+FR3 entry gate to data that FR3 and later product phases must first make fully
+representable. That interpretation is superseded by the
+[FR2E gate audit](frontend-robustness-fr2e-gate-audit.md).
+
+Exact cross-OS `RP-R`/`RP-L` `QS-05` evidence is still absent and MUST NOT be
+claimed. It is a final `FR7B` qualification gate. FR3 remains blocked for now by
+the incomplete current-format reference fixture and missing owner architecture
+acceptance, not by nonexistent future-format data.

--- a/docs/project/evidence/frontend-robustness-fr2e-gate-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2e-gate-audit.md
@@ -1,0 +1,108 @@
+# Frontend robustness FR2E qualification-gate audit
+
+- Date: 2026-08-25
+- Delivery baseline: `origin/main@0d578cfc8f37b75d8fcb4673c8f2f5a91de5782e`
+- Sprint: `FR2E` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+- Change class: documentation-only architecture correction
+- Gate verdict: **FR2 remains open / no-go for FR3**
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap, acceptance matrix, and FR2D audit;
+- the original Electron greenfield roadmap, especially the deliberately narrow
+  name-only Campaign `M1` gate and the later `M2` Campaign-knowledge scope;
+- `program-technical-needs.md`, including the population rule, `RP-H`, `RP-R`,
+  `RP-L`, `TN-16`, and `QS-05`;
+- the Electron target architecture, Campaign Management requirements, Live
+  Session requirements, and Live Session persistence contract;
+- the current Campaign schema/bootstrap, Scene, Party, Hex/Travel, catalog,
+  loot, planning, and import stores plus the E2E fixture materializer and suite
+  registry;
+- live `origin/main`, the clean worktree, and current open pull requests.
+
+## Root finding
+
+The roadmap incorrectly made completed `QS-05` evidence an FR2 prerequisite for
+FR3. `QS-05` requires exact `RP-R` and `RP-L` Campaigns with every declared
+Campaign object, record, reusable-definition, media, Running Scene, mask,
+travel, override, and reconciliation class. The current product format does not
+yet represent that complete set. In particular, there is no Campaign-owned
+local-media persistence owner and no complete generic object/record model for
+the normative profile. Those capabilities belong to later product milestones.
+
+The resulting dependency was circular:
+
+| Gate dependency | Why it cannot close before FR3 |
+| --- | --- |
+| exact complete `RP-R`/`RP-L` fixture | the current format cannot encode all normative profile classes |
+| final Running Play useful-state oracle | FR3 owns the Running Play projection and Scene/Party command boundary being qualified |
+| final Travel/spatial ownership | FR6 owns joint Travel/Session publication and rendering-leaf isolation |
+| all-OS final qualification | FR7B owns the complete functional, scale, resource, and cross-OS matrix |
+
+This is a roadmap defect, not permission to weaken `QS-05`. A scaled-down or
+current-format fixture still cannot be called `RP-R` or `RP-L`.
+
+## Decision and implementation packet
+
+The roadmap now distinguishes two evidence maturities:
+
+1. FR2 must prove the replacement Campaign Workspace ownership model against a
+   reproducible, complete **current-format** fixture. The production journey
+   must retain all representable useful state, execute and persist a focused-
+   Scene next mutation, restart cleanly, meet the one-second p95 target, and
+   receive explicit owner architecture acceptance.
+2. FR7B must run exact `RP-R` and `RP-L` `QS-05` populations separately on every
+   supported calibrated operating system after all required data owners exist.
+
+The acceptance matrix records both proof stages on `FR-A07`. No process,
+renderer, IPC, persistence, or product behavior changes in this slice.
+
+## Negative findings and shortcuts
+
+1. FR2D's empty-installation run remains useful only as a mechanics baseline.
+   It is not the complete current-format reference fixture and cannot close the
+   revised FR2 gate.
+2. The focused-Scene next-action/restart oracle and isolated disposition for
+   the Travel/SwiftShader timeout are still absent.
+3. The current format has no single declared applicability manifest listing
+   every represented and absent `RP-R`/`RP-L` class. FR2F must create that
+   record before constructing its fixture so omissions remain visible.
+4. `program-technical-needs.md` declares exact totals but its `RP-L` prose does
+   not fully spell out construction for non-integral runtime/definition cohort
+   multiples. An executable final profile manifest must resolve that ambiguity
+   without changing the normative totals before FR7B timing can be valid.
+5. This documentation-only correction introduces no executable proof. Its gate
+   is repository consistency and the complete documentation/test gate.
+6. Owner architecture acceptance is still absent. FR3 is therefore not
+   authorized by this correction alone.
+
+## Verification
+
+- `git diff --check`: passed;
+- `pnpm check:frontend-robustness`: 23 files and 159 tests passed;
+- the complete local `pnpm check` passed formatting, every lint partition, both
+  TypeScript projects, and 91/91 architecture tests, then reproduced the same
+  four unrelated host-sensitive failures recorded by FR2D: three Encounter
+  Generator settings cases exceeded their 30-second test timeout and the
+  16-ms Reference Matcher gate measured 32.375 ms. The portable unit result was
+  194/196 files and 801/805 tests passed;
+- none of the failed tests imports or evaluates a changed documentation path;
+  thresholds were not weakened. Clean-host remote `Check` remains the broad
+  repository gate;
+- the slice changes only Markdown. It does not change application inputs and
+  therefore requires no AppImage handoff.
+
+## Follow-up phases
+
+- `FR2F`: inventory every current-format profile class, construct the complete
+  reproducible fixture through owning persistence boundaries, add the focused-
+  Scene mutation/restart oracle, and isolate the Travel/SwiftShader behavior;
+- `FR2G`: run the separate current-format production population, attach the
+  semantic oracle, and obtain owner architecture go/no-go;
+- `FR7B`: after later owners exist, generate independently validated exact
+  `RP-R`/`RP-L` fixtures and run the full calibrated cross-OS `QS-05` matrix.
+
+FR3 remains no-go until `FR2F`, `FR2G`, and explicit owner architecture
+acceptance close. Exact `QS-05` remains open until `FR7B` and must remain
+reported as such throughout the intervening migrations.


### PR DESCRIPTION
## Ergebnis

Der FR2D-Nachaudit hat einen zirkulären Gate-Vertrag gefunden: vollständiges QS-05 war vor FR3 verlangt, obwohl FR3 und spätere Phasen Teile der dafür nötigen Daten- und Zustandsbesitzer erst herstellen. Dieser PR korrigiert die Roadmap, ohne QS-05 abzuschwächen oder als bestanden zu markieren.

## Auditdetails

- FR2 bleibt ein Architektur-Go/No-Go mit vollständiger Current-Format-Fixture, A/B/A-Produktionspopulation, vollständiger Zustandsäquivalenz, fokussierter Scene-Folgemutation, Restart-Orakel und Owner-Entscheidung.
- Exakte RP-R/RP-L-Populationen auf Linux, Windows und macOS bleiben verbindliche finale QS-05-Qualifikation in FR7B.
- Verkleinerte oder Current-Format-Profile dürfen weiterhin nicht als RP-R oder RP-L bezeichnet werden.
- Der historische FR2D-Audit bleibt erhalten und verweist auf die korrigierte Gate-Interpretation.
- Der neue FR2E-Audit dokumentiert Quellen, Root Finding, Entscheidungslogik, negative Befunde, schwächere Evidenz und die Folgeslices FR2F/FR2G.

## Offene Gates

FR3 bleibt aktuell no-go: vollständige Current-Format-Fixture, fokussierte Scene-Mutation, Travel/SwiftShader-Disposition, Produktionspopulation und Owner-Architekturentscheidung fehlen. Die finale QS-05-Qualifikation bleibt bis FR7B offen.

## Verifikation

- git diff --check: grün
- Prettier auf allen vier geänderten Dokumenten: grün
- pnpm check:frontend-robustness: 23 Dateien, 159 Tests grün
- pnpm check lokal: Format, alle Lint-Partitionen, beide TypeScript-Projekte und 91/91 Architekturtests grün; danach dieselben vier bereits in FR2D isolierten host-sensitiven Altfehler: drei Encounter-Settings-Timeouts und Reference Matcher 32.375 ms bei 16-ms-Gate. Schwellen wurden nicht verändert; Remote Check auf Clean Host ist der breite Gate-Nachweis.
- Dokumentations-only: kein AppImage-Handoff erforderlich.