### PR TITLE
test: add current-format spatial qualification protocol

### DIFF
--- a/docs/project/evidence/frontend-robustness-current-format-spatial-fixture.v1.json
+++ b/docs/project/evidence/frontend-robustness-current-format-spatial-fixture.v1.json
@@ -1,0 +1,123 @@
+{
+  "version": 1,
+  "identity": "frontend-robustness-current-format-spatial-v1",
+  "rootFixtureIdentity": "frontend-robustness-current-format-root-v1",
+  "liveFixtureIdentity": "frontend-robustness-current-format-live-v1",
+  "qualificationClaim": "partial-fr2f2b2-spatial-cohort-not-complete-current-format",
+  "coveredCampaignRegistrations": ["hex"],
+  "extendedCampaignRegistrations": ["world-locations", "party", "scene"],
+  "campaigns": [
+    {
+      "role": "A",
+      "materialization": {
+        "mapSemanticKey": "hex-map:salt-coast",
+        "mapName": "Salt Coast March",
+        "commandIds": {
+          "createMap": "00000000-0000-4000-8000-0000000000a1",
+          "paintRoute": "00000000-0000-4000-8000-0000000000a2",
+          "paintSparseSentinel": "00000000-0000-4000-8000-0000000000a3",
+          "placeLocation": "00000000-0000-4000-8000-0000000000a4"
+        },
+        "routeBiomeId": "grassland",
+        "routeCoordinates": [
+          { "q": 0, "r": 0 },
+          { "q": 1, "r": 0 },
+          { "q": 2, "r": 0 }
+        ],
+        "sparseSentinel": {
+          "coordinate": { "q": 100000, "r": -100000 },
+          "biomeId": "mountain"
+        },
+        "placedLocationExternalKey": "location:salt-harbor",
+        "placedLocationCoordinate": { "q": 1, "r": 0 },
+        "travel": {
+          "startCoordinate": { "q": 0, "r": 0 },
+          "waypoints": [{ "q": 2, "r": 0 }],
+          "multiplier": 1,
+          "startedAt": 1000000,
+          "advanceTo": 1001000,
+          "finalStatus": "paused"
+        }
+      },
+      "expected": {
+        "catalogRevision": 1,
+        "mapMetadataRevision": 0,
+        "mapContentRevision": 3,
+        "authoredTileCount": 4,
+        "chunkCount": 2,
+        "historyUndoLabel": "location_place",
+        "partyRevision": 6,
+        "sceneRevision": 8,
+        "combatRevision": 0,
+        "travelRevision": 2,
+        "travelStatus": "paused",
+        "currentIndex": 1,
+        "segmentGameSeconds": 3600,
+        "gameTimeSeconds": 32400,
+        "currentCoordinate": { "q": 1, "r": 0 },
+        "routeLength": 3,
+        "locationName": "Salt Harbor",
+        "segmentStartedAt": null,
+        "segmentEndsAt": null,
+        "nextBoundaryDelay": null,
+        "semanticSha256": "5b125785743dd73313874cb716171d68a1de704b867e56da2a0195a6e159bb42"
+      }
+    },
+    {
+      "role": "B",
+      "materialization": {
+        "mapSemanticKey": "hex-map:moon-marsh",
+        "mapName": "Moon Marsh Expanse",
+        "commandIds": {
+          "createMap": "00000000-0000-4000-8000-0000000000b1",
+          "paintRoute": "00000000-0000-4000-8000-0000000000b2",
+          "paintSparseSentinel": "00000000-0000-4000-8000-0000000000b3",
+          "placeLocation": "00000000-0000-4000-8000-0000000000b4"
+        },
+        "routeBiomeId": "swamp",
+        "routeCoordinates": [
+          { "q": 4, "r": -3 },
+          { "q": 5, "r": -3 },
+          { "q": 6, "r": -3 }
+        ],
+        "sparseSentinel": {
+          "coordinate": { "q": -100000, "r": 100000 },
+          "biomeId": "forest"
+        },
+        "placedLocationExternalKey": "location:moon-marsh",
+        "placedLocationCoordinate": { "q": 5, "r": -3 },
+        "travel": {
+          "startCoordinate": { "q": 4, "r": -3 },
+          "waypoints": [{ "q": 6, "r": -3 }],
+          "multiplier": 2,
+          "startedAt": 2000000,
+          "advanceTo": 2002400,
+          "finalStatus": "travelling"
+        }
+      },
+      "expected": {
+        "catalogRevision": 1,
+        "mapMetadataRevision": 0,
+        "mapContentRevision": 3,
+        "authoredTileCount": 4,
+        "chunkCount": 2,
+        "historyUndoLabel": "location_place",
+        "partyRevision": 6,
+        "sceneRevision": 8,
+        "combatRevision": 0,
+        "travelRevision": 1,
+        "travelStatus": "travelling",
+        "currentIndex": 1,
+        "segmentGameSeconds": 17280,
+        "gameTimeSeconds": 46080,
+        "currentCoordinate": { "q": 5, "r": -3 },
+        "routeLength": 3,
+        "locationName": "Moon Marsh",
+        "segmentStartedAt": 2002400,
+        "segmentEndsAt": 2004800,
+        "nextBoundaryDelay": 2400,
+        "semanticSha256": "14a9d77307f54834c527e4a069ed55c114f9d5ead3376805dbc33aa0d6c1aeb8"
+      }
+    }
+  ]
+}

--- a/docs/project/evidence/frontend-robustness-fr2f2b2-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2f2b2-audit.md
@@ -4,7 +4,7 @@
 - Delivery baseline: `origin/main@02a0e9c2e25700489157a017806b7cfeaa4c6134`
 - Sprint: `FR2F2B2` from the
   [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
-- Change class: qualification and documentation only
+- Change class: qualification plus app-relevant post-phase robustness follow-up
 - Gate verdict: **FR2 remains open / no-go for FR3**
 
 ## Sources reviewed before implementation
@@ -142,6 +142,34 @@ This slice owns:
     masks only that qualified field for mapped Party members and re-applies the
     complete root oracle. A public Location-notes mutation proves unrelated
     root drift still fails; no later phase is used to hide this omission.
+13. The first exact-SHA Candidate run
+    [32819591384](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32819591384)
+    failed only `Linux Visual · goldens-campaign`; every root job and every
+    other downstream E2E/Visual job passed. Failure artifact readback proved
+    that `Verfallener Turm` had been deleted from the Location table while the
+    Scene still contained its now-dangling Location identity. The rendered
+    Session nevertheless still showed the deleted label. This is a real stale
+    Renderer projection, not failed persistence and not a visual-golden drift.
+14. Root cause is the former route-local ownership boundary: Location deletion
+    commits in Utility, then the Catalog route unmounts and cancels its
+    hook-local latest-only coordinator before its follow-up Session refresh can
+    publish. `CampaignWorkspaceProjection` already outlives both routes, but
+    previously did not consume the existing identity-bound `session.changed`
+    channel. A blind retry was rejected because it would preserve this race.
+15. The follow-up publishes `projection-invalidated` after public Location
+    catalog save/delete commits and makes the provider-lived Campaign workspace
+    owner refresh only the matching active Campaign Session. It neither polls
+    nor remounts the application and ignores inactive-Campaign events. The E2E
+    path also waits for the preceding Scene-location command to become visible
+    before starting deletion, so two independent writes are not accidentally
+    overlapped by the test.
+16. The invalidation intentionally performs one coarse complete active-Session
+    read instead of synthesizing a partial Location patch. It does not yet
+    provide a joint Location/Session command receipt, and asynchronous refresh
+    failure retains the projection owner's existing failure/cached-state
+    behavior rather than adding a new user-facing error surface. Those are
+    bounded later owner/receipt concerns; this follow-up claims only removal of
+    the demonstrated cross-route stale projection.
 
 ## Verification
 
@@ -157,20 +185,35 @@ This slice owns:
   including invalid-B preflight, public Hex, Travel, and Location mutations,
   root preservation, coverage and identity/hash drift, exact receipt identity
   after reopen, complete semantic hashes, and A/B isolation;
+- targeted projection, Utility-event, and architecture verification: 3 files
+  and 21 tests passed, covering matching active-Campaign refresh,
+  inactive-Campaign isolation, disposal/unsubscription, exact event Campaign,
+  Scene, revision, reason, and both Location publisher callsites;
 - after the post-phase follow-up, `pnpm check:frontend-robustness`: 28 files and
-  185 tests passed, including both TypeScript projects;
-- the complete local `pnpm check` passed formatting, every lint partition, both
-  TypeScript projects, and 91/91 architecture tests. Its portable unit phase
-  reproduced only the four unrelated host-sensitive failures already recorded
-  through FR2F2B1: three Encounter Generator settings tests exceeded their
-  unchanged 30-second timeout and the 16-ms Reference Matcher gate measured
-  30.572 ms. The result was 195/197 files and 803/807 tests; no failing test
-  imports the new spatial fixture, protocol, reader, or integration test, and
-  no timeout or threshold was weakened;
-- baseline and candidate app-build input fingerprint are both
-  `00e52f0d9d8d3f826d5aef5e1080d4b08e29af23cacafc8230b25e447da64ea1`;
-  this qualification/documentation-only SHA therefore does not require a local
-  application handoff;
+  186 tests passed, including both TypeScript projects and the provider-lived
+  invalidation plus publisher-wiring architecture coverage;
+- the final complete local `pnpm check` passed formatting, every lint
+  partition, both TypeScript projects, and 91/91 architecture tests. On the
+  same overloaded host that timed out both direct Visual scenarios, its
+  portable unit phase ended at 195/197 files and 802/809 tests: five unchanged
+  30-second timeouts in the previously recorded Encounter Generator settings
+  suite, one follow-on duplicate Escape callback in that same file after the
+  timeouts, and the 16-ms Reference Matcher gate at 66.015 ms. All 30 directly
+  affected provider tests passed together; all 186 focused robustness tests
+  passed. No failing test imports the changed projection/event code or spatial
+  qualification, and no timeout, threshold, worker count, or product behavior
+  was weakened to obtain a local green result;
+- the qualification-only SHA retained baseline app-build input fingerprint
+  `00e52f0d9d8d3f826d5aef5e1080d4b08e29af23cacafc8230b25e447da64ea1`.
+  The robustness follow-up changes production Renderer and Utility inputs and
+  therefore produces fingerprint
+  `f4a545959738c83b8ee3c88ed2b62df55d021ffa992ed46bc8984140917e63c6`;
+  an exact-SHA canonical application handoff is mandatory before promotion;
+- a direct local `goldens-campaign` run was attempted without `xvfb` on the
+  desktop host. It failed first in the unchanged preceding Hex Map scenario
+  through repeated 30-second Renderer and screenshot timeouts. This host-bound
+  run is not used as functional proof; the exact-SHA remote Visual job remains
+  authoritative for the corrected Campaign Combat path;
 - formatting and diff validation passed; remote Candidate result and Main
   attestation are recorded at delivery time rather than predeclared here.
 

--- a/docs/project/evidence/frontend-robustness-fr2f2b2-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2f2b2-audit.md
@@ -1,0 +1,190 @@
+# Frontend robustness FR2F2B2 spatial materialization audit
+
+- Date: 2026-08-25
+- Delivery baseline: `origin/main@02a0e9c2e25700489157a017806b7cfeaa4c6134`
+- Sprint: `FR2F2B2` from the
+  [frontend robustness roadmap](../architecture/frontend-robustness-roadmap.md)
+- Change class: qualification and documentation only
+- Gate verdict: **FR2 remains open / no-go for FR3**
+
+## Sources reviewed before implementation
+
+- the complete frontend robustness roadmap and acceptance matrix, including
+  the FR2 protocol, FR-A07, TN-16, TN-21, QS-05, RP-R, and RP-L;
+- the original Electron M1/M3/M4 migration intent, target architecture Hex and
+  Travel boundaries, current product requirements, and current green
+  `origin/main@02a0e9c2`;
+- the FR2F1 owner manifest, FR2F2A root fixture/protocol/audit, FR2F2B1 Live
+  fixture/protocol/audit, focused-check manifest, and current open pull
+  requests;
+- `CampaignStore`, `HexMapService`, `HexMapEditingCommandHandler`,
+  `HexMapStore`, `HexEditJournalStore`, `HexTravelService`, `HexTravelStore`,
+  `PartyStore`, `SceneStore`, `WorldLocationStore`, `LivePlayService`, their
+  shared contracts, Utility Hex composition, and current spatial integration
+  tests.
+
+## Sprint sizing and implementation packet
+
+The mandatory pre-phase review kept `FR2F2B2` as one sprint. The manifest has
+one primary owner registration, `hex`, while a meaningful Travel readback
+requires the same publicly authored map, Location placement, Party position,
+Scene time, and journey. Splitting those operations would close neither half
+independently and would misrepresent one owner as two guarantees.
+
+This slice owns:
+
+- one strict static A/B spatial fixture whose primary owner coverage is exactly
+  `hex` and whose semantic extensions are exactly `world-locations`, `party`,
+  and `scene`;
+- per Campaign, one named map, a three-tile adjacent route, one far sparse tile
+  in another chunk, one mapped root Location at the first checkpoint, exact
+  command identities, and readable expected revisions;
+- public map creation, route painting, sparse painting, and Location placement
+  through `HexMapEditingCommandHandler`; no fixture SQL writes;
+- public Party positioning, route evaluation, Travel start, controlled-clock
+  advancement to exactly one boundary, and a paused A versus still-travelling
+  B through `HexTravelService`;
+- a separately opened readback through fresh Live, Hex, editing, and Travel
+  owners, including the complete updated Live Session, map catalog, every
+  declared authored chunk, used biome definitions, edit history, all command
+  receipts, journey, runtime overlay, and next-boundary delay;
+- normalization of every generated UUID to a static semantic identity, raw-UUID
+  rejection, canonical complete-projection hashes, readable sentinels, exact
+  materializer-receipt readback, and A/B identity isolation;
+- fail-closed preflight for coverage, upstream identities, external references,
+  adjacency, sparse separation, passability, Party speed, controlled boundary,
+  journey state, and semantic hashes before publication;
+- public Hex and Travel mutations that must invalidate the oracle;
+- a standalone `qualify-current-format-spatial.ts --data-root <empty-root>`
+  receipt with the literal partial claim
+  `partial-fr2f2b2-spatial-cohort-not-complete-current-format`.
+
+## Dispatch, failure, reopen, and identity trace
+
+1. The owner manifest and complete root, Live, and spatial A/B fixtures are
+   parsed and cross-validated before the empty installation is mutated.
+2. The established FR2F2A and FR2F2B1 public materializers publish A/B root and
+   Live truth, leave A active, close their connections, and return identities.
+3. A new `CampaignStore` resolves each Campaign by import source identity and
+   visits its database without changing installation switch authority.
+4. An explicit qualification owner factory composes the real editing command
+   handler from its Unit of Work, map, journal, Travel, Party, Scene, and
+   Location stores. It executes four receipt-backed spatial commands.
+5. `HexTravelService` positions the focused Scene Party, evaluates the authored
+   route, starts the journey, and advances a fixture-owned clock to exactly the
+   first segment boundary. A is then paused; B remains travelling with its next
+   boundary scheduled.
+6. The materializer closes and returns generated identities plus command IDs
+   only. A separate reader reopens root and both Campaign databases, repeats
+   root readback, and uses fresh public domain services.
+7. The reader covers Live state plus catalog, all fixture-authored chunks,
+   biome definitions, history, command receipts, Travel, overlays, and boundary
+   delay. It also re-applies the complete FR2F2A root oracle after masking only
+   the newly qualified imported-Party Travel positions. Imported, Live,
+   spatial, and command identities are replaced with static semantic keys; any
+   remaining raw UUID fails qualification.
+8. Static A/B hashes cover the complete normalized projections. The identity
+   receipt separately proves that exact generated Campaign, Scene, map, and
+   receipt identities survived reopen. Registry revision and active Campaign
+   must remain unchanged throughout.
+
+## Post-implementation negative findings and shortcuts
+
+1. The materializer uses an explicit fixed-database qualification adapter
+   inside `visitCampaignDatabase`. This proves the real domain owners and
+   persisted bytes, but not Renderer -> Preload -> Utility production
+   switching. FR2F2B2 is not production-route evidence.
+2. The Domain `HexMapService.readChunks` returns stored map/chunk truth, while
+   the Utility operation handler enriches it with the referenced biome
+   definitions required by the public IPC result. The reader reproduces that
+   deterministic composition with the built-in biome catalog. This adapter
+   difference is explicit and its definitions are hashed; it is not evidence
+   that the Utility route was exercised.
+3. `HexTravelService.position` and `start` both persist Party position and Scene
+   Location even when those values are unchanged. Together with the boundary
+   tick this increases the B1 Party revision from 3 to 6 and Scene revision
+   from 5 to 8. The fixture records current behavior so drift fails closed, but
+   does not bless the redundant writes as target architecture; their ownership
+   should be simplified during the production Hex/Travel cutover.
+4. The current product still exposes only the bootstrapped standard Running
+   Scene. This qualification extends that Scene spatially; it does not satisfy
+   the original M3 second-Scene intent.
+5. Each Campaign has one map and four authored tiles across two sparse chunks.
+   That is sufficient for a deterministic current-format owner oracle, not for
+   RP-R/RP-L large-population or cross-OS performance qualification.
+6. Readback requests every chunk derivable from the static materializer. The
+   public catalog does not enumerate all persisted chunk keys, so completeness
+   relies on starting from a dedicated empty root and allowing only the public
+   materializer to author it. This is weaker than arbitrary existing-profile
+   discovery and must not be generalized into a production migration reader.
+7. A/B clocks use fixed historical millisecond values and B remains travelling
+   only relative to that controlled clock. This proves deterministic lifecycle
+   persistence and boundary math, not wall-clock scheduling in the packaged
+   application.
+8. Root, Live, and spatial materialization are not one cross-Campaign
+   transaction. Semantic errors for both A/B spatial descriptions are
+   preflighted before root publication, but an external runtime/I/O failure
+   after earlier commits can leave the dedicated qualification root partial.
+   Preserve it as evidence or discard only that dedicated root and restart.
+9. Built-in biome labels, colors, passability, and travel costs influence the
+   complete hashes. Any legitimate catalog change therefore requires explicit
+   fixture review rather than silently blessing new current behavior.
+10. Full-projection hashes are intentionally fail-closed but opaque during
+    diagnosis. Readable map, chunk, receipt, revision, position, time, journey,
+    and overlay sentinels identify common drift; deeper drift requires
+    inspecting the exposed semantic projection.
+11. No renderer dispatch, warm-switch duration, focused-Scene next mutation,
+    restart scheduling, SwiftShader disposition, app handoff, or owner
+    acceptance is claimed. Those gates remain in FR2F3, FR2G, and FR7B.
+12. The first post-phase review found that spatial readback reopened the
+    FR2F2A root but did not re-assert its content because imported Party Travel
+    positions legitimately differ from the root fixture. The follow-up now
+    masks only that qualified field for mapped Party members and re-applies the
+    complete root oracle. A public Location-notes mutation proves unrelated
+    root drift still fails; no later phase is used to hide this omission.
+
+## Verification
+
+- the standalone CLI against a new temporary installation reproduced A/B,
+  exact A authority, four authored tiles and four applied command receipts per
+  Campaign, A paused at `(1,0)` with Party revision 6, Scene revision 8,
+  Travel revision 2, game time 32400, and hash
+  `5b125785743dd73313874cb716171d68a1de704b867e56da2a0195a6e159bb42`;
+  B remained travelling at `(5,-3)` with Party revision 6, Scene revision 8,
+  Travel revision 1, game time 46080, next-boundary delay 2400, and hash
+  `14a9d77307f54834c527e4a069ed55c114f9d5ead3376805dbc33aa0d6c1aeb8`;
+- focused root plus Live plus spatial integration: 3 files and 15 tests passed,
+  including invalid-B preflight, public Hex, Travel, and Location mutations,
+  root preservation, coverage and identity/hash drift, exact receipt identity
+  after reopen, complete semantic hashes, and A/B isolation;
+- after the post-phase follow-up, `pnpm check:frontend-robustness`: 28 files and
+  185 tests passed, including both TypeScript projects;
+- the complete local `pnpm check` passed formatting, every lint partition, both
+  TypeScript projects, and 91/91 architecture tests. Its portable unit phase
+  reproduced only the four unrelated host-sensitive failures already recorded
+  through FR2F2B1: three Encounter Generator settings tests exceeded their
+  unchanged 30-second timeout and the 16-ms Reference Matcher gate measured
+  30.572 ms. The result was 195/197 files and 803/807 tests; no failing test
+  imports the new spatial fixture, protocol, reader, or integration test, and
+  no timeout or threshold was weakened;
+- baseline and candidate app-build input fingerprint are both
+  `00e52f0d9d8d3f826d5aef5e1080d4b08e29af23cacafc8230b25e447da64ea1`;
+  this qualification/documentation-only SHA therefore does not require a local
+  application handoff;
+- formatting and diff validation passed; remote Candidate result and Main
+  attestation are recorded at delivery time rather than predeclared here.
+
+## Gate decision and follow-up
+
+FR2F2B2 closes only the reproducible Hex/Travel spatial owner protocol. It does
+not close FR2F2, FR2, FR-A07, TN-16, TN-21, or QS-05.
+
+- `FR2F2C` must add preparation, economy, and installation owners and enforce
+  exactly one primary disposition for every manifest registration;
+- `FR2F3` retains the focused-Scene next-action/restart oracle and isolated
+  Travel/SwiftShader disposition;
+- `FR2G` retains current-format production timing and explicit owner
+  architecture go/no-go;
+- `FR7B` retains exact cross-OS RP-R/RP-L qualification.
+
+FR3 remains no-go.

--- a/scripts/qualification/current-format-live-readback.ts
+++ b/scripts/qualification/current-format-live-readback.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict'
-import { createHash } from 'node:crypto'
 import { LivePlayService } from '../../src/core/encounter/live-combat.js'
 import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
 import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
@@ -20,6 +19,12 @@ import type {
   CurrentFormatLiveFixture
 } from './current-format-live-fixture.js'
 import type { CurrentFormatLiveMaterializationReceipt } from './current-format-live-materializer.js'
+import {
+  assertNoRawUuid,
+  collectUuids,
+  replaceSemanticIdentities,
+  semanticHash
+} from './qualification-semantic-oracle.js'
 
 export type CurrentFormatLiveCampaignReadback = Readonly<{
   role: 'A' | 'B'
@@ -182,12 +187,30 @@ function assertCampaign(
   )
 }
 
-function semanticLiveProjection(
+export function semanticLiveProjection(
   configured: CurrentFormatLiveCampaign,
   root: CurrentFormatRootCampaignReadback,
-  session: LiveSessionSnapshot
+  session: LiveSessionSnapshot,
+  additionalIdentities: ReadonlyMap<string, string> = new Map()
 ): unknown {
-  const identities = new Map<string, string>()
+  const identities = currentFormatLiveSemanticIdentities(
+    configured,
+    root,
+    session,
+    additionalIdentities
+  )
+  const projected = replaceSemanticIdentities(session, identities)
+  assertNoRawUuid(projected, `Campaign ${configured.role}`)
+  return projected
+}
+
+export function currentFormatLiveSemanticIdentities(
+  configured: CurrentFormatLiveCampaign,
+  root: CurrentFormatRootCampaignReadback,
+  session: LiveSessionSnapshot,
+  additionalIdentities: ReadonlyMap<string, string> = new Map()
+): ReadonlyMap<string, string> {
+  const identities = new Map<string, string>(additionalIdentities)
   for (const mapping of root.mappings)
     if (mapping.kind === 'party' || mapping.kind === 'locations')
       identities.set(mapping.internalId, mapping.externalKey)
@@ -248,64 +271,5 @@ function semanticLiveProjection(
     }
   }
   if (session.combat) identities.set(session.combat.id, 'combat:focused')
-
-  const projected = replaceSemanticIds(session, identities)
-  assertNoRawUuid(projected, configured.role)
-  return projected
-}
-
-function replaceSemanticIds(
-  value: unknown,
-  identities: ReadonlyMap<string, string>
-): unknown {
-  if (Array.isArray(value))
-    return value.map((entry) => replaceSemanticIds(entry, identities))
-  if (typeof value === 'object' && value !== null)
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [
-        key,
-        replaceSemanticIds(entry, identities)
-      ])
-    )
-  if (typeof value !== 'string') return value
-  let projected = value
-  for (const [id, semanticKey] of [...identities].sort(
-    ([left], [right]) => right.length - left.length
-  ))
-    projected = projected.replaceAll(id, semanticKey)
-  return projected
-}
-
-function assertNoRawUuid(value: unknown, role: 'A' | 'B'): void {
-  const serialized = JSON.stringify(value)
-  const match = serialized.match(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
-  )
-  if (match)
-    throw new Error(
-      `Campaign ${role} semantic projection left raw identity ${match[0]}.`
-    )
-}
-
-function semanticHash(value: unknown): string {
-  return createHash('sha256')
-    .update(JSON.stringify(canonicalize(value)))
-    .digest('hex')
-}
-
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize)
-  if (typeof value !== 'object' || value === null) return value
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, canonicalize(entry)])
-  )
-}
-
-function collectUuids(value: unknown): Set<string> {
-  const matches = JSON.stringify(value).match(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi
-  )
-  return new Set(matches ?? [])
+  return identities
 }

--- a/scripts/qualification/current-format-spatial-fixture.ts
+++ b/scripts/qualification/current-format-spatial-fixture.ts
@@ -1,0 +1,414 @@
+import { readFileSync } from 'node:fs'
+import { z } from 'zod'
+import { biomeDefinition } from '../../src/core/hex/biome-catalog.js'
+import { chunkKeyFor } from '../../src/core/hex/hex-map-store.js'
+import {
+  axialDistance,
+  travelGameSeconds
+} from '../../src/core/hex/hex-travel.js'
+import {
+  axialCoordinateSchema,
+  hexBiomeIdSchema
+} from '../../src/shared/contracts/hex.js'
+import type { CurrentFormatCampaignManifest } from './current-format-campaign-manifest.js'
+import type {
+  CurrentFormatLiveCampaign,
+  CurrentFormatLiveFixture
+} from './current-format-live-fixture.js'
+import type {
+  CurrentFormatRootCampaign,
+  CurrentFormatRootFixture
+} from './current-format-root-fixture.js'
+
+export const currentFormatSpatialRegistrations = Object.freeze(['hex'] as const)
+
+export const currentFormatSpatialExtendedRegistrations = Object.freeze([
+  'world-locations',
+  'party',
+  'scene'
+] as const)
+
+const spatialCommandIdsSchema = z
+  .object({
+    createMap: z.uuid(),
+    paintRoute: z.uuid(),
+    paintSparseSentinel: z.uuid(),
+    placeLocation: z.uuid()
+  })
+  .strict()
+
+const spatialMaterializationSchema = z
+  .object({
+    mapSemanticKey: z.string().regex(/^hex-map:[a-z0-9-]+$/),
+    mapName: z.string().trim().min(1).max(100),
+    commandIds: spatialCommandIdsSchema,
+    routeBiomeId: hexBiomeIdSchema,
+    routeCoordinates: z.array(axialCoordinateSchema).length(3),
+    sparseSentinel: z
+      .object({
+        coordinate: axialCoordinateSchema,
+        biomeId: hexBiomeIdSchema
+      })
+      .strict(),
+    placedLocationExternalKey: z.string().min(1),
+    placedLocationCoordinate: axialCoordinateSchema,
+    travel: z
+      .object({
+        startCoordinate: axialCoordinateSchema,
+        waypoints: z.array(axialCoordinateSchema).length(1),
+        multiplier: z.union([
+          z.literal(1),
+          z.literal(2),
+          z.literal(5),
+          z.literal(10)
+        ]),
+        startedAt: z.number().int().nonnegative(),
+        advanceTo: z.number().int().nonnegative(),
+        finalStatus: z.enum(['paused', 'travelling'])
+      })
+      .strict()
+  })
+  .strict()
+
+const spatialExpectedSchema = z
+  .object({
+    catalogRevision: z.literal(1),
+    mapMetadataRevision: z.literal(0),
+    mapContentRevision: z.literal(3),
+    authoredTileCount: z.literal(4),
+    chunkCount: z.literal(2),
+    historyUndoLabel: z.literal('location_place'),
+    partyRevision: z.number().int().nonnegative(),
+    sceneRevision: z.number().int().nonnegative(),
+    combatRevision: z.number().int().nonnegative(),
+    travelRevision: z.number().int().nonnegative(),
+    travelStatus: z.enum(['paused', 'travelling']),
+    currentIndex: z.literal(1),
+    segmentGameSeconds: z.number().int().positive(),
+    gameTimeSeconds: z.number().int().positive(),
+    currentCoordinate: axialCoordinateSchema,
+    routeLength: z.literal(3),
+    locationName: z.string().min(1),
+    segmentStartedAt: z.number().int().nonnegative().nullable(),
+    segmentEndsAt: z.number().int().nonnegative().nullable(),
+    nextBoundaryDelay: z.number().int().nonnegative().nullable(),
+    semanticSha256: z.string().regex(/^[0-9a-f]{64}$/)
+  })
+  .strict()
+
+const spatialCampaignSchema = z
+  .object({
+    role: z.enum(['A', 'B']),
+    materialization: spatialMaterializationSchema,
+    expected: spatialExpectedSchema
+  })
+  .strict()
+
+export const currentFormatSpatialFixtureSchema = z
+  .object({
+    version: z.literal(1),
+    identity: z.literal('frontend-robustness-current-format-spatial-v1'),
+    rootFixtureIdentity: z.literal(
+      'frontend-robustness-current-format-root-v1'
+    ),
+    liveFixtureIdentity: z.literal(
+      'frontend-robustness-current-format-live-v1'
+    ),
+    qualificationClaim: z.literal(
+      'partial-fr2f2b2-spatial-cohort-not-complete-current-format'
+    ),
+    coveredCampaignRegistrations: z
+      .array(z.string())
+      .length(currentFormatSpatialRegistrations.length),
+    extendedCampaignRegistrations: z
+      .array(z.string())
+      .length(currentFormatSpatialExtendedRegistrations.length),
+    campaigns: z.array(spatialCampaignSchema).length(2)
+  })
+  .strict()
+  .superRefine((fixture, context) => {
+    if (fixture.campaigns.map(({ role }) => role).join(',') !== 'A,B')
+      context.addIssue({
+        code: 'custom',
+        path: ['campaigns'],
+        message: 'Spatial fixture Campaign roles must be exactly A then B.'
+      })
+    unique(
+      fixture.campaigns.map(
+        ({ materialization }) => materialization.mapSemanticKey
+      ),
+      ['campaigns'],
+      context
+    )
+    unique(
+      fixture.campaigns.map(({ materialization }) => materialization.mapName),
+      ['campaigns'],
+      context
+    )
+    unique(
+      fixture.campaigns.flatMap(({ materialization }) =>
+        Object.values(materialization.commandIds)
+      ),
+      ['campaigns'],
+      context
+    )
+    if (
+      fixture.campaigns
+        .map(({ materialization }) => materialization.travel.finalStatus)
+        .join(',') !== 'paused,travelling'
+    )
+      context.addIssue({
+        code: 'custom',
+        path: ['campaigns'],
+        message: 'Spatial fixture must cover paused A and travelling B.'
+      })
+  })
+
+export type CurrentFormatSpatialFixture = Readonly<
+  z.infer<typeof currentFormatSpatialFixtureSchema>
+>
+export type CurrentFormatSpatialCampaign = Readonly<
+  CurrentFormatSpatialFixture['campaigns'][number]
+>
+
+export function loadCurrentFormatSpatialFixture(
+  path: string,
+  manifest: CurrentFormatCampaignManifest,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture
+): CurrentFormatSpatialFixture {
+  return validateCurrentFormatSpatialFixture(
+    JSON.parse(readFileSync(path, 'utf8')),
+    manifest,
+    rootFixture,
+    liveFixture
+  )
+}
+
+export function validateCurrentFormatSpatialFixture(
+  raw: unknown,
+  manifest: CurrentFormatCampaignManifest,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture
+): CurrentFormatSpatialFixture {
+  const fixture = currentFormatSpatialFixtureSchema.parse(raw)
+  assertExactOrder(
+    fixture.coveredCampaignRegistrations,
+    currentFormatSpatialRegistrations,
+    'coverage'
+  )
+  assertExactOrder(
+    fixture.extendedCampaignRegistrations,
+    currentFormatSpatialExtendedRegistrations,
+    'extended coverage'
+  )
+  if (fixture.rootFixtureIdentity !== rootFixture.identity)
+    throw new Error('Current-format spatial fixture root identity is stale.')
+  if (fixture.liveFixtureIdentity !== liveFixture.identity)
+    throw new Error('Current-format spatial fixture Live identity is stale.')
+
+  const owner = manifest.campaignOwners.find(
+    ({ registration }) => registration === 'hex'
+  )
+  if (!owner || owner.disposition !== 'switch-oracle')
+    throw new Error('Current-format spatial owner hex is not a switch oracle.')
+  const manifestOrder = manifest.campaignOwners
+    .map(({ registration }) => registration)
+    .filter((registration) => registration === 'hex')
+  assertExactOrder(manifestOrder, currentFormatSpatialRegistrations, 'order')
+  for (const registration of ['world-locations', 'party'] as const)
+    if (!rootFixture.coveredCampaignRegistrations.includes(registration))
+      throw new Error(
+        `Current-format spatial extension ${registration} is not rooted in FR2F2A.`
+      )
+  if (!liveFixture.coveredCampaignRegistrations.includes('scene'))
+    throw new Error(
+      'Current-format spatial extension scene is not rooted in FR2F2B1.'
+    )
+
+  for (const configured of fixture.campaigns) {
+    const root = rootFixture.campaigns.find(
+      ({ role }) => role === configured.role
+    )
+    const live = liveFixture.campaigns.find(
+      ({ role }) => role === configured.role
+    )
+    if (!root || !live)
+      throw new Error(
+        `Current-format spatial Campaign ${configured.role} has no root/Live Campaign.`
+      )
+    validateCampaign(configured, root, live)
+  }
+  return fixture
+}
+
+function validateCampaign(
+  configured: CurrentFormatSpatialCampaign,
+  root: CurrentFormatRootCampaign,
+  live: CurrentFormatLiveCampaign
+): void {
+  const materialization = configured.materialization
+  const route = materialization.routeCoordinates
+  if (
+    route
+      .slice(1)
+      .some(
+        (coordinate, index) => axialDistance(route[index]!, coordinate) !== 1
+      )
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} route is not adjacent.`
+    )
+  if (!sameCoordinate(materialization.travel.startCoordinate, route[0]!))
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} start is not the route origin.`
+    )
+  if (
+    !sameCoordinate(
+      materialization.travel.waypoints[0]!,
+      route[route.length - 1]!
+    )
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} waypoint is not the route destination.`
+    )
+  if (!sameCoordinate(materialization.placedLocationCoordinate, route[1]!))
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} placement is not the first checkpoint.`
+    )
+  if (
+    materialization.placedLocationExternalKey !==
+    live.materialization.focusedLocationExternalKey
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} placement does not restore the focused Location.`
+    )
+  const location = root.bundle.locations.find(
+    ({ externalKey }) =>
+      externalKey === materialization.placedLocationExternalKey
+  )
+  if (!location)
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} references an unknown Location.`
+    )
+  if (
+    chunkId(chunkKeyFor(materialization.sparseSentinel.coordinate)) ===
+    chunkId(chunkKeyFor(route[0]!))
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} sparse sentinel is not in a distinct chunk.`
+    )
+
+  const routeBiome = biomeDefinition(materialization.routeBiomeId)
+  const sparseBiome = biomeDefinition(materialization.sparseSentinel.biomeId)
+  if (!routeBiome.passable || !sparseBiome.passable)
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} uses an impassable biome.`
+    )
+  const activeMembers =
+    live.materialization.importedActivePartyExternalKeys.map((externalKey) =>
+      root.bundle.party.find((member) => member.externalKey === externalKey)
+    )
+  if (activeMembers.some((member) => !member))
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} has an unknown travelling Party member.`
+    )
+  const speed = Math.min(
+    ...activeMembers.map((member) => member!.movementSpeedFeet ?? 30)
+  )
+  const gameSeconds = travelGameSeconds(speed, routeBiome.travelCost)
+  const boundaryMilliseconds =
+    (gameSeconds * 1_000) / 3_600 / materialization.travel.multiplier
+  if (!Number.isInteger(boundaryMilliseconds))
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} has a fractional controlled boundary.`
+    )
+  if (
+    materialization.travel.advanceTo !==
+    materialization.travel.startedAt + boundaryMilliseconds
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} clock does not stop at the first boundary.`
+    )
+
+  const expected = configured.expected
+  if (
+    expected.travelStatus !== materialization.travel.finalStatus ||
+    expected.currentCoordinate.q !== route[1]!.q ||
+    expected.currentCoordinate.r !== route[1]!.r ||
+    expected.segmentGameSeconds !== gameSeconds ||
+    expected.gameTimeSeconds !== 28_800 + gameSeconds ||
+    expected.locationName !== location.displayName
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} readable oracle is inconsistent.`
+    )
+  const paused = materialization.travel.finalStatus === 'paused'
+  if (
+    expected.travelRevision !== (paused ? 2 : 1) ||
+    expected.segmentStartedAt !==
+      (paused ? null : materialization.travel.advanceTo) ||
+    expected.segmentEndsAt !==
+      (paused
+        ? null
+        : materialization.travel.advanceTo + boundaryMilliseconds) ||
+    expected.nextBoundaryDelay !== (paused ? null : boundaryMilliseconds)
+  )
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} journey oracle is inconsistent.`
+    )
+}
+
+export function spatialChunkKeys(
+  configured: CurrentFormatSpatialCampaign
+): readonly Readonly<{ q: number; r: number }>[] {
+  const keys = new Map<string, Readonly<{ q: number; r: number }>>()
+  for (const coordinate of [
+    ...configured.materialization.routeCoordinates,
+    configured.materialization.sparseSentinel.coordinate
+  ]) {
+    const key = chunkKeyFor(coordinate)
+    keys.set(chunkId(key), key)
+  }
+  return [...keys.values()].sort(
+    (left, right) => left.q - right.q || left.r - right.r
+  )
+}
+
+function sameCoordinate(
+  left: Readonly<{ q: number; r: number }>,
+  right: Readonly<{ q: number; r: number }>
+): boolean {
+  return left.q === right.q && left.r === right.r
+}
+
+function chunkId(key: Readonly<{ q: number; r: number }>): string {
+  return `${key.q}:${key.r}`
+}
+
+function assertExactOrder(
+  actual: readonly string[],
+  expected: readonly string[],
+  label: string
+): void {
+  if (
+    actual.length !== expected.length ||
+    actual.some((value, index) => value !== expected[index])
+  )
+    throw new Error(
+      `Current-format spatial fixture ${label} does not match the FR2F2B2 contract.`
+    )
+}
+
+function unique(
+  values: readonly string[],
+  path: readonly (string | number)[],
+  context: z.RefinementCtx
+): void {
+  if (new Set(values).size === values.length) return
+  context.addIssue({
+    code: 'custom',
+    path: [...path],
+    message: 'Spatial fixture semantic identities must be unique.'
+  })
+}

--- a/scripts/qualification/current-format-spatial-materializer.ts
+++ b/scripts/qualification/current-format-spatial-materializer.ts
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict'
+import type Database from 'better-sqlite3'
+import { z } from 'zod'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { HexTravelService } from '../../src/core/hex/hex-travel.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import type { HexBrushStrokeResult } from '../../src/shared/contracts/hex.js'
+import type { CurrentFormatLiveFixture } from './current-format-live-fixture.js'
+import { materializeCurrentFormatLiveFixture } from './current-format-live-materializer.js'
+import type { CurrentFormatRootFixture } from './current-format-root-fixture.js'
+import type {
+  CurrentFormatSpatialCampaign,
+  CurrentFormatSpatialFixture
+} from './current-format-spatial-fixture.js'
+import { createCurrentFormatSpatialEditingOwner } from './current-format-spatial-owner.js'
+
+const spatialCampaignReceiptSchema = z
+  .object({
+    role: z.enum(['A', 'B']),
+    campaignId: z.uuid(),
+    sceneId: z.uuid(),
+    mapId: z.uuid(),
+    commandIds: z
+      .object({
+        createMap: z.uuid(),
+        paintRoute: z.uuid(),
+        paintSparseSentinel: z.uuid(),
+        placeLocation: z.uuid()
+      })
+      .strict(),
+    advancedAt: z.number().int().nonnegative(),
+    finalTravelRevision: z.number().int().nonnegative()
+  })
+  .strict()
+
+const spatialMaterializationReceiptSchema = z
+  .object({
+    fixtureIdentity: z.literal('frontend-robustness-current-format-spatial-v1'),
+    qualificationClaim: z.literal(
+      'partial-fr2f2b2-spatial-cohort-not-complete-current-format'
+    ),
+    campaigns: z.array(spatialCampaignReceiptSchema).length(2),
+    activeCampaignRole: z.literal('A')
+  })
+  .strict()
+
+export type CurrentFormatSpatialMaterializationReceipt = Readonly<
+  z.infer<typeof spatialMaterializationReceiptSchema>
+>
+
+export function materializeCurrentFormatSpatialFixture(
+  dataRoot: string,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture,
+  spatialFixture: CurrentFormatSpatialFixture
+): CurrentFormatSpatialMaterializationReceipt {
+  const liveReceipt = materializeCurrentFormatLiveFixture(
+    dataRoot,
+    rootFixture,
+    liveFixture
+  )
+  const liveCampaigns = new Map(
+    liveReceipt.campaigns.map((campaign) => [campaign.role, campaign])
+  )
+  const campaigns = new CampaignStore(dataRoot)
+  try {
+    const before = campaigns.list()
+    const receipts = spatialFixture.campaigns.map((configured) => {
+      const liveCampaign = liveCampaigns.get(configured.role)
+      const rootCampaign = rootFixture.campaigns.find(
+        ({ role }) => role === configured.role
+      )
+      if (!liveCampaign || !rootCampaign)
+        throw new Error(
+          `Current-format spatial Campaign ${configured.role} is missing its root/Live receipt.`
+        )
+      const receipt = campaigns.visitCampaignDatabase(
+        liveCampaign.campaignId,
+        (database) =>
+          materializeCampaign(
+            campaigns,
+            database,
+            liveCampaign.campaignId,
+            liveCampaign.sceneId,
+            rootCampaign.bundle.source.id,
+            configured
+          )
+      )
+      if (!receipt)
+        throw new Error(
+          `Current-format spatial Campaign ${configured.role} database is unavailable.`
+        )
+      return receipt
+    })
+    assert.deepStrictEqual(
+      campaigns.list(),
+      before,
+      'Current-format spatial materialization changed Campaign switch authority.'
+    )
+    return spatialMaterializationReceiptSchema.parse({
+      fixtureIdentity: spatialFixture.identity,
+      qualificationClaim: spatialFixture.qualificationClaim,
+      campaigns: receipts,
+      activeCampaignRole: 'A'
+    })
+  } finally {
+    campaigns.close()
+  }
+}
+
+function materializeCampaign(
+  campaigns: CampaignStore,
+  database: Database.Database,
+  campaignId: string,
+  sceneId: string,
+  sourceId: string,
+  configured: CurrentFormatSpatialCampaign
+) {
+  const access = fixedSqliteDatabaseAccess(database)
+  const clock = { now: configured.materialization.travel.startedAt }
+  const now = () => clock.now
+  const editing = createCurrentFormatSpatialEditingOwner(database, now)
+  const travel = new HexTravelService(access, now)
+  const play = new LivePlayService(access)
+  const commands = configured.materialization.commandIds
+
+  const created = applied(
+    editing.createMap({
+      commandId: commands.createMap,
+      displayName: configured.materialization.mapName,
+      expectedCatalogRevision: 0
+    }),
+    configured.role,
+    'create map'
+  )
+  const map = created.maps[0]!
+  let contentRevision = map.contentRevision
+
+  const routePaint = applied(
+    editing.applyBrushStroke({
+      commandId: commands.paintRoute,
+      mapId: map.id,
+      mode: 'paint',
+      biomeId: configured.materialization.routeBiomeId,
+      path: configured.materialization.routeCoordinates,
+      radius: 0,
+      expectedContentRevision: contentRevision,
+      confirmationToken: null
+    }),
+    configured.role,
+    'paint route'
+  )
+  contentRevision = routePaint.maps[0]!.contentRevision
+
+  const sparsePaint = applied(
+    editing.applyBrushStroke({
+      commandId: commands.paintSparseSentinel,
+      mapId: map.id,
+      mode: 'paint',
+      biomeId: configured.materialization.sparseSentinel.biomeId,
+      path: [configured.materialization.sparseSentinel.coordinate],
+      radius: 0,
+      expectedContentRevision: contentRevision,
+      confirmationToken: null
+    }),
+    configured.role,
+    'paint sparse sentinel'
+  )
+  contentRevision = sparsePaint.maps[0]!.contentRevision
+
+  const mappings = campaigns
+    .campaignImportRepository()
+    .entityMappings(database, sourceId)
+  const locationId = mappings.find(
+    ({ kind, externalKey }) =>
+      kind === 'locations' &&
+      externalKey === configured.materialization.placedLocationExternalKey
+  )?.internalId
+  if (!locationId)
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} has no mapped placement Location.`
+    )
+  const placed = applied(
+    editing.placeLocation({
+      commandId: commands.placeLocation,
+      mapId: map.id,
+      locationId,
+      coordinate: configured.materialization.placedLocationCoordinate,
+      expectedContentRevision: contentRevision
+    }),
+    configured.role,
+    'place Location'
+  )
+  assert.equal(
+    placed.maps[0]!.contentRevision,
+    configured.expected.mapContentRevision
+  )
+
+  const session = play.readSession()
+  assert.equal(session.scene.focusedSceneId, sceneId)
+  const positioned = travel.position({
+    sceneId,
+    mapId: map.id,
+    coordinate: configured.materialization.travel.startCoordinate,
+    expectedSceneRevision: session.scene.revision
+  })
+  assert.equal(positioned.status, 'ready')
+  const evaluation = travel.evaluate({
+    sceneId,
+    mapId: map.id,
+    waypoints: configured.materialization.travel.waypoints
+  })
+  if (evaluation.status !== 'ready')
+    throw new Error(
+      `Current-format spatial Campaign ${configured.role} route was rejected.`
+    )
+  assert.deepStrictEqual(
+    evaluation.path,
+    configured.materialization.routeCoordinates
+  )
+  assert.equal(
+    evaluation.totalGameSeconds,
+    configured.expected.segmentGameSeconds * 2
+  )
+
+  const started = travel.start({
+    sceneId,
+    mapId: map.id,
+    waypoints: configured.materialization.travel.waypoints,
+    multiplier: configured.materialization.travel.multiplier,
+    expectedRevision: positioned.revision
+  })
+  assert.equal(started.status, 'travelling')
+  assert.equal(
+    started.segmentEndsAt,
+    configured.materialization.travel.advanceTo
+  )
+
+  clock.now = configured.materialization.travel.advanceTo
+  const ticked = travel.tick()
+  assert.equal(ticked.changed.length, 1)
+  assert.equal(ticked.changed[0]!.currentIndex, 1)
+  let final = ticked.changed[0]!
+  if (configured.materialization.travel.finalStatus === 'paused')
+    final = travel.pause({ sceneId, expectedRevision: final.revision })
+  assert.equal(final.status, configured.expected.travelStatus)
+  assert.equal(final.revision, configured.expected.travelRevision)
+  assert.equal(final.gameTimeSeconds, configured.expected.gameTimeSeconds)
+  assert.deepStrictEqual(final.current, configured.expected.currentCoordinate)
+
+  return spatialCampaignReceiptSchema.parse({
+    role: configured.role,
+    campaignId,
+    sceneId,
+    mapId: map.id,
+    commandIds: commands,
+    advancedAt: clock.now,
+    finalTravelRevision: final.revision
+  })
+}
+
+function applied(
+  result: HexBrushStrokeResult,
+  role: 'A' | 'B',
+  operation: string
+): Extract<HexBrushStrokeResult, { status: 'applied' }> {
+  if (result.status !== 'applied')
+    throw new Error(
+      `Current-format spatial Campaign ${role} could not ${operation}: ${result.status}.`
+    )
+  return result
+}

--- a/scripts/qualification/current-format-spatial-owner.ts
+++ b/scripts/qualification/current-format-spatial-owner.ts
@@ -1,0 +1,28 @@
+import type Database from 'better-sqlite3'
+import { CampaignUnitOfWork } from '../../src/core/application/campaign-unit-of-work.js'
+import { HexMapEditingCommandHandler } from '../../src/core/application/hex-map-editing.js'
+import { HexEditJournalStore } from '../../src/core/hex/hex-edit-journal-store.js'
+import { HexMapStore } from '../../src/core/hex/hex-map-store.js'
+import { HexTravelStore } from '../../src/core/hex/hex-travel.js'
+import { PartyStore } from '../../src/core/party/party-store.js'
+import { SceneStore } from '../../src/core/scene/scene-store.js'
+import { WorldLocationStore } from '../../src/core/worldplanner/location-store.js'
+
+export function createCurrentFormatSpatialEditingOwner(
+  database: Database.Database,
+  now: () => number
+): HexMapEditingCommandHandler {
+  return new HexMapEditingCommandHandler(() => {
+    const locations = new WorldLocationStore(database)
+    const maps = new HexMapStore(database, locations)
+    const party = new PartyStore(database)
+    const scenes = new SceneStore(database, () => locations.read().locations)
+    return {
+      unitOfWork: new CampaignUnitOfWork(database),
+      maps,
+      party,
+      travel: new HexTravelStore(database, maps, party, scenes, now),
+      journal: new HexEditJournalStore(database)
+    }
+  })
+}

--- a/scripts/qualification/current-format-spatial-readback.ts
+++ b/scripts/qualification/current-format-spatial-readback.ts
@@ -1,0 +1,418 @@
+import assert from 'node:assert/strict'
+import { LivePlayService } from '../../src/core/encounter/live-combat.js'
+import { biomeDefinition } from '../../src/core/hex/biome-catalog.js'
+import { HexMapService } from '../../src/core/hex/hex-map-store.js'
+import { HexTravelService } from '../../src/core/hex/hex-travel.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import type {
+  HexBrushStrokeResult,
+  HexChunkReadResult,
+  HexHistoryState,
+  HexMapCatalogSnapshot,
+  HexRuntimeOverlayProjection,
+  HexTravelSnapshot
+} from '../../src/shared/contracts/hex.js'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import type {
+  CurrentFormatLiveCampaign,
+  CurrentFormatLiveFixture
+} from './current-format-live-fixture.js'
+import { currentFormatLiveSemanticIdentities } from './current-format-live-readback.js'
+import type { CurrentFormatRootFixture } from './current-format-root-fixture.js'
+import {
+  assertCurrentFormatRootReadback,
+  readCurrentFormatRootFixture,
+  type CurrentFormatRootCampaignReadback,
+  type CurrentFormatRootReadback
+} from './current-format-root-readback.js'
+import type {
+  CurrentFormatSpatialCampaign,
+  CurrentFormatSpatialFixture
+} from './current-format-spatial-fixture.js'
+import { spatialChunkKeys } from './current-format-spatial-fixture.js'
+import type { CurrentFormatSpatialMaterializationReceipt } from './current-format-spatial-materializer.js'
+import { createCurrentFormatSpatialEditingOwner } from './current-format-spatial-owner.js'
+import {
+  assertNoRawUuid,
+  collectUuids,
+  replaceSemanticIdentities,
+  semanticHash
+} from './qualification-semantic-oracle.js'
+
+type SpatialCommandReceipts = Readonly<{
+  createMap: HexBrushStrokeResult
+  paintRoute: HexBrushStrokeResult
+  paintSparseSentinel: HexBrushStrokeResult
+  placeLocation: HexBrushStrokeResult
+}>
+
+export type CurrentFormatSpatialCampaignReadback = Readonly<{
+  role: 'A' | 'B'
+  campaignId: string
+  sceneId: string
+  mapId: string
+  session: LiveSessionSnapshot
+  catalog: HexMapCatalogSnapshot
+  chunks: HexChunkReadResult
+  history: HexHistoryState
+  commandReceipts: SpatialCommandReceipts
+  travel: HexTravelSnapshot
+  overlays: HexRuntimeOverlayProjection
+  nextBoundaryDelay: number | null
+  semanticProjection: unknown
+  semanticSha256: string
+}>
+
+export type CurrentFormatSpatialReadback = Readonly<{
+  fixtureIdentity: string
+  qualificationClaim: string
+  root: CurrentFormatRootReadback
+  campaigns: readonly CurrentFormatSpatialCampaignReadback[]
+}>
+
+export function readCurrentFormatSpatialFixture(
+  dataRoot: string,
+  rootFixture: CurrentFormatRootFixture,
+  liveFixture: CurrentFormatLiveFixture,
+  spatialFixture: CurrentFormatSpatialFixture
+): CurrentFormatSpatialReadback {
+  const root = readCurrentFormatRootFixture(dataRoot, rootFixture)
+  const campaigns = new CampaignStore(dataRoot)
+  try {
+    const registry = campaigns.list()
+    const readbacks = spatialFixture.campaigns.map((configured) => {
+      const rootCampaign = root.campaigns.find(
+        ({ role }) => role === configured.role
+      )
+      const liveCampaign = liveFixture.campaigns.find(
+        ({ role }) => role === configured.role
+      )
+      if (!rootCampaign || !liveCampaign)
+        throw new Error(
+          `Current-format spatial Campaign ${configured.role} has no root/Live readback.`
+        )
+      const readback = campaigns.visitCampaignDatabase(
+        rootCampaign.campaignId,
+        (database) => {
+          const now = () => configured.materialization.travel.advanceTo
+          const access = fixedSqliteDatabaseAccess(database)
+          const session = new LivePlayService(access).readSession()
+          const maps = new HexMapService(access)
+          const catalog = maps.catalog()
+          const matchingMaps = catalog.maps.filter(
+            ({ displayName }) =>
+              displayName === configured.materialization.mapName
+          )
+          assert.equal(
+            matchingMaps.length,
+            1,
+            `Campaign ${configured.role} spatial map is not singular.`
+          )
+          assert.equal(
+            catalog.maps.length,
+            1,
+            `Campaign ${configured.role} contains an unaccounted Hex map.`
+          )
+          const map = matchingMaps[0]!
+          const storedChunks = maps.readChunks(
+            map.id,
+            spatialChunkKeys(configured)
+          )
+          const chunks: HexChunkReadResult = {
+            ...storedChunks,
+            biomes: [
+              ...new Set(
+                storedChunks.chunks.flatMap((chunk) =>
+                  chunk.authoredTiles.map(({ biomeId }) => biomeId)
+                )
+              )
+            ].map(biomeDefinition)
+          }
+          const editing = createCurrentFormatSpatialEditingOwner(database, now)
+          const commandReceipts = readCommandReceipts(configured, editing)
+          const travelOwner = new HexTravelService(access, now)
+          const travel = travelOwner.read(session.scene.focusedSceneId)
+          const overlays = travelOwner.runtimeOverlays(map.id)
+          const nextBoundaryDelay = travelOwner.nextBoundaryDelay()
+          const semanticProjection = semanticSpatialProjection(
+            configured,
+            liveCampaign,
+            rootCampaign,
+            session,
+            map.id,
+            {
+              catalog,
+              chunks,
+              history: editing.history(map.id),
+              commandReceipts,
+              travel,
+              overlays,
+              nextBoundaryDelay
+            }
+          )
+          return {
+            role: configured.role,
+            campaignId: rootCampaign.campaignId,
+            sceneId: session.scene.focusedSceneId,
+            mapId: map.id,
+            session,
+            catalog,
+            chunks,
+            history: editing.history(map.id),
+            commandReceipts,
+            travel,
+            overlays,
+            nextBoundaryDelay,
+            semanticProjection,
+            semanticSha256: semanticHash(semanticProjection)
+          }
+        }
+      )
+      if (!readback)
+        throw new Error(
+          `Current-format spatial Campaign ${configured.role} database is unavailable.`
+        )
+      return Object.freeze(readback)
+    })
+    assert.deepStrictEqual(
+      campaigns.list(),
+      registry,
+      'Independent spatial readback must not mutate Campaign registry state.'
+    )
+    return Object.freeze({
+      fixtureIdentity: spatialFixture.identity,
+      qualificationClaim: spatialFixture.qualificationClaim,
+      root,
+      campaigns: Object.freeze(readbacks)
+    })
+  } finally {
+    campaigns.close()
+  }
+}
+
+export function assertCurrentFormatSpatialReadback(
+  rootFixture: CurrentFormatRootFixture,
+  spatialFixture: CurrentFormatSpatialFixture,
+  readback: CurrentFormatSpatialReadback
+): void {
+  assertSpatialRootPreservation(rootFixture, readback.root)
+  assert.equal(readback.fixtureIdentity, spatialFixture.identity)
+  assert.equal(readback.qualificationClaim, spatialFixture.qualificationClaim)
+  assert.equal(readback.root.fixtureIdentity, rootFixture.identity)
+  assert.equal(readback.campaigns.length, spatialFixture.campaigns.length)
+  const campaignA = readback.campaigns.find(({ role }) => role === 'A')
+  assert.ok(campaignA)
+  assert.equal(
+    readback.root.activeCampaignId,
+    campaignA.campaignId,
+    'Campaign A must remain active after independent spatial readback.'
+  )
+
+  const campaignUuidSets: Set<string>[] = []
+  for (const expected of spatialFixture.campaigns) {
+    const actual = readback.campaigns.find(({ role }) => role === expected.role)
+    assert.ok(actual, `Missing spatial readback for Campaign ${expected.role}.`)
+    assertCampaign(expected, actual)
+    campaignUuidSets.push(
+      collectUuids({
+        session: actual.session,
+        catalog: actual.catalog,
+        chunks: actual.chunks,
+        commandReceipts: actual.commandReceipts,
+        travel: actual.travel,
+        overlays: actual.overlays
+      })
+    )
+  }
+  for (const id of campaignUuidSets[0] ?? [])
+    assert.ok(
+      !(campaignUuidSets[1]?.has(id) ?? false),
+      `Spatial identity ${id} leaked across Campaign A/B.`
+    )
+}
+
+function assertSpatialRootPreservation(
+  fixture: CurrentFormatRootFixture,
+  root: CurrentFormatRootReadback
+): void {
+  assertCurrentFormatRootReadback(fixture, {
+    ...root,
+    campaigns: root.campaigns.map((campaign) => ({
+      ...campaign,
+      party: {
+        ...campaign.party,
+        members: campaign.party.members.map((member) => ({
+          ...member,
+          travelPosition: null
+        }))
+      }
+    }))
+  })
+}
+
+export function assertCurrentFormatSpatialReceipt(
+  receipt: CurrentFormatSpatialMaterializationReceipt,
+  readback: CurrentFormatSpatialReadback
+): void {
+  assert.equal(receipt.fixtureIdentity, readback.fixtureIdentity)
+  assert.equal(receipt.qualificationClaim, readback.qualificationClaim)
+  for (const expected of receipt.campaigns) {
+    const actual = readback.campaigns.find(({ role }) => role === expected.role)
+    assert.ok(actual, `Missing spatial receipt for Campaign ${expected.role}.`)
+    assert.equal(actual.campaignId, expected.campaignId)
+    assert.equal(actual.sceneId, expected.sceneId)
+    assert.equal(actual.mapId, expected.mapId)
+    assert.equal(actual.travel.revision, expected.finalTravelRevision)
+    assert.deepStrictEqual(
+      Object.fromEntries(
+        Object.entries(actual.commandReceipts).map(([key, value]) => [
+          key,
+          value.commandId
+        ])
+      ),
+      expected.commandIds
+    )
+  }
+}
+
+function assertCampaign(
+  expected: CurrentFormatSpatialCampaign,
+  actual: CurrentFormatSpatialCampaignReadback
+): void {
+  const sentinels = expected.expected
+  const map = actual.catalog.maps[0]!
+  assert.equal(actual.catalog.revision, sentinels.catalogRevision)
+  assert.equal(map.id, actual.mapId)
+  assert.equal(map.metadataRevision, sentinels.mapMetadataRevision)
+  assert.equal(map.contentRevision, sentinels.mapContentRevision)
+  assert.equal(actual.chunks.map.id, actual.mapId)
+  assert.equal(actual.chunks.chunks.length, sentinels.chunkCount)
+  assert.equal(
+    actual.chunks.chunks.reduce(
+      (count, chunk) => count + chunk.authoredTiles.length,
+      0
+    ),
+    sentinels.authoredTileCount
+  )
+  assert.equal(
+    actual.chunks.chunks.reduce(
+      (count, chunk) => count + chunk.locations.length,
+      0
+    ),
+    1
+  )
+  assert.deepStrictEqual(actual.history, {
+    canUndo: true,
+    canRedo: false,
+    undoLabel: sentinels.historyUndoLabel,
+    redoLabel: null
+  })
+  for (const command of Object.values(actual.commandReceipts))
+    assert.equal(command.status, 'applied')
+
+  assert.equal(actual.session.party.revision, sentinels.partyRevision)
+  assert.equal(actual.session.scene.revision, sentinels.sceneRevision)
+  assert.equal(actual.session.revision, sentinels.sceneRevision)
+  assert.equal(actual.session.combat?.revision, sentinels.combatRevision)
+  assert.equal(actual.travel.sceneId, actual.sceneId)
+  assert.equal(actual.travel.mapId, actual.mapId)
+  assert.equal(actual.travel.revision, sentinels.travelRevision)
+  assert.equal(actual.travel.status, sentinels.travelStatus)
+  assert.equal(actual.travel.currentIndex, sentinels.currentIndex)
+  assert.equal(actual.travel.gameTimeSeconds, sentinels.gameTimeSeconds)
+  assert.deepStrictEqual(actual.travel.current, sentinels.currentCoordinate)
+  assert.equal(actual.travel.path.length, sentinels.routeLength)
+  assert.equal(actual.travel.locationName, sentinels.locationName)
+  assert.equal(actual.travel.segmentStartedAt, sentinels.segmentStartedAt)
+  assert.equal(actual.travel.segmentEndsAt, sentinels.segmentEndsAt)
+  assert.equal(actual.nextBoundaryDelay, sentinels.nextBoundaryDelay)
+  assert.deepStrictEqual(actual.overlays, {
+    mapId: actual.mapId,
+    overlays: [
+      {
+        sceneId: actual.sceneId,
+        label: 'Standardszene',
+        token: sentinels.currentCoordinate,
+        route: actual.travel.path,
+        focused: true
+      }
+    ]
+  })
+  assert.equal(
+    actual.semanticSha256,
+    sentinels.semanticSha256,
+    `Campaign ${expected.role} complete semantic spatial hash drifted; actual ${actual.semanticSha256}.`
+  )
+}
+
+function readCommandReceipts(
+  configured: CurrentFormatSpatialCampaign,
+  editing: ReturnType<typeof createCurrentFormatSpatialEditingOwner>
+): SpatialCommandReceipts {
+  const read = (key: keyof SpatialCommandReceipts): HexBrushStrokeResult => {
+    const receipt = editing.commandReceipt(
+      configured.materialization.commandIds[key]
+    )
+    if (!receipt)
+      throw new Error(
+        `Current-format spatial Campaign ${configured.role} is missing command receipt ${key}.`
+      )
+    return receipt
+  }
+  return Object.freeze({
+    createMap: read('createMap'),
+    paintRoute: read('paintRoute'),
+    paintSparseSentinel: read('paintSparseSentinel'),
+    placeLocation: read('placeLocation')
+  })
+}
+
+function semanticSpatialProjection(
+  configured: CurrentFormatSpatialCampaign,
+  live: CurrentFormatLiveCampaign,
+  root: CurrentFormatRootCampaignReadback,
+  session: LiveSessionSnapshot,
+  mapId: string,
+  spatial: Readonly<{
+    catalog: HexMapCatalogSnapshot
+    chunks: HexChunkReadResult
+    history: HexHistoryState
+    commandReceipts: SpatialCommandReceipts
+    travel: HexTravelSnapshot
+    overlays: HexRuntimeOverlayProjection
+    nextBoundaryDelay: number | null
+  }>
+): unknown {
+  const additions = new Map<string, string>([
+    [mapId, configured.materialization.mapSemanticKey],
+    [configured.materialization.commandIds.createMap, 'command:hex-create-map'],
+    [
+      configured.materialization.commandIds.paintRoute,
+      'command:hex-paint-route'
+    ],
+    [
+      configured.materialization.commandIds.paintSparseSentinel,
+      'command:hex-paint-sparse'
+    ],
+    [
+      configured.materialization.commandIds.placeLocation,
+      'command:hex-place-location'
+    ]
+  ])
+  const identities = currentFormatLiveSemanticIdentities(
+    live,
+    root,
+    session,
+    additions
+  )
+  const projection = replaceSemanticIdentities(
+    {
+      liveSession: session,
+      hex: spatial
+    },
+    identities
+  )
+  assertNoRawUuid(projection, `Campaign ${configured.role} spatial`)
+  return projection
+}

--- a/scripts/qualification/qualification-semantic-oracle.ts
+++ b/scripts/qualification/qualification-semantic-oracle.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto'
+
+export function replaceSemanticIdentities(
+  value: unknown,
+  identities: ReadonlyMap<string, string>
+): unknown {
+  if (Array.isArray(value))
+    return value.map((entry) => replaceSemanticIdentities(entry, identities))
+  if (typeof value === 'object' && value !== null)
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        replaceSemanticIdentities(entry, identities)
+      ])
+    )
+  if (typeof value !== 'string') return value
+  let projected = value
+  for (const [id, semanticKey] of [...identities].sort(
+    ([left], [right]) => right.length - left.length
+  ))
+    projected = projected.replaceAll(id, semanticKey)
+  return projected
+}
+
+export function assertNoRawUuid(value: unknown, label: string): void {
+  const serialized = JSON.stringify(value)
+  const match = serialized.match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+  )
+  if (match)
+    throw new Error(
+      `${label} semantic projection left raw identity ${match[0]}.`
+    )
+}
+
+export function semanticHash(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex')
+}
+
+export function collectUuids(value: unknown): Set<string> {
+  const matches = JSON.stringify(value).match(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi
+  )
+  return new Set(matches ?? [])
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (typeof value !== 'object' || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)])
+  )
+}

--- a/scripts/qualify-current-format-spatial.ts
+++ b/scripts/qualify-current-format-spatial.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { createDefaultCampaignSchemaBootstrapper } from '../src/core/persistence/sqlite/campaign-schema-bootstrapper.js'
+import { databaseSchemaVersions } from '../src/core/persistence/sqlite/database.js'
+import { validateCurrentFormatCampaignManifest } from './qualification/current-format-campaign-manifest.js'
+import { loadCurrentFormatLiveFixture } from './qualification/current-format-live-fixture.js'
+import { loadCurrentFormatRootFixture } from './qualification/current-format-root-fixture.js'
+import { loadCurrentFormatSpatialFixture } from './qualification/current-format-spatial-fixture.js'
+import { materializeCurrentFormatSpatialFixture } from './qualification/current-format-spatial-materializer.js'
+import {
+  assertCurrentFormatSpatialReadback,
+  assertCurrentFormatSpatialReceipt,
+  readCurrentFormatSpatialFixture
+} from './qualification/current-format-spatial-readback.js'
+
+const dataRoot = resolve(requiredArgument('--data-root'))
+const manifest = validateCurrentFormatCampaignManifest(
+  JSON.parse(
+    readFileSync(
+      'docs/project/evidence/frontend-robustness-current-format-manifest.v1.json',
+      'utf8'
+    )
+  ),
+  {
+    campaignDatabaseSchemaVersion: databaseSchemaVersions.campaign,
+    campaignSchemaRegistrations:
+      createDefaultCampaignSchemaBootstrapper().names()
+  }
+)
+const rootFixture = loadCurrentFormatRootFixture(
+  'docs/project/evidence/frontend-robustness-current-format-root-fixture.v1.json',
+  manifest
+)
+const liveFixture = loadCurrentFormatLiveFixture(
+  'docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json',
+  manifest,
+  rootFixture
+)
+const spatialFixture = loadCurrentFormatSpatialFixture(
+  'docs/project/evidence/frontend-robustness-current-format-spatial-fixture.v1.json',
+  manifest,
+  rootFixture,
+  liveFixture
+)
+const materialization = materializeCurrentFormatSpatialFixture(
+  dataRoot,
+  rootFixture,
+  liveFixture,
+  spatialFixture
+)
+const readback = readCurrentFormatSpatialFixture(
+  dataRoot,
+  rootFixture,
+  liveFixture,
+  spatialFixture
+)
+assertCurrentFormatSpatialReadback(rootFixture, spatialFixture, readback)
+assertCurrentFormatSpatialReceipt(materialization, readback)
+
+process.stdout.write(
+  `${JSON.stringify({
+    kind: 'current-format-spatial-qualification',
+    fixtureIdentity: spatialFixture.identity,
+    qualificationClaim: spatialFixture.qualificationClaim,
+    coveredCampaignRegistrations: spatialFixture.coveredCampaignRegistrations,
+    extendedCampaignRegistrations: spatialFixture.extendedCampaignRegistrations,
+    activeCampaignRole: materialization.activeCampaignRole,
+    campaigns: readback.campaigns.map((campaign) => ({
+      role: campaign.role,
+      campaignId: campaign.campaignId,
+      mapId: campaign.mapId,
+      mapContentRevision: campaign.catalog.maps[0]?.contentRevision ?? null,
+      partyRevision: campaign.session.party.revision,
+      sceneRevision: campaign.session.scene.revision,
+      travelRevision: campaign.travel.revision,
+      travelStatus: campaign.travel.status,
+      current: campaign.travel.current,
+      gameTimeSeconds: campaign.travel.gameTimeSeconds,
+      semanticSha256: campaign.semanticSha256
+    })),
+    semanticReadback: true
+  })}\n`
+)
+
+function requiredArgument(name: string): string {
+  const index = process.argv.indexOf(name)
+  const value = process.argv[index + 1]
+  if (index < 0 || !value) throw new Error(`${name} is required`)
+  return value
+}

--- a/scripts/test-manifests/frontend-robustness.json
+++ b/scripts/test-manifests/frontend-robustness.json
@@ -22,6 +22,7 @@
     "tests/integration/campaign-registry-revision.test.ts",
     "tests/integration/current-format-root-qualification.test.ts",
     "tests/integration/current-format-live-qualification.test.ts",
+    "tests/integration/current-format-spatial-qualification.test.ts",
     "tests/unit/generator-preset-application.test.ts",
     "tests/unit/generator-preset-reconciliation-ui.test.tsx",
     "tests/unit/core-process-supervisor.test.ts",

--- a/src/renderer/capabilities/campaign-workspace-projection.ts
+++ b/src/renderer/capabilities/campaign-workspace-projection.ts
@@ -101,6 +101,7 @@ export class CampaignWorkspaceProjection {
   >
   readonly #listeners = new Set<() => void>()
   readonly #unsubscribeCatalog: () => void
+  readonly #unsubscribeSessionChanges: () => void
   #unsubscribeSession: (() => void) | null = null
   #subscribedCampaignId: string | null = null
   #pendingReconciliation: PendingCampaignReconciliation | null = null
@@ -128,6 +129,9 @@ export class CampaignWorkspaceProjection {
     this.#unsubscribeCatalog = this.#catalog.subscribe(
       campaignCatalogAuthority,
       this.#synchronize
+    )
+    this.#unsubscribeSessionChanges = api.session.onChanged(
+      this.#handleSessionChange
     )
   }
 
@@ -411,6 +415,7 @@ export class CampaignWorkspaceProjection {
     if (this.#disposed) return
     this.#disposed = true
     this.#unsubscribeCatalog()
+    this.#unsubscribeSessionChanges()
     this.#unsubscribeSession?.()
     this.#unsubscribeSession = null
     this.#catalog.dispose()
@@ -478,6 +483,17 @@ export class CampaignWorkspaceProjection {
     if (sameSnapshot(this.#snapshot, next)) return
     this.#snapshot = next
     for (const listener of this.#listeners) listener()
+  }
+
+  readonly #handleSessionChange: Parameters<
+    SaltMarcherApi['session']['onChanged']
+  >[0] = (notice) => {
+    if (this.#disposed) return
+    const campaignId = this.#catalog.current(
+      campaignCatalogAuthority
+    )?.activeCampaignId
+    if (!campaignId || notice.campaignId !== campaignId) return
+    void this.#refreshSession(campaignId)
   }
 
   async #settleCampaignWrite<Receipt extends CampaignCommandReceipt>(

--- a/src/utility/application.ts
+++ b/src/utility/application.ts
@@ -298,6 +298,7 @@ const referenceChanges = new ReferenceChangeCoordinator(
 )
 const {
   mutateReferences,
+  publishSessionProjectionInvalidation,
   publishSessionChange,
   publishLootChange,
   publishPreparationChange,
@@ -388,6 +389,7 @@ const worldPlannerHandlers = createWorldPlannerHandlers({
   worldNpcs,
   biomes: biomeService,
   mutateReferences,
+  publishSessionProjectionInvalidation,
   publishLocationChange,
   publishLocationMarkerHexChanges,
   publishSymbolChange,

--- a/src/utility/composition/world-planner.ts
+++ b/src/utility/composition/world-planner.ts
@@ -39,6 +39,7 @@ export function createWorldPlannerHandlers(dependencies: {
     work: () => T,
     changes: (result: T) => readonly ReferenceChangeDescriptor[]
   ) => T
+  publishSessionProjectionInvalidation: () => void
   publishLocationChange: (
     ids: readonly string[],
     reason: 'catalog' | 'presentation' | 'symbol-replacement'
@@ -86,6 +87,7 @@ export function createWorldPlannerHandlers(dependencies: {
     worldNpcs,
     biomes,
     mutateReferences,
+    publishSessionProjectionInvalidation,
     publishLocationChange,
     publishLocationMarkerHexChanges,
     publishSymbolChange,
@@ -109,6 +111,7 @@ export function createWorldPlannerHandlers(dependencies: {
           () => {
             const execution = save.execute(input)
             publishLocationChange([execution.receipt.saved.id], 'catalog')
+            publishSessionProjectionInvalidation()
             if (execution.hexResult) publishHexChange(execution.hexResult)
             return execution.receipt
           },
@@ -143,6 +146,7 @@ export function createWorldPlannerHandlers(dependencies: {
                 [result.notice.changedChunk]
               )
             publishLocationChange([input.id], 'catalog')
+            publishSessionProjectionInvalidation()
             return result.receipt
           },
           () => [{ kind: 'location', id: input.id }]

--- a/src/utility/domain-events.ts
+++ b/src/utility/domain-events.ts
@@ -38,6 +38,23 @@ export class CoreEventSink {
   }
 }
 
+export function publishSessionProjectionInvalidation(deps: {
+  sink: CoreEventSink
+  campaigns: Pick<CampaignStore, 'activeCampaignId'>
+  play: Pick<LivePlayService, 'readSession'>
+}): void {
+  const snapshot = deps.play.readSession()
+  deps.sink.post({
+    kind: 'session.changed',
+    notice: {
+      campaignId: deps.campaigns.activeCampaignId(),
+      sceneId: snapshot.scene.focusedSceneId,
+      revision: snapshot.revision,
+      reason: 'projection-invalidated'
+    }
+  })
+}
+
 interface DomainEventDependencies {
   sink: CoreEventSink
   campaigns: CampaignStore
@@ -149,6 +166,8 @@ export function createDomainEventPublishers(deps: DomainEventDependencies) {
       deps.referenceChanges.record(changes(result))
       return result
     },
+    publishSessionProjectionInvalidation: () =>
+      publishSessionProjectionInvalidation(deps),
     publishSessionChange,
     publishLootChange: (
       reason: 'created' | 'updated' | 'moved' | 'accepted' | 'distributed'

--- a/tests/architecture/frontend-robustness-architecture.test.ts
+++ b/tests/architecture/frontend-robustness-architecture.test.ts
@@ -175,6 +175,18 @@ architectureGate(
     expect(projection.stringLiterals).toContain('campaign.live-session')
     expect(projection.stringLiterals).toContain('read-projection')
     expect(projection.stringLiterals).toContain('receipt-reconciliation')
+    expect(projection.propertyAccesses).toContain('api.session.onChanged')
+
+    const worldPlanner = readTypeScriptModule(
+      'src/utility/composition/world-planner.ts'
+    )
+    expect(
+      worldPlanner.calls.filter(
+        (call) => call === 'publishSessionProjectionInvalidation'
+      )
+    ).toHaveLength(2)
+    const domainEvents = readTypeScriptModule('src/utility/domain-events.ts')
+    expect(domainEvents.stringLiterals).toContain('projection-invalidated')
 
     const coordinator = readTypeScriptModule(
       'src/renderer/features/workspace/use-campaign-session-coordinator.ts'

--- a/tests/e2e/support/campaign-walking-scenarios.ts
+++ b/tests/e2e/support/campaign-walking-scenarios.ts
@@ -451,6 +451,7 @@ export async function runCampaignCombatScenario(): Promise<void> {
   await (await client.$('button[aria-label="Ort Details schließen"]')).click()
   await (await client.$('button[aria-label="Session"]')).click()
   await setSceneLocation(client, 'Verfallener Turm')
+  await waitForSceneLocation(client, 'Verfallener Turm')
   await (await client.$('button[aria-label="Katalog"]')).click()
   await (await client.$('button=Orte')).click()
   await (await client.$('button=Verfallener Turm')).click()

--- a/tests/integration/current-format-spatial-qualification.test.ts
+++ b/tests/integration/current-format-spatial-qualification.test.ts
@@ -1,0 +1,302 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { HexMapService } from '../../src/core/hex/hex-map-store.js'
+import { HexTravelService } from '../../src/core/hex/hex-travel.js'
+import { CampaignStore } from '../../src/core/persistence/sqlite/campaign-store.js'
+import { createDefaultCampaignSchemaBootstrapper } from '../../src/core/persistence/sqlite/campaign-schema-bootstrapper.js'
+import { databaseSchemaVersions } from '../../src/core/persistence/sqlite/database.js'
+import { fixedSqliteDatabaseAccess } from '../../src/core/persistence/sqlite/database-access.js'
+import { WorldLocationStore } from '../../src/core/worldplanner/location-store.js'
+import { validateCurrentFormatCampaignManifest } from '../../scripts/qualification/current-format-campaign-manifest.js'
+import { loadCurrentFormatLiveFixture } from '../../scripts/qualification/current-format-live-fixture.js'
+import { loadCurrentFormatRootFixture } from '../../scripts/qualification/current-format-root-fixture.js'
+import {
+  loadCurrentFormatSpatialFixture,
+  type CurrentFormatSpatialFixture,
+  validateCurrentFormatSpatialFixture
+} from '../../scripts/qualification/current-format-spatial-fixture.js'
+import { materializeCurrentFormatSpatialFixture } from '../../scripts/qualification/current-format-spatial-materializer.js'
+import {
+  assertCurrentFormatSpatialReadback,
+  assertCurrentFormatSpatialReceipt,
+  readCurrentFormatSpatialFixture
+} from '../../scripts/qualification/current-format-spatial-readback.js'
+
+const manifest = validateCurrentFormatCampaignManifest(
+  JSON.parse(
+    readFileSync(
+      'docs/project/evidence/frontend-robustness-current-format-manifest.v1.json',
+      'utf8'
+    )
+  ),
+  {
+    campaignDatabaseSchemaVersion: databaseSchemaVersions.campaign,
+    campaignSchemaRegistrations:
+      createDefaultCampaignSchemaBootstrapper().names()
+  }
+)
+const rootFixture = loadCurrentFormatRootFixture(
+  'docs/project/evidence/frontend-robustness-current-format-root-fixture.v1.json',
+  manifest
+)
+const liveFixture = loadCurrentFormatLiveFixture(
+  'docs/project/evidence/frontend-robustness-current-format-live-fixture.v1.json',
+  manifest,
+  rootFixture
+)
+const spatialFixturePath =
+  'docs/project/evidence/frontend-robustness-current-format-spatial-fixture.v1.json'
+const spatialFixture = loadCurrentFormatSpatialFixture(
+  spatialFixturePath,
+  manifest,
+  rootFixture,
+  liveFixture
+)
+
+describe('FR2F2B2 current-format spatial qualification protocol', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'salt-marcher-fr2f2b2-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('materializes A/B through spatial owners and reopens complete semantic projections', () => {
+    const receipt = materializeCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    const readback = readCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+
+    expect(() =>
+      assertCurrentFormatSpatialReadback(rootFixture, spatialFixture, readback)
+    ).not.toThrow()
+    expect(() =>
+      assertCurrentFormatSpatialReceipt(receipt, readback)
+    ).not.toThrow()
+    expect(
+      readback.campaigns.map(({ role, travel, chunks, commandReceipts }) => ({
+        role,
+        status: travel.status,
+        current: travel.current,
+        authoredTiles: chunks.chunks.reduce(
+          (count, chunk) => count + chunk.authoredTiles.length,
+          0
+        ),
+        commands: Object.values(commandReceipts).map(({ status }) => status)
+      }))
+    ).toEqual([
+      {
+        role: 'A',
+        status: 'paused',
+        current: { q: 1, r: 0 },
+        authoredTiles: 4,
+        commands: ['applied', 'applied', 'applied', 'applied']
+      },
+      {
+        role: 'B',
+        status: 'travelling',
+        current: { q: 5, r: -3 },
+        authoredTiles: 4,
+        commands: ['applied', 'applied', 'applied', 'applied']
+      }
+    ])
+  })
+
+  it('rejects invalid Campaign B spatial truth before publishing Campaign A', () => {
+    const raw = structuredClone(
+      spatialFixture
+    ) as DeepMutable<CurrentFormatSpatialFixture>
+    raw.campaigns[1]!.materialization.routeBiomeId = 'water'
+
+    expect(() =>
+      validateCurrentFormatSpatialFixture(
+        raw,
+        manifest,
+        rootFixture,
+        liveFixture
+      )
+    ).toThrow('uses an impassable biome')
+    const campaigns = new CampaignStore(root)
+    try {
+      expect(campaigns.list().campaigns).toEqual([])
+    } finally {
+      campaigns.close()
+    }
+  })
+
+  it('detects a public Hex map mutation instead of accepting changed spatial bytes', () => {
+    materializeCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    visitCampaign(root, 'A', (database) => {
+      const maps = new HexMapService(fixedSqliteDatabaseAccess(database))
+      const map = maps.catalog().maps[0]!
+      maps.update({
+        mapId: map.id,
+        displayName: 'Changed through HexMapService',
+        expectedMetadataRevision: map.metadataRevision
+      })
+    })
+
+    expect(() =>
+      readCurrentFormatSpatialFixture(
+        root,
+        rootFixture,
+        liveFixture,
+        spatialFixture
+      )
+    ).toThrow('spatial map is not singular')
+  })
+
+  it('detects a public Travel mutation instead of accepting a changed journey', () => {
+    materializeCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    visitCampaign(root, 'B', (database) => {
+      const travel = new HexTravelService(
+        fixedSqliteDatabaseAccess(database),
+        () => 2_002_400
+      )
+      const current = travel.read()
+      travel.pause({
+        sceneId: current.sceneId,
+        expectedRevision: current.revision
+      })
+    })
+
+    const changed = readCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    expect(() =>
+      assertCurrentFormatSpatialReadback(rootFixture, spatialFixture, changed)
+    ).toThrow()
+  })
+
+  it('preserves the upstream root oracle except for qualified Travel position', () => {
+    materializeCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    visitCampaign(root, 'A', (database) => {
+      const locations = new WorldLocationStore(database)
+      const snapshot = locations.read()
+      const location = snapshot.locations.find(
+        ({ displayName }) => displayName === 'Salt Harbor'
+      )!
+      locations.update(
+        location.id,
+        {
+          displayName: location.displayName,
+          tags: location.tags,
+          readAloud: location.readAloud,
+          notes: 'Changed after spatial materialization.',
+          factionIds: location.factionIds,
+          encounterTableIds: location.encounterTableIds
+        },
+        snapshot.revision
+      )
+    })
+
+    const changed = readCurrentFormatSpatialFixture(
+      root,
+      rootFixture,
+      liveFixture,
+      spatialFixture
+    )
+    expect(() =>
+      assertCurrentFormatSpatialReadback(rootFixture, spatialFixture, changed)
+    ).toThrow()
+  })
+
+  it('rejects coverage, upstream identity, and semantic-hash drift before mutation', () => {
+    const raw = JSON.parse(readFileSync(spatialFixturePath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    expect(() =>
+      validateCurrentFormatSpatialFixture(
+        { ...raw, coveredCampaignRegistrations: ['scene'] },
+        manifest,
+        rootFixture,
+        liveFixture
+      )
+    ).toThrow('coverage does not match')
+    expect(() =>
+      validateCurrentFormatSpatialFixture(
+        { ...raw, liveFixtureIdentity: 'stale-live' },
+        manifest,
+        rootFixture,
+        liveFixture
+      )
+    ).toThrow()
+
+    const campaigns = structuredClone(raw['campaigns']) as Array<{
+      expected: { semanticSha256: string }
+    }>
+    campaigns[0]!.expected.semanticSha256 = 'not-a-hash'
+    expect(() =>
+      validateCurrentFormatSpatialFixture(
+        { ...raw, campaigns },
+        manifest,
+        rootFixture,
+        liveFixture
+      )
+    ).toThrow()
+    const store = new CampaignStore(root)
+    try {
+      expect(store.list().campaigns).toEqual([])
+    } finally {
+      store.close()
+    }
+  })
+})
+
+function visitCampaign(
+  dataRoot: string,
+  role: 'A' | 'B',
+  work: Parameters<CampaignStore['visitCampaignDatabase']>[1]
+): void {
+  const campaigns = new CampaignStore(dataRoot)
+  try {
+    const sourceId = rootFixture.campaigns.find(
+      (campaign) => campaign.role === role
+    )!.bundle.source.id
+    const campaign = campaigns.campaignImportRepository().previous(sourceId)
+    expect(campaign).not.toBeNull()
+    campaigns.visitCampaignDatabase(campaign!.campaignId, work)
+  } finally {
+    campaigns.close()
+  }
+}
+
+type DeepMutable<T> = {
+  -readonly [Key in keyof T]: T[Key] extends readonly (infer Item)[]
+    ? DeepMutable<Item>[]
+    : T[Key] extends object
+      ? DeepMutable<T[Key]>
+      : T[Key]
+}

--- a/tests/unit/campaign-workspace-projection.test.ts
+++ b/tests/unit/campaign-workspace-projection.test.ts
@@ -132,6 +132,56 @@ describe('Campaign Workspace projection', () => {
     expect(read).toHaveBeenCalledOnce()
   })
 
+  it('refreshes the active Session from provider-lived invalidation events across consumer routes', async () => {
+    let changed!: Parameters<SaltMarcherApi['session']['onChanged']>[0]
+    const unsubscribe = vi.fn()
+    const onChanged = vi.fn<SaltMarcherApi['session']['onChanged']>(
+      (listener) => {
+        changed = listener
+        return unsubscribe
+      }
+    )
+    const refreshed = session(2)
+    const read = vi.fn<SaltMarcherApi['session']['read']>(() =>
+      Promise.resolve(refreshed)
+    )
+    const projection = new CampaignWorkspaceProjection(
+      apiWithCampaigns({}, { read, onChanged })
+    )
+    projection.publishCampaigns(catalog(campaignA))
+    projection.publishSession(campaignA, session(1))
+
+    changed({
+      campaignId: campaignB,
+      sceneId: campaignB,
+      revision: 2,
+      reason: 'projection-invalidated'
+    })
+    await Promise.resolve()
+    expect(read).not.toHaveBeenCalled()
+
+    changed({
+      campaignId: campaignA,
+      sceneId: campaignA,
+      revision: 2,
+      reason: 'projection-invalidated'
+    })
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+    expect(read).toHaveBeenCalledWith({ campaignId: campaignA })
+    expect(projection.snapshot().session).toBe(refreshed)
+
+    projection.dispose()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    changed({
+      campaignId: campaignA,
+      sceneId: campaignA,
+      revision: 3,
+      reason: 'projection-invalidated'
+    })
+    await Promise.resolve()
+    expect(read).toHaveBeenCalledOnce()
+  })
+
   it('queues same-authority commands and selects the accepted revision at transport time', async () => {
     const created =
       deferred<Awaited<ReturnType<SaltMarcherApi['campaigns']['create']>>>()
@@ -500,7 +550,7 @@ function api(
 ): SaltMarcherApi {
   return {
     campaigns: { list },
-    session: { read }
+    session: { read, onChanged: vi.fn(() => () => undefined) }
   } as unknown as SaltMarcherApi
 }
 
@@ -516,6 +566,7 @@ function apiWithCampaigns(
     },
     session: {
       read: vi.fn(() => Promise.resolve(session(0))),
+      onChanged: vi.fn(() => () => undefined),
       ...sessionCapability
     }
   } as unknown as SaltMarcherApi

--- a/tests/unit/domain-events.test.ts
+++ b/tests/unit/domain-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { CoreEventSink } from '../../src/utility/domain-events.js'
+import type { LiveSessionSnapshot } from '../../src/shared/contracts/live-session.js'
+import {
+  CoreEventSink,
+  publishSessionProjectionInvalidation
+} from '../../src/utility/domain-events.js'
 
 describe('CoreEventSink', () => {
   it('validates events and accounts for each published message', () => {
@@ -26,6 +30,47 @@ describe('CoreEventSink', () => {
     expect(messages).toHaveLength(1)
     expect(counters.eventsPublished).toBe(1)
     expect(() => sink.post({ kind: 'unknown' })).toThrow()
+    expect(counters.eventsPublished).toBe(1)
+  })
+
+  it('publishes an identity-bound Session invalidation from current Live truth', () => {
+    const messages: unknown[] = []
+    const counters = {
+      messagesReceived: 0,
+      requestsCompleted: 0,
+      eventsPublished: 0,
+      scheduledWakeups: 0
+    }
+    const sink = new CoreEventSink(
+      { postMessage: (message) => messages.push(message) },
+      counters
+    )
+    const campaignId = '018f1f9c-4f5e-8a12-9234-123456789abc'
+    const sceneId = '018f1f9c-4f5e-8a12-9234-123456789abd'
+
+    publishSessionProjectionInvalidation({
+      sink,
+      campaigns: { activeCampaignId: () => campaignId },
+      play: {
+        readSession: () =>
+          ({
+            revision: 7,
+            scene: { focusedSceneId: sceneId }
+          }) as LiveSessionSnapshot
+      }
+    })
+
+    expect(messages).toEqual([
+      {
+        kind: 'session.changed',
+        notice: {
+          campaignId,
+          sceneId,
+          revision: 7,
+          reason: 'projection-invalidated'
+        }
+      }
+    ])
     expect(counters.eventsPublished).toBe(1)
   })
 })

--- a/tests/unit/encounter-panel.test.tsx
+++ b/tests/unit/encounter-panel.test.tsx
@@ -80,7 +80,8 @@ describe('encounter scenario panel', () => {
 
   beforeEach(() => {
     api = {
-      encounter: { evaluate: vi.fn().mockResolvedValue(null) }
+      encounter: { evaluate: vi.fn().mockResolvedValue(null) },
+      session: { onChanged: vi.fn(() => () => undefined) }
     } as unknown as SaltMarcherApi
   })
 

--- a/tests/unit/hex-map-canvas.test.tsx
+++ b/tests/unit/hex-map-canvas.test.tsx
@@ -100,7 +100,8 @@ const api = {
   runtime: {
     reportRendererIncident: vi.fn().mockResolvedValue(undefined),
     reloadRenderer: vi.fn().mockResolvedValue(undefined)
-  }
+  },
+  session: { onChanged: vi.fn(() => () => undefined) }
 } as unknown as SaltMarcherApi
 const asyncAssertion = { timeout: 5_000 } as const
 

--- a/tests/unit/installation-settings-projection.test.tsx
+++ b/tests/unit/installation-settings-projection.test.tsx
@@ -120,6 +120,9 @@ function settingsApi(
     settings: {
       read,
       update
+    },
+    session: {
+      onChanged: vi.fn(() => () => undefined)
     }
   } as unknown as SaltMarcherApi
 }

--- a/tests/unit/loot-scene-controller.test.tsx
+++ b/tests/unit/loot-scene-controller.test.tsx
@@ -117,6 +117,7 @@ describe('Loot scene controller', () => {
 
 function lootApi(overrides: Partial<SaltMarcherApi['loot']>): SaltMarcherApi {
   return {
+    session: { onChanged: vi.fn(() => () => undefined) },
     loot: {
       scene: vi.fn(({ sceneId }: { sceneId: string }) =>
         Promise.resolve(projection(sceneId, 0))

--- a/tests/unit/loot-ui.test.tsx
+++ b/tests/unit/loot-ui.test.tsx
@@ -77,7 +77,13 @@ describe('Loot UI', () => {
     }
 
     render(
-      <CapabilityProvider api={{} as SaltMarcherApi}>
+      <CapabilityProvider
+        api={
+          {
+            session: { onChanged: vi.fn(() => () => undefined) }
+          } as unknown as SaltMarcherApi
+        }
+      >
         <GroupsPanelHarness snapshot={snapshot} loot={loot} focused={focused} />
       </CapabilityProvider>
     )
@@ -157,7 +163,10 @@ describe('Loot UI', () => {
     } as unknown as LiveSessionSnapshot
     const api = {
       loot: { distribute },
-      session: { read: vi.fn() }
+      session: {
+        read: vi.fn(),
+        onChanged: vi.fn(() => () => undefined)
+      }
     } as unknown as SaltMarcherApi
 
     const view = render(

--- a/tests/unit/party-profile-ui.test.tsx
+++ b/tests/unit/party-profile-ui.test.tsx
@@ -67,7 +67,10 @@ describe('structured party profile UI', () => {
         return Promise.resolve(party)
       }
     )
-    const api = { party: { update } } as unknown as SaltMarcherApi
+    const api = {
+      party: { update },
+      session: { onChanged: vi.fn(() => () => undefined) }
+    } as unknown as SaltMarcherApi
     render(
       <CapabilityProvider api={api}>
         <PartyDropdown

--- a/tests/unit/session-workspace-controller.test.tsx
+++ b/tests/unit/session-workspace-controller.test.tsx
@@ -139,6 +139,7 @@ function snapshot(revision: number, archived = false): LiveSessionSnapshot {
 
 function sessionApi(sceneOverrides: Record<string, unknown>): SaltMarcherApi {
   return {
+    session: { onChanged: vi.fn(() => () => undefined) },
     loot: {
       scene: vi.fn().mockResolvedValue({
         revision: 0,

--- a/tests/unit/session-workspace-layout.test.tsx
+++ b/tests/unit/session-workspace-layout.test.tsx
@@ -143,7 +143,13 @@ describe('session workspace layout', () => {
 
   it('shows control selectors only while their register row is edited', () => {
     render(
-      <CapabilityProvider api={{} as SaltMarcherApi}>
+      <CapabilityProvider
+        api={
+          {
+            session: { onChanged: vi.fn(() => () => undefined) }
+          } as unknown as SaltMarcherApi
+        }
+      >
         <SessionControlPanel
           model={{
             focusedSceneId: sceneId,
@@ -173,7 +179,8 @@ describe('session workspace layout', () => {
     const value = snapshot()
     const setScenario = vi.fn()
     const api = {
-      encounter: { evaluate: vi.fn().mockResolvedValue(null) }
+      encounter: { evaluate: vi.fn().mockResolvedValue(null) },
+      session: { onChanged: vi.fn(() => () => undefined) }
     } as unknown as SaltMarcherApi
     render(
       <CapabilityProvider api={api}>


### PR DESCRIPTION
## Ergebnis

Implementiert `FR2F2B2` als reproduzierbares Current-Format-Protokoll für Hex/Travel und behebt zusätzlich den im ersten Candidate-Gate nachgewiesenen cross-route Session-Projektionsfehler.

Versioniertes Detail-Audit: `docs/project/evidence/frontend-robustness-fr2f2b2-audit.md`

## FR2F2B2-Qualifikation

- statisches A/B-Spatial-Fixture mit `hex` als Primary Coverage sowie `world-locations`, `party` und `scene`
- öffentliche Materialisierung über `HexMapEditingCommandHandler` und `HexTravelService`, ohne Fixture-SQL
- Map, angrenzende Route, Sparse-Chunk, Location, Party-/Scene-Position und vier persistierte Command Receipts je Campaign
- kontrollierte Boundary: A pausiert, B bleibt travelling
- unabhängiger Reopen-Readback von Live Session, Catalog, Chunks, Biomen, History, Receipts, Travel, Overlay und Delay
- UUID-Normalisierung, vollständige SHA-256-Oracles, lesbare Sentinels, A/B-Isolation und fail-closed Mutationsnachweise
- vollständige FR2F2A-Root-Erhaltungsprüfung nach Maskierung ausschließlich der qualifizierten Travel-Position

## Candidate-Failure und Forensik

Der erste exakte Candidate-SHA `9c6c89b32d1485d2acb6f1507a9b1aeac504553e` scheiterte in [Run 32819591384](https://github.com/ThonkTank/Salt-Marcher/actions/runs/32819591384) ausschließlich an `Linux Visual · goldens-campaign`; alle Root-Jobs und alle anderen E2E-/Visual-Jobs waren grün.

Das Failure-Profil bewies:

- `Verfallener Turm` war korrekt aus der Location-Tabelle gelöscht.
- Die Scene enthielt weiterhin die nun dangling Location-ID.
- Der Renderer zeigte trotzdem den alten Location-Namen.

Damit war Persistence korrekt, aber die providerweite Session-Projektion stale. Ursache: Nach dem Utility-Commit unmountete die Catalog-Route und verwarf den hook-lokalen Follow-up-Refresh ihres latest-only Coordinators. Der bereits provider-lived `CampaignWorkspaceProjection` konsumierte das vorhandene identity-bound `session.changed`-Signal bislang nicht. Ein Retry hätte die Race Condition nur verdeckt.

## Follow-up-Fix

Candidate-SHA: `74a628b98c37d12fbac6d3940a6ff8700322945f`

- Utility publiziert nach Location-Catalog-Save/Delete `projection-invalidated` mit aktueller Campaign-, Scene- und Session-Revision.
- Der provider-lived Workspace-Owner subscribed genau einmal, filtert auf die aktive Campaign, führt einen koordinierten Full-Session-Read aus und unsubscribed beim Dispose.
- Keine Polling-Schleife, kein globaler Remount und kein synthetischer Partial-Patch.
- Der E2E-Pfad wartet nach dem Setzen von `Verfallener Turm` auf sichtbare Session-Wahrheit, bevor die unabhängige Delete-Operation beginnt.
- Bestehende partielle Provider-Test-Doubles wurden um den nun unmittelbar konsumierten Pflichtvertrag `session.onChanged` ergänzt; der Produktionsvertrag bleibt strikt.

## Negativbefunde / nicht beansprucht

- Die Spatial-Qualifikation nutzt einen festen Qualification-Database-Adapter und beweist nicht Renderer → Preload → Utility Production Switching.
- Der Domain-Reader ergänzt Utility-Biome-Komposition deterministisch, übt aber nicht den Utility-Transport aus.
- Hex Travel schreibt aktuell teils unveränderte Party-/Scene-Positionen erneut; das Fixture erfasst diesen Ist-Zustand, erklärt ihn nicht zur Zielarchitektur.
- Current Format hat weiterhin nur die bootstrapped Standardszene; M3-Zweitszene bleibt offen.
- Chunk-Vollständigkeit gilt nur für den dedizierten leeren Qualification Root.
- Die neue Session-Invalidierung ist bewusst grob und besitzt noch kein gemeinsames Location/Session Command Receipt.
- Asynchrone Refresh-Fehler behalten die bestehende Projection-Failure/Cached-State-Semantik; es wurde keine neue sichtbare Fehleroberfläche eingeführt.
- FR2F2C, FR2F3, FR2G, FR-A07, TN-16, TN-21, QS-05 und FR7B bleiben offen. FR3 bleibt No-Go.

## Verifikation

- Standalone Clean-Root Spatial CLI: A/B-Oracles bestanden
- Root + Live + Spatial: 3 Dateien, 15 Tests grün
- Projection + Utility Event + Architektur: 3 Dateien, 21 Tests grün
- betroffene Provider-Tests: 8 Dateien, 30 Tests grün
- `pnpm check:frontend-robustness`: 28 Dateien, 186 Tests und beide TypeScript-Projekte grün
- vollständiger lokaler `pnpm check`: Format, alle Lint-Partitionen, beide TypeScript-Projekte und 91/91 Architekturtests grün; portable Units auf dem stark belasteten Host 195/197 Dateien und 802/809 Tests, begrenzt auf fünf bekannte Encounter-30-s-Timeouts, einen daraus folgenden doppelten Escape-Callback derselben Suite und das 16-ms Reference-Gate bei 66,015 ms
- direkter lokaler `goldens-campaign`-Versuch ohne xvfb: beide Szenarien durch wiederholte Renderer-/Screenshot-Timeouts abgebrochen; kein fachlicher Nachweis, Remote Visual ist autoritativ
- `git diff --check` und Audit-Prettier grün
- App-Build-Fingerprint Main: `00e52f0d9d8d3f826d5aef5e1080d4b08e29af23cacafc8230b25e447da64ea1`
- App-Build-Fingerprint Candidate: `f4a545959738c83b8ee3c88ed2b62df55d021ffa992ed46bc8984140917e63c6`

## Delivery-Gate

Der Follow-up ist app-relevant. Der exakte Candidate-SHA muss vollständig remote grün sein, danach `pnpm handoff:app` mit exakt diesem SHA bestehen; erst dann darf derselbe SHA nach `main` promoted werden.
