### PR TITLE
FR2F3B: isolate Travel SwiftShader route

### DIFF
--- a/docs/project/evidence/frontend-robustness-fr2f3b-audit.md
+++ b/docs/project/evidence/frontend-robustness-fr2f3b-audit.md
@@ -1,0 +1,107 @@
+# FR2F3B Travel/SwiftShader isolation audit
+
+Date: 2026-08-25
+
+Baseline: `8a6912547cdae8f52925686c982372800d7aadfe`
+
+Verdict: the historical empty-profile Travel/SwiftShader timeout has an
+isolated disposition. Empty and mapped Travel routes both start under the
+repository's real SwiftShader Electron configuration, the mapped route creates
+an actual SwiftShader WebGL 2 Pixi context, and that context accepts the next
+map interaction. `FR2G` and exact cross-platform `RP-R`/`RP-L` `QS-05` remain
+open.
+
+## Reviewed current truth
+
+The mandatory review covered the FR2 roadmap and prior FR2D--FR2F3A audits,
+the target and Electron migration architectures, `TN-16`, the original
+empty-profile timeout record, `wdio.conf.ts`, the E2E registry/runner and
+failure diagnostics, the v2 Travel fixture and materializer, the production
+Travel integration/provider/controller, Pixi map surface and WebGL utilities,
+the comprehensive `session-travel` E2E, runtime GPU observation capability,
+and current clean `origin/main`/PR state.
+
+The review retained `FR2F3B` as one independently closed guarantee. It adds no
+Campaign timing or Current-Format owner claim and does not reopen `FR2F3A`.
+
+## Closed guarantee
+
+One dedicated functional suite uses the established v2 mapped Travel fixture
+and one Electron process:
+
+1. it creates a second empty Campaign through the rendered Campaign UI;
+2. it invokes the exact quick-action `Reise` path that timed out in the FR2D
+   draft;
+3. it requires a rendered, non-error Travel console with a deliberately
+   disabled empty map selector in less than the existing ten-second timeout;
+4. it switches back to the mapped `Reise-Abnahme` Campaign through the UI;
+5. it opens `Reise`, requires the enabled `Reiseküste` map, and opens the Pixi
+   map surface;
+6. it reads `VERSION` and `UNMASKED_RENDERER_WEBGL` from the canvas's existing
+   WebGL 2 context;
+7. it requires the actual renderer to contain `SwiftShader`; and
+8. it enters route-planning mode, moves the keyboard selection to q=1/r=0,
+   confirms it in a later browser turn, and requires the resulting four-hour
+   Travel evaluation.
+
+The local evidence was:
+
+- empty Travel readiness: `1516.624 ms`, below the `10000 ms` timeout;
+- WebGL version: `WebGL 2.0 (OpenGL ES 3.0 Chromium)`;
+- renderer:
+  `ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)`;
+- test time: 1 minute 22.5 seconds;
+- isolated total including Electron startup/teardown: 1 minute 50 seconds;
+- result: 1/1 passed.
+
+This disposes the old ambiguity: an empty Travel surface is valid and bounded
+under SwiftShader, and the same runtime can instantiate and interact with the
+real Pixi map. The original timeout is not evidence of a Travel or Pixi product
+defect.
+
+## Negative audit and harness findings
+
+1. An initial draft awaited `runtime.gpuObservation()` in a synchronous
+   Webdriver execution before any Travel action. That diagnostic exceeded the
+   renderer channel's ten-second wait. It therefore cannot classify the old
+   Travel timeout. The final proof observes the renderer on the actual Pixi
+   context instead. The runtime handler currently requests complete GPU info
+   before its helper requests complete GPU info again; whether that is an
+   intentional warm-up or redundant diagnostic work remains a separate render-
+   qualification question for `FR7B`.
+2. A draft combined a CSS ancestor and Webdriver text selector into one invalid
+   selector. The final journey resolves the action container first and then its
+   text button. The rejected selector never reached product code.
+3. A draft dispatched `ArrowRight` and `Enter` in one browser turn, before
+   React could publish the new selection. Its failed assertion triggered the
+   known slow Pixi failure-screenshot path. The final journey waits for the
+   selected Hex before confirming it, matching the established Travel suite.
+4. `wdio.conf.ts` still forces `--use-angle=swiftshader` and
+   `--enable-unsafe-swiftshader`; the WebGL renderer readback proves those flags
+   affected the actual Pixi context rather than serving as configuration-only
+   evidence.
+5. This is a bounded disposition, not production hardware evidence. It adds no
+   5+100 population, p95, calibrated host, native-GPU, cross-OS, memory/CPU,
+   context-loss, or exact `QS-05` claim.
+6. The complete Travel command/lifecycle and idle-render journey remains the
+   existing `session-travel` suite. F3B adds only the missing empty-route and
+   actual-SwiftShader identity/next-interaction oracle.
+
+## Proof packet and delivery class
+
+- focused ESLint for the suite and typed registry: passed;
+- E2E registry and CI matrix: 2/2 files, 8/8 tests passed;
+- `pnpm test:e2e:built --suite travelSwiftshaderIsolation`: 1/1 passed;
+- `pnpm check:frontend-robustness`: 31/31 files and 203/203 tests passed;
+- the complete local `pnpm check` passed formatting, every lint partition, and
+  typecheck. Its architecture population reached 90/91: the unchanged renderer
+  import/call ownership gate exceeded its 30-second test timeout at
+  `31.370 s`. An immediate one-worker run of the complete renderer architecture
+  file passed 19/19; the same gate completed in `22.227 s`. The portable Unit
+  phase was not reached in that invocation. No architecture timeout or source
+  threshold was changed; clean-host Candidate CI remains the broad delivery
+  gate.
+
+The packet changes a qualification registry, one E2E test, and this audit only.
+It changes no `src/`, resource, dependency, Electron/build, or packaging input;
+the app-build fingerprint is unchanged and no AppImage handoff is required.

--- a/scripts/e2e-suite-registry.ts
+++ b/scripts/e2e-suite-registry.ts
@@ -202,6 +202,15 @@ export const e2eSuiteRegistry = [
         measuredSeconds: 82
       }
     }
+  },
+  {
+    name: 'travelSwiftshaderIsolation',
+    spec: './tests/e2e/travel-swiftshader-isolation.e2e.ts',
+    fixture: 'v2/travel-scenario',
+    types: ['functional'],
+    ci: {
+      functional: { shard: 'group-loot-travel', measuredSeconds: 110 }
+    }
   }
 ] as const satisfies readonly E2eSuiteRegistration[]
 

--- a/tests/e2e/travel-swiftshader-isolation.e2e.ts
+++ b/tests/e2e/travel-swiftshader-isolation.e2e.ts
@@ -1,0 +1,183 @@
+import { browser, expect } from '@wdio/globals'
+import { performance } from 'node:perf_hooks'
+import type { Browser as WdioBrowser } from 'webdriverio'
+
+const travelTimeoutMs = 10_000
+
+describe('Travel SwiftShader isolation', () => {
+  it('opens empty and mapped Travel routes and accepts the next Pixi interaction', async () => {
+    const client = browser as unknown as WdioBrowser
+
+    progress('create-empty-campaign')
+    await createCampaign(client, 'SwiftShader leer')
+    const emptyStartedAt = performance.now()
+    await openTravel(client)
+    const emptyConsole = await travelConsole(client)
+    const emptySelect = await emptyConsole.$('select[aria-label="Hex-Karte"]')
+    await emptySelect.waitForExist({ timeout: travelTimeoutMs })
+    expect(await emptySelect.isEnabled()).toBe(false)
+    expect(await emptyConsole.$('[role="alert"]').isExisting()).toBe(false)
+    const emptyTravelReadyMs = performance.now() - emptyStartedAt
+    expect(emptyTravelReadyMs).toBeLessThan(travelTimeoutMs)
+
+    progress('switch-to-mapped-campaign')
+    await switchCampaign(client, 'Reise-Abnahme')
+    await openTravel(client)
+    const mappedConsole = await travelConsole(client)
+    const mappedSelect = await mappedConsole.$('select[aria-label="Hex-Karte"]')
+    await mappedSelect.waitForEnabled({ timeout: travelTimeoutMs })
+    expect(await mappedSelect.getValue()).not.toBe('')
+    expect(await mappedSelect.$('option:checked').getText()).toBe('Reiseküste')
+
+    progress('open-pixi-map')
+    await (await mappedConsole.$('button=Karte öffnen')).click()
+    const map = await client.$(
+      '[role="region"][aria-label="Hex-Karte Reiseküste"]'
+    )
+    await map.waitForExist({ timeout: travelTimeoutMs })
+    const webgl = await webglObservation(client)
+    expect(webgl.version).toContain('WebGL 2')
+    expect(webgl.renderer.toLowerCase()).toContain('swiftshader')
+
+    progress('next-pixi-interaction')
+    await (await client.$('button=Route planen')).click()
+    await client.execute(() => {
+      const region = document.querySelector<HTMLElement>(
+        '[role="region"][aria-label="Hex-Karte Reiseküste"]'
+      )
+      region?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+      )
+    })
+    await (
+      await client.$('.travel-current-hex*=q 1 · r 0')
+    ).waitForExist({
+      timeout: 5_000,
+      timeoutMsg: 'SwiftShader Pixi map did not accept the next interaction.'
+    })
+    await client.execute(() => {
+      const region = document.querySelector<HTMLElement>(
+        '[role="region"][aria-label="Hex-Karte Reiseküste"]'
+      )
+      region?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      )
+    })
+    await (
+      await client.$('.travel-route-facts*=4 Std.')
+    ).waitForExist({
+      timeout: 5_000,
+      timeoutMsg: 'Travel route evaluation did not follow the Pixi interaction.'
+    })
+
+    process.stdout.write(
+      `${JSON.stringify({
+        kind: 'travel-swiftshader-isolation',
+        emptyTravelReadyMs: Number(emptyTravelReadyMs.toFixed(3)),
+        timeoutMs: travelTimeoutMs,
+        webgl,
+        emptyTravelRoute: true,
+        mappedTravelRoute: true,
+        nextPixiInteraction: true,
+        qualificationClaim:
+          'isolated-travel-swiftshader-disposition-not-production-timing'
+      })}\n`
+    )
+  })
+})
+
+function progress(stage: string): void {
+  process.stdout.write(`[travel-swiftshader-isolation] ${stage}\n`)
+}
+
+async function createCampaign(
+  client: WdioBrowser,
+  name: string
+): Promise<void> {
+  await openCampaignDialog(client)
+  const field = await client.$('#campaign-name')
+  await field.setValue(name)
+  await (await client.$('button=Anlegen')).click()
+  await (
+    await client.$(`h1=Session · ${name}`)
+  ).waitForExist({
+    timeout: travelTimeoutMs
+  })
+  await waitForCampaignDialogClosed(client)
+}
+
+async function switchCampaign(
+  client: WdioBrowser,
+  name: string
+): Promise<void> {
+  await openCampaignDialog(client)
+  const target = await client.$(`button[aria-label="${name}"]`)
+  await target.waitForClickable({ timeout: 5_000 })
+  await target.click()
+  await (
+    await client.$(`h1=Session · ${name}`)
+  ).waitForExist({
+    timeout: travelTimeoutMs
+  })
+  await waitForCampaignDialogClosed(client)
+}
+
+async function openCampaignDialog(client: WdioBrowser): Promise<void> {
+  const menuButton = await client.$('button[aria-label="Menü"]')
+  if ((await menuButton.getAttribute('aria-expanded')) !== 'true')
+    await menuButton.click()
+  const menu = await client.$('nav#campaign-menu')
+  await menu.waitForDisplayed({ timeout: 5_000 })
+  await (await menu.$('button=Kampagnen')).click()
+  await (await client.$('#campaign-name')).waitForDisplayed({ timeout: 5_000 })
+}
+
+async function waitForCampaignDialogClosed(client: WdioBrowser): Promise<void> {
+  const menuButton = await client.$('button[aria-label="Menü"]')
+  await client.waitUntil(
+    async () => (await menuButton.getAttribute('aria-expanded')) === 'false',
+    {
+      timeout: 5_000,
+      interval: 25,
+      timeoutMsg: 'Campaign dialog did not close.'
+    }
+  )
+}
+
+async function openTravel(client: WdioBrowser): Promise<void> {
+  const actions = await client.$('.shell-quick-actions')
+  const button = await actions.$('button=Reise')
+  await button.waitForClickable({ timeout: 5_000 })
+  await button.click()
+}
+
+async function travelConsole(client: WdioBrowser) {
+  const console = await client.$('section.travel-console[aria-label="Reise"]')
+  await console.waitForExist({ timeout: travelTimeoutMs })
+  return console
+}
+
+async function webglObservation(
+  client: WdioBrowser
+): Promise<Readonly<{ version: string; renderer: string }>> {
+  const serialized = await client.execute(() => {
+    const canvas = document.querySelector<HTMLCanvasElement>(
+      '.hex-travel-map canvas'
+    )
+    if (!canvas) throw new Error('Travel Pixi canvas is missing.')
+    const context = canvas.getContext('webgl2')
+    if (!context) throw new Error('Travel Pixi canvas has no WebGL 2 context.')
+    const debug = context.getExtension('WEBGL_debug_renderer_info')
+    return JSON.stringify({
+      version: String(context.getParameter(context.VERSION)),
+      renderer:
+        debug === null
+          ? 'unavailable (WEBGL_debug_renderer_info disabled)'
+          : String(context.getParameter(debug.UNMASKED_RENDERER_WEBGL))
+    })
+  })
+  return JSON.parse(serialized) as Readonly<{
+    version: string
+    renderer: string
+  }>
+}


### PR DESCRIPTION
# FR2F3B Travel/SwiftShader isolation audit

Date: 2026-08-25

Baseline: `8a6912547cdae8f52925686c982372800d7aadfe`

Verdict: the historical empty-profile Travel/SwiftShader timeout has an
isolated disposition. Empty and mapped Travel routes both start under the
repository's real SwiftShader Electron configuration, the mapped route creates
an actual SwiftShader WebGL 2 Pixi context, and that context accepts the next
map interaction. `FR2G` and exact cross-platform `RP-R`/`RP-L` `QS-05` remain
open.

## Reviewed current truth

The mandatory review covered the FR2 roadmap and prior FR2D--FR2F3A audits,
the target and Electron migration architectures, `TN-16`, the original
empty-profile timeout record, `wdio.conf.ts`, the E2E registry/runner and
failure diagnostics, the v2 Travel fixture and materializer, the production
Travel integration/provider/controller, Pixi map surface and WebGL utilities,
the comprehensive `session-travel` E2E, runtime GPU observation capability,
and current clean `origin/main`/PR state.

The review retained `FR2F3B` as one independently closed guarantee. It adds no
Campaign timing or Current-Format owner claim and does not reopen `FR2F3A`.

## Closed guarantee

One dedicated functional suite uses the established v2 mapped Travel fixture
and one Electron process:

1. it creates a second empty Campaign through the rendered Campaign UI;
2. it invokes the exact quick-action `Reise` path that timed out in the FR2D
   draft;
3. it requires a rendered, non-error Travel console with a deliberately
   disabled empty map selector in less than the existing ten-second timeout;
4. it switches back to the mapped `Reise-Abnahme` Campaign through the UI;
5. it opens `Reise`, requires the enabled `Reiseküste` map, and opens the Pixi
   map surface;
6. it reads `VERSION` and `UNMASKED_RENDERER_WEBGL` from the canvas's existing
   WebGL 2 context;
7. it requires the actual renderer to contain `SwiftShader`; and
8. it enters route-planning mode, moves the keyboard selection to q=1/r=0,
   confirms it in a later browser turn, and requires the resulting four-hour
   Travel evaluation.

The local evidence was:

- empty Travel readiness: `1516.624 ms`, below the `10000 ms` timeout;
- WebGL version: `WebGL 2.0 (OpenGL ES 3.0 Chromium)`;
- renderer:
  `ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)`;
- test time: 1 minute 22.5 seconds;
- isolated total including Electron startup/teardown: 1 minute 50 seconds;
- result: 1/1 passed.

This disposes the old ambiguity: an empty Travel surface is valid and bounded
under SwiftShader, and the same runtime can instantiate and interact with the
real Pixi map. The original timeout is not evidence of a Travel or Pixi product
defect.

## Negative audit and harness findings

1. An initial draft awaited `runtime.gpuObservation()` in a synchronous
   Webdriver execution before any Travel action. That diagnostic exceeded the
   renderer channel's ten-second wait. It therefore cannot classify the old
   Travel timeout. The final proof observes the renderer on the actual Pixi
   context instead. The runtime handler currently requests complete GPU info
   before its helper requests complete GPU info again; whether that is an
   intentional warm-up or redundant diagnostic work remains a separate render-
   qualification question for `FR7B`.
2. A draft combined a CSS ancestor and Webdriver text selector into one invalid
   selector. The final journey resolves the action container first and then its
   text button. The rejected selector never reached product code.
3. A draft dispatched `ArrowRight` and `Enter` in one browser turn, before
   React could publish the new selection. Its failed assertion triggered the
   known slow Pixi failure-screenshot path. The final journey waits for the
   selected Hex before confirming it, matching the established Travel suite.
4. `wdio.conf.ts` still forces `--use-angle=swiftshader` and
   `--enable-unsafe-swiftshader`; the WebGL renderer readback proves those flags
   affected the actual Pixi context rather than serving as configuration-only
   evidence.
5. This is a bounded disposition, not production hardware evidence. It adds no
   5+100 population, p95, calibrated host, native-GPU, cross-OS, memory/CPU,
   context-loss, or exact `QS-05` claim.
6. The complete Travel command/lifecycle and idle-render journey remains the
   existing `session-travel` suite. F3B adds only the missing empty-route and
   actual-SwiftShader identity/next-interaction oracle.

## Proof packet and delivery class

- focused ESLint for the suite and typed registry: passed;
- E2E registry and CI matrix: 2/2 files, 8/8 tests passed;
- `pnpm test:e2e:built --suite travelSwiftshaderIsolation`: 1/1 passed;
- `pnpm check:frontend-robustness`: 31/31 files and 203/203 tests passed;
- the complete local `pnpm check` passed formatting, every lint partition, and
  typecheck. Its architecture population reached 90/91: the unchanged renderer
  import/call ownership gate exceeded its 30-second test timeout at
  `31.370 s`. An immediate one-worker run of the complete renderer architecture
  file passed 19/19; the same gate completed in `22.227 s`. The portable Unit
  phase was not reached in that invocation. No architecture timeout or source
  threshold was changed; clean-host Candidate CI remains the broad delivery
  gate.

The packet changes a qualification registry, one E2E test, and this audit only.
It changes no `src/`, resource, dependency, Electron/build, or packaging input;
the app-build fingerprint is unchanged and no AppImage handoff is required.
