### PR TITLE
test: add current-format Live Play qualification protocol

### DIFF
--- a/docs/project/architecture/frontend-robustness-roadmap.md
+++ b/docs/project/architecture/frontend-robustness-roadmap.md
@@ -326,7 +326,8 @@ decision.
 | `FR2E` | Correctly separate the current-format architecture gate from final `QS-05`, with an explicit applicability and absence record |
 | `FR2F1` | Executable Current-Format owner/applicability manifest with schema/owner drift gate and explicit future-profile absences |
 | `FR2F2A` | Static A/B root/import fixture, public Campaign-import materializer, and independent reopen readback for the root/import owner cohort |
-| `FR2F2B` | Extend A/B materialization/readback to the Live Play and spatial owner cohort without direct fixture SQL |
+| `FR2F2B1` | Extend A/B materialization/readback to Scene and Combat through the public Live Play owner, including inactive Roster, focused Location, and active/archived Group sentinels without direct fixture SQL |
+| `FR2F2B2` | Extend A/B materialization/readback to Hex maps and Travel through their public owners, including sparse map, Location placement, Party position, Scene time, and controlled-clock journey sentinels without direct fixture SQL |
 | `FR2F2C` | Extend A/B materialization/readback to preparation, economy, and installation owners and fail closed unless every manifest disposition is covered exactly once |
 | `FR2F3` | Focused-Scene next-action/restart oracle and isolated Travel/SwiftShader disposition |
 | `FR2G` | Current-format production timing and owner architecture go/no-go; exact `QS-05` remains open for `FR7B` |

--- a/docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json
+++ b/docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json
@@ -1,0 +1,124 @@
+{
+  "version": 1,
+  "identity": "frontend-robustness-current-format-live-v1",
+  "rootFixtureIdentity": "frontend-robustness-current-format-root-v1",
+  "qualificationClaim": "partial-fr2f2b1-live-cohort-not-complete-current-format",
+  "coveredCampaignRegistrations": ["scene", "combat"],
+  "extendedRootRegistrations": ["world-locations", "party"],
+  "campaigns": [
+    {
+      "role": "A",
+      "materialization": {
+        "importedActivePartyExternalKeys": ["pc:alrik"],
+        "addedInactiveParty": {
+          "semanticKey": "pc:ione",
+          "draft": {
+            "name": "Ione",
+            "playerName": "Taylor",
+            "species": "Human",
+            "characterClass": "Bard",
+            "languages": ["Common", "Elvish"],
+            "level": 2,
+            "passivePerception": 13,
+            "passiveInvestigation": 10,
+            "passiveInsight": 15,
+            "armorClass": 12,
+            "movementSpeedFeet": 30
+          }
+        },
+        "focusedLocationExternalKey": "location:salt-harbor",
+        "groups": [
+          {
+            "semanticKey": "group:salt-wolves",
+            "name": "Salt Wolves",
+            "note": "Two circle the harbor while one lies defeated.",
+            "disposition": "hostile",
+            "archived": false,
+            "entries": [
+              { "creatureId": "wolf", "quantity": 2, "deadQuantity": 1 }
+            ]
+          },
+          {
+            "semanticKey": "group:vault-watch",
+            "name": "Vault Watch",
+            "note": "Resolved negotiation retained in the archive.",
+            "disposition": "neutral",
+            "archived": true,
+            "entries": []
+          }
+        ],
+        "combatGroupSemanticKey": "group:salt-wolves"
+      },
+      "expected": {
+        "partyRevision": 3,
+        "sceneRevision": 5,
+        "combatRevision": 0,
+        "combatPhase": "initiative",
+        "activePartyCount": 1,
+        "inactivePartyCount": 1,
+        "groupCount": 2,
+        "archivedGroupCount": 1,
+        "focusedLocationName": "Salt Harbor",
+        "semanticSha256": "cbb66a99d3c72a5e9dd51c5f4bec562026346a7e56e23a2a7271238be7305034"
+      }
+    },
+    {
+      "role": "B",
+      "materialization": {
+        "importedActivePartyExternalKeys": ["pc:mira"],
+        "addedInactiveParty": {
+          "semanticKey": "pc:thorne",
+          "draft": {
+            "name": "Thorne",
+            "playerName": "Morgan",
+            "species": "Dwarf",
+            "characterClass": "Cleric",
+            "languages": ["Common", "Dwarvish"],
+            "level": 4,
+            "passivePerception": 16,
+            "passiveInvestigation": 11,
+            "passiveInsight": 17,
+            "armorClass": 18,
+            "movementSpeedFeet": 25
+          }
+        },
+        "focusedLocationExternalKey": "location:moon-marsh",
+        "groups": [
+          {
+            "semanticKey": "group:marsh-goblins",
+            "name": "Marsh Goblins",
+            "note": "Three scouts hold the flooded causeway.",
+            "disposition": "hostile",
+            "archived": false,
+            "entries": [
+              { "creatureId": "goblin", "quantity": 3, "deadQuantity": 0 }
+            ]
+          },
+          {
+            "semanticKey": "group:reed-guides",
+            "name": "Reed Guides",
+            "note": "A completed escort kept for reference.",
+            "disposition": "allied",
+            "archived": true,
+            "entries": [
+              { "creatureId": "scout", "quantity": 0, "deadQuantity": 1 }
+            ]
+          }
+        ],
+        "combatGroupSemanticKey": "group:marsh-goblins"
+      },
+      "expected": {
+        "partyRevision": 3,
+        "sceneRevision": 5,
+        "combatRevision": 0,
+        "combatPhase": "initiative",
+        "activePartyCount": 1,
+        "inactivePartyCount": 1,
+        "groupCount": 2,
+        "archivedGroupCount": 1,
+        "focusedLocationName": "Moon Marsh",
+        "semanticSha256": "fdede16729f51f3bd282d5527265867c6d61184c4d444f7f25a9f0478afc6038"
+      }
+    }
+  ]
+}

--- a/docs/project/evidence/frontend-robustness-fr2f2b1-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2f2b1-audit.md
@@ -118,6 +118,15 @@ This slice owns:
 9. Hex maps, Party travel position, Scene time progression, active/paused
    journey state, renderer dispatch, warm-switch timing, focused-Scene next
    mutation, SwiftShader, handoff, and owner acceptance remain absent by design.
+10. The first exact-SHA Candidate run exposed a pre-existing Windows-native test
+    granularity defect: each of four Campaign replacement cases executed five or
+    nine complete interruption boundaries under one 30-second Vitest deadline.
+    Two different boundary groups timed out on each of two attempts while the
+    other platform and product jobs passed. The bounded follow-up decomposes the
+    same active/inactive and rollback/roll-forward matrix into one test per
+    boundary. It removes no assertion, changes no product timeout, and does not
+    raise the test timeout; the replacement guarantees and failure injection
+    remain identical while each failure now identifies its exact boundary.
 
 ## Verification
 
@@ -142,6 +151,18 @@ This slice owns:
   test, and no timeout or threshold was weakened;
 - final diff validation, remote Candidate result, and Main attestation are
   recorded at delivery time rather than predeclared here.
+- Candidate run `32810330784` attempts 1 and 2 reproduced only the Windows test
+  granularity issue described above; the decomposed-boundary follow-up requires
+  a new exact SHA and a complete fresh Candidate run rather than blessing the
+  failed run or repeatedly retrying it.
+- after that follow-up, the decomposed Campaign replacement file passed all 35
+  boundary cases, the isolated native-persistence suite passed 5 files and 77
+  tests, and `pnpm check:frontend-robustness` passed 27 files and 179 tests. A
+  fresh serial `pnpm check` again passed formatting, every lint partition, both
+  TypeScript projects, and 91/91 architecture tests, then reproduced only the
+  same unrelated three Encounter Generator timeouts and Reference Matcher
+  16-ms gate (34.17 ms), for 195/197 files and 803/807 tests. No product or test
+  timeout was increased.
 
 ## Gate decision and follow-up
 

--- a/docs/project/evidence/frontend-robustness-fr2f2b1-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2f2b1-audit.md
@@ -1,0 +1,161 @@
+# Frontend robustness FR2F2B1 Live Play materialization audit
+
+- Date: 2026-08-25
+- Delivery baseline: `origin/main@ffc3112d462a8e2b6f5d6692a7f1efd6ecff3ba5`
+- Sprint: `FR2F2B1` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+- Change class: qualification and documentation only
+- Gate verdict: **FR2 remains open / no-go for FR3**
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap and acceptance matrix, including
+  the FR2 protocol, FR-A07, the original Electron roadmap, and the target
+  architecture;
+- the FR2F1 manifest, FR2F2A fixture/protocol/audit, current Campaign bootstrap
+  order, and live `origin/main@ffc3112d` with green Main attestation;
+- current Live Session, Party, Scene, Encounter, Hex, and Travel requirements,
+  plus `TN-16`, `TN-21`, `QS-05`, `RP-R`, and `RP-L`;
+- `CampaignStore`, `CampaignImportService`, `PartyStore`, `SceneStore`,
+  `LivePlayService`, `CombatService`, `HexMapStore`, `HexTravelService`, the E2E
+  fixture materializer, current integration journeys, focused-check manifest,
+  workspace input classification, and current open pull requests.
+
+## Sprint split and implementation packet
+
+The pre-phase dispatch trace confirmed that Live Play and spatial state do not
+fit one clean sprint. Scene/Combat use revisioned aggregate commands, while Hex
+and Travel additionally couple sparse map revisions, Party position, Scene
+time, a controlled clock, and journey lifecycle. `FR2F2B` is therefore split:
+
+1. `FR2F2B1`: Live Play Scene/Combat plus Party/Location semantic extension;
+2. `FR2F2B2`: Hex/Travel plus Party/Location/Scene spatial extension.
+
+This slice owns:
+
+- one strict static A/B Live fixture whose primary owner coverage is exactly
+  `scene` and `combat`, in Campaign bootstrap order;
+- explicit extension of the already-covered `world-locations` and `party`
+  roots without double-counting either registration;
+- one added inactive character, one imported active and assigned character,
+  the publicly bootstrapped standard Scene, a distinct focused Location, one
+  active and one archived Group, living/dead member state, and one non-empty
+  initiative-phase Combat per Campaign;
+- preflight of roles, coverage, root identity, external references, semantic
+  identities, Group constraints, Creature references, and immutable expected
+  snapshot hashes before root publication;
+- materialization through `LivePlayService` only after the FR2F2A public import
+  path has published A/B; no fixture SQL writes;
+- a separately opened reader that obtains each complete `LiveSessionSnapshot`
+  through `LivePlayService`, normalizes every generated UUID to a static
+  semantic identity, rejects any unaccounted raw UUID, and compares a canonical
+  hash of the entire normalized snapshot;
+- readable revision/count/location/phase sentinels in addition to full-snapshot
+  hashes, exact materializer-receipt identity readback after reopen, A/B UUID
+  isolation, and a public Group mutation that must invalidate the oracle;
+- a standalone `qualify-current-format-live.ts --data-root <empty-root>` receipt
+  with the literal partial claim
+  `partial-fr2f2b1-live-cohort-not-complete-current-format`.
+
+## Dispatch, failure, reopen, and identity trace
+
+1. The manifest, root fixture, and complete Live A/B fixture are parsed and
+   cross-validated before the empty installation is opened for mutation.
+2. FR2F2A imports A/B through `CampaignImportService`, activates A, and closes
+   all connections.
+3. A new `CampaignStore` resolves each imported Campaign by source identity and
+   visits its database without changing installation switch authority.
+4. The explicit qualification adapter gives `LivePlayService` that one visited
+   database. It creates the inactive character, assigns imported active Party
+   members, sets the focused Location, saves active/archived Groups, archives
+   the configured Group, and prepares initiative Combat through public owner
+   methods.
+5. The materializer closes and returns identities only. A separate reader
+   reopens root storage, repeats root semantic readback, then reads each complete
+   `LiveSessionSnapshot` through a fresh `LivePlayService`.
+6. Imported Party/Location mappings, the added Party receipt, standard Scene,
+   Groups, entries, members, Combat, and embedded command-row identities are
+   normalized to static semantic keys. Any UUID not explicitly accounted for
+   fails qualification rather than disappearing from the digest.
+7. Static A/B hashes cover every normalized snapshot field. The identity
+   receipt separately proves that exact generated Campaign, Scene, Party,
+   Group, and Combat identities survived reopen.
+8. Readback must leave registry revision and active Campaign unchanged; A
+   remains installation authority throughout.
+
+## Post-implementation negative findings and shortcuts
+
+1. The materializer uses the explicit fixed-database qualification adapter
+   inside `visitCampaignDatabase`. This proves real domain owners and bytes, but
+   not Renderer -> Preload -> Utility production switching. FR2F2B1 is not a
+   production-route warm-switch result.
+2. The current product has no public command to create a second Running Scene.
+   The fixture correctly retains only the bootstrapped standard Scene; the M3
+   absence remains open and direct SQL is not substituted as evidence.
+3. Combat stops in the non-empty initiative phase. It proves persisted Combat
+   selection and sources, not rapid turns, damage, resolution, or Loot. Those
+   are FR3 guarantees, not a hidden expansion of this FR2 qualification slice.
+4. `PartyStore` generates character identities internally and exposes no
+   client-provided semantic key. The additional inactive character is located
+   by a fixture-validated unique name, while its generated UUID is separately
+   retained in and checked against the materialization receipt. This is more
+   awkward than imported entity mappings but does not weaken identity proof.
+5. Full-snapshot hashes are intentionally fail-closed but opaque during manual
+   diagnosis. Readable sentinels identify common drift; deeper drift requires
+   inspecting the exposed `semanticProjection` in the focused test/readback.
+6. `world-locations` and `party` already have primary FR2F2A coverage. B1 only
+   extends their semantics and assigns primary coverage solely to `scene` and
+   `combat`; B2 must follow the same rule for `hex` so FR2F2C can enforce one
+   primary disposition per manifest registration.
+7. Root plus Live materialization is not one cross-Campaign transaction.
+   Semantic errors in both A/B Live descriptions are preflighted before root
+   publication, but an external runtime/I/O failure after root or Live A
+   commits can leave the dedicated qualification root partial. Re-run refuses
+   it; preserve it as evidence or discard that dedicated root and restart.
+8. The fixed Creature and generator defaults influence initiative rows. Their
+   drift changes the static complete-snapshot hash and therefore requires an
+   explicit fixture review rather than silently blessing new current behavior.
+9. Hex maps, Party travel position, Scene time progression, active/paused
+   journey state, renderer dispatch, warm-switch timing, focused-Scene next
+   mutation, SwiftShader, handoff, and owner acceptance remain absent by design.
+
+## Verification
+
+- the standalone CLI against a new temporary installation reproduced A/B with
+  Party revision 3, Scene revision 5, Combat revision 0, A hash
+  `cbb66a99d3c72a5e9dd51c5f4bec562026346a7e56e23a2a7271238be7305034`,
+  B hash
+  `fdede16729f51f3bd282d5527265867c6d61184c4d444f7f25a9f0478afc6038`,
+  exact A authority, and semantic readback true;
+- focused root plus Live integration: 2 files and 9 tests passed, including
+  invalid-B preflight, public-owner mutation, coverage/root/hash drift, exact
+  receipt identity after reopen, complete semantic hashes, and A/B isolation;
+- `pnpm check:frontend-robustness`: 27 files and 179 tests passed, including
+  both TypeScript projects;
+- the complete local `pnpm check` passed formatting, every lint partition,
+  both TypeScript projects, and 91/91 architecture tests. Its portable unit
+  phase reproduced only the four unrelated host-sensitive failures already
+  recorded from FR2D through FR2F2A: three Encounter Generator settings tests
+  exceeded their unchanged 30-second timeout and the 16-ms Reference Matcher
+  gate measured 30.897 ms. The result was 195/197 files and 803/807 tests;
+  no failing test imports the new fixture, protocol, reader, or integration
+  test, and no timeout or threshold was weakened;
+- final diff validation, remote Candidate result, and Main attestation are
+  recorded at delivery time rather than predeclared here.
+
+## Gate decision and follow-up
+
+FR2F2B1 closes only the reproducible Live Play Scene/Combat owner protocol. It
+does not close FR2F2B, FR2, FR-A07, TN-16, or QS-05.
+
+- `FR2F2B2` must add Hex/Travel public-owner materialization and independent
+  controlled-clock spatial readback;
+- `FR2F2C` must add preparation, economy, installation owners and exact
+  one-primary-coverage enforcement across the complete manifest;
+- `FR2F3` retains the focused-Scene next-action/restart oracle and isolated
+  Travel/SwiftShader disposition;
+- `FR2G` retains current-format production timing and explicit owner
+  architecture go/no-go;
+- `FR7B` retains exact cross-OS `RP-R`/`RP-L` qualification.
+
+FR3 remains no-go.

--- a/scripts/qualification/current-format-live-fixture.ts
+++ b/scripts/qualification/current-format-live-fixture.ts
@@ -1,0 +1,295 @@
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+import { creatureById } from '../../src/core/creatures/catalog.js'
+import { partyCharacterDraftSchema } from '../../src/shared/contracts/party.js'
+import {
+  sceneGroupDispositionSchema,
+  sceneGroupDraftEntrySchema
+} from '../../src/shared/contracts/scene.js'
+import type { CurrentFormatCampaignManifest } from './current-format-campaign-manifest.js'
+import type {
+  CurrentFormatRootCampaign,
+  CurrentFormatRootFixture
+} from './current-format-root-fixture.js'
+
+export const currentFormatLiveRegistrations = Object.freeze([
+  'scene',
+  'combat'
+] as const)
+
+export const currentFormatLiveExtendedRootRegistrations = Object.freeze([
+  'world-locations',
+  'party'
+] as const)
+
+const liveGroupSchema = z
+  .object({
+    semanticKey: z.string().regex(/^group:[a-z0-9-]+$/),
+    name: z.string().trim().min(1).max(100),
+    note: z.string().trim().max(1_000),
+    disposition: sceneGroupDispositionSchema,
+    archived: z.boolean(),
+    entries: z.array(sceneGroupDraftEntrySchema)
+  })
+  .strict()
+
+const liveCampaignMaterializationSchema = z
+  .object({
+    importedActivePartyExternalKeys: z.array(z.string().min(1)).min(1),
+    addedInactiveParty: z
+      .object({
+        semanticKey: z.string().regex(/^pc:[a-z0-9-]+$/),
+        draft: partyCharacterDraftSchema
+      })
+      .strict(),
+    focusedLocationExternalKey: z.string().min(1),
+    groups: z.array(liveGroupSchema).min(2),
+    combatGroupSemanticKey: z.string().regex(/^group:[a-z0-9-]+$/)
+  })
+  .strict()
+  .superRefine((materialization, context) => {
+    unique(
+      materialization.importedActivePartyExternalKeys,
+      ['importedActivePartyExternalKeys'],
+      context
+    )
+    unique(
+      materialization.groups.map(({ semanticKey }) => semanticKey),
+      ['groups'],
+      context
+    )
+    unique(
+      materialization.groups.map(({ name }) => name),
+      ['groups'],
+      context
+    )
+    const combatGroup = materialization.groups.find(
+      ({ semanticKey }) =>
+        semanticKey === materialization.combatGroupSemanticKey
+    )
+    if (!combatGroup)
+      context.addIssue({
+        code: 'custom',
+        path: ['combatGroupSemanticKey'],
+        message: 'Live fixture Combat Group must exist.'
+      })
+    else if (combatGroup.archived || combatGroup.entries.length === 0)
+      context.addIssue({
+        code: 'custom',
+        path: ['combatGroupSemanticKey'],
+        message: 'Live fixture Combat Group must be active and non-empty.'
+      })
+    if (!materialization.groups.some(({ archived }) => archived))
+      context.addIssue({
+        code: 'custom',
+        path: ['groups'],
+        message: 'Live fixture needs an archived Group sentinel.'
+      })
+  })
+
+const liveExpectedSchema = z
+  .object({
+    partyRevision: z.number().int().nonnegative(),
+    sceneRevision: z.number().int().nonnegative(),
+    combatRevision: z.number().int().nonnegative(),
+    combatPhase: z.literal('initiative'),
+    activePartyCount: z.number().int().positive(),
+    inactivePartyCount: z.number().int().positive(),
+    groupCount: z.number().int().min(2),
+    archivedGroupCount: z.number().int().positive(),
+    focusedLocationName: z.string().min(1),
+    semanticSha256: z.string().regex(/^[0-9a-f]{64}$/)
+  })
+  .strict()
+
+const liveCampaignSchema = z
+  .object({
+    role: z.enum(['A', 'B']),
+    materialization: liveCampaignMaterializationSchema,
+    expected: liveExpectedSchema
+  })
+  .strict()
+
+export const currentFormatLiveFixtureSchema = z
+  .object({
+    version: z.literal(1),
+    identity: z.literal('frontend-robustness-current-format-live-v1'),
+    rootFixtureIdentity: z.literal(
+      'frontend-robustness-current-format-root-v1'
+    ),
+    qualificationClaim: z.literal(
+      'partial-fr2f2b1-live-cohort-not-complete-current-format'
+    ),
+    coveredCampaignRegistrations: z
+      .array(z.string())
+      .length(currentFormatLiveRegistrations.length),
+    extendedRootRegistrations: z
+      .array(z.string())
+      .length(currentFormatLiveExtendedRootRegistrations.length),
+    campaigns: z.array(liveCampaignSchema).length(2)
+  })
+  .strict()
+  .superRefine((fixture, context) => {
+    if (fixture.campaigns.map(({ role }) => role).join(',') !== 'A,B')
+      context.addIssue({
+        code: 'custom',
+        path: ['campaigns'],
+        message: 'Live fixture Campaign roles must be exactly A then B.'
+      })
+    unique(
+      fixture.campaigns.map(
+        ({ materialization }) => materialization.addedInactiveParty.semanticKey
+      ),
+      ['campaigns'],
+      context
+    )
+    unique(
+      fixture.campaigns.flatMap(({ materialization }) =>
+        materialization.groups.map(({ semanticKey }) => semanticKey)
+      ),
+      ['campaigns'],
+      context
+    )
+  })
+
+export type CurrentFormatLiveFixture = Readonly<
+  z.infer<typeof currentFormatLiveFixtureSchema>
+>
+export type CurrentFormatLiveCampaign = Readonly<
+  CurrentFormatLiveFixture['campaigns'][number]
+>
+
+export function loadCurrentFormatLiveFixture(
+  path: string,
+  manifest: CurrentFormatCampaignManifest,
+  rootFixture: CurrentFormatRootFixture
+): CurrentFormatLiveFixture {
+  return validateCurrentFormatLiveFixture(
+    JSON.parse(readFileSync(path, 'utf8')),
+    manifest,
+    rootFixture
+  )
+}
+
+export function validateCurrentFormatLiveFixture(
+  raw: unknown,
+  manifest: CurrentFormatCampaignManifest,
+  rootFixture: CurrentFormatRootFixture
+): CurrentFormatLiveFixture {
+  const fixture = currentFormatLiveFixtureSchema.parse(raw)
+  assertExactOrder(
+    fixture.coveredCampaignRegistrations,
+    currentFormatLiveRegistrations,
+    'coverage'
+  )
+  assertExactOrder(
+    fixture.extendedRootRegistrations,
+    currentFormatLiveExtendedRootRegistrations,
+    'extended root coverage'
+  )
+  if (fixture.rootFixtureIdentity !== rootFixture.identity)
+    throw new Error('Current-format live fixture root identity is stale.')
+
+  const manifestOwners = new Map(
+    manifest.campaignOwners.map((owner) => [owner.registration, owner])
+  )
+  for (const registration of currentFormatLiveRegistrations) {
+    const owner = manifestOwners.get(registration)
+    if (!owner)
+      throw new Error(
+        `Current-format live fixture references unknown owner ${registration}.`
+      )
+    if (owner.disposition !== 'switch-oracle')
+      throw new Error(
+        `Current-format live owner ${registration} is not a switch oracle.`
+      )
+  }
+  for (const registration of currentFormatLiveExtendedRootRegistrations) {
+    if (!rootFixture.coveredCampaignRegistrations.includes(registration))
+      throw new Error(
+        `Current-format live extension ${registration} is not rooted in FR2F2A.`
+      )
+  }
+  const covered = new Set<string>(currentFormatLiveRegistrations)
+  const manifestOrder = manifest.campaignOwners
+    .map(({ registration }) => registration)
+    .filter((registration) => covered.has(registration))
+  assertExactOrder(manifestOrder, currentFormatLiveRegistrations, 'order')
+
+  for (const configured of fixture.campaigns) {
+    const rootCampaign = rootFixture.campaigns.find(
+      ({ role }) => role === configured.role
+    )
+    if (!rootCampaign)
+      throw new Error(
+        `Current-format live Campaign ${configured.role} has no root Campaign.`
+      )
+    validateCampaign(configured, rootCampaign)
+  }
+  return fixture
+}
+
+function validateCampaign(
+  configured: CurrentFormatLiveCampaign,
+  rootCampaign: CurrentFormatRootCampaign
+): void {
+  const materialization = configured.materialization
+  const partyKeys = new Set(
+    rootCampaign.bundle.party.map(({ externalKey }) => externalKey)
+  )
+  for (const externalKey of materialization.importedActivePartyExternalKeys)
+    if (!partyKeys.has(externalKey))
+      throw new Error(
+        `Current-format live Campaign ${configured.role} references unknown Party ${externalKey}.`
+      )
+  if (
+    rootCampaign.bundle.party.some(
+      ({ name }) => name === materialization.addedInactiveParty.draft.name
+    )
+  )
+    throw new Error(
+      `Current-format live Campaign ${configured.role} has a duplicate Party name.`
+    )
+  if (
+    !rootCampaign.bundle.locations.some(
+      ({ externalKey }) =>
+        externalKey === materialization.focusedLocationExternalKey
+    )
+  )
+    throw new Error(
+      `Current-format live Campaign ${configured.role} references an unknown Location.`
+    )
+  for (const group of materialization.groups)
+    for (const entry of group.entries)
+      if (!creatureById(entry.creatureId))
+        throw new Error(
+          `Current-format live Campaign ${configured.role} references unknown creature ${entry.creatureId}.`
+        )
+}
+
+function assertExactOrder(
+  actual: readonly string[],
+  expected: readonly string[],
+  label: string
+): void {
+  if (
+    actual.length !== expected.length ||
+    actual.some((value, index) => value !== expected[index])
+  )
+    throw new Error(
+      `Current-format live fixture ${label} does not match the FR2F2B1 contract.`
+    )
+}
+
+function unique(
+  values: readonly string[],
+  path: readonly (string | number)[],
+  context: z.RefinementCtx
+): void {
+  if (new Set(values).size === values.length) return
+  context.addIssue({
+    code: 'custom',
+    path: [...path],
+    message: 'Live fixture semantic identities must be unique.'
+  })
+}

--- a/scripts/qualification/current-format-live-materializer.ts
+++ b/scripts/qualification/current-format-live-materializer.ts
@@ -1,0 +1,212 @@
+import type Database from 'better-sqlite3'
+import { z } from 'zod'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import type { CurrentFormatRootFixture } from './current-format-root-fixture.js'
+import { materializeCurrentFormatRootFixture } from './current-format-root-materializer.js'
+import type {
+  CurrentFormatLiveCampaign,
+  CurrentFormatLiveFixture
+} from './current-format-live-fixture.js'
+
+const liveCampaignReceiptSchema = z
+  .object({
+    role: z.enum(['A', 'B']),
+    campaignId: z.uuid(),
+    sceneId: z.uuid(),
+    addedInactivePartyId: z.uuid(),
+    groupIds: z.array(z.uuid()).min(2),
+    combatId: z.uuid()
+  })
+  .strict()
+
+const liveMaterializationReceiptSchema = z
+  .object({
+    fixtureIdentity: z.literal('frontend-robustness-current-format-live-v1'),
+    qualificationClaim: z.literal(
+      'partial-fr2f2b1-live-cohort-not-complete-current-format'
+    ),
+    campaigns: z.array(liveCampaignReceiptSchema).length(2),
+    activeCampaignRole: z.literal('A')
+  })
+  .strict()
+
+export type CurrentFormatLiveMaterializationReceipt = Readonly<
+  z.infer<typeof liveMaterializationReceiptSchema>
+>
+
+export function materializeCurrentFormatLiveFixture(
+  dataRoot: string,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture
+): CurrentFormatLiveMaterializationReceipt {
+  const rootReceipt = materializeCurrentFormatRootFixture(dataRoot, rootFixture)
+  const rootCampaigns = new Map(
+    rootReceipt.campaigns.map((campaign) => [campaign.role, campaign])
+  )
+  const campaigns = new CampaignStore(dataRoot)
+  try {
+    const before = campaigns.list()
+    const receipts = liveFixture.campaigns.map((configured) => {
+      const rootCampaign = rootCampaigns.get(configured.role)
+      if (!rootCampaign)
+        throw new Error(
+          `Current-format live Campaign ${configured.role} is missing its root receipt.`
+        )
+      const receipt = campaigns.visitCampaignDatabase(
+        rootCampaign.campaignId,
+        (database) =>
+          materializeCampaign(
+            campaigns,
+            database,
+            rootCampaign.sourceId,
+            rootCampaign.campaignId,
+            configured
+          )
+      )
+      if (!receipt)
+        throw new Error(
+          `Current-format live Campaign ${configured.role} database is unavailable.`
+        )
+      return receipt
+    })
+    const after = campaigns.list()
+    if (
+      after.activeCampaignId !== before.activeCampaignId ||
+      after.revision !== before.revision
+    )
+      throw new Error(
+        'Current-format live materialization changed Campaign switch authority.'
+      )
+    return liveMaterializationReceiptSchema.parse({
+      fixtureIdentity: liveFixture.identity,
+      qualificationClaim: liveFixture.qualificationClaim,
+      campaigns: receipts,
+      activeCampaignRole: 'A'
+    })
+  } finally {
+    campaigns.close()
+  }
+}
+
+function materializeCampaign(
+  campaigns: CampaignStore,
+  database: Database.Database,
+  sourceId: string,
+  campaignId: string,
+  configured: CurrentFormatLiveCampaign
+) {
+  const access = fixedSqliteDatabaseAccess(database)
+  const play = new LivePlayService(access)
+  const mappings = campaigns
+    .campaignImportRepository()
+    .entityMappings(database, sourceId)
+  const mappedId = (
+    kind: 'party' | 'locations',
+    externalKey: string
+  ): string => {
+    const mapping = mappings.find(
+      (candidate) =>
+        candidate.kind === kind && candidate.externalKey === externalKey
+    )
+    if (!mapping)
+      throw new Error(
+        `Current-format live Campaign ${configured.role} is missing ${kind}:${externalKey}.`
+      )
+    return mapping.internalId
+  }
+
+  let party = play.readParty()
+  party = play.createPartyCharacter(
+    configured.materialization.addedInactiveParty.draft,
+    party.revision
+  )
+  const inactive = party.members.find(
+    ({ name }) =>
+      name === configured.materialization.addedInactiveParty.draft.name
+  )
+  if (!inactive || inactive.active)
+    throw new Error(
+      `Current-format live Campaign ${configured.role} did not create its inactive Party sentinel.`
+    )
+
+  let session = play.readSession()
+  const sceneId = session.scene.focusedSceneId
+  session = play.setSceneLocation(
+    sceneId,
+    mappedId(
+      'locations',
+      configured.materialization.focusedLocationExternalKey
+    ),
+    session.scene.revision
+  )
+  for (const externalKey of configured.materialization
+    .importedActivePartyExternalKeys) {
+    const partyMemberId = mappedId('party', externalKey)
+    const member = party.members.find(({ id }) => id === partyMemberId)
+    if (!member?.active)
+      throw new Error(
+        `Current-format live Campaign ${configured.role} Party ${externalKey} is not active.`
+      )
+    const scene = session.scene.scenes.find(({ id }) => id === sceneId)
+    if (!scene?.partyMemberIds.includes(partyMemberId))
+      session = play.assignScenePartyMember(
+        sceneId,
+        partyMemberId,
+        true,
+        session.scene.revision
+      )
+  }
+
+  const groupIds = new Map<string, string>()
+  for (const group of configured.materialization.groups) {
+    const result = play.saveSceneGroup(
+      sceneId,
+      null,
+      group.name,
+      group.note,
+      group.disposition,
+      group.entries,
+      session.scene.revision,
+      null
+    )
+    const saved = result.scenePatch.upsertedGroups.find(
+      ({ name }) => name === group.name
+    )
+    if (!saved)
+      throw new Error(
+        `Current-format live Campaign ${configured.role} did not save Group ${group.semanticKey}.`
+      )
+    groupIds.set(group.semanticKey, saved.id)
+    session = play.readSession()
+    if (group.archived) {
+      play.setSceneGroupArchived(sceneId, saved.id, true, saved.revision)
+      session = play.readSession()
+    }
+  }
+
+  const combatGroupId = groupIds.get(
+    configured.materialization.combatGroupSemanticKey
+  )
+  if (!combatGroupId)
+    throw new Error(
+      `Current-format live Campaign ${configured.role} has no materialized Combat Group.`
+    )
+  const combat = play.prepareCombat(sceneId, session.scene.revision, [
+    combatGroupId
+  ]).combat
+  if (!combat || combat.phase !== 'initiative')
+    throw new Error(
+      `Current-format live Campaign ${configured.role} did not enter initiative.`
+    )
+
+  return liveCampaignReceiptSchema.parse({
+    role: configured.role,
+    campaignId,
+    sceneId,
+    addedInactivePartyId: inactive.id,
+    groupIds: [...groupIds.values()],
+    combatId: combat.id
+  })
+}

--- a/scripts/qualification/current-format-live-readback.ts
+++ b/scripts/qualification/current-format-live-readback.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import type {
+  RunningScene,
+  SceneGroup
+} from '../../src/shared/contracts/scene.js'
+import type { CurrentFormatRootFixture } from './current-format-root-fixture.js'
+import {
+  assertCurrentFormatRootReadback,
+  readCurrentFormatRootFixture,
+  type CurrentFormatRootCampaignReadback,
+  type CurrentFormatRootReadback
+} from './current-format-root-readback.js'
+import type {
+  CurrentFormatLiveCampaign,
+  CurrentFormatLiveFixture
+} from './current-format-live-fixture.js'
+import type { CurrentFormatLiveMaterializationReceipt } from './current-format-live-materializer.js'
+
+export type CurrentFormatLiveCampaignReadback = Readonly<{
+  role: 'A' | 'B'
+  campaignId: string
+  session: LiveSessionSnapshot
+  semanticProjection: unknown
+  semanticSha256: string
+}>
+
+export type CurrentFormatLiveReadback = Readonly<{
+  fixtureIdentity: string
+  qualificationClaim: string
+  root: CurrentFormatRootReadback
+  campaigns: readonly CurrentFormatLiveCampaignReadback[]
+}>
+
+export function readCurrentFormatLiveFixture(
+  dataRoot: string,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture
+): CurrentFormatLiveReadback {
+  const root = readCurrentFormatRootFixture(dataRoot, rootFixture)
+  const campaigns = new CampaignStore(dataRoot)
+  try {
+    const registry = campaigns.list()
+    const readbacks = liveFixture.campaigns.map((configured) => {
+      const rootCampaign = root.campaigns.find(
+        ({ role }) => role === configured.role
+      )
+      if (!rootCampaign)
+        throw new Error(
+          `Current-format live Campaign ${configured.role} has no root readback.`
+        )
+      const session = campaigns.visitCampaignDatabase(
+        rootCampaign.campaignId,
+        (database) =>
+          new LivePlayService(fixedSqliteDatabaseAccess(database)).readSession()
+      )
+      if (!session)
+        throw new Error(
+          `Current-format live Campaign ${configured.role} database is unavailable.`
+        )
+      const semanticProjection = semanticLiveProjection(
+        configured,
+        rootCampaign,
+        session
+      )
+      return Object.freeze({
+        role: configured.role,
+        campaignId: rootCampaign.campaignId,
+        session,
+        semanticProjection,
+        semanticSha256: semanticHash(semanticProjection)
+      })
+    })
+    assert.deepStrictEqual(
+      campaigns.list(),
+      registry,
+      'Independent live readback must not mutate Campaign registry state.'
+    )
+    return Object.freeze({
+      fixtureIdentity: liveFixture.identity,
+      qualificationClaim: liveFixture.qualificationClaim,
+      root,
+      campaigns: Object.freeze(readbacks)
+    })
+  } finally {
+    campaigns.close()
+  }
+}
+
+export function assertCurrentFormatLiveReadback(
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture,
+  readback: CurrentFormatLiveReadback
+): void {
+  assertCurrentFormatRootReadback(rootFixture, readback.root)
+  assert.equal(readback.fixtureIdentity, liveFixture.identity)
+  assert.equal(readback.qualificationClaim, liveFixture.qualificationClaim)
+  assert.equal(readback.campaigns.length, liveFixture.campaigns.length)
+  const campaignUuidSets: Set<string>[] = []
+  for (const expected of liveFixture.campaigns) {
+    const actual = readback.campaigns.find(({ role }) => role === expected.role)
+    assert.ok(actual, `Missing live readback for Campaign ${expected.role}.`)
+    assertCampaign(expected, actual)
+    campaignUuidSets.push(collectUuids(actual.session))
+  }
+  for (const id of campaignUuidSets[0] ?? [])
+    assert.ok(
+      !(campaignUuidSets[1]?.has(id) ?? false),
+      `Live identity ${id} leaked across Campaign A/B.`
+    )
+}
+
+export function assertCurrentFormatLiveReceipt(
+  receipt: CurrentFormatLiveMaterializationReceipt,
+  readback: CurrentFormatLiveReadback
+): void {
+  assert.equal(receipt.fixtureIdentity, readback.fixtureIdentity)
+  assert.equal(receipt.qualificationClaim, readback.qualificationClaim)
+  for (const expected of receipt.campaigns) {
+    const actual = readback.campaigns.find(({ role }) => role === expected.role)
+    assert.ok(actual, `Missing receipt readback for Campaign ${expected.role}.`)
+    assert.equal(actual.campaignId, expected.campaignId)
+    assert.equal(actual.session.scene.focusedSceneId, expected.sceneId)
+    assert.equal(actual.session.combat?.id, expected.combatId)
+    assert.ok(
+      actual.session.party.members.some(
+        ({ id, active }) => id === expected.addedInactivePartyId && !active
+      ),
+      `Campaign ${expected.role} inactive Party receipt did not survive reopen.`
+    )
+    const focused = actual.session.scene.scenes.find(
+      ({ id }) => id === expected.sceneId
+    )
+    assert.ok(focused)
+    assert.deepStrictEqual(
+      new Set(focused.groups.map(({ id }) => id)),
+      new Set(expected.groupIds),
+      `Campaign ${expected.role} Group receipts did not survive reopen.`
+    )
+  }
+}
+
+function assertCampaign(
+  expected: CurrentFormatLiveCampaign,
+  actual: CurrentFormatLiveCampaignReadback
+): void {
+  const session = actual.session
+  const focused: RunningScene | undefined = session.scene.scenes.find(
+    ({ id }) => id === session.scene.focusedSceneId
+  )
+  assert.ok(focused, `Campaign ${expected.role} has no focused Scene.`)
+  assert.equal(session.party.revision, expected.expected.partyRevision)
+  assert.equal(session.scene.revision, expected.expected.sceneRevision)
+  assert.equal(session.revision, expected.expected.sceneRevision)
+  assert.equal(
+    session.party.members.filter(({ active }) => active).length,
+    expected.expected.activePartyCount
+  )
+  assert.equal(
+    session.party.members.filter(({ active }) => !active).length,
+    expected.expected.inactivePartyCount
+  )
+  assert.equal(focused.locationName, expected.expected.focusedLocationName)
+  assert.equal(focused.groups.length, expected.expected.groupCount)
+  assert.equal(
+    focused.groups.filter(({ archived }) => archived).length,
+    expected.expected.archivedGroupCount
+  )
+  assert.ok(session.combat, `Campaign ${expected.role} has no Combat.`)
+  assert.equal(session.combat.phase, expected.expected.combatPhase)
+  assert.equal(session.combat.revision, expected.expected.combatRevision)
+  assert.equal(session.combat.cards.length, 0)
+  assert.equal(session.combat.resolution, null)
+  assert.equal(
+    actual.semanticSha256,
+    expected.expected.semanticSha256,
+    `Campaign ${expected.role} complete semantic LiveSessionSnapshot hash drifted; actual ${actual.semanticSha256}.`
+  )
+}
+
+function semanticLiveProjection(
+  configured: CurrentFormatLiveCampaign,
+  root: CurrentFormatRootCampaignReadback,
+  session: LiveSessionSnapshot
+): unknown {
+  const identities = new Map<string, string>()
+  for (const mapping of root.mappings)
+    if (mapping.kind === 'party' || mapping.kind === 'locations')
+      identities.set(mapping.internalId, mapping.externalKey)
+
+  const addedParty = session.party.members.filter(
+    ({ name }) =>
+      name === configured.materialization.addedInactiveParty.draft.name
+  )
+  assert.equal(
+    addedParty.length,
+    1,
+    `Campaign ${configured.role} inactive Party sentinel is not singular.`
+  )
+  identities.set(
+    addedParty[0]!.id,
+    configured.materialization.addedInactiveParty.semanticKey
+  )
+
+  const focused = session.scene.scenes.find(
+    ({ id }) => id === session.scene.focusedSceneId
+  )
+  assert.ok(focused, `Campaign ${configured.role} focused Scene is missing.`)
+  assert.equal(
+    session.scene.scenes.length,
+    1,
+    `Campaign ${configured.role} invented an unsupported additional Scene.`
+  )
+  identities.set(focused.id, 'scene:default')
+
+  for (const expectedGroup of configured.materialization.groups) {
+    const groups: readonly SceneGroup[] = focused.groups.filter(
+      ({ name }) => name === expectedGroup.name
+    )
+    assert.equal(
+      groups.length,
+      1,
+      `Campaign ${configured.role} Group ${expectedGroup.semanticKey} is not singular.`
+    )
+    const group = groups[0]!
+    identities.set(group.id, expectedGroup.semanticKey)
+    assert.equal(group.entries.length, expectedGroup.entries.length)
+    for (const expectedEntry of expectedGroup.entries) {
+      const entries: readonly SceneGroup['entries'][number][] =
+        group.entries.filter(
+          ({ creatureId }) => creatureId === expectedEntry.creatureId
+        )
+      assert.equal(
+        entries.length,
+        1,
+        `Campaign ${configured.role} Group ${expectedGroup.semanticKey} entry ${expectedEntry.creatureId} is not singular.`
+      )
+      const entry = entries[0]!
+      const entryKey = `${expectedGroup.semanticKey}/entry:${expectedEntry.creatureId}`
+      identities.set(entry.id, entryKey)
+      entry.members.forEach((member, index) =>
+        identities.set(member.id, `${entryKey}/member:${index}`)
+      )
+    }
+  }
+  if (session.combat) identities.set(session.combat.id, 'combat:focused')
+
+  const projected = replaceSemanticIds(session, identities)
+  assertNoRawUuid(projected, configured.role)
+  return projected
+}
+
+function replaceSemanticIds(
+  value: unknown,
+  identities: ReadonlyMap<string, string>
+): unknown {
+  if (Array.isArray(value))
+    return value.map((entry) => replaceSemanticIds(entry, identities))
+  if (typeof value === 'object' && value !== null)
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        replaceSemanticIds(entry, identities)
+      ])
+    )
+  if (typeof value !== 'string') return value
+  let projected = value
+  for (const [id, semanticKey] of [...identities].sort(
+    ([left], [right]) => right.length - left.length
+  ))
+    projected = projected.replaceAll(id, semanticKey)
+  return projected
+}
+
+function assertNoRawUuid(value: unknown, role: 'A' | 'B'): void {
+  const serialized = JSON.stringify(value)
+  const match = serialized.match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+  )
+  if (match)
+    throw new Error(
+      `Campaign ${role} semantic projection left raw identity ${match[0]}.`
+    )
+}
+
+function semanticHash(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex')
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (typeof value !== 'object' || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)])
+  )
+}
+
+function collectUuids(value: unknown): Set<string> {
+  const matches = JSON.stringify(value).match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi
+  )
+  return new Set(matches ?? [])
+}

--- a/scripts/qualify-current-format-live.ts
+++ b/scripts/qualify-current-format-live.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { createDefaultCampaignSchemaBootstrapper } from '../src/core/persistence/sqlite/campaign-schema-bootstrapper.js'
+import { databaseSchemaVersions } from '../src/core/persistence/sqlite/database.js'
+import { validateCurrentFormatCampaignManifest } from './qualification/current-format-campaign-manifest.js'
+import { loadCurrentFormatRootFixture } from './qualification/current-format-root-fixture.js'
+import { loadCurrentFormatLiveFixture } from './qualification/current-format-live-fixture.js'
+import { materializeCurrentFormatLiveFixture } from './qualification/current-format-live-materializer.js'
+import {
+  assertCurrentFormatLiveReceipt,
+  assertCurrentFormatLiveReadback,
+  readCurrentFormatLiveFixture
+} from './qualification/current-format-live-readback.js'
+
+const dataRoot = resolve(requiredArgument('--data-root'))
+const manifest = validateCurrentFormatCampaignManifest(
+  JSON.parse(
+    readFileSync(
+      'docs/project/evidence/frontend-robustness-current-format-manifest.v1.json',
+      'utf8'
+    )
+  ),
+  {
+    campaignDatabaseSchemaVersion: databaseSchemaVersions.campaign,
+    campaignSchemaRegistrations:
+      createDefaultCampaignSchemaBootstrapper().names()
+  }
+)
+const rootFixture = loadCurrentFormatRootFixture(
+  'docs/project/evidence/frontend-robustness-current-format-root-fixture.v1.json',
+  manifest
+)
+const liveFixture = loadCurrentFormatLiveFixture(
+  'docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json',
+  manifest,
+  rootFixture
+)
+const materialization = materializeCurrentFormatLiveFixture(
+  dataRoot,
+  rootFixture,
+  liveFixture
+)
+const readback = readCurrentFormatLiveFixture(
+  dataRoot,
+  rootFixture,
+  liveFixture
+)
+assertCurrentFormatLiveReadback(rootFixture, liveFixture, readback)
+assertCurrentFormatLiveReceipt(materialization, readback)
+
+process.stdout.write(
+  `${JSON.stringify({
+    kind: 'current-format-live-qualification',
+    fixtureIdentity: liveFixture.identity,
+    qualificationClaim: liveFixture.qualificationClaim,
+    coveredCampaignRegistrations: liveFixture.coveredCampaignRegistrations,
+    extendedRootRegistrations: liveFixture.extendedRootRegistrations,
+    activeCampaignRole: materialization.activeCampaignRole,
+    campaigns: readback.campaigns.map((campaign) => ({
+      role: campaign.role,
+      campaignId: campaign.campaignId,
+      partyRevision: campaign.session.party.revision,
+      sceneRevision: campaign.session.scene.revision,
+      combatRevision: campaign.session.combat?.revision ?? null,
+      semanticSha256: campaign.semanticSha256
+    })),
+    semanticReadback: true
+  })}\n`
+)
+
+function requiredArgument(name: string): string {
+  const index = process.argv.indexOf(name)
+  const value = process.argv[index + 1]
+  if (index < 0 || !value) throw new Error(`${name} is required`)
+  return value
+}

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -21,6 +21,7 @@
     "tests/integration/campaign-command-receipts.test.ts",
     "tests/integration/campaign-registry-revision.test.ts",
     "tests/integration/current-format-root-qualification.test.ts",
+    "tests/integration/current-format-live-qualification.test.ts",
     "tests/unit/generator-preset-application.test.ts",
     "tests/unit/generator-preset-reconciliation-ui.test.tsx",
     "tests/unit/core-process-supervisor.test.ts",

--- a/tests/integration/campaign-replacement-safety.test.ts
+++ b/tests/integration/campaign-replacement-safety.test.ts
@@ -40,20 +40,16 @@ afterEach(() => {
 })
 
 describe('campaign replacement safety', () => {
-  it.each(['active', 'inactive'] as const)(
-    'preserves the original for every uncommitted boundary of an %s campaign',
-    (activity) => {
-      for (const failurePhase of rollbackPhases)
-        assertFailureConverges(activity, failurePhase, false)
-    }
+  it.each(boundaryCases(rollbackPhases))(
+    'preserves the original for an %s campaign interrupted at %s',
+    (activity, failurePhase) =>
+      assertFailureConverges(activity, failurePhase, false)
   )
 
-  it.each(['active', 'inactive'] as const)(
-    'preserves the verified replacement after registry commit for an %s campaign',
-    (activity) => {
-      for (const failurePhase of rollForwardPhases)
-        assertFailureConverges(activity, failurePhase, true)
-    }
+  it.each(boundaryCases(rollForwardPhases))(
+    'preserves the verified replacement for an %s campaign interrupted at %s',
+    (activity, failurePhase) =>
+      assertFailureConverges(activity, failurePhase, true)
   )
 
   it.each([
@@ -109,6 +105,14 @@ describe('campaign replacement safety', () => {
     }
   )
 })
+
+function boundaryCases<T extends CampaignLifecycleBoundary>(
+  boundaries: readonly T[]
+): ReadonlyArray<readonly ['active' | 'inactive', T]> {
+  return (['active', 'inactive'] as const).flatMap((activity) =>
+    boundaries.map((boundary) => [activity, boundary] as const)
+  )
+}
 
 function assertFailureConverges(
   activity: 'active' | 'inactive',

--- a/tests/integration/current-format-live-qualification.test.ts
+++ b/tests/integration/current-format-live-qualification.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { createDefaultCampaignSchemaBootstrapper } from '../../src/core/persistence/sqlite/campaign-schema-bootstrapper.js'
+import { databaseSchemaVersions } from '../../src/core/persistence/sqlite/database.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import { validateCurrentFormatCampaignManifest } from '../../scripts/qualification/current-format-campaign-manifest.js'
+import { loadCurrentFormatRootFixture } from '../../scripts/qualification/current-format-root-fixture.js'
+import {
+  loadCurrentFormatLiveFixture,
+  validateCurrentFormatLiveFixture
+} from '../../scripts/qualification/current-format-live-fixture.js'
+import { materializeCurrentFormatLiveFixture } from '../../scripts/qualification/current-format-live-materializer.js'
+import {
+  assertCurrentFormatLiveReceipt,
+  assertCurrentFormatLiveReadback,
+  readCurrentFormatLiveFixture
+} from '../../scripts/qualification/current-format-live-readback.js'
+
+const manifest = validateCurrentFormatCampaignManifest(
+  JSON.parse(
+    readFileSync(
+      'docs/project/evidence/frontend-robustness-current-format-manifest.v1.json',
+      'utf8'
+    )
+  ),
+  {
+    campaignDatabaseSchemaVersion: databaseSchemaVersions.campaign,
+    campaignSchemaRegistrations:
+      createDefaultCampaignSchemaBootstrapper().names()
+  }
+)
+const rootFixture = loadCurrentFormatRootFixture(
+  'docs/project/evidence/frontend-robustness-current-format-root-fixture.v1.json',
+  manifest
+)
+const liveFixturePath =
+  'docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json'
+const liveFixture = loadCurrentFormatLiveFixture(
+  liveFixturePath,
+  manifest,
+  rootFixture
+)
+
+describe('FR2F2B1 current-format Live Play qualification protocol', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'salt-marcher-fr2f2b1-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('materializes A/B through Live Play and reads complete semantic snapshots after reopen', () => {
+    const receipt = materializeCurrentFormatLiveFixture(
+      root,
+      rootFixture,
+      liveFixture
+    )
+
+    expect(receipt.qualificationClaim).toBe(
+      'partial-fr2f2b1-live-cohort-not-complete-current-format'
+    )
+    expect(receipt.campaigns.map(({ role }) => role)).toEqual(['A', 'B'])
+    expect(
+      new Set(receipt.campaigns.map(({ combatId }) => combatId)).size
+    ).toBe(2)
+
+    const readback = readCurrentFormatLiveFixture(
+      root,
+      rootFixture,
+      liveFixture
+    )
+    expect(() =>
+      assertCurrentFormatLiveReadback(rootFixture, liveFixture, readback)
+    ).not.toThrow()
+    expect(() =>
+      assertCurrentFormatLiveReceipt(receipt, readback)
+    ).not.toThrow()
+    expect(
+      readback.campaigns.map(({ role, session }) => ({
+        role,
+        location: session.scene.scenes[0]?.locationName,
+        active: session.party.members.filter(({ active }) => active).length,
+        inactive: session.party.members.filter(({ active }) => !active).length,
+        combat: session.combat?.phase
+      }))
+    ).toEqual([
+      {
+        role: 'A',
+        location: 'Salt Harbor',
+        active: 1,
+        inactive: 1,
+        combat: 'initiative'
+      },
+      {
+        role: 'B',
+        location: 'Moon Marsh',
+        active: 1,
+        inactive: 1,
+        combat: 'initiative'
+      }
+    ])
+  })
+
+  it('rejects invalid Campaign B Live truth before publishing Campaign A', () => {
+    const raw = JSON.parse(readFileSync(liveFixturePath, 'utf8')) as {
+      campaigns: Array<{
+        materialization: {
+          groups: Array<{ entries: Array<{ creatureId: string }> }>
+        }
+      }>
+    }
+    raw.campaigns[1]!.materialization.groups[0]!.entries[0]!.creatureId =
+      'missing-creature'
+
+    expect(() =>
+      validateCurrentFormatLiveFixture(raw, manifest, rootFixture)
+    ).toThrow('references unknown creature')
+    const campaigns = new CampaignStore(root)
+    try {
+      expect(campaigns.list()).toEqual({
+        revision: 0,
+        activeCampaignId: null,
+        campaigns: [],
+        trashedCampaigns: []
+      })
+    } finally {
+      campaigns.close()
+    }
+  })
+
+  it('detects a public Live Play mutation instead of accepting changed bytes', () => {
+    materializeCurrentFormatLiveFixture(root, rootFixture, liveFixture)
+    const campaigns = new CampaignStore(root)
+    try {
+      const sourceA = rootFixture.campaigns[0]!.bundle.source.id
+      const campaignA = campaigns.campaignImportRepository().previous(sourceA)
+      expect(campaignA).not.toBeNull()
+      campaigns.visitCampaignDatabase(campaignA!.campaignId, (database) => {
+        const play = new LivePlayService(fixedSqliteDatabaseAccess(database))
+        const session = play.readSession()
+        const scene = session.scene.scenes.find(
+          ({ id }) => id === session.scene.focusedSceneId
+        )!
+        const archived = scene.groups.find(({ archived }) => archived)!
+        play.setSceneGroupArchived(
+          scene.id,
+          archived.id,
+          false,
+          archived.revision
+        )
+      })
+    } finally {
+      campaigns.close()
+    }
+
+    const changed = readCurrentFormatLiveFixture(root, rootFixture, liveFixture)
+    expect(() =>
+      assertCurrentFormatLiveReadback(rootFixture, liveFixture, changed)
+    ).toThrow()
+  })
+
+  it('rejects coverage, root identity, and malformed semantic hashes before mutation', () => {
+    const raw = JSON.parse(readFileSync(liveFixturePath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    expect(() =>
+      validateCurrentFormatLiveFixture(
+        { ...raw, coveredCampaignRegistrations: ['combat', 'scene'] },
+        manifest,
+        rootFixture
+      )
+    ).toThrow('coverage does not match')
+    expect(() =>
+      validateCurrentFormatLiveFixture(
+        { ...raw, rootFixtureIdentity: 'stale-root' },
+        manifest,
+        rootFixture
+      )
+    ).toThrow()
+
+    const campaigns = structuredClone(raw['campaigns']) as Array<{
+      expected: { semanticSha256: string }
+    }>
+    campaigns[0]!.expected.semanticSha256 = 'not-a-hash'
+    expect(() =>
+      validateCurrentFormatLiveFixture(
+        { ...raw, campaigns },
+        manifest,
+        rootFixture
+      )
+    ).toThrow()
+    const store = new CampaignStore(root)
+    try {
+      expect(store.list().campaigns).toEqual([])
+    } finally {
+      store.close()
+    }
+  })
+})


### PR DESCRIPTION
## Ergebnis

Implements frontend-robustness sprint FR2F2B1 as the Live Play half of the previously oversized FR2F2B row. It extends the static A/B qualification from root/import truth to Scene and Combat without fixture SQL writes.

## Included

- strict static A/B Live fixture with Scene/Combat primary coverage and Party/Location semantic extensions
- public LivePlayService materialization for inactive roster, focused Location, active/archived Groups, living/dead members, and initiative Combat
- independent reopen readback of complete LiveSessionSnapshot values
- UUID-to-semantic normalization with fail-closed rejection of unaccounted identities
- immutable complete-snapshot SHA-256 oracles plus readable sentinels
- exact materialization receipt identity proof across reopen and A/B isolation
- invalid-B preflight and public-owner mutation rejection
- standalone qualify-current-format-live.ts CLI
- roadmap split into FR2F2B1 Live Play and FR2F2B2 Spatial/Travel
- committed post-implementation audit with limitations and follow-ups

## Audit limits

This closes only FR2F2B1. It does not claim production Renderer/Preload/Utility switching, warm-switch timing, a second public Scene, Combat turns/resolution/Loot, Hex/Travel, focused-Scene next-action proof, FR-A07, TN-16, QS-05, or FR2 completion. FR3 remains no-go.

The materialization root is dedicated and not cross-Campaign transactional. Both A/B descriptions are preflighted before publication, but an external I/O failure after a commit can leave partial qualification evidence; the correct recovery is preserve/discard and restart, not ambiguous resume.

## Verification

- standalone clean-root CLI: semantic A/B readback passed
- focused root + Live integration: 2 files, 9 tests passed
- pnpm check:frontend-robustness: 27 files, 179 tests passed, including both TypeScript projects
- complete local pnpm check: format, all lint partitions, both TypeScript projects, and 91/91 architecture tests passed; the portable unit phase reproduced only the known host-sensitive 3 Encounter Generator 30-second timeouts and Reference Matcher 16-ms gate (30.897 ms), totaling 195/197 files and 803/807 tests
- git diff --check: passed

## Delivery class

Qualification and documentation only. No application-build input changed, so the canonical docs/test path is pnpm check; no AppImage handoff is required.